### PR TITLE
feat: let a correction be asked for inside a dictation

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1264,13 +1264,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         if let capability = Router.local(instruction: instruction, catalogue: catalogue) {
             Log.write("inline router: \"\(instruction)\" named \(capability.name) outright")
-            // An action opens a panel or writes a rule — neither is a rewrite of
-            // the words in front of it, so there is nothing to apply here.
-            guard case .transform(let prompt) = capability else {
-                giveUp("\"\(instruction)\" is not something to change in the text")
-                return
+            switch capability {
+            case .transform(let prompt): run(prompt)
+            case .action(let action): runInlineAction(action, text: text, instruction: instruction)
             }
-            run(prompt)
             return
         }
 
@@ -1294,8 +1291,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     case .matched(.transform(let prompt)):
                         Log.write("inline router: \"\(instruction)\" → \(prompt.name)")
                         run(prompt)
-                    case .matched(let capability):
-                        giveUp("\(capability.name) is not something to change in the text")
+                    case .matched(.action(let action)):
+                        self.runInlineAction(action, text: text, instruction: instruction)
                     case .anything:
                         Log.write("inline router: \"\(instruction)\" → \(FreeForm.name)")
                         run(FreeForm.prompt)
@@ -1307,6 +1304,164 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 await MainActor.run { giveUp(error.localizedDescription, tone: .failure) }
             }
         }
+    }
+
+    /// A built-in action asked for inside a dictation.
+    ///
+    /// The command path has to find what the action applies to — a selection,
+    /// or the last thing dictated — and then write into it where it sits, which
+    /// is the ladder in `saveCorrections` and where the risk of this app lives.
+    /// Inline there is nothing to find: the text is the words in front of the
+    /// phrase, and it has not been written yet. The panel opens first, and what
+    /// goes in afterwards is already corrected.
+    ///
+    /// Cancelling writes what was dictated. Refusing the whole utterance
+    /// because a panel was dismissed would lose the sentence over a change of
+    /// mind about a rule.
+    private func runInlineAction(
+        _ action: Capability.Action, text: String, instruction: String
+    ) {
+        switch action {
+        case .vocabulary:
+            // "…by the way parrot, fix vocabulary" — nothing to extract, the
+            // panel opens on the sentence itself and you correct it by hand.
+            endProgress()
+            Log.write("inline: correction panel over \"\(text)\"")
+            showInlineCorrection(over: text, rule: nil)
+
+        case .spelling:
+            // "…by the way parrot, Tasmin spells T A S M E E N" — the rule has
+            // to be read out of the instruction first, which is a model call of
+            // its own and not part of routing.
+            guard config.llm.enabled else {
+                giveUpInline(text, why: "\"\(instruction)\" needs the local model to read the spelling")
+                return
+            }
+            beginProgress("Thinking…")
+            let llm = llmConfig()
+            // From the dictated text, not the instruction: the instruction is a
+            // name plus a run of loose capitals, which reads as English
+            // whatever was actually said.
+            let language = DictationLanguage.forCorrection(
+                transcript: text, allowed: config.transcription.languages
+            )
+            Task { [weak self] in
+                do {
+                    let result = try await VoiceCommand.interpret(
+                        command: instruction, lastTranscript: text,
+                        language: language, config: llm
+                    )
+                    await MainActor.run {
+                        guard let self else { return }
+                        self.endProgress()
+                        switch result {
+                        case .addRule(let heard, let corrected):
+                            Log.write("inline: proposed rule \(heard) -> \(corrected)")
+                            self.showInlineCorrection(
+                                over: text, rule: (heard: heard, corrected: corrected)
+                            )
+                        case .openCorrectionPanel:
+                            self.showInlineCorrection(over: text, rule: nil)
+                        case .unrecognised:
+                            self.giveUpInline(text, why: "Didn't understand \"\(instruction)\"")
+                        }
+                    }
+                } catch {
+                    await MainActor.run {
+                        guard let self else { return }
+                        self.endProgress()
+                        self.giveUpInline(text, why: error.localizedDescription, tone: .failure)
+                    }
+                }
+            }
+        }
+    }
+
+    /// The correction panel, with the dictated text waiting behind it.
+    ///
+    /// `pendingSelection` and `focusAtPress` are deliberately cleared: they are
+    /// how `saveCorrections` decides to write into a field somewhere else, and
+    /// here the only place the text should land is where a dictation would put
+    /// it. Leaving them set would rewrite whatever happened to be selected when
+    /// the hotkey went down.
+    private func showInlineCorrection(
+        over text: String, rule: (heard: String, corrected: String)?
+    ) {
+        pendingSelection = nil
+
+        /// Hand focus back before writing anything.
+        ///
+        /// `CorrectionPanel.show` calls `NSApp.activate(ignoringOtherApps:)` to
+        /// put itself in front, so by the time you press Save we are the
+        /// frontmost app and the paste lands in our own window. It leaves no
+        /// trace: the insert reports `.pasted`, which is silent, so the log
+        /// showed a rule proposed and then nothing at all. `applyTransform`
+        /// learned this the same way and does the same thing.
+        func handBack() {
+            guard let owner = focusAtPress?.owner, !owner.isActive else { return }
+            owner.activate()
+            // Let it come forward before the keystroke is posted.
+            Thread.sleep(forTimeInterval: 0.15)
+        }
+        correctionPanel.onSave = { [weak self] rules, correctedText in
+            guard let self else { return }
+            for rule in rules {
+                do {
+                    try ConfigWriter.addReplacement(heard: rule.heard, corrected: rule.corrected)
+                    Log.write("learned replacement: \(rule.heard) -> \(rule.corrected)")
+                } catch {
+                    self.presentAlert(
+                        title: "Could not save the rule", message: error.localizedDescription
+                    )
+                }
+            }
+            // A rule taught about the sentence you just said should be true of
+            // that sentence. Applied here rather than by re-running the
+            // pipeline: the config on disk has only just changed, and the copy
+            // in memory is reloaded by a file watcher that has not fired yet.
+            let corrected = rules.isEmpty ? text : Replacements.applyExact(
+                to: text,
+                rules: rules.map {
+                    Config.Transcription.Rule(source: $0.heard, replacement: $0.corrected)
+                }
+            )
+            if corrected != text {
+                Log.write("inline: applied the new rule(s) to the transcript")
+                Log.write("    before: \(text)")
+                Log.write("    after:  \(corrected)")
+            }
+            // The panel edits words, not the sentence, when it was opened on a
+            // proposed rule — so its text is only the target when it was opened
+            // on the sentence itself.
+            let final = rule == nil && !correctedText.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            ).isEmpty ? correctedText : corrected
+            self.settings.model.lastTranscript = final
+            handBack()
+            Log.write("inline: writing into \(self.focusAtPress?.owner?.localizedName ?? "the frontmost app")")
+            self.insertDictation(final)
+        }
+        correctionPanel.onCancel = { [weak self] in
+            guard let self else { return }
+            Log.write("inline: correction dismissed; wrote the text as dictated")
+            handBack()
+            self.insertDictation(text)
+        }
+
+        if let rule {
+            correctionPanel.show(rule: rule)
+        } else {
+            correctionPanel.show(selection: text)
+        }
+    }
+
+    /// Write what was said, and say why it is not what was asked for.
+    private func giveUpInline(_ text: String, why: String, tone: NoticeTone = .caution) {
+        endProgress()
+        Log.write("inline: \(why); wrote the text as dictated")
+        insertDictation(text)
+        notice.show(why, tone: tone, duration: 7)
+        setLabel(why, clearAfter: 7)
     }
 
     /// The text, exactly as dictation puts it in.

--- a/scripts/check-wake.sh
+++ b/scripts/check-wake.sh
@@ -14,11 +14,10 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BIN="$ROOT/.build/release/ParrotFlow"
 [ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
 
-pass=0; total=0; failed=""
+pass=0; total=0; known=0; failed=""
 while IFS='|' read -r phrases input want; do
   case "$phrases" in \#*) continue;; esac
   [ -z "$input" ] && continue
-  total=$((total + 1))
 
   out="$("$BIN" --command "$input" --phrases "$phrases" 2>/dev/null)"
   if printf '%s' "$out" | grep -q "not a command"; then
@@ -28,6 +27,17 @@ while IFS='|' read -r phrases input want; do
     [ -z "$got" ] && got="EMPTY"
   fi
 
+  # KNOWN: the right answer, not yet given. Counted apart so the number means
+  # "what works", and so a fix announces itself instead of sitting unnoticed.
+  case "$want" in
+    KNOWN:*)
+      known=$((known + 1))
+      [ "$got" = "${want#KNOWN:}" ] \
+        && printf '  ! %s\n      now passes — drop the KNOWN: marker\n' "$input"
+      continue;;
+  esac
+
+  total=$((total + 1))
   if [ "$got" = "$want" ]; then
     pass=$((pass + 1))
     printf '  ✓ %-52s [%s]\n' "$input" "${phrases:-no phrases}"
@@ -40,5 +50,5 @@ while IFS='|' read -r phrases input want; do
 done < "$ROOT/tests/wake-cases.txt"
 
 echo
-echo "  $pass/$total$failed"
+echo "  $pass/$total   plus $known known-unfixed$failed"
 [ "$pass" = "$total" ]

--- a/tests/wake-cases.txt
+++ b/tests/wake-cases.txt
@@ -40,3 +40,21 @@ by the way parrot,hey parrot|by the way parrot format the function|format the fu
 
 # --- no phrases at all is how you turn spoken commands off ---------------
 |hey parrot fix vocabulary|NONE
+
+# --- known, and not fixed here -------------------------------------------
+# The prefix matcher is fuzzy on purpose: the wake phrase is the first thing
+# said and the audio engine is still starting up, so "hey parrot, X" arrives as
+# "parrot, X" or "hey parrots X". The cost is that any sentence beginning with
+# something that sounds like "<word> parrot" is taken as a command and never
+# written down.
+#
+# Found by throwing sentences at it, not by a user losing one. Left failing and
+# counted apart rather than quietly dropped: the fix is a judgement about the
+# 0.7 threshold, which trades these against the clipped audio the fuzziness
+# exists to recover, and that trade wants its own change and its own numbers.
+#
+# `KNOWN:` means "this is the right answer and we do not give it yet". If one
+# starts passing, the runner says so — that is the signal to promote it.
+hey parrot|my parrot escaped this morning|KNOWN:NONE
+hey parrot|the parrot is green|KNOWN:NONE
+hey parrot|a parrot flew past the window|KNOWN:NONE


### PR DESCRIPTION
Follow-up to #16. That one split a dictation at an activation phrase and routed
what came after; this one handles the case where what came after is a built-in
action rather than a text transform.

## The gap

> "…by the way parrot, Tasmin spells T A S M E E N"

routed to the `spelling` action, and the inline path had nothing to do with an
action: it wrote the text and said this is not something to change. True — a
spelling rule does not rewrite the sentence, it teaches a word — but refusing
was the wrong answer to the right observation.

## Inline is the easier case, not the harder one

The command path has to *find* what the action applies to — a selection, or the
last dictation — and then write into it where it sits. That is the fallback
ladder in `saveCorrections`, and it is where the risk of this app lives.

Here there is nothing to find. The text is the words in front of the phrase and
it has not been written yet, so the panel opens first and what goes in
afterwards is already corrected:

```
inline: proposed rule James -> Gamez
learned replacement: James -> Gamez
inline: applied the new rule(s) to the transcript
inline: writing into Ghostty
```

Cancelling writes what was dictated — losing the sentence over a change of mind
about a rule would be the wrong trade, and it is the same rule as everywhere
else on this path: every exit writes the words.

"…by the way parrot, fix vocabulary" opens the panel on the sentence itself.

`pendingSelection` is cleared and `focusAtPress` is not used as a target: those
are how `saveCorrections` decides to write into a field somewhere else, and the
only place this text should land is where a dictation would put it. The rule is
applied in memory rather than by re-running the pipeline — the config on disk
has only just changed, and the copy in memory is reloaded by a watcher that has
not fired yet.

## Found by testing it

The first version wrote nothing at all. `CorrectionPanel.show` calls
`NSApp.activate(ignoringOtherApps:)` to come forward, so by the time Save is
pressed we are frontmost and the paste lands in our own window. It left no trace
either: a successful insert reports `.pasted`, which is silent, so the log showed
a rule proposed and then nothing.

`applyTransform` had learned this already, on a TUI. Same hand-back, plus a log
line naming the app being written into so the next silence is not silent.

## Battle testing turned up something older

`tests/wake-cases.txt` gains three cases marked `KNOWN:`. The prefix matcher is
fuzzy by design — the wake phrase is the first thing said, while the audio
engine is still starting up, so it arrives clipped or misheard. The cost is that
any sentence starting with something that sounds like "&lt;word&gt; parrot" is taken
as a command and never written:

```
my parrot escaped this morning   ->  command: "escaped this morning"
```

**Pre-existing and unchanged by this** — identical with one phrase configured or
two, verified both ways. Left failing under its own counter rather than dropped,
because the fix is a judgement about the 0.7 threshold that trades these against
the clipped audio the fuzziness exists to recover. That wants its own change and
its own numbers.

## Checks

| set | result |
|---|---|
| `check-wake` | 13/13, plus 3 known-unfixed |
| `check-split` | 14/14 |
| `check-dotted` | 54/54, plus 2 known-unfixable |
| `check-pipeline` | 20/20 |
| `check-replacements` | 23/23 |
| `check-numbers` | 97/97 |
| `check-default-config` | ✓ |
| `check-routing` | 41/45 — the number recorded in the set's own header |
| `check-spelling` | 43/44 |

The last two need Ollama and were run locally; the router and the spelling
extractor are untouched by this change, and both scored their baseline.

swiftlint: 13 lines before and after, no new violations. The five new compiler
warnings are all `SendableClosureCaptures`, the pattern this file already
carries 36 times; the ones that bind cleanly now do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018L6J1Kw7SVxnoCAJ1Gw4WS