### PR TITLE
fix: refuse an app that was signed by someone else

### DIFF
--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -97,6 +97,30 @@ The certificate is therefore a durable asset, not a build artefact. Regenerating
 it breaks every existing install. It lives outside the repo and its `.p12` is a
 repository secret.
 
+It also does a second job, once `install.sh` pins it. `codesign --verify` proves
+a signature matches the bundle it covers and says nothing about who produced it:
+a self-signed certificate is free to make, can carry any common name — including
+this one — and passes that check. So the installer compares the SHA-256 of the
+leaf certificate against a pinned value, which is what turns "this archive is
+internally consistent" into "this archive is ours". A swapped release fails
+before anything is copied into `/Applications`.
+
+Pinning inside a script is usually how a project strands itself on a key it
+later has to rotate. It is safe here for the reason the file already relies on:
+`install.sh` is read from `main` on every run, so the pin travels in the same
+commit as the new certificate. And it fails in the right direction anyway — a
+release signed with a different certificate is one TCC would refuse the user's
+existing grants to, so refusing it in the installer converts a silent loss of
+Microphone and Accessibility into a stop with a reason.
+
+The fingerprint is derivable from the certificate itself, which is what makes
+rotating it a one-line change rather than an archaeology exercise:
+
+```sh
+openssl x509 -in ~/.parrotflow-release/cert.pem -outform DER | shasum -a 256
+codesign -d --extract-certificates=/tmp/c ParrotFlow.app && shasum -a 256 /tmp/c0
+```
+
 ## Gatekeeper without notarization is now genuinely bad
 
 This used to be a shrug — right-click, Open, done. Not since macOS 15:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -84,9 +84,10 @@ fetch "$BASE/$APP_NAME.zip.sha256" "$TMP/$APP_NAME.zip.sha256" \
     || die "the app downloaded but its checksum did not. Not installing an
        archive that cannot be verified."
 
-# Integrity, not authenticity: the checksum travels with the archive, so it
-# catches a truncated or corrupted download and nothing more. Verifying the
-# publisher needs a signature, which arrives with Developer ID.
+# The checksum travels with the archive, so on its own it catches a truncated
+# or corrupted download and nothing more: whoever could replace the archive
+# could replace the checksum beside it. Authenticity comes from the certificate
+# check further down.
 say "Checking the download"
 EXPECTED="$(cut -d' ' -f1 < "$TMP/$APP_NAME.zip.sha256")"
 ACTUAL="$(shasum -a 256 "$TMP/$APP_NAME.zip" | cut -d' ' -f1)"
@@ -102,6 +103,45 @@ ditto -x -k "$TMP/$APP_NAME.zip" "$TMP/unpacked" || die "could not unpack the do
 
 codesign --verify --deep --strict "$TMP/unpacked/$APP_NAME.app" 2>/dev/null \
     || die "the downloaded app failed signature verification; not installing it"
+
+# And then: signed by whom.
+#
+# The check above proves the signature matches the bundle. It does not prove
+# whose signature it is — anyone can make a self-signed certificate, sign an
+# app with it, and pass. Without the line below, an archive swapped for
+# somebody else's would install without a word, on a machine that is then asked
+# for the microphone and for permission to type into every window.
+#
+# So the leaf certificate's SHA-256 is pinned. The name is not enough: a
+# certificate can be issued to any common name, "ParrotFlow Release" included.
+#
+# Pinning a value inside a script is normally how you strand yourself on a
+# rotated key. Not here: this file is read from main on every run, so the day
+# the certificate changes, the pin changes with it in the same commit. And a
+# release signed with a different certificate is one macOS would refuse the
+# user's existing Microphone and Accessibility grants to anyway — refusing it
+# here turns a silent loss of permissions into a stop with a reason.
+CERT_SHA256="1fe06cb4b110d3f60ddb0a4d54e2694528b50ca1f40e939994306c8b068d2689"
+
+if [ -n "${PARROTFLOW_BASE_URL:-}" ]; then
+    # A local rehearsal (make try-install) builds and signs with whatever
+    # identity is on that machine, which is the dev certificate for anyone who
+    # is not cutting releases. Say the check was skipped rather than let a
+    # rehearsal look like it proved more than it did.
+    say "Local install — skipping the certificate check"
+else
+    codesign -d --extract-certificates="$TMP/cert" "$TMP/unpacked/$APP_NAME.app" 2>/dev/null \
+        || die "could not read the signing certificate of the downloaded app"
+    SIGNER="$(shasum -a 256 "$TMP/cert0" | cut -d' ' -f1)"
+    [ "$SIGNER" = "$CERT_SHA256" ] || die "this app was signed by someone else — not installing it.
+       expected certificate $CERT_SHA256
+       found                $SIGNER
+
+       Nothing on this Mac has been changed. If you did not expect this,
+       do not install ParrotFlow from anywhere else either — report it at
+       https://github.com/$REPO/issues"
+    say "Signed by the ParrotFlow release certificate"
+fi
 
 # --- Install -----------------------------------------------------------------
 


### PR DESCRIPTION
`install.sh` verified the checksum and ran `codesign --verify --deep --strict`. Neither says **who** signed the app: a self-signed certificate is free to make and can carry any common name, `ParrotFlow Release` included. An archive swapped for someone else's installed silently — on a Mac that is then asked for the microphone and for permission to type into every window. The checksum could not have caught it either, since it is published beside the archive.

This pins the SHA-256 of the leaf certificate. The name is deliberately not what is compared.

Pinning a constant in a script is usually how you strand yourself on a rotated key. Not here: `install.sh` is read from `main` on every run, so the pin travels in the same commit as a new certificate. It also fails in the useful direction — an app signed with a different certificate is one TCC denies the existing Microphone and Accessibility grants to, so refusing it turns a silent loss of permissions into a stop that says why.

`make try-install` skips the check and says so, since a local rehearsal signs with whatever identity that machine has.

**Verified both ways:**

```
=== the published v0.3.0 ===
==> Signed by the ParrotFlow release certificate

=== an app signed with a different certificate (the dev build) ===
error: this app was signed by someone else — not installing it.
       expected certificate 1fe06cb4b110d3f6…068d2689
       found                8198e154c429cc6a…6054b7d2
```

The pinned value is derivable from the certificate itself — `openssl` on the `.pem` and `codesign` on a release app produce the same fingerprint, which is what keeps a rotation to a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LF9RbnYCnKs5suARU4maok