### PR TITLE
perf: draw the menu bar icon when it changes, not ten times a second

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -15,6 +15,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var statusInfoItem: NSMenuItem!
     private var toggleItem: NSMenuItem!
 
+    /// The recording state the menu bar icon was last drawn for.
+    private var shownRecording: Bool?
+
     private lazy var transcriber = Transcriber { [weak self] status in
         DispatchQueue.main.async { self?.handleTranscriberStatus(status) }
     }
@@ -1074,16 +1077,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func updateUI() {
         let recording = recorder.isRecording
 
-        statusItem.button?.image = NSImage(
-            systemSymbolName: recording
-                ? AppVariant.menuBarSymbolRecording
-                : AppVariant.menuBarSymbol,
-            accessibilityDescription: AppVariant.displayName
-        )
-        // Stays a template image so `contentTintColor` applies — a non-template
-        // symbol ignores the tint and renders black in a dark menu bar.
-        statusItem.button?.image?.isTemplate = true
-        statusItem.button?.contentTintColor = recording ? .systemRed : nil
+        // Only when it actually changes. updateUI runs on a 0.1s timer while
+        // recording, to redraw the elapsed clock, and the icon is the one thing
+        // in here that cannot change between two ticks of the same state —
+        // rebuilding the symbol regardless was ten identical NSImages a second.
+        if shownRecording != recording {
+            shownRecording = recording
+            statusItem.button?.image = NSImage(
+                systemSymbolName: recording
+                    ? AppVariant.menuBarSymbolRecording
+                    : AppVariant.menuBarSymbol,
+                accessibilityDescription: AppVariant.displayName
+            )
+            // Stays a template image so `contentTintColor` applies — a
+            // non-template symbol ignores the tint and renders black in a dark
+            // menu bar.
+            statusItem.button?.image?.isTemplate = true
+            statusItem.button?.contentTintColor = recording ? .systemRed : nil
+        }
 
         let shortcut = hotKeys.binding?.displayName
             ?? KeyCodes.displayString(key: config.hotkey.key, modifiers: config.hotkey.modifiers)


### PR DESCRIPTION
`updateUI` runs on a 0.1s timer while recording, to redraw the elapsed clock. The icon has two states and cannot change between two ticks of the same one, yet it was rebuilt from its symbol name on every tick — ten identical `NSImage`s a second, plus the template flag and the tint.

Nobody would notice it. That is the argument for fixing it now: it is the same misfiling as the `problems()` call that #11 had to keep out of the same function, and whatever is added to `updateUI` next will copy what it finds there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LF9RbnYCnKs5suARU4maok