### PR TITLE
feat: capture groups, named transforms, and dotted paths by app

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -91,6 +91,12 @@ jobs:
       - name: Pipeline
         run: scripts/check-pipeline.sh
 
+      # Reads its pattern out of Config.defaultYAML, so this is also what keeps
+      # the shipped default honest: the one rewrite that fires on ordinary
+      # language rather than on a name someone taught it.
+      - name: Dotted paths
+        run: scripts/check-dotted.sh
+
       - name: Dates
         run: scripts/check-dates.sh
 

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -72,7 +72,7 @@ enum CheckConfigCommand {
                     ? "nothing — the list is empty"
                     : pipeline.steps.map { step -> String in
                         var described = step.stage.name
-                        if let prompt = step.prompt { described += " \(prompt)" }
+                        if let transform = step.transform { described += " \(transform)" }
                         if let when = step.when { described += " when \(when)" }
                         if let unless = step.unless { described += " unless \(unless)" }
                         if let app = step.app { described += " in \(app)" }
@@ -110,6 +110,21 @@ enum CheckConfigCommand {
             print("      free-form  \(FreeForm.name) — \(FreeForm.prompt.description)")
         } else {
             print("  · free_form         off — an instruction no prompt covers is refused")
+        }
+
+        // A `replace:` transform is not in the catalogue — the router reaches
+        // prompts only, for now — so it would otherwise be invisible here, and
+        // "I wrote it and nothing says it exists" is the wrong way to find out
+        // that it runs from a pipeline and not from your voice.
+        let tables = config.transforms.filter { !$0.isPrompt }
+        if !tables.isEmpty {
+            print("  · replace           \(tables.count) transform(s), reachable from a pipeline"
+                + " and not by voice")
+            for table in tables {
+                let rules = table.rules.count
+                print("      table     \(table.name) — \(rules) rule(s)"
+                    + (table.description.isEmpty ? "" : ", \(table.description)"))
+            }
         }
 
         for prompt in config.prompts where prompt.description.isEmpty {

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -16,13 +16,31 @@ enum ConfigError: LocalizedError {
 ///
 /// The file is written from `Config.defaultYAML` on first launch and re-read
 /// whenever it changes on disk, so iterating on a hotkey is edit-and-save.
-struct Config: Codable, Equatable {
+/// Decodable and not Encodable: nothing has ever written a Config back out —
+/// `defaultYAML` is what a file is created from — and `prompts` is now a view
+/// over `transforms` rather than storage, which there is no honest way to
+/// encode.
+struct Config: Decodable, Equatable {
     var hotkey: Hotkey = Hotkey()
     var audio: Audio = Audio()
     var feedback: Feedback = Feedback()
     var transcription: Transcription = Transcription()
     var llm: LLM = LLM()
-    var prompts: [Prompt] = []
+    /// Everything nameable: `transforms:`, plus anything still written under
+    /// the older `prompts:`.
+    var transforms: [Transform] = []
+
+    /// The prompt-bodied transforms, in order.
+    ///
+    /// Computed rather than stored so there is one list to keep straight. Every
+    /// existing caller — the catalogue, the router, `PromptRunner`, the panels
+    /// — asks for prompts and still gets exactly what it used to; a `replace:`
+    /// transform is simply not one of them.
+    var prompts: [Prompt] { transforms.compactMap(\.asPrompt) }
+
+    func transform(named name: String) -> Transform? {
+        transforms.first { $0.name.caseInsensitiveCompare(name) == .orderedSame }
+    }
 
     /// Do what was asked even when no prompt matches — see `FreeForm`.
     ///
@@ -39,8 +57,151 @@ struct Config: Codable, Equatable {
     var freeForm: Bool = true
 
     enum CodingKeys: String, CodingKey {
-        case hotkey, audio, feedback, transcription, llm, prompts
+        case hotkey, audio, feedback, transcription, llm, transforms, prompts
         case freeForm = "free_form"
+    }
+
+    /// One entry of `transforms:` as it is written, before it is known to be
+    /// valid. `content:` is accepted alongside `prompt:` because that is what
+    /// `prompts:` has always called it, and moving a section should not mean
+    /// renaming a key inside every entry of it.
+    private struct TransformEntry: Decodable {
+        var name = ""
+        var description = ""
+        var confirm = true
+        var body: Transform.Body?
+        /// `prompt:` and `replace:` on the same entry.
+        var namesBoth = false
+
+        enum CodingKeys: String, CodingKey {
+            case name, description, confirm, prompt, content, replace
+        }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            func trimmed(_ key: CodingKeys) throws -> String {
+                (try c.decodeIfPresent(String.self, forKey: key) ?? "")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            name = try trimmed(.name)
+            description = try trimmed(.description)
+            confirm = try c.decodeIfPresent(Bool.self, forKey: .confirm) ?? true
+
+            let instructions = try trimmed(.prompt).isEmpty ? trimmed(.content) : trimmed(.prompt)
+            let table = try c.decodeIfPresent([String: [String]].self, forKey: .replace)
+            namesBoth = !instructions.isEmpty && table != nil
+            if let table {
+                body = .replace(table)
+            } else if !instructions.isEmpty {
+                body = .prompt(instructions)
+            }
+        }
+    }
+
+    /// A `transforms:` section, wherever it is written.
+    ///
+    /// Exposed so a `--pipeline` fixture can carry one and have it read by the
+    /// type that reads the real thing, rather than by a second parser that
+    /// would be free to disagree about what a transform is.
+    static func transforms(from decoder: Decoder) throws -> [Transform] {
+        assembled(try [TransformEntry](from: decoder))
+    }
+
+    /// The entries worth keeping, with a line in the log for each that is not.
+    ///
+    /// An entry with no name, or with no body to run, cannot be routed to or
+    /// run, and dropping it silently is how a typo becomes an evening. Reported
+    /// rather than thrown, so one bad entry does not cost you the rest.
+    private static func assembled(_ entries: [TransformEntry]) -> [Transform] {
+        var kept: [Transform] = []
+        for entry in entries {
+            guard !entry.name.isEmpty else {
+                Log.write("transforms: skipped an entry with no name")
+                continue
+            }
+            if entry.namesBoth {
+                // Preferring one would run something the config did not ask
+                // for, on text nobody sees beforehand.
+                Log.write("transforms: \"\(entry.name)\" names both `prompt:` and `replace:`; skipped")
+                continue
+            }
+            guard let body = entry.body else {
+                Log.write("transforms: \"\(entry.name)\" has neither `prompt:` nor `replace:`; skipped")
+                continue
+            }
+            guard !kept.contains(where: {
+                $0.name.caseInsensitiveCompare(entry.name) == .orderedSame
+            }) else {
+                // First wins, which puts `transforms:` ahead of the older
+                // `prompts:` — a config carrying both has moved an entry and
+                // not yet deleted the old one.
+                Log.write("transforms: \"\(entry.name)\" is defined twice; kept the first")
+                continue
+            }
+            if entry.description.isEmpty {
+                Log.write("transforms: \"\(entry.name)\" has no description; the router cannot pick it")
+            }
+            kept.append(Transform(
+                name: entry.name, description: entry.description,
+                confirm: entry.confirm, body: body
+            ))
+        }
+        return kept
+    }
+
+    /// A named thing that takes text and gives text back.
+    ///
+    /// Two bodies, because the two ways to rewrite a transcript have nothing in
+    /// common but their shape. A `prompt:` asks the local model, costs about a
+    /// second and can do what no table expresses. A `replace:` is a
+    /// substitution table of its own, costs nothing, and is exact.
+    ///
+    /// They live in one list because everything downstream wants them in one
+    /// list: a pipeline step names either with `transform:`, and the voice
+    /// router reads the same `description` off both. Two sections would have
+    /// meant two namespaces for one question — "what can this app do to my
+    /// text" — and a pipeline key per kind.
+    ///
+    /// `replace:` exists because `transcription.replacements` is a single table
+    /// applied by a single stage: it cannot be two tables running in two places
+    /// under two conditions. Wanting "user dot name" to become `user.name` in a
+    /// terminal and `` `user.name` `` in chat is what a named table is for.
+    struct Transform: Equatable {
+        var name: String
+        var description: String
+        /// Show the result and wait before replacing anything. Only consulted
+        /// when a transform is run over your selection — a pipeline stage runs
+        /// on a transcript nobody has seen yet, so there is nothing to confirm.
+        var confirm: Bool = true
+        var body: Body
+
+        enum Body: Equatable {
+            /// Instructions for the local model.
+            case prompt(String)
+            /// A table of its own, in the shape of `transcription.replacements`
+            /// — the spelling you want, and the ways it comes out wrong.
+            case replace([String: [String]])
+        }
+
+        var isPrompt: Bool {
+            if case .prompt = body { return true }
+            return false
+        }
+
+        /// The prompt-shaped view of this transform, for everything that
+        /// already speaks `Prompt` — the router, `PromptRunner`, the panels.
+        var asPrompt: Prompt? {
+            guard case .prompt(let content) = body else { return nil }
+            return Prompt(
+                name: name, description: description, content: content, confirm: confirm
+            )
+        }
+
+        /// The rules a `replace:` body applies, flattened.
+        var rules: [Transcription.Rule] {
+            guard case .replace(let table) = body else { return [] }
+            return Transcription.rules(from: table)
+        }
     }
 
     /// An instruction you can reach by voice: "hey parrot, make that a list".
@@ -215,8 +376,12 @@ struct Config: Codable, Equatable {
         var contradictoryEntries: [String] = []
 
         /// One rule per mishearing, flattened for the substitution pass.
-        var rules: [Rule] {
-            replacements.flatMap { target, sources in
+        var rules: [Rule] { Self.rules(from: replacements) }
+
+        /// Shared with `Transform.replace`, which is the same table in another
+        /// place — one flattening, so the two cannot drift.
+        static func rules(from table: [String: [String]]) -> [Rule] {
+            table.flatMap { target, sources in
                 sources.map { Rule(source: $0, replacement: target) }
             }
         }
@@ -235,22 +400,26 @@ struct Config: Codable, Equatable {
         ///     - prompt: hesitation
         ///       when: /genre/
         ///
-        /// A prompt names itself with `prompt:` rather than `stage: prompt`
-        /// plus a second key, because every prompt stage would need both and a
-        /// form that repeats itself is a form people mistype.
+        /// A transform names itself with `transform:` rather than
+        /// `stage: transform` plus a second key, because every one of them
+        /// would need both and a form that repeats itself is a form people
+        /// mistype. `prompt:` is the older spelling of the same thing and still
+        /// reads, since a prompt is a transform with a prompt body.
         ///
         /// The short form is the one almost every line wants, and a format that
         /// makes the common case verbose is a format people work around.
         struct PipelineEntry: Decodable {
             let name: String
-            var prompt: String?
+            var transform: String?
             var when: String?
             var unless: String?
             var app: String?
-            /// `stage:` and `prompt:` on the same entry.
+            /// `stage:` and `transform:`/`prompt:` on the same entry.
             var namesBoth = false
 
-            private enum CodingKeys: String, CodingKey { case stage, prompt, when, unless, app }
+            private enum CodingKeys: String, CodingKey {
+                case stage, transform, prompt, when, unless, app
+            }
 
             init(from decoder: Decoder) throws {
                 if let bare = try? decoder.singleValueContainer().decode(String.self) {
@@ -259,9 +428,11 @@ struct Config: Codable, Equatable {
                 }
                 let c = try decoder.container(keyedBy: CodingKeys.self)
                 let stage = try c.decodeIfPresent(String.self, forKey: .stage)
-                if let named = try c.decodeIfPresent(String.self, forKey: .prompt) {
-                    name = "prompt"
-                    prompt = named
+                let named = try c.decodeIfPresent(String.self, forKey: .transform)
+                    ?? c.decodeIfPresent(String.self, forKey: .prompt)
+                if let named {
+                    name = "transform"
+                    transform = named
                     // Both keys on one entry is a contradiction, not a
                     // preference to resolve — recorded so the caller refuses it
                     // rather than dropping whichever it liked less.
@@ -388,11 +559,11 @@ struct Config: Codable, Equatable {
                             if entry.namesBoth {
                                 // Silently preferring one would delete a stage
                                 // the config asked for.
-                                contradictoryEntries.append(entry.prompt ?? "prompt")
+                                contradictoryEntries.append(entry.transform ?? "transform")
                                 return nil
                             }
                             return Pipeline.Step(
-                                stage: stage, prompt: entry.prompt,
+                                stage: stage, transform: entry.transform,
                                 when: entry.when, unless: entry.unless, app: entry.app
                             )
                         }
@@ -552,21 +723,13 @@ struct Config: Codable, Equatable {
             self.transcription = transcription
         }
         if let llm = try c.decodeIfPresent(LLM.self, forKey: .llm) { self.llm = llm }
-        if let prompts = try c.decodeIfPresent([Prompt].self, forKey: .prompts) {
-            // A prompt missing a name or content cannot be routed to or run, and
-            // dropping it silently is how a typo becomes an evening. Named here
-            // rather than thrown, so one bad entry doesn't cost you the others.
-            self.prompts = prompts.filter { prompt in
-                guard !prompt.name.isEmpty, !prompt.content.isEmpty else {
-                    Log.write("prompts: skipped an entry missing a name or content")
-                    return false
-                }
-                if prompt.description.isEmpty {
-                    Log.write("prompts: \"\(prompt.name)\" has no description; the router cannot pick it")
-                }
-                return true
-            }
-        }
+        // `transforms:` first, then anything still under `prompts:`. Both are
+        // read: `prompts:` is what every config written before this existed
+        // says, and a rename that silently empties the section is the one
+        // outcome a rename must not have.
+        var entries = try c.decodeIfPresent([TransformEntry].self, forKey: .transforms) ?? []
+        entries += try c.decodeIfPresent([TransformEntry].self, forKey: .prompts) ?? []
+        transforms = Self.assembled(entries)
         if let freeForm = try c.decodeIfPresent(Bool.self, forKey: .freeForm) {
             self.freeForm = freeForm
         }
@@ -583,15 +746,19 @@ struct Config: Codable, Equatable {
     /// What is wrong with the replacement table alone.
     ///
     /// Split out of `problems()` so a pipeline fixture can be checked against
-    /// it without dragging in the rest: `--pipeline` fixtures name prompts that
-    /// deliberately do not exist, and "no prompt named" is a case those sets
-    /// test rather than a complaint they want raised.
+    /// it without dragging in the rest: `--pipeline` fixtures name transforms
+    /// that deliberately do not exist, and "no transform named" is a case those
+    /// sets test rather than a complaint they want raised.
+    ///
+    /// Covers every table there is, `transcription.replacements` and each
+    /// `replace:` transform, because a template is wrong in the same way
+    /// wherever it is written.
     func replacementProblems() -> [String] {
         var found: [String] = []
         // A template referring to a group the pattern never captures is
         // written as nothing at all — the rule fires, the output is quietly
         // short, and the log shows a substitution that looks like it worked.
-        for rule in transcription.rules {
+        for rule in transcription.rules + transforms.flatMap(\.rules) {
             let referenced = Set(rule.referencedGroups).sorted()
             guard !referenced.isEmpty,
                   let expression = try? NSRegularExpression(pattern: rule.pattern)
@@ -628,10 +795,13 @@ struct Config: Codable, Equatable {
             for problem in pipeline.validate() {
                 found.append("pipeline \(language): \(problem)")
             }
-            for step in pipeline.steps where step.stage == .prompt {
-                guard let name = step.prompt, !name.isEmpty else { continue }
-                let known = prompts.contains { $0.name.caseInsensitiveCompare(name) == .orderedSame }
-                if !known { found.append("pipeline \(language): no prompt named \"\(name)\"") }
+            for step in pipeline.steps where step.stage == .transform {
+                guard let name = step.transform, !name.isEmpty else { continue }
+                if transform(named: name) == nil {
+                    found.append("pipeline \(language): no transform named \"\(name)\""
+                        + (transforms.isEmpty ? " — `transforms:` is empty"
+                            : " — have: \(transforms.map(\.name).joined(separator: ", "))"))
+                }
             }
         }
         return found
@@ -778,7 +948,7 @@ enum ConfigStore {
 
 
     # The local Ollama model behind spoken commands. Without it dictation still
-    # works and everything under `prompts:` stops.
+    # works and every `prompt:` transform below stops.
     llm:
       enabled: true
       model: gemma4:e4b
@@ -788,7 +958,7 @@ enum ConfigStore {
       # get those seconds back as free RAM.
       keep_loaded: true
 
-    # What the activation phrase can reach: say it, then the instruction.
+    # What the activation phrase can reach, and what a pipeline can name.
     #
     #     "hey parrot, make that a bullet list"
     #
@@ -797,27 +967,41 @@ enum ConfigStore {
     # reaches the prompt, which is why one entry covers "format those dates
     # ISO" and "format those dates with slashes".
     #
+    # An entry has either `prompt:`, which asks the local model and costs about
+    # a second, or `replace:`, a substitution table of its own that costs
+    # nothing:
+    #
+    #   - name: dotted
+    #     description: spoken dotted paths as code
+    #     replace:
+    #       $1.$2: ['/\\b(\\w+) (?:dot|point) (\\w+)\\b/']
+    #
+    # A table is not reached by voice — it runs from a pipeline, which is where
+    # it can be scoped to one app. Two tables with the same pattern and
+    # different output are how "user dot name" becomes user.name in a terminal
+    # and `user.name` in chat. See docs/pipelines.md.
+    #
     # Results are shown before they replace your selection; add
-    # `confirm: false` to a prompt you have come to trust.
+    # `confirm: false` to one you have come to trust.
     #
     # Fixing a misheard name is built in and does not appear here — run
     # --check-config to see everything the phrase reaches.
-    prompts:
+    transforms:
       - name: bullets
         description: turn text into a short bullet list
-        content: |
+        prompt: |
           Rewrite the text as concise bullets, one idea each.
           Keep the speaker's wording. Return only the bullets.
 
       - name: terse
         description: shorten text without losing anything it says
-        content: |
+        prompt: |
           Cut this down. No filler, same facts, same voice.
           Return only the shortened text.
 
       - name: grammar
         description: fix grammar and punctuation mistakes, not formatting or numbers
-        content: |
+        prompt: |
           Correct grammar, spelling and punctuation. Make the smallest change
           that makes the text correct — and make it. Every error is fixed.
           Nothing else is touched.

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1034,24 +1034,34 @@ enum ConfigStore {
 
           Return only the text.
 
-      # The two tables the pipeline above names. Same pattern, different
-      # output: that is the whole reason a table has a name.
+      # The two tables the pipeline above names. Same pattern, different output:
+      # that is the whole reason a table has a name.
       #
-      # `dot` only, not `point`. "point" is an ordinary French word and this
-      # pattern joins whatever surrounds it — "voilà le point sur les tests"
-      # becomes "voilà le.sur les tests". Add it if you never dictate French
-      # into a terminal:
+      # The pattern reads "a word, then dot or point, then a word" — and then
+      # refuses it when either side is a word code does not use there. Without
+      # that, "voilà le point sur les tests" becomes "voilà le.sur les tests":
+      # "point" is an everyday French word and "dot com" is an English one. The
+      # first list is what may not come before, the second what may not come
+      # after — determiners, prepositions, and the heads of set phrases like
+      # "point final" or "dot product".
       #
-      #   ['/\\b(\\w+) (?:dot|point) (\\w+)\\b/']
+      # 45/45 on tests/dotted-cases.txt, plus two it cannot do: two ordinary
+      # words either side ("réunion point hebdomadaire") is a shape only a
+      # dictionary would tell from code. Both are unlikely in a terminal or a
+      # chat window, which is the only reason this is on by default. Score it
+      # with scripts/check-dotted.sh — it reads the pattern from this file.
+      #
+      # The second word is matched but not consumed, so a chain still works:
+      # "user point profile point name" -> user.profile.name.
       - name: dotted
         description: spoken dotted paths as code
         replace:
-          $1.$2: ['/\\b(\\w+) dot (\\w+)\\b/']
+          '$1.': ['/\\b(?!(?:le|la|les|l|un|une|des|du|de|d|ce|cet|cette|ces|mon|ma|mes|ton|ta|tes|son|sa|ses|notre|nos|votre|vos|leur|leurs|au|aux|à|quel|quelle|chaque|autre|même|premier|première|deuxième|dernier|dernière|seul|seule|bon|bonne|mauvais|certain|tel|telle|quelque|the|a|an)\\b)(\\w+) (?:dot|point) (?!(?:de|du|des|d|le|la|les|l|un|une|sur|dans|en|et|ou|que|qui|où|à|au|aux|pour|par|avec|sans|est|sont|était|sera|me|te|se|ne|n|c|il|elle|je|tu|nous|vous|ils|elles|ce|plus|moins|très|mais|donc|car|si|comme|final|finale|barre|virgule|commun|commune|faible|faibles|fort|forts|mort|culminant|névralgique|chaud|sensible|positif|négatif|clé|focal|nommé|com|net|org|matrix|product|notation|plot)\\b)(?=\\w)/']
 
-      - name: dotted-chat
-        description: the same, wrapped for a chat window
+      - name: backticks
+        description: wrap dotted paths in backticks, for chat
         replace:
-          "`$1.$2`": ['/\\b(\\w+) dot (\\w+)\\b/']
+          '`$1`': ['/\\b([A-Za-z_]\\w*(?:\\.[A-Za-z_]\\w*)+)/']
 
     # Do what was asked even when no prompt above matches:
     #

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -928,7 +928,18 @@ enum ConfigStore {
       #
       # See docs/pipelines.md.
       pipelines:
-        default: [replacements, fuzzy, numbers]
+        default:
+          - replacements
+          - fuzzy
+          - numbers
+          # "read user dot name" -> read user.name in a terminal, and
+          # `user.name` in a chat window. Both steps are here and both
+          # conditions are read; at most one matches. Anywhere else — a mail
+          # window, a document — the sentence is left as spoken.
+          - transform: dotted
+            app: /term|ghostty|warp|kitty|alacritty|hyper/
+          - transform: dotted-chat
+            app: /slack|discord/
 
       # The spelling you want, and the ways it comes out wrong. Whole words,
       # case-insensitive. A source in /slashes/ is a regular expression, and an
@@ -1022,6 +1033,25 @@ enum ConfigStore {
           please or thanks does not.
 
           Return only the text.
+
+      # The two tables the pipeline above names. Same pattern, different
+      # output: that is the whole reason a table has a name.
+      #
+      # `dot` only, not `point`. "point" is an ordinary French word and this
+      # pattern joins whatever surrounds it — "voilà le point sur les tests"
+      # becomes "voilà le.sur les tests". Add it if you never dictate French
+      # into a terminal:
+      #
+      #   ['/\\b(\\w+) (?:dot|point) (\\w+)\\b/']
+      - name: dotted
+        description: spoken dotted paths as code
+        replace:
+          $1.$2: ['/\\b(\\w+) dot (\\w+)\\b/']
+
+      - name: dotted-chat
+        description: the same, wrapped for a chat window
+        replace:
+          "`$1.$2`": ['/\\b(\\w+) dot (\\w+)\\b/']
 
     # Do what was asked even when no prompt above matches:
     #

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -294,6 +294,39 @@ struct Config: Codable, Equatable {
                 return String(source.dropFirst().dropLast())
             }
 
+            /// What gets written, as the replacement API wants it.
+            ///
+            /// A literal source keeps a literal target: a name is a word you
+            /// want written exactly, and `$` in one has to survive — escaping
+            /// is what stops "AT&T" or a price from being read as a group
+            /// reference nobody wrote.
+            ///
+            /// A source in slashes has already said it is a pattern, so its
+            /// target is a template and `$1` refers back to what the pattern
+            /// captured. That is the only way to write a rule whose output
+            /// depends on its input:
+            ///
+            ///     $1.$2: ['/(\\w+) dot (\\w+)/']    # "user dot name" -> user.name
+            ///
+            /// Without it a rule can only map a fixed phrase to a fixed one,
+            /// and "spoken dotted path" is not a fixed set.
+            var template: String {
+                isRegex ? replacement : NSRegularExpression.escapedTemplate(for: replacement)
+            }
+
+            /// Groups the template refers to. `$1` and `${1}`, not `\$1`.
+            var referencedGroups: [Int] {
+                guard isRegex else { return [] }
+                let expression = try? NSRegularExpression(
+                    pattern: "(?<!\\\\)\\$\\{?(\\d+)\\}?"
+                )
+                let range = NSRange(replacement.startIndex..., in: replacement)
+                return (expression?.matches(in: replacement, range: range) ?? []).compactMap {
+                    guard let group = Range($0.range(at: 1), in: replacement) else { return nil }
+                    return Int(replacement[group])
+                }
+            }
+
             /// Fuzzy matching compares spellings, so a pattern is not a
             /// candidate and neither is a deletion — there is nothing to match
             /// against.
@@ -547,6 +580,31 @@ struct Config: Codable, Equatable {
     /// app running with `replacements` silently missing looked exactly like an
     /// app whose replacement table was empty. The command prints these; the app
     /// logs them at every load.
+    /// What is wrong with the replacement table alone.
+    ///
+    /// Split out of `problems()` so a pipeline fixture can be checked against
+    /// it without dragging in the rest: `--pipeline` fixtures name prompts that
+    /// deliberately do not exist, and "no prompt named" is a case those sets
+    /// test rather than a complaint they want raised.
+    func replacementProblems() -> [String] {
+        var found: [String] = []
+        // A template referring to a group the pattern never captures is
+        // written as nothing at all — the rule fires, the output is quietly
+        // short, and the log shows a substitution that looks like it worked.
+        for rule in transcription.rules {
+            let referenced = Set(rule.referencedGroups).sorted()
+            guard !referenced.isEmpty,
+                  let expression = try? NSRegularExpression(pattern: rule.pattern)
+            else { continue }
+            for group in referenced where group > expression.numberOfCaptureGroups {
+                found.append("replacements: \"\(rule.source)\" writes $\(group), but the pattern"
+                    + " captures \(expression.numberOfCaptureGroups) group(s)"
+                    + " — $\(group) comes out as nothing")
+            }
+        }
+        return found
+    }
+
     func problems() -> [String] {
         var found: [String] = []
         for key in transcription.retired {
@@ -564,6 +622,7 @@ struct Config: Codable, Equatable {
             found.append("pipelines: \"\(name)\" is not a configured language, so that pipeline never runs"
                 + " — configured: \(transcription.languages.joined(separator: ", "))")
         }
+        found += replacementProblems()
         for language in transcription.languages {
             let pipeline = Pipeline.resolved(config: self, language: language)
             for problem in pipeline.validate() {
@@ -704,10 +763,16 @@ enum ConfigStore {
       # The spelling you want, and the ways it comes out wrong. Whole words,
       # case-insensitive. A source in /slashes/ is a regular expression, and an
       # empty target deletes rather than substitutes — which is how filler
-      # words go.
+      # words go. With a regex source the target is a template, so $1 writes
+      # back what the pattern captured.
       #
       #   Supabase: [super base, superbees]
       #   "": ['/[,]?\\s*\\b(?:u+m+|u+h+|erm+|hmm+)\\b[,]?/']
+      #   $1.$2: ['/\\b(\\w+) dot (\\w+)\\b/']   # "user dot name" -> user.name
+      #
+      # That last one joins any two words either side of "dot", prose included
+      # — a pattern cannot tell your code from your sentence. Put it in a
+      # pipeline behind `app:` if you only mean it in a terminal.
       replacements: {}
 
 

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -932,14 +932,17 @@ enum ConfigStore {
           - replacements
           - fuzzy
           - numbers
-          # "read user dot name" -> read user.name in a terminal, and
-          # `user.name` in a chat window. Both steps are here and both
-          # conditions are read; at most one matches. Anywhere else — a mail
-          # window, a document — the sentence is left as spoken.
+          # "read user dot name" -> read user.name, wherever you write
+          # code-ish text. Anywhere else — a mail window, a document — the
+          # sentence is left exactly as spoken.
+          #
+          # `backticks` below would wrap it for chat, and is deliberately not
+          # in this list. Slack's composer converts markdown as you type it
+          # and never re-reads text that arrives by paste, so the backticks
+          # land in your message as characters. Add the step if your chat app
+          # renders pasted markup.
           - transform: dotted
             app: /term|ghostty|warp|kitty|alacritty|hyper|slack|discord/
-          - transform: backticks
-            app: /slack|discord/
 
       # The spelling you want, and the ways it comes out wrong. Whole words,
       # case-insensitive. A source in /slashes/ is a regular expression, and an

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -937,8 +937,8 @@ enum ConfigStore {
           # conditions are read; at most one matches. Anywhere else — a mail
           # window, a document — the sentence is left as spoken.
           - transform: dotted
-            app: /term|ghostty|warp|kitty|alacritty|hyper/
-          - transform: dotted-chat
+            app: /term|ghostty|warp|kitty|alacritty|hyper|slack|discord/
+          - transform: backticks
             app: /slack|discord/
 
       # The spelling you want, and the ways it comes out wrong. Whole words,

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -38,17 +38,17 @@ struct Pipeline: Equatable, Codable {
         case fuzzy
         /// Spoken numbers as digits, in the language its own pass resolves.
         case numbers
-        /// One of the prompts in `prompts:`, run over the whole transcript.
-        /// The only stage that calls a model, and the only one that names
-        /// something outside itself — see `Step.prompt`.
-        case prompt
+        /// One of the entries in `transforms:`, run over the whole
+        /// transcript. The only stage that names something outside itself, and
+        /// the only one that might call a model — see `Step.transform`.
+        case transform
 
         var name: String { rawValue }
 
-        /// Whether it can be in a default nobody wrote. `prompt` cannot: it
-        /// needs a name, and there is no prompt every install is guaranteed to
-        /// have. Everything else is in the default the moment it exists.
-        var isAutomatic: Bool { self != .prompt }
+        /// Whether it can be in a default nobody wrote. `transform` cannot: it
+        /// needs a name, and there is no transform every install is guaranteed
+        /// to have. Everything else is in the default the moment it exists.
+        var isAutomatic: Bool { self != .transform }
     }
 
     /// The app a transcript is on its way into, for `Step.app`.
@@ -82,10 +82,11 @@ struct Pipeline: Equatable, Codable {
     /// can be skipped on the transcripts that do not need it.
     struct Step: Equatable, Codable {
         let stage: Stage
-        /// Which prompt, for a `prompt` stage. Meaningless on any other, and
-        /// required on that one — a prompt stage with nothing to run is a
-        /// config error rather than a stage that does nothing.
-        var prompt: String?
+        /// Which entry of `transforms:`, for a `transform` stage. Meaningless
+        /// on any other, and required on that one — a transform stage with
+        /// nothing to run is a config error rather than a stage that quietly
+        /// does nothing.
+        var transform: String?
         /// Run only when this matches the text as it stands *at this point* —
         /// after the stages before it, not on the original. That ordering is
         /// what lets a cheap deterministic stage make an expensive one
@@ -199,8 +200,14 @@ struct Pipeline: Equatable, Codable {
     }
 
     /// The stage a config line names, or nil if it names nothing.
+    ///
+    /// "prompt" still resolves, because `- prompt: grammar` is what every
+    /// pipeline written before `transforms:` says and there is no reading of it
+    /// that has become ambiguous — a prompt is a transform with a prompt body.
     static func stage(named name: String) -> Stage? {
-        Stage(rawValue: name.trimmingCharacters(in: .whitespaces).lowercased())
+        let key = name.trimmingCharacters(in: .whitespaces).lowercased()
+        if key == "prompt" { return .transform }
+        return Stage(rawValue: key)
     }
 
     static var stageNames: [String] { Stage.allCases.map(\.rawValue) }
@@ -215,7 +222,7 @@ struct Pipeline: Equatable, Codable {
     /// enough against "Supabase" to swallow the preceding word.
     func validate() -> [String] {
         var problems: [String] = []
-        for step in steps where step.stage == .prompt && (step.prompt ?? "").isEmpty {
+        for step in steps where step.stage == .transform && (step.transform ?? "").isEmpty {
             problems.append("a prompt stage names no prompt — write `- prompt: <name>`")
         }
         for step in steps {
@@ -271,7 +278,7 @@ struct Pipeline: Equatable, Codable {
     static func skipReason(
         for step: Step, text: String, config: Config, allowPrompts: Bool, app: App? = nil
     ) -> String? {
-        if step.stage == .prompt {
+        if step.stage == .transform {
             if !allowPrompts { return "prompts are off on this path" }
             if VoiceCommand.commandAfterWakePhrase(
                 text, phrase: config.transcription.activationPhrase
@@ -312,7 +319,7 @@ struct Pipeline: Equatable, Codable {
                 // Said out loud: a stage that silently does not run is
                 // indistinguishable from one that ran and found nothing, and
                 // only one of those is answerable by editing a condition.
-                let named = step.prompt.map { "\(step.stage.name) \($0)" } ?? step.stage.name
+                let named = step.transform.map { "\(step.stage.name) \($0)" } ?? step.stage.name
                 Log.write("pipeline: skipped \(named) — \(reason)")
                 continue
             }
@@ -338,8 +345,39 @@ struct Pipeline: Equatable, Codable {
             return Replacements.applyFuzzy(to: text, targets: Array(targets))
         case .numbers:
             return Numbers.apply(to: text, languages: config.transcription.languages)
+        case .transform:
+            return await runTransform(step, on: text, config: config)
+        }
+    }
+
+    /// Whichever kind of transform the step named.
+    ///
+    /// A missing one returns the transcript rather than emptying it, same as
+    /// every other way this stage declines — the name may be a typo, and
+    /// `--check-config` is where that gets said.
+    private func runTransform(_ step: Step, on text: String, config: Config) async -> String {
+        guard let name = step.transform else {
+            Log.write("pipeline: a transform stage names no transform; skipped")
+            return text
+        }
+        guard let transform = config.transform(named: name) else {
+            Log.write("pipeline: no transform named \"\(name)\"; skipped")
+            return text
+        }
+        switch transform.body {
         case .prompt:
-            return await runPrompt(step, on: text, config: config)
+            return await runPrompt(step, named: name, on: text, config: config)
+        case .replace:
+            // Exact and free, so there is nothing to guard and nothing to
+            // report beyond what the table did — the log line is the same one
+            // `replacements` writes, with the name that asked for it.
+            let result = Replacements.applyExact(to: text, rules: transform.rules)
+            if result != text {
+                Log.write("pipeline: transform \(name) rewrote the transcript")
+                Log.write("    before: \(text)")
+                Log.write("    after:  \(result)")
+            }
+            return result
         }
     }
 
@@ -351,18 +389,14 @@ struct Pipeline: Equatable, Codable {
     /// quiet — a model rewriting your words is the one stage whose before and
     /// after belong in the log whether or not anything went wrong, because
     /// nothing on screen will ever show you it happened.
-    private func runPrompt(_ step: Step, on text: String, config: Config) async -> String {
-        guard let name = step.prompt else {
-            Log.write("pipeline: a prompt stage names no prompt; skipped")
-            return text
-        }
+    private func runPrompt(
+        _ step: Step, named name: String, on text: String, config: Config
+    ) async -> String {
         guard config.llm.enabled else {
             Log.write("pipeline: skipped prompt \(name) — llm.enabled is false")
             return text
         }
-        guard let prompt = config.prompts.first(where: {
-            $0.name.caseInsensitiveCompare(name) == .orderedSame
-        }) else {
+        guard let prompt = config.transform(named: name)?.asPrompt else {
             Log.write("pipeline: no prompt named \"\(name)\"; skipped")
             return text
         }

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -326,7 +326,15 @@ struct Pipeline: Equatable, Codable {
         case .replacements:
             return Replacements.applyExact(to: text, rules: config.transcription.rules)
         case .fuzzy:
-            let targets = config.transcription.replacements.keys.filter { !$0.isEmpty }
+            // From the rules, not from the table's keys. Fuzzy matching
+            // compares spellings, so a target is only a candidate if it is one
+            // — `$1.$2` is a template, not a word anything could sound like,
+            // and offering it as one puts a string in the list that every
+            // comparison has to lose to. `isFuzzyCandidate` was written for
+            // this and had never been wired to anything.
+            let targets = Set(
+                config.transcription.rules.filter(\.isFuzzyCandidate).map(\.replacement)
+            )
             return Replacements.applyFuzzy(to: text, targets: Array(targets))
         case .numbers:
             return Numbers.apply(to: text, languages: config.transcription.languages)

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -279,7 +279,19 @@ struct Pipeline: Equatable, Codable {
         for step: Step, text: String, config: Config, allowPrompts: Bool, app: App? = nil
     ) -> String? {
         if step.stage == .transform {
-            if !allowPrompts { return "prompts are off on this path" }
+            // Only the prompt-bodied ones. `allowPrompts` is there to keep
+            // `--replace` off the network, and a `replace:` transform is a
+            // table — blocking it would make the flag mean "no transforms",
+            // which is not what any caller asked for.
+            //
+            // A name that resolves to nothing counts as a prompt, which is the
+            // conservative reading: the stage is about to be skipped anyway,
+            // and the one thing this must not do is let an unresolved name
+            // become a way onto the network.
+            let named = step.transform.flatMap { config.transform(named: $0) }
+            if !allowPrompts, named?.isPrompt ?? true {
+                return "prompts are off on this path"
+            }
             if VoiceCommand.commandAfterWakePhrase(
                 text, phrase: config.transcription.activationPhrase
             ) != nil {

--- a/Sources/ParrotFlow/PipelineCommand.swift
+++ b/Sources/ParrotFlow/PipelineCommand.swift
@@ -68,8 +68,13 @@ enum PipelineCommand {
     /// thing here, and saying so lets a caller pass the flag unconditionally.
     /// scripts/check-pipeline.sh does exactly that, because the alternative in
     /// bash 3.2 is an empty array under `set -u`, which is an error.
+    ///
+    /// `--no-prompts` mirrors what `--replace` does, the only other caller that
+    /// turns them off. Without it, "a table still runs when prompts are off" is
+    /// a claim no fixture can make — and it was wrong until something ran it.
     static func run(
-        path: String, text: String?, quiet: Bool = false, app: String? = nil
+        path: String, text: String?, quiet: Bool = false, app: String? = nil,
+        allowPrompts: Bool = true
     ) -> Int32 {
         let named = (app ?? "").trimmingCharacters(in: .whitespaces)
         let front = named.isEmpty ? nil : Pipeline.App(name: named, bundleID: "")
@@ -135,7 +140,9 @@ enum PipelineCommand {
         let done = DispatchSemaphore(value: 0)
         if quiet {
             Task {
-                print(await pipeline.run(text, config: config, app: front))
+                print(await pipeline.run(
+                    text, config: config, allowPrompts: allowPrompts, app: front
+                ))
                 done.signal()
             }
             done.wait()
@@ -151,7 +158,8 @@ enum PipelineCommand {
         var current = text
         for step in steps {
             if let reason = Pipeline.skipReason(
-                for: step, text: current, config: config, allowPrompts: true, app: front
+                for: step, text: current, config: config,
+                allowPrompts: allowPrompts, app: front
             ) {
                 print("  ⊘ \(step.stage.name)  — skipped, \(reason)")
                 continue
@@ -159,7 +167,9 @@ enum PipelineCommand {
             var after = current
             let stepDone = DispatchSemaphore(value: 0)
             Task {
-                after = await Pipeline(steps: [step]).run(current, config: config, app: front)
+                after = await Pipeline(steps: [step]).run(
+                    current, config: config, allowPrompts: allowPrompts, app: front
+                )
                 stepDone.signal()
             }
             stepDone.wait()

--- a/Sources/ParrotFlow/PipelineCommand.swift
+++ b/Sources/ParrotFlow/PipelineCommand.swift
@@ -31,8 +31,13 @@ enum PipelineCommand {
         var languages: [String] = ["en"]
         var replacements: [String: [String]] = [:]
         var pipeline: [Config.Transcription.PipelineEntry] = []
+        /// Its own `transforms:`, decoded by `Config` rather than re-read here,
+        /// so a fixture cannot disagree with a config about what a transform is.
+        var transforms: [Config.Transform] = []
 
-        enum CodingKeys: String, CodingKey { case languages, replacements, pipeline }
+        enum CodingKeys: String, CodingKey {
+            case languages, replacements, pipeline, transforms
+        }
 
         init(from decoder: Decoder) throws {
             let c = try decoder.container(keyedBy: CodingKeys.self)
@@ -43,6 +48,12 @@ enum PipelineCommand {
             pipeline = try c.decodeIfPresent(
                 [Config.Transcription.PipelineEntry].self, forKey: .pipeline
             ) ?? []
+            if c.contains(.transforms) {
+                // Round-tripped through Config's own decoder: the fixture's
+                // section is handed back to the type that reads the real one.
+                let nested = try c.superDecoder(forKey: .transforms)
+                transforms = try Config.transforms(from: nested)
+            }
         }
     }
 
@@ -80,7 +91,7 @@ enum PipelineCommand {
                 return nil
             }
             return Pipeline.Step(
-                stage: stage, prompt: entry.prompt, when: entry.when,
+                stage: stage, transform: entry.transform, when: entry.when,
                 unless: entry.unless, app: entry.app
             )
         }
@@ -94,6 +105,7 @@ enum PipelineCommand {
         config.transcription.languages = fixture.languages
         config.transcription.replacements = fixture.replacements
         config.transcription.pipelines = ["default": pipeline]
+        config.transforms = fixture.transforms
 
         // The fixture's own table is checked too, not just its stage list — a
         // template naming a group the pattern never captures is refused here
@@ -111,7 +123,7 @@ enum PipelineCommand {
             print("languages:  \(fixture.languages.joined(separator: ", "))")
             for step in steps {
                 var line = "  \(step.stage.name)"
-                if let prompt = step.prompt { line += " \(prompt)" }
+                if let transform = step.transform { line += " \(transform)" }
                 if let when = step.when { line += "  when \(when)" }
                 if let unless = step.unless { line += "  unless \(unless)" }
                 if let app = step.app { line += "  app \(app)" }

--- a/Sources/ParrotFlow/PipelineCommand.swift
+++ b/Sources/ParrotFlow/PipelineCommand.swift
@@ -95,7 +95,11 @@ enum PipelineCommand {
         config.transcription.replacements = fixture.replacements
         config.transcription.pipelines = ["default": pipeline]
 
-        var problems = pipeline.validate()
+        // The fixture's own table is checked too, not just its stage list — a
+        // template naming a group the pattern never captures is refused here
+        // for the same reason `--check-config` refuses it, and being reachable
+        // from a fixture is what lets a validation set cover it at all.
+        var problems = pipeline.validate() + config.replacementProblems()
         for problem in problems { print("✗ \(problem)") }
         guard problems.isEmpty else { return 1 }
 

--- a/Sources/ParrotFlow/ReplaceCommand.swift
+++ b/Sources/ParrotFlow/ReplaceCommand.swift
@@ -1,13 +1,23 @@
 import Foundation
 
-/// `--replace "<text>"` — runs the replacement passes over a line and prints
-/// the result. Lets the substitution logic be exercised without dictating.
+/// `--replace "<text>" [--app <name>]` — runs the replacement passes over a
+/// line and prints the result. Lets the substitution logic be exercised without
+/// dictating.
+///
+/// `--app` says who to pretend was in front, because otherwise a stage carrying
+/// an `app:` condition is unreachable from here: with no app a positive
+/// condition fails closed, so every such stage would be reported as doing
+/// nothing, and the one way left to check your own rules would be to dictate
+/// into each app in turn. Same string as `--pipeline --app`, matched the same
+/// way — name and bundle identifier joined.
 enum ReplaceCommand {
-    static func run(text: String) -> Int32 {
+    static func run(text: String, app: String? = nil) -> Int32 {
         guard let config = try? ConfigStore.load() else {
             print("✗ could not read config")
             return 1
         }
+        let named = (app ?? "").trimmingCharacters(in: .whitespaces)
+        let front = named.isEmpty ? nil : Pipeline.App(name: named, bundleID: "")
         // A command exits the moment it has printed, so it has to wait for
         // the pipeline rather than return into an empty runloop.
         let done = DispatchSemaphore(value: 0)
@@ -18,7 +28,9 @@ enum ReplaceCommand {
             // it — a replacement set failing wholesale for a reason that has
             // nothing to do with the replacement table. It is also not what
             // the name promises: --replace should not reach the network.
-            print(await Replacements.apply(to: text, config: config, allowPrompts: false))
+            print(await Replacements.apply(
+                to: text, config: config, allowPrompts: false, app: front
+            ))
             done.signal()
         }
         done.wait()

--- a/Sources/ParrotFlow/Replacements.swift
+++ b/Sources/ParrotFlow/Replacements.swift
@@ -63,7 +63,7 @@ enum Replacements {
             output = pattern.stringByReplacingMatches(
                 in: output,
                 range: NSRange(output.startIndex..., in: output),
-                withTemplate: NSRegularExpression.escapedTemplate(for: rule.replacement)
+                withTemplate: rule.template
             )
             if rule.isDeletion, output != before { deleted = true }
         }

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -33,6 +33,12 @@ if arguments.contains("--check-config") {
     exit(CheckConfigCommand.run())
 }
 
+/// `--app <name>`, for the commands that run a pipeline. Shared so the flag
+/// means the same thing to each of them.
+let appArgument: String? = arguments.firstIndex(of: "--app").flatMap { index in
+    arguments.indices.contains(index + 1) ? arguments[index + 1] : nil
+}
+
 if let index = arguments.firstIndex(of: "--record") {
     let seconds = arguments.indices.contains(index + 1) ? Double(arguments[index + 1]) : nil
     exit(RecordTestCommand.run(seconds: seconds ?? 3))
@@ -48,10 +54,10 @@ if let index = arguments.firstIndex(of: "--transcribe") {
 
 if let index = arguments.firstIndex(of: "--replace") {
     guard arguments.indices.contains(index + 1) else {
-        print("usage: ParrotFlow --replace \"<text>\"")
+        print("usage: ParrotFlow --replace \"<text>\" [--app <name>]")
         exit(2)
     }
-    exit(ReplaceCommand.run(text: arguments[index + 1]))
+    exit(ReplaceCommand.run(text: arguments[index + 1], app: appArgument))
 }
 
 if let index = arguments.firstIndex(of: "--numbers") {
@@ -103,17 +109,16 @@ if let index = arguments.firstIndex(of: "--prompt") {
 
 if let index = arguments.firstIndex(of: "--pipeline") {
     guard arguments.indices.contains(index + 1) else {
-        print("usage: ParrotFlow --pipeline <file.yaml> [\"<text>\"] [--app <name>] [--quiet]")
+        print("usage: ParrotFlow --pipeline <file.yaml> [\"<text>\"]"
+            + " [--app <name>] [--no-prompts] [--quiet]")
         exit(2)
     }
     let text = arguments.indices.contains(index + 2) && !arguments[index + 2].hasPrefix("--")
         ? arguments[index + 2] : nil
-    let app = arguments.firstIndex(of: "--app").flatMap { index -> String? in
-        arguments.indices.contains(index + 1) ? arguments[index + 1] : nil
-    }
     exit(PipelineCommand.run(
         path: arguments[index + 1], text: text,
-        quiet: arguments.contains("--quiet"), app: app
+        quiet: arguments.contains("--quiet"), app: appArgument,
+        allowPrompts: !arguments.contains("--no-prompts")
     ))
 }
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -54,8 +54,8 @@ transcription:
       # most one matches. Anywhere else — a mail window, a document — the
       # sentence is left exactly as spoken.
       - transform: dotted
-        app: /term|ghostty|warp|kitty|alacritty|hyper/
-      - transform: dotted-chat
+        app: /term|ghostty|warp|kitty|alacritty|hyper|slack|discord/
+      - transform: backticks
         app: /slack|discord/
 
   # The spelling you want, and the ways it comes out wrong. Whole words,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -146,24 +146,34 @@ transforms:
 
       Return only the text.
 
-  # The two tables the pipeline above names. Same pattern, different
-  # output: that is the whole reason a table has a name.
+  # The two tables the pipeline above names. Same pattern, different output:
+  # that is the whole reason a table has a name.
   #
-  # `dot` only, not `point`. "point" is an ordinary French word and this
-  # pattern joins whatever surrounds it — "voilà le point sur les tests"
-  # becomes "voilà le.sur les tests". Add it if you never dictate French
-  # into a terminal:
+  # The pattern reads "a word, then dot or point, then a word" — and then
+  # refuses it when either side is a word code does not use there. Without
+  # that, "voilà le point sur les tests" becomes "voilà le.sur les tests":
+  # "point" is an everyday French word and "dot com" is an English one. The
+  # first list is what may not come before, the second what may not come
+  # after — determiners, prepositions, and the heads of set phrases like
+  # "point final" or "dot product".
   #
-  #   ['/\b(\w+) (?:dot|point) (\w+)\b/']
+  # 45/45 on tests/dotted-cases.txt, plus two it cannot do: two ordinary
+  # words either side ("réunion point hebdomadaire") is a shape only a
+  # dictionary would tell from code. Both are unlikely in a terminal or a
+  # chat window, which is the only reason this is on by default. Score it
+  # with scripts/check-dotted.sh — it reads the pattern from this file.
+  #
+  # The second word is matched but not consumed, so a chain still works:
+  # "user point profile point name" -> user.profile.name.
   - name: dotted
     description: spoken dotted paths as code
     replace:
-      $1.$2: ['/\b(\w+) dot (\w+)\b/']
+      '$1.': ['/\b(?!(?:le|la|les|l|un|une|des|du|de|d|ce|cet|cette|ces|mon|ma|mes|ton|ta|tes|son|sa|ses|notre|nos|votre|vos|leur|leurs|au|aux|à|quel|quelle|chaque|autre|même|premier|première|deuxième|dernier|dernière|seul|seule|bon|bonne|mauvais|certain|tel|telle|quelque|the|a|an)\b)(\w+) (?:dot|point) (?!(?:de|du|des|d|le|la|les|l|un|une|sur|dans|en|et|ou|que|qui|où|à|au|aux|pour|par|avec|sans|est|sont|était|sera|me|te|se|ne|n|c|il|elle|je|tu|nous|vous|ils|elles|ce|plus|moins|très|mais|donc|car|si|comme|final|finale|barre|virgule|commun|commune|faible|faibles|fort|forts|mort|culminant|névralgique|chaud|sensible|positif|négatif|clé|focal|nommé|com|net|org|matrix|product|notation|plot)\b)(?=\w)/']
 
-  - name: dotted-chat
-    description: the same, wrapped for a chat window
+  - name: backticks
+    description: wrap dotted paths in backticks, for chat
     replace:
-      "`$1.$2`": ['/\b(\w+) dot (\w+)\b/']
+      '`$1`': ['/\b([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)+)/']
 
 # Do what was asked even when no prompt above matches:
 #

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -45,7 +45,18 @@ transcription:
   #
   # See docs/pipelines.md.
   pipelines:
-    default: [replacements, fuzzy, numbers]
+    default:
+      - replacements
+      - fuzzy
+      - numbers
+      # "read user dot name" -> read user.name in a terminal, and `user.name`
+      # in a chat window. Both steps are here and both conditions are read; at
+      # most one matches. Anywhere else — a mail window, a document — the
+      # sentence is left exactly as spoken.
+      - transform: dotted
+        app: /term|ghostty|warp|kitty|alacritty|hyper/
+      - transform: dotted-chat
+        app: /slack|discord/
 
   # The spelling you want, and the ways it comes out wrong. Whole words,
   # case-insensitive. A source in /slashes/ is a regular expression, and an
@@ -134,6 +145,25 @@ transforms:
       please or thanks does not.
 
       Return only the text.
+
+  # The two tables the pipeline above names. Same pattern, different
+  # output: that is the whole reason a table has a name.
+  #
+  # `dot` only, not `point`. "point" is an ordinary French word and this
+  # pattern joins whatever surrounds it — "voilà le point sur les tests"
+  # becomes "voilà le.sur les tests". Add it if you never dictate French
+  # into a terminal:
+  #
+  #   ['/\b(\w+) (?:dot|point) (\w+)\b/']
+  - name: dotted
+    description: spoken dotted paths as code
+    replace:
+      $1.$2: ['/\b(\w+) dot (\w+)\b/']
+
+  - name: dotted-chat
+    description: the same, wrapped for a chat window
+    replace:
+      "`$1.$2`": ['/\b(\w+) dot (\w+)\b/']
 
 # Do what was asked even when no prompt above matches:
 #

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -49,14 +49,17 @@ transcription:
       - replacements
       - fuzzy
       - numbers
-      # "read user dot name" -> read user.name in a terminal, and `user.name`
-      # in a chat window. Both steps are here and both conditions are read; at
-      # most one matches. Anywhere else — a mail window, a document — the
-      # sentence is left exactly as spoken.
+      # "read user dot name" -> read user.name, wherever you write code-ish
+      # text. Anywhere else — a mail window, a document — the sentence is left
+      # exactly as spoken.
+      #
+      # `backticks` below would wrap it for chat, and is deliberately not in
+      # this list. Slack's composer converts markdown as you type it and never
+      # re-reads text that arrives by paste, so the backticks land in your
+      # message as characters. Add the step if your chat app renders pasted
+      # markup.
       - transform: dotted
         app: /term|ghostty|warp|kitty|alacritty|hyper|slack|discord/
-      - transform: backticks
-        app: /slack|discord/
 
   # The spelling you want, and the ways it comes out wrong. Whole words,
   # case-insensitive. A source in /slashes/ is a regular expression, and an

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -61,7 +61,7 @@ transcription:
     Supabase: [super base, superbees]
 
 # The local Ollama model behind spoken commands. Without it dictation still
-# works and everything under `prompts:` stops.
+# works and every `prompt:` transform below stops.
 llm:
   enabled: true
   model: gemma4:e4b
@@ -71,7 +71,7 @@ llm:
   # those seconds back as free RAM.
   keep_loaded: true
 
-# What the activation phrase can reach: say it, then the instruction.
+# What the activation phrase can reach, and what a pipeline can name.
 #
 #     "hey parrot, make that a bullet list"
 #
@@ -80,27 +80,40 @@ llm:
 # reaches the prompt, which is why one entry covers "format those dates ISO"
 # and "format those dates with slashes".
 #
+# An entry has either `prompt:`, which asks the local model and costs about a
+# second, or `replace:`, a substitution table of its own that costs nothing:
+#
+#   - name: dotted
+#     description: spoken dotted paths as code
+#     replace:
+#       $1.$2: ['/\b(\w+) (?:dot|point) (\w+)\b/']
+#
+# A table is not reached by voice — it runs from a pipeline, which is where it
+# can be scoped to one app. Two tables with the same pattern and different
+# output are how "user dot name" becomes user.name in a terminal and `user.name`
+# in chat. See docs/pipelines.md.
+#
 # Results are shown before they replace your selection; add `confirm: false`
-# to a prompt you have come to trust.
+# to one you have come to trust.
 #
 # Fixing a misheard name is built in and does not appear here — run
 # --check-config to see everything the phrase reaches.
-prompts:
+transforms:
   - name: bullets
     description: turn text into a short bullet list
-    content: |
+    prompt: |
       Rewrite the text as concise bullets, one idea each.
       Keep the speaker's wording. Return only the bullets.
 
   - name: terse
     description: shorten text without losing anything it says
-    content: |
+    prompt: |
       Cut this down. No filler, same facts, same voice.
       Return only the shortened text.
 
   - name: grammar
     description: fix grammar and punctuation mistakes, not formatting or numbers
-    content: |
+    prompt: |
       Correct grammar, spelling and punctuation. Make the smallest change
       that makes the text correct — and make it. Every error is fixed.
       Nothing else is touched.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -50,7 +50,8 @@ transcription:
   # The spelling you want, and the ways it comes out wrong. Whole words,
   # case-insensitive. A source in /slashes/ is a regular expression, and an
   # empty target deletes rather than substitutes — which is how filler words
-  # go, punctuation and spacing included.
+  # go, punctuation and spacing included. With a regex source the target is a
+  # template, so $1 writes back what the pattern captured.
   #
   # Workflow: dictate, run --transcribe on the clip, map whatever the model
   # wrote to what you meant.

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -61,22 +61,21 @@ under two conditions. Named ones can:
 pipelines:
   default:
     - replacements
-    - transform: dotted
-      app: /term|ghostty|iterm|warp/
-    - transform: dotted-chat
-      app: /slack|discord/
     - fuzzy
     - numbers
+    - transform: dotted
+      app: /term|ghostty|iterm|warp/
+    - transform: prose
+      app: /^(?!.*(term|ghostty|iterm|warp))/
 ```
 
-Same sentence, two outputs, decided by where it is going — `user.name` in a
-terminal, `` `user.name` `` in chat. Both steps are in the pipeline and both
-conditions are evaluated; at most one matches.
+Two tables, two conditions, at most one matching. A single `replacements:`
+cannot express that: it is one table run by one stage, in one place.
 
-**This pair ships.** A new install is written with `dotted` and `dotted-chat`
-already in the default pipeline, because this is a tool for people who dictate
-identifiers. Delete the two steps and it stops; delete the two transforms and
-`--check-config` tells you the steps name nothing.
+**`dotted` ships.** A new install is written with it already in the default
+pipeline, because this is a tool for people who dictate identifiers. Delete the
+step and it stops; delete the transform and `--check-config` tells you the step
+names nothing.
 
 ### The one rewrite that fires on ordinary language
 
@@ -109,21 +108,31 @@ defensible.
 `scripts/check-dotted.sh` reads the pattern out of `Config.defaultYAML` rather
 than from a fixture, so what is scored is what a new install gets.
 
-### Chat wraps in a second step
+### `backticks`, defined and not used
 
-`backticks` is a separate transform, not a cleverer pattern:
+A second transform wraps a dotted path for a chat window:
 
 ```yaml
-- transform: dotted
-  app: /term|ghostty|warp|kitty|alacritty|hyper|slack|discord/
 - transform: backticks
   app: /slack|discord/
 ```
 
-`dotted` does not consume the word after the dot, so it has nowhere to put a
-closing backtick — the first attempt produced ``lis `config.`port``. Building
-the path and wrapping it are two jobs, and the second only runs where markdown
-means something. It requires a letter to start, so `21.5` is left alone.
+It is a separate transform rather than a cleverer pattern because `dotted` does
+not consume the word after the dot, so it has nowhere to put a closing backtick
+— the first attempt produced ``lis `config.`port``. It requires a letter to
+start, so `21.5` is left alone.
+
+**It is not in the shipped pipeline.** Slack's composer converts markdown as you
+type it and never re-reads text that arrives by paste, which is every way this
+app inserts text — so the backticks land in the message as characters. Tried on
+a real Slack, including with *Format messages with markup* enabled, and it did
+not render either way. A default that depends on a setting in another
+application, and does not work when that setting is on, is not a default: it
+puts noise in your messages and gives you nowhere to look.
+
+Add the step if your chat app renders pasted markup. Getting this to work
+properly means putting rich text on the clipboard rather than markdown
+characters, which is a different feature.
 
 ### Order matters, and only one set notices
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -78,13 +78,59 @@ already in the default pipeline, because this is a tool for people who dictate
 identifiers. Delete the two steps and it stops; delete the two transforms and
 `--check-config` tells you the steps name nothing.
 
-**`dot` only, not `point`.** The pattern joins whatever surrounds the word, and
-"point" is ordinary French: "voilà le point sur les tests" would become "voilà
-le.sur les tests". Add the alternation — `(?:dot|point)` — if you never dictate
-French into a terminal. English is not entirely safe either, only luckier: "the
-dot com era" is the same shape. Scoping to terminals and chat is what makes the
-odds acceptable, and it is why this is not in `replacements:` where it would
-run everywhere.
+### The one rewrite that fires on ordinary language
+
+Every other substitution waits for a name you taught it. This one reads "a
+word, then dot or point, then a word", and that shape occurs in prose: "voilà le
+point sur les tests" would become "voilà le.sur les tests", and "the dot com
+era" would become "the.com era". `point` is an everyday French word.
+
+What keeps them apart is two stop lists, one for what may not come *before* and
+one for what may not come *after*. In code both sides are identifiers; in prose
+at least one side is nearly always a determiner, a preposition, or the head of a
+set phrase — `le point de vue`, `un bon point pour`, `a dot product`.
+
+```
+\b(?!(?:le|la|les|…|the|a|an)\b)(\w+) (?:dot|point) (?!(?:de|du|…|product)\b)(?=\w)
+```
+
+The second word is matched but not consumed, which is what lets a chain work:
+`user point profile point name` → `user.profile.name`. Consuming it would leave
+the middle token unavailable to the next match.
+
+**54/54 on `tests/dotted-cases.txt`, plus two it cannot do.** Two ordinary words
+either side — "réunion point hebdomadaire" — is a shape only a dictionary would
+tell from code, and both residual cases are kept in the set, failing, rather
+than dropped to make the number look better. They are unlikely in a terminal or
+a chat window, which together with the `app:` scoping is the only reason this is
+on by default; in `replacements:` it would run everywhere and would not be
+defensible.
+
+`scripts/check-dotted.sh` reads the pattern out of `Config.defaultYAML` rather
+than from a fixture, so what is scored is what a new install gets.
+
+### Chat wraps in a second step
+
+`backticks` is a separate transform, not a cleverer pattern:
+
+```yaml
+- transform: dotted
+  app: /term|ghostty|warp|kitty|alacritty|hyper|slack|discord/
+- transform: backticks
+  app: /slack|discord/
+```
+
+`dotted` does not consume the word after the dot, so it has nowhere to put a
+closing backtick — the first attempt produced ``lis `config.`port``. Building
+the path and wrapping it are two jobs, and the second only runs where markdown
+means something. It requires a letter to start, so `21.5` is left alone.
+
+### Order matters, and only one set notices
+
+`numbers` runs before `dotted`, because English says "three point one four" for
+a decimal and it is `numbers` that consumes that word. Swap the two and `dotted`
+gets there first: "three one.four". The `DECIMAL` cases in the set exist to fail
+if anyone reorders them.
 
 Transforms with a `prompt:` body are also what the activation phrase reaches:
 "hey parrot, tidy that up" routes on the same `description`. A `replace:`

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -73,6 +73,19 @@ Same sentence, two outputs, decided by where it is going — `user.name` in a
 terminal, `` `user.name` `` in chat. Both steps are in the pipeline and both
 conditions are evaluated; at most one matches.
 
+**This pair ships.** A new install is written with `dotted` and `dotted-chat`
+already in the default pipeline, because this is a tool for people who dictate
+identifiers. Delete the two steps and it stops; delete the two transforms and
+`--check-config` tells you the steps name nothing.
+
+**`dot` only, not `point`.** The pattern joins whatever surrounds the word, and
+"point" is ordinary French: "voilà le point sur les tests" would become "voilà
+le.sur les tests". Add the alternation — `(?:dot|point)` — if you never dictate
+French into a terminal. English is not entirely safe either, only luckier: "the
+dot com era" is the same shape. Scoping to terminals and chat is what makes the
+odds acceptable, and it is why this is not in `replacements:` where it would
+run everywhere.
+
 Transforms with a `prompt:` body are also what the activation phrase reaches:
 "hey parrot, tidy that up" routes on the same `description`. A `replace:`
 transform is not routable by voice today — it runs from a pipeline only, and

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -26,9 +26,62 @@ get every stage back — a missing section is silence, not a choice. Write
 | `replacements` | The substitutions in `replacements:` — literal, word-boundary, case-insensitive, or a regex between slashes. |
 | `fuzzy` | The same table against renderings you have not taught, so "super bays" reaches Supabase. Only words the spell checker does not know are eligible, which is what keeps "Excel" from becoming "Vercel". Needs `replacements` before it and says so if it does not have one, because on its own it swallows the preceding word. |
 | `numbers` | Spoken numbers as digits: "two hundred forty-three" → 243, plus ordinals, decimals, years and spoken digits. English and French, septante/huitante/nonante included, chosen per transcript. A number word on its own stays a word below ten, so "chapter three" and "on est deux" are left alone. |
+| `transform` | One entry of `transforms:`, named — see below. The only stage that names something outside itself. |
 
 `numbers` rewrites transcripts that were already correct, so run `--numbers` on
 a line to see exactly what it would do before leaving it in.
+
+## Transforms
+
+The three stages above are fixed. A **transform** is one you write, named in
+`transforms:` and run with `- transform: <name>`. It has one of two bodies:
+
+```yaml
+transforms:
+  - name: prose
+    description: tidy up dictated prose
+    prompt: |
+      Fix grammar and punctuation. Return only the text.
+
+  - name: dotted
+    description: spoken dotted paths as code
+    replace:
+      $1.$2: ['/\b(\w+) (?:dot|point) (\w+)\b/']
+```
+
+`prompt:` asks the local model — about a second, and the reason conditions
+exist. `replace:` is a substitution table of its own, in the same shape as
+`transcription.replacements`, and costs nothing.
+
+**Why a table needs a name.** `transcription.replacements` is a single table
+applied by a single stage, so it cannot be two tables running in two places
+under two conditions. Named ones can:
+
+```yaml
+pipelines:
+  default:
+    - replacements
+    - transform: dotted
+      app: /term|ghostty|iterm|warp/
+    - transform: dotted-chat
+      app: /slack|discord/
+    - fuzzy
+    - numbers
+```
+
+Same sentence, two outputs, decided by where it is going — `user.name` in a
+terminal, `` `user.name` `` in chat. Both steps are in the pipeline and both
+conditions are evaluated; at most one matches.
+
+Transforms with a `prompt:` body are also what the activation phrase reaches:
+"hey parrot, tidy that up" routes on the same `description`. A `replace:`
+transform is not routable by voice today — it runs from a pipeline only, and
+`--check-config` lists it apart from the catalogue so that is visible rather
+than surprising.
+
+`prompts:` is the older name for this section and still reads, `content:`
+alongside `prompt:` with it. `- prompt: <name>` still works as a pipeline step.
+An entry defined in both sections is taken from `transforms:`.
 
 ## Conditions
 
@@ -131,15 +184,14 @@ before you go looking for `not_app:` — it is not there and will not be.
 It cannot hand the stage a different table or a different prompt per app; two
 behaviours mean two steps, each with its own condition.
 
-## Prompt stages
+## Prompt transforms
 
-A prompt from `prompts:` can be a stage too, and it is the reason conditions
-exist: it calls the local model, so it costs about a second where every other
-stage costs nothing. Measured on one line, 3.2s with the prompt running against
-0.035s with it skipped.
+A `prompt:` transform is the reason conditions exist: it calls the local model,
+so it costs about a second where every other stage costs nothing. Measured on
+one line, 3.2s with the prompt running against 0.035s with it skipped.
 
 ```yaml
-- prompt: hesitation
+- transform: hesitation
   when: /\b(genre|du coup|en fait)\b/
 ```
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -495,7 +495,7 @@ it. Do not read them a list of commands to memorise.
 
 **3. Optional — add the tuned prompts.**
 
-A new config has no `prompts:` section, so every command goes through
+A new config has no `transforms:` section, so every command goes through
 `free_form`. That is fine, but three prompts in the example config score better
 on their own test sets than free-form does. Offer them:
 
@@ -503,7 +503,7 @@ on their own test sets than free-form does. Offer them:
 > They are more accurate than the general one for those three jobs. Shall I add
 > them?
 
-If yes, take the `prompts:` block from the published example and append it to
+If yes, take the `transforms:` block from the published example and append it to
 their config — the block only, not the whole file:
 
 ```sh

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -493,32 +493,33 @@ at all — they are handled by `free_form`, which sends the whole instruction to
 the model. This is why the list is not a menu: the user does not have to learn
 it. Do not read them a list of commands to memorise.
 
-**3. Optional — add the tuned prompts.**
+**3. The tuned ones are already there.**
 
-A new config has no `transforms:` section, so every command goes through
-`free_form`. That is fine, but three prompts in the example config score better
-on their own test sets than free-form does. Offer them:
+A new install is written with three transforms — `bullets`, `terse` and
+`grammar` — so there is nothing to add and nothing to fetch. They are in the
+`capabilities` lines you printed a moment ago. Each exists because it scores
+better on its own test set than `free_form` does at that one job; everything
+else is free-form's, which is why the list is not a menu.
 
-> There are three ready-made commands: bullet points, shorter text, and grammar.
-> They are more accurate than the general one for those three jobs. Shall I add
-> them?
+Point at them rather than offering them:
 
-If yes, take the `transforms:` block from the published example and append it to
-their config — the block only, not the whole file:
+> Three of those are tuned for one job each: bullet points, shorter text, and
+> grammar. Everything else you say goes to the general one. You do not have to
+> remember which is which — it works that out.
 
-```sh
-curl -fsSL https://raw.githubusercontent.com/znat/parrotflow/main/config.example.yaml
-```
-
-Then check that ParrotFlow accepted them:
+If they want one of their own, it goes in `transforms:` and it needs a
+`description`: that is the text the router matches spoken words against, so an
+entry without one can never be picked, and `--check-config` reports it as an
+error rather than leaving it to look like the router misbehaving.
 
 ```sh
 /Applications/ParrotFlow.app/Contents/MacOS/ParrotFlow --check-config
 ```
 
-The `capabilities` count goes up and each prompt is listed by name. A prompt
-with no `description` is reported as an error — the router reads descriptions to
-choose, so a prompt without one can never be picked.
+The `capabilities` count goes up and the new entry is listed by name. A
+`transforms:` entry can also be a substitution table rather than a prompt, and
+those run from a pipeline instead of by voice — docs/pipelines.md, not something
+to cover in a handover.
 
 **If the Gemma download is still running,** say this now:
 

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -44,6 +44,32 @@ Word boundaries do the rest of the work: "umbrella" and "hummingbird" contain
 fillers and are left alone. Fuzzy matching skips regex and deletion rules
 entirely — they are exact by construction.
 
+A regex source can also write back what it captured. `$1` in the target refers
+to the first group, and that is the only way to express a rule whose output
+depends on its input:
+
+```yaml
+replacements:
+  $1.$2: ['/\b(\w+) dot (\w+)\b/']    # "user dot name" -> user.name
+```
+
+The slashes switch the target into a template the same way they switch the
+source into a pattern. A **literal** source keeps a literal target: a name is a
+word you want written exactly, so `$` in one survives and "AT$T" comes out as
+typed. That escaping is why a template needs the regex form to be reachable at
+all.
+
+A template naming a group its pattern never captures is refused by
+`--check-config` and by `--pipeline`, rather than being written as nothing —
+the rule would fire, the output would be quietly short, and the log would show
+a substitution that looked like it worked.
+
+A rule like this generalises, which is the thing the map otherwise cannot do.
+It cuts both ways: `\b(\w+) dot (\w+)\b` joins any two words either side of
+"dot", ordinary prose included, and no pattern tells "user dot name" from "the
+word dot on" — they are the same sentence to a regex. Scope it to where you
+mean it with `app:`, which is in docs/pipelines.md.
+
 FluidAudio's acoustic context biasing was tried and removed. It is real and
 their Earnings22 numbers are real — 91.7% vocabulary F-score — but it is built
 for hour-long audio with hundreds of domain terms, where 15% WER is an
@@ -63,9 +89,11 @@ well past the 0.70 their comments call too conservative. Damage throughout.
 Worth knowing that `rescorerConfig(forVocabSize:)` gives *small* vocabularies
 the most permissive threshold, which is backwards for this use.
 
-Substitution cannot generalise to a mishearing you have not seen, so the map
-grows one entry at a time. It also cannot corrupt a transcript that was
-already right, which turned out to matter more.
+A literal substitution cannot generalise to a mishearing you have not seen, so
+that half of the map grows one entry at a time. It also cannot corrupt a
+transcript that was already right, which turned out to matter more — and a
+pattern rule gives that property up in exchange for reach, which is the trade
+`app:` exists to bound.
 
 ### 2. A local LLM pass — for everything else
 

--- a/scripts/check-default-config.sh
+++ b/scripts/check-default-config.sh
@@ -74,8 +74,27 @@ for name in sorted(names(example) - names(template)):
     print(f"  ✗ transform \"{name}\" is documented but not written on install")
     ok = False
 
+# A pipeline step naming a transform the file does not define is a config the
+# app refuses on first launch. It happened: `dotted-chat` was renamed to
+# `backticks` and the steps were not brought along, and nothing here noticed
+# because the key check and the name check both looked only at what exists,
+# never at whether the two halves agree.
+def steps(doc):
+    named = []
+    for entries in ((doc.get("transcription") or {}).get("pipelines") or {}).values():
+        for entry in entries or []:
+            if isinstance(entry, dict) and entry.get("transform"):
+                named.append(entry["transform"])
+    return named
+
+for doc, where in ((template, "a new install"), (example, "config.example.yaml")):
+    for step in sorted(set(steps(doc)) - {n for n in names(doc) if n}):
+        print(f"  ✗ {where} runs `transform: {step}`, which it never defines")
+        ok = False
+
 if ok:
     print(f"  ✓ a new install gets every key config.example.yaml documents"
-          f"  ({len(keys(template))} keys, {len(names(template))} transforms)")
+          f"  ({len(keys(template))} keys, {len(names(template))} transforms,"
+          f" {len(steps(template))} transform step(s))")
 sys.exit(0 if ok else 1)
 PY

--- a/scripts/check-default-config.sh
+++ b/scripts/check-default-config.sh
@@ -64,15 +64,18 @@ if extra:
     print(f"  · {len(extra)} keys are written on install and not documented in the example"
           f" ({', '.join(sorted({k.split('.')[0] for k in extra}))})")
 
-# Prompts are a list, so the key check above says nothing about which ones.
+# Transforms are a list, so the key check above says nothing about which ones.
+# `prompts:` is read too: it is the older name for the same section, still
+# accepted, and a config written before the rename must not read as empty here.
 def names(doc):
-    return {p.get("name") for p in (doc.get("prompts") or [])}
+    entries = (doc.get("transforms") or []) + (doc.get("prompts") or [])
+    return {e.get("name") for e in entries}
 for name in sorted(names(example) - names(template)):
-    print(f"  ✗ prompt \"{name}\" is documented but not written on install")
+    print(f"  ✗ transform \"{name}\" is documented but not written on install")
     ok = False
 
 if ok:
     print(f"  ✓ a new install gets every key config.example.yaml documents"
-          f"  ({len(keys(template))} keys, {len(names(template))} prompts)")
+          f"  ({len(keys(template))} keys, {len(names(template))} transforms)")
 sys.exit(0 if ok else 1)
 PY

--- a/scripts/check-dotted.sh
+++ b/scripts/check-dotted.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Scores the `dotted` transform against tests/dotted-cases.txt.
+#
+#   scripts/check-dotted.sh
+#
+# The pattern is not written in the case file or in a fixture. It is read out of
+# `Config.defaultYAML`, so this scores the rule a new install actually gets — a
+# committed copy would be free to drift from the thing that ships, and this is
+# the one rewrite that fires on ordinary language rather than on a name someone
+# taught it.
+#
+# Only the transform's own steps are run. The default pipeline also carries
+# replacements, fuzzy and numbers, and `numbers` would turn "quinze heures" into
+# "15 heures" — a case failing for a reason that has nothing to do with what is
+# being measured. The other passes have sets of their own.
+#
+# `RESIDUE` cases are expected to fail. Two content words either side of the
+# word is a shape no stop list distinguishes, and a set that scores 100% by
+# omitting what it cannot do is worse than a number.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/release/ParrotFlow"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+
+FIXTURE="$(mktemp -t parrotflow-dotted).yaml"
+CHAT="$(mktemp -t parrotflow-chat).yaml"
+DECIMAL="$(mktemp -t parrotflow-decimal).yaml"
+trap 'rm -f "$FIXTURE" "$CHAT" "$DECIMAL"' EXIT
+
+python3 - "$ROOT" "$FIXTURE" "$CHAT" "$DECIMAL" <<'PY'
+import re, sys, pathlib, yaml
+
+root, out, chat, decimal = (pathlib.Path(a) for a in sys.argv[1:5])
+src = (root / "Sources/ParrotFlow/Config.swift").read_text()
+start = src.index("static var defaultYAML: String {")
+open_quote = src.index('"""', start) + 3
+close_quote = src.index('"""', open_quote)
+# A Swift literal: interpolations stand in for per-variant values, and an
+# escaped backslash is one backslash by the time YAML sees it.
+raw = re.sub(r"\\\((.*?)\)", "placeholder", src[open_quote:close_quote]).replace("\\\\", "\\")
+doc = yaml.safe_load(raw)
+
+transforms = [t for t in doc.get("transforms") or [] if "replace" in t]
+if not any(t["name"] == "dotted" for t in transforms):
+    print("  ✗ Config.defaultYAML has no `dotted` transform to score")
+    sys.exit(1)
+
+def fixture(steps):
+    return yaml.safe_dump({
+        "languages": doc["transcription"]["languages"],
+        "transforms": transforms,
+        "pipeline": [{"transform": name} for name in steps],
+    }, allow_unicode=True, sort_keys=False)
+
+out.write_text(fixture(["dotted"]))
+# What a chat window gets: the path is built, then wrapped. The wrapping is a
+# second table because a rule that does not consume the word after it cannot
+# put anything on the far side of it — which is how the first attempt at this
+# produced `lis `config.`port`.
+chat.write_text(fixture(["dotted", "backticks"]))
+# `numbers` before `dotted`, as the shipped pipeline has them. English says
+# "three point one four" for a decimal, and it is `numbers` that consumes the
+# word — reorder the two and dotted gets there first, turning it into
+# "three one.four". Nothing else would notice.
+decimal.write_text(fixture(["numbers", "dotted"]).replace(
+    "- transform: numbers", "- numbers"))
+PY
+[ -s "$FIXTURE" ] || exit 1
+
+pass=0; total=0; residue=0; failed=""
+while IFS='|' read -r kind input want; do
+  case "$kind" in \#*|"") continue;; esac
+  case "$kind" in
+    CHAT)    use="$CHAT";;
+    DECIMAL) use="$DECIMAL";;
+    *)       use="$FIXTURE";;
+  esac
+  got="$("$BIN" --pipeline "$use" "$input" --quiet 2>/dev/null | tail -1)"
+
+  if [ "$kind" = "RESIDUE" ]; then
+    residue=$((residue + 1))
+    [ "$got" = "$want" ] && printf '  ! %s\n      now passes — move it out of RESIDUE\n' "$input"
+    continue
+  fi
+
+  total=$((total + 1))
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1))
+    printf '  ✓ %-46s [%s]\n' "$input" "$kind"
+  else
+    failed="$failed
+      $input"
+    printf '  ✗ %s  [%s]\n      got   %s\n      want  %s\n' "$kind" "$input" "$got" "$want"
+  fi
+done < "$ROOT/tests/dotted-cases.txt"
+
+echo
+echo "  $pass/$total   plus $residue known-unfixable$failed"
+[ "$pass" = "$total" ]

--- a/scripts/check-pipeline.sh
+++ b/scripts/check-pipeline.sh
@@ -19,7 +19,7 @@ BIN="$ROOT/.build/release/ParrotFlow"
 
 pass=0; total=0; failed=""
 
-while IFS='|' read -r name fixture app input expect; do
+while IFS='|' read -r name fixture app noprompts input expect; do
   [ -z "$name" ] && continue
   total=$((total + 1))
   [ "$expect" = "unchanged" ] && want="$input" || want="$expect"
@@ -27,6 +27,10 @@ while IFS='|' read -r name fixture app input expect; do
   # An `app:` case says who was in front. Passed unconditionally: an empty
   # --app is "nothing in front", which is itself a case — an app-conditioned
   # stage has to fail closed — and it avoids an empty array under `set -u`.
+  #
+  # `no_prompts: true` runs the case the way --replace does. A `replace:`
+  # transform must still run there; only a `prompt:` one is held back.
+  [ "$noprompts" = "True" ] && off="--no-prompts" || off=""
 
   path="$ROOT/tests/pipelines/$fixture.yaml"
   if [ ! -f "$path" ]; then
@@ -36,7 +40,7 @@ while IFS='|' read -r name fixture app input expect; do
     continue
   fi
 
-  got="$("$BIN" --pipeline "$path" "$input" --app "$app" --quiet 2>/dev/null | tail -1)"
+  got="$("$BIN" --pipeline "$path" "$input" --app "$app" $off --quiet 2>/dev/null | tail -1)"
 
   if [ "$got" = "$want" ]; then
     pass=$((pass + 1))
@@ -46,12 +50,13 @@ while IFS='|' read -r name fixture app input expect; do
       $name"
     printf '  ✗ %s  [%s]\n      in    %s\n      got   %s\n      want  %s\n' \
       "$name" "$fixture" "$input" "$got" "$want"
-    "$BIN" --pipeline "$path" "$input" --app "$app" 2>/dev/null | sed 's/^/        /'
+    "$BIN" --pipeline "$path" "$input" --app "$app" $off 2>/dev/null | sed 's/^/        /'
   fi
 done < <(python3 -c '
 import sys, yaml
 for c in yaml.safe_load(open(sys.argv[1]))["cases"]:
-    print("|".join(str(c.get(k, "")) for k in ("name", "pipeline", "app", "input", "expect")))
+    print("|".join(str(c.get(k, "")) for k in
+                   ("name", "pipeline", "app", "no_prompts", "input", "expect")))
 ' "$ROOT/tests/pipeline-cases.yaml")
 
 echo

--- a/tests/dotted-cases.txt
+++ b/tests/dotted-cases.txt
@@ -1,0 +1,95 @@
+# kind | what was dictated | what should come out
+#
+# Run with: scripts/check-dotted.sh
+#
+# The `dotted` transform is the one rewrite this app ships that fires on
+# ordinary language rather than on a name you taught it. "user point name"
+# should become user.name; "voilà le point sur les tests" must not become
+# "voilà le.sur les tests", and "point" is an everyday French word.
+#
+# What keeps them apart is two stop lists — the word before "dot"/"point" and
+# the word after. In code both sides are identifiers; in prose at least one
+# side is almost always a determiner, a preposition, or the head of a set
+# phrase ("point final", "point de vue", "dot com").
+#
+# Almost always, not always: the last two cases below are the residue, and they
+# fail. Two content words either side is a shape no stop list distinguishes —
+# only a dictionary would. They are kept here failing on purpose, because a set
+# that scores 100% by leaving out what it cannot do is worse than a number.
+#
+# The pattern is not written here. scripts/check-dotted.sh reads it out of
+# Config.defaultYAML, so this scores what a new install actually gets rather
+# than a copy of it that is free to drift.
+
+CODE|read user dot name|read user.name
+CODE|lis config point port|lis config.port
+CODE|ouvre server point js|ouvre server.js
+CODE|dans user point profile point name|dans user.profile.name
+CODE|package point json|package.json
+CODE|il faut modifier config point yaml|il faut modifier config.yaml
+CODE|window point location point href|window.location.href
+CODE|regarde app point swift|regarde app.swift
+CODE|cat readme point md|cat readme.md
+CODE|npm run build point sh|npm run build.sh
+CODE|edit dockerfile point dev|edit dockerfile.dev
+
+FR|voilà le point sur les tests|voilà le point sur les tests
+FR|à ce point que je doute|à ce point que je doute
+FR|un point de détail|un point de détail
+FR|le point d orgue de la soirée|le point d orgue de la soirée
+FR|au point où j en suis|au point où j en suis
+FR|mettre au point le système|mettre au point le système
+FR|de ce point de vue|de ce point de vue
+FR|il faut faire le point rapidement|il faut faire le point rapidement
+FR|chaque point compte vraiment|chaque point compte vraiment
+FR|mon point de vue diffère|mon point de vue diffère
+FR|à quel point tu veux|à quel point tu veux
+FR|il n y a point de doute|il n y a point de doute
+FR|le premier point concerne les tests|le premier point concerne les tests
+FR|le deuxième point est simple|le deuxième point est simple
+FR|un bon point pour toi|un bon point pour toi
+FR|sur ce point précis je cède|sur ce point précis je cède
+FR|nous marquons un point important|nous marquons un point important
+FR|ce point mérite discussion|ce point mérite discussion
+FR|le dernier point avant de partir|le dernier point avant de partir
+FR|arrivé à point nommé|arrivé à point nommé
+FR|c est cuit à point parfait|c est cuit à point parfait
+FR|le rapport point par point|le rapport point par point
+FR|quinze heures point final|quinze heures point final
+FR|son point faible reste évident|son point faible reste évident
+FR|le point culminant du récit|le point culminant du récit
+FR|ils ont un point commun|ils ont un point commun
+FR|j ai marqué trois points importants|j ai marqué trois points importants
+FR|revenons au point crucial maintenant|revenons au point crucial maintenant
+FR|voici mon point principal ici|voici mon point principal ici
+FR|elle marque un point décisif|elle marque un point décisif
+
+EN|the dot com era was wild|the dot com era was wild
+EN|a dot product of two vectors|a dot product of two vectors
+EN|the dot matrix printer|the dot matrix printer
+EN|a dot file in home|a dot file in home
+
+# The residue. Two content words either side, so nothing in the sentence says
+# which one it is. Both are unlikely in a terminal or a chat window, which is
+# the only reason this ships.
+RESIDUE|réunion point hebdomadaire demain|réunion point hebdomadaire demain
+RESIDUE|polka dot dress today|polka dot dress today
+
+# A chat window runs the wrapping table after the path-building one. It is a
+# second table and not a cleverer pattern: the first does not consume the word
+# after it, so it has nowhere to put a closing backtick. Trying it locally
+# produced `lis `config.`port` before this was split in two.
+CHAT|read user dot name|read `user.name`
+CHAT|lis config point port|lis `config.port`
+CHAT|user point profile point name|`user.profile.name`
+CHAT|voilà le point sur les tests|voilà le point sur les tests
+CHAT|il faut modifier config point yaml|il faut modifier `config.yaml`
+
+# `numbers` runs before `dotted` in the shipped pipeline, and English says
+# "three point one four" for a decimal. It is `numbers` that consumes the word;
+# swap the two stages and dotted gets there first, turning it into
+# "three one.four". Nothing else in any set would notice.
+DECIMAL|three point one four|3.14
+DECIMAL|twenty one point five|21.5
+DECIMAL|version two point one|version 2.1
+DECIMAL|it costs ninety nine point five percent|it costs 99.5 percent

--- a/tests/pipeline-cases.yaml
+++ b/tests/pipeline-cases.yaml
@@ -140,6 +140,16 @@ cases:
     input: lis user point name
     expect: lis user.name
 
+  # `--replace` turns prompts off so it cannot reach the network. A table is
+  # not a prompt, and holding it back would make the flag mean "no transforms".
+  # It did mean that, until this was run against a real config.
+  - name: a table still runs when prompts are off
+    pipeline: transforms
+    app: Ghostty
+    no_prompts: true
+    input: read user dot name
+    expect: read user.name
+
   # --- an empty pipeline is a choice --------------------------------------
   - name: nothing listed, so nothing runs
     pipeline: empty

--- a/tests/pipeline-cases.yaml
+++ b/tests/pipeline-cases.yaml
@@ -111,6 +111,35 @@ cases:
     input: on en a vingt et un
     expect: on en a 21
 
+  # --- named tables, chosen by app ----------------------------------------
+  # The same sentence, two outputs, decided by where it is going. Both steps
+  # are in the pipeline and both conditions are evaluated; only one matches.
+  - name: a table transform runs where its app matches
+    pipeline: transforms
+    app: Ghostty
+    input: read user dot name
+    expect: read user.name
+
+  - name: the other app gets the other table
+    pipeline: transforms
+    app: Slack
+    input: read user dot name
+    expect: "read `user.name`"
+
+  - name: an app matching neither gets neither
+    pipeline: transforms
+    app: Mail
+    input: read user dot name
+    expect: unchanged
+
+  # The spoken word varies, not the language of the transcript, so the
+  # alternation belongs in the pattern and not in a per-language pipeline.
+  - name: point works as well as dot
+    pipeline: transforms
+    app: Ghostty
+    input: lis user point name
+    expect: lis user.name
+
   # --- an empty pipeline is a choice --------------------------------------
   - name: nothing listed, so nothing runs
     pipeline: empty

--- a/tests/pipelines/replacements.yaml
+++ b/tests/pipelines/replacements.yaml
@@ -16,6 +16,10 @@ replacements:
   Matthieu: [Mathieu]
   Mik: [Meek, Mick]
   "": ['/[,]?\s*\b(?:mm[-‑]?hmm|uh[-‑]?huh|mhm|u+m+|u+h+|erm+|hmm+|mm+)\b[,]?/']
+  # A template, not a word: the source is a pattern, so `$1` and `$2` are what
+  # it captured. Also the case that keeps `$1.$2` out of the fuzzy target list,
+  # where it would be a spelling nothing can sound like.
+  $1.$2: ['/\b(\w+) dot (\w+)\b/']
 pipeline:
   - replacements
   - fuzzy

--- a/tests/pipelines/transforms.yaml
+++ b/tests/pipelines/transforms.yaml
@@ -1,0 +1,26 @@
+# Two named tables, the same pattern, different output, chosen by app.
+#
+# This is the case `transforms:` exists for and the one `transcription.
+# replacements` cannot express: it is a single table applied by a single stage,
+# so it cannot be two tables running in two places under two conditions.
+#
+# `dot` and `point` are alternated in the pattern rather than split across
+# per-language pipelines, because what varies is the word spoken, not the
+# language of the transcript — "user point name" is said in English too.
+languages: [en, fr]
+transforms:
+  - name: dotted
+    description: spoken dotted paths as code
+    replace:
+      $1.$2: ['/\b(\w+) (?:dot|point) (\w+)\b/']
+
+  - name: dotted-chat
+    description: the same, wrapped for a chat window
+    replace:
+      "`$1.$2`": ['/\b(\w+) (?:dot|point) (\w+)\b/']
+
+pipeline:
+  - transform: dotted
+    app: /term|ghostty|iterm|warp/
+  - transform: dotted-chat
+    app: /slack|discord/

--- a/tests/replacement-cases.txt
+++ b/tests/replacement-cases.txt
@@ -24,3 +24,15 @@ So um I was thinking, uh, that we could ship it|So I was thinking that we could 
 It was mostly something related to Um AI search|It was mostly something related to AI search
 The hummingbird is umbrella shaped|The hummingbird is umbrella shaped
 I said mm-hmm to the summary|I said to the summary
+# A template rule: the source is a pattern, so $1 and $2 are what it captured.
+Read config dot port from user dot name|Read config.port from user.name
+# It composes with the passes around it — the filler goes, the name is fixed,
+# and the dotted path is built from the corrected word. The capital is `tidy`
+# putting one back after a leading filler was removed, as everywhere else.
+Um call super base dot query|Call Supabase.query
+# And the limitation, recorded rather than wished away: a rule this shape joins
+# any two words either side of "dot", ordinary prose included. There is no
+# pattern that separates "user dot name" from "the word dot on" — they are the
+# same sentence to a regex. That is what `app:` is for: scope it to a terminal
+# and the sentence below never meets it.
+The word dot on its own is a phrase|The word.on its own is a phrase


### PR DESCRIPTION
Stacked on #5 — base is `feat/app-conditions`. Seven commits.

## What a new install gets

```yaml
pipelines:
  default:
    - replacements
    - fuzzy
    - numbers
    - transform: dotted
      app: /term|ghostty|warp|kitty|alacritty|hyper|slack|discord/
```

"lis config point port" → `lis config.port` where you write code-ish text, and
left exactly as spoken in a mail window or a document. Chains work:
`user point profile point name` → `user.profile.name`.

## The one rewrite that fires on ordinary language

Every other substitution waits for a name you taught it. This one reads "a word,
then dot or point, then a word", and that shape occurs in prose — "voilà le
point sur les tests" would become "voilà le.sur les tests", and "point" is an
everyday French word.

Two stop lists keep them apart: what may not come *before*, and what may not
come *after*. In code both sides are identifiers; in prose at least one side is
a determiner, a preposition, or the head of a set phrase — `le point de vue`,
`un bon point pour`, `a dot product`.

**54/54 on `tests/dotted-cases.txt`** — 11 code, 20 French prose, 4 English
prose, 5 chat, 4 decimals — **plus two it cannot do**. "réunion point
hebdomadaire" and "polka dot dress" are a shape only a dictionary tells from
code. Both stay in the set, failing, under a `RESIDUE` kind the runner counts
separately; a set that scores 100% by omitting what it cannot do is worse than a
number.

`scripts/check-dotted.sh` reads the pattern out of `Config.defaultYAML` instead
of carrying a copy, so what is scored is what a new install gets.

## How it got there

**1. A regex replacement can write back what it captured.** The target was
always escaped, so `$1` came out as two characters. The slashes now switch the
target into a template the same way they already switch the source into a
pattern — literal source, escaped target, so `"$1 million"` and `"AT$T"` still
come out as typed. A template naming a group the pattern never captures is now
refused instead of being written as nothing. Fuzzy matching took its targets
from the table's keys, so `$1.$2` would have joined the spellings a misheard
word is compared against — `docs/transcription.md` already promised it skipped
regex rules and `Rule.isFuzzyCandidate` already existed to say so, wired to
nothing.

**2. `transforms:` — a named table, runnable as a stage.**
`transcription.replacements` is one table applied by one stage, so it cannot be
two tables in two places under two conditions. An entry has one of two bodies:
`prompt:` asks the model, `replace:` is a table of its own. One list, not two
sections: a pipeline step names either with `transform:`, and the router reads
the same `description` off both. Nothing written before today changes meaning —
`prompts:` still reads, `content:` alongside `prompt:`, `- prompt: <name>` still
names a step. Verified against two real configs.

**3. The setup guide** was still telling readers to curl the example and append
its prompts, on the grounds that a new config has none — false since the
template started shipping them.

**4–7. Defaults, and four bugs that only showed up when run.**

- `allowPrompts: false` blocked every transform stage, not just prompt-bodied
  ones, so the flag had come to mean "no transforms" — which is what `--replace`
  reported for the shipped default.
- Renaming `dotted-chat` to `backticks` left both pipeline steps naming the old
  name. A new install would have got a config the app refuses on first launch.
  `check-default-config` now reads the steps as well as the names; verified by
  reintroducing the rename.
- `numbers` has to run before `dotted`: English says "three point one four" for
  a decimal. Reordered, dotted writes "three one.four". The `DECIMAL` cases
  exist to fail if anyone moves them.
- `backticks` is out of the default pipeline. On a real Slack it puts the
  backtick characters in the message — the composer converts markdown as it
  watches you type and never re-reads pasted text, and *Format messages with
  markup* did not help. The transform stays defined and documented, one step
  away.

`--replace` and `--pipeline` take `--app`; `--pipeline` takes `--no-prompts`.
Without the first, a stage carrying `app:` is unreachable from the terminal.
Without the second, "a table still runs when prompts are off" is a claim no
fixture can make — and it was false until one did.

## Checks

| set | result |
|---|---|
| `check-dotted` | 54/54, plus 2 known-unfixable — new |
| `check-pipeline` | 20/20 — 11 new |
| `check-replacements` | 23/23 — 3 new |
| `check-numbers` | 97/97 |
| `check-default-config` | ✓ 24 keys, 5 transforms, 1 step |

Run as the app too, installed as the dev variant and dictated into: the log
confirms `Je voudrais faire le point sur test.grep.` — the French set phrase
left alone and the path built, in one sentence.

The four sets needing Ollama, a screen or a microphone were not run — CI does
not run them either.

### Known gap

A `replace:` transform is not routable by voice; the catalogue still takes
prompts only, and `--check-config` lists tables apart from the capabilities so
that is visible rather than surprising. Wiring them into the router wants
`check-routing`, which needs Ollama.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018L6J1Kw7SVxnoCAJ1Gw4WS