### PR TITLE
feat: several activation phrases, and one said inside a dictation

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -96,6 +96,11 @@ jobs:
       - name: Wake phrase
         run: scripts/check-wake.sh
 
+      # And the same question for a phrase found mid-sentence, where a false
+      # positive splits an ordinary sentence and sends half of it to a model.
+      - name: Instruction inside a dictation
+        run: scripts/check-split.sh
+
       # Reads its pattern out of Config.defaultYAML, so this is also what keeps
       # the shipped default honest: the one rewrite that fires on ordinary
       # language rather than on a name someone taught it.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -91,6 +91,11 @@ jobs:
       - name: Pipeline
         run: scripts/check-pipeline.sh
 
+      # Where the wake phrase ends and the instruction begins. Deterministic,
+      # unlike the routing that follows it, so it runs here.
+      - name: Wake phrase
+        run: scripts/check-wake.sh
+
       # Reads its pattern out of Config.defaultYAML, so this is also what keeps
       # the shipped default honest: the one rewrite that fires on ordinary
       # language rather than on a name someone taught it.

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -997,10 +997,138 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
+        // An instruction said inside the dictation, about the words in front of
+        // it. Checked after the command case above, which is the same phrase in
+        // the first position and means something else entirely.
+        if let split = VoiceCommand.inlineInstruction(
+            trimmed, phrases: config.transcription.activationPhrases
+        ) {
+            Log.write("inline: \"\(split.instruction)\" over \"\(split.text)\"")
+            settings.model.lastTranscript = split.text
+            runInline(text: split.text, instruction: split.instruction)
+            return
+        }
+
         Log.write("transcribed: \(trimmed)")
         settings.model.lastTranscript = trimmed
+        insertDictation(trimmed)
+    }
 
-        switch TextInserter.insert(trimmed, mode: config.transcription.insertMode) {
+    /// An instruction found inside a dictation: route it, run it over the words
+    /// that came before it, and write the result.
+    ///
+    /// Every way this can fail writes the dictated text instead, and says what
+    /// went wrong for long enough to read. That is the opposite of the rule
+    /// elsewhere in the app, where a transform that fails leaves the text
+    /// alone — there the words are already on screen, and here they exist
+    /// nowhere but in this function. Losing the instruction costs you a second
+    /// attempt; losing the sentence costs you the sentence.
+    ///
+    /// No preview panel, whatever the transform's `confirm` says. That setting
+    /// guards text you selected and are about to have overwritten; nothing is
+    /// being overwritten here, and a dialog in the middle would give back the
+    /// second round trip this exists to remove. The rewrite goes to the log
+    /// with its before and after, as pipeline transforms do.
+    private func runInline(text: String, instruction: String) {
+        let catalogue = Catalogue(prompts: config.prompts)
+
+        /// Write what was said, and say why it is not what was asked for.
+        func giveUp(_ why: String, tone: NoticeTone = .caution) {
+            endProgress()
+            Log.write("inline: \(why); wrote the text as dictated")
+            insertDictation(text)
+            notice.show(why, tone: tone, duration: 7)
+            setLabel(why, clearAfter: 7)
+        }
+
+        func run(_ prompt: Config.Prompt) {
+            beginProgress("\(prompt.name)…")
+            let llm = llmConfig()
+            Task { [weak self] in
+                do {
+                    let result = try await PromptRunner.run(
+                        prompt: prompt, instruction: instruction, text: text, config: llm
+                    )
+                    await MainActor.run {
+                        guard let self else { return }
+                        self.endProgress()
+                        let cleaned = result.trimmingCharacters(in: .whitespacesAndNewlines)
+                        guard !cleaned.isEmpty else {
+                            giveUp("\(prompt.name) returned nothing", tone: .failure)
+                            return
+                        }
+                        if cleaned != text {
+                            Log.write("inline: \(prompt.name) rewrote the transcript")
+                            Log.write("    before: \(text)")
+                            Log.write("    after:  \(cleaned)")
+                        }
+                        self.settings.model.lastTranscript = cleaned
+                        self.insertDictation(cleaned)
+                    }
+                } catch {
+                    await MainActor.run {
+                        giveUp(error.localizedDescription, tone: .failure)
+                    }
+                }
+            }
+        }
+
+        if let capability = Router.local(instruction: instruction, catalogue: catalogue) {
+            Log.write("inline router: \"\(instruction)\" named \(capability.name) outright")
+            // An action opens a panel or writes a rule — neither is a rewrite of
+            // the words in front of it, so there is nothing to apply here.
+            guard case .transform(let prompt) = capability else {
+                giveUp("\"\(instruction)\" is not something to change in the text")
+                return
+            }
+            run(prompt)
+            return
+        }
+
+        guard config.llm.enabled else {
+            giveUp("\"\(instruction)\" needs the local model — llm.enabled is false")
+            return
+        }
+
+        beginProgress("Thinking…")
+        let llm = llmConfig()
+        let freeForm = config.freeForm
+        Task { [weak self] in
+            do {
+                let decision = try await Router.route(
+                    instruction: instruction, catalogue: catalogue,
+                    freeForm: freeForm, config: llm
+                )
+                await MainActor.run {
+                    guard let self else { return }
+                    switch decision {
+                    case .matched(.transform(let prompt)):
+                        Log.write("inline router: \"\(instruction)\" → \(prompt.name)")
+                        run(prompt)
+                    case .matched(let capability):
+                        giveUp("\(capability.name) is not something to change in the text")
+                    case .anything:
+                        Log.write("inline router: \"\(instruction)\" → \(FreeForm.name)")
+                        run(FreeForm.prompt)
+                    case .none:
+                        giveUp("Not something to change in the text: \"\(instruction)\"")
+                    }
+                }
+            } catch {
+                await MainActor.run { giveUp(error.localizedDescription, tone: .failure) }
+            }
+        }
+    }
+
+    /// The text, exactly as dictation puts it in.
+    ///
+    /// Its own function because the inline path needs it too: every way that
+    /// path fails has to still write what you said. A transform over a
+    /// selection can fail with nothing but a message, because the words are
+    /// already on screen — here they have never been written, and a toast is
+    /// not somewhere you can copy them back out of.
+    private func insertDictation(_ text: String) {
+        switch TextInserter.insert(text, mode: config.transcription.insertMode) {
         case .pasted:
             if config.feedback.sound { NSSound(named: "Glass")?.play() }
         case .copied:

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -424,7 +424,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// spelling is the whole point of the command.
     private func commandAfterWakePhrase(_ text: String) -> String? {
         VoiceCommand.commandAfterWakePhrase(
-            text, phrase: config.transcription.activationPhrase
+            text, phrases: config.transcription.activationPhrases
         )
     }
 

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -52,7 +52,9 @@ enum CheckConfigCommand {
                 ? "paste into frontmost app (needs Accessibility)"
                 : "copy to clipboard"
             print("  · insert mode       \(mode)")
-            print("  · wake phrase       \"\(transcription.activationPhrase)\"")
+            let listed = transcription.activationPhrases
+                .map { "\"\($0)\"" }.joined(separator: ", ")
+            print("  · wake phrase       \(listed.isEmpty ? "none — spoken commands are off" : listed)")
             print("  · rewrite line      \(transcription.rewriteLine ? "on" : "off (terminals can't be edited without it)")")
             // The pipeline, per language, because "why was this not
             // converted" is a question about the order and not about a
@@ -162,7 +164,7 @@ enum CheckConfigCommand {
         // bundle run from a terminal reported Not granted. A check that says no
         // when the answer is yes is worse than no check, so it reports where the
         // real answer lives instead — the app tests it at launch and logs it.
-        if transcription.insertMode == .paste || !transcription.activationPhrase.isEmpty {
+        if transcription.insertMode == .paste || !transcription.activationPhrases.isEmpty {
             print("  · accessibility     needed, but not checkable from a terminal")
             print("      macOS credits this check to the shell, not to ParrotFlow.")
             print("      The app records the true value each time it starts:")

--- a/Sources/ParrotFlow/CommandTestCommand.swift
+++ b/Sources/ParrotFlow/CommandTestCommand.swift
@@ -28,6 +28,16 @@ enum CommandTestCommand {
         }
 
         guard let command = VoiceCommand.commandAfterWakePhrase(text, phrases: phrases) else {
+            // A phrase found mid-sentence is an instruction about the words in
+            // front of it, not about the selection — printed here rather than
+            // in a command of its own, because "what would this utterance do"
+            // has one answer and wants one place to ask it.
+            if let split = VoiceCommand.inlineInstruction(text, phrases: phrases) {
+                print("text:        \"\(split.text)\"")
+                print("instruction: \"\(split.instruction)\"")
+                print("→ an instruction inside a dictation; the text above is what it edits")
+                return 0
+            }
             print("→ not a command; this would be dictated as normal text")
             return 0
         }

--- a/Sources/ParrotFlow/CommandTestCommand.swift
+++ b/Sources/ParrotFlow/CommandTestCommand.swift
@@ -5,22 +5,29 @@ import Foundation
 ///
 /// Voice commands are otherwise only testable by speaking, which makes
 /// iterating on the prompt slow and makes regressions easy to miss.
+///
+/// `--phrases "hey parrot,by the way parrot"` stands in for the configured
+/// list, the same way `--lang` stands in for the configured languages: a case
+/// file can then state the environment it assumes instead of inheriting
+/// whichever phrases happen to be on this machine.
 enum CommandTestCommand {
 
-    static func run(text: String, lastTranscript: String? = nil) -> Int32 {
+    static func run(
+        text: String, lastTranscript: String? = nil, phrases override: [String]? = nil
+    ) -> Int32 {
         let config: Config
         do { config = try ConfigStore.load() } catch {
             print("✗ config: \(CheckConfigCommand.describe(error))")
             return 1
         }
 
-        let phrase = config.transcription.activationPhrase
-        print("wake phrase: \"\(phrase)\"")
+        let phrases = override ?? config.transcription.activationPhrases
+        print("wake phrase: \(phrases.map { "\"\($0)\"" }.joined(separator: ", "))")
         if let lastTranscript {
             print("context:     \"\(lastTranscript)\"")
         }
 
-        guard let command = VoiceCommand.commandAfterWakePhrase(text, phrase: phrase) else {
+        guard let command = VoiceCommand.commandAfterWakePhrase(text, phrases: phrases) else {
             print("→ not a command; this would be dictated as normal text")
             return 0
         }

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -919,9 +919,15 @@ enum ConfigStore {
       # instruction: "hey parrot, make that a bullet list". An empty list
       # disables spoken commands.
       #
-      # Several, because one phrase cannot be said in every position — and the
+      # One of them mid-sentence turns the rest into an instruction about the
+      # words before it, in the same breath:
+      #
+      #   "there is a bug in get username by the way parrot format that name"
+      #
+      # which is why there are two: "hey parrot" opens an utterance and reads
+      # as nonsense inside one, and "by the way parrot" is the reverse. The
       # first is the one to teach someone.
-      activation_phrases: [hey parrot]
+      activation_phrases: [hey parrot, by the way parrot]
 
       # Last resort for fields Accessibility cannot write, terminals mostly:
       # clear the input line with Ctrl-A Ctrl-K and retype it corrected. It

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -283,7 +283,10 @@ struct Config: Decodable, Equatable {
         }
     }
 
-    struct Transcription: Codable, Equatable {
+    /// Decodable and not Encodable, like `Config` itself and for the same
+    /// reason: nothing writes a config back out, and `activationPhrase` is a
+    /// view over the list rather than storage.
+    struct Transcription: Decodable, Equatable {
         var enabled: Bool = true
         /// `paste` types the transcript into the frontmost app (needs
         /// Accessibility). `clipboard` just copies it and lets you paste.
@@ -292,9 +295,18 @@ struct Config: Decodable, Equatable {
         /// rather than text. Empty disables it.
         ///
         /// Called `correction_phrase` when the only instruction was fixing a
-        /// spelling; that key still works and is still in configs written
-        /// before prompts existed.
-        var activationPhrase: String = "hey parrot"
+        /// spelling, and `activation_phrase` when there was only ever one.
+        /// Both still read, and either may be written as a single phrase or as
+        /// a list — a config in any of the three shapes decodes the same way.
+        ///
+        /// Several because one phrase cannot be said in every position. "hey
+        /// parrot" opens an utterance and reads as nonsense inside one; "by the
+        /// way parrot" is the reverse. Empty disables the whole thing.
+        var activationPhrases: [String] = ["hey parrot"]
+
+        /// The one to show when a single phrase has to be named — a menu
+        /// label, a first-run message. The first is the one to teach.
+        var activationPhrase: String { activationPhrases.first ?? "" }
         /// Last-resort in-place correction for surfaces the accessibility API
         /// cannot write, such as terminals: clear the input line with readline
         /// keys and retype it.
@@ -322,6 +334,7 @@ struct Config: Decodable, Equatable {
         enum CodingKeys: String, CodingKey {
             case enabled, replacements, pipelines, languages
             case insertMode = "insert_mode"
+            case activationPhrases = "activation_phrases"
             case activationPhrase = "activation_phrase"
             case rewriteLine = "rewrite_line"
         }
@@ -520,14 +533,30 @@ struct Config: Decodable, Equatable {
                 }
                 self.insertMode = mode
             }
-            // The new name wins if both are present, which is what someone
-            // mid-rename would expect.
+            // Three spellings, oldest first, so the newest present wins — which
+            // is what someone mid-rename would expect. Each accepts a phrase or
+            // a list: the shape is not what the rename was about, and refusing
+            // `activation_phrase: [a, b]` would be a rule with no reason.
             let legacy = try decoder.container(keyedBy: LegacyKeys.self)
-            if let phrase = try legacy.decodeIfPresent(String.self, forKey: .correctionPhrase) {
-                self.activationPhrase = phrase
+            func phrases<K: CodingKey>(
+                _ container: KeyedDecodingContainer<K>, _ key: K
+            ) throws -> [String]? {
+                if let one = try? container.decodeIfPresent(String.self, forKey: key) {
+                    return [one]
+                }
+                return try container.decodeIfPresent([String].self, forKey: key)
             }
-            if let phrase = try c.decodeIfPresent(String.self, forKey: .activationPhrase) {
-                self.activationPhrase = phrase
+            for found in [
+                try phrases(legacy, LegacyKeys.correctionPhrase),
+                try phrases(c, CodingKeys.activationPhrase),
+                try phrases(c, CodingKeys.activationPhrases),
+            ] {
+                guard let found else { continue }
+                // Blanks would match nothing and cost a comparison per
+                // transcript; an all-blank list is how you turn this off.
+                activationPhrases = found
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .filter { !$0.isEmpty }
             }
             if let v = try c.decodeIfPresent(Bool.self, forKey: .rewriteLine) { rewriteLine = v }
             if let v = try c.decodeIfPresent([String].self, forKey: .languages) {
@@ -886,9 +915,13 @@ enum ConfigStore {
       # clipboard -> copied, you press Cmd-V
       insert_mode: paste
 
-      # Say this instead of dictating and what follows is an instruction:
-      # "hey parrot, make that a bullet list". Empty disables it.
-      activation_phrase: hey parrot
+      # Say one of these instead of dictating and what follows is an
+      # instruction: "hey parrot, make that a bullet list". An empty list
+      # disables spoken commands.
+      #
+      # Several, because one phrase cannot be said in every position — and the
+      # first is the one to teach someone.
+      activation_phrases: [hey parrot]
 
       # Last resort for fields Accessibility cannot write, terminals mostly:
       # clear the input line with Ctrl-A Ctrl-K and retype it corrected. It

--- a/Sources/ParrotFlow/LocalLLM.swift
+++ b/Sources/ParrotFlow/LocalLLM.swift
@@ -225,12 +225,29 @@ enum VoiceCommand {
     /// Understood as nothing actionable.
     case unrecognised(String)
 
-    /// Everything said after the wake phrase, or nil for plain dictation.
+    /// Everything said after a wake phrase, or nil for plain dictation.
     /// Empty string means the phrase was said on its own.
     ///
     /// Shared by the app and by `--command`; when these were two copies, the
     /// test harness silently exercised different logic from the app.
-    static func commandAfterWakePhrase(_ text: String, phrase rawPhrase: String) -> String? {
+    ///
+    /// Several phrases are tried and the best-scoring one wins, rather than the
+    /// first that clears the bar. They overlap on purpose — "hey parrot" and
+    /// "by the way parrot" share their distinctive word — so first-past-the-post
+    /// would let a poor match on one phrase beat a good match on another and
+    /// swallow a different number of words.
+    static func commandAfterWakePhrase(_ text: String, phrases: [String]) -> String? {
+        var best: (score: Double, command: String)?
+        for phrase in phrases {
+            guard let found = match(text, phrase: phrase) else { continue }
+            if best == nil || found.score > best!.score { best = found }
+        }
+        return best?.command
+    }
+
+    /// One phrase, and how well it matched — the score is what lets the caller
+    /// choose between phrases.
+    private static func match(_ text: String, phrase rawPhrase: String) -> (score: Double, command: String)? {
         let phrase = rawPhrase.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !phrase.isEmpty else { return nil }
 
@@ -266,20 +283,25 @@ enum VoiceCommand {
         }
 
         // Last chance: the distinctive word survived on its own ("parrot"),
-        // which is what a clipped "hey" leaves behind.
-        if matchedWords == nil, let keyword = phraseWords.last, keyword.count >= 4,
-           similarity(normalised[0], keyword) >= 0.8 {
-            matchedWords = 1
+        // which is what a clipped "hey" leaves behind. Scored below any real
+        // match, so a phrase that matched properly always wins over one that
+        // only recognised its own last word.
+        if matchedWords == nil, let keyword = phraseWords.last, keyword.count >= 4 {
+            let score = similarity(normalised[0], keyword)
+            if score >= 0.8 {
+                matchedWords = 1
+                bestScore = score * 0.5
+            }
         }
 
         guard let matchedWords else { return nil }
 
         guard spokenWords.count == normalised.count else {
-            return normalised.dropFirst(matchedWords).joined(separator: " ")
+            return (bestScore, normalised.dropFirst(matchedWords).joined(separator: " "))
         }
-        return spokenWords.dropFirst(matchedWords)
+        return (bestScore, spokenWords.dropFirst(matchedWords)
             .joined(separator: " ")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: .whitespacesAndNewlines))
     }
 
     /// Phrases handled without troubling the LLM. Cheap, deterministic, and

--- a/Sources/ParrotFlow/LocalLLM.swift
+++ b/Sources/ParrotFlow/LocalLLM.swift
@@ -245,6 +245,80 @@ enum VoiceCommand {
         return best?.command
     }
 
+    /// An instruction said *inside* a dictation, and the text it applies to.
+    ///
+    ///     "there is a bug in get username by the way parrot format it"
+    ///      └─ text ────────────────────┘        └─ instruction ─────┘
+    ///
+    /// The point is one breath instead of two. Saying it afterwards means a
+    /// second dictation, and a transform that has to find its target again —
+    /// reading a selection, or editing a field in place, which is where the
+    /// risk lives. Here the target is the same utterance and nothing has been
+    /// written yet.
+    ///
+    /// Exact, unlike the prefix matcher. That one is fuzzy because the wake
+    /// phrase is the first thing said and the audio engine is still starting
+    /// up, so "hey parrot" arrives clipped or misheard. Mid-sentence the audio
+    /// is clean, and there is a whole sentence of ordinary words for a fuzzy
+    /// match to fire on — "…the parrots are loud…" would split a sentence in
+    /// two and send half of it to a model.
+    ///
+    /// Nil when no phrase is found, or when one is found at the very start:
+    /// that is the whole utterance being a command, which is a different thing
+    /// and already handled.
+    static func inlineInstruction(
+        _ text: String, phrases: [String]
+    ) -> (text: String, instruction: String)? {
+        var best: (range: NSRange, length: Int)?
+        let whole = NSRange(text.startIndex..., in: text)
+
+        for phrase in phrases {
+            let words = phrase
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .split(separator: " ")
+                .map { NSRegularExpression.escapedPattern(for: String($0)) }
+            guard !words.isEmpty else { continue }
+            // Punctuation between the words because a transcript has it —
+            // "by the way, parrot" is what gets written down when you pause.
+            let pattern = "\\b" + words.joined(separator: "[\\s,]+") + "\\b"
+            guard let expression = try? NSRegularExpression(
+                pattern: pattern, options: [.caseInsensitive]
+            ) else { continue }
+
+            for match in expression.matches(in: text, range: whole) {
+                guard match.range.location > 0 else { continue }
+                // Earliest wins, so the text is everything you said before
+                // changing your mind. On a tie the longer phrase wins: "by the
+                // way parrot" and "parrot" start in different places, but two
+                // phrases sharing a start would otherwise be decided by the
+                // order they happen to sit in the config.
+                if let found = best,
+                   match.range.location > found.range.location
+                    || (match.range.location == found.range.location
+                        && match.range.length <= found.length) {
+                    continue
+                }
+                best = (match.range, match.range.length)
+            }
+        }
+
+        guard let best, let split = Range(best.range, in: text) else { return nil }
+        let before = String(text[..<split.lowerBound])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: ",;:—-"))
+            .trimmingCharacters(in: .whitespaces)
+        let after = String(text[split.upperBound...])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: ",;:—-"))
+            .trimmingCharacters(in: .whitespaces)
+
+        // Nothing before it is the command case wearing a disguise, and nothing
+        // after it is a phrase said for its own sake — neither has an edit in
+        // it, and guessing would rewrite a sentence nobody asked about.
+        guard !before.isEmpty, !after.isEmpty else { return nil }
+        return (before, after)
+    }
+
     /// One phrase, and how well it matched — the score is what lets the caller
     /// choose between phrases.
     private static func match(_ text: String, phrase rawPhrase: String) -> (score: Double, command: String)? {

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -292,10 +292,18 @@ struct Pipeline: Equatable, Codable {
             if !allowPrompts, named?.isPrompt ?? true {
                 return "prompts are off on this path"
             }
-            if VoiceCommand.commandAfterWakePhrase(
-                text, phrases: config.transcription.activationPhrases
-            ) != nil {
+            // Either position. A phrase at the front means the whole utterance
+            // is an instruction; one in the middle means the instruction is
+            // about the words before it. Both are read after this runs, and a
+            // transform that rewrote the sentence first could eat the phrase
+            // and leave what should have been a command to be typed into the
+            // document.
+            let phrases = config.transcription.activationPhrases
+            if VoiceCommand.commandAfterWakePhrase(text, phrases: phrases) != nil {
                 return "this is a spoken command"
+            }
+            if VoiceCommand.inlineInstruction(text, phrases: phrases) != nil {
+                return "this carries an instruction of its own"
             }
         }
         if let wanted = step.app {

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -293,7 +293,7 @@ struct Pipeline: Equatable, Codable {
                 return "prompts are off on this path"
             }
             if VoiceCommand.commandAfterWakePhrase(
-                text, phrase: config.transcription.activationPhrase
+                text, phrases: config.transcription.activationPhrases
             ) != nil {
                 return "this is a spoken command"
             }

--- a/Sources/ParrotFlow/RouteTestCommand.swift
+++ b/Sources/ParrotFlow/RouteTestCommand.swift
@@ -16,12 +16,12 @@ enum RouteTestCommand {
         }
 
         let catalogue = Catalogue(prompts: config.prompts)
-        let phrase = config.transcription.activationPhrase
+        let phrases = config.transcription.activationPhrases
 
         // The wake phrase is stripped first, exactly as the app does it, so a
         // case written the way you'd actually say it still exercises the
         // router rather than silently testing the wrong string.
-        let instruction = VoiceCommand.commandAfterWakePhrase(text, phrase: phrase) ?? text
+        let instruction = VoiceCommand.commandAfterWakePhrase(text, phrases: phrases) ?? text
 
         if !quiet {
             print("catalogue:   \(catalogue.names.joined(separator: ", "))")

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -76,12 +76,24 @@ if let index = arguments.firstIndex(of: "--normalize") {
 
 if let index = arguments.firstIndex(of: "--command") {
     guard arguments.indices.contains(index + 1) else {
-        print("usage: ParrotFlow --command \"hey parrot, Tasmin spells T A S M E E N\"")
+        print("usage: ParrotFlow --command \"hey parrot, Tasmin spells T A S M E E N\""
+            + " [--phrases \"a,b\"]")
         exit(2)
     }
     let context = arguments.indices.contains(index + 2) && !arguments[index + 2].hasPrefix("--")
         ? arguments[index + 2] : nil
-    exit(CommandTestCommand.run(text: arguments[index + 1], lastTranscript: context))
+    // An empty list is a case of its own — spoken commands turned off — so it
+    // has to survive as [] rather than collapse back to the configured list.
+    let phrases = arguments.firstIndex(of: "--phrases").flatMap { at -> [String]? in
+        guard arguments.indices.contains(at + 1) else { return nil }
+        return arguments[at + 1]
+            .split(separator: ",", omittingEmptySubsequences: true)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+    }
+    exit(CommandTestCommand.run(
+        text: arguments[index + 1], lastTranscript: context, phrases: phrases
+    ))
 }
 
 if let index = arguments.firstIndex(of: "--route") {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,9 +3,13 @@ transcription:
   # clipboard -> copied, you press Cmd-V
   insert_mode: clipboard
 
-  # Say this instead of dictating and what follows is an instruction:
-  # "hey parrot, make that a bullet list". Empty disables it.
-  activation_phrase: hey parrot
+  # Say one of these instead of dictating and what follows is an
+  # instruction: "hey parrot, make that a bullet list". An empty list
+  # disables spoken commands.
+  #
+  # Several, because one phrase cannot be said in every position — and the
+  # first is the one to teach someone.
+  activation_phrases: [hey parrot]
 
   # Last resort for fields Accessibility cannot write, terminals mostly: clear
   # the input line with Ctrl-A Ctrl-K and retype it corrected. It only fires

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -7,9 +7,15 @@ transcription:
   # instruction: "hey parrot, make that a bullet list". An empty list
   # disables spoken commands.
   #
-  # Several, because one phrase cannot be said in every position — and the
+  # One of them mid-sentence turns the rest into an instruction about the
+  # words before it, in the same breath:
+  #
+  #   "there is a bug in get username by the way parrot format that name"
+  #
+  # which is why there are two: "hey parrot" opens an utterance and reads
+  # as nonsense inside one, and "by the way parrot" is the reverse. The
   # first is the one to teach someone.
-  activation_phrases: [hey parrot]
+  activation_phrases: [hey parrot, by the way parrot]
 
   # Last resort for fields Accessibility cannot write, terminals mostly: clear
   # the input line with Ctrl-A Ctrl-K and retype it corrected. It only fires

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -283,3 +283,44 @@ written for one subject does when handed a whole sentence.
 `grammar` ships for the opposite reason. It has a validation set of its own and
 beats the built-in on it, 5/5 against 4/5, and the case it wins is the one that
 matters most here: leaving alone a sentence that was already right.
+
+## An instruction inside a dictation
+
+An activation phrase in the *first* position means the whole utterance is a
+command, about your selection or your last dictation. The same phrase in the
+*middle* means something else: the rest is an instruction about the words in
+front of it, in the same breath.
+
+```
+"there is a bug in get username by the way parrot format that name"
+ └─ what gets written, once edited ──┘        └─ what to do to it ─┘
+```
+
+Two phrases ship, because one cannot be said in both positions: "hey parrot"
+opens an utterance and reads as nonsense inside one, and "by the way parrot" is
+the reverse. Configure them with `activation_phrases:`.
+
+**Why it exists.** Saying it afterwards means a second dictation, and a
+transform that then has to find its target again — reading a selection, or
+editing a field in place, which is where the risk is. Here the target is the
+same utterance, and nothing has been written yet.
+
+**The mid-sentence match is exact**, where the first-position one is
+deliberately fuzzy. That one has to survive a clipped or misheard wake phrase,
+because the audio engine is still starting up when you say it. Mid-sentence the
+audio is clean, and there is a whole sentence of ordinary words for a loose
+match to fire on — "the parrots are loud today" must stay a sentence.
+`tests/split-cases.txt` scores this at 14/14, and half of it is sentences that
+must *not* split.
+
+**Every failure still writes what you said.** No model, a router that says this
+is not an edit, a prompt that returns nothing — the dictated text goes in and
+the reason appears for seven seconds. This is the opposite of the rule
+everywhere else, where a failed transform leaves the text alone: there the
+words are already on screen, and here they exist nowhere else. Losing the
+instruction costs a second attempt; losing the sentence costs the sentence.
+
+**No preview**, whatever the transform's `confirm` says. That setting guards
+text you selected and are about to have overwritten, and nothing is being
+overwritten here — a dialog in the middle would give back the round trip this
+removes. The rewrite goes to the log with its before and after.

--- a/scripts/check-spelling.sh
+++ b/scripts/check-spelling.sh
@@ -23,7 +23,11 @@ PHRASE="$(python3 -c '
 import yaml, pathlib
 cfg = yaml.safe_load((pathlib.Path.home() / ".config/parrotflow/config.yaml").read_text())
 t = cfg.get("transcription") or {}
-print(t.get("activation_phrase") or t.get("correction_phrase") or "hey parrot")
+phrases = (t.get("activation_phrases") or t.get("activation_phrase")
+           or t.get("correction_phrase") or "hey parrot")
+# One phrase or several, and the set says it the way the app teaches it:
+# the first is the one to use.
+print(phrases if isinstance(phrases, str) else phrases[0])
 ')"
 
 pass=0; total=0; missed=0; wrong=0; invented=0

--- a/scripts/check-split.sh
+++ b/scripts/check-split.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Scores where an instruction begins inside a dictation, against
+# tests/split-cases.txt.
+#
+#   scripts/check-split.sh
+#
+# Not to be confused with scripts/check-inplace.sh, which is about writing into
+# a field that refuses accessibility writes. This one is about a sentence that
+# carries its own instruction:
+#
+#   "there is a bug in get username by the way parrot format the function"
+#
+# Deterministic: no model is consulted to find the split, only to act on it,
+# and acting on it is scored by tests/routing-cases.yaml.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/release/ParrotFlow"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+
+pass=0; total=0; failed=""
+while IFS='~' read -r phrases input wantText wantInstruction; do
+  case "$phrases" in \#*) continue;; esac
+  [ -z "$input" ] && continue
+  total=$((total + 1))
+
+  out="$("$BIN" --command "$input" --phrases "$phrases" 2>/dev/null)"
+  gotText="$(printf '%s' "$out" | sed -n 's/^text:        "\(.*\)"$/\1/p')"
+  gotInstruction="$(printf '%s' "$out" | sed -n 's/^instruction: "\(.*\)"$/\1/p')"
+  if [ -z "$gotText" ]; then
+    got="NONE~"
+  else
+    got="$gotText~$gotInstruction"
+  fi
+
+  if [ "$got" = "$wantText~$wantInstruction" ]; then
+    pass=$((pass + 1))
+    printf '  ✓ %s\n' "$input"
+  else
+    failed="$failed
+      $input"
+    printf '  ✗ %s\n      got   %s\n      want  %s\n' \
+      "$input" "$got" "$wantText~$wantInstruction"
+  fi
+done < "$ROOT/tests/split-cases.txt"
+
+echo
+echo "  $pass/$total$failed"
+[ "$pass" = "$total" ]

--- a/scripts/check-wake.sh
+++ b/scripts/check-wake.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Scores wake-phrase splitting against tests/wake-cases.txt.
+#
+#   scripts/check-wake.sh
+#
+# What is measured is only where the phrase ends and the instruction begins —
+# not what the instruction then resolves to, which needs a model and has
+# tests/routing-cases.yaml. This half is deterministic and runs anywhere.
+#
+# Each case states its own phrases, passed with --phrases, so the set reads the
+# same on any machine.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/release/ParrotFlow"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+
+pass=0; total=0; failed=""
+while IFS='|' read -r phrases input want; do
+  case "$phrases" in \#*) continue;; esac
+  [ -z "$input" ] && continue
+  total=$((total + 1))
+
+  out="$("$BIN" --command "$input" --phrases "$phrases" 2>/dev/null)"
+  if printf '%s' "$out" | grep -q "not a command"; then
+    got="NONE"
+  else
+    got="$(printf '%s' "$out" | sed -n 's/^command:     "\(.*\)"$/\1/p')"
+    [ -z "$got" ] && got="EMPTY"
+  fi
+
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1))
+    printf '  ✓ %-52s [%s]\n' "$input" "${phrases:-no phrases}"
+  else
+    failed="$failed
+      $input"
+    printf '  ✗ %s  [%s]\n      got   %s\n      want  %s\n' \
+      "$input" "${phrases:-no phrases}" "$got" "$want"
+  fi
+done < "$ROOT/tests/wake-cases.txt"
+
+echo
+echo "  $pass/$total$failed"
+[ "$pass" = "$total" ]

--- a/tests/split-cases.txt
+++ b/tests/split-cases.txt
@@ -1,0 +1,52 @@
+# phrases (comma-separated) ~ what was said ~ the text ~ the instruction
+#
+# Run with: scripts/check-split.sh
+#
+# NONE in the third field means no split: the sentence is dictation, or it is a
+# command in its own right and tests/wake-cases.txt covers that instead.
+#
+# `~` separates the fields because the sentences contain commas.
+#
+# This measures only where the instruction begins. What it then resolves to
+# needs a model and belongs to tests/routing-cases.yaml.
+
+# --- the shape this exists for -------------------------------------------
+hey parrot,by the way parrot~there is a bug in get username by the way parrot format the function in TypeScript~there is a bug in get username~format the function in TypeScript
+hey parrot,by the way parrot~the deadline is march third by the way parrot make that date ISO~the deadline is march third~make that date ISO
+
+# A transcript has punctuation where you paused, and it lands in the middle of
+# the phrase as often as around it. The phrase itself is words only — you say
+# words, and where the commas go is the transcriber's guess, not yours.
+hey parrot,by the way parrot~there is a bug in get username, by the way parrot, format the function~there is a bug in get username~format the function
+
+# Case is what the model felt like writing, not what you said.
+hey parrot,by the way parrot~There is a bug in get username By The Way Parrot format the function~There is a bug in get username~format the function
+
+# --- French, because the phrase is configurable and so is the language ----
+coucou perroquet,au fait perroquet~il y a un bug dans get username au fait perroquet formate la fonction~il y a un bug dans get username~formate la fonction
+
+# --- what must not split -------------------------------------------------
+# At the start it is a command about your selection, which is a different thing
+# and already handled. Nothing before it means there is no text to edit.
+hey parrot,by the way parrot~by the way parrot format the function~NONE~
+hey parrot,by the way parrot~hey parrot fix vocabulary~NONE~
+
+# Nothing after it: a phrase said for its own sake. Guessing would rewrite a
+# sentence nobody asked about.
+hey parrot,by the way parrot~there is a bug in get username by the way parrot~NONE~
+
+# Exact, not fuzzy — this is the whole reason the mid-sentence matcher does not
+# reuse the forgiving one. A sentence about parrots is a sentence, and half of
+# it must not go to a model.
+hey parrot,by the way parrot~the parrots are loud today~NONE~
+hey parrot,by the way parrot~he was parroting the answer back at me~NONE~
+hey parrot,by the way parrot~by the way I fixed the parser~NONE~
+hey parrot,by the way parrot~there is a bug in the parrot enclosure~NONE~
+
+# No phrases configured is how spoken commands are turned off.
+~there is a bug by the way parrot format it~NONE~
+
+# --- several occurrences: the earliest wins -------------------------------
+# Everything before the first one is what you said; everything after is the
+# instruction, however many times you say the phrase in it.
+hey parrot,by the way parrot~fix get username by the way parrot format it by the way parrot in TypeScript~fix get username~format it by the way parrot in TypeScript

--- a/tests/wake-cases.txt
+++ b/tests/wake-cases.txt
@@ -1,0 +1,42 @@
+# phrases (comma-separated) | what was said | what the command should be
+#
+# Run with: scripts/check-wake.sh
+#
+# NONE means "not a command" — the sentence goes into your document as
+# dictation. EMPTY means the phrase was said on its own, which opens the
+# correction panel.
+#
+# The phrases are stated per case rather than read from the config, the same
+# way tests/pipeline-cases.yaml carries its own fixture: a set that inherits
+# whichever phrases happen to be on the machine only means something on that
+# machine.
+#
+# The clipped and misheard cases are not hypothetical. The wake phrase is the
+# first thing said, which is exactly where the audio engine is still starting
+# up, so "hey parrot, X" arrives as "parrot, X" or "hey parrots X" often
+# enough that an exact prefix match would lose most of them.
+
+# --- one phrase, as it has always worked -------------------------------
+hey parrot|hey parrot fix vocabulary|fix vocabulary
+hey parrot|parrot fix vocabulary|fix vocabulary
+hey parrot|hey parrots fix vocabulary|fix vocabulary
+hey parrot|hey parrot|EMPTY
+hey parrot|there is a bug in the parser|NONE
+
+# --- several, which is what this adds -----------------------------------
+# The two overlap on their distinctive word on purpose: "parrot" is what
+# survives a clipped "hey", and it is also the last word of the other phrase.
+# Each has to keep taking the right number of words off the front, which is
+# why the best-scoring phrase wins rather than the first one over the bar.
+hey parrot,by the way parrot|hey parrot format the function|format the function
+hey parrot,by the way parrot|by the way parrot format the function|format the function
+hey parrot,by the way parrot|by the way parrot, format the function in TypeScript|format the function in TypeScript
+hey parrot,by the way parrot|parrot format the function|format the function
+hey parrot,by the way parrot|there is a bug in get username|NONE
+
+# --- order must not matter ----------------------------------------------
+by the way parrot,hey parrot|hey parrot format the function|format the function
+by the way parrot,hey parrot|by the way parrot format the function|format the function
+
+# --- no phrases at all is how you turn spoken commands off ---------------
+|hey parrot fix vocabulary|NONE


### PR DESCRIPTION
Two commits. The first widens what counts as an activation phrase; the second
acts on one found mid-sentence.

## What it does

```
"there is a bug in get username by the way parrot format that name"
 └─ what gets written, once edited ──┘        └─ what to do to it ─┘
```

A phrase in the **first** position still means the whole utterance is a command,
about your selection or your last dictation. The same phrase in the **middle**
now means the rest is an instruction about the words in front of it.

One breath instead of two. Saying it afterwards means a second dictation and a
transform that has to find its target again — reading a selection, or editing a
field in place, which is where the risk is. Here the target is the same
utterance and nothing has been written yet.

Two phrases ship, because one cannot be said in both positions:

```yaml
activation_phrases: [hey parrot, by the way parrot]
```

## Compatibility

Four spellings decode to the same list, each checked against a real config
rather than argued about: `correction_phrase`, `activation_phrase`, either of
those written as a list, and the new plural. The newest present wins. An empty
list turns spoken commands off.

## Two matchers, on purpose

The first-position one is **fuzzy** — the wake phrase is the first thing said
and the audio engine is still starting up, so it arrives clipped ("parrot, X")
or misheard ("hey parrots X"). An exact prefix match would lose most of those.

The mid-sentence one is **exact**. Mid-sentence the audio is clean, and there is
a whole sentence of ordinary words for a loose match to fire on. "the parrots
are loud today" must stay a sentence. It tolerates punctuation *between* the
phrase's words, because that is where a pause lands in a transcript, and it
requires something on both sides of the phrase.

It also now takes the best-scoring phrase rather than the first over the bar:
the phrases overlap on their distinctive word, so first-past-the-post would let
a poor match take a different number of words off the front than a good one.

## Failure writes the sentence

Every way the inline path can fail writes the dictated text and says why for
seven seconds — no model, a router answering "not an edit", a capability that is
an action rather than a rewrite, a prompt returning nothing, a call that throws.

This inverts the rule everywhere else, where a failed transform leaves the text
alone. There the words are already on screen; here they exist nowhere but in
that function. Losing the instruction costs a second attempt; losing the
sentence costs the sentence.

No preview panel either, whatever `confirm` says: it guards text you selected
and are about to have overwritten, and nothing is overwritten here. A dialog in
the middle would give back the round trip this removes.

## Also

A pipeline prompt stage now stands aside for a phrase found mid-sentence, not
just one at the front. It runs before either is read, so a transform that
rewrote the sentence first could eat the phrase and leave what should have been
an instruction to be typed into the document.

`--command` reports the split, and takes `--phrases "a,b"` standing in for the
configured list the way `--lang` does for languages — so both sets read the same
on any machine.

## Checks

| set | result |
|---|---|
| `check-split` | 14/14 — new, half of it sentences that must not split |
| `check-wake` | 13/13 — new |
| `check-dotted` | 54/54, plus 2 known-unfixable |
| `check-pipeline` | 20/20 |
| `check-replacements` | 23/23 |
| `check-numbers` | 97/97 |
| `check-default-config` | ✓ |

`Config.Transcription` drops `Encodable`, which nothing used, because
`activationPhrase` is now a view over the list.

The three sets needing Ollama, a screen or a microphone were not run — CI does
not run them either. The routing that follows a split is one of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018L6J1Kw7SVxnoCAJ1Gw4WS