### PR TITLE
docs: make the README a landing page, and the rest a map an agent can follow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,66 @@
+# Notes for agents
+
+You are most likely here for one of three jobs. Each has a page written for it;
+this file is the router.
+
+| Job | Read | Then |
+|---|---|---|
+| Install ParrotFlow on someone's Mac | [docs/setup.md](docs/setup.md) | Follow it in order. It expects to be followed, not summarised. |
+| Configure it — hotkey, languages, replacements, updates | [docs/configuration.md](docs/configuration.md) | Verify with `--check-config` before saying it is done. |
+| Write or improve a rewrite — a prompt, a pipeline stage, a substitution table, a script | [docs/authoring.md](docs/authoring.md) | Score it against the case set for the thing you touched. |
+
+The full map is [docs/README.md](docs/README.md).
+
+## Rules that hold across all three
+
+**Validate with the binary, not by reading the file.**
+
+```sh
+PF=/Applications/ParrotFlow.app/Contents/MacOS/ParrotFlow
+
+$PF --check-config                                  # what will actually run
+$PF --pipeline <file.yaml> "<text>" --app <name>    # a stage, without a mic
+$PF --replace "<text>"                              # the substitution tables
+$PF --route "<what someone would say>"              # which transform that reaches
+```
+
+`--check-config` reports what survived parsing, which is not what the file
+says. Everything else is in [docs/cli.md](docs/cli.md).
+
+**Never change a prompt or a pattern without scoring it.** Every rewrite in
+this repo has a case set in `tests/` and a runner in `scripts/`. Get the number
+before, change one thing, get it after. "It looks better" is how a change fixes
+the example in front of you and breaks two you are not looking at.
+
+**Fail open.** A stage that errors, times out or finds no model must leave the
+transcript exactly as it arrived. Test it by stopping Ollama and running the
+pipeline again — the sentence should come through untouched. Losing a stage
+costs a rewrite; losing a sentence costs the sentence.
+
+**Prefer a table or a script to a prompt.** A substitution costs nothing, a
+script costs a process start, a model call costs about a second and a half warm
+and nearly seven cold. Measured here: the same model scores 68% asked to
+rewrite a sentence and 8/8 asked only to identify which words matter, with a
+script doing the rest. Split the job before reaching for a bigger prompt.
+
+**A stage that costs a model call needs a condition.** `when:`, `unless:` or
+`app:`, so it is skipped on the transcripts that never needed it.
+
+**Say out loud what executes.** A `command:` transform makes `config.yaml` run
+a program. If you add one, tell the person whose machine it runs on, in the
+same breath as telling them it works.
+
+**Write commit subjects with a type.** `feat:`, `fix:` and `perf:` cut
+releases; anything else does not. A subject without one is invisible to the
+release machinery and gets no warning. `make hooks` refuses it locally — see
+[docs/development.md](docs/development.md).
+
+## What not to change without being asked
+
+- `Config.defaultYAML` and `config.example.yaml` are what a new install gets,
+  and several check scripts read the real file rather than a fixture. Changing
+  a default changes what everyone gets on first launch.
+- The stop lists in the `dotted` pattern and in `examples/code_identifiers.py`
+  are judgements about how people speak, tuned against scored sets. They are
+  meant to be edited by the person whose speech they describe — not silently
+  widened to make one sentence work.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+See [AGENTS.md](AGENTS.md) — the entry point for any agent working in this
+repository, and the map to the documentation in [docs/](docs/README.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2026 Nathan Zylbersztejn
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Nathan Zylbersztejn
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -4,71 +4,81 @@
 
 ### Local dictation for people who type for a living
 
-Open source Wispr Flow alternative. No need to create an account or subscribe. Install, hold a key, talk, and get work done.
+An open source alternative to Wispr Flow. No account, no subscription, no cloud —
+your audio never leaves your Mac.
 
 [![Release](https://img.shields.io/github/v/release/znat/parrotflow?color=0c8c7c&label=release)](https://github.com/znat/parrotflow/releases)
 ![macOS 14+](https://img.shields.io/badge/macOS-14%2B%20·%20Apple%20silicon-1d1d1f?logo=apple&logoColor=white)
 ![License Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-0c8c7c)
 ![No cloud](https://img.shields.io/badge/audio-never%20leaves%20your%20Mac-39cdb6)
 
-**[Install](#install) · [Documentation](docs/README.md) · [Pipelines](docs/pipelines.md) · [Writing a transform](docs/authoring.md)**
+**[Install](#install)** · [Documentation](docs/README.md)
 
 </div>
 
 ---
 
-A fully featured open source alternative to Wispr Flow:
+Hold <kbd>right ⌥</kbd>, say the words on the left, let go. What lands at your
+cursor is on the right.
 
+| You say | You get |
+| --- | --- |
+| *"read user dot name"* | `read user.name` |
+| *"lis config point port"* | `lis config.port` |
+| *"the meeting is December 3rd"* | `the meeting is 3/12` |
+| *"on a dépensé deux cents euros"* | `on a dépensé 200 euros` |
+| *"a typescript function named get user profile"* | `a typescript function named getUserProfile` |
+| *"a python constant called max retry count"* | `a python constant called MAX_RETRY_COUNT` |
 
-- **Dictate anywhere** — hold a key, talk, and the text lands at your cursor:
-  editor, terminal, browser, chat.
-- **Small, efficient local models** — Parakeet TDT v3 runs on the Neural Engine,
-  and anything needing judgement asks a Gemma 4B model through Ollama. Both fit in
-  RAM you already have.
-- **Really Fast** — a normal sentence is text about a second after you let go of the
-  key. Follow ups are conditional or activated with voice commands, so you pay for it where you want it.
-- **Your vocabulary, taught out loud** — say "hey parrot, elastic search is one
-  word and takes a capital E" and it is right from then on, with a fuzzy pass for the spellings you
-  never taught it.
-- **Spoken numbers, paths and identifiers** — "two hundred forty-three" → `243`,
-  "user point name" → `user.name`, "a function called max retries" →
-  `max_retries`.
-- **Spoken commands** — select some text and say "hey parrot, use Slack handles"
-  or "hey parrot, format the function names for TypeScript". A transform that
-  describes the job runs; otherwise the model does what was asked, and you see
-  the result before it replaces anything.
-- **A programmable pipeline** — every stage of your own pipeline is a `transform`. A `transform` can be a regex, a prompt, or a script in any language running on your Mac. No limits.
-- **A prompt tuner** — so a 4B model on your Mac get a chance to approximate frontier accuracy
-  on a narrow text transform. Need a new prompt? Ask Claude to tune it with ParrotFlow's prompt tuner.
-
-No account, no API key, no server. It uses local models and your audio or text
-never leaves your Mac.
+Every row is a case in [`tests/`](tests/), scored on each change rather than
+checked by eye — including the ones that still fail, which stay in the sets.
 
 ## Install
 
 **Requires** an Apple Silicon Mac on macOS 14 or later.
 
-Paste this into Claude Code, or any agent that can run shell commands:
+> [!TIP]
+> **Let an agent do it.** Paste the block below into Claude Code, or anything
+> else that can run shell commands. It installs the app, walks you through the
+> two macOS permissions, and confirms transcription works before it hands over.
+> About five minutes.
 
 ```text
 Set up ParrotFlow on my Mac by following
 https://raw.githubusercontent.com/znat/parrotflow/main/docs/setup.md
 ```
 
-It installs the app, walks you through the two macOS permissions, and confirms
-transcription works. About five minutes.
-
-By hand, the app itself is one command — the rest is in
-[docs/setup.md](docs/setup.md):
+Or install it yourself. The app is one command; the permissions that follow are
+in [docs/setup.md](docs/setup.md).
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/znat/parrotflow/main/scripts/install.sh | sh
 ```
 
-## Why ParrotFlow
+Your first dictation downloads the speech model, about 1.2 GB. Everything after
+that is immediate.
+
+## Talk to it
+
+**Teach it a word.** Say *"hey parrot, elastic search is one word and takes a
+capital E"* and it is right from then on. A fuzzy pass catches the spellings you
+never taught it, so *"super bays"* still reaches `Supabase`.
+
+**Give it an instruction.** Select some text and say *"hey parrot, use Slack
+handles"* or *"hey parrot, format the function names for TypeScript"*. You see
+the result before it replaces anything.
+
+**It runs on your own hardware.** Parakeet TDT v3 on the Neural Engine turns
+speech into text — that part needs nothing else, and a normal sentence lands
+about a second after you let go. Teaching it words and giving it instructions
+ask a Gemma 4B through your own [Ollama](https://ollama.com); dictation works
+without it.
+
+## Program it
 
 Other dictation tools let you configure what someone else decided to expose.
-Here your transcript runs through stages you wrote, in the order you chose:
+Here the transcript runs through stages you wrote, in the order you chose, each
+one conditional on the text, the language, or the app you dictated into:
 
 ```yaml
 pipelines:
@@ -79,9 +89,14 @@ pipelines:
       app: /term|ghostty|code|cursor/   #   but only where you write code
 ```
 
-It is a text file, not a settings pane. `~/.config/parrotflow/config.yaml`,
-reloaded on save, commentable, diffable, committable. Apache 2.0, no paid tier,
-no telemetry.
+A stage is a regex, a prompt to the local model, or **a script of yours** —
+transcript on stdin, rewrite on stdout, in any language. If one fails, times
+out, or the model is not running, your sentence comes through exactly as you
+said it.
+
+It is a text file, not a settings pane: `~/.config/parrotflow/config.yaml`,
+reloaded on save, commentable, diffable, committable. No paid tier, no
+telemetry.
 
 Pipelines: [docs/pipelines.md](docs/pipelines.md) · Writing a transform:
 [docs/authoring.md](docs/authoring.md) · Where the time goes:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,40 @@ paragraph and no markup it cannot render. The mail window gets a greeting on
 its own line and a signature on theirs. **That is the config it ships with**,
 not one you have to write.
 
+## Fast, and none of it leaves your Mac
+
+Text at your cursor a second after you let go. Small models on hardware you own
+— Parakeet on the Neural Engine, a Gemma 4B through your own
+[Ollama](https://ollama.com). No account, no key, no bill.
+
+## It gets your words right
+
+*"read user dot name"* → `read user.name`. *"two hundred forty-three"* → `243`.
+It mishears a name? Fix it out loud, once.
+
+## There is no ceiling
+
+Every stage is yours — a regex, a prompt, or a script in any language. This is
+the whole of what produced the table above:
+
+```yaml
+pipelines:
+  default:
+    - replacements                       # the names you taught it
+    - numbers                            # "two hundred forty-three" -> 243
+    - transform: dotted                  # "user point name" -> user.name
+      app: /term|ghostty|warp|slack/     #   but never in an email
+    - transform: email                   # greeting, paragraphs, signature
+      app: /mail|outlook|superhuman/
+    - transform: slack                   # one paragraph, no markup
+      app: /slack/
+```
+
+Or skip the file and just say it: *"hey parrot, use Slack mentions"*.
+
+[Pipelines](docs/pipelines.md) · [Writing a transform](docs/authoring.md) ·
+[Where the time goes](docs/architecture.md#where-the-time-goes)
+
 ## Install
 
 **Requires** an Apple Silicon Mac on macOS 14 or later.
@@ -57,63 +91,6 @@ curl -fsSL https://raw.githubusercontent.com/znat/parrotflow/main/scripts/instal
 
 Your first dictation downloads the speech model, about 1.2 GB. Everything after
 that is immediate.
-
-## What else it does
-
-**It writes code the way you say it.** *"read user dot name"* → `read user.name`,
-*"a python constant called max retry count"* → `MAX_RETRY_COUNT`. In terminals
-and editors only — *"point"* is an ordinary word in an email.
-
-**It learns your vocabulary.** Say *"hey parrot, elastic search is one word and
-takes a capital E"* and it is right from then on. A fuzzy pass catches spellings
-you never taught it, so *"super bays"* still reaches `Supabase`.
-
-**Slack mentions, when you ask for them.** *"hey parrot, use Slack mentions"* →
-`tell @marie.dupont the deadline moved`. Never automatic: a wrong handle pings
-the wrong person.
-
-**Spoken numbers and dates, English or French.** *"two hundred forty-three"* →
-`243`. *"on a dépensé deux cents euros"* → `on a dépensé 200 euros`.
-
-**Nothing leaves your Mac.** Parakeet TDT v3 on the Neural Engine, about a
-second for a sentence. The stages that need judgement ask a Gemma 4B on your own
-[Ollama](https://ollama.com); dictation works without it.
-
-Every rewrite here has a scored case set in [`tests/`](tests/) — including the
-cases it still fails, which stay in rather than being dropped to flatter a
-number.
-
-## Program it
-
-Other dictation tools let you configure what someone else decided to expose.
-Here it is a list you own. This is the whole of what produced the table above,
-with the app patterns shortened:
-
-```yaml
-pipelines:
-  default:
-    - replacements                       # the names you taught it
-    - numbers                            # "two hundred forty-three" -> 243
-    - transform: dotted                  # "user point name" -> user.name
-      app: /term|ghostty|warp|slack/     #   but never in an email
-    - transform: email                   # greeting, paragraphs, signature
-      app: /mail|outlook|superhuman/
-    - transform: slack                   # one paragraph, no markup
-      app: /slack/
-```
-
-Reorder it, delete a line, scope a stage to one app. A stage is a regex, a
-prompt to the local model, or **a script of yours** — transcript on stdin,
-rewrite on stdout, in any language. If one fails, times out, or the model is not
-running, your sentence comes through exactly as you said it.
-
-It is a text file, not a settings pane: `~/.config/parrotflow/config.yaml`,
-reloaded on save, commentable, diffable, committable. No paid tier, no
-telemetry.
-
-Pipelines: [docs/pipelines.md](docs/pipelines.md) · Writing a transform:
-[docs/authoring.md](docs/authoring.md) · Where the time goes:
-[docs/architecture.md](docs/architecture.md#where-the-time-goes)
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -5,41 +5,85 @@
 ### Local dictation for people who type for a living
 
 Hold a key, talk, and the text lands where your cursor is — editor, terminal,
-browser, chat. Nothing you say leaves your Mac. Every rewrite it makes is a
-line in a config file you own.
+browser, chat. Nothing you say leaves your Mac.
 
 [![Release](https://img.shields.io/github/v/release/znat/parrotflow?color=0c8c7c&label=release)](https://github.com/znat/parrotflow/releases)
 ![macOS 14+](https://img.shields.io/badge/macOS-14%2B%20·%20Apple%20silicon-1d1d1f?logo=apple&logoColor=white)
 ![License MIT](https://img.shields.io/badge/license-MIT-0c8c7c)
 ![No cloud](https://img.shields.io/badge/audio-never%20leaves%20your%20Mac-39cdb6)
 
-**[Install](#install) · [Docs](docs/README.md) · [Pipelines](docs/pipelines.md) · [Writing a transform](docs/authoring.md)**
+**[Install](#install) · [Documentation](docs/README.md) · [Pipelines](docs/pipelines.md) · [Writing a transform](docs/authoring.md)**
 
 </div>
 
 ---
 
-An open-source alternative to Wispr Flow, for developers and anyone else who
-would rather configure a tool than be configured by it. Speech recognition runs
-on the Neural Engine; the optional model behind spoken commands runs on your own
-Ollama. There is no account, no API key, and no server — which is the whole
-point, because most of what a developer dictates is a bug report, a customer
-name, or a half-finished idea about their own product.
+An **open source, programmable** alternative to Wispr Flow, for developers and
+anyone else who would rather configure a tool than be configured by it.
+
+Speech recognition runs on the Neural Engine. Everything the app then does to
+your words — fixing the names it mishears, turning spoken numbers into digits,
+writing `user.name` when you say "user dot name" — is a line in a config file
+you own, in an order you choose, and you can add your own in a substitution
+table, a prompt, or a script in any language. There is no account, no API key
+and no server, which is the whole point: most of what a developer dictates is a
+bug report, a customer name, or a half-finished idea about their own product.
 
 Two things use the network, and neither carries your audio or your text: the
 speech model downloads once on first use, and once a day the app asks GitHub
 whether a newer version exists. `updates.after_days: -1` stops the second one.
 
+## Install
+
+**Requires** an Apple Silicon Mac on macOS 14 or later.
+
+### Let Claude Code do it
+
+Paste this into Claude Code, or any agent that can run shell commands:
+
+```
+Set up ParrotFlow on my Mac by following
+https://raw.githubusercontent.com/znat/parrotflow/main/docs/setup.md
+```
+
+It installs the app, walks you through the two macOS permissions, checks your
+Ollama version, sizes the model settings to your RAM, and confirms transcription
+works before it hands over. About five minutes of attention. The instructions it
+follows are [docs/setup.md](docs/setup.md) — worth reading first if you would
+rather know what is about to run.
+
+### Or by hand
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/znat/parrotflow/main/scripts/install.sh | sh
+```
+
+Downloads the latest release, checks it against its published SHA-256, and puts
+`ParrotFlow.app` in `/Applications`. Then:
+
+1. Say yes to the microphone prompt.
+2. Grant **Accessibility** in System Settings — that is what lets it type into
+   other apps. `transcription.insert_mode: clipboard` needs no permission at
+   all, and you press ⌘V yourself.
+3. Hold **right ⌥**, say something, let go.
+
+The first dictation downloads the speech model (about 1.2 GB) and takes a
+couple of minutes. Everything after that is immediate.
+
+Spoken corrections and `prompt:` transforms need [Ollama](https://ollama.com)
+0.22 or later with `ollama pull gemma4:e4b`. Optional — dictation works without
+it.
+
+Building from source: [docs/development.md](docs/development.md).
+
 ## Why this one
 
-### It is fast enough to dictate in
+### It is fast
 
-| | |
-|---|---|
-| Key down → recording | ~60–70 ms, the engine is warmed at launch |
-| Transcript, normal sentence | about a second after you let go |
-| Substitutions, numbers, dotted paths | 0.035 s for the whole set |
-| A stage that asks the local model | ~1.5 s warm — which is why stages carry conditions |
+A normal sentence is text about a second after you let go of the key, and the
+rewrites that fix your vocabulary cost nothing measurable on top. Only a stage
+that asks the local model costs real time, which is why any stage can be made
+conditional — see [where the time goes](docs/architecture.md#where-the-time-goes).
 
 ### It gets your vocabulary right
 
@@ -104,97 +148,13 @@ the measurement loop: [docs/authoring.md](docs/authoring.md).
 committable. `--check-config` tells you what the app would actually run before
 you trust it. MIT, no paid tier, no telemetry.
 
-## Install
-
-**Requires** an Apple Silicon Mac on macOS 14 or later.
-
-### Let Claude Code do it
-
-Paste this into Claude Code, or any agent that can run shell commands:
-
-```
-Set up ParrotFlow on my Mac by following
-https://raw.githubusercontent.com/znat/parrotflow/main/docs/setup.md
-```
-
-It installs the app, walks you through the two macOS permissions, checks your
-Ollama version, sizes the model settings to your RAM, and confirms transcription
-works before it hands over. About five minutes of attention. The instructions it
-follows are [docs/setup.md](docs/setup.md) — worth reading first if you would
-rather know what is about to run.
-
-### Or by hand
-
-```sh
-curl -fsSL https://raw.githubusercontent.com/znat/parrotflow/main/scripts/install.sh | sh
-```
-
-Downloads the latest release, checks it against its published SHA-256, and puts
-`ParrotFlow.app` in `/Applications`. Then:
-
-1. Say yes to the microphone prompt.
-2. Grant **Accessibility** in System Settings — that is what lets it type into
-   other apps.
-3. Hold **right ⌥**, say something, let go.
-
-The first dictation downloads the speech model (about 1.2 GB) and takes a
-couple of minutes. Everything after that is immediate.
-
-Spoken corrections and `prompt:` transforms need [Ollama](https://ollama.com)
-0.22 or later with `ollama pull gemma4:e4b`. Optional — dictation works without
-it.
-
-### Or from source
-
-```sh
-git clone https://github.com/znat/parrotflow && cd parrotflow
-make dev-certificate    # once, so permissions survive rebuilds
-make hooks              # once, so commit subjects can cut releases
-make install
-```
-
-Needs the Xcode command line tools. No Xcode project, no Apple developer
-account. This installs **ParrotFlow Dev**, a separate app from the released one
-— see [docs/development.md](docs/development.md).
-
-## The first minute
-
-Hold **right ⌥**, talk, let go. The text is typed where your cursor is.
-
-Set `transcription.insert_mode: clipboard` to have it copied instead of typed —
-that mode needs no Accessibility permission, but you press ⌘V yourself.
-
-The menu bar item offers *Correct a Word…*, *Open Recordings Folder*,
-*Settings…* — which opens `config.yaml` — and *Permissions…*. Transcripts are
-logged to `~/Library/Logs/ParrotFlow.log`.
-
 ## Documentation
 
-| | |
-|---|---|
-| [setup.md](docs/setup.md) | The guided install, written to be handed to an agent |
-| [configuration.md](docs/configuration.md) | Every setting, and what happens when it is wrong |
-| [corrections.md](docs/corrections.md) | Teaching it a name, by voice or by panel |
-| [pipelines.md](docs/pipelines.md) | Stages, transforms, conditions, per-app and per-language |
-| [authoring.md](docs/authoring.md) | Writing a prompt, a table or a script — and proving it works |
-| [cli.md](docs/cli.md) | Every flag; how to test a change without a microphone |
-| [permissions.md](docs/permissions.md) | What needs Accessibility, and what does not |
-| [architecture.md](docs/architecture.md) | What each file does, and where the time goes |
-| [development.md](docs/development.md) | Building, the dev variant, cutting a release |
-| [transcription.md](docs/transcription.md) | Why Parakeet, and why it cannot be prompted |
-| [distribution.md](docs/distribution.md) | Signing, updates, and why this ships by curl |
+**[docs/README.md](docs/README.md)** — configuration, pipelines, writing a
+transform, the command line, permissions, architecture, and why it is built
+this way.
 
 Working on this with an agent? [AGENTS.md](AGENTS.md) is the entry point.
-
-## Roadmap
-
-- [ ] Developer ID signing + notarization, then a Homebrew cask
-- [ ] App icon
-- [ ] Spike Apple `SpeechTranscriber` (macOS 26+) — no model download at all
-- [ ] Custom vocabulary as acoustic context biasing, not find-and-replace
-- [ ] Optional pre-roll buffer for zero-latency capture
-- [ ] Double-tap and long-press activation
-- [ ] More correction-prompt languages than `en` and `fr`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -18,30 +18,30 @@ your audio never leaves your Mac.
 
 ---
 
-Hold <kbd>right ⌥</kbd>, say the words on the left, let go. What lands at your
-cursor is on the right.
+You say it once, holding <kbd>right ⌥</kbd>:
 
-| You say | You get |
+> *"hi marie um the staging deploy is broken again can you take a look when you
+> get a chance thanks nathan"*
+
+What gets typed depends on the window it lands in.
+
+| Where you were | What got typed |
 | --- | --- |
-| *"read user dot name"* | `read user.name` |
-| *"lis config point port"* | `lis config.port` |
-| *"the meeting is December 3rd"* | `the meeting is 3/12` |
-| *"on a dépensé deux cents euros"* | `on a dépensé 200 euros` |
-| *"a typescript function named get user profile"* | `a typescript function named getUserProfile` |
-| *"a python constant called max retry count"* | `a python constant called MAX_RETRY_COUNT` |
+| **A terminal**<br><sub>Ghostty, Warp, Claude Code</sub> | Hi marie the staging deploy is broken again can you take a look when you get a chance thanks nathan |
+| **Slack** | Hi Marie, the staging deploy is broken again. Can you take a look when you get a chance? Thanks, Nathan. |
+| **Outlook**<br><sub>Mail, Superhuman, Missive</sub> | Hi Marie,<br><br>The staging deploy is broken again. Can you take a look when you get a chance?<br><br>Thanks,<br>Nathan |
 
-Every row is a case in [`tests/`](tests/), scored on each change rather than
-checked by eye — including the ones that still fail, which stay in the sets.
+The terminal keeps your words and drops the *um*. Slack gets one clean
+paragraph and no markup it cannot render. The mail window gets a greeting on
+its own line and a signature on theirs. **That is the config it ships with**,
+not one you have to write.
 
 ## Install
 
 **Requires** an Apple Silicon Mac on macOS 14 or later.
 
 > [!TIP]
-> **Let an agent do it.** Paste the block below into Claude Code, or anything
-> else that can run shell commands. It installs the app, walks you through the
-> two macOS permissions, and confirms transcription works before it hands over.
-> About five minutes.
+> **Let an agent do it.** Paste the block below into Claude Code, or any other agent.
 
 ```text
 Set up ParrotFlow on my Mac by following
@@ -58,41 +58,54 @@ curl -fsSL https://raw.githubusercontent.com/znat/parrotflow/main/scripts/instal
 Your first dictation downloads the speech model, about 1.2 GB. Everything after
 that is immediate.
 
-## Talk to it
+## What else it does
 
-**Teach it a word.** Say *"hey parrot, elastic search is one word and takes a
-capital E"* and it is right from then on. A fuzzy pass catches the spellings you
-never taught it, so *"super bays"* still reaches `Supabase`.
+**It writes code the way you say it.** *"read user dot name"* → `read user.name`,
+*"a python constant called max retry count"* → `MAX_RETRY_COUNT`. In terminals
+and editors only — *"point"* is an ordinary word in an email.
 
-**Give it an instruction.** Select some text and say *"hey parrot, use Slack
-handles"* or *"hey parrot, format the function names for TypeScript"*. You see
-the result before it replaces anything.
+**It learns your vocabulary.** Say *"hey parrot, elastic search is one word and
+takes a capital E"* and it is right from then on. A fuzzy pass catches spellings
+you never taught it, so *"super bays"* still reaches `Supabase`.
 
-**It runs on your own hardware.** Parakeet TDT v3 on the Neural Engine turns
-speech into text — that part needs nothing else, and a normal sentence lands
-about a second after you let go. Teaching it words and giving it instructions
-ask a Gemma 4B through your own [Ollama](https://ollama.com); dictation works
-without it.
+**Slack mentions, when you ask for them.** *"hey parrot, use Slack mentions"* →
+`tell @marie.dupont the deadline moved`. Never automatic: a wrong handle pings
+the wrong person.
+
+**Spoken numbers and dates, English or French.** *"two hundred forty-three"* →
+`243`. *"on a dépensé deux cents euros"* → `on a dépensé 200 euros`.
+
+**Nothing leaves your Mac.** Parakeet TDT v3 on the Neural Engine, about a
+second for a sentence. The stages that need judgement ask a Gemma 4B on your own
+[Ollama](https://ollama.com); dictation works without it.
+
+Every rewrite here has a scored case set in [`tests/`](tests/) — including the
+cases it still fails, which stay in rather than being dropped to flatter a
+number.
 
 ## Program it
 
 Other dictation tools let you configure what someone else decided to expose.
-Here the transcript runs through stages you wrote, in the order you chose, each
-one conditional on the text, the language, or the app you dictated into:
+Here it is a list you own. This is the whole of what produced the table above,
+with the app patterns shortened:
 
 ```yaml
 pipelines:
   default:
-    - replacements                      # the names you taught it
-    - numbers                           # "two hundred forty-three" -> 243
-    - transform: dotted                 # "user point name" -> user.name
-      app: /term|ghostty|code|cursor/   #   but only where you write code
+    - replacements                       # the names you taught it
+    - numbers                            # "two hundred forty-three" -> 243
+    - transform: dotted                  # "user point name" -> user.name
+      app: /term|ghostty|warp|slack/     #   but never in an email
+    - transform: email                   # greeting, paragraphs, signature
+      app: /mail|outlook|superhuman/
+    - transform: slack                   # one paragraph, no markup
+      app: /slack/
 ```
 
-A stage is a regex, a prompt to the local model, or **a script of yours** —
-transcript on stdin, rewrite on stdout, in any language. If one fails, times
-out, or the model is not running, your sentence comes through exactly as you
-said it.
+Reorder it, delete a line, scope a stage to one app. A stage is a regex, a
+prompt to the local model, or **a script of yours** — transcript on stdin,
+rewrite on stdout, in any language. If one fails, times out, or the model is not
+running, your sentence comes through exactly as you said it.
 
 It is a text file, not a settings pane: `~/.config/parrotflow/config.yaml`,
 reloaded on save, commentable, diffable, committable. No paid tier, no

--- a/README.md
+++ b/README.md
@@ -4,12 +4,11 @@
 
 ### Local dictation for people who type for a living
 
-Hold a key, talk, and the text lands where your cursor is — editor, terminal,
-browser, chat. Nothing you say leaves your Mac.
+Open source Wispr Flow alternative. No need to create an account or subscribe. Install, hold a key, talk, and get work done.
 
 [![Release](https://img.shields.io/github/v/release/znat/parrotflow?color=0c8c7c&label=release)](https://github.com/znat/parrotflow/releases)
 ![macOS 14+](https://img.shields.io/badge/macOS-14%2B%20·%20Apple%20silicon-1d1d1f?logo=apple&logoColor=white)
-![License MIT](https://img.shields.io/badge/license-MIT-0c8c7c)
+![License Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-0c8c7c)
 ![No cloud](https://img.shields.io/badge/audio-never%20leaves%20your%20Mac-39cdb6)
 
 **[Install](#install) · [Documentation](docs/README.md) · [Pipelines](docs/pipelines.md) · [Writing a transform](docs/authoring.md)**
@@ -18,147 +17,85 @@ browser, chat. Nothing you say leaves your Mac.
 
 ---
 
-An **open source, programmable** alternative to Wispr Flow, for developers and
-anyone else who would rather configure a tool than be configured by it.
+A fully featured open source alternative to Wispr Flow:
 
-Speech recognition runs on the Neural Engine. Everything the app then does to
-your words — fixing the names it mishears, turning spoken numbers into digits,
-writing `user.name` when you say "user dot name" — is a line in a config file
-you own, in an order you choose, and you can add your own in a substitution
-table, a prompt, or a script in any language. There is no account, no API key
-and no server, which is the whole point: most of what a developer dictates is a
-bug report, a customer name, or a half-finished idea about their own product.
 
-Two things use the network, and neither carries your audio or your text: the
-speech model downloads once on first use, and once a day the app asks GitHub
-whether a newer version exists. `updates.after_days: -1` stops the second one.
+- **Dictate anywhere** — hold a key, talk, and the text lands at your cursor:
+  editor, terminal, browser, chat.
+- **Small, efficient local models** — Parakeet TDT v3 runs on the Neural Engine,
+  and anything needing judgement asks a Gemma 4B model through Ollama. Both fit in
+  RAM you already have.
+- **Really Fast** — a normal sentence is text about a second after you let go of the
+  key. Follow ups are conditional or activated with voice commands, so you pay for it where you want it.
+- **Your vocabulary, taught out loud** — say "hey parrot, elastic search is one
+  word and takes a capital E" and it is right from then on, with a fuzzy pass for the spellings you
+  never taught it.
+- **Spoken numbers, paths and identifiers** — "two hundred forty-three" → `243`,
+  "user point name" → `user.name`, "a function called max retries" →
+  `max_retries`.
+- **Spoken commands** — select some text and say "hey parrot, use Slack handles"
+  or "hey parrot, format the function names for TypeScript". A transform that
+  describes the job runs; otherwise the model does what was asked, and you see
+  the result before it replaces anything.
+- **A programmable pipeline** — every stage of your own pipeline is a `transform`. A `transform` can be a regex, a prompt, or a script in any language running on your Mac. No limits.
+- **A prompt tuner** — so a 4B model on your Mac get a chance to approximate frontier accuracy
+  on a narrow text transform. Need a new prompt? Ask Claude to tune it with ParrotFlow's prompt tuner.
+
+No account, no API key, no server. It uses local models and your audio or text
+never leaves your Mac.
 
 ## Install
 
 **Requires** an Apple Silicon Mac on macOS 14 or later.
 
-### Let Claude Code do it
-
 Paste this into Claude Code, or any agent that can run shell commands:
 
-```
+```text
 Set up ParrotFlow on my Mac by following
 https://raw.githubusercontent.com/znat/parrotflow/main/docs/setup.md
 ```
 
-It installs the app, walks you through the two macOS permissions, checks your
-Ollama version, sizes the model settings to your RAM, and confirms transcription
-works before it hands over. About five minutes of attention. The instructions it
-follows are [docs/setup.md](docs/setup.md) — worth reading first if you would
-rather know what is about to run.
+It installs the app, walks you through the two macOS permissions, and confirms
+transcription works. About five minutes.
 
-### Or by hand
+By hand, the app itself is one command — the rest is in
+[docs/setup.md](docs/setup.md):
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/znat/parrotflow/main/scripts/install.sh | sh
 ```
 
-Downloads the latest release, checks it against its published SHA-256, and puts
-`ParrotFlow.app` in `/Applications`. Then:
+## Why ParrotFlow
 
-1. Say yes to the microphone prompt.
-2. Grant **Accessibility** in System Settings — that is what lets it type into
-   other apps. `transcription.insert_mode: clipboard` needs no permission at
-   all, and you press ⌘V yourself.
-3. Hold **right ⌥**, say something, let go.
-
-The first dictation downloads the speech model (about 1.2 GB) and takes a
-couple of minutes. Everything after that is immediate.
-
-Spoken corrections and `prompt:` transforms need [Ollama](https://ollama.com)
-0.22 or later with `ollama pull gemma4:e4b`. Optional — dictation works without
-it.
-
-Building from source: [docs/development.md](docs/development.md).
-
-## Why this one
-
-### It is fast
-
-A normal sentence is text about a second after you let go of the key, and the
-rewrites that fix your vocabulary cost nothing measurable on top. Only a stage
-that asks the local model costs real time, which is why any stage can be made
-conditional — see [where the time goes](docs/architecture.md#where-the-time-goes).
-
-### It gets your vocabulary right
-
-Speech models mishear exactly the words you use most: library names, CLI tools,
-your teammates' names. Teach it one and it is right from then on — select the
-word, hold the hotkey, and say:
-
-```
-"hey parrot, Tasmin spells T A S M E E N"
-"hey parrot, Elastic search is one word"
-"hey parrot, Mathieu ne prend qu'un seul t"
-```
-
-The rule is written to your `config.yaml`, and a fuzzy pass catches renderings
-you never taught it, so "super bays" still reaches Supabase.
-
-Nothing here is tuned by eye. Every rewrite the app ships has a scored case set
-in `tests/` — 62 spelling corrections, 97 number cases, 56 dotted paths, 75
-spoken identifiers — and the cases it *cannot* do are kept in the sets, failing,
-rather than dropped to make a number look better.
-
-### It is programmable, which is the actual difference
-
-A transcript runs through a pipeline you define. Stages can be conditional on
-the text, on the language, or on the app you dictated into:
+Other dictation tools let you configure what someone else decided to expose.
+Here your transcript runs through stages you wrote, in the order you chose:
 
 ```yaml
 pipelines:
   default:
     - replacements                      # the names you taught it
-    - fuzzy                             # and the ways they come out wrong
     - numbers                           # "two hundred forty-three" -> 243
     - transform: dotted                 # "user point name" -> user.name
       app: /term|ghostty|code|cursor/   #   but only where you write code
-    - transform: prose                  # a local model tidies the sentence
-      when: /\b(genre|du coup|basically)\b/   #   only when it needs it
 ```
 
-A transform is a substitution table, a prompt to the local model, **or a
-program of yours** — transcript on stdin, rewrite on stdout, in whatever
-language you like. That contract is why the app stops needing new features:
+It is a text file, not a settings pane. `~/.config/parrotflow/config.yaml`,
+reloaded on save, commentable, diffable, committable. Apache 2.0, no paid tier,
+no telemetry.
 
-```yaml
-transforms:
-  - name: code_identifiers
-    description: spoken names as identifiers
-    command: code_identifiers.py    # ships as an example; it is yours to edit
-```
-
-"a python function called max retries" comes out as
-`…called max_retries`, in the convention of the language you named. If a
-transform fails, times out, or the model is not running, your sentence comes
-through exactly as you said it — a dictation tool can afford to skip a stage
-and cannot afford to lose a sentence.
-
-Full reference: [docs/pipelines.md](docs/pipelines.md). Writing your own, with
-the measurement loop: [docs/authoring.md](docs/authoring.md).
-
-### It is a text file, not a settings pane
-
-`~/.config/parrotflow/config.yaml`, reloaded on save, commentable, diffable,
-committable. `--check-config` tells you what the app would actually run before
-you trust it. MIT, no paid tier, no telemetry.
+Pipelines: [docs/pipelines.md](docs/pipelines.md) · Writing a transform:
+[docs/authoring.md](docs/authoring.md) · Where the time goes:
+[docs/architecture.md](docs/architecture.md#where-the-time-goes)
 
 ## Documentation
 
-**[docs/README.md](docs/README.md)** — configuration, pipelines, writing a
-transform, the command line, permissions, architecture, and why it is built
-this way.
-
-Working on this with an agent? [AGENTS.md](AGENTS.md) is the entry point.
+**[docs/README.md](docs/README.md)** — configuration, pipelines, transforms, the
+command line, permissions, architecture. Working on this with an agent?
+[AGENTS.md](AGENTS.md).
 
 ## License
 
-MIT.
+[Apache 2.0](LICENSE).
 
 <div align="center">
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,112 @@
+<div align="center">
+
 # ParrotFlow
 
-Dictation for people who type for a living. Hold a key, talk, and the text
-lands in whatever you are in — editor, terminal, browser, chat.
+### Local dictation for people who type for a living
 
-Everything runs on your Mac. No account, no API key, and nothing you say is
-ever sent anywhere — which is the whole point: most of what a developer
-dictates is a bug report, a customer name, or a half-finished idea about their
-own product.
+Hold a key, talk, and the text lands where your cursor is — editor, terminal,
+browser, chat. Nothing you say leaves your Mac. Every rewrite it makes is a
+line in a config file you own.
 
-Two things do use the network, and neither carries your audio or your text: the
-speech model downloads once, on first use, and once a day the app asks GitHub
+[![Release](https://img.shields.io/github/v/release/znat/parrotflow?color=0c8c7c&label=release)](https://github.com/znat/parrotflow/releases)
+![macOS 14+](https://img.shields.io/badge/macOS-14%2B%20·%20Apple%20silicon-1d1d1f?logo=apple&logoColor=white)
+![License MIT](https://img.shields.io/badge/license-MIT-0c8c7c)
+![No cloud](https://img.shields.io/badge/audio-never%20leaves%20your%20Mac-39cdb6)
+
+**[Install](#install) · [Docs](docs/README.md) · [Pipelines](docs/pipelines.md) · [Writing a transform](docs/authoring.md)**
+
+</div>
+
+---
+
+An open-source alternative to Wispr Flow, for developers and anyone else who
+would rather configure a tool than be configured by it. Speech recognition runs
+on the Neural Engine; the optional model behind spoken commands runs on your own
+Ollama. There is no account, no API key, and no server — which is the whole
+point, because most of what a developer dictates is a bug report, a customer
+name, or a half-finished idea about their own product.
+
+Two things use the network, and neither carries your audio or your text: the
+speech model downloads once on first use, and once a day the app asks GitHub
 whether a newer version exists. `updates.after_days: -1` stops the second one.
 
-It also learns the words you actually use. Say a library name once, tell it
-how the name is spelled, and it gets it right from then on.
+## Why this one
 
-**Requires** an Apple Silicon Mac on macOS 14 or later.
+### It is fast enough to dictate in
+
+| | |
+|---|---|
+| Key down → recording | ~60–70 ms, the engine is warmed at launch |
+| Transcript, normal sentence | about a second after you let go |
+| Substitutions, numbers, dotted paths | 0.035 s for the whole set |
+| A stage that asks the local model | ~1.5 s warm — which is why stages carry conditions |
+
+### It gets your vocabulary right
+
+Speech models mishear exactly the words you use most: library names, CLI tools,
+your teammates' names. Teach it one and it is right from then on — select the
+word, hold the hotkey, and say:
+
+```
+"hey parrot, Tasmin spells T A S M E E N"
+"hey parrot, Elastic search is one word"
+"hey parrot, Mathieu ne prend qu'un seul t"
+```
+
+The rule is written to your `config.yaml`, and a fuzzy pass catches renderings
+you never taught it, so "super bays" still reaches Supabase.
+
+Nothing here is tuned by eye. Every rewrite the app ships has a scored case set
+in `tests/` — 62 spelling corrections, 97 number cases, 56 dotted paths, 75
+spoken identifiers — and the cases it *cannot* do are kept in the sets, failing,
+rather than dropped to make a number look better.
+
+### It is programmable, which is the actual difference
+
+A transcript runs through a pipeline you define. Stages can be conditional on
+the text, on the language, or on the app you dictated into:
+
+```yaml
+pipelines:
+  default:
+    - replacements                      # the names you taught it
+    - fuzzy                             # and the ways they come out wrong
+    - numbers                           # "two hundred forty-three" -> 243
+    - transform: dotted                 # "user point name" -> user.name
+      app: /term|ghostty|code|cursor/   #   but only where you write code
+    - transform: prose                  # a local model tidies the sentence
+      when: /\b(genre|du coup|basically)\b/   #   only when it needs it
+```
+
+A transform is a substitution table, a prompt to the local model, **or a
+program of yours** — transcript on stdin, rewrite on stdout, in whatever
+language you like. That contract is why the app stops needing new features:
+
+```yaml
+transforms:
+  - name: code_identifiers
+    description: spoken names as identifiers
+    command: code_identifiers.py    # ships as an example; it is yours to edit
+```
+
+"a python function called max retries" comes out as
+`…called max_retries`, in the convention of the language you named. If a
+transform fails, times out, or the model is not running, your sentence comes
+through exactly as you said it — a dictation tool can afford to skip a stage
+and cannot afford to lose a sentence.
+
+Full reference: [docs/pipelines.md](docs/pipelines.md). Writing your own, with
+the measurement loop: [docs/authoring.md](docs/authoring.md).
+
+### It is a text file, not a settings pane
+
+`~/.config/parrotflow/config.yaml`, reloaded on save, commentable, diffable,
+committable. `--check-config` tells you what the app would actually run before
+you trust it. MIT, no paid tier, no telemetry.
 
 ## Install
+
+**Requires** an Apple Silicon Mac on macOS 14 or later.
 
 ### Let Claude Code do it
 
@@ -51,8 +140,9 @@ Downloads the latest release, checks it against its published SHA-256, and puts
 The first dictation downloads the speech model (about 1.2 GB) and takes a
 couple of minutes. Everything after that is immediate.
 
-Spoken corrections need [Ollama](https://ollama.com) 0.22 or later with
-`ollama pull gemma4:e4b`. Optional — dictation works without it.
+Spoken corrections and `prompt:` transforms need [Ollama](https://ollama.com)
+0.22 or later with `ollama pull gemma4:e4b`. Optional — dictation works without
+it.
 
 ### Or from source
 
@@ -64,410 +154,37 @@ make install
 ```
 
 Needs the Xcode command line tools. No Xcode project, no Apple developer
-account. Note that this installs **ParrotFlow Dev**, a separate app from the
-released one — see [Working on it](#working-on-it).
+account. This installs **ParrotFlow Dev**, a separate app from the released one
+— see [docs/development.md](docs/development.md).
 
-## Using it
+## The first minute
 
-Hold **right ⌥**, talk, let go. A second or so later the text is typed where
-your cursor is.
+Hold **right ⌥**, talk, let go. The text is typed where your cursor is.
 
 Set `transcription.insert_mode: clipboard` to have it copied instead of typed —
 that mode needs no Accessibility permission, but you press ⌘V yourself.
 
-**With no cursor in a field, nothing is typed.** A Finder window, a video, a
-page you are reading — they are frontmost and they have nowhere to put a
-sentence, and a ⌘V sent there does whatever that window makes of it. So the
-pill leaves the app icon out while you talk, which is the warning, and when the
-transcript arrives it goes to your clipboard with a notice saying where it went.
-Terminals are the exception: what they show macOS is a screen rather than a
-field, so they are recognised by name and always counted as somewhere to write.
-
-Audio is kept in `~/Recordings/ParrotFlow` and every transcript is logged to
-`~/Library/Logs/ParrotFlow.log`.
-
-The menu bar item shows the current state and offers *Correct a Word…*, *Open
-Recordings Folder*, *Settings…* — which opens `config.yaml` — and *Permissions…*.
-
-## Teaching it a word
-
-When a name comes out wrong, select it in whatever app you're in, hold the
-hotkey and say **"hey parrot"**. A panel opens showing what it heard and a
-field for what it should have written.
-
-    HEARD AS         SHOULD BE
-    Tasmin      →   [Tasmeen            ]  ×
-    and         →   [                   ]  ×
-    Mick        →   [Mik                ]  ×
-    return Save   esc Cancel              2 rules
-
-You get a row per word, because rules are per-word — a phrase you selected
-once will never recur verbatim. Leave a row blank and it is skipped, so
-selecting a whole sentence to fix two names costs nothing. × drops a row you
-do not want to think about.
-
-Saving writes each filled-in rule to `config.yaml` — comments and your other
-settings untouched — and puts the corrected phrase back where it came from,
-punctuation and spacing intact.
-
-### Saying the spelling instead
-
-You can skip the panel entirely and just say the correction:
-
-    "hey parrot, Tasmin spells T A S M E E N"
-    "hey parrot, Mick is spelled M I K"
-    "hey parrot, it's spelled S U P A B A S E not super base"
-
-A local model works out which word was wrong; the panel opens prefilled so you
-confirm with one keystroke rather than trusting it blindly.
-
-You do not have to spell it. Describing the change works too, in either
-language:
-
-    "hey parrot, Jerome with a G at the beginning"
-    "hey parrot, Mathieu ne prend qu'un seul t"
-    "hey parrot, Elastic search is one word"
-    "hey parrot, Jean Luc avec un trait d'union"
-
-And one breath can carry two corrections, which open as two rows in the panel:
-
-    "hey parrot, Tasmin spells T A S M E E N and Mick spells M I K"
-    "hey parrot, Nathalie sans le h et Philipe avec deux p"
-
-The spelled-out letters are read from the text, not the model — a run of single
-letters can only be the target spelling, and relying on the model for that got
-the direction backwards on "X spells Y" phrasing in three of seven test cases.
-Described changes are applied by code for the same reason: asked to write
-"Phillip with one l", the models answered "Phill" and "Philp". The model's only
-job is finding which words in your transcript you meant.
-
-The word being corrected is found in your **previous transcript**, not in the
-command. The command is dictated too, so the name gets misheard a second time:
-saying "Tasmine spells T A S M E E N" can come through as "Das mean spells…",
-and a rule for "Das mean" matches nothing you will ever say. Since the target
-spelling is already known from the letters, the closest match to it in the last
-transcript is the word that needs fixing.
-
-Needs Ollama running with the model in `llm.model` (`ollama pull gemma4:e4b`).
-
-ParrotFlow loads that model at launch and asks Ollama to keep it there. Ollama
-otherwise drops it after five minutes idle, and reloading is most of what you
-wait for: measured 6.7s cold against 1.5s warm, so in practice almost every
-correction paid for a reload. The cost is the model sitting in memory for as
-long as the app runs — 9.6 GB for `gemma4:e4b`. Set `llm.keep_loaded: false` to
-have the RAM back and the wait with it. On a 16 GB Mac that is the right
-setting; on 32 GB it is not.
-
-`tests/spelling-cases.yaml` holds 62 cases — French, Indian, Chinese, Turkish,
-Vietnamese, Korean, Nigerian, Polish, Irish, Arabic names, plus product names
-recognition splits, described changes, two-in-a-breath corrections, and
-negative cases; `tests/french-cases.yaml` holds 45 more where the dictated
-sentence is French. Score a model or a prompt against them with
-`scripts/validate-prompt.py gemma4:e4b`. Without a model, `"hey parrot"`
-and `"hey parrot, fix vocabulary"` still open the panel — those are matched
-without one.
-
-*Correct a Word…* in the menu does the same without speaking,
-`--learn <heard> <corrected>` adds a rule from the terminal, and
-`--command "<what you'd say>"` shows how a phrase would be routed.
-
-Needs the Accessibility permission — reading your selection is exactly what
-that permission governs. Change the trigger with `transcription.activation_phrase`.
-
-**In a terminal**, selections are fragile: they get dropped on a keystroke or
-when focus moves, often before the transcript comes back. ParrotFlow snapshots
-the selection the moment the hotkey goes down, which covers most of it, and
-falls back to your clipboard when there is nothing to read. So if a terminal
-selection does not come through, copy it first — select, ⌘C, then say the
-phrase. The panel always opens either way, with a row you can type into.
-
-## Configuration
-
-`~/.config/parrotflow/config.yaml`, created on first launch. Save the file and
-the app picks it up immediately — no restart.
-
-```yaml
-hotkey:
-  key: right_option     # a bare modifier, or a character key + modifiers
-  modifiers: []         # required for a character key, ignored for a modifier
-  mode: push_to_talk    # or toggle
-  release_tail_seconds: 0.3   # keep recording this long after you let go
-
-audio:
-  output_dir: ~/Recordings/ParrotFlow
-  speech_gate: true     # skip clips with no speech in them
-
-transcription:
-  insert_mode: paste    # or clipboard
-  activation_phrase: hey parrot
-  languages: [en]       # en and fr are the supported values
-
-feedback:
-  sound: true
-  overlay: true
-```
-
-**Bare modifiers**, used alone: `right_option`, `left_option`,
-`right_command`, `left_command`, `right_control`, `left_control`,
-`right_shift`, `left_shift`, `fn`. `modifiers` is ignored for these.
-
-**Character keys:** `a`–`z`, `0`–`9`, `f1`–`f20`, `space`, `return`, `tab`,
-`escape`, `delete`, arrows, `home`, `end`, `pageup`, `pagedown`, and
-punctuation (`comma`, `period`, `slash`, `semicolon`, `quote`, `backslash`,
-`leftbracket`, `rightbracket`, `minus`, `equal`, `grave`). These need at least
-one modifier from `command`, `control`, `option`, `shift` (aliases `cmd`,
-`ctrl`, `alt`, `opt`) — macOS won't hand out a bare character key system-wide.
-
-If a combo is already owned by another app, registration fails and the menu bar
-item says so. Pick another one.
-
-**`release_tail_seconds`** keeps the mic open after you let go, because the hand
-is faster than the mouth and the last syllable lands after the key is up.
-Push-to-talk only. Raise it if endings still get clipped, `0` to stop the moment
-you release.
-
-**`languages`** is not passed to the speech model — Parakeet transcribes
-multilingually by itself and reports no language back. The list is what
-ParrotFlow uses to work out which language a transcript was in, so naming only
-what you actually speak makes that more accurate, and it selects the correction
-prompt written for that language. One entry means no detection runs at all.
-
-### Bare modifiers want push-to-talk
-
-On `toggle`, right ⌥ would start recording every time you used it to type an
-accented character. Hold-to-talk is the mode that makes sense for these; it's
-also why apps in this category gravitate to `fn` or a right-hand modifier.
-
-## Checking things from the terminal
-
-The binary inside the bundle takes a few diagnostic flags — useful when a
-hotkey isn't firing and you want to know whether the config is the reason, or
-when you want to prove the microphone is reaching the app.
-
-```sh
-PF=/Applications/ParrotFlow.app/Contents/MacOS/ParrotFlow
-
-$PF --check-config       # validate the YAML, print what the app would use
-$PF --record 3           # record 3s and verify the file it produced
-$PF --watch-modifiers    # print which modifier keys are physically down, live
-$PF --transcribe a.wav   # transcribe a clip
-$PF --panels preview 20  # put one floating surface on screen and leave it there
-$PF --panel-sheet s.png  # draw every surface into one PNG, light beside dark
-```
-
-```
-$ $PF --check-config
-config: /Users/you/.config/parrotflow/config.yaml
-  ✓ hotkey            Right ⌥  (push-to-talk, polled)
-  ✓ sample rate       16000 Hz mono
-  ✓ output dir        /Users/you/Recordings/ParrotFlow
-  ✓ min duration      0.3s
-  · feedback          sound=true overlay=true
-  ✓ microphone        Granted
-  ✓ input device      MacBook Pro Microphone
-```
-
-`--record` checks the result, not just that it ran: sample rate, channel count,
-bit depth, peak level, and whether the file is the right size for its duration.
-A silent clip or a short file gets a non-zero exit.
-
-`--watch-modifiers` is the one to reach for if a bare-modifier hotkey seems
-dead — it shows whether the key is reaching the app at all, and whether left
-and right are distinguishable on your keyboard.
-
-`--panels` takes `pill`, `notice`, `caution`, `failure`, `thinking`,
-`vocabulary`, `rule` or `preview`, and shows that one surface for as long as
-you ask. It is how the floating surfaces get looked at without dictating
-anything; `--panel-sheet` draws all of them at once, which is where drift
-between them shows up.
-
-You can make a test clip without a microphone at all — `say` writes exactly the
-format the model wants:
-
-```sh
-say -o /tmp/t.wav --data-format=LEI16@16000 --channels=1 "testing one two three"
-$PF --transcribe /tmp/t.wav
-```
-
-**Accessibility is the one thing these flags cannot tell you.** macOS credits a
-permission check made from a terminal to the terminal, not to ParrotFlow, so
-`--check-config` reports it as missing even when it is granted. The app tests it
-properly at launch and writes the answer down:
-
-```sh
-grep "launched —" ~/Library/Logs/ParrotFlow.log | tail -1
-```
-
-The log (`make logs` tails it) records the hotkey, both permission states and
-every clip written, which is the fastest way to tell "the hotkey never fired"
-from "the recording was thrown away for being too short".
-
-## Permissions
-
-**Microphone** — required. Requested on first launch.
-
-**Accessibility** — required for `insert_mode: paste` (the default) and for
-spoken corrections, because reading your selection is exactly what that
-permission governs. `insert_mode: clipboard` works without it.
-
-### Why permissions don't survive a rebuild
-
-TCC — the subsystem behind these grants — identifies an app by its **code
-signature**, not its path. With an ad-hoc signature the designated requirement
-pins the binary's `cdhash`, which changes on every single build.
-
-So the grant you gave to yesterday's build does not apply to today's. Worse,
-the entry stays in System Settings pointing at a binary that no longer exists,
-so it *looks* granted. Un-ticking and re-ticking that entry doesn't help —
-it reuses the same dead record. Accessibility enforces this strictly;
-Microphone is more forgiving but still breaks when the bundle is replaced.
-
-The symptom is unmistakable: System Settings shows the app ticked, and the app
-insists the permission isn't granted.
-
-**The fix, once:**
-
-```sh
-make dev-certificate                 # asks for your password
-make install                         # picks the identity up automatically
-```
-
-That creates a self-signed code-signing certificate. The designated requirement
-then keys on the certificate rather than the binary hash, so grants survive
-every rebuild. Grant permissions *after* that install, not before.
-
-Released builds are signed with a stable certificate for the same reason, so
-upgrading does not cost you your permissions.
-
-Since the dev build is a separate application, this only ever costs you the dev
-app's grants. The copy you rely on is untouched by anything you rebuild.
-
-If a grant is already stuck, `make reset-permissions` deletes the record
-properly — un-ticking the box in System Settings does not, it leaves the dead
-entry in place, which is why re-ticking it never helps.
-
-## How it works
-
-| Piece | Where | Note |
-| --- | --- | --- |
-| Global hotkey | `HotKeyManager.swift` | Carbon `RegisterEventHotKey` — no Accessibility permission needed, and it swallows the keystroke so it doesn't leak into the app you're typing in |
-| Bare modifiers | `ModifierKey.swift` | `RegisterEventHotKey` can't express these, so they poll `CGEventSource.flagsState` for the device-dependent left/right bits — also permission-free |
-| Audio capture | `Recorder.swift` | `AVAudioEngine` tap → `AVAudioConverter` → 16 kHz mono WAV |
-| Transcription | `Transcriber.swift` | Parakeet TDT v3 via [FluidAudio](https://github.com/FluidInference/FluidAudio), CoreML on the Neural Engine |
-| Spoken commands | `LocalLLM.swift` | HTTP to a local Ollama; degrades to "unavailable" when it isn't there |
-| Config | `Config.swift` | Yams + a `DispatchSource` file watcher for live reload |
-| Permissions | `Permissions.swift` | `AVCaptureDevice` for mic, `AXIsProcessTrusted` for Accessibility |
-| Menu bar & wiring | `AppDelegate.swift` | |
-| Logging | `Log.swift` | `~/Library/Logs/ParrotFlow.log` — a menu bar app has no console |
-| Recording pill | `RecordingOverlay.swift` | Borderless non-activating `NSPanel` |
-| Where the words go | `Destination.swift` | Asks the focused element whether it takes text, at the press — decides the pill's icon and whether the transcript is typed or copied |
-
-Two wrinkles worth knowing about push-to-talk:
-
-Carbon only reports the release of the *character* key. Let go of ⌃ before
-Space and no release event ever arrives, so `AppDelegate` also polls
-`NSEvent.modifierFlags` while recording as a backstop.
-
-Bare modifiers are polled rather than tapped. An event tap could swallow the
-keystroke, but it costs the Accessibility permission and a keystroke-monitoring
-prompt — a steep price when a bare modifier types nothing on its own, so there
-is nothing to swallow. Polling `CGEventSource.flagsState` every 25 ms needs no
-permission at all. The trade is ~25 ms of latency and no way to stop the key
-also reaching the frontmost app.
-
-### Start-up latency
-
-`AVAudioEngine` needs a moment to open the input stream, so the first fraction
-of a second after the hotkey isn't captured. Warming the engine up at launch
-brings that down to roughly 60–70 ms, which a natural pause after pressing the
-key covers.
-
-Getting to zero means keeping the mic open continuously and buffering into a
-ring — which also means the orange recording indicator is lit the entire time
-the app runs. Not the right default for a tool whose pitch is that it doesn't
-listen to you. Worth revisiting as an opt-in setting if the clipping ever
-actually bites.
-
-## Working on it
-
-The build you are changing and the build you use to get work done are **two
-separate applications**. Both can be installed, and both can run at once.
-
-|  | Released | Dev |
-| --- | --- | --- |
-| App | `ParrotFlow.app` | `ParrotFlowDev.app` |
-| Bundle id | `com.parrotflow.app` | `com.parrotflow.app.dev` |
-| Hotkey | right ⌥ | right ⌘ |
-| Config | `~/.config/parrotflow/` | `~/.config/parrotflow-dev/` |
-| Log | `ParrotFlow.log` | `ParrotFlow-Dev.log` |
-| Recordings | `~/Recordings/ParrotFlow` | `~/Recordings/ParrotFlow Dev` |
-| Menu bar | `mic` | `mic.circle` |
-
-This is not tidiness. macOS grants microphone and Accessibility **per bundle
-identifier**, so one identifier for both means every rebuild is revoking and
-re-granting permissions on the app you actually rely on — and a half-finished
-config change can break it. Separate identifiers make that impossible.
-
-Different hotkeys are what let both run at once: same key and both would record
-the same sentence and both paste it. You choose which build hears you by which
-key you hold.
-
-Everything in the Makefile works on the dev build by default:
-
-```sh
-make run                  # build and launch ParrotFlow Dev
-make logs                 # tail the dev log
-make which                # print what this variant resolves to
-make stop                 # quit dev; the installed app keeps running
-
-VARIANT=release make logs  # act on the shipped app instead
-```
-
-`scripts/variant.sh` is the one place the two identities are defined, and
-`AppVariant.swift` is where the app derives its own paths from the identifier it
-was built with.
-
-## Releasing
-
-Nobody picks a version number. release-please reads the commit subjects since
-the last tag and works it out: a `feat:` bumps the minor, a `fix:` or `perf:`
-the patch, and anything else releases nothing at all. It keeps a release PR open
-with that version and the changelog it derived, and **merging that PR is the
-release** — it tags, builds on a macOS runner, signs, and attaches the archive
-that `install.sh` downloads.
-
-So the subject line is not housekeeping. A commit written without a type is
-invisible to all of this: no bump, no changelog entry, and no warning that it
-was skipped. `make hooks` points git at `.githooks/commit-msg`, which refuses
-one before it lands. Run it once per clone — hooks are not cloned.
-
-```
-feat:  a capability that was not there before   -> minor
-fix:   behaviour that was wrong is now right    -> patch
-perf:  same behaviour, measurably faster        -> patch
-docs: refactor: test: build: ci: chore:         -> no release
-```
-
-The body of the message is unaffected. It is still the place to say what broke
-and how you know it is fixed.
-
-```sh
-make hooks                       # once per clone
-scripts/release-certificate.sh   # once, ever — see the warning in the file
-scripts/release.sh               # build the artefacts locally to inspect them
-```
-
-Re-running the workflow by hand (Actions → release → Run workflow) recomputes
-the release PR. It cannot force a release: with no releasable commits since the
-last tag there is nothing to open a PR for.
-
-## Design notes
-
-- [docs/setup.md](docs/setup.md) — the guided install an agent follows
-- [docs/transcription.md](docs/transcription.md) — picking a Parakeet runtime,
-  why the model can't be prompted, and what to do instead
-- [docs/distribution.md](docs/distribution.md) — why this ships by curl rather
-  than Homebrew, and what notarization would change
+The menu bar item offers *Correct a Word…*, *Open Recordings Folder*,
+*Settings…* — which opens `config.yaml` — and *Permissions…*. Transcripts are
+logged to `~/Library/Logs/ParrotFlow.log`.
+
+## Documentation
+
+| | |
+|---|---|
+| [setup.md](docs/setup.md) | The guided install, written to be handed to an agent |
+| [configuration.md](docs/configuration.md) | Every setting, and what happens when it is wrong |
+| [corrections.md](docs/corrections.md) | Teaching it a name, by voice or by panel |
+| [pipelines.md](docs/pipelines.md) | Stages, transforms, conditions, per-app and per-language |
+| [authoring.md](docs/authoring.md) | Writing a prompt, a table or a script — and proving it works |
+| [cli.md](docs/cli.md) | Every flag; how to test a change without a microphone |
+| [permissions.md](docs/permissions.md) | What needs Accessibility, and what does not |
+| [architecture.md](docs/architecture.md) | What each file does, and where the time goes |
+| [development.md](docs/development.md) | Building, the dev variant, cutting a release |
+| [transcription.md](docs/transcription.md) | Why Parakeet, and why it cannot be prompted |
+| [distribution.md](docs/distribution.md) | Signing, updates, and why this ships by curl |
+
+Working on this with an agent? [AGENTS.md](AGENTS.md) is the entry point.
 
 ## Roadmap
 
@@ -481,4 +198,11 @@ last tag there is nothing to open a PR for.
 
 ## License
 
-MIT
+MIT.
+
+<div align="center">
+
+macOS dictation · offline speech to text · local voice typing · open source
+Wispr Flow alternative · privacy-first transcription · Parakeet · Ollama
+
+</div>

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,7 +1,7 @@
 transcription:
   # paste     -> typed into the app you're in (needs Accessibility)
   # clipboard -> copied, you press Cmd-V
-  insert_mode: clipboard
+  insert_mode: paste
 
   # Say one of these instead of dictating and what follows is an
   # instruction: "hey parrot, make that a bullet list". An empty list

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,59 @@
+# ParrotFlow documentation
+
+Start from the question you have.
+
+## Getting it running
+
+| | |
+|---|---|
+| [setup.md](setup.md) | The guided install, written to be handed to an agent. Permissions, Ollama, model sizing, and a check that transcription works before it hands over. |
+| [permissions.md](permissions.md) | Microphone and Accessibility: what needs which, and why a rebuilt app loses its grants. |
+| [configuration.md](configuration.md) | Every setting in `config.yaml`, what it does, and what happens when it is wrong. |
+
+## Using it
+
+| | |
+|---|---|
+| [corrections.md](corrections.md) | Teaching it a name — by panel, by spelling it out, or by describing the change. |
+| [pipelines.md](pipelines.md) | The reference for what a transcript goes through: stages, transforms, conditions, per-app and per-language gating. |
+| [cli.md](cli.md) | Every terminal flag. How to test a config change without speaking into a microphone. |
+
+## Changing it
+
+| | |
+|---|---|
+| [authoring.md](authoring.md) | **Start here to write a prompt, a table or a script.** The procedure, with the measurement loop that says whether you improved it. |
+| [development.md](development.md) | Dev and released builds are separate apps. Building, the Makefile, and how a release is cut. |
+| [architecture.md](architecture.md) | What each file is for, where the time goes, and what the app deliberately does not do. |
+
+## Why it is built this way
+
+| | |
+|---|---|
+| [transcription.md](transcription.md) | Why Parakeet and not Whisper, why it cannot be prompted, and what covers that instead. |
+| [distribution.md](distribution.md) | Why this ships by curl rather than Homebrew, what notarization would change, and how updates work. |
+
+---
+
+## If you are an agent
+
+Configuring this for someone, or changing a rewrite on their behalf:
+
+1. **Read [authoring.md](authoring.md) first** if the task is a prompt, a
+   pipeline, a substitution or a script. It contains the decision that the rest
+   of the work hangs on — whether the job wants a model at all — and the loop
+   that proves the change was an improvement.
+2. **Validate with the binary, not by reading.** `--check-config` reports what
+   the app would actually use; `--pipeline <file.yaml> "<text>" --app <name>`
+   runs a stage against a sentence without a microphone. Both in
+   [cli.md](cli.md).
+3. **Never change a prompt or a pattern without scoring it.** Every rewrite has
+   a case set in `tests/` and a runner in `scripts/`. Record the number before
+   and after; a change that cannot be measured has not been shown to help.
+4. **Fail open.** A stage that errors must leave the transcript exactly as it
+   arrived. Check it by killing Ollama and running the pipeline again.
+5. **Say what a `command:` transform runs.** Config that executes code is worth
+   naming out loud to the person whose machine it will run on.
+
+Installing rather than configuring: [setup.md](setup.md) is written for you,
+step by step, and expects to be followed in order.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,83 @@
+# How it works
+
+| Piece | Where | Note |
+| --- | --- | --- |
+| Global hotkey | `HotKeyManager.swift` | Carbon `RegisterEventHotKey` — no Accessibility permission needed, and it swallows the keystroke so it doesn't leak into the app you're typing in |
+| Bare modifiers | `ModifierKey.swift` | `RegisterEventHotKey` can't express these, so they poll `CGEventSource.flagsState` for the device-dependent left/right bits — also permission-free |
+| Audio capture | `Recorder.swift` | `AVAudioEngine` tap → `AVAudioConverter` → 16 kHz mono WAV |
+| Transcription | `Transcriber.swift` | Parakeet TDT v3 via [FluidAudio](https://github.com/FluidInference/FluidAudio), CoreML on the Neural Engine |
+| The pipeline | `Pipeline.swift` | Stages, conditions, app gating — [pipelines.md](pipelines.md) |
+| Replacements | `Replacements.swift` | Literal, regex and fuzzy substitution |
+| Numbers | `NumberGrammar*.swift` | Spoken numbers as digits, English and French, no model |
+| Transforms | `PromptRunner.swift`, `CommandRunner.swift` | A prompt to the local model, or a program of yours on stdin/stdout |
+| Routing | `Router.swift`, `FreeForm.swift` | Which transform an instruction reaches, and what happens when none does |
+| Spoken commands | `LocalLLM.swift` | HTTP to a local Ollama; degrades to "unavailable" when it isn't there |
+| Config | `Config.swift` | Yams + a `DispatchSource` file watcher for live reload |
+| Permissions | `Permissions.swift` | `AVCaptureDevice` for mic, `AXIsProcessTrusted` for Accessibility |
+| Text insertion | `TextInserter.swift`, `SelectionReader.swift` | Paste-via-clipboard, then the pasteboard is put back |
+| Menu bar & wiring | `AppDelegate.swift` | |
+| Logging | `Log.swift` | `~/Library/Logs/ParrotFlow.log` — a menu bar app has no console |
+| Floating surfaces | `RecordingOverlay.swift`, `PreviewPanel.swift`, `NoticeHUD.swift`, `ParrotStyle.swift` | Borderless non-activating `NSPanel`s, one look between them |
+| Variants | `AppVariant.swift` | Dev and released builds are separate apps — [development.md](development.md) |
+
+## Two wrinkles about push-to-talk
+
+Carbon only reports the release of the *character* key. Let go of ⌃ before
+Space and no release event ever arrives, so `AppDelegate` also polls
+`NSEvent.modifierFlags` while recording as a backstop.
+
+Bare modifiers are polled rather than tapped. An event tap could swallow the
+keystroke, but it costs the Accessibility permission and a keystroke-monitoring
+prompt — a steep price when a bare modifier types nothing on its own, so there
+is nothing to swallow. Polling `CGEventSource.flagsState` every 25 ms needs no
+permission at all. The trade is ~25 ms of latency and no way to stop the key
+also reaching the frontmost app.
+
+## Where the time goes
+
+| Step | Cost |
+| --- | --- |
+| Hotkey down → capture running | ~60–70 ms, warmed at launch |
+| Bare-modifier polling | 25 ms, on top of the above |
+| Transcription of a normal sentence | about a second after you let go |
+| `replacements`, `fuzzy`, `numbers`, a `replace:` transform | 0.035 s measured on a line |
+| A `command:` transform | one process start — ~30 ms for `python3`, ~5 ms for a shell script |
+| A `prompt:` transform, model warm | ~1.5 s |
+| A `prompt:` transform, model cold | 6.7 s, which `llm.keep_loaded` exists to avoid |
+
+The gap between the last three rows is the reason stages carry conditions: a
+`when:` that costs nothing is what keeps a stage that costs a second off the
+transcripts that never needed it.
+
+### Start-up latency
+
+`AVAudioEngine` needs a moment to open the input stream, so the first fraction
+of a second after the hotkey isn't captured. Warming the engine up at launch
+brings that down to roughly 60–70 ms, which a natural pause after pressing the
+key covers.
+
+Getting to zero means keeping the mic open continuously and buffering into a
+ring — which also means the orange recording indicator is lit the entire time
+the app runs. Not the right default for a tool whose pitch is that it doesn't
+listen to you. Worth revisiting as an opt-in setting if the clipping ever
+actually bites.
+
+## What the app does not do
+
+**It does not stream.** A clip is finished before anything looks at it, which
+is what lets the whole pipeline run on a complete sentence and what lets a
+stage be skipped on the text as it stands at that point.
+
+**It does not learn anything on its own.** Every rule in your config got there
+because you put it there, or confirmed a panel that proposed it.
+
+**It ships no model weights and no inference engine.** Parakeet is fetched once
+by FluidAudio; the language model is Ollama's, on localhost. Every LLM feature
+degrades to "not available" rather than failing.
+
+## See also
+
+- [transcription.md](transcription.md) — why Parakeet rather than Whisper, why
+  it cannot be prompted, and what covers that instead
+- [pipelines.md](pipelines.md) — the stage model in full
+- [distribution.md](distribution.md) — signing, updates, why this ships by curl

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,7 @@
 | Config | `Config.swift` | Yams + a `DispatchSource` file watcher for live reload |
 | Permissions | `Permissions.swift` | `AVCaptureDevice` for mic, `AXIsProcessTrusted` for Accessibility |
 | Text insertion | `TextInserter.swift`, `SelectionReader.swift` | Paste-via-clipboard, then the pasteboard is put back |
+| Where the words go | `Destination.swift` | Asks the focused element whether it takes text, at the press — decides the pill's icon and whether the transcript is typed or copied |
 | Menu bar & wiring | `AppDelegate.swift` | |
 | Logging | `Log.swift` | `~/Library/Logs/ParrotFlow.log` — a menu bar app has no console |
 | Floating surfaces | `RecordingOverlay.swift`, `PreviewPanel.swift`, `NoticeHUD.swift`, `ParrotStyle.swift` | Borderless non-activating `NSPanel`s, one look between them |

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -1,0 +1,250 @@
+# Writing a transform, and proving it works
+
+How to add a rewrite to ParrotFlow — a substitution, a prompt, or a program of
+your own — and how to know you improved it rather than moved the failure.
+
+Written to be followed start to finish, by a person or by an agent. The
+reference for what the pieces mean is [pipelines.md](pipelines.md); this is the
+procedure.
+
+## The one decision that matters
+
+Before writing a prompt, decide what should be doing the job at all:
+
+| Body | Costs | Right when |
+|---|---|---|
+| `replace:` | nothing (0.035 s for a whole pipeline) | the answer is already in the text, marked by a pattern you can write |
+| `command:` | one process start (~30 ms `python3`, ~5 ms shell) | the rule is real but needs code — casing, a lookup table, anything with a branch |
+| `prompt:` | ~1.5 s warm, 6.7 s cold | only judgement will do — which words the speaker meant, what an instruction is asking for |
+
+Getting this wrong is the expensive mistake, and it is usually made in the
+direction of the model. Two measurements from this repo:
+
+- Asked to **rewrite** a sentence containing a spoken identifier, the model
+  scores 68% and fails expensively — capitalising "python", adding articles,
+  translating French names. Asked only to **extract** which words are a name,
+  and leaving the casing to a table in a script, the same model gets 8/8 on the
+  cases rules cannot see. Split the job: the model judges, code decides.
+- Told "Phillip with one l", models answered "Phill" and "Philp". The described
+  change is applied by code for that reason; the model's only job is finding
+  which word was meant.
+
+`.claude/skills/prompt-iteration/SKILL.md` is the long form of this argument,
+including how to build a validation set that can tell you which one you need.
+
+## The loop
+
+```
+1. write the cases            tests/<thing>-cases.yaml
+2. score what exists now      scripts/check-<thing>.sh        <- the baseline
+3. change one thing
+4. score again                same command, same set
+5. keep it only if the number went up and no category collapsed
+```
+
+Steps 1 and 2 are not optional overhead. Tuning by eye fixes the example in
+front of you and silently breaks one you are not looking at — which is why
+every rewrite in this repo ships with a set, and why the sets keep their
+failures in rather than dropping them to make a number look better.
+
+## Recipe: a substitution
+
+For a name that comes out wrong, nothing needs writing — say
+`"hey parrot"` and fill in the panel, or:
+
+```sh
+$PF --learn "super base" Supabase
+```
+
+For a pattern, add it to `transcription.replacements` and check it:
+
+```yaml
+replacements:
+  Supabase: [super base, superbees]
+  "": ['/\b(?:u+m+|erm+)\b/']          # empty target deletes
+  '$1 ticket': ['/\bticket number (\d+)\b/']
+```
+
+```sh
+$PF --replace "we deployed to super base and um it worked"
+scripts/check-replacements.sh
+```
+
+## Recipe: a named table, scoped to an app
+
+A table gets a name when it has to run somewhere specific, or twice with
+different output. That is the whole reason `transforms:` exists.
+
+```yaml
+transforms:
+  - name: backticks
+    description: wrap dotted paths in backticks, for chat
+    replace:
+      '`$1`': ['/\b([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)+)/']
+
+transcription:
+  pipelines:
+    default:
+      - replacements
+      - transform: backticks
+        app: /slack|discord/
+```
+
+```sh
+$PF --pipeline my-test.yaml "read config.port" --app Slack     # should wrap
+$PF --pipeline my-test.yaml "read config.port" --app Ghostty   # should not
+```
+
+Write the pipeline you are testing into its own YAML file rather than editing
+your real config: `--pipeline` takes the file, so the test states its own setup
+and does not inherit this machine's. `tests/pipelines/` holds the ones the
+check scripts use.
+
+**There is no `not_app:`.** Exclusion is a negative lookahead —
+`/^(?!.*(term|ghostty))/` — and the `^` anchor is not optional. Unanchored it
+matches one character into the name it was meant to exclude, and the stage runs
+everywhere. `--check-config` refuses it rather than letting that ship.
+
+## Recipe: a prompt
+
+```yaml
+transforms:
+  - name: hesitation
+    description: strip filler words from dictated speech
+    prompt: |
+      Remove filler words. Change nothing else.
+      Return only the text.
+```
+
+```sh
+$PF --prompt hesitation "strip the filler" "so like, we should genre ship it"
+$PF --route "hey parrot, clean up the ums"      # does the description match?
+```
+
+Two things about the `description` that are easy to miss:
+
+- **It is not a comment.** It is what the router matches spoken words against,
+  so write it the way someone would say it. `--route` is how you find out it is
+  too vague before a user does.
+- **The whole instruction reaches the prompt.** One entry therefore covers
+  "format those dates ISO" and "format those dates with slashes" — you do not
+  need an entry per phrasing.
+
+Then decide whether it belongs in a pipeline at all. A prompt reached by voice
+runs when asked. A prompt in a pipeline runs on **every** transcript that
+matches its conditions, at ~1.5 s each, and rewrites your words without you
+asking — so it wants a `when:` narrow enough to earn it:
+
+```yaml
+- transform: hesitation
+  when: /\b(genre|du coup|en fait|like|basically)\b/
+```
+
+`when:` and `unless:` read the text *as it stands at that point*, after the
+stages above — so a cheap stage can make an expensive one unnecessary rather
+than merely earlier.
+
+## Recipe: a program
+
+The transcript arrives on **stdin** and comes back on **stdout**. That is the
+whole contract.
+
+```yaml
+transforms:
+  - name: shout
+    description: everything in capitals
+    command: shout.py
+    timeout_seconds: 2
+```
+
+- A relative path is relative to **the file that named it**, and runs with that
+  directory as its working directory. A bare name that is not a file there
+  (`sed`, `tr`) is looked up on PATH, so a one-liner with arguments works.
+- The script is run directly, so its **shebang** picks the interpreter, and it
+  needs the **execute bit** — a script that is there but not `chmod +x` is the
+  likeliest thing to be wrong with a `command:` transform. Both the log and
+  `--check-config` name that case as itself rather than as "command not found".
+- Non-zero exit, no output, or over `timeout_seconds` leaves the transcript
+  exactly as it arrived, and says so in the log. A script you are halfway
+  through writing is an ordinary state to be in.
+- Two seconds is right for a script and wrong for one that asks a model. A
+  command ending in `--model something` wants `timeout_seconds: 12` beside it.
+
+`examples/code_identifiers.py` is the shipped one, and the best template: rules
+first, model behind a flag, a table of language conventions that is edited
+rather than prompted.
+
+**Remember that this makes `config.yaml` execute code.** Nothing else in that
+file does. `--check-config` names every `command:` transform out loud, every
+time — a config that runs something you have forgotten about, or that arrived
+in a config you copied from somewhere, should not be able to stay quiet.
+
+## Recipe: a language
+
+`pipelines:` takes a key per language, and a language's own list wins over
+`default:`:
+
+```yaml
+pipelines:
+  default: [replacements, fuzzy, numbers]
+  fr:      [replacements, numbers]
+```
+
+A key that is neither `default` nor one of your `languages:` is reported by
+`--check-config` rather than silently never running. Test one without changing
+your machine's setup:
+
+```sh
+$PF --pipeline my-test.yaml "on en a vingt et un" --lang fr
+```
+
+## Writing the case set
+
+Twenty to forty cases. Fewer and you cannot tell a real change from noise; more
+and you stop running it.
+
+- **Use real inputs.** These come out of speech recognition, so the test inputs
+  must be mangled the way speech recognition mangles them. A set built from
+  tidy sentences measures nothing, because tidy sentences were never the
+  problem.
+- **Include negatives — a lot of them.** Roughly one in five, and closer to
+  half for anything that runs on every transcript rather than on demand. Models
+  are strongly biased toward producing output, and a confident wrong answer
+  beats a refusal on any set without negatives. `tests/code-identifier-cases.yaml`
+  is 32 of 75 cases that must come back untouched, and that half is the one that
+  catches regressions.
+- **Keep the residue in, failing.** `tests/dotted-cases.txt` scores 54/54 and
+  carries two more it cannot do. A set that reaches 100% by dropping what it
+  cannot do is worse than a number.
+- **Write the contract at the top of the file**, in prose: what counts as a
+  case for this feature and what is deliberately out of scope. It is the thing
+  you will disagree with yourself about in a week.
+- **Group by category**, so a regression reads as "all the two-word ones broke"
+  rather than an unattributable drop of four points.
+
+The sets that exist: `spelling` (62) and `french` (45) for corrections,
+`numbers` (97), `routing` (45), `dotted` (56), `code-identifier` (75),
+`grammar` (17), `wake` (25), `split` (14), `generic`, `dates`, `inplace`,
+`pipeline`, `replacement`. Each has a runner in `scripts/`.
+
+## Before you call it done
+
+- [ ] `--check-config` is clean, and names every `command:` transform you added
+- [ ] the check script for what you touched still passes, and you know its
+      number before and after
+- [ ] any stage costing a model call has a `when:`, an `unless:` or an `app:`
+- [ ] failure leaves the transcript alone — kill the model, run it again, see
+      the sentence come through untouched
+- [ ] a new default in `config.example.yaml` is covered by
+      `scripts/check-default-config.sh`, which reads the real file rather than a
+      fixture
+
+## See also
+
+- [pipelines.md](pipelines.md) — the reference: stages, conditions, apps, the
+  ordering constraints, and what each shipped transform costs
+- [cli.md](cli.md) — every flag these recipes use
+- [configuration.md](configuration.md) — where `transforms:` and `pipelines:`
+  sit in the file
+- `.claude/skills/prompt-iteration/SKILL.md` — deciding between a prompt, a
+  regex and a script by measuring instead of by eye

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,197 @@
+# The command line
+
+Every flag the app takes, and what it answers. This is how a change to
+`config.yaml` gets tested without speaking into a microphone, which makes it
+the page to read if you are an agent configuring this for someone.
+
+```sh
+PF=/Applications/ParrotFlow.app/Contents/MacOS/ParrotFlow          # released
+PF=/Applications/ParrotFlowDev.app/Contents/MacOS/ParrotFlow       # dev build
+```
+
+Each flag runs and exits; nothing here launches the menu bar app. **Exit code 0
+means it did what it says**, so these compose into scripts — which is what
+`scripts/check-*.sh` are.
+
+## Start here
+
+| Command | Answers |
+|---|---|
+| `--check-config` | Is the config valid, and what will actually run? |
+| `--pipeline <file.yaml> "<text>"` | What does this pipeline do to this sentence? |
+| `--replace "<text>"` | What do my replacement rules do to this sentence? |
+| `--route "<what you'd say>"` | Which transform does this instruction reach? |
+
+### `--check-config`
+
+Validates the YAML and prints what the app would use — not what the file says,
+what survives it.
+
+```
+$ $PF --check-config
+config: /Users/you/.config/parrotflow/config.yaml
+  ✓ hotkey            Right ⌥  (push-to-talk, polled)
+  ✓ sample rate       16000 Hz mono
+  ✓ output dir        /Users/you/Recordings/ParrotFlow
+  ✓ min duration      0.3s
+  · feedback          sound=true overlay=true
+  ✓ microphone        Granted
+  ✓ input device      MacBook Pro Microphone
+```
+
+It also names, every time and whether or not anything is wrong:
+
+- every `command:` transform, because that is config that executes code
+- a pipeline step naming a transform that does not exist
+- a pipeline key that is neither `default` nor one of your `languages:`
+- an `app:` lookahead that is not anchored, which would run the stage
+  everywhere it was written to exclude
+- a `fuzzy` stage with no `replacements` stage before it
+
+**Accessibility is the one thing it cannot tell you.** macOS credits a
+permission check made from a terminal to the terminal, not to ParrotFlow, so
+this reports it missing even when it is granted. The app tests it properly at
+launch and writes the answer down:
+
+```sh
+grep "launched —" ~/Library/Logs/ParrotFlow.log | tail -1
+```
+
+## Testing a rewrite
+
+```sh
+$PF --pipeline tests/pipelines/apps.yaml "on en a vingt et un" --app Ghostty
+$PF --replace "we deployed to super base" [--app <name>]
+$PF --numbers "two hundred forty three" [--lang fr]
+$PF --normalize "<text>"
+$PF --dates "<instruction>" "<text>" [--locale FR] [--lang en,fr]
+```
+
+`--pipeline` takes a YAML file holding a pipeline — its own, not your config —
+so a case file states the setup it assumes instead of inheriting this machine's.
+`tests/pipelines/` holds the ones the check scripts use.
+
+- `--app <name>` is the app the stage conditions are matched against. An empty
+  `--app ""` means "nothing was in front", which is a different question from
+  not passing the flag, and is how the fail-closed rule gets tested.
+- `--no-prompts` skips the stages that would call the model, so a run stays
+  deterministic and fast.
+- `--quiet` prints only the result, for scripts.
+- `--lang en,fr` stands in for the configured `languages:`, so a case file does
+  not depend on how this Mac is set up.
+
+## Testing a spoken instruction
+
+```sh
+$PF --route "hey parrot, make that a bullet list"
+$PF --prompt <name> "<instruction>" "<text>"
+$PF --command "hey parrot, Tasmin spells T A S M E E N" "<last transcript>" \
+    [--phrases "hey parrot,by the way parrot"]
+$PF --learn <heard> <corrected>
+```
+
+`--route` shows which transform an instruction reaches and why — the router
+matches your words against each transform's `description`, so this is how you
+find out that a description is too vague before a user does.
+
+`--prompt` runs one named transform against text you supply, with the
+instruction that would have been spoken. `--command` runs the whole
+wake-phrase path: is this a command at all, is it a correction, which words in
+the previous transcript does it target.
+
+`--learn` writes a replacement rule from the terminal, the same one the
+correction panel would have written.
+
+## Proving the microphone and the model work
+
+```sh
+$PF --record 3           # record 3s and verify the file it produced
+$PF --transcribe a.wav   # transcribe a clip
+$PF --watch-modifiers    # print which modifier keys are physically down, live
+```
+
+`--record` checks the result, not just that it ran: sample rate, channel count,
+bit depth, peak level, and whether the file is the right size for its duration.
+A silent clip or a short file gets a non-zero exit.
+
+`--watch-modifiers` is the one to reach for if a bare-modifier hotkey seems
+dead — it shows whether the key is reaching the app at all, and whether left
+and right are distinguishable on your keyboard.
+
+You can make a test clip without a microphone at all — `say` writes exactly the
+format the model wants:
+
+```sh
+say -o /tmp/t.wav --data-format=LEI16@16000 --channels=1 "testing one two three"
+$PF --transcribe /tmp/t.wav
+```
+
+## Text insertion, which is the risky path
+
+```sh
+$PF --peek 3 [--find <sentinel>]
+$PF --edit-test <needle> <replacement> --find <sentinel> [--after 3] [--literal]
+```
+
+`--peek` reads the selection the way the app would. `--edit-test` performs a
+real in-place edit in the frontmost window after a delay, which is why
+`--find <sentinel>` is **required**: without it this writes into whatever
+happens to be in front, which during a test run is as likely to be a real
+window as the scratch one you meant.
+
+## Looking at the floating surfaces
+
+```sh
+$PF --panels preview 20  # put one surface on screen and leave it there
+$PF --panel-sheet s.png  # draw every surface into one PNG, light beside dark
+```
+
+`--panels` takes `pill`, `notice`, `caution`, `failure`, `thinking`,
+`vocabulary`, `rule` or `preview`. `--panel-sheet` draws all of them at once,
+which is where drift between them shows up.
+
+## Updates
+
+```sh
+$PF --update-check [--after-days N]
+$PF --update-install [--dry-run]
+```
+
+## The check scripts
+
+Every rewrite in this repo has a case set and a script that scores it. They are
+the fastest way to know whether a change to a prompt, a pattern or a stop list
+made things better or only different.
+
+```sh
+scripts/check-pipeline.sh          scripts/check-replacements.sh
+scripts/check-dotted.sh            scripts/check-numbers.sh
+scripts/check-routing.sh           scripts/check-wake.sh
+scripts/check-split.sh             scripts/check-grammar.sh
+scripts/check-dates.sh             scripts/check-inplace.sh
+scripts/check-default-config.sh    scripts/check-example-script.sh
+
+scripts/validate-prompt.py gemma4:e4b        # spelling + French correction sets
+scripts/validate-code-identifiers.py         # the identifier transform
+scripts/validate-generic.py                  # free-form instructions
+scripts/validate-gate.py                     # what should never be treated as a command
+```
+
+Several read their input out of `Config.defaultYAML` or `config.example.yaml`
+rather than a fixture, so what gets scored is what a new install actually gets.
+
+See [authoring.md](authoring.md) for the loop these belong to.
+
+## The log
+
+```sh
+make logs                                # tail the dev log
+VARIANT=release make logs                # tail the shipped app's
+tail -f ~/Library/Logs/ParrotFlow.log
+```
+
+It records the hotkey, both permission states, every clip written, every stage
+that was skipped and why, and the before-and-after of every rewrite a model
+made. A stage that silently does not run looks exactly like one that ran and
+found nothing — only one of those is answerable by editing a condition, so the
+log distinguishes them.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,6 +14,7 @@ hotkey:
   key: right_option     # a bare modifier, or a character key + modifiers
   modifiers: []         # required for a character key, ignored for a modifier
   mode: push_to_talk    # or toggle
+  release_tail_seconds: 0.3   # keep recording this long after you let go
 
 audio:
   output_dir: ~/Recordings/ParrotFlow
@@ -76,6 +77,12 @@ one modifier from `command`, `control`, `option`, `shift` (aliases `cmd`,
 If a combo is already owned by another app, registration fails and the menu bar
 item says so. Pick another one.
 
+### `release_tail_seconds`
+
+Keeps the mic open after you let go, because the hand is faster than the mouth
+and the last syllable lands after the key is up. Push-to-talk only. Raise it if
+endings still get clipped, `0` to stop the moment you release.
+
 ### Bare modifiers want push-to-talk
 
 On `toggle`, right ⌥ would start recording every time you used it to type an
@@ -87,6 +94,14 @@ also why apps in this category gravitate to `fn` or a right-hand modifier.
 `paste` types the transcript into the app you are in and needs the
 Accessibility permission. `clipboard` copies it and needs no permission at all;
 you press ⌘V. See [permissions.md](permissions.md).
+
+**With no cursor in a field, neither one types.** A Finder window, a video, a
+page you are reading — they are frontmost and they have nowhere to put a
+sentence, and a ⌘V sent there does whatever that window makes of it. So the
+pill leaves the app icon out while you talk, which is the warning, and when the
+transcript arrives it goes to your clipboard with a notice saying where it went.
+Terminals are the exception: what they show macOS is a screen rather than a
+field, so they are recognised by name and always counted as somewhere to write.
 
 ## `transcription.languages`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,22 @@ feedback:
   overlay: true
 ```
 
+## Where things live
+
+| | |
+|---|---|
+| Config | `~/.config/parrotflow/config.yaml` |
+| Recordings | `~/Recordings/ParrotFlow` |
+| Log | `~/Library/Logs/ParrotFlow.log` |
+| The example script | `~/.config/parrotflow/code_identifiers.py`, written on first launch and never overwritten |
+
+The menu bar item shows the current state and offers *Correct a Word…*, *Open
+Recordings Folder*, *Settings…* — which opens `config.yaml` in your editor —
+and *Permissions…*.
+
+The dev build keeps its own copies of all of these; see
+[development.md](development.md).
+
 ## `hotkey`
 
 **Bare modifiers**, used alone: `right_option`, `left_option`,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,170 @@
+# Configuration
+
+Every setting, what it does, and what happens when it is wrong.
+
+`~/.config/parrotflow/config.yaml`, created on first launch. Save the file and
+the app picks it up immediately — no restart. `config.example.yaml` in the repo
+is the same file with every comment kept.
+
+**Validate before you trust it:** `--check-config` prints what the app would
+actually use, and names anything it had to ignore. See [cli.md](cli.md).
+
+```yaml
+hotkey:
+  key: right_option     # a bare modifier, or a character key + modifiers
+  modifiers: []         # required for a character key, ignored for a modifier
+  mode: push_to_talk    # or toggle
+
+audio:
+  output_dir: ~/Recordings/ParrotFlow
+  speech_gate: true     # skip clips with no speech in them
+
+transcription:
+  insert_mode: paste    # or clipboard
+  activation_phrases: [hey parrot, by the way parrot]
+  languages: [en]       # en and fr are the supported values
+  rewrite_line: true
+  pipelines: …          # see pipelines.md
+  replacements: …       # see below
+  transforms: …         # see pipelines.md
+
+llm:
+  enabled: true
+  model: gemma4:e4b
+  endpoint: http://localhost:11434
+  keep_loaded: true
+
+updates:
+  after_days: 7
+
+free_form: true
+
+feedback:
+  sound: true
+  overlay: true
+```
+
+## `hotkey`
+
+**Bare modifiers**, used alone: `right_option`, `left_option`,
+`right_command`, `left_command`, `right_control`, `left_control`,
+`right_shift`, `left_shift`, `fn`. `modifiers` is ignored for these.
+
+**Character keys:** `a`–`z`, `0`–`9`, `f1`–`f20`, `space`, `return`, `tab`,
+`escape`, `delete`, arrows, `home`, `end`, `pageup`, `pagedown`, and
+punctuation (`comma`, `period`, `slash`, `semicolon`, `quote`, `backslash`,
+`leftbracket`, `rightbracket`, `minus`, `equal`, `grave`). These need at least
+one modifier from `command`, `control`, `option`, `shift` (aliases `cmd`,
+`ctrl`, `alt`, `opt`) — macOS won't hand out a bare character key system-wide.
+
+If a combo is already owned by another app, registration fails and the menu bar
+item says so. Pick another one.
+
+### Bare modifiers want push-to-talk
+
+On `toggle`, right ⌥ would start recording every time you used it to type an
+accented character. Hold-to-talk is the mode that makes sense for these; it's
+also why apps in this category gravitate to `fn` or a right-hand modifier.
+
+## `transcription.insert_mode`
+
+`paste` types the transcript into the app you are in and needs the
+Accessibility permission. `clipboard` copies it and needs no permission at all;
+you press ⌘V. See [permissions.md](permissions.md).
+
+## `transcription.languages`
+
+Not passed to the speech model — Parakeet transcribes multilingually by itself
+and reports no language back. The list is what ParrotFlow uses to work out
+which language a transcript was in, so naming only what you actually speak
+makes that more accurate, and it selects the correction prompt written for that
+language. One entry means no detection runs at all.
+
+Most spoken first: the first entry is the fallback for transcripts too short to
+judge, under four words. Supported values are `en` and `fr`.
+
+## `transcription.activation_phrases`
+
+Say one of these instead of dictating and what follows is an instruction:
+"hey parrot, make that a bullet list". An empty list disables spoken commands.
+
+One of them **mid-sentence** turns the rest into an instruction about the words
+before it, in the same breath — which is why there are two. See
+[corrections.md](corrections.md).
+
+## `transcription.rewrite_line`
+
+Last resort for fields Accessibility cannot write, terminals mostly: clear the
+input line with ⌃A ⌃K and retype it corrected. Destructive by nature, so it only
+fires when the line still holds what you dictated.
+
+## `transcription.replacements`
+
+The spelling you want, and the ways it comes out wrong. Whole words,
+case-insensitive.
+
+```yaml
+replacements:
+  Tasmeen: [Tasmid, Tasmin, Tasmine]
+  Supabase: [super base, superbees]
+  "": ['/[,]?\s*\b(?:u+m+|u+h+|erm+|hmm+)\b[,]?/']
+```
+
+A source in `/slashes/` is a regular expression, and with one the target is a
+template, so `$1` writes back what the pattern captured. An **empty target
+deletes** rather than substitutes, which is how filler words go, punctuation
+and spacing included.
+
+Grouped by the spelling you want rather than one line per mistake, because the
+same name comes out wrong a dozen ways and they all mean one thing.
+
+The table runs as the `replacements` stage; the `fuzzy` stage runs the same
+table against renderings you never taught it. Both are pipeline stages, so
+whether they run at all is [pipelines.md](pipelines.md).
+
+## `llm`
+
+The local Ollama model behind spoken commands and every `prompt:` transform.
+Without it dictation still works and those stages stop.
+
+`keep_loaded: true` pins the model in RAM at launch. Ollama otherwise drops it
+after five minutes idle and the next command waits for a reload — measured
+**6.7 s cold against 1.5 s warm**, so in practice almost every correction paid
+for one. The cost is the model sitting in memory for as long as the app runs:
+9.6 GB for `gemma4:e4b`. On a 16 GB Mac, turn it off. On 32 GB, do not.
+
+## `updates`
+
+One call a day to GitHub's release API — no account, nothing about you, nothing
+about what you dictate.
+
+The number is a waiting period, not a frequency: `-1` never asks, `0` offers a
+release the day it is published, `7` only offers one that has existed for a
+week. The wait is the point — a bad release is one that gets noticed and
+pulled, and a week of distance means your Mac never saw it.
+
+## `free_form`
+
+Do what was asked even when no transform description matches: "hey parrot, use
+the 24 hour clock". A remark that was never an instruction is still refused,
+and you see every result before it replaces anything. Turn it off to go back to
+a fixed menu of transforms.
+
+## `audio.speech_gate`
+
+Skips clips with no speech in them, so a key pressed by accident costs nothing.
+Gated on speech being *present*, not on how much — a one-word dictation is a
+real one.
+
+## `feedback`
+
+`sound` is the chime when a transcript lands. `overlay` is the floating pill
+that shows the mic is hot. Both on by default; the pill is the only thing on
+screen that says recording is happening, so turning it off is a real choice.
+
+## See also
+
+- [pipelines.md](pipelines.md) — `pipelines:`, `transforms:`, conditions, apps
+- [corrections.md](corrections.md) — teaching it a word, spoken corrections
+- [cli.md](cli.md) — validating a config, and testing a change without speaking
+- [permissions.md](permissions.md) — what needs Accessibility and what does not

--- a/docs/corrections.md
+++ b/docs/corrections.md
@@ -1,0 +1,131 @@
+# Teaching it a word
+
+The part that matters if you dictate library names, CLI tools and your
+colleagues' names all day. A rule you teach once is written to your
+`config.yaml` and applied to every transcript afterwards.
+
+When a name comes out wrong, select it in whatever app you're in, hold the
+hotkey and say **"hey parrot"**. A panel opens showing what it heard and a
+field for what it should have written.
+
+    HEARD AS         SHOULD BE
+    Tasmin      →   [Tasmeen            ]  ×
+    and         →   [                   ]  ×
+    Mick        →   [Mik                ]  ×
+    return Save   esc Cancel              2 rules
+
+You get a row per word, because rules are per-word — a phrase you selected
+once will never recur verbatim. Leave a row blank and it is skipped, so
+selecting a whole sentence to fix two names costs nothing. × drops a row you
+do not want to think about.
+
+Saving writes each filled-in rule to `config.yaml` — comments and your other
+settings untouched — and puts the corrected phrase back where it came from,
+punctuation and spacing intact.
+
+## Saying the spelling instead
+
+You can skip the panel entirely and just say the correction:
+
+    "hey parrot, Tasmin spells T A S M E E N"
+    "hey parrot, Mick is spelled M I K"
+    "hey parrot, it's spelled S U P A B A S E not super base"
+
+A local model works out which word was wrong; the panel opens prefilled so you
+confirm with one keystroke rather than trusting it blindly.
+
+You do not have to spell it. Describing the change works too, in either
+language:
+
+    "hey parrot, Jerome with a G at the beginning"
+    "hey parrot, Mathieu ne prend qu'un seul t"
+    "hey parrot, Elastic search is one word"
+    "hey parrot, Jean Luc avec un trait d'union"
+
+And one breath can carry two corrections, which open as two rows in the panel:
+
+    "hey parrot, Tasmin spells T A S M E E N and Mick spells M I K"
+    "hey parrot, Nathalie sans le h et Philipe avec deux p"
+
+## Why the model does so little of this
+
+The spelled-out letters are read from the text, not the model — a run of single
+letters can only be the target spelling, and relying on the model for that got
+the direction backwards on "X spells Y" phrasing in three of seven test cases.
+Described changes are applied by code for the same reason: asked to write
+"Phillip with one l", the models answered "Phill" and "Philp". The model's only
+job is finding which words in your transcript you meant.
+
+The word being corrected is found in your **previous transcript**, not in the
+command. The command is dictated too, so the name gets misheard a second time:
+saying "Tasmine spells T A S M E E N" can come through as "Das mean spells…",
+and a rule for "Das mean" matches nothing you will ever say. Since the target
+spelling is already known from the letters, the closest match to it in the last
+transcript is the word that needs fixing.
+
+## What it needs
+
+Ollama running with the model in `llm.model` (`ollama pull gemma4:e4b`), and
+the Accessibility permission — reading your selection is exactly what that
+permission governs.
+
+ParrotFlow loads that model at launch and asks Ollama to keep it there. Ollama
+otherwise drops it after five minutes idle, and reloading is most of what you
+wait for: measured 6.7 s cold against 1.5 s warm, so in practice almost every
+correction paid for a reload. The cost is the model sitting in memory for as
+long as the app runs — 9.6 GB for `gemma4:e4b`. Set `llm.keep_loaded: false` to
+have the RAM back and the wait with it. On a 16 GB Mac that is the right
+setting; on 32 GB it is not.
+
+Without a model, `"hey parrot"` and `"hey parrot, fix vocabulary"` still open
+the panel — those are matched without one.
+
+Change the trigger with `transcription.activation_phrases`.
+
+## How it is scored
+
+`tests/spelling-cases.yaml` holds 62 cases — French, Indian, Chinese, Turkish,
+Vietnamese, Korean, Nigerian, Polish, Irish, Arabic names, plus product names
+recognition splits, described changes, two-in-a-breath corrections, and
+negative cases; `tests/french-cases.yaml` holds 45 more where the dictated
+sentence is French. Score a model or a prompt against them with
+`scripts/validate-prompt.py gemma4:e4b`.
+
+## Without speaking
+
+*Correct a Word…* in the menu opens the same panel,
+`--learn <heard> <corrected>` adds a rule from the terminal, and
+`--command "<what you'd say>"` shows how a phrase would be routed. See
+[cli.md](cli.md).
+
+## In a terminal
+
+Selections are fragile: they get dropped on a keystroke or when focus moves,
+often before the transcript comes back. ParrotFlow snapshots the selection the
+moment the hotkey goes down, which covers most of it, and falls back to your
+clipboard when there is nothing to read. So if a terminal selection does not
+come through, copy it first — select, ⌘C, then say the phrase. The panel always
+opens either way, with a row you can type into.
+
+## An instruction inside a dictation
+
+The same phrase said mid-sentence means something else: the rest is an
+instruction about the words in front of it, in the same breath.
+
+```
+"there is a bug in get username by the way parrot format that name"
+ └─ what gets written, once edited ──┘        └─ what to do to it ─┘
+```
+
+Fully described in [pipelines.md](pipelines.md#an-instruction-inside-a-dictation),
+along with why two phrases ship and why this path writes your sentence even when
+everything about the instruction fails.
+
+## See also
+
+- [configuration.md](configuration.md#transcriptionreplacements) — the rule
+  table a correction writes into
+- [pipelines.md](pipelines.md) — the `fuzzy` stage, which catches renderings you
+  never taught
+- [authoring.md](authoring.md) — changing the prompts behind any of this, with
+  the case sets that say whether you made it better

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,98 @@
+# Working on it
+
+The build you are changing and the build you use to get work done are **two
+separate applications**. Both can be installed, and both can run at once.
+
+|  | Released | Dev |
+| --- | --- | --- |
+| App | `ParrotFlow.app` | `ParrotFlowDev.app` |
+| Bundle id | `com.parrotflow.app` | `com.parrotflow.app.dev` |
+| Hotkey | right ⌥ | right ⌘ |
+| Config | `~/.config/parrotflow/` | `~/.config/parrotflow-dev/` |
+| Log | `ParrotFlow.log` | `ParrotFlow-Dev.log` |
+| Recordings | `~/Recordings/ParrotFlow` | `~/Recordings/ParrotFlow Dev` |
+| Menu bar | `mic` | `mic.circle` |
+
+This is not tidiness. macOS grants microphone and Accessibility **per bundle
+identifier**, so one identifier for both means every rebuild is revoking and
+re-granting permissions on the app you actually rely on — and a half-finished
+config change can break it. Separate identifiers make that impossible.
+
+Different hotkeys are what let both run at once: same key and both would record
+the same sentence and both paste it. You choose which build hears you by which
+key you hold.
+
+## Building
+
+```sh
+git clone https://github.com/znat/parrotflow && cd parrotflow
+make dev-certificate    # once, so permissions survive rebuilds
+make hooks              # once, so commit subjects can cut releases
+make install
+```
+
+Needs the Xcode command line tools. No Xcode project, no Apple developer
+account.
+
+Everything in the Makefile works on the dev build by default:
+
+```sh
+make run                  # build and launch ParrotFlow Dev
+make logs                 # tail the dev log
+make which                # print what this variant resolves to
+make stop                 # quit dev; the installed app keeps running
+
+VARIANT=release make logs  # act on the shipped app instead
+```
+
+`scripts/variant.sh` is the one place the two identities are defined, and
+`AppVariant.swift` is where the app derives its own paths from the identifier it
+was built with.
+
+## Releasing
+
+Nobody picks a version number. release-please reads the commit subjects since
+the last tag and works it out: a `feat:` bumps the minor, a `fix:` or `perf:`
+the patch, and anything else releases nothing at all. It keeps a release PR open
+with that version and the changelog it derived, and **merging that PR is the
+release** — it tags, builds on a macOS runner, signs, and attaches the archive
+that `install.sh` downloads.
+
+So the subject line is not housekeeping. A commit written without a type is
+invisible to all of this: no bump, no changelog entry, and no warning that it
+was skipped. `make hooks` points git at `.githooks/commit-msg`, which refuses
+one before it lands. Run it once per clone — hooks are not cloned.
+
+```
+feat:  a capability that was not there before   -> minor
+fix:   behaviour that was wrong is now right    -> patch
+perf:  same behaviour, measurably faster        -> patch
+docs: refactor: test: build: ci: chore:         -> no release
+```
+
+The body of the message is unaffected. It is still the place to say what broke
+and how you know it is fixed.
+
+```sh
+make hooks                       # once per clone
+scripts/release-certificate.sh   # once, ever — see the warning in the file
+scripts/release.sh               # build the artefacts locally to inspect them
+```
+
+Re-running the workflow by hand (Actions → release → Run workflow) recomputes
+the release PR. It cannot force a release: with no releasable commits since the
+last tag there is nothing to open a PR for.
+
+## Before you push
+
+```sh
+scripts/check-default-config.sh   # the config a new install gets still parses
+scripts/check-pipeline.sh         # stages, conditions, app gating
+scripts/check-dotted.sh           # the one rewrite that fires on ordinary language
+scripts/check-numbers.sh          # 97 cases, English and French
+scripts/check-routing.sh          # which transform an instruction reaches
+```
+
+The full list is in [cli.md](cli.md#the-check-scripts). Anything touching a
+prompt or a pattern wants [authoring.md](authoring.md) first — the point of
+those sets is that "it looks better" is not a measurement.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,0 +1,60 @@
+# Permissions
+
+**Microphone** — required. Requested on first launch.
+
+**Accessibility** — required for `insert_mode: paste` (the default) and for
+spoken corrections, because reading your selection is exactly what that
+permission governs. `insert_mode: clipboard` works without it: the transcript
+is copied and you press ⌘V.
+
+Nothing else is asked for. Gating a pipeline stage by app reads the frontmost
+app from `NSWorkspace` rather than off the focused element, so it costs no
+permission that gating by text does not.
+
+## Checking them
+
+`--check-config` reports the microphone honestly. It cannot report
+Accessibility: macOS credits a permission check made from a terminal to the
+terminal, not to ParrotFlow, so it reads as missing even when granted. The app
+tests it properly at launch and writes the answer down:
+
+```sh
+grep "launched —" ~/Library/Logs/ParrotFlow.log | tail -1
+```
+
+## Why permissions don't survive a rebuild
+
+Only relevant if you build from source. Released builds are signed with a
+stable certificate, so upgrading does not cost you your grants.
+
+TCC — the subsystem behind these grants — identifies an app by its **code
+signature**, not its path. With an ad-hoc signature the designated requirement
+pins the binary's `cdhash`, which changes on every single build.
+
+So the grant you gave to yesterday's build does not apply to today's. Worse,
+the entry stays in System Settings pointing at a binary that no longer exists,
+so it *looks* granted. Un-ticking and re-ticking that entry doesn't help —
+it reuses the same dead record. Accessibility enforces this strictly;
+Microphone is more forgiving but still breaks when the bundle is replaced.
+
+The symptom is unmistakable: System Settings shows the app ticked, and the app
+insists the permission isn't granted.
+
+**The fix, once:**
+
+```sh
+make dev-certificate                 # asks for your password
+make install                         # picks the identity up automatically
+```
+
+That creates a self-signed code-signing certificate. The designated requirement
+then keys on the certificate rather than the binary hash, so grants survive
+every rebuild. Grant permissions *after* that install, not before.
+
+Since the dev build is a separate application, this only ever costs you the dev
+app's grants. The copy you rely on is untouched by anything you rebuild — see
+[development.md](development.md).
+
+If a grant is already stuck, `make reset-permissions` deletes the record
+properly — un-ticking the box in System Settings does not, it leaves the dead
+entry in place, which is why re-ticking it never helps.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,39 +1,29 @@
 # Setting up ParrotFlow
 
-**These are instructions for a coding agent, not for a person.** Someone has
-asked you to set ParrotFlow up on their Mac. Follow this file top to bottom.
-
-Read the whole thing before you start, then work through it. Do not invent extra
-steps, and do not skip the checks — most of what goes wrong here is invisible
-until you look for it.
+**Instructions for a coding agent, not for a person.** Someone asked you to set
+ParrotFlow up on their Mac. Read the whole file, then work top to bottom. Do not
+invent steps, and do not skip the checks — most of what goes wrong here is
+invisible until you look for it.
 
 ## How to talk while you do this
 
-The person watching is a developer, but they know nothing about this app. Many
-of them do not speak English as a first language.
-
-- **Use simple, international English.** Short sentences. One idea each.
-- Use common words. Say "delete", not "purge". Say "start", not "kick off".
-- No idioms. No phrasal verbs where a plain verb exists.
-- No jargon they did not use first. Not "TCC", not "ASR", not "quantised".
-- Say what you are about to do, do it, say what happened.
-- Never say "should work". Check, then say what is true.
-- Lines shown as `> quoted text` are for you to say. Use your own words if they
-  fit better, but keep them short and keep them simple.
+They are a developer who knows nothing about this app, often not a native
+English speaker. Short sentences, common words, no jargon they did not use
+first. Say what you are about to do, do it, say what happened. Never say "should
+work" — check, then say what is true. Lines shown as `> quoted text` are for you
+to say; shorter words of your own are fine.
 
 Two things you cannot do, ever:
 
-1. **Grant permissions.** macOS only accepts those from a human, clicking. You
-   can open the right window and wait. You cannot click for them.
+1. **Grant permissions.** macOS only accepts those from a human, clicking.
 2. **Test dictation.** It needs a voice. Only they have one.
 
-When you hit either, stop and ask. Then check what they say they did — people
+When you hit either, stop and ask — then check what they say they did. People
 tick the wrong row in System Settings often.
 
 ## What you are installing
 
-Three separate downloads, in this order. Say which one you are on, because the
-sizes are very different and a silent 10 GB download looks like a hang.
+Say which download you are on. A silent 10 GB download looks like a hang.
 
 | What | Size | When | Needed for |
 | --- | --- | --- | --- |
@@ -41,50 +31,28 @@ sizes are very different and a silent 10 GB download looks like a hang.
 | Parakeet, the speech model | 1.2 GB | Step 5, automatic | dictation |
 | Gemma, the language model | 10 GB | Step 9, optional | voice commands |
 
-Dictation works after Step 5. Everything after that is extra.
+Dictation works after Step 5. Everything after is extra.
 
-## If ParrotFlow is already installed
-
-Check first:
-
-```sh
-ls -d /Applications/ParrotFlow.app 2>/dev/null
-```
-
-If it is there, this is an upgrade or a repair, not a first install. Go to
-Step 3 and run the installer anyway — it replaces the app in place. Then go to
-Step 7. Read `~/.config/parrotflow/config.yaml` first and only ask about what is
-missing. Do not ask questions they have already answered.
+**Already installed** (`ls -d /Applications/ParrotFlow.app`)? This is an
+upgrade. Run Step 3 anyway — it replaces the app in place — then go to Step 7,
+read `~/.config/parrotflow/config.yaml`, and ask only about what is missing.
 
 ---
 
 ## Step 1 — Say what is about to happen
 
-Before you run anything. They should be able to stop you here.
+They should be able to stop you here.
 
 > ParrotFlow is dictation that runs on your Mac. You hold a key, you talk, and
-> the text appears in the app you are using. Nothing is uploaded. No account, no
-> API key, no network call.
+> the text appears in the app you are using. Nothing is uploaded — no account,
+> no API key, no network call.
 >
-> Setup takes about five minutes of your time, plus one large download that runs
-> in the background.
->
-> I will:
-> 1. Check your Mac can run it
-> 2. Install the app
-> 3. Help you through two macOS permission windows
-> 4. Prove that transcription works
-> 5. Ask you a few questions about how you want it to work
-> 6. Start an optional 10 GB download, for commands you say out loud
->
-> You will have to click twice in System Settings. I cannot do that part for
-> you.
->
-> Ready?
+> I will check your Mac, install the app, help you through two permission
+> windows, prove transcription works, and ask you a few questions. About five
+> minutes. You have to click twice in System Settings yourself. Ready?
 
-Wait for an answer. If they ask what the 10 GB is for: it is only for spoken
-commands, like *"hey parrot, Tasmin spells T A S M E E N"* or *"hey parrot, fix
-the grammar"*. Dictation does not need it.
+If they ask what the 10 GB is for: only spoken commands. Dictation does not need
+it.
 
 ## Step 2 — Check the Mac
 
@@ -95,15 +63,11 @@ sysctl -n hw.memsize                   # bytes of RAM — write this down, Step 
 df -g / | tail -1 | awk '{print $4}'   # GB free — need 15 or more
 ```
 
-**Remember the RAM number.** It decides a setting in Step 9, and it is easy to
-forget to look.
+**Remember the RAM number.** It decides a setting in Step 9.
 
-Stop if macOS is older than 14, or if the Mac has an Intel processor. Speech
-recognition runs on the Neural Engine, and Intel Macs do not have one. Say this
-plainly and stop. There is no way around it.
-
-If free disk space is under 15 GB, say so and ask whether to continue.
-Dictation needs about 1.5 GB. The 10 GB model is optional and can be skipped.
+Stop if macOS is older than 14, or if the Mac is Intel — speech recognition runs
+on the Neural Engine and Intel Macs have none. Under 15 GB free: say so and ask
+whether to continue. Dictation needs 1.5 GB; the 10 GB model is optional.
 
 ## Step 3 — Install the app
 
@@ -111,108 +75,80 @@ Dictation needs about 1.5 GB. The 10 GB model is optional and can be skipped.
 curl -fsSL https://raw.githubusercontent.com/znat/parrotflow/main/scripts/install.sh | sh
 ```
 
-This downloads about 3 MB, checks it against its published checksum, puts the
-app in `/Applications`, and starts it.
+Checks 3 MB against its published checksum, installs to `/Applications`, starts
+it.
 
-> The app is installed. There is a microphone icon in your menu bar now, at the
-> top right. Can you see it?
+> The app is installed. There is a microphone icon in your menu bar now, top
+> right. Can you see it?
 
-If the download fails, there may be no release published yet — check
-`https://github.com/znat/parrotflow/releases`. If `/Applications` cannot be
-written to, run the same command again with `PARROTFLOW_DEST=~/Applications`.
+Download fails → check `https://github.com/znat/parrotflow/releases` for a
+release. `/Applications` not writable → rerun with
+`PARROTFLOW_DEST=~/Applications`.
 
 ## Step 4 — Microphone permission
 
-The app asks for this the first time it starts. The window may already be open.
+The app asks at first launch; the window may already be open.
 
-> macOS is asking if ParrotFlow can use your microphone. Please say yes. Without
-> it there is nothing to transcribe.
+> macOS is asking if ParrotFlow can use your microphone. Please say yes.
 
-Then check. Do not take their word for it:
+Check it yourself — do not take their word:
 
 ```sh
 /Applications/ParrotFlow.app/Contents/MacOS/ParrotFlow --check-config
 ```
 
-Look for `✓ microphone  Granted`. Anything else: send them to **System Settings
-→ Privacy & Security → Microphone**, then check again.
-
-This command also prints the whole config the app is using. Read it. You will
-come back to it several times below.
+Want `✓ microphone  Granted`. Anything else: **System Settings → Privacy &
+Security → Microphone**, then check again. This also prints the config the app
+is using. Read it; you will come back to it.
 
 ## Step 5 — Prove transcription works, and download Parakeet
 
-This is the step that makes the app real, and it does not need a microphone.
+Needs no microphone.
 
 ```sh
 say -o /tmp/pf-check.wav --data-format=LEI16@16000 --channels=1 "Testing one two three"
 /Applications/ParrotFlow.app/Contents/MacOS/ParrotFlow --transcribe /tmp/pf-check.wav
 ```
 
-`say` is part of macOS. It writes exactly the 16 kHz mono WAV file the speech
-model expects.
+`say` writes exactly the 16 kHz mono WAV the model expects. The first run
+downloads that model — tell them first:
 
-The first run downloads that model and prints its progress. Tell them before it
-starts, because 1.2 GB with no explanation looks like a problem:
+> Downloading the speech model now. It is called Parakeet, about 1.2 GB, and it
+> runs on your Mac. A few minutes.
 
-> Now I am downloading the speech model. It is called Parakeet, it is about
-> 1.2 GB, and it runs on your Mac. This is the part that turns your voice into
-> text, so dictation needs it. It takes a few minutes.
-
-A transcript appears at the end. It will be close to "Testing one two three" but
-not identical — `Testing 123.` is a normal and correct result. What matters is
-that text came back at all.
-
-If this fails, stop and fix it before going further. Nothing after this step can
-work if this step does not.
+`Testing 123.` is a correct result; what matters is that text came back. If this
+fails, stop and fix it — nothing after this step can work.
 
 ## Step 6 — Accessibility permission, or the clipboard instead
 
-There is a real choice here. Ask it before you open any settings window.
+A real choice. Ask before opening any settings window.
 
-> One more permission, and you have a choice.
+> **Type the text for me** — ParrotFlow types straight into the app you are
+> using. Needs the Accessibility permission.
 >
-> **Type the text for me.** ParrotFlow types your words straight into the app
-> you are using. This needs the Accessibility permission.
->
-> **Copy the text instead.** ParrotFlow copies your words, and you press
-> Command-V yourself. This needs no permission.
+> **Copy the text instead** — ParrotFlow copies, you press Command-V. Needs no
+> permission.
 >
 > Typing is what most people want. Which do you prefer?
 
-If they choose the clipboard, set this in `~/.config/parrotflow/config.yaml`,
-under `transcription`:
+Clipboard → set `transcription: insert_mode: clipboard`, and say what it costs.
+The cost is the missing permission, not the setting — reading a selection is
+exactly what Accessibility controls:
 
-```yaml
-transcription:
-  insert_mode: clipboard
-```
+> Two things will not work: fixing a word by voice, and the voice commands in
+> Step 10. Both have to read the text you selected. Dictation is not affected,
+> and you can turn the permission on later without reinstalling anything.
 
-Tell them what that costs, plainly. The cost comes from the permission, not from
-the setting — without Accessibility the app cannot read the text they selected,
-and reading a selection is exactly what that permission controls:
-
-> Two things will not work without that permission: fixing a word by voice, and
-> the voice commands in Step 10. Both of them have to read the text you
-> selected. Dictation itself is not affected. You can turn the permission on
-> later at any time, and nothing needs to be reinstalled.
-
-Then go to Step 7. If they later change their mind, come back to this step.
-
-If they choose typing — the default — open the window for them:
+Typing — the default — open the window:
 
 ```sh
 open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
 ```
 
-> I opened the settings window. Find ParrotFlow in the list and turn the switch
-> on.
-
-**Checking this is not obvious, so do it exactly this way.** `--check-config`
-does *not* tell you. macOS credits a check made from a terminal to the terminal,
-not to ParrotFlow, so it reports "not granted" for an app that has the
-permission. The app tests it properly when it starts and writes the answer in
-its log. So restart the app, then read the log:
+**Check this exactly this way.** `--check-config` does *not* tell you: macOS
+credits a check made from a terminal to the terminal, so it reports "not
+granted" for an app that has the permission. The app tests it properly at launch
+and writes the answer to its log.
 
 ```sh
 pkill -f "ParrotFlow.app/Contents/MacOS/ParrotFlow"; sleep 1
@@ -220,198 +156,120 @@ open -a ParrotFlow; sleep 3
 grep "launched —" ~/Library/Logs/ParrotFlow.log | tail -1
 ```
 
-You want `accessibility=Granted` on that line. If it says `NotGranted`, the
-switch is off, or they turned on a different app. Ask them to look again,
-restart the app, and read the log again.
+Want `accessibility=Granted`. `NotGranted` means the switch is off or they
+ticked a different app.
 
 ## Step 7 — The questions that shape the config
 
-Ask these together. They are short. Edit
-`~/.config/parrotflow/config.yaml` after each answer — the app reloads the file
-when you save it, so no restart is needed.
+Ask together, edit `~/.config/parrotflow/config.yaml` after each answer. The app
+reloads on save.
 
-**1. Languages.**
-
-> Which languages do you dictate in?
-
-Dictation itself understands many languages and needs no setting. This list does
-something narrower: it tells ParrotFlow which language a transcript was in, so
-it can pick the right correction rules.
-
-**Only `en` and `fr` work today.** Anything else is ignored. If they name
-another language, be honest:
-
-> Dictation will work in that language. The speech model understands many
-> languages. But the correction rules are only written for English and French so
-> far, so I will leave this setting on English.
-
-Most used language first:
+**1. Languages.** Dictation understands many languages with no setting. This
+list only tells ParrotFlow which language a transcript was in, so it can pick
+the right correction rules. **Only `en` and `fr` work today** — if they name
+another, say dictation works in it but the correction rules are not written yet,
+and leave this on English.
 
 ```yaml
 transcription:
-  languages: [en, fr]
+  languages: [en, fr]     # most used first; one entry skips detection entirely
 ```
 
-One entry means no language detection runs at all. That is faster and more
-accurate, so use one entry if they only dictate in one language.
-
 **Then write the filler words for those languages.** Do not skip this because
-the config looks like it already handles it. A new config has
-`replacements: {}` — the filler rule exists only in `config.example.yaml`, so
-a fresh install deletes nothing. And the rule in that example is English only:
-`um`, `uh`, `erm`, `hmm`. A French speaker keeps every `euh`.
+the config looks like it handles it — a new config has `replacements: {}`, and
+the rule in `config.example.yaml` is English only. A French speaker keeps every
+`euh`.
 
-> When people talk, they make sounds like "um" and "euh". I can remove those
-> from your text. Do you want that?
-
-Some people want them kept. Ask, do not assume. If they want it, write one rule
-per language they named:
+> When people talk they make sounds like "um" and "euh". Shall I remove those?
 
 ```yaml
 transcription:
   replacements:
-    # English
+    # English; add French euh+|heu+|hein|bah to this same list
     "": ['/[,]?\s*\b(?:mm[-‑]?hmm|uh[-‑]?huh|mhm|u+m+|u+h+|erm+|hmm+|mm+)\b[,]?/']
-    # French — add these words to the same list
-    #          euh+|heu+|hein|bah
 ```
 
-Merge them into the single `""` entry rather than writing two — it is one map,
-and a repeated key is invalid YAML. Check the result with `--check-config`,
-which prints every rule and reports a pattern it cannot compile.
+One `""` entry, not two — it is one map, and a repeated key is invalid YAML.
 
-**Only add words that are not words in the other language.** Rules are not
-language-scoped: every rule runs on every transcript. `euh`, `heu` and `hein`
-are safe. Never add `ben`, `genre`, `quoi`, `voilà`, `donc` or `alors` — they
-are ordinary French words, and `ben` is an English name. Deleting one of those
-damages a sentence that was already correct, which is the one thing a
-replacement rule must never do.
+**Only add words that are not words in the other language.** Every rule runs on
+every transcript. `euh`, `heu`, `hein` are safe. Never add `ben`, `genre`,
+`quoi`, `voilà`, `donc` or `alors` — ordinary French words, and `ben` is an
+English name. Deleting one damages a sentence that was already correct.
 
-**2. The key.**
+**2. The key.** Right Option also types `é`, `ü`, `ñ`. If they need it:
+`hotkey: key: right_command` (or `fn`, `right_control`, or a character key plus
+modifiers — all listed in the config file).
 
-> The key is the right Option key. You hold it, you talk, you let it go. Is that
-> key free on your Mac, or do you use it for something else?
-
-The right Option key is used to type accented characters — `é`, `ü`, `ñ`. If
-they need it, change the key:
-
-```yaml
-hotkey:
-  key: right_command    # or fn, right_control, or a character key plus modifiers
-```
-
-`--check-config` prints the key it will use, and says so if another app already
-owns it. Every key name is listed in the config file itself.
-
-**3. Numbers.**
-
-> When you say "two hundred and forty three", do you want to see 243 or the
-> words?
-
-Off by default. Show them what it would do instead of explaining it, in the
-language they dictate in:
+**3. Numbers.** Off by default. Show, do not explain:
 
 ```sh
 PF=/Applications/ParrotFlow.app/Contents/MacOS/ParrotFlow
 $PF --numbers "I need two hundred and forty three of them by nineteen eighty four"
-$PF --numbers "il m'en faut deux cent quarante trois avant quatre-vingt-dix-sept jours"
 ```
 
-Which grammar reads the numbers comes from the `languages` list you just set, so
-run this after that edit and it answers the way dictation will. `--lang fr` pins
-it if you want to show them one language on purpose.
+The grammar used comes from `languages`, so run this after that edit. If they
+want it: `transcription: numbers: true`.
 
-If they want it: `transcription: numbers: true`.
+Check every edit with `--check-config`. It prints each rule and reports a
+pattern it cannot compile.
 
 ## Step 8 — Let them try it
 
-The first real dictation. You cannot do this one.
+You cannot do this one.
 
-> Your turn. Open any text box — a note, a chat window, this terminal.
->
-> Hold the **right Option key**, say a sentence, then let the key go.
->
-> Wait about one second. The text appears where your cursor is.
-
-If nothing arrives:
+> Your turn. Open any text box, hold the **right Option key**, say a sentence,
+> let go. About a second later the text appears at your cursor.
 
 ```sh
 grep -E "transcribed|speech gate|hotkey" ~/Library/Logs/ParrotFlow.log | tail -5
 ```
 
-- Nothing in the log at all → the key never fired. Check `--check-config` for a
-  registration failure, and ask if another app uses that key.
-- `speech gate: no speech detected` → the microphone heard nothing. Wrong input
-  device, or they let the key go too early.
-- `transcribed: …` but no text appeared → Accessibility. Go back to Step 6.
-
-Once it works, say so and move on. This is the moment they decide whether they
-like the app.
+- Nothing in the log → the key never fired. Check `--check-config` for a
+  registration failure; ask if another app owns that key.
+- `speech gate: no speech detected` → wrong input device, or they let go early.
+- `transcribed: …` but no text → Accessibility. Back to Step 6.
 
 ## Step 9 — Voice commands (the 10 GB part)
 
-Everything above already works. This step adds one thing: talking to the app
-instead of typing at it. Teaching it a name by voice, fixing grammar in text you
-selected, turning a paragraph into bullet points.
+> Optional, and last. It downloads a 10 GB model called Gemma, which understands
+> the commands you say out loud. Everything else already works without it, and
+> the download runs in the background. Do you want it?
 
-> The last part, and it is optional. It downloads a 10 GB model called Gemma.
-> That model is what understands the commands you say out loud.
->
-> Everything else already works without it. The download runs in the background,
-> and you can keep using dictation the whole time.
->
-> Do you want it?
+No → set `llm: enabled: false`, tell them they can still fix words by hand from
+the menu bar, skip to Step 12.
 
-If they say no: set `llm: enabled: false` in the config, tell them they can
-still fix words by hand from the menu bar, and go to Step 11.
-
-**Ollama runs the model. Check it is installed and running.** This one call
-answers both questions:
+**Ollama runs the model.** These answer whether it is installed and running:
 
 ```sh
 curl -s --max-time 3 http://localhost:11434/api/version
+command -v ollama
 ```
 
-- Returns `{"version":"0.31.1"}` or similar → it is running. Check the version
-  below.
-- Returns nothing → it is not installed, or not started.
-
-```sh
-command -v ollama            # installed?
-```
-
-Say what Ollama is before you install it. Do not install software on someone's
-machine silently:
+Say what it is before installing — do not put software on someone's machine
+silently:
 
 > Gemma needs a program called Ollama to run it. Ollama runs language models on
 > your own Mac, offline. I will install it now.
 
 ```sh
-brew install ollama
-brew services start ollama
+brew install ollama && brew services start ollama
 ```
 
-If it is installed but not answering, start it. Use `brew services start ollama`
-when it came from Homebrew — the path starts with `/opt/homebrew` or
-`/usr/local/Cellar`. Otherwise, ask them to open the Ollama app.
+Installed but not answering → `brew services start ollama` if the path starts
+with `/opt/homebrew` or `/usr/local/Cellar`, otherwise ask them to open the
+Ollama app.
 
-**The minimum version is 0.22.0.** Older builds cannot run the `gemma4` e-series
-models at all. Compare what `/api/version` returned. If it is older:
+**Minimum version 0.22.0** — older builds cannot run `gemma4` e-series models at
+all. Homebrew: `brew upgrade ollama`. The Ollama app: they must update it
+themselves, you cannot.
 
-- Installed with Homebrew → `brew upgrade ollama`
-- The Ollama app → they must update it from the Ollama menu, or download it
-  again from ollama.com. You cannot update that one for them.
-
-**Now use the RAM number from Step 2.** The model needs 9.6 GB of memory while
-it is loaded. This setting decides whether it stays in memory between commands:
+**Now use the RAM number from Step 2.** The model needs 9.6 GB while loaded:
 
 | RAM | `llm.keep_loaded` | Why |
 | --- | --- | --- |
-| 32 GB or more | `true` | 9.6 GB in memory is affordable. Commands answer in 1–2 seconds. |
-| 16 to 32 GB | `false` | Keeping 9.6 GB of 16 would slow down everything else. Commands take 7–10 seconds, because Ollama loads the model again each time. |
-| under 16 GB | `false`, and say something | It will work, but the Mac will swap memory to disk. Tell them, and offer `llm: enabled: false` instead. |
-
-Write it into `~/.config/parrotflow/config.yaml`:
+| 32 GB or more | `true` | 9.6 GB is affordable. Commands answer in 1–2 s. |
+| 16 to 32 GB | `false` | Commands take 7–10 s; Ollama reloads each time. |
+| under 16 GB | `false`, and say so | Works, but the Mac swaps to disk. Offer `llm: enabled: false` instead. |
 
 ```yaml
 llm:
@@ -420,208 +278,164 @@ llm:
   keep_loaded: true    # or false, from the table above
 ```
 
-**Then start the download in the background.** Do not wait for it:
+**Start the download in the background. Do not wait for it:**
 
 ```sh
 nohup ollama pull gemma4:e4b > /tmp/parrotflow-pull.log 2>&1 &
 ```
 
-> The download has started in the background. It is 9.6 GB, so it takes from a
-> few minutes to half an hour, depending on your connection.
->
-> Dictation works right now. Please do not wait for this. The only thing missing
-> until it finishes is the commands you say out loud.
+> 9.6 GB, so a few minutes to half an hour. Dictation works right now — please
+> do not wait for this.
 
-Check on it later with:
-
-```sh
-tail -2 /tmp/parrotflow-pull.log
-ollama list | grep gemma4
-```
-
-If the download fails with an error about the model or the manifest, Ollama is
-too old, whatever its version string said. Upgrade it and pull again.
+Check later with `tail -2 /tmp/parrotflow-pull.log` and `ollama list | grep
+gemma4`. An error about the model or manifest means Ollama is too old, whatever
+its version string said.
 
 ## Step 10 — Teach them what they can say
 
-Do this while the download runs. It is the part people miss, and the app is
-half as useful without it.
+Do this while the download runs. It is the part people miss.
 
-Everything below starts with the **wake phrase**: `hey parrot`. Hold the same
-key you hold for dictation, say the wake phrase, then say what you want. The app
-knows this is a command and not dictation, so it never types those words into
-your document.
+Everything starts with the wake phrase `hey parrot`: hold the same key, say the
+phrase, then say what you want. Those words are never typed into the document.
+Print the real list first — the `capabilities` lines from `--check-config` —
+rather than describing what this file assumes.
 
-Print the real list first, so you describe what is actually installed rather
-than what this file assumes:
-
-```sh
-/Applications/ParrotFlow.app/Contents/MacOS/ParrotFlow --check-config
-```
-
-Read the `capabilities` lines. Then explain, in three parts:
-
-**1. Teach it a name.**
-
-> Say a name it always gets wrong, and spell it:
+> Say a name it gets wrong, and spell it:
 >
 >     "hey parrot, Tasmin spells T A S M E E N"
 >
-> A panel opens with the correction already filled in. You press Return. From
-> then on, that name is written correctly every time.
+> A panel opens with the correction filled in. Press Return, and that name is
+> right every time after. You can also select the wrong word and just say "hey
+> parrot".
 >
-> You can also select the wrong word first and just say "hey parrot". The panel
-> opens with what it heard and an empty box for what it should be.
-
-**2. Change text you selected.**
-
-> Select some text, hold the key, and say what you want:
+> Or select some text and say what you want:
 >
 >     "hey parrot, fix the grammar"
 >     "hey parrot, make that a bullet list"
->     "hey parrot, sort that list alphabetically"
 >     "hey parrot, use the 24 hour clock"
 >
-> A panel shows you the new text before it replaces anything. You can edit it in
-> the panel. Command-Return replaces the text, Escape cancels.
+> You see the new text before it replaces anything. Command-Return replaces,
+> Escape cancels. Select nothing and it works on the last thing you dictated.
+
+The last example matches no prompt at all — `free_form` sends the whole
+instruction to the model. **This is why the list is not a menu. Do not read them
+commands to memorise.** A new install ships `bullets`, `terse` and `grammar`,
+each tuned because it beats `free_form` at that one job:
+
+> Three are tuned for one job each. Everything else goes to the general one. You
+> do not have to remember which is which.
+
+A transform of their own goes in `transforms:` and needs a `description` — that
+is what the router matches spoken words against, and `--check-config` reports an
+entry without one as an error.
+
+## Step 11 — Slack handles, if they use Slack
+
+Skip unless they use Slack, and skip if they said no in Step 9 — this needs the
+model.
+
+The config ships a `slack_mentions` transform that turns names into handles when
+you ask for it out loud. It carries three example names, and the list is the
+whole point of it.
+
+> Do you use Slack? I can teach it your colleagues' handles — then "hey parrot,
+> use Slack mentions" turns "tell Marie the deadline moved" into "tell
+> @marie.dupont the deadline moved".
 >
-> If you select nothing, it works on the last thing you dictated. That is useful
-> right after you speak, when there is nothing to select yet.
+> I need names and handles, and I cannot read your workspace. If your Slack has
+> an assistant, ask it for the members of your team channel, or the people you
+> have messaged in the last month. Paste the answer here in any format.
 
-The first two examples come from the prompt list. The last two match no prompt
-at all — they are handled by `free_form`, which sends the whole instruction to
-the model. This is why the list is not a menu: the user does not have to learn
-it. Do not read them a list of commands to memorise.
+They can also just name the handful of people they message most. Either way the
+source is them: **never invent or guess a handle.** A wrong one pings the wrong
+colleague and the person dictating will not notice.
 
-**3. The tuned ones are already there.**
+Put what they paste into the list inside that transform's prompt, one per line,
+keeping the shape and dropping the examples:
 
-A new install is written with three transforms — `bullets`, `terse` and
-`grammar` — so there is nothing to add and nothing to fetch. They are in the
-`capabilities` lines you printed a moment ago. Each exists because it scores
-better on its own test set than `free_form` does at that one job; everything
-else is free-form's, which is why the list is not a menu.
-
-Point at them rather than offering them:
-
-> Three of those are tuned for one job each: bullet points, shorter text, and
-> grammar. Everything else you say goes to the general one. You do not have to
-> remember which is which — it works that out.
-
-If they want one of their own, it goes in `transforms:` and it needs a
-`description`: that is the text the router matches spoken words against, so an
-entry without one can never be picked, and `--check-config` reports it as an
-error rather than leaving it to look like the router misbehaving.
-
-```sh
-/Applications/ParrotFlow.app/Contents/MacOS/ParrotFlow --check-config
+```yaml
+transforms:
+  - name: slack_mentions
+    prompt: |
+      ...
+        Marie   -> @marie.dupont
+        Thomas  -> @tleroy
 ```
 
-The `capabilities` count goes up and the new entry is listed by name. A
-`transforms:` entry can also be a substitution table rather than a prompt, and
-those run from a pipeline instead of by voice — docs/pipelines.md, not something
-to cover in a handover.
+Then `--check-config`, and say what it does and does not do:
 
-**If the Gemma download is still running,** say this now:
+> It only runs when you ask — a message that names someone is not always a
+> message that should ping them. With text selected you see the result first.
+> And it never sends anything: you get text in your Slack box, and the last look
+> is yours.
 
-> These commands start working the moment the download finishes. Nothing to
-> restart.
+Check one thing with them, because it decides whether this is worth having:
+ParrotFlow inserts by paste, and Slack's composer does not always re-read pasted
+text. Ask them to paste a handle into a message **without sending** and say
+whether it turns blue. If it stays plain, it looks like a mention and notifies
+nobody — tell them that rather than leaving them to find out.
 
-You can prove routing works without saying anything out loud, once the model is
-there:
+## Step 12 — Hand over
 
-```sh
-PF=/Applications/ParrotFlow.app/Contents/MacOS/ParrotFlow
-$PF --command "hey parrot, Tasmin spells T A S M E E N"   # shows the rule it would add
-$PF --route "make that a bullet list"                     # shows which prompt it picked
-```
-
-## Step 11 — Hand over
-
-Keep this short. Three things they need, and where to look.
-
-> Done. Three things to remember:
+> Done. Three things:
 >
-> **Dictate** — hold the right Option key, talk, let it go.
+> **Dictate** — hold right Option, talk, let go.
 >
-> **Fix a word** — when a name is wrong, select it, hold the key, and say
-> "hey parrot". Or say the spelling: "hey parrot, Tasmin spells T A S M E E N".
+> **Fix a word** — select it, hold the key, say "hey parrot". Or say the
+> spelling: "hey parrot, Tasmin spells T A S M E E N".
 >
-> **Change text** — select it, hold the key, and say what you want. For example
-> "hey parrot, fix the grammar". You always see the result before it replaces
-> anything.
+> **Change text** — select it, hold the key, say what you want. You always see
+> the result first.
 >
-> Your settings are in `~/.config/parrotflow/config.yaml`. Save the file and the
-> app reloads it immediately.
->
-> The menu bar icon has *Correct a Word…*, *Settings…* and *Permissions…*.
+> Settings are in `~/.config/parrotflow/config.yaml` and reload on save. The
+> menu bar icon has *Correct a Word…*, *Settings…* and *Permissions…*.
 
 ---
 
 ## When things go wrong
 
-**Nearly everything is in the log.**
-
-```sh
-tail -30 ~/Library/Logs/ParrotFlow.log
-```
-
-Every start records the key and both permissions. Every clip records whether
+**Nearly everything is in the log** — `tail -30 ~/Library/Logs/ParrotFlow.log`.
+Every start records the key and both permissions; every clip records whether
 speech was found and what was transcribed.
 
-**The key does nothing.** Another app may own the same combination. Registration
-failures appear in `--check-config` and in the menu bar item. For a single
-modifier key like right Option, check that the key physically reaches the app:
+**The key does nothing.** Another app may own the combination; registration
+failures show in `--check-config`. For a single modifier key, check it reaches
+the app at all with `--watch-modifiers`.
 
-```sh
-/Applications/ParrotFlow.app/Contents/MacOS/ParrotFlow --watch-modifiers
-```
-
-**Permissions look granted but the app disagrees.** This is almost always a
-signature problem. macOS ties these grants to the app's signature, and an app
-replaced by a different build loses them while System Settings still shows it
-ticked. Turning the switch off and on again does not fix it — the dead record is
-reused. Reset it properly, then grant it again:
+**Permissions look granted but the app disagrees.** Almost always a signature
+problem: macOS ties grants to the app's signature, and a replaced build loses
+them while System Settings still shows the tick. Toggling does not fix it — the
+dead record is reused.
 
 ```sh
 tccutil reset Accessibility com.parrotflow.app
 tccutil reset Microphone com.parrotflow.app
 ```
 
-Then restart the app and grant the permission from a clean start.
+Then restart and grant from a clean start.
 
-**A voice command does nothing, or says nothing to change.** The app tells you
-what text it looked at. Read the log:
+**A voice command does nothing, or says nothing to change.**
 
 ```sh
 grep -E "router|transform|command|selection" ~/Library/Logs/ParrotFlow.log | tail -10
 ```
 
-If it worked on the wrong text, the selection was not readable — common in
-terminals, where a selection is dropped as soon as focus moves. Copy the text
-first, then say the command.
+Wrong text → the selection was not readable, common in terminals where it is
+dropped as soon as focus moves. Copy the text first, then say the command.
 
-**Voice commands do nothing at all.** Check Ollama is running and has the model:
+**Voice commands do nothing at all.** `curl -s --max-time 3
+http://localhost:11434/api/version` and `ollama list | grep gemma4`.
 
-```sh
-curl -s --max-time 3 http://localhost:11434/api/version
-ollama list | grep gemma4
-```
+**A name is still wrong after teaching it.**
+`grep -A5 replacements ~/.config/parrotflow/config.yaml`.
 
-**A name is still wrong after teaching it.** Check the rule was written:
+**Dictation is slow the first time.** The first clip after launch loads the
+speech model.
 
-```sh
-grep -A5 replacements ~/.config/parrotflow/config.yaml
-```
+**A command never returns.** The app ignores an unknown flag and starts as a
+menu bar app, which never exits — the installed app is older than this file.
+Ctrl-C, rerun Step 3, retry.
 
-**Dictation is slow the first time.** The first clip after the app starts loads
-the speech model. After that it is fast.
-
-**A command you ran never returns.** The app ignores a flag it does not know and
-starts as a menu bar app instead, which never exits. That means the installed
-app is older than this file. Press Ctrl-C, run Step 3 again to update it, and
-retry.
-
-**Do not** suggest turning off Gatekeeper, running
-`xattr -dr com.apple.quarantine`, or `sudo` for anything. Nothing in this setup
-needs them. If something looks like it does, something else is wrong. Say so and
-stop.
+**Do not** suggest turning off Gatekeeper, `xattr -dr com.apple.quarantine`, or
+`sudo`. Nothing here needs them. If something looks like it does, something else
+is wrong. Say so and stop.


### PR DESCRIPTION
Rebuilt on top of current `main` — the previous version of this branch predated the pipeline, transform and update work and was rewritten from scratch. Docs only, no code touched.

## The problem

The README had grown into the manual: 469 lines, in which the reason to install this was three paragraphs and the rest was hotkey internals, TCC records and release mechanics. Someone deciding whether to try it read none of it, and someone configuring it had to scroll past the pitch to reach the reference.

None of it mentioned pipelines or transforms — the thing that actually separates this from every other dictation app.

## The README now

Value and install, nothing else:

- **Fast enough to dictate in** — the measured numbers as a table: ~60–70 ms to capture, ~1 s to transcript, 0.035 s for the deterministic stages, ~1.5 s for a warm model call, and why that last row is the reason stages carry conditions.
- **It gets your vocabulary right** — teaching a name by voice, the fuzzy pass, and the fact that every rewrite has a scored case set with its failures kept in.
- **It is programmable** — a readable pipeline snippet with `app:` and `when:` gating, and the stdin/stdout `command:` contract. This is the section aimed at the people the tool is for.
- **It is a text file, not a settings pane** — reloaded on save, diffable, committable, checkable with `--check-config`.
- Then the three install routes, the first minute, and a table of every doc page.

## The docs

Moved out of the README, whole rather than rewritten:

| New page | Was |
|---|---|
| `docs/configuration.md` | README § Configuration, plus the `llm`, `updates`, `free_form` and `speech_gate` settings that only lived in `config.example.yaml` |
| `docs/corrections.md` | README § Teaching it a word |
| `docs/cli.md` | README § Checking things from the terminal — extended to every flag `main.swift` actually takes, grouped by the question each answers |
| `docs/permissions.md` | README § Permissions |
| `docs/architecture.md` | README § How it works, plus a where-the-time-goes table |
| `docs/development.md` | README §§ Working on it, Releasing |

`docs/README.md` is the index, and ends with a short section for agents.

## The page that did not exist

**`docs/authoring.md`** — writing a transform, and proving it works. `pipelines.md` documents what the pieces mean; nothing documented the procedure, and the procedure is where the mistakes are: reaching for a prompt where a table would do, tuning by eye, shipping something that fixed one sentence and broke two.

It carries the decision table (`replace:` / `command:` / `prompt:`, with what each costs), the measure-change-measure loop, four recipes, the rules for writing a case set, and a pre-flight checklist. It cites this repo's own measurements for why the model should be given the smallest possible job.

## Agent entry point

**`AGENTS.md`** at the root, with a two-line `CLAUDE.md` pointing at it. Three jobs (install / configure / change a rewrite), each routed to its page, then the rules that are not visible from the code:

- validate with the binary — `--check-config`, `--pipeline … --app`, `--replace`, `--route` — not by reading the file back
- never change a prompt or a pattern without scoring it against the set
- fail open: kill Ollama, re-run, the sentence should come through untouched
- prefer a table or a script to a prompt
- say out loud when a config executes something

## Checked

All relative links and cross-page anchors resolve. Nothing in the old README was dropped — every section has a destination in the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYQy1hwQqusCRFv82RZ2Rd