### PR TITLE
feat: gate a pipeline stage by the app you dictated into

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ without one.
 `--command "<what you'd say>"` shows how a phrase would be routed.
 
 Needs the Accessibility permission — reading your selection is exactly what
-that permission governs. Change the trigger with `transcription.correction_phrase`.
+that permission governs. Change the trigger with `transcription.activation_phrase`.
 
 **In a terminal**, selections are fragile: they get dropped on a keystroke or
 when focus moves, often before the transcript comes back. ParrotFlow snapshots
@@ -163,14 +163,12 @@ hotkey:
   mode: push_to_talk    # or toggle
 
 audio:
-  sample_rate: 16000    # Parakeet wants 16 kHz mono; leave it
   output_dir: ~/Recordings/ParrotFlow
-  min_duration_seconds: 0.3
   speech_gate: true     # skip clips with no speech in them
 
 transcription:
   insert_mode: paste    # or clipboard
-  correction_phrase: hey parrot
+  activation_phrase: hey parrot
   languages: [en]       # en and fr are the supported values
 
 feedback:

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -31,6 +31,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Where the text was being typed when the hotkey went down, so a rule
     /// learned by voice can fix the word already in the field.
     private var focusAtPress: SelectionReader.Selection?
+    /// Which app you were dictating into, for pipeline `app:` conditions.
+    ///
+    /// Read from NSWorkspace rather than off `focusAtPress`, which is nil
+    /// without Accessibility — an app condition has no business needing a
+    /// permission that gating a stage by app does not otherwise require.
+    private var appAtPress: Pipeline.App?
 
     private var tickTimer: Timer?
     private var pushToTalkPoll: Timer?
@@ -161,6 +167,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let snapshotStart = Date()
         selectionAtPress = SelectionReader.snapshot()
         focusAtPress = selectionAtPress ?? SelectionReader.focusSnapshot()
+        appAtPress = Self.appInFront()
         let elapsed = Date().timeIntervalSince(snapshotStart)
         if elapsed > 0.15 {
             Log.write(String(format: "selection snapshot was slow: %.2fs", elapsed))
@@ -285,14 +292,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Transcription
 
+    /// The app in front right now, or nil if there isn't one to name.
+    private static func appInFront() -> Pipeline.App? {
+        guard let front = NSWorkspace.shared.frontmostApplication else { return nil }
+        let app = Pipeline.App(
+            name: front.localizedName ?? "", bundleID: front.bundleIdentifier ?? ""
+        )
+        // Both empty is not an app you could write a condition against, and
+        // saying so is what makes `app:` fail closed instead of matching "  ".
+        return app.searchable.trimmingCharacters(in: .whitespaces).isEmpty ? nil : app
+    }
+
     private func transcribe(_ recording: Recorder.Recording) {
         transcriptionLabel = "Transcribing…"
         updateUI()
 
         let config = self.config
+        // Taken at the press, not here: a transcript arrives seconds later and
+        // the window you dictated into may not be the one in front by then.
+        let app = appAtPress
         Task { [weak self] in
             do {
-                let text = try await self?.transcriber.transcribe(url: recording.url, config: config) ?? ""
+                let text = try await self?.transcriber.transcribe(
+                    url: recording.url, config: config, app: app
+                ) ?? ""
                 await MainActor.run {
                     guard let self else { return }
                     self.transcriptionLabel = nil

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -75,6 +75,7 @@ enum CheckConfigCommand {
                         if let prompt = step.prompt { described += " \(prompt)" }
                         if let when = step.when { described += " when \(when)" }
                         if let unless = step.unless { described += " unless \(unless)" }
+                        if let app = step.app { described += " in \(app)" }
                         return described
                     }.joined(separator: " → ")
                 print("  · pipeline \(language)        \(stages)  (\(source))")

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -136,9 +136,13 @@ struct Config: Codable, Equatable {
         var activationPhrase: String = "hey parrot"
         /// Last-resort in-place correction for surfaces the accessibility API
         /// cannot write, such as terminals: clear the input line with readline
-        /// keys and retype it. Destructive if the guesses are wrong, so it is
-        /// opt-in and only fires when the line is recognisably one we wrote.
-        var rewriteLine: Bool = false
+        /// keys and retype it.
+        ///
+        /// On by default, because a terminal is where a developer dictates and
+        /// without this a correction there does nothing. It clears the line to
+        /// do it, so it only fires when the line is recognisably one we wrote —
+        /// that guard is what makes the default defensible.
+        var rewriteLine: Bool = true
         /// Languages you dictate in, most common first.
         ///
         /// Not passed to Parakeet — it transcribes multilingually on its own
@@ -242,10 +246,11 @@ struct Config: Codable, Equatable {
             var prompt: String?
             var when: String?
             var unless: String?
+            var app: String?
             /// `stage:` and `prompt:` on the same entry.
             var namesBoth = false
 
-            private enum CodingKeys: String, CodingKey { case stage, prompt, when, unless }
+            private enum CodingKeys: String, CodingKey { case stage, prompt, when, unless, app }
 
             init(from decoder: Decoder) throws {
                 if let bare = try? decoder.singleValueContainer().decode(String.self) {
@@ -266,6 +271,7 @@ struct Config: Codable, Equatable {
                 }
                 when = try c.decodeIfPresent(String.self, forKey: .when)
                 unless = try c.decodeIfPresent(String.self, forKey: .unless)
+                app = try c.decodeIfPresent(String.self, forKey: .app)
             }
         }
 
@@ -354,7 +360,7 @@ struct Config: Codable, Equatable {
                             }
                             return Pipeline.Step(
                                 stage: stage, prompt: entry.prompt,
-                                when: entry.when, unless: entry.unless
+                                when: entry.when, unless: entry.unless, app: entry.app
                             )
                         }
                         let key = language.lowercased()
@@ -612,35 +618,30 @@ enum ConfigStore {
     static var defaultYAML: String {
         """
     # \(AppVariant.displayName) configuration
-    # Edit and save — changes are picked up automatically.
+    # Edit and save — changes are picked up automatically. Delete any line to
+    # get its default back. `--check-config` says what the file adds up to.
 
     hotkey:
-      # Either a bare modifier used on its own:
+      # A bare modifier used on its own:
       #   right_option, left_option, right_command, left_command,
       #   right_control, left_control, right_shift, left_shift, fn
-      # ...or a character key plus modifiers:
+      # ...or a character key, which needs modifiers below:
       #   a-z, 0-9, space, return, tab, escape, f1-f20, arrows,
       #   comma, period, slash, semicolon, quote, backslash,
       #   leftbracket, rightbracket, minus, equal, grave, delete
       key: \(AppVariant.defaultHotkey)
 
       # Any of: command, control, option, shift (aliases: cmd, ctrl, alt, opt).
-      # Required for a character key; ignored for a bare modifier.
       modifiers: []
 
-      # toggle       -> tap to start, tap again to stop
-      # push_to_talk -> record only while the key is held
-      #
-      # Bare modifiers want push_to_talk: on toggle, Right Option would start
+      # push_to_talk records while the key is held; toggle taps on and off.
+      # Bare modifiers want push_to_talk — on toggle, Right Option would start
       # recording every time you typed an accented character with it.
       mode: push_to_talk
 
     audio:
-      # 16 kHz mono is what Parakeet wants. Leave this alone.
-      sample_rate: 16000
+      # Where the recordings pile up.
       output_dir: \(AppVariant.defaultOutputDir)
-      # Discard anything shorter than this (seconds)
-      min_duration_seconds: 0.3
 
       # Check for speech before transcribing, and skip clips that have none.
       # Without it a stray hotkey press decodes room tone into "Yeah." or
@@ -648,138 +649,94 @@ enum ConfigStore {
       speech_gate: true
 
     feedback:
-      sound: true
-      overlay: true
+      sound: true     # a click when recording starts and stops
+      overlay: true   # the floating pill while you speak
 
     transcription:
-      enabled: true
-
-      # paste     -> type it straight into the app you're in (needs Accessibility)
-      # clipboard -> just copy it, you press Cmd-V
+      # paste     -> typed into the app you're in (needs Accessibility)
+      # clipboard -> copied, you press Cmd-V
       insert_mode: paste
 
-      # Select a wrong word anywhere, hold the hotkey and say this, and a panel
-      # opens to teach ParrotFlow the right spelling. Needs Accessibility.
-      correction_phrase: hey parrot
+      # Say this instead of dictating and what follows is an instruction:
+      # "hey parrot, make that a bullet list". Empty disables it.
+      activation_phrase: hey parrot
 
-      # When a field refuses accessibility writes — terminals, mostly — clear the
-      # input line with Ctrl-A Ctrl-K and retype it corrected. Destructive by
-      # nature, so it only fires when the line still contains what you dictated.
+      # Last resort for fields Accessibility cannot write, terminals mostly:
+      # clear the input line with Ctrl-A Ctrl-K and retype it corrected. It
+      # only fires when the line still holds what you dictated.
       rewrite_line: true
 
-      # Languages you dictate in, most common first. Not sent to Parakeet — it
-      # transcribes multilingually by itself and reports no language back. This
-      # is the list ParrotFlow chooses between when working out which language a
-      # transcript was in, so naming only what you actually speak makes that
-      # more accurate. It picks the correction prompt and the number grammar.
+      # Languages you dictate in, most spoken first — the first one is the
+      # fallback for transcripts too short to judge, under four words.
+      # Supported: en, fr. A single entry means no detection runs at all.
       #
-      # The first entry is the fallback, used when a transcript is too short to
-      # judge — under four words. Supported: en, fr.
+      # Not sent to Parakeet, which transcribes multilingually by itself and
+      # reports no language back. This is the list ParrotFlow chooses between,
+      # so naming only what you actually speak makes it more accurate.
       languages: [en]
 
-      # Everything a finished transcript goes through, in order, per language.
-      # A language's own list wins over `default`.
+      # What a finished transcript runs through, in order. Listed in full
+      # because a stage runs only if it is here: switching one off is deleting
+      # a line you can see.
       #
-      # Being in a pipeline is the only way a stage runs, so this list is written
-      # out with all of them: turning one off means deleting a line you can see,
-      # not finding a setting you cannot. Delete `pipelines:` entirely and you get
-      # every stage back; write `default: []` and you get none, which is a choice
-      # rather than silence.
+      #   replacements  the table below
+      #   fuzzy         the same table against words the spell checker does not
+      #                 know, so "super bays" still reaches Supabase without
+      #                 "Excel" becoming "Vercel". Needs replacements before it
+      #   numbers       "two hundred forty-three" -> 243, plus ordinals,
+      #                 decimals and years, English and French
       #
-      # A stage can carry a condition, which is what makes an expensive one
-      # affordable — it is skipped on the transcripts that do not need it:
+      # Per language, which wins over `default`: fr: [replacements, numbers]
+      #
+      # A prompt can be a stage, and any stage can carry a condition — on the
+      # text with `when:` / `unless:`, or on the app you dictated into:
       #
       #   - stage: numbers
-      #     when: /\\b(vingt|cent|mille)\\b/     # only if a number word is left
-      #   - stage: fuzzy
-      #     unless: /```/                      # never inside a code fence
+      #     app: /term|ghostty/          # only in a terminal
+      #   - prompt: prose
+      #     app: /^(?!.*term)/           # everywhere but; no not_app, the
+      #                                  # negation goes in the pattern
       #
-      # `when` and `unless` read the text as it stands *at that point*, after the
-      # stages above — so a cheap stage can make an expensive one unnecessary
-      # rather than merely earlier. Both may be set; `unless` wins. The pattern is
-      # written like a replacement source: between slashes it is a regular
-      # expression, otherwise a word matched on word boundaries. Case-insensitive
-      # either way. A skipped stage says so in the log, because a stage that
-      # silently does not run looks exactly like one that ran and found nothing.
-      #
-      # A prompt from `prompts:` can be a stage too, which is the reason conditions
-      # exist: it calls the local model, so it costs about a second where every
-      # other stage costs nothing. Measured on one line, 3.2s with the prompt
-      # running against 0.035s with it skipped.
-      #
-      #   - prompt: hesitation
-      #     when: /\\b(genre|du coup|en fait)\\b/
-      #
-      # It is the only stage that rewrites your words without you asking, and
-      # nothing on screen shows it happened — so every rewrite is written to the
-      # log with the text before and after. If the model is not running, the prompt
-      # does not exist, or the call fails, the transcript comes back exactly as it
-      # arrived; a dictation tool can afford to skip a stage and cannot afford to
-      # lose a sentence.
-      #
-      # This is written out in full on purpose. The stages are few enough to
-      # read at a glance, and deleting a line you can see beats discovering a
-      # setting you cannot.
-      #
-      #   replacements  the substitutions below: literal, word-boundary,
-      #                 case-insensitive, or a regex between slashes
-      #   fuzzy         the same table, used to catch renderings you have not
-      #                 taught — "super bays" reaches Supabase. Only words the
-      #                 spell checker does not know are eligible, which is what
-      #                 keeps "Excel" from becoming "Vercel". Needs
-      #                 `replacements` before it, and says so if it does not
-      #                 have one.
-      #   numbers       spoken numbers as digits: "two hundred forty-three"
-      #                 -> 243, ordinals, decimals, years, spoken digits.
-      #                 English and French, chosen per transcript. A number
-      #                 word on its own stays a word below ten, so "chapter
-      #                 three" is left alone. It does rewrite transcripts that
-      #                 were already correct — run --numbers on a line to see
-      #                 exactly what it would do before leaving it in.
+      # See docs/pipelines.md.
       pipelines:
         default: [replacements, fuzzy, numbers]
 
-      # Grouped by the spelling you want, listing the ways it gets misheard.
-      # Word-boundary matched and case-insensitive.
+      # The spelling you want, and the ways it comes out wrong. Whole words,
+      # case-insensitive. A source in /slashes/ is a regular expression, and an
+      # empty target deletes rather than substitutes — which is how filler
+      # words go.
       #
-      #   replacements:
-      #     Tasmeen: [Tasmid, Tasmin, Tasmine]
-      #
-      # A source in /slashes/ is a regular expression, and an empty target
-      # deletes rather than substitutes — which is how filler words go:
-      #
-      #     "": ['/[,]?\\s*\\b(?:u+m+|u+h+|erm+|hmm+)\\b[,]?/']
+      #   Supabase: [super base, superbees]
+      #   "": ['/[,]?\\s*\\b(?:u+m+|u+h+|erm+|hmm+)\\b[,]?/']
       replacements: {}
 
 
 
-    # A local Ollama model, used to interpret what you say after the wake
-    # phrase. Everything still works without it — you just lose spoken
-    # commands like "hey parrot, Tasmin spells T A S M E E N".
+    # The local Ollama model behind spoken commands. Without it dictation still
+    # works and everything under `prompts:` stops.
     llm:
       enabled: true
       model: gemma4:e4b
       endpoint: http://localhost:11434
-      timeout_seconds: 20
-      # Load the model at launch and keep it there. Ollama otherwise drops it
-      # after five minutes, and reloading costs 7-10s on the next correction.
-      # Turn off to get those seconds back as free RAM.
+      # Pin the model in RAM at launch. Ollama otherwise drops it after five
+      # minutes and the next command waits 7-10s for the reload. Turn off to
+      # get those seconds back as free RAM.
       keep_loaded: true
 
-    # Things you can ask for by voice: say the wake phrase, then the instruction.
+    # What the activation phrase can reach: say it, then the instruction.
     #
     #     "hey parrot, make that a bullet list"
     #
-    # A router picks which one you meant, reading the descriptions below — so a
-    # description is not a comment, it is the thing being matched against. Write it
-    # the way you would say it.
+    # A description is not a comment — it is what the router matches your words
+    # against, so write it the way you would say it. The whole instruction then
+    # reaches the prompt, which is why one entry covers "format those dates
+    # ISO" and "format those dates with slashes".
     #
-    # The whole instruction is then passed to the prompt, not just the part that
-    # chose it. That is what lets one prompt serve "format those dates ISO" and
-    # "format those dates with slashes" without needing two entries.
+    # Results are shown before they replace your selection; add
+    # `confirm: false` to a prompt you have come to trust.
     #
     # Fixing a misheard name is built in and does not appear here — run
-    # --check-config to see everything the wake phrase reaches.
+    # --check-config to see everything the phrase reaches.
     prompts:
       - name: bullets
         description: turn text into a short bullet list
@@ -792,19 +749,6 @@ enum ConfigStore {
         content: |
           Cut this down. No filler, same facts, same voice.
           Return only the shortened text.
-
-      # There used to be a `dates` prompt and a `digits` prompt here. Both are gone,
-      # because free_form does their job and the measurement said so: on the sixteen
-      # cases they covered in tests/generic-cases.yaml they scored 12/16 against the
-      # built-in's 14/16. `digits` was a straight tie, five cases to five. `dates`
-      # was worse — asked to make "the deadline is March 3 2026" ISO it answered
-      # "2026-03-03", dropping the sentence around the date, which is what a prompt
-      # written for one subject does when handed a whole sentence.
-      #
-      # `grammar` below stays for the opposite reason. It has a validation set of
-      # its own and it beats the built-in on it, 5/5 against 4/5, and the case it
-      # wins is the one that matters most here: leaving alone a sentence that was
-      # already right.
 
       - name: grammar
         description: fix grammar and punctuation mistakes, not formatting or numbers
@@ -830,26 +774,14 @@ enum ConfigStore {
 
           Return only the text.
 
-      # Show the result before it replaces anything. On by default — a transform
-      # overwrites text you selected, and it is triggered by voice, so there is no
-      # dialog in the way. Set false per prompt once you trust it.
-      #
-      #   confirm: false
-
-
-    # Do what was asked even when no prompt matches — which, with no `prompts:`
-    # section yet, is everything:
+    # Do what was asked even when no prompt above matches:
     #
     #     "hey parrot, use the 24 hour clock"
-    #     "hey parrot, make sure fifty dollars is formatted as money"
     #     "hey parrot, sort that list alphabetically"
     #
-    # A remark that was never an instruction is still refused: the router
-    # answers three ways, and separating "an edit nothing covers" from "not an
-    # edit at all" is what keeps a passing question away from your selection.
-    # You see every result before it replaces anything.
-    #
-    # Turn it off to go back to a fixed menu of prompts.
+    # A remark that was never an instruction is still refused, and you see
+    # every result before it replaces anything. Turn off to go back to a fixed
+    # menu of prompts.
     free_form: true
     """
     }

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -51,6 +51,32 @@ struct Pipeline: Equatable, Codable {
         var isAutomatic: Bool { self != .prompt }
     }
 
+    /// The app a transcript is on its way into, for `Step.app`.
+    ///
+    /// Captured when the hotkey goes down, never read at stage time. Between
+    /// the two there is a transcription and possibly a model call, and the
+    /// window you were dictating into is not reliably the one still in front
+    /// when the text comes back. `SelectionReader.snapshot()` takes the owner
+    /// at press for the same reason, and this rides along with it.
+    ///
+    /// Name and bundle identifier are matched as **one string**, not either-or.
+    /// The name is what you know an app by and the identifier is what stays
+    /// put, so both have to be reachable — but two haystacks and a negative
+    /// pattern do not mix: `/^(?!.*microsoft)/` matches "Code" while failing
+    /// `com.microsoft.VSCode`, and "one of the two matched" would then run the
+    /// stage in the app it was written to exclude. Joined, the question has one
+    /// answer.
+    struct App: Equatable {
+        let name: String
+        let bundleID: String
+
+        /// What a pattern is matched against.
+        var searchable: String { "\(name) \(bundleID)" }
+
+        /// How it reads in a log line.
+        var described: String { name.isEmpty ? bundleID : name }
+    }
+
     /// A stage plus when it runs. The condition is the whole reason a pipeline
     /// beats a list: a stage that costs a second is affordable exactly when it
     /// can be skipped on the transcripts that do not need it.
@@ -68,6 +94,14 @@ struct Pipeline: Equatable, Codable {
         /// Skip when this matches. Both may be set; `unless` wins, because a
         /// reason not to run is a stronger statement than a reason to.
         var unless: String?
+        /// Run only in apps this matches — see `App`.
+        ///
+        /// There is no `not_app`, deliberately: the pattern is a regular
+        /// expression like every other one here, so exclusion is a negative
+        /// lookahead, `/^(?!.*term)/`. That keeps one key instead of two, at
+        /// the cost of an anchor people forget — which `validate` refuses
+        /// rather than leaving to run everywhere in silence.
+        var app: String?
 
         /// Same convention as `replacements`, so there is one thing to learn:
         /// between slashes it is a regular expression, otherwise it is a word,
@@ -185,12 +219,27 @@ struct Pipeline: Equatable, Codable {
             problems.append("a prompt stage names no prompt — write `- prompt: <name>`")
         }
         for step in steps {
-            for (label, condition) in [("when", step.when), ("unless", step.unless)] {
+            for (label, condition) in [
+                ("when", step.when), ("unless", step.unless), ("app", step.app)
+            ] {
                 guard let condition else { continue }
                 if Step.expression(for: condition) == nil {
                     // Otherwise the stage simply never runs, which looks
                     // exactly like the stage being broken.
                     problems.append("\(step.stage.name): \(label) \"\(condition)\" is not a valid pattern")
+                    continue
+                }
+                // A negative lookahead is how exclusion is written here, and
+                // unanchored it is a lie: patterns are matched with
+                // `firstMatch`, so `/(?!.*term)/` succeeds one character into
+                // "Terminal" and the stage runs everywhere it was meant to be
+                // kept out of. Nothing about that failure is visible — the
+                // stage does not error, it just runs — so it is refused here.
+                if Step.pattern(for: condition).hasPrefix("(?!") {
+                    problems.append(
+                        "\(step.stage.name): \(label) \"\(condition)\" is an unanchored negative"
+                            + " lookahead — it matches almost anything. Anchor it: /^(?!.*…)/"
+                    )
                 }
             }
         }
@@ -220,7 +269,7 @@ struct Pipeline: Equatable, Codable {
     /// skipped was reported as having "ran, changed nothing". A diagnostic that
     /// disagrees with the thing it is diagnosing is worse than none.
     static func skipReason(
-        for step: Step, text: String, config: Config, allowPrompts: Bool
+        for step: Step, text: String, config: Config, allowPrompts: Bool, app: App? = nil
     ) -> String? {
         if step.stage == .prompt {
             if !allowPrompts { return "prompts are off on this path" }
@@ -228,6 +277,18 @@ struct Pipeline: Equatable, Codable {
                 text, phrase: config.transcription.activationPhrase
             ) != nil {
                 return "this is a spoken command"
+            }
+        }
+        if let wanted = step.app {
+            // Fails closed. Without Accessibility, or on a path that never had
+            // a window to read, there is no app — and "run it anyway" would run
+            // a terminal-only stage in your editor, which is the one outcome
+            // asking for `app:` was meant to prevent.
+            guard let app else {
+                return "app \(wanted) cannot be checked — nothing was in front"
+            }
+            if !step.matches(app.searchable, wanted) {
+                return "app \(wanted) did not match \(app.described)"
             }
         }
         if let unless = step.unless, step.matches(text, unless) {
@@ -239,11 +300,14 @@ struct Pipeline: Equatable, Codable {
         return nil
     }
 
-    func run(_ text: String, config: Config, allowPrompts: Bool = true) async -> String {
+    func run(
+        _ text: String, config: Config, allowPrompts: Bool = true, app: App? = nil
+    ) async -> String {
         var output = text
         for step in steps {
             if let reason = Pipeline.skipReason(
-                for: step, text: output, config: config, allowPrompts: allowPrompts
+                for: step, text: output, config: config,
+                allowPrompts: allowPrompts, app: app
             ) {
                 // Said out loud: a stage that silently does not run is
                 // indistinguishable from one that ran and found nothing, and

--- a/Sources/ParrotFlow/PipelineCommand.swift
+++ b/Sources/ParrotFlow/PipelineCommand.swift
@@ -46,7 +46,22 @@ enum PipelineCommand {
         }
     }
 
-    static func run(path: String, text: String?, quiet: Bool = false) -> Int32 {
+    /// `--app "Ghostty com.mitchellh.ghostty"` — who to pretend is in front.
+    ///
+    /// Without it an `app:` condition is only reachable by speaking into the
+    /// right window, which is not a thing a validation set can do. The string
+    /// is matched exactly as the real one is: name and bundle identifier
+    /// joined, so a fixture can name either or both.
+    ///
+    /// Empty is "nothing in front", not "no flag given" — the two mean the same
+    /// thing here, and saying so lets a caller pass the flag unconditionally.
+    /// scripts/check-pipeline.sh does exactly that, because the alternative in
+    /// bash 3.2 is an empty array under `set -u`, which is an error.
+    static func run(
+        path: String, text: String?, quiet: Bool = false, app: String? = nil
+    ) -> Int32 {
+        let named = (app ?? "").trimmingCharacters(in: .whitespaces)
+        let front = named.isEmpty ? nil : Pipeline.App(name: named, bundleID: "")
         let url = URL(fileURLWithPath: (path as NSString).expandingTildeInPath)
         let fixture: Fixture
         do {
@@ -65,7 +80,8 @@ enum PipelineCommand {
                 return nil
             }
             return Pipeline.Step(
-                stage: stage, prompt: entry.prompt, when: entry.when, unless: entry.unless
+                stage: stage, prompt: entry.prompt, when: entry.when,
+                unless: entry.unless, app: entry.app
             )
         }
         for name in unknown {
@@ -94,6 +110,7 @@ enum PipelineCommand {
                 if let prompt = step.prompt { line += " \(prompt)" }
                 if let when = step.when { line += "  when \(when)" }
                 if let unless = step.unless { line += "  unless \(unless)" }
+                if let app = step.app { line += "  app \(app)" }
                 print(line)
             }
             return 0
@@ -102,7 +119,7 @@ enum PipelineCommand {
         let done = DispatchSemaphore(value: 0)
         if quiet {
             Task {
-                print(await pipeline.run(text, config: config))
+                print(await pipeline.run(text, config: config, app: front))
                 done.signal()
             }
             done.wait()
@@ -114,10 +131,11 @@ enum PipelineCommand {
         // say. Re-run one stage at a time rather than instrumenting `run`: the
         // scored path stays the one the app uses, and this stays a viewer.
         print("in:   \(text)")
+        if let front { print("app:  \(front.described)") }
         var current = text
         for step in steps {
             if let reason = Pipeline.skipReason(
-                for: step, text: current, config: config, allowPrompts: true
+                for: step, text: current, config: config, allowPrompts: true, app: front
             ) {
                 print("  ⊘ \(step.stage.name)  — skipped, \(reason)")
                 continue
@@ -125,7 +143,7 @@ enum PipelineCommand {
             var after = current
             let stepDone = DispatchSemaphore(value: 0)
             Task {
-                after = await Pipeline(steps: [step]).run(current, config: config)
+                after = await Pipeline(steps: [step]).run(current, config: config, app: front)
                 stepDone.signal()
             }
             stepDone.wait()

--- a/Sources/ParrotFlow/Replacements.swift
+++ b/Sources/ParrotFlow/Replacements.swift
@@ -37,10 +37,10 @@ enum Replacements {
     /// Kept as the entry point everything already calls, so moving the order
     /// out of this function did not move the call sites too.
     static func apply(
-        to text: String, config: Config, allowPrompts: Bool = true
+        to text: String, config: Config, allowPrompts: Bool = true, app: Pipeline.App? = nil
     ) async -> String {
         await Pipeline.forText(text, config: config).0.run(
-            text, config: config, allowPrompts: allowPrompts
+            text, config: config, allowPrompts: allowPrompts, app: app
         )
     }
 

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -110,7 +110,7 @@ actor Transcriber {
     // MARK: - Transcription
 
     /// Transcribes a finished recording. Returns the cleaned-up text.
-    func transcribe(url: URL, config: Config) async throws -> String {
+    func transcribe(url: URL, config: Config, app: Pipeline.App? = nil) async throws -> String {
         try await prepare(config: config)
         let manager = try await makeManager()
 
@@ -137,7 +137,7 @@ actor Transcriber {
         }
 
         let raw = try await manager.finish()
-        return await Self.applyReplacements(to: raw, config: config)
+        return await Self.applyReplacements(to: raw, config: config, app: app)
     }
 
     /// True when the clip holds no speech worth transcribing.
@@ -188,8 +188,10 @@ actor Transcriber {
     /// that boosting missed. Word-boundary matched and case-insensitive so
     /// "mick" and "Mick" both land, but "Mickey" is left alone.
     /// How names get fixed — see `Replacements`.
-    nonisolated static func applyReplacements(to text: String, config: Config) async -> String {
-        await Replacements.apply(to: text, config: config)
+    nonisolated static func applyReplacements(
+        to text: String, config: Config, app: Pipeline.App? = nil
+    ) async -> String {
+        await Replacements.apply(to: text, config: config, app: app)
     }
 }
 

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -103,13 +103,17 @@ if let index = arguments.firstIndex(of: "--prompt") {
 
 if let index = arguments.firstIndex(of: "--pipeline") {
     guard arguments.indices.contains(index + 1) else {
-        print("usage: ParrotFlow --pipeline <file.yaml> [\"<text>\"] [--quiet]")
+        print("usage: ParrotFlow --pipeline <file.yaml> [\"<text>\"] [--app <name>] [--quiet]")
         exit(2)
     }
     let text = arguments.indices.contains(index + 2) && !arguments[index + 2].hasPrefix("--")
         ? arguments[index + 2] : nil
+    let app = arguments.firstIndex(of: "--app").flatMap { index -> String? in
+        arguments.indices.contains(index + 1) ? arguments[index + 1] : nil
+    }
     exit(PipelineCommand.run(
-        path: arguments[index + 1], text: text, quiet: arguments.contains("--quiet")
+        path: arguments[index + 1], text: text,
+        quiet: arguments.contains("--quiet"), app: app
     ))
 }
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,136 +1,89 @@
 transcription:
-  enabled: true
-
-  # paste     -> type it straight into the app you're in (needs Accessibility)
-  # clipboard -> just copy it, you press Cmd-V
+  # paste     -> typed into the app you're in (needs Accessibility)
+  # clipboard -> copied, you press Cmd-V
   insert_mode: clipboard
 
-  # Select a wrong word anywhere, hold the hotkey and say this, and a panel
-  # opens to teach ParrotFlow the right spelling. Needs Accessibility.
-  correction_phrase: hey parrot
+  # Say this instead of dictating and what follows is an instruction:
+  # "hey parrot, make that a bullet list". Empty disables it.
+  activation_phrase: hey parrot
 
-  # When a field refuses accessibility writes — terminals, mostly — clear the
-  # input line with Ctrl-A Ctrl-K and retype it corrected. Destructive by
-  # nature, so it only fires when the line still contains what you dictated.
+  # Last resort for fields Accessibility cannot write, terminals mostly: clear
+  # the input line with Ctrl-A Ctrl-K and retype it corrected. It only fires
+  # when the line still holds what you dictated.
   rewrite_line: true
 
-  # Languages you dictate in, most common first. Not sent to Parakeet — it
-  # transcribes multilingually by itself and reports no language back. This
-  # list is what ParrotFlow uses to work out which language a transcript was
-  # in, so listing only what you actually speak makes that more accurate, and
-  # it picks the correction prompt written for that language.
+  # Languages you dictate in, most spoken first — the first one is the
+  # fallback for transcripts too short to judge, under four words.
+  # Supported: en, fr. A single entry means no detection runs at all.
   #
-  # One entry means no detection runs at all. Supported: en, fr.
+  # Not sent to Parakeet, which transcribes multilingually by itself and
+  # reports no language back. This is the list ParrotFlow chooses between, so
+  # naming only what you actually speak makes it more accurate.
   languages: [en, fr]
 
-  # Everything a finished transcript goes through, in order, per language.
-  # A language's own list wins over `default`.
+  # What a finished transcript runs through, in order. Listed in full because
+  # a stage runs only if it is here: switching one off is deleting a line you
+  # can see.
   #
-  # Being in a pipeline is the only way a stage runs, so this list is written
-  # out with all of them: turning one off means deleting a line you can see,
-  # not finding a setting you cannot. Delete `pipelines:` entirely and you get
-  # every stage back; write `default: []` and you get none, which is a choice
-  # rather than silence.
+  #   replacements  the table below
+  #   fuzzy         the same table against words the spell checker does not
+  #                 know, so "super bays" still reaches Supabase without
+  #                 "Excel" becoming "Vercel". Needs replacements before it
+  #   numbers       "two hundred forty-three" -> 243, plus ordinals, decimals
+  #                 and years, English and French
   #
-  # A stage can carry a condition, which is what makes an expensive one
-  # affordable — it is skipped on the transcripts that do not need it:
+  # Per language, which wins over `default`: fr: [replacements, numbers]
+  #
+  # A prompt can be a stage, and any stage can carry a condition — on the text
+  # with `when:` / `unless:`, or on the app you dictated into:
   #
   #   - stage: numbers
-  #     when: /\b(vingt|cent|mille)\b/     # only if a number word is left
-  #   - stage: fuzzy
-  #     unless: /```/                      # never inside a code fence
+  #     app: /term|ghostty/          # only in a terminal
+  #   - prompt: prose
+  #     app: /^(?!.*term)/           # everywhere but; no not_app, the negation
+  #                                  # goes in the pattern
   #
-  # `when` and `unless` read the text as it stands *at that point*, after the
-  # stages above — so a cheap stage can make an expensive one unnecessary
-  # rather than merely earlier. Both may be set; `unless` wins. The pattern is
-  # written like a replacement source: between slashes it is a regular
-  # expression, otherwise a word matched on word boundaries. Case-insensitive
-  # either way. A skipped stage says so in the log, because a stage that
-  # silently does not run looks exactly like one that ran and found nothing.
-  #
-  # A prompt from `prompts:` can be a stage too, which is the reason conditions
-  # exist: it calls the local model, so it costs about a second where every
-  # other stage costs nothing. Measured on one line, 3.2s with the prompt
-  # running against 0.035s with it skipped.
-  #
-  #   - prompt: hesitation
-  #     when: /\b(genre|du coup|en fait)\b/
-  #
-  # It is the only stage that rewrites your words without you asking, and
-  # nothing on screen shows it happened — so every rewrite is written to the
-  # log with the text before and after. If the model is not running, the prompt
-  # does not exist, or the call fails, the transcript comes back exactly as it
-  # arrived; a dictation tool can afford to skip a stage and cannot afford to
-  # lose a sentence.
-  #
-  # Written out in full on purpose. The stages are few enough to read at a
-  # glance, and deleting a line you can see beats discovering a setting you
-  # cannot.
-  #
-  #   replacements  the substitutions below: literal, word-boundary,
-  #                 case-insensitive, or a regex between slashes
-  #   fuzzy         the same table, used to catch renderings you have not
-  #                 taught — "super bays" reaches Supabase. Only words the
-  #                 spell checker does not know are eligible, which is what
-  #                 keeps "Excel" from becoming "Vercel". It needs
-  #                 `replacements` before it and says so if it does not have
-  #                 one, because on its own it swallows the preceding word.
-  #   numbers       spoken numbers as digits: "two hundred forty-three" -> 243,
-  #                 plus ordinals, decimals, years and spoken digits. English
-  #                 and French, septante/huitante/nonante included, chosen per
-  #                 transcript. A number word on its own stays a word below
-  #                 ten, so "chapter three" and "on est deux" are left alone.
-  #                 It does rewrite transcripts that were already correct — run
-  #                 --numbers on a line to see exactly what it would do.
-  #
-  # Per language, when they should differ:
-  #
-  #   pipelines:
-  #     default: [replacements, fuzzy]
-  #     fr: [replacements, fuzzy, numbers]
+  # See docs/pipelines.md.
   pipelines:
     default: [replacements, fuzzy, numbers]
 
-
-  # How names get fixed: literal, word-boundary, case-insensitive swaps on
-  # the finished transcript.
+  # The spelling you want, and the ways it comes out wrong. Whole words,
+  # case-insensitive. A source in /slashes/ is a regular expression, and an
+  # empty target deletes rather than substitutes — which is how filler words
+  # go, punctuation and spacing included.
   #
   # Workflow: dictate, run --transcribe on the clip, map whatever the model
   # wrote to what you meant.
   replacements:
-    # Removed from every transcript. A source in /slashes/ is a regular
-    # expression; an empty target means delete. The pattern takes any comma
-    # and spacing with it, so nothing is left behind.
     "": ['/[,]?\s*\b(?:mm[-‑]?hmm|uh[-‑]?huh|mhm|u+m+|u+h+|erm+|hmm+|mm+)\b[,]?/']
     Tasmeen: [Tasmid, Tasmin, Tasmine]
     Supabase: [super base, superbees]
 
-# A local Ollama model, used to interpret what you say after the wake phrase.
-# Everything else works without it — you just lose free-form spoken commands.
+# The local Ollama model behind spoken commands. Without it dictation still
+# works and everything under `prompts:` stops.
 llm:
   enabled: true
   model: gemma4:e4b
   endpoint: http://localhost:11434
-  timeout_seconds: 20
-  # Load the model at launch and keep it there. Ollama otherwise drops it
-  # after five minutes, and reloading costs 7-10s on the next correction.
-  # Turn off to get those seconds back as free RAM.
+  # Pin the model in RAM at launch. Ollama otherwise drops it after five
+  # minutes and the next command waits 7-10s for the reload. Turn off to get
+  # those seconds back as free RAM.
   keep_loaded: true
 
-# Things you can ask for by voice: say the wake phrase, then the instruction.
+# What the activation phrase can reach: say it, then the instruction.
 #
 #     "hey parrot, make that a bullet list"
 #
-# A router picks which one you meant, reading the descriptions below — so a
-# description is not a comment, it is the thing being matched against. Write it
-# the way you would say it.
+# A description is not a comment — it is what the router matches your words
+# against, so write it the way you would say it. The whole instruction then
+# reaches the prompt, which is why one entry covers "format those dates ISO"
+# and "format those dates with slashes".
 #
-# The whole instruction is then passed to the prompt, not just the part that
-# chose it. That is what lets one prompt serve "format those dates ISO" and
-# "format those dates with slashes" without needing two entries.
+# Results are shown before they replace your selection; add `confirm: false`
+# to a prompt you have come to trust.
 #
 # Fixing a misheard name is built in and does not appear here — run
-# --check-config to see everything the wake phrase reaches.
+# --check-config to see everything the phrase reaches.
 prompts:
   - name: bullets
     description: turn text into a short bullet list
@@ -143,19 +96,6 @@ prompts:
     content: |
       Cut this down. No filler, same facts, same voice.
       Return only the shortened text.
-
-  # There used to be a `dates` prompt and a `digits` prompt here. Both are gone,
-  # because free_form does their job and the measurement said so: on the sixteen
-  # cases they covered in tests/generic-cases.yaml they scored 12/16 against the
-  # built-in's 14/16. `digits` was a straight tie, five cases to five. `dates`
-  # was worse — asked to make "the deadline is March 3 2026" ISO it answered
-  # "2026-03-03", dropping the sentence around the date, which is what a prompt
-  # written for one subject does when handed a whole sentence.
-  #
-  # `grammar` below stays for the opposite reason. It has a validation set of
-  # its own and it beats the built-in on it, 5/5 against 4/5, and the case it
-  # wins is the one that matters most here: leaving alone a sentence that was
-  # already right.
 
   - name: grammar
     description: fix grammar and punctuation mistakes, not formatting or numbers
@@ -181,30 +121,12 @@ prompts:
 
       Return only the text.
 
-  # Show the result before it replaces anything. On by default — a transform
-  # overwrites text you selected, and it is triggered by voice, so there is no
-  # dialog in the way. Set false per prompt once you trust it.
-  #
-  #   confirm: false
-
-# Do what was asked even when nothing above matches.
+# Do what was asked even when no prompt above matches:
 #
 #     "hey parrot, use the 24 hour clock"
-#     "hey parrot, make sure fifty dollars is formatted as money"
 #     "hey parrot, sort that list alphabetically"
 #
-# No prompt covers those and no list ever would, so the whole instruction goes
-# to a built-in transform instead. It is the difference between a fixed menu and
-# saying what you want.
-#
-# What it costs, stated plainly. The router now answers three ways instead of
-# two: a prompt name, ANY for "an edit nothing above handles", or NONE for "that
-# was not an edit at all". NONE is what keeps a passing remark — "what is the
-# weather tomorrow", said with text selected — away from a prompt whose one job
-# is to rewrite your selection. Measured at 18/19; the miss was a prompt name
-# used as an ordinary noun. The transform itself scores 32/38 on
-# tests/generic-cases.yaml, against 11/38 for changing nothing at all, and
-# `confirm` shows you the result before it lands.
-#
-# Turn it off and an instruction nothing matches is refused, as it was before.
+# A remark that was never an instruction is still refused, and you see every
+# result before it replaces anything. Turn off to go back to a fixed menu of
+# prompts.
 free_form: true

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -1,0 +1,165 @@
+# Pipelines
+
+Everything a finished transcript goes through, in order, per language:
+
+```yaml
+transcription:
+  pipelines:
+    default: [replacements, fuzzy, numbers]
+    fr: [replacements, fuzzy, numbers]
+```
+
+A language's own list wins over `default`. A key that is neither `default` nor
+one of your `languages:` is reported by `--check-config` rather than silently
+never running.
+
+Being in a pipeline is the only way a stage runs, which is why a new install is
+written with all of them spelled out: turning one off means deleting a line you
+can see, not finding a setting you cannot. Delete `pipelines:` entirely and you
+get every stage back — a missing section is silence, not a choice. Write
+`default: []` and you get none, which is a choice.
+
+## The stages
+
+| Stage | What it does |
+|---|---|
+| `replacements` | The substitutions in `replacements:` — literal, word-boundary, case-insensitive, or a regex between slashes. |
+| `fuzzy` | The same table against renderings you have not taught, so "super bays" reaches Supabase. Only words the spell checker does not know are eligible, which is what keeps "Excel" from becoming "Vercel". Needs `replacements` before it and says so if it does not have one, because on its own it swallows the preceding word. |
+| `numbers` | Spoken numbers as digits: "two hundred forty-three" → 243, plus ordinals, decimals, years and spoken digits. English and French, septante/huitante/nonante included, chosen per transcript. A number word on its own stays a word below ten, so "chapter three" and "on est deux" are left alone. |
+
+`numbers` rewrites transcripts that were already correct, so run `--numbers` on
+a line to see exactly what it would do before leaving it in.
+
+## Conditions
+
+A stage can carry a condition, which is what makes an expensive one affordable
+— it is skipped on the transcripts that do not need it:
+
+```yaml
+pipelines:
+  fr:
+    - replacements
+    - stage: fuzzy
+      unless: /```/                      # never inside a code fence
+    - stage: numbers
+      when: /\b(vingt|cent|mille)\b/     # only if a number word is left
+```
+
+`when` and `unless` read the text *as it stands at that point*, after the
+stages above — so a cheap stage can make an expensive one unnecessary rather
+than merely earlier. Both may be set and `unless` wins, because a reason not to
+run is a stronger statement than a reason to.
+
+The pattern is written like a replacement source: between slashes it is a
+regular expression, otherwise a word matched on word boundaries.
+Case-insensitive either way.
+
+A skipped stage says so in the log. A stage that silently does not run looks
+exactly like one that ran and found nothing, and only one of those is
+answerable by editing a condition.
+
+## Apps
+
+`app:` runs a stage only where you want it — the rewrite that belongs in a
+terminal and nowhere near an email:
+
+```yaml
+pipelines:
+  default:
+    - replacements
+    - stage: numbers
+      app: /term|ghostty|iterm|warp/
+    - prompt: prose
+      app: /^(?!.*(term|ghostty|iterm|warp))/
+```
+
+**There is no `not_app:`.** The pattern is a regular expression like every
+other one here, so exclusion is a negative lookahead. One key covers both
+directions, at the cost of the anchor in `/^(?!.*…)/` — and forgetting it is
+not a silent failure: `--check-config` and `--pipeline` both refuse an
+unanchored lookahead, because unanchored it matches one character into the very
+name it was meant to exclude, and the stage would run everywhere.
+
+**The app is the one that was in front when the hotkey went down**, not when
+the transcript came back. Between the two there is a transcription and possibly
+a model call, and the window you dictated into is not reliably still in front.
+
+**Name and bundle identifier are matched as one string** — `Ghostty
+com.mitchellh.ghostty` — so a pattern can name either. Match on the identifier
+when you want the rule to survive someone renaming an app, on the name when you
+want to read it back in six months. It is one string rather than two on
+purpose: `/^(?!.*microsoft)/` matches `Code` while failing
+`com.microsoft.VSCode`, and "either one matched" would run the stage in the app
+it was written to exclude.
+
+**No app means the stage does not run.** On a path with no window to read, a
+positive `app:` fails closed — running anyway would put a terminal-only stage
+everywhere else, which is the one outcome the condition existed to prevent. The
+log says which it was.
+
+To try one without speaking into the right window:
+
+```sh
+ParrotFlow --pipeline tests/pipelines/apps.yaml "on en a vingt et un" --app Ghostty
+```
+
+An empty `--app ""` means "nothing in front" rather than "no flag given" — the
+two are the same question, and saying so lets a caller pass the flag
+unconditionally. `scripts/check-pipeline.sh` relies on it.
+
+### What app conditions do not do
+
+**They do not need Accessibility.** The app is read from `NSWorkspace`, not off
+the focused element, so gating a stage by app costs no permission that gating
+it by text does not.
+
+**They only apply to dictation.** The pipeline runs on a transcript on its way
+into a window. A voice command — anything after the activation phrase — is
+routed and transformed on a different path that never assembles a pipeline, so
+an `app:` there gates nothing. `--replace` likewise passes no app, which means
+an app-conditioned stage never runs under it; that is the fail-closed rule
+doing its job on a path with no window, not a bug to work around.
+
+**Negation reads differently for text and for apps.** `unless:` excludes on
+text; an app is excluded with a negative lookahead inside `app:`. Two idioms
+for one idea, and the reason is that an app pattern is matched against one
+joined string where a lookahead is exact, while a second key would have been a
+second thing to learn for a case the pattern already covers. Worth knowing
+before you go looking for `not_app:` — it is not there and will not be.
+
+**A stage is gated, not parameterised.** `app:` decides whether a stage runs.
+It cannot hand the stage a different table or a different prompt per app; two
+behaviours mean two steps, each with its own condition.
+
+## Prompt stages
+
+A prompt from `prompts:` can be a stage too, and it is the reason conditions
+exist: it calls the local model, so it costs about a second where every other
+stage costs nothing. Measured on one line, 3.2s with the prompt running against
+0.035s with it skipped.
+
+```yaml
+- prompt: hesitation
+  when: /\b(genre|du coup|en fait)\b/
+```
+
+It is the only stage that rewrites your words without you asking, and nothing
+on screen shows it happened — so every rewrite is written to the log with the
+text before and after.
+
+If the model is not running, the prompt does not exist, or the call fails, the
+transcript comes back exactly as it arrived. A dictation tool can afford to
+skip a stage and cannot afford to lose a sentence.
+
+## Why there is no `dates` or `digits` prompt
+
+There used to be both, and `free_form` does their job. On the sixteen cases
+they covered in `tests/generic-cases.yaml` they scored 12/16 against the
+built-in's 14/16. `digits` was a straight tie, five cases to five. `dates` was
+worse — asked to make "the deadline is March 3 2026" ISO it answered
+"2026-03-03", dropping the sentence around the date, which is what a prompt
+written for one subject does when handed a whole sentence.
+
+`grammar` ships for the opposite reason. It has a validation set of its own and
+beats the built-in on it, 5/5 against 4/5, and the case it wins is the one that
+matters most here: leaving alone a sentence that was already right.

--- a/scripts/check-pipeline.sh
+++ b/scripts/check-pipeline.sh
@@ -19,10 +19,14 @@ BIN="$ROOT/.build/release/ParrotFlow"
 
 pass=0; total=0; failed=""
 
-while IFS='|' read -r name fixture input expect; do
+while IFS='|' read -r name fixture app input expect; do
   [ -z "$name" ] && continue
   total=$((total + 1))
   [ "$expect" = "unchanged" ] && want="$input" || want="$expect"
+
+  # An `app:` case says who was in front. Passed unconditionally: an empty
+  # --app is "nothing in front", which is itself a case — an app-conditioned
+  # stage has to fail closed — and it avoids an empty array under `set -u`.
 
   path="$ROOT/tests/pipelines/$fixture.yaml"
   if [ ! -f "$path" ]; then
@@ -32,7 +36,7 @@ while IFS='|' read -r name fixture input expect; do
     continue
   fi
 
-  got="$("$BIN" --pipeline "$path" "$input" --quiet 2>/dev/null | tail -1)"
+  got="$("$BIN" --pipeline "$path" "$input" --app "$app" --quiet 2>/dev/null | tail -1)"
 
   if [ "$got" = "$want" ]; then
     pass=$((pass + 1))
@@ -42,12 +46,12 @@ while IFS='|' read -r name fixture input expect; do
       $name"
     printf '  ✗ %s  [%s]\n      in    %s\n      got   %s\n      want  %s\n' \
       "$name" "$fixture" "$input" "$got" "$want"
-    "$BIN" --pipeline "$path" "$input" 2>/dev/null | sed 's/^/        /'
+    "$BIN" --pipeline "$path" "$input" --app "$app" 2>/dev/null | sed 's/^/        /'
   fi
 done < <(python3 -c '
 import sys, yaml
 for c in yaml.safe_load(open(sys.argv[1]))["cases"]:
-    print("|".join(str(c[k]) for k in ("name", "pipeline", "input", "expect")))
+    print("|".join(str(c.get(k, "")) for k in ("name", "pipeline", "app", "input", "expect")))
 ' "$ROOT/tests/pipeline-cases.yaml")
 
 echo

--- a/tests/pipeline-cases.yaml
+++ b/tests/pipeline-cases.yaml
@@ -63,6 +63,54 @@ cases:
     input: on en a genre vingt et un
     expect: On en a vingt et un
 
+  # --- app conditions -----------------------------------------------------
+  # `app:` is matched against the name and bundle identifier joined into one
+  # string, and the app is the one that was in front when the hotkey went down.
+  # `--app` is how a case gets to say who that was; without it there is no app
+  # at all, which is its own case below.
+  - name: the app matches, so the stage runs
+    pipeline: apps
+    app: Ghostty
+    input: on en a vingt et un
+    expect: on en a 21
+
+  - name: another app, so the stage is skipped
+    pipeline: apps
+    app: TextEdit
+    input: on en a vingt et un
+    expect: unchanged
+
+  # The identifier is half the haystack, so a pattern can name an app by the
+  # thing that does not change when someone renames the binary.
+  - name: the bundle identifier is matched too
+    pipeline: apps
+    app: com.mitchellh.ghostty
+    input: on en a vingt et un
+    expect: on en a 21
+
+  # Fails closed. No Accessibility, no window, a path that never had an app —
+  # running anyway would put a terminal-only stage everywhere else, which is
+  # the opposite of what asking for `app:` means.
+  - name: no app at all, so an app-conditioned stage does not run
+    pipeline: apps
+    input: on en a vingt et un
+    expect: unchanged
+
+  # --- exclusion, with no not_app --------------------------------------
+  # The negative lookahead is the whole reason `not_app:` does not exist. These
+  # two are what says it works in both directions.
+  - name: a negative lookahead keeps the stage out of a terminal
+    pipeline: apps-excluded
+    app: Ghostty
+    input: on en a vingt et un
+    expect: unchanged
+
+  - name: and lets it run everywhere else
+    pipeline: apps-excluded
+    app: TextEdit
+    input: on en a vingt et un
+    expect: on en a 21
+
   # --- an empty pipeline is a choice --------------------------------------
   - name: nothing listed, so nothing runs
     pipeline: empty

--- a/tests/pipelines/apps-excluded.yaml
+++ b/tests/pipelines/apps-excluded.yaml
@@ -1,0 +1,14 @@
+# The other direction: everywhere *except* a terminal, written as a negative
+# lookahead because there is no `not_app:`.
+#
+# The anchor is the point. Unanchored, `/(?!.*term)/` succeeds one character
+# into "Terminal" and the stage runs in the app it was written to avoid —
+# `Pipeline.validate` refuses that shape, and this fixture is what proves the
+# anchored one actually excludes.
+languages: [en, fr]
+replacements:
+  Supabase: [super base]
+pipeline:
+  - replacements
+  - stage: numbers
+    app: /^(?!.*(term|ghostty|iterm))/

--- a/tests/pipelines/apps.yaml
+++ b/tests/pipelines/apps.yaml
@@ -1,0 +1,15 @@
+# App conditions, on a stage cheap enough to score deterministically. What is
+# tested is that `app:` decides, not what the stage does — `numbers` stands in
+# for whatever you would really scope to a terminal.
+#
+# Both directions from one key: inclusion is a plain pattern, exclusion is a
+# negative lookahead. There is no `not_app:`, so the second one is the whole
+# case for that decision — if a lookahead cannot express exclusion here, the
+# key was needed after all.
+languages: [en, fr]
+replacements:
+  Supabase: [super base]
+pipeline:
+  - replacements
+  - stage: numbers
+    app: /term|ghostty|iterm/


### PR DESCRIPTION
Two changes that both land on the config surface, so they travel together.

## The default config, trimmed

The template was 230 lines and about half was prose — measurements, history,
design justification. That is project documentation living in every user's
config file.

Dropped from what a new install is written with, still read if written by hand:
`transcription.enabled` (off means the app does nothing), `audio.sample_rate`
(its own comment said to leave it alone), `audio.min_duration_seconds`,
`llm.timeout_seconds`. `llm.enabled` stays — turning it off leaves a working
app that dictates, which is a real choice.

Two things the reading turned up:

- The template wrote `correction_phrase`, which is in `LegacyKeys`. Every new
  install started on the deprecated name, under a comment describing only
  spelling correction although it is now the wake phrase for every prompt.
- `rewrite_line` contradicted itself: the struct defaulted to `false` and
  called itself opt-in while both config files wrote `true`. The default now
  follows what was already being written, and the comment says why.

The cut prose is in the new `docs/pipelines.md`.

## `app:` conditions

```yaml
- stage: numbers
  app: /term|ghostty|iterm/
- prompt: prose
  app: /^(?!.*(term|ghostty|iterm))/
```

**No `not_app:`** — the pattern is a regular expression like every other one
here, so exclusion is a negative lookahead. One key instead of two, at the cost
of an anchor people forget. Unanchored it is a lie: patterns are matched with
`firstMatch`, so `/(?!.*term)/` succeeds one character into "Terminal" and the
stage runs everywhere it was written to avoid. `validate` refuses that shape,
`--check-config` and `--pipeline` both report it with the fix, and the rule
fires only on a lookahead at the head of a pattern so `/Term(?!inator)/` is
untouched.

**Name and bundle identifier are matched as one joined string**, not either of
two — which is what makes negation correct. `/^(?!.*microsoft)/` matches "Code"
while failing "com.microsoft.VSCode", and "one of the two matched" would run
the stage in the app it was written to exclude.

**Captured at hotkey-down**, never read at stage time: a transcript arrives
seconds later and the window you dictated into is not reliably still in front.
Read from `NSWorkspace`, not off `focusAtPress`, so an app condition needs no
Accessibility grant that a text condition does not.

**No app means the stage does not run.** Fail-closed — running anyway puts a
terminal-only stage everywhere else.

## Checks

`swift build -c release` clean, no new warnings (132 before and after, all
pre-existing `SendableClosureCaptures`).

| set | result |
|---|---|
| `check-pipeline` | 15/15 — 6 new |
| `check-numbers` | 97/97 |
| `check-replacements` | 20/20 |
| `check-default-config` | ✓ 24 keys, 3 prompts |

The four sets needing Ollama, a screen or a microphone were not run, as CI
does not run them either.

`--pipeline` takes `--app` so any of this is reachable from a validation set
without speaking into the right window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018L6J1Kw7SVxnoCAJ1Gw4WS