### PR TITLE
feat: install an update from inside the app

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -99,3 +99,8 @@ jobs:
       # drifted twice, both times silently.
       - name: The config a new install gets
         run: scripts/check-default-config.sh
+
+      # Two ways in, one certificate. A pin that is only right in the script or
+      # only right in the app is a door that checks less than the other one.
+      - name: Both install paths pin the same certificate
+        run: scripts/check-pinned-certificate.sh

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -212,6 +212,40 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    /// Downloads, checks, and hands over to the swap.
+    ///
+    /// Nothing is replaced until the archive has matched its published
+    /// checksum, verified as signed, and been signed by our certificate —
+    /// the same three the curl installer applies, for the same reason.
+    ///
+    /// Quitting is part of the update rather than a side effect: the swap
+    /// waits for this process to exit before it moves anything, so an update
+    /// that could not close the app would simply hang.
+    private func install(_ release: Updates.Release) {
+        beginProgress("Downloading ParrotFlow \(release.version)…")
+        Task<Void, Never> {
+            do {
+                let app = try await UpdateInstaller.prepare(release)
+                try await MainActor.run {
+                    self.endProgress()
+                    try UpdateInstaller.swapAndRelaunch(newApp: app)
+                    NSApp.terminate(nil)
+                }
+            } catch {
+                await MainActor.run {
+                    self.endProgress()
+                    Log.write("updates: install failed — \(error.localizedDescription)")
+                    self.presentAlert(
+                        title: "Could not install the update",
+                        message: error.localizedDescription
+                            + "\n\nNothing on this Mac has been changed. You can still upgrade with:\n\n"
+                            + Updates.installCommand
+                    )
+                }
+            }
+        }
+    }
+
     /// The release notes, and the three answers to them.
     ///
     /// No download button yet: taking the update in place means replacing a
@@ -228,11 +262,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         alert.informativeText = (release.notes.isEmpty ? "No release notes." : release.notes)
             + "\n\nYou are running \(Updates.current ?? "an unknown version")."
         alert.alertStyle = .informational
+        // Installing in place is only offered when it can actually be done.
+        // An app in a read-only location, or one someone put somewhere odd,
+        // still gets the command it was installed with rather than a button
+        // that fails after downloading 3 MB.
+        let canInstall = UpdateInstaller.canInstallInPlace
+        if canInstall { alert.addButton(withTitle: "Update and restart") }
         alert.addButton(withTitle: "Copy the upgrade command")
         alert.addButton(withTitle: "Skip this version")
         alert.addButton(withTitle: "Later")
 
-        switch alert.runModal() {
+        var answer = alert.runModal()
+        if canInstall, answer == .alertFirstButtonReturn {
+            install(release)
+            return
+        }
+        // With the install button present every other answer sits one place
+        // further along, so it is shifted back rather than each case being
+        // written twice.
+        if canInstall { answer = NSApplication.ModalResponse(rawValue: answer.rawValue - 1) }
+
+        switch answer {
         case .alertFirstButtonReturn:
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(Updates.installCommand, forType: .string)

--- a/Sources/ParrotFlow/UpdateInstallCommand.swift
+++ b/Sources/ParrotFlow/UpdateInstallCommand.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Downloads and checks a release without installing it.
+///
+///     ParrotFlow --update-install --dry-run     # everything but the swap
+///     ParrotFlow --update-install               # and the swap
+///
+/// The dry run exists because every interesting failure happens before the
+/// swap — a checksum that does not match, an archive signed by someone else, a
+/// release whose asset was built from the wrong tag. Those are the paths worth
+/// exercising, and none of them should require replacing the app on the
+/// machine doing the exercising.
+enum UpdateInstallCommand {
+
+    static func run(dryRun: Bool) -> Int32 {
+        guard let current = Updates.current else {
+            print("✗ this binary is running outside its app bundle, so there is nothing to replace")
+            return 1
+        }
+
+        var code: Int32 = 0
+        let done = DispatchSemaphore(value: 0)
+        Task<Void, Never> {
+            do {
+                let release = try await Updates.latest()
+                print("current            \(current)")
+                print("latest             \(release.version)")
+
+                guard Updates.isNewer(release.version, than: current) else {
+                    print("decision           nothing to install")
+                    done.signal()
+                    return
+                }
+
+                print("downloading        \(release.zip.lastPathComponent)")
+                let app = try await UpdateInstaller.prepare(release)
+                print("checksum           matches the published one")
+                print("signature          valid")
+                print("certificate        \(try UpdateInstaller.certificateFingerprint(of: app))")
+                print("identity           \(Bundle.main.bundleIdentifier ?? "?")")
+                print("verified           \(app.path)")
+
+                guard !dryRun else {
+                    print("dry run            not installing")
+                    done.signal()
+                    return
+                }
+                guard UpdateInstaller.canInstallInPlace else {
+                    print("✗ \(UpdateInstaller.destination.path) cannot be replaced from here")
+                    code = 1
+                    done.signal()
+                    return
+                }
+                try UpdateInstaller.swapAndRelaunch(newApp: app)
+                print("installing         after this process exits")
+            } catch {
+                print("✗ \(error.localizedDescription)")
+                code = 1
+            }
+            done.signal()
+        }
+        done.wait()
+        return code
+    }
+}

--- a/Sources/ParrotFlow/UpdateInstaller.swift
+++ b/Sources/ParrotFlow/UpdateInstaller.swift
@@ -1,0 +1,224 @@
+import CryptoKit
+import Foundation
+
+/// Takes a release and puts it where the running app is.
+///
+/// Every check `scripts/install.sh` performs is performed here, in the same
+/// order and for the same reasons, because this is the other way in and a door
+/// that checks less is the door that gets used. Published checksum, signature,
+/// and the pinned certificate — an update is refused unless all three agree.
+///
+/// The last step is the awkward one: an app cannot replace the bundle it is
+/// running from. So the swap is handed to a detached shell that waits for this
+/// process to exit, moves the old bundle aside, moves the new one in, and
+/// relaunches. If the move fails the old one goes back, because the worst
+/// outcome here is not a failed update — it is a Mac with no ParrotFlow on it
+/// and no idea why.
+enum UpdateInstaller {
+
+    enum Failure: Error, LocalizedError {
+        case download(String)
+        case checksum(expected: String, got: String)
+        case signature(String)
+        case certificate(expected: String, got: String)
+        case contents(String)
+        case notWritable(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .download(let why):
+                return "could not download the update: \(why)"
+            case .checksum(let expected, let got):
+                return "the download does not match its published checksum "
+                    + "(expected \(expected.prefix(12))…, got \(got.prefix(12))…)"
+            case .signature(let why):
+                return "the downloaded app failed signature verification: \(why)"
+            case .certificate(let expected, let got):
+                return "the downloaded app was signed by someone else "
+                    + "(expected \(expected.prefix(12))…, found \(got.prefix(12))…)"
+            case .contents(let what):
+                return "the download is not what it should be: \(what)"
+            case .notWritable(let path):
+                return "\(path) cannot be written to, so the update has to be installed by hand"
+            }
+        }
+    }
+
+    /// Where this app is, and whether it can be replaced in place.
+    static var destination: URL { Bundle.main.bundleURL }
+
+    static var canInstallInPlace: Bool {
+        FileManager.default.isWritableFile(atPath: destination.deletingLastPathComponent().path)
+    }
+
+    // MARK: - Fetch and verify
+
+    /// Downloads, checks, and unpacks — everything except the part that cannot
+    /// be undone. Returns the verified bundle, still in a temporary directory.
+    static func prepare(_ release: Updates.Release) async throws -> URL {
+        let scratch = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("parrotflow-update-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+
+        let zip = scratch.appendingPathComponent("ParrotFlow.zip")
+        try await download(release.zip, to: zip)
+
+        let publishedSum = try await string(from: release.checksum)
+            .split(separator: " ").first.map(String.init) ?? ""
+        let actualSum = try sha256(ofFileAt: zip)
+        guard publishedSum == actualSum else {
+            throw Failure.checksum(expected: publishedSum, got: actualSum)
+        }
+
+        // ditto, not unzip: a .app is a bundle, and unzip drops the metadata
+        // the signature covers — which would cost the user their permissions.
+        let unpacked = scratch.appendingPathComponent("unpacked")
+        guard run("/usr/bin/ditto", ["-x", "-k", zip.path, unpacked.path]).status == 0 else {
+            throw Failure.contents("could not unpack the archive")
+        }
+        let app = unpacked.appendingPathComponent(destination.lastPathComponent)
+        guard FileManager.default.fileExists(atPath: app.path) else {
+            throw Failure.contents("the archive does not contain \(destination.lastPathComponent)")
+        }
+
+        try verify(app, expecting: release.version)
+        return app
+    }
+
+    /// The three checks, in the order install.sh runs them.
+    static func verify(_ app: URL, expecting version: String) throws {
+        let verified = run("/usr/bin/codesign", ["--verify", "--deep", "--strict", app.path])
+        guard verified.status == 0 else {
+            throw Failure.signature(verified.error.isEmpty ? "unknown reason" : verified.error)
+        }
+
+        let signer = try certificateFingerprint(of: app)
+        guard signer == Updates.expectedCertificateSHA256 else {
+            throw Failure.certificate(expected: Updates.expectedCertificateSHA256, got: signer)
+        }
+
+        // Identity and version, because a valid archive can still be the wrong
+        // one: a release asset built from the wrong tag would pass everything
+        // above and then downgrade the user.
+        guard let plist = NSDictionary(contentsOf: app.appendingPathComponent("Contents/Info.plist")),
+              let identifier = plist["CFBundleIdentifier"] as? String,
+              let shipped = plist["CFBundleShortVersionString"] as? String else {
+            throw Failure.contents("no readable Info.plist")
+        }
+        guard identifier == Bundle.main.bundleIdentifier else {
+            throw Failure.contents("it is \(identifier), not \(Bundle.main.bundleIdentifier ?? "us")")
+        }
+        guard shipped == version else {
+            throw Failure.contents("the archive says \(shipped), the release says \(version)")
+        }
+    }
+
+    /// The SHA-256 of the leaf certificate — the same value `install.sh` pins,
+    /// derived the same way.
+    static func certificateFingerprint(of app: URL) throws -> String {
+        let out = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("pf-cert-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: URL(fileURLWithPath: out.path + "0")) }
+
+        let extracted = run("/usr/bin/codesign", ["-d", "--extract-certificates=\(out.path)", app.path])
+        guard extracted.status == 0,
+              let der = FileManager.default.contents(atPath: out.path + "0") else {
+            throw Failure.signature("could not read its signing certificate")
+        }
+        return SHA256.hash(data: der).map { String(format: "%02x", $0) }.joined()
+    }
+
+    // MARK: - Swap
+
+    /// Hands the swap to a process that outlives this one, then leaves.
+    ///
+    /// Paths are passed as arguments rather than pasted into the script text:
+    /// they contain the app's name and its parent directory, and a path with a
+    /// space in it would otherwise become two words at the worst possible
+    /// moment.
+    static func swapAndRelaunch(newApp: URL) throws {
+        guard canInstallInPlace else {
+            throw Failure.notWritable(destination.deletingLastPathComponent().path)
+        }
+
+        // The outcome goes to the log because by then there is nobody left to
+        // tell. This process has exited, and the app that comes back up is
+        // whichever one won — so an update that failed and one that worked look
+        // exactly alike from the outside: the app relaunches either way.
+        let script = """
+        while kill -0 "$1" 2>/dev/null; do sleep 0.2; done
+        backup="$2.replaced-$$"
+        if ! mv "$2" "$backup"; then
+            echo "updates: could not move the current app aside; nothing changed" >> "$4"
+            exit 1
+        fi
+        if mv "$3" "$2"; then
+            rm -rf "$backup"
+            echo "updates: replaced with the downloaded version" >> "$4"
+        else
+            mv "$backup" "$2"
+            echo "updates: the swap failed — put the previous version back" >> "$4"
+        fi
+        open "$2"
+        """
+
+        let swap = Process()
+        swap.executableURL = URL(fileURLWithPath: "/bin/sh")
+        swap.arguments = [
+            "-c", script, "swap",
+            String(ProcessInfo.processInfo.processIdentifier),
+            destination.path,
+            newApp.path,
+            Log.fileURL.path,
+        ]
+        try swap.run()
+        Log.write("updates: swapping in \(newApp.path), then relaunching")
+    }
+
+    // MARK: - Plumbing
+
+    private static func download(_ url: URL, to file: URL) async throws {
+        do {
+            let (temporary, response) = try await URLSession.shared.download(from: url)
+            if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+                throw Failure.download("GitHub answered \(http.statusCode)")
+            }
+            try? FileManager.default.removeItem(at: file)
+            try FileManager.default.moveItem(at: temporary, to: file)
+        } catch let failure as Failure {
+            throw failure
+        } catch {
+            throw Failure.download(error.localizedDescription)
+        }
+    }
+
+    private static func string(from url: URL) async throws -> String {
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            return String(decoding: data, as: UTF8.self)
+        } catch {
+            throw Failure.download(error.localizedDescription)
+        }
+    }
+
+    private static func sha256(ofFileAt url: URL) throws -> String {
+        let data = try Data(contentsOf: url)
+        return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func run(_ tool: String, _ arguments: [String]) -> (status: Int32, error: String) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: tool)
+        process.arguments = arguments
+        let errors = Pipe()
+        process.standardError = errors
+        process.standardOutput = Pipe()
+        do { try process.run() } catch { return (-1, error.localizedDescription) }
+        let data = errors.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return (
+            process.terminationStatus,
+            String(decoding: data, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
+}

--- a/Sources/ParrotFlow/Updates.swift
+++ b/Sources/ParrotFlow/Updates.swift
@@ -21,6 +21,19 @@ enum Updates {
 
     static let repo = "znat/parrotflow"
 
+    /// SHA-256 of the leaf certificate every release is signed with.
+    ///
+    /// The same value `scripts/install.sh` pins, and it has to stay the same
+    /// value — scripts/check-pinned-certificate.sh fails the build if the two
+    /// drift apart, because a pin that is only correct in one of the two ways
+    /// in is worth very little.
+    ///
+    /// Derived, never typed from memory:
+    ///
+    ///     openssl x509 -in ~/.parrotflow-release/cert.pem -outform DER | shasum -a 256
+    static let expectedCertificateSHA256 =
+        "1fe06cb4b110d3f60ddb0a4d54e2694528b50ca1f40e939994306c8b068d2689"
+
     /// What is published, as the API describes it.
     struct Release: Equatable {
         let version: String

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -190,6 +190,10 @@ if let index = arguments.firstIndex(of: "--panels") {
     exit(PanelsCommand.run(surface: arguments[index + 1], seconds: seconds ?? 20))
 }
 
+if arguments.contains("--update-install") {
+    exit(UpdateInstallCommand.run(dryRun: arguments.contains("--dry-run")))
+}
+
 if arguments.contains("--update-check") {
     let after = arguments.firstIndex(of: "--after-days").flatMap { index in
         arguments.indices.contains(index + 1) ? Int(arguments[index + 1]) : nil

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -97,6 +97,30 @@ The certificate is therefore a durable asset, not a build artefact. Regenerating
 it breaks every existing install. It lives outside the repo and its `.p12` is a
 repository secret.
 
+It also does a second job, once `install.sh` pins it. `codesign --verify` proves
+a signature matches the bundle it covers and says nothing about who produced it:
+a self-signed certificate is free to make, can carry any common name — including
+this one — and passes that check. So the installer compares the SHA-256 of the
+leaf certificate against a pinned value, which is what turns "this archive is
+internally consistent" into "this archive is ours". A swapped release fails
+before anything is copied into `/Applications`.
+
+Pinning inside a script is usually how a project strands itself on a key it
+later has to rotate. It is safe here for the reason the file already relies on:
+`install.sh` is read from `main` on every run, so the pin travels in the same
+commit as the new certificate. And it fails in the right direction anyway — a
+release signed with a different certificate is one TCC would refuse the user's
+existing grants to, so refusing it in the installer converts a silent loss of
+Microphone and Accessibility into a stop with a reason.
+
+The fingerprint is derivable from the certificate itself, which is what makes
+rotating it a one-line change rather than an archaeology exercise:
+
+```sh
+openssl x509 -in ~/.parrotflow-release/cert.pem -outform DER | shasum -a 256
+codesign -d --extract-certificates=/tmp/c ParrotFlow.app && shasum -a 256 /tmp/c0
+```
+
 ## Gatekeeper without notarization is now genuinely bad
 
 This used to be a shrug — right-click, Open, done. Not since macOS 15:

--- a/scripts/check-pinned-certificate.sh
+++ b/scripts/check-pinned-certificate.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# The certificate is pinned in two places, because there are two ways to
+# install: the curl script and the app updating itself. A pin that is only
+# right in one of them is a door that checks less than the other, and that is
+# the door an attacker uses.
+#
+# So they are compared here rather than trusted to stay in step.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+from_script="$(sed -n 's/^CERT_SHA256="\([0-9a-f]*\)"$/\1/p' "$ROOT/scripts/install.sh" | head -1)"
+from_swift="$(sed -n 's/^ *"\([0-9a-f]\{64\}\)"$/\1/p' "$ROOT/Sources/ParrotFlow/Updates.swift" | head -1)"
+
+if [ -z "$from_script" ]; then
+    echo "✗ no pinned certificate found in scripts/install.sh" >&2
+    exit 1
+fi
+if [ -z "$from_swift" ]; then
+    echo "✗ no pinned certificate found in Sources/ParrotFlow/Updates.swift" >&2
+    exit 1
+fi
+if [ "$from_script" != "$from_swift" ]; then
+    echo "✗ the two pinned certificates disagree" >&2
+    echo "    scripts/install.sh   $from_script" >&2
+    echo "    Updates.swift        $from_swift" >&2
+    exit 1
+fi
+
+echo "✓ both install paths pin the same certificate  ${from_script:0:16}…"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -84,9 +84,10 @@ fetch "$BASE/$APP_NAME.zip.sha256" "$TMP/$APP_NAME.zip.sha256" \
     || die "the app downloaded but its checksum did not. Not installing an
        archive that cannot be verified."
 
-# Integrity, not authenticity: the checksum travels with the archive, so it
-# catches a truncated or corrupted download and nothing more. Verifying the
-# publisher needs a signature, which arrives with Developer ID.
+# The checksum travels with the archive, so on its own it catches a truncated
+# or corrupted download and nothing more: whoever could replace the archive
+# could replace the checksum beside it. Authenticity comes from the certificate
+# check further down.
 say "Checking the download"
 EXPECTED="$(cut -d' ' -f1 < "$TMP/$APP_NAME.zip.sha256")"
 ACTUAL="$(shasum -a 256 "$TMP/$APP_NAME.zip" | cut -d' ' -f1)"
@@ -102,6 +103,45 @@ ditto -x -k "$TMP/$APP_NAME.zip" "$TMP/unpacked" || die "could not unpack the do
 
 codesign --verify --deep --strict "$TMP/unpacked/$APP_NAME.app" 2>/dev/null \
     || die "the downloaded app failed signature verification; not installing it"
+
+# And then: signed by whom.
+#
+# The check above proves the signature matches the bundle. It does not prove
+# whose signature it is — anyone can make a self-signed certificate, sign an
+# app with it, and pass. Without the line below, an archive swapped for
+# somebody else's would install without a word, on a machine that is then asked
+# for the microphone and for permission to type into every window.
+#
+# So the leaf certificate's SHA-256 is pinned. The name is not enough: a
+# certificate can be issued to any common name, "ParrotFlow Release" included.
+#
+# Pinning a value inside a script is normally how you strand yourself on a
+# rotated key. Not here: this file is read from main on every run, so the day
+# the certificate changes, the pin changes with it in the same commit. And a
+# release signed with a different certificate is one macOS would refuse the
+# user's existing Microphone and Accessibility grants to anyway — refusing it
+# here turns a silent loss of permissions into a stop with a reason.
+CERT_SHA256="1fe06cb4b110d3f60ddb0a4d54e2694528b50ca1f40e939994306c8b068d2689"
+
+if [ -n "${PARROTFLOW_BASE_URL:-}" ]; then
+    # A local rehearsal (make try-install) builds and signs with whatever
+    # identity is on that machine, which is the dev certificate for anyone who
+    # is not cutting releases. Say the check was skipped rather than let a
+    # rehearsal look like it proved more than it did.
+    say "Local install — skipping the certificate check"
+else
+    codesign -d --extract-certificates="$TMP/cert" "$TMP/unpacked/$APP_NAME.app" 2>/dev/null \
+        || die "could not read the signing certificate of the downloaded app"
+    SIGNER="$(shasum -a 256 "$TMP/cert0" | cut -d' ' -f1)"
+    [ "$SIGNER" = "$CERT_SHA256" ] || die "this app was signed by someone else — not installing it.
+       expected certificate $CERT_SHA256
+       found                $SIGNER
+
+       Nothing on this Mac has been changed. If you did not expect this,
+       do not install ParrotFlow from anywhere else either — report it at
+       https://github.com/$REPO/issues"
+    say "Signed by the ParrotFlow release certificate"
+fi
 
 # --- Install -----------------------------------------------------------------
 


### PR DESCRIPTION
Stacked on #14 (and carries #10, whose pinned certificate this needs). **Merge #10 and #14 first** — GitHub will retarget this at `main`.

The check could only offer to copy a command into a terminal. This adds the button, and almost all of the work is what happens before it does anything.

## The same three checks as `install.sh`, in the same order

Published checksum → `codesign --verify` → **pinned certificate**. This is the second way in, and a second door that checks less than the first is the door that gets used.

Two more are specific to updating in place: the bundle identifier must be ours, and the version inside the archive must be the version the release claims — an asset built from the wrong tag passes everything else and then quietly downgrades the user.

The pin now lives in a shell script *and* in Swift, so it can drift. `scripts/check-pinned-certificate.sh` compares them and runs in CI.

## Replacing a running bundle

The failure that matters is not a failed update — it is a Mac with no ParrotFlow on it and no explanation. So: a detached shell waits for the process to exit, moves the current app aside, moves the new one in, and **puts the old one back if that fails**. Paths are passed as arguments, never pasted into the script text.

It writes the outcome to the log, which is the only listener left by then. This process is gone, and an app relaunching after a failed swap looks exactly like one relaunching after a successful one.

The button only appears when the app can actually be replaced where it sits; anywhere read-only, the offer stays the command.

## Verified

From a release-variant bundle stamped back to `0.2.0`, against the published v0.3.0:

```
current            0.2.0
latest             0.3.0
downloading        ParrotFlow.zip
checksum           matches the published one
signature          valid
certificate        1fe06cb4b110d3f60ddb0a4d54e2694528b50ca1f40e939994306c8b068d2689
identity           com.parrotflow.app
dry run            not installing
```

And the swap script on stand-in directories, both ways:

```
1. échange réussi   -> contenu: new  log: updates: replaced with the downloaded version
2. échange échoué   -> contenu: old  log: updates: the swap failed — put the previous version back
```

**Not verified:** the alert and its buttons on screen — that needs a run with the menu open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LF9RbnYCnKs5suARU4maok