### PR TITLE
feat: notice when a newer version exists, after it has aged

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,14 @@
 Dictation for people who type for a living. Hold a key, talk, and the text
 lands in whatever you are in — editor, terminal, browser, chat.
 
-Everything runs on your Mac. No account, no API key, no network call. The
-audio never leaves the machine, which is the whole point: most of what a
-developer dictates is a bug report, a customer name, or a half-finished idea
-about their own product.
+Everything runs on your Mac. No account, no API key, and nothing you say is
+ever sent anywhere — which is the whole point: most of what a developer
+dictates is a bug report, a customer name, or a half-finished idea about their
+own product.
+
+Two things do use the network, and neither carries your audio or your text: the
+speech model downloads once, on first use, and once a day the app asks GitHub
+whether a newer version exists. `updates.after_days: -1` stops the second one.
 
 It also learns the words you actually use. Say a library name once, tell it
 how the name is spelled, and it gets it right from then on.

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -15,6 +15,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var statusInfoItem: NSMenuItem!
     private var toggleItem: NSMenuItem!
 
+    /// Shown only once a release has been found, waited out, and not refused.
+    private var updateItem: NSMenuItem!
+    private var updateAvailable: Updates.Release?
+    private var updatesTimer: Timer?
+    /// So the notice fires when a version first becomes available, and not
+    /// again every day for as long as the user leaves it alone.
+    private var announcedUpdate: String?
+
     private lazy var transcriber = Transcriber { [weak self] status in
         DispatchQueue.main.async { self?.handleTranscriberStatus(status) }
     }
@@ -142,7 +150,102 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         settings.model.outputDir = config.audio.outputDir
 
         startKeepWarm()
+        startUpdateChecks()
         updateUI()
+    }
+
+    // MARK: - Updates
+
+    /// Once shortly after launch, then daily.
+    ///
+    /// Restarted on every config load, since `after_days` can turn the whole
+    /// thing off — and a setting that only takes effect after a restart is one
+    /// that will be reported as not working.
+    private func startUpdateChecks() {
+        updatesTimer?.invalidate()
+        updatesTimer = nil
+
+        guard config.updates.afterDays >= 0 else {
+            updateAvailable = nil
+            return
+        }
+
+        // Not at launch: the first seconds belong to the hotkey, the mic and
+        // the model. Nothing here is urgent enough to compete with them.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 20) { [weak self] in
+            self?.checkForUpdate()
+        }
+        let timer = Timer(timeInterval: 86_400, repeats: true) { [weak self] _ in
+            self?.checkForUpdate()
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        updatesTimer = timer
+    }
+
+    private func checkForUpdate() {
+        let afterDays = config.updates.afterDays
+        guard afterDays >= 0 else { return }
+
+        Task<Void, Never> {
+            let latest = try? await Updates.latest()
+            await MainActor.run { [weak self] in
+                guard let self else { return }
+                let decision = Updates.decide(
+                    current: Updates.current, latest: latest, afterDays: afterDays
+                )
+                switch decision {
+                case .available(let release):
+                    self.updateAvailable = release
+                    if self.announcedUpdate != release.version {
+                        self.announcedUpdate = release.version
+                        Log.write("updates: \(release.version) is available")
+                        self.flash("ParrotFlow \(release.version) is available")
+                    }
+                case .waiting(let release, let days):
+                    self.updateAvailable = nil
+                    Log.write("updates: holding \(release.version) for \(days) more day(s)")
+                default:
+                    self.updateAvailable = nil
+                }
+                self.updateUI()
+            }
+        }
+    }
+
+    /// The release notes, and the three answers to them.
+    ///
+    /// No download button yet: taking the update in place means replacing a
+    /// running bundle, which is a separate piece of work and a worse thing to
+    /// get wrong than a missing button. Until then the command is the same one
+    /// that installed the app, and it is put on the clipboard rather than
+    /// printed for retyping.
+    @objc private func showUpdate() {
+        guard let release = updateAvailable else { return }
+
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        alert.messageText = "ParrotFlow \(release.version) is available"
+        alert.informativeText = (release.notes.isEmpty ? "No release notes." : release.notes)
+            + "\n\nYou are running \(Updates.current ?? "an unknown version")."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Copy the upgrade command")
+        alert.addButton(withTitle: "Skip this version")
+        alert.addButton(withTitle: "Later")
+
+        switch alert.runModal() {
+        case .alertFirstButtonReturn:
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(Updates.installCommand, forType: .string)
+            flash("Upgrade command copied — paste it into a terminal", tone: .done)
+        case .alertSecondButtonReturn:
+            Updates.skip(release.version)
+            updateAvailable = nil
+            updateUI()
+        default:
+            Updates.remindLater()
+            updateAvailable = nil
+            updateUI()
+        }
     }
 
     private func watchConfig() {
@@ -1022,6 +1125,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         statusInfoItem = NSMenuItem(title: "Idle", action: nil, keyEquivalent: "")
         statusInfoItem.isEnabled = false
         menu.addItem(statusInfoItem)
+
+        updateItem = NSMenuItem(title: "", action: #selector(showUpdate), keyEquivalent: "")
+        updateItem.target = self
+        updateItem.isHidden = true
+        menu.addItem(updateItem)
+
         menu.addItem(.separator())
 
         toggleItem = NSMenuItem(
@@ -1100,6 +1209,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         toggleItem.title = recording ? "Stop Dictation" : "Start Dictation"
+
+        updateItem.isHidden = updateAvailable == nil
+        if let release = updateAvailable {
+            updateItem.title = "↑ ParrotFlow \(release.version) is available"
+        }
     }
 
     // MARK: - Menu actions

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -124,6 +124,15 @@ enum CheckConfigCommand {
             print("  · llm               disabled — no free-form spoken commands")
         }
 
+        switch config.updates.afterDays {
+        case ..<0:
+            print("  · updates           never checked")
+        case 0:
+            print("  · updates           checked daily, offered as soon as published")
+        case let days:
+            print("  · updates           checked daily, offered after \(days) day\(days == 1 ? "" : "s")")
+        }
+
         // Environment
         let mic = Permissions.microphone
         print("  \(mic == .granted ? "✓" : "✗") microphone        \(mic.label)")

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -22,6 +22,7 @@ struct Config: Codable, Equatable {
     var feedback: Feedback = Feedback()
     var transcription: Transcription = Transcription()
     var llm: LLM = LLM()
+    var updates: UpdatePolicy = UpdatePolicy()
     var prompts: [Prompt] = []
 
     /// Do what was asked even when no prompt matches — see `FreeForm`.
@@ -39,7 +40,7 @@ struct Config: Codable, Equatable {
     var freeForm: Bool = true
 
     enum CodingKeys: String, CodingKey {
-        case hotkey, audio, feedback, transcription, llm, prompts
+        case hotkey, audio, feedback, transcription, llm, prompts, updates
         case freeForm = "free_form"
     }
 
@@ -94,6 +95,31 @@ struct Config: Codable, Equatable {
     }
 
     /// A local Ollama model, used to interpret spoken commands.
+    /// How long a release has to have existed before this Mac will take it.
+    ///
+    /// Not a polling interval — the check itself is daily. This is a waiting
+    /// period, and it is the only defence a one-person project has against its
+    /// own release pipeline being taken: a bad release that is noticed and
+    /// pulled inside the window is one nobody's app ever offered. See
+    /// `Updates` for why that is worth a setting.
+    struct UpdatePolicy: Codable, Equatable {
+        /// Negative never asks GitHub at all. Zero takes a release the day it
+        /// is published. Anything else waits that many days.
+        var afterDays: Int = 7
+
+        enum CodingKeys: String, CodingKey {
+            case afterDays = "after_days"
+        }
+
+        init() {}
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            self.init()
+            if let v = try c.decodeIfPresent(Int.self, forKey: .afterDays) { afterDays = v }
+        }
+    }
+
     struct LLM: Codable, Equatable {
         var enabled: Bool = true
         var model: String = "gemma4:e4b"
@@ -513,6 +539,9 @@ struct Config: Codable, Equatable {
             self.transcription = transcription
         }
         if let llm = try c.decodeIfPresent(LLM.self, forKey: .llm) { self.llm = llm }
+        if let updates = try c.decodeIfPresent(UpdatePolicy.self, forKey: .updates) {
+            self.updates = updates
+        }
         if let prompts = try c.decodeIfPresent([Prompt].self, forKey: .prompts) {
             // A prompt missing a name or content cannot be routed to or run, and
             // dropping it silently is how a typo becomes an evening. Named here
@@ -765,6 +794,27 @@ enum ConfigStore {
       # after five minutes, and reloading costs 7-10s on the next correction.
       # Turn off to get those seconds back as free RAM.
       keep_loaded: true
+
+    # Checking whether a newer ParrotFlow exists.
+    #
+    # One call a day to GitHub's release API — no account, nothing about you, and
+    # nothing about what you dictate. It is the only request this app makes on its
+    # own; the speech model is fetched once on first use, and the language model
+    # never leaves your Mac.
+    #
+    # The number is a waiting period, not how often it looks:
+    #
+    #   -1   never ask at all
+    #    0   offer a release the day it is published
+    #    7   only offer a release that has existed for a week
+    #
+    # The wait is the point. A release that turns out to be bad — a pipeline taken,
+    # a key stolen — is one that gets noticed and pulled, and a week of distance
+    # means your Mac never saw it. What proves an archive is ours is the pinned
+    # signing certificate in scripts/install.sh; this is the other half, and buys
+    # the time someone needs to notice in the first place.
+    updates:
+      after_days: 7
 
     # Things you can ask for by voice: say the wake phrase, then the instruction.
     #

--- a/Sources/ParrotFlow/UpdateCheckCommand.swift
+++ b/Sources/ParrotFlow/UpdateCheckCommand.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Asks the same question the app asks daily, and shows its working.
+///
+///     ParrotFlow --update-check
+///     ParrotFlow --update-check --after-days 0
+///
+/// The `--after-days` override is what makes the waiting period testable at
+/// all: the alternative is publishing a release and coming back in a week.
+enum UpdateCheckCommand {
+
+    static func run(afterDays override: Int?) -> Int32 {
+        let config = (try? ConfigStore.load()) ?? Config()
+        let afterDays = override ?? config.updates.afterDays
+
+        let current = Updates.current
+        print("current            \(current ?? "unknown (running outside the app bundle)")")
+        print("waiting period     \(describe(afterDays))")
+
+        if afterDays < 0 {
+            print("decision           no check — updates.after_days is negative")
+            return 0
+        }
+
+        var latest: Updates.Release?
+        let done = DispatchSemaphore(value: 0)
+        Task<Void, Never> {
+            do {
+                latest = try await Updates.latest()
+            } catch {
+                // Being offline is a normal state, not a failed command: a
+                // non-zero exit here would make a laptop on a train look like
+                // a broken build.
+                print("decision           could not ask GitHub: \(error.localizedDescription)")
+            }
+            done.signal()
+        }
+        done.wait()
+
+        guard let latest else { return 0 }
+
+        print("latest             \(latest.version)")
+        print("published          \(latest.publishedAt) (\(latest.ageInDays) days ago)")
+
+        let state = Updates.State.standard
+        if let skipped = state.skipped { print("skipped            \(skipped)") }
+        if let remind = state.remindAfter { print("remind after       \(remind)") }
+
+        switch Updates.decide(current: current, latest: latest, afterDays: afterDays, state: state) {
+        case .disabled:
+            print("decision           no check — updates.after_days is negative")
+        case .upToDate(let running, let published):
+            print("decision           up to date (\(running), latest is \(published))")
+        case .waiting(let release, let days):
+            print("decision           holding \(release.version) for \(days) more day(s)")
+        case .skipped(let release):
+            print("decision           \(release.version) was skipped")
+        case .snoozed(let release, let until):
+            print("decision           \(release.version) postponed until \(until)")
+        case .available(let release):
+            print("decision           offer \(release.version)")
+            print()
+            print(release.notes.isEmpty ? "(no release notes)" : release.notes)
+        }
+        return 0
+    }
+
+    private static func describe(_ days: Int) -> String {
+        switch days {
+        case ..<0: return "never check (\(days))"
+        case 0: return "none — take a release the day it is published"
+        case 1: return "1 day"
+        default: return "\(days) days"
+        }
+    }
+}

--- a/Sources/ParrotFlow/Updates.swift
+++ b/Sources/ParrotFlow/Updates.swift
@@ -1,0 +1,227 @@
+import Foundation
+
+/// Whether a newer ParrotFlow exists — and whether it is old enough to take.
+///
+/// The second half is the unusual one. `updates.after_days` is a waiting period,
+/// not a polling interval: a release is ignored until it has existed for that
+/// many days. Nothing about this repository is special enough to be attacked,
+/// but the shape of it is the shape everyone in this category has — a
+/// self-signed binary, downloaded over `curl`, that then asks for the
+/// microphone and for permission to type into every window. The delay is what
+/// turns "a bad release was published" into "a bad release was published and
+/// pulled before anyone's app looked", which is the only realistic defence a
+/// one-person project has against its own release pipeline being taken.
+///
+/// It is a delay, not a proof. What proves the archive is ours is the pinned
+/// signing certificate, checked before anything is installed — see
+/// `scripts/install.sh`. The two answer different questions and neither
+/// replaces the other: the certificate answers "is this from you", the waiting
+/// period answers "have you had time to notice it should not have been".
+enum Updates {
+
+    static let repo = "znat/parrotflow"
+
+    /// What is published, as the API describes it.
+    struct Release: Equatable {
+        let version: String
+        let publishedAt: Date
+        let notes: String
+        let zip: URL
+        let checksum: URL
+
+        var age: TimeInterval { Date().timeIntervalSince(publishedAt) }
+        var ageInDays: Int { Int(age / 86_400) }
+    }
+
+    /// Every answer the check can give, including the ones that are not "yes".
+    ///
+    /// Separate cases rather than an optional Release, because `--update-check`
+    /// has to be able to say *why* nothing is being offered. "No update" and
+    /// "an update exists but you asked to wait five more days" look identical
+    /// from the outside and are entirely different situations to debug.
+    enum Decision: Equatable {
+        case disabled
+        case upToDate(current: String, latest: String)
+        case waiting(Release, daysToGo: Int)
+        case skipped(Release)
+        case snoozed(Release, until: Date)
+        case available(Release)
+    }
+
+    enum Failure: Error, LocalizedError {
+        case offline(String)
+        case malformed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .offline(let why): return why
+            case .malformed(let what): return "GitHub answered with something unexpected: \(what)"
+            }
+        }
+    }
+
+    // MARK: - This build
+
+    /// Empty when the binary is run outside its bundle, which is how the test
+    /// scripts run it. Reported rather than papered over with a zero: a version
+    /// that reads "0.0.0" would make every release look like an upgrade.
+    static var current: String? {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    }
+
+    // MARK: - Deciding
+
+    static func decide(
+        current: String?,
+        latest: Release?,
+        afterDays: Int,
+        state: State = .standard
+    ) -> Decision {
+        guard afterDays >= 0 else { return .disabled }
+        guard let latest else { return .upToDate(current: current ?? "?", latest: "?") }
+        guard let current, isNewer(latest.version, than: current) else {
+            return .upToDate(current: current ?? "?", latest: latest.version)
+        }
+        if state.skipped == latest.version { return .skipped(latest) }
+
+        let ready = latest.publishedAt.addingTimeInterval(Double(afterDays) * 86_400)
+        if ready > Date() {
+            // Rounded up: with a 7 day wait and a release six and a half days
+            // old, "1 day to go" is true and "0 days to go" is a lie that
+            // invites the user to wonder why nothing is being offered.
+            let remaining = Int(ceil(ready.timeIntervalSinceNow / 86_400))
+            return .waiting(latest, daysToGo: max(remaining, 1))
+        }
+        if let until = state.remindAfter, until > Date() {
+            return .snoozed(latest, until: until)
+        }
+        return .available(latest)
+    }
+
+    /// Numeric, field by field. String comparison would put 0.10.0 before
+    /// 0.9.0, which is exactly the release where it would first matter.
+    static func isNewer(_ candidate: String, than current: String) -> Bool {
+        let a = fields(candidate), b = fields(current)
+        for i in 0..<max(a.count, b.count) {
+            let left = i < a.count ? a[i] : 0
+            let right = i < b.count ? b[i] : 0
+            if left != right { return left > right }
+        }
+        return false
+    }
+
+    private static func fields(_ version: String) -> [Int] {
+        version
+            .trimmingCharacters(in: CharacterSet(charactersIn: "v "))
+            .split(separator: "-").first
+            .map(String.init)?
+            .split(separator: ".")
+            .map { Int($0.filter(\.isNumber)) ?? 0 }
+            ?? []
+    }
+
+    // MARK: - Asking GitHub
+
+    /// One call, no authentication. Unauthenticated GitHub allows 60 an hour
+    /// per address, and this runs once a day.
+    static func latest(timeout: TimeInterval = 10) async throws -> Release {
+        guard let url = URL(string: "https://api.github.com/repos/\(repo)/releases/latest") else {
+            throw Failure.malformed("bad URL")
+        }
+        var request = URLRequest(url: url, timeoutInterval: timeout)
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        // GitHub rejects an unidentified caller outright, and the version makes
+        // their rate-limit logs useful to us if this ever misbehaves in the wild.
+        request.setValue(
+            "ParrotFlow/\(current ?? "dev") (+https://github.com/\(repo))",
+            forHTTPHeaderField: "User-Agent"
+        )
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            throw Failure.offline(error.localizedDescription)
+        }
+        if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+            throw Failure.offline("GitHub answered \(http.statusCode)")
+        }
+        return try parse(data)
+    }
+
+    static func parse(_ data: Data) throws -> Release {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw Failure.malformed("not JSON")
+        }
+        guard let tag = root["tag_name"] as? String else { throw Failure.malformed("no tag_name") }
+        guard let published = root["published_at"] as? String,
+              let date = ISO8601DateFormatter().date(from: published) else {
+            throw Failure.malformed("no published_at")
+        }
+
+        let assets = root["assets"] as? [[String: Any]] ?? []
+        func asset(named name: String) -> URL? {
+            assets
+                .first { $0["name"] as? String == name }
+                .flatMap { $0["browser_download_url"] as? String }
+                .flatMap(URL.init(string:))
+        }
+        // A release with no archive attached is a build that failed after the
+        // tag was cut. Offering it would send someone to a download that is not
+        // there, so it does not count as a release at all.
+        guard let zip = asset(named: "ParrotFlow.zip"),
+              let checksum = asset(named: "ParrotFlow.zip.sha256") else {
+            throw Failure.malformed("the release has no ParrotFlow.zip attached")
+        }
+
+        return Release(
+            version: tag.trimmingCharacters(in: CharacterSet(charactersIn: "v ")),
+            publishedAt: date,
+            notes: (root["body"] as? String ?? "").trimmingCharacters(in: .whitespacesAndNewlines),
+            zip: zip,
+            checksum: checksum
+        )
+    }
+
+    // MARK: - What the user already answered
+
+    /// Deliberately not in config.yaml. "Skip 0.4.0" and "not now" are answers
+    /// to a question the app asked, not settings anybody would go and write by
+    /// hand — and putting them in the config file would mean rewriting a file
+    /// full of the user's own comments every time they press Later.
+    struct State {
+        var skipped: String?
+        var remindAfter: Date?
+
+        /// Read on every access, not once. As a `static let` this was
+        /// resolved at first use and cached for the life of the process, so
+        /// pressing Skip changed nothing until the app was restarted — the
+        /// decision would keep being made against the state from launch.
+        static var standard: State {
+            State(
+                skipped: UserDefaults.standard.string(forKey: skippedKey),
+                remindAfter: UserDefaults.standard.object(forKey: remindKey) as? Date
+            )
+        }
+
+        static let skippedKey = "updates.skipped"
+        static let remindKey = "updates.remindAfter"
+    }
+
+    static func skip(_ version: String) {
+        UserDefaults.standard.set(version, forKey: State.skippedKey)
+        Log.write("updates: skipping \(version)")
+    }
+
+    static func remindLater(days: Int = 3) {
+        let until = Date().addingTimeInterval(Double(days) * 86_400)
+        UserDefaults.standard.set(until, forKey: State.remindKey)
+        Log.write("updates: reminding again after \(until)")
+    }
+
+    /// The command a user runs to take the update, ready to paste.
+    static var installCommand: String {
+        "curl -fsSL https://raw.githubusercontent.com/\(repo)/main/scripts/install.sh | sh"
+    }
+}

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -190,6 +190,13 @@ if let index = arguments.firstIndex(of: "--panels") {
     exit(PanelsCommand.run(surface: arguments[index + 1], seconds: seconds ?? 20))
 }
 
+if arguments.contains("--update-check") {
+    let after = arguments.firstIndex(of: "--after-days").flatMap { index in
+        arguments.indices.contains(index + 1) ? Int(arguments[index + 1]) : nil
+    }
+    exit(UpdateCheckCommand.run(afterDays: after))
+}
+
 if let index = arguments.firstIndex(of: "--watch-modifiers") {
     let seconds = arguments.indices.contains(index + 1) ? Double(arguments[index + 1]) : nil
     exit(WatchModifiersCommand.run(seconds: seconds ?? 10))

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -117,6 +117,27 @@ llm:
   # Turn off to get those seconds back as free RAM.
   keep_loaded: true
 
+# Checking whether a newer ParrotFlow exists.
+#
+# One call a day to GitHub's release API — no account, nothing about you, and
+# nothing about what you dictate. It is the only request this app makes on its
+# own; the speech model is fetched once on first use, and the language model
+# never leaves your Mac.
+#
+# The number is a waiting period, not how often it looks:
+#
+#   -1   never ask at all
+#    0   offer a release the day it is published
+#    7   only offer a release that has existed for a week
+#
+# The wait is the point. A release that turns out to be bad — a pipeline taken,
+# a key stolen — is one that gets noticed and pulled, and a week of distance
+# means your Mac never saw it. What proves an archive is ours is the pinned
+# signing certificate in scripts/install.sh; this is the other half, and buys
+# the time someone needs to notice in the first place.
+updates:
+  after_days: 7
+
 # Things you can ask for by voice: say the wake phrase, then the instruction.
 #
 #     "hey parrot, make that a bullet list"


### PR DESCRIPTION
The app did not know its own version. release-please stamps `CFBundleShortVersionString` into the bundle on every release and nothing read it, so an install stayed where it was until somebody happened to visit the repo.

It now asks GitHub once a day. The interesting part is what it does with the answer.

## `updates.after_days` is a waiting period, not a polling interval

```yaml
updates:
  after_days: 7    # -1 never asks · 0 takes it the day it is published
```

A release is ignored until it has existed that long. A one-person project signs its own binaries, ships them over `curl`, and then asks for the microphone and for permission to type into every window. Against its own pipeline being taken, distance is the only realistic defence: a bad release noticed and pulled inside the window is one that no Mac with a waiting period ever saw.

It is not a proof and does not pretend to be. #10 pins the certificate, which says the archive is **ours**; this buys the time in which someone could find out it should not have been. Different questions.

## Five answers, not two

`no update` and `an update exists but you asked me to wait five more days` look identical from outside and are completely different to debug. `--update-check` prints which one and why; `--after-days` overrides the setting, which is the only way to test a waiting period without publishing a release and waiting a week.

**Verified against the live API on every branch**, with the bundle stamped back to `0.2.0` so a real upgrade could be observed:

```
$ ParrotFlow --update-check --after-days 7
current            0.2.0
latest             0.3.0
published          2026-08-02 06:54:13 +0000 (0 days ago)
decision           holding 0.3.0 for 7 more day(s)

$ ParrotFlow --update-check --after-days 0
decision           offer 0.3.0
   ## [0.3.0](…) — ### Features — * configure the transcript pipeline per language…
```

plus `was skipped`, `postponed until …`, and no request at all at `-1`. `scripts/check-default-config.sh` confirms the seeded config still parses.

## What is not here

**No download button.** Taking an update in place means replacing a running bundle — its own piece of work, and a worse thing to get wrong than a missing button. The upgrade command goes to the clipboard instead. That is the next PR.

## One correction

The README claimed *no network call*. There are two — the speech model, once, and this — and neither carries audio or text. Saying so plainly is worth more than the sentence was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LF9RbnYCnKs5suARU4maok