### PR TITLE
feat: two corrections in one breath, or describe the change instead of spelling it

### DIFF
--- a/.claude/skills/prompt-iteration/SKILL.md
+++ b/.claude/skills/prompt-iteration/SKILL.md
@@ -214,3 +214,20 @@ Then the same set across models, scored end-to-end as the app runs it:
 The 0.8B is the floor: four variants, an output format designed around its
 weakness, and thinking mode all left it level with the control. The 3B is the
 actual answer — a fifth of the disk and five times the speed for five points.
+
+Later the set grew to cover two shapes it had never had: two corrections in one
+breath, and a speaker who describes the change instead of spelling it
+("Mathieu ne prend qu'un seul t"). The described shape is the same lesson as
+the letters, arriving in a disguise good enough to be missed. There is nothing
+to read, so the obvious answer is to let the model write the corrected name —
+and it scores 5/10 on the 4B and 8/10 on the 12B, failing by dropping and
+transposing characters: "Phillip with one l" came back "Phill" and "Philp".
+Applying the described change in code instead scores 10/10 on both. A bigger
+model bought three points; taking the job away from the model bought five and
+cost nothing.
+
+Two things follow that are worth generalising. Ask what the model is *for* at
+every new shape, not once at the start — the second shape re-opened a decision
+the first had settled. And a capability check on a larger model is the cheap
+way to tell "the prompt is wrong" from "no prompt will fix this": here the 12B
+failing the same way as the 4B is what said the answer was code.

--- a/README.md
+++ b/README.md
@@ -113,9 +113,25 @@ You can skip the panel entirely and just say the correction:
 A local model works out which word was wrong; the panel opens prefilled so you
 confirm with one keystroke rather than trusting it blindly.
 
+You do not have to spell it. Describing the change works too, in either
+language:
+
+    "hey parrot, Jerome with a G at the beginning"
+    "hey parrot, Mathieu ne prend qu'un seul t"
+    "hey parrot, Elastic search is one word"
+    "hey parrot, Jean Luc avec un trait d'union"
+
+And one breath can carry two corrections, which open as two rows in the panel:
+
+    "hey parrot, Tasmin spells T A S M E E N and Mick spells M I K"
+    "hey parrot, Nathalie sans le h et Philipe avec deux p"
+
 The spelled-out letters are read from the text, not the model — a run of single
 letters can only be the target spelling, and relying on the model for that got
 the direction backwards on "X spells Y" phrasing in three of seven test cases.
+Described changes are applied by code for the same reason: asked to write
+"Phillip with one l", the models answered "Phill" and "Philp". The model's only
+job is finding which words in your transcript you meant.
 
 The word being corrected is found in your **previous transcript**, not in the
 command. The command is dictated too, so the name gets misheard a second time:
@@ -134,10 +150,12 @@ long as the app runs — 9.6 GB for `gemma4:e4b`. Set `llm.keep_loaded: false` t
 have the RAM back and the wait with it. On a 16 GB Mac that is the right
 setting; on 32 GB it is not.
 
-`tests/spelling-cases.yaml` holds 35 names — French, Indian, Chinese, Turkish,
-Vietnamese, Korean, Nigerian, Polish, Irish, Arabic — plus product names
-recognition splits, and negative cases. Score a model or a prompt against it
-with `scripts/validate-prompt.py gemma4:e4b`. Without a model, `"hey parrot"`
+`tests/spelling-cases.yaml` holds 62 cases — French, Indian, Chinese, Turkish,
+Vietnamese, Korean, Nigerian, Polish, Irish, Arabic names, plus product names
+recognition splits, described changes, two-in-a-breath corrections, and
+negative cases; `tests/french-cases.yaml` holds 45 more where the dictated
+sentence is French. Score a model or a prompt against them with
+`scripts/validate-prompt.py gemma4:e4b`. Without a model, `"hey parrot"`
 and `"hey parrot, fix vocabulary"` still open the panel — those are matched
 without one.
 

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1024,15 +1024,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         switch command {
         case .openCorrectionPanel:
             beginCorrection()
-        case .addRule(let heard, let corrected):
-            // Prefilled, not saved: the model proposed it, you confirm it.
-            Log.write("command proposed rule: \(heard) -> \(corrected)")
+        case .addRules(let rules):
+            // Prefilled, not saved: the model proposed them, you confirm them.
+            // One utterance can carry more than one, so the panel opens with a
+            // row per rule and each is confirmed or edited on its own.
+            for rule in rules {
+                Log.write("command proposed rule: \(rule.heard) -> \(rule.corrected)")
+            }
             pendingSelection = nil
             correctionPanel.onSave = { [weak self] rules, text in
                 self?.saveCorrections(rules, correctedText: text)
             }
             correctionPanel.onCancel = { [weak self] in self?.pendingSelection = nil }
-            correctionPanel.show(rule: (heard: heard, corrected: corrected))
+            correctionPanel.show(rules: rules)
         case .unrecognised(let text):
             Log.write("command not understood: \(text)")
             flash("Didn't understand \"\(spoken)\"", tone: .caution)
@@ -1330,7 +1334,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // panel opens on the sentence itself and you correct it by hand.
             endProgress()
             Log.write("inline: correction panel over \"\(text)\"")
-            showInlineCorrection(over: text, rule: nil)
+            showInlineCorrection(over: text, rules: nil)
 
         case .spelling:
             // "…by the way parrot, Tasmin spells T A S M E E N" — the rule has
@@ -1358,13 +1362,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         guard let self else { return }
                         self.endProgress()
                         switch result {
-                        case .addRule(let heard, let corrected):
-                            Log.write("inline: proposed rule \(heard) -> \(corrected)")
-                            self.showInlineCorrection(
-                                over: text, rule: (heard: heard, corrected: corrected)
-                            )
+                        case .addRules(let rules):
+                            for rule in rules {
+                                Log.write("inline: proposed rule \(rule.heard) -> \(rule.corrected)")
+                            }
+                            self.showInlineCorrection(over: text, rules: rules)
                         case .openCorrectionPanel:
-                            self.showInlineCorrection(over: text, rule: nil)
+                            self.showInlineCorrection(over: text, rules: nil)
                         case .unrecognised:
                             self.giveUpInline(text, why: "Didn't understand \"\(instruction)\"")
                         }
@@ -1388,7 +1392,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// it. Leaving them set would rewrite whatever happened to be selected when
     /// the hotkey went down.
     private func showInlineCorrection(
-        over text: String, rule: (heard: String, corrected: String)?
+        over text: String, rules: [(heard: String, corrected: String)]?
     ) {
         pendingSelection = nil
 
@@ -1433,10 +1437,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 Log.write("    before: \(text)")
                 Log.write("    after:  \(corrected)")
             }
-            // The panel edits words, not the sentence, when it was opened on a
-            // proposed rule — so its text is only the target when it was opened
-            // on the sentence itself.
-            let final = rule == nil && !correctedText.trimmingCharacters(
+            // The panel edits words, not the sentence, when it was opened on
+            // proposed rules — so its text is only the target when it was
+            // opened on the sentence itself.
+            let final = rules == nil && !correctedText.trimmingCharacters(
                 in: .whitespacesAndNewlines
             ).isEmpty ? correctedText : corrected
             self.settings.model.lastTranscript = final
@@ -1451,8 +1455,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self.insertDictation(text)
         }
 
-        if let rule {
-            correctionPanel.show(rule: rule)
+        if let rules {
+            correctionPanel.show(rules: rules)
         } else {
             correctionPanel.show(selection: text)
         }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -914,14 +914,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             else { continue }
             written += 1
         }
-        if written > 0 {
+        if written == edits.count {
             Log.write("rewrote \(written) occurrence(s) in the focused field")
             return .replaced
         }
 
+        // Some but not all. Reporting success here said the whole batch had
+        // landed while one of the corrections had quietly not been made, and
+        // the clipboard fallback the caller keeps for exactly that never ran —
+        // so a rule you confirmed was neither in the field nor anywhere you
+        // could reach it. Two rules in one breath is what made this reachable;
+        // with one edit there was no partial state to be wrong about.
+        if written > 0 {
+            Log.write("rewrite: \(written) of \(edits.count) landed in the field;"
+                + " retyping the line so the rest do too")
+        }
+
         guard config.transcription.rewriteLine else {
             Log.write("rewrite: rewrite_line is off; not retyping")
-            return .notAttempted
+            // A partial write is not "nothing happened". The caller treats both
+            // the same today, but saying `failed` keeps the log and the return
+            // value telling the same story.
+            return written > 0 ? .failed : .notAttempted
         }
         Log.write("rewrite: retyping the line via keystrokes")
         let retyped = SelectionReader.rewriteCurrentLine(dictated: dictated, in: element) { line in

--- a/Sources/ParrotFlow/CommandTestCommand.swift
+++ b/Sources/ParrotFlow/CommandTestCommand.swift
@@ -60,8 +60,12 @@ enum CommandTestCommand {
             timeout: config.llm.timeoutSeconds,
             keepLoaded: config.llm.keepLoaded
         )
-        if let spelled = VoiceCommand.spelledOutWord(in: command) {
-            print("spelled-out: \"\(spelled)\"  (taken from the text, not the model)")
+        let spelled = VoiceCommand.spellingSegments(in: command)
+        if !spelled.isEmpty {
+            let shown = spelled
+                .map { "\"\($0.letters)\"\($0.letterish ? "" : " (not read out as letters)")" }
+                .joined(separator: ", ")
+            print("spelled-out: \(shown)  (taken from the text, not the model)")
         }
 
         // Resolved the same way the app resolves it, from the transcript. When
@@ -97,8 +101,10 @@ enum CommandTestCommand {
         switch command {
         case .openCorrectionPanel:
             print("   action: open the correction panel")
-        case .addRule(let heard, let corrected):
-            print("   action: add rule   \(heard) → \(corrected)")
+        case .addRules(let rules):
+            for rule in rules {
+                print("   action: add rule   \(rule.heard) → \(rule.corrected)")
+            }
         case .unrecognised(let text):
             print("   action: none — didn't understand \"\(text)\"")
         }

--- a/Sources/ParrotFlow/CorrectionPanel.swift
+++ b/Sources/ParrotFlow/CorrectionPanel.swift
@@ -35,10 +35,14 @@ final class CorrectionPanel {
         panel?.riseIntoView(makeKey: true)
     }
 
-    /// Opens with a rule already filled in — the model proposed it, the user
-    /// confirms it. One keystroke, and nothing is written on a guess.
-    func show(rule: (heard: String, corrected: String)) {
-        model.loadRule(heard: rule.heard, corrected: rule.corrected)
+    /// Opens with the rules already filled in — the model proposed them, the
+    /// user confirms them. One keystroke, and nothing is written on a guess.
+    ///
+    /// More than one row when the utterance carried more than one correction:
+    /// "Tasmeen spells T A S M E E N and Mick spells M I K" is two rules, and
+    /// splitting them across two panels would mean saying it twice.
+    func show(rules: [(heard: String, corrected: String)]) {
+        model.loadRules(rules)
         model.onSubmit = { [weak self] in self?.commit() }
         model.onCancel = { [weak self] in self?.dismiss(cancelled: true) }
 
@@ -184,8 +188,10 @@ final class CorrectionModel: ObservableObject {
         }
     }
 
-    func loadRule(heard: String, corrected: String) {
-        tokens = [CorrectionToken(word: heard, replacement: corrected, isManual: true)]
+    func loadRules(_ rules: [(heard: String, corrected: String)]) {
+        tokens = rules.map {
+            CorrectionToken(word: $0.heard, replacement: $0.corrected, isManual: true)
+        }
     }
 
     func remove(_ id: UUID) {

--- a/Sources/ParrotFlow/LocalLLM.swift
+++ b/Sources/ParrotFlow/LocalLLM.swift
@@ -220,8 +220,10 @@ enum LocalLLM {
 enum VoiceCommand {
     /// Open the correction panel for the current selection.
     case openCorrectionPanel
-    /// A spelling rule the model extracted from speech.
-    case addRule(heard: String, corrected: String)
+    /// The spelling rules the model extracted from speech. One utterance can
+    /// carry more than one: "Tasmeen spells T A S M E E N and Mick spells
+    /// M I K" is two rules, and the panel opens with a row for each.
+    case addRules([(heard: String, corrected: String)])
     /// Understood as nothing actionable.
     case unrecognised(String)
 
@@ -397,30 +399,30 @@ enum VoiceCommand {
         return nil
     }
 
-    /// Asks the model to pull a spelling rule out of something like
-    /// "Tasmin spells T A S M E E N".
-    /// Asks the model which word in the transcript the speaker meant to fix.
+    /// Asks the model which words in the transcript the speaker meant to fix.
     ///
-    /// The model picks the span only; the spelling comes from the letters via
-    /// `spelledOutWord`. Scored against tests/spelling-cases.yaml — 39 names
-    /// across French, Indian, Chinese, Turkish, Vietnamese, Korean, Nigerian,
-    /// Polish, Irish and Arabic, plus split product names and negative cases,
-    /// on gemma4:e4b with prompt v8:
+    /// The model names the span and nothing else. Everything to the right of
+    /// the arrow is built here: the letters when the speaker spelled them out,
+    /// and `describedEdit` when they described the change instead. Scored
+    /// against tests/spelling-cases.yaml (62 cases) and tests/french-cases.yaml
+    /// (45), on gemma4:e4b, end to end as the app runs it:
     ///
-    ///     span only             39/39
-    ///     span + model spelling 37/39
-    ///     what this returns     38/39
+    ///                       English  French
+    ///     shipped before      71%      89%   <- v14 / v13, no multi, no described
+    ///     shipped now         89%      96%   <- v26 / v23
+    ///     granite4:3b         89%      69%
+    ///     no model at all     50%      40%   <- the control
     ///
-    /// The two the model loses are both it mangling letters it was copying —
-    /// "S I O B H A N" came back "Sibhan". That job belongs to the regex.
+    /// The English gain is the two new shapes; the French one is mostly that
+    /// too, since v13 already handled described changes once the code applied
+    /// them. granite matching gemma on English at a sixth of the latency is
+    /// new, and is the repair layer doing the work: its raw spans score 74%.
     ///
-    /// The one this loses is "Sam spells S A M", where the guard below drops a
-    /// rule mapping a word to itself. That is deliberate, so the set's
-    /// expectation for that case is what is wrong.
-    ///
-    /// The fallback matters more than the prompt on a weak model: it repaired
-    /// granite4:3b from 85% to 92%, and it is most of the reason
-    /// qwen3.5:0.8b's 62% is barely above the 59% that no model at all scores.
+    /// Four English cases are known losses. "Sam spells S A M" is deliberate —
+    /// a rule mapping a word to itself is not a rule. "Jon is spelled with an
+    /// h" needs to know that Jon becomes John, which is knowledge rather than
+    /// character surgery, so it falls through to nothing and misses. The other
+    /// two are spans truncated to their first word.
     static func interpret(
         command: String,
         lastTranscript: String?,
@@ -439,63 +441,99 @@ enum VoiceCommand {
         )
         let reply = raw.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        // "I like apples => NO MATCH" is the right decision, clumsily phrased.
-        if reply.range(of: "no match", options: .caseInsensitive) != nil || reply.isEmpty {
-            return .unrecognised(command)
+        let candidates = spellingSegments(in: command)
+        var used = Set<Int>()
+        var rules: [(heard: String, corrected: String)] = []
+
+        for line in replyLines(reply) {
+            // Both shapes are accepted, because the two prompts answer
+            // differently and a missing arrow was once a total loss rather
+            // than a formatting one. English (v26) replies with the span
+            // alone; French (v23) still writes "span => spelling", which is
+            // not decoration there — measured span-only on French and it cost
+            // ten points, the model under-trimming "Say goal enn" to "Say
+            // goal" once it no longer had to write the name out. Spelling the
+            // target out evidently disciplines the span, and French needs the
+            // crutch where English does not.
+            let (heard, proposed) = splitRule(line)
+            guard !heard.isEmpty else { continue }
+
+            // The letters are unambiguous; the model's version of them is not.
+            let letters = chooseSpelling(
+                proposed: proposed, span: heard, candidates: candidates, used: &used
+            )
+
+            // Catch the model naming a word that is not actually in the
+            // transcript — it either copied from the command, where the name
+            // was misheard a second time, or invented one. Nothing close
+            // enough means no rule at all: a half-heard "X spells ... and Y
+            // spells ..." should produce the half it can see, not invent the
+            // other.
+            let resolved: String
+            if let transcript = lastTranscript, !transcript.isEmpty,
+               !containsWord(heard, in: transcript) {
+                Log.write("command: \"\(heard)\" is not in the transcript, matching instead")
+                let matches = [letters ?? proposed, heard]
+                    .filter { !$0.isEmpty }
+                    .compactMap { candidate -> (String, Double)? in
+                        guard let match = closestWord(to: candidate, in: transcript) else { return nil }
+                        return (match, similarity(match, candidate))
+                    }
+                guard let best = matches.max(by: { $0.1 < $1.1 }) else { continue }
+                resolved = best.0
+            } else {
+                resolved = heard
+            }
+
+            // No letters were read out, so the change was described. Applying
+            // it is code's job: a model asked to edit characters loses some,
+            // which is the same reason the letters are read from the text.
+            let corrected = letters
+                ?? describedEdit(in: clause(for: heard, proposed: proposed, in: command),
+                                 word: resolved)
+                ?? proposed
+            guard !corrected.isEmpty,
+                  resolved.lowercased() != corrected.lowercased() else { continue }
+            guard !rules.contains(where: {
+                $0.heard.lowercased() == resolved.lowercased()
+                    && $0.corrected.lowercased() == corrected.lowercased()
+            }) else { continue }
+            rules.append((heard: resolved, corrected: corrected))
         }
 
-        // Both shapes are accepted, because the two prompts answer differently
-        // and a missing arrow was previously a total loss rather than a
-        // formatting one. English (v14) replies with the span alone; French
-        // (v13) still writes "span => spelling", which is not decoration there
-        // — measured span-only on French and it cost ten points, the model
-        // under-trimming "Say goal enn" to "Say goal" once it no longer had to
-        // write the name out. Spelling out the target evidently disciplines
-        // the span. English does not need the crutch and is 61 tokens lighter
-        // without it.
-        let heard: String
-        let modelSpelling: String
-        if let arrow = reply.range(of: "=>") {
-            heard = reply[reply.startIndex..<arrow.lowerBound]
+        return rules.isEmpty ? .unrecognised(command) : .addRules(rules)
+    }
+
+    /// The reply's lines, without the ones that decline.
+    ///
+    /// "I like apples => NO MATCH" is the right decision, clumsily phrased, and
+    /// a model that numbers or bullets its lines has still answered.
+    static func replyLines(_ reply: String) -> [String] {
+        reply.components(separatedBy: .newlines)
+            .map { line -> String in
+                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                return trimmed.replacingOccurrences(
+                    of: "^(?:[-*•]|\\d+[.)])\\s*", with: "", options: .regularExpression
+                )
+            }
+            .filter { line in
+                !line.isEmpty
+                    && line.range(of: "no match", options: .caseInsensitive) == nil
+                    && line.range(of: "\\bnone\\b", options: [.regularExpression, .caseInsensitive]) == nil
+            }
+    }
+
+    /// "span => spelling" as a pair; a line with no arrow is all span.
+    static func splitRule(_ line: String) -> (String, String) {
+        guard let arrow = line.range(of: "=>") else {
+            return (line.trimmingCharacters(in: .whitespacesAndNewlines), "")
+        }
+        return (
+            line[line.startIndex..<arrow.lowerBound]
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+            line[arrow.upperBound...]
                 .trimmingCharacters(in: .whitespacesAndNewlines)
-            modelSpelling = reply[arrow.upperBound...]
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-                .components(separatedBy: .newlines).first?
-                .trimmingCharacters(in: .whitespaces) ?? ""
-        } else {
-            heard = reply
-                .components(separatedBy: .newlines).first?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            modelSpelling = ""
-        }
-
-        guard !heard.isEmpty else { return .unrecognised(command) }
-
-        // The letters are unambiguous; the model's version of them is not.
-        let corrected = spelledOutWord(in: command) ?? modelSpelling
-        guard !corrected.isEmpty else { return .unrecognised(command) }
-
-        // Catch the model naming a word that is not actually in the transcript
-        // — it either copied from the command, where the name was misheard a
-        // second time, or invented one.
-        let resolved: String
-        if let transcript = lastTranscript, !transcript.isEmpty,
-           !containsWord(heard, in: transcript) {
-            Log.write("command: \"\(heard)\" is not in the transcript, matching instead")
-            resolved = [corrected, heard]
-                .compactMap { candidate -> (String, Double)? in
-                    guard let match = closestWord(to: candidate, in: transcript) else { return nil }
-                    return (match, similarity(match, candidate))
-                }
-                .max { $0.1 < $1.1 }?.0 ?? heard
-        } else {
-            resolved = heard
-        }
-
-        guard resolved.lowercased() != corrected.lowercased() else {
-            return .unrecognised(command)
-        }
-        return .addRule(heard: resolved, corrected: corrected)
+        )
     }
 
     /// Prompt v8. Earlier versions and the scores that rejected them are in
@@ -559,16 +597,19 @@ enum VoiceCommand {
     Find the words in the source line that the speaker is correcting.
 
     You get a source transcription, and a correction transcription in which \
-    the speaker says a name then spells it letter by letter.
+    the speaker names a word and then says how it is written — either by \
+    spelling it letter by letter, or by describing what to change about it.
 
-    Reply with those words copied from the source line, and nothing else.
-    Or reply NO MATCH.
+    Reply with those words copied from the source line, and nothing else. \
+    One line per correction. Or reply NO MATCH.
 
     - Copy the words from the SOURCE. The correction transcription mishears \
     the name a second time; ignore how it appears there.
     - The source span is often two or three words, because recognition splits \
     names it does not know. Take the whole name, and only the name.
-    - Reply NO MATCH when nothing in the source sounds like the spelled name.
+    - Never write the corrected spelling. Only the words being corrected.
+    - One utterance can carry two corrections. Give each its own line.
+    - Reply NO MATCH when nothing in the source sounds like the name.
 
     source: I work with Tasmin
     correction: Das mean spells T-A-S-M-E-E-N
@@ -580,6 +621,10 @@ enum VoiceCommand {
 
     source: I like apples
     correction: Oranges spells O-R-A-N-G-E-S
+    NO MATCH
+
+    source: We are shipping on Friday
+    correction: Katia with a C at the beginning
     NO MATCH
 
     source: We deployed to Versal yesterday
@@ -597,6 +642,19 @@ enum VoiceCommand {
     source: Anna ees joined the design team
     correction: Anna east spells A N A I S
     Anna ees
+
+    source: Katia opened the ticket
+    correction: Katia with a C at the beginning
+    Katia
+
+    source: The Rabbit em queue broker is down
+    correction: Rabbit MQ is one word
+    Rabbit em queue
+
+    source: Anna ees and Emmilie are on the call
+    correction: Anna east spells A N A I S and Emmilie takes one m
+    Anna ees
+    Emmilie
     """
 
     /// The English prompt's structure, in French, with French examples.
@@ -625,13 +683,14 @@ enum VoiceCommand {
     /// positive, and a three-word example (v21), aimed at the short span.
     /// Both scored 93% with the same two failures.
     static let frenchExtractionPrompt = """
-    Associe un nom mal transcrit a l'orthographe que la personne vient d'epeler.
+    Associe un nom mal transcrit a l'orthographe que la personne vient d'indiquer.
 
     Tu recois une transcription source, et une transcription de correction dans \
-    laquelle la personne dit un nom puis l'epelle lettre par lettre.
+    laquelle la personne dit un nom puis indique comment il s'ecrit — soit en \
+    l'epelant lettre par lettre, soit en decrivant ce qu'il faut changer.
 
-    Reponds par une seule ligne, et rien d'autre :
-    <les mots exactement comme ils apparaissent dans la source> => <les lettres epelees assemblees>
+    Reponds par une ligne par correction, et rien d'autre :
+    <les mots exactement comme ils apparaissent dans la source> => <l'orthographe corrigee>
     ou
     NO MATCH
 
@@ -641,9 +700,12 @@ enum VoiceCommand {
     - Le nom occupe souvent deux ou trois mots dans la source, parce que la \
     reconnaissance vocale decoupe les noms qu'elle ne connait pas. Prends le \
     nom entier, et rien que le nom.
-    - La partie droite est constituee des lettres epelees, dans l'ordre donne, \
-    assemblees avec une majuscule au debut.
-    - Reponds NO MATCH si rien dans la source ne ressemble au nom epele.
+    - Quand la personne epelle, la partie droite est constituee des lettres \
+    epelees, dans l'ordre donne, assemblees avec une majuscule au debut.
+    - Quand la personne decrit le changement au lieu de l'epeler, applique \
+    exactement ce qui est decrit au mot de la source, et ne change rien d'autre.
+    - Une seule phrase peut porter deux corrections. Donne une ligne a chacune.
+    - Reponds NO MATCH si rien dans la source ne ressemble au nom.
 
     source: J'ai vu Ni cola hier au bureau
     correction: Nicolas s'ecrit N I C O L A S
@@ -672,6 +734,15 @@ enum VoiceCommand {
     source: Cle mence a rejoint l'equipe hier
     correction: Clemence s'ecrit C L E M E N C E
     Cle mence => Clemence
+
+    source: Frederic a relu la maquette
+    correction: Frédéric avec des accents sur les e
+    Frederic => Frédéric
+
+    source: Nathalie et Philipe sont sur l'appel
+    correction: Nathalie sans le h et Philipe avec deux p
+    Nathalie => Natalie
+    Philipe => Philippe
     """
 
     /// Whether `word` actually occurs in `transcript`, ignoring case and
@@ -760,6 +831,48 @@ enum VoiceCommand {
         return 1 - previous[y.count] / Double(Swift.max(x.count, y.count))
     }
 
+    /// The spelling to use for one line of the reply: the letters when they
+    /// were read out, nothing when they were not.
+    ///
+    /// The letters are exact and the model's copy of them is not, so they win
+    /// wherever they exist — that is why the right-hand side has never been
+    /// trusted. But a described change has no letters, and the trigger regex
+    /// happily returns "Avecungaudebut" for "s'écrit avec un G au début".
+    ///
+    /// Rather than a list of description words, which would have to grow
+    /// forever and would misfire on spellings that merge into ordinary words,
+    /// the two are told apart by corroboration. A segment read out as letters
+    /// carries its own evidence. One that was not — recognition merges them,
+    /// so "Tas Meen" is real — has to look like something else in the
+    /// utterance: the span, which is the same name heard once already, or the
+    /// spelling the model proposed. "Withanh" resembles neither Jon nor John.
+    static func chooseSpelling(
+        proposed: String,
+        span: String,
+        candidates: [(letters: String, letterish: Bool)],
+        used: inout Set<Int>,
+        floor: Double = 0.55
+    ) -> String? {
+        var best: Int?
+        var score = 0.0
+        for (index, candidate) in candidates.enumerated() where !used.contains(index) {
+            let agreement = max(
+                proposed.isEmpty ? 0 : similarity(candidate.letters, proposed),
+                span.isEmpty ? 0 : similarity(candidate.letters, span)
+            )
+            // Read out as letters. Only which line it belongs to can be wrong,
+            // so the best available agreement still decides the pairing.
+            let value = candidate.letterish ? max(agreement, floor) : agreement
+            if value > score {
+                best = index
+                score = value
+            }
+        }
+        guard let best, score >= floor else { return nil }
+        used.insert(best)
+        return candidates[best].letters
+    }
+
     /// Words that end the spelling: "spelled S U P A B A S E not super base",
     /// or "s'écrit R E D I S pas Reddis".
     ///
@@ -772,6 +885,44 @@ enum VoiceCommand {
         "not", "instead", "rather", "but", "no",
         "pas", "non", "plutôt", "plutot", "mais",
     ]
+
+    /// What joins two corrections in one breath: "T A S M E E N and Mick spells
+    /// M I K". Without these the first spelling ran to the end of the sentence
+    /// and came back "Tasmeenandmickspellsmik".
+    ///
+    /// The risk is a spelling that merges *into* the conjunction — "Alexander
+    /// spells A L E X and er" is a real rendering — so a conjunction only ends
+    /// a segment when at least two tokens follow it, or when another spelling
+    /// clause follows and everything after it plainly belongs to that one.
+    private static let spellingConjunctions: Set<String> = [
+        "and", "et", "puis", "then", "ensuite", "also", "aussi",
+    ]
+
+    /// Alphanumeric runs, each with whether a comma or semicolon preceded it.
+    ///
+    /// The punctuation flag is what lets ", Priyanka spells" end a segment when
+    /// there is no conjunction to break on.
+    private static func tokensWithBreaks(_ text: Substring) -> [(text: String, punctuated: Bool)] {
+        var out: [(String, Bool)] = []
+        var current = ""
+        var punctuated = false
+        for character in text {
+            if character.isLetter || character.isNumber {
+                current.append(character)
+            } else {
+                if !current.isEmpty {
+                    out.append((current, punctuated))
+                    current = ""
+                    punctuated = false
+                }
+                if character == "," || character == ";" || character == ":" {
+                    punctuated = true
+                }
+            }
+        }
+        if !current.isEmpty { out.append((current, punctuated)) }
+        return out
+    }
 
     /// The spelling the speaker read out.
     ///
@@ -790,37 +941,324 @@ enum VoiceCommand {
     /// did not know and a merged tail, so it fell through to the single-letter
     /// pattern and yielded "Math". Adding them took tests/french-cases.yaml
     /// from 76% to 84% on gemma4:e4b, and left the English set at 97%.
-    static func spelledOutWord(in text: String) -> String? {
-        if let trigger = text.range(
-            of: "(?:\\b(?:spells?|spelled|spelling)\\b"
-                + "|s['’]\\s*(?:é|e)(?:crit|pelle)"
-                + "|\\b(?:é|e)(?:crit|pelle)\\b)",
-            options: [.regularExpression, .caseInsensitive]
+    /// Every spelling read out in the utterance, in order, with whether each
+    /// was actually read out as letters.
+    ///
+    /// A trigger no longer runs to the end of the sentence, because one
+    /// utterance can carry two corrections: a conjunction ends a segment, and
+    /// so does a comma when another clause plainly follows.
+    ///
+    /// A described change ("s'écrit avec un G au début") matches a trigger and
+    /// yields "Avecungaudebut" here, flagged as not read out as letters.
+    /// Nothing tries to detect that; `chooseSpelling` discards it because
+    /// nothing in the utterance corroborates it.
+    static func spellingSegments(in text: String) -> [(letters: String, letterish: Bool)] {
+        let pattern = "(?:\\b(?:spells?|spelled|spelling)\\b"
+            + "|s['’]\\s*(?:é|e)(?:crit|pelle)"
+            + "|\\b(?:é|e)(?:crit|pelle)\\b)"
+        var triggers: [Range<String.Index>] = []
+        var searchFrom = text.startIndex
+        while let found = text.range(
+            of: pattern, options: [.regularExpression, .caseInsensitive],
+            range: searchFrom..<text.endIndex
         ) {
+            triggers.append(found)
+            searchFrom = found.upperBound
+        }
+
+        guard !triggers.isEmpty else {
+            // No trigger word: fall back to a run of single letters anywhere.
+            let letterRun = "\\b(?:[A-Za-z0-9][\\s\\-.]+){2,}[A-Za-z0-9]\\b"
+            guard let range = text.range(of: letterRun, options: .regularExpression) else {
+                return []
+            }
+            let letters = text[range].filter { $0.isLetter || $0.isNumber }
+            guard letters.count >= 3 else { return [] }
+            return [(letters.prefix(1).uppercased() + letters.dropFirst().lowercased(), true)]
+        }
+
+        var out: [(letters: String, letterish: Bool)] = []
+        for (index, trigger) in triggers.enumerated() {
+            let bounded = index + 1 < triggers.count
+            let end = bounded ? triggers[index + 1].lowerBound : text.endIndex
+            let tokens = tokensWithBreaks(text[trigger.upperBound..<end])
+
             var letters = ""
-            for token in text[trigger.upperBound...]
-                .components(separatedBy: CharacterSet.alphanumerics.inverted)
-                .filter({ !$0.isEmpty }) {
+            var taken: [String] = []
+            var broke = false
+            for (position, token) in tokens.enumerated() {
+                let lowered = token.text.lowercased()
+                // A conjunction always ends a bounded segment: whatever follows
+                // it belongs to the next clause. Unbounded, it has to earn the
+                // break with two real tokens after it, or "A L E X and er"
+                // loses its tail.
+                let conjunction = spellingConjunctions.contains(lowered)
+                    && (bounded || tokens.count - position - 1 >= 2)
                 // Never on the first token. Recognition merges letters into
                 // syllables, so "Pascal s'écrit Pas cal" opens on something
                 // that reads as a stop word; breaking there would yield
                 // nothing at all rather than "Pascal".
-                if !letters.isEmpty, spellingStopWords.contains(token.lowercased()) { break }
-                letters += token
+                if !letters.isEmpty,
+                   spellingStopWords.contains(lowered) || conjunction
+                       || (token.punctuated && bounded) {
+                    broke = true
+                    break
+                }
+                letters += token.text
+                taken.append(token.text)
             }
-            if letters.count >= 2 {
-                return letters.prefix(1).uppercased() + letters.dropFirst().lowercased()
+            // Nothing ended it and another clause follows: what is left on the
+            // end is that clause's name ("... M I K" has none, "... and Mick"
+            // does).
+            if bounded, !broke, taken.count > 1 {
+                letters.removeLast(taken.removeLast().count)
             }
+            guard letters.count >= 2 else { continue }
+            // Most of a spelled segment arrives as single characters even when
+            // the tail merges into syllables, and no description of a change
+            // does. It is the cheap half of telling the two apart; the
+            // expensive half is corroboration, in chooseSpelling.
+            let singles = taken.filter { $0.count == 1 }.count
+            let letterish = taken.count >= 2
+                && Double(singles) / Double(taken.count) >= 0.6
+            out.append((letters.prefix(1).uppercased() + letters.dropFirst().lowercased(),
+                        letterish))
         }
-
-        // No trigger word: fall back to a run of single letters anywhere.
-        let pattern = "\\b(?:[A-Za-z0-9][\\s\\-.]+){2,}[A-Za-z0-9]\\b"
-        guard let range = text.range(of: pattern, options: .regularExpression) else {
-            return nil
-        }
-        let letters = text[range].filter { $0.isLetter || $0.isNumber }
-        guard letters.count >= 3 else { return nil }
-        return letters.prefix(1).uppercased() + letters.dropFirst().lowercased()
+        return out
     }
 
+}
+
+// MARK: - Changes the speaker describes instead of spelling out
+
+/// "Mathieu ne prend qu'un seul t" has no letters in it, so the regex that
+/// builds the spelling from what was read out has nothing to read.
+///
+/// The obvious answer is to let the model write the corrected name, and it is
+/// the wrong one. Measured on the ten described cases in the English set,
+/// gemma4:e4b scores 5/10 and gemma4:12b 8/10, and the failures are not
+/// misunderstandings: "Phillip with one l" came back "Phill" and "Philp",
+/// "Elisabeth with a z" came back "Elizabith". It is the same weakness the
+/// spelled path already routes around — a model asked to copy characters loses
+/// some — and the answer is the same. The model finds the span; this applies
+/// the change, and scores 10/10.
+///
+/// What is not recognised here falls through to whatever the model proposed,
+/// which is what "Jon is spelled with an h" would need: knowing that Jon
+/// becomes John is knowledge rather than character surgery.
+extension VoiceCommand {
+
+    /// Letters as recognition renders them when they are dictated on their own
+    /// — "one t" arrives as "one tea", "un seul t" as "un seul thé". Only ever
+    /// consulted in a slot the pattern has already decided is a letter, which
+    /// is what makes it safe to include forms like "en" and "elle".
+    private static let letterWords: [String: Character] = [
+        "tea": "t", "tee": "t", "zed": "z", "zee": "z", "see": "c", "sea": "c",
+        "ex": "x", "why": "y", "are": "r", "ar": "r", "you": "u", "jay": "j",
+        "kay": "k", "el": "l", "em": "m", "en": "n", "oh": "o", "pea": "p",
+        "pee": "p", "cue": "q", "queue": "q", "ess": "s", "vee": "v",
+        "bee": "b", "dee": "d", "eff": "f", "gee": "g", "aitch": "h",
+        "eye": "i",
+        "thé": "t", "the": "t", "té": "t", "cé": "c", "dé": "d", "gé": "g",
+        "jé": "j", "pé": "p", "vé": "v", "bé": "b", "zède": "z", "ixe": "x",
+        "ache": "h", "esse": "s", "èsse": "s", "effe": "f", "elle": "l",
+        "emme": "m", "enne": "n", "erre": "r", "ka": "k", "ku": "q",
+    ]
+
+    /// The letter a slot names, however recognition rendered it.
+    static func asLetter(_ token: String) -> Character? {
+        let cleaned = token
+            .trimmingCharacters(in: CharacterSet(charactersIn: "'’ "))
+            .lowercased()
+        if cleaned.count == 1, let only = cleaned.first, only.isLetter { return only }
+        return letterWords[cleaned]
+    }
+
+    private enum DescribedOp {
+        case join, hyphen, strip, accent, double, single, atStart, atEnd, remove, swap
+    }
+
+    /// Ordered, because the looser patterns would eat the tighter ones:
+    /// "without the h" has to be read before "with ... h", and "one l" before
+    /// "a G at the beginning".
+    private static let describedOps: [(op: DescribedOp, pattern: String)] = {
+        let letter = "([^\\W\\d_]{1,5}['’]?)"
+        let atStart = "(?:at\\s+the\\s+(?:beginning|start)|au\\s+d[ée]but|en\\s+premier)"
+        let atEnd = "(?:at\\s+the\\s+end|[àa]\\s+la\\s+fin|en\\s+dernier)"
+        return [
+            (.join, "\\b(?:in|en)\\s+(?:one|a|un)\\s+(?:single\\s+|seul\\s+)?(?:word|mot)\\b"),
+            (.join, "\\b(?:is|est)\\s+one\\s+word\\b"),
+            (.hyphen, "\\b(?:hyphens?|hyphenated|dash|trait\\s+d['’ ]?union|tiret)\\b"),
+            (.strip, "\\b(?:without|sans)\\s+(?:the\\s+)?accents?\\b"),
+            (.accent, "\\b(?:accents?|tr[ée]ma|c[ée]dille)\\b(?:\\s+\\w+)*?\\s+"
+                + "(?:sur|on)\\s+(?:l[ea]s?|the)?\\s*" + letter),
+            (.double, "\\b(?:two|double|deux)\\s+" + letter + "\\b"),
+            (.single, "\\b(?:only\\s+)?(?:one|a\\s+single|un\\s+seul|une\\s+seule)\\s+"
+                + letter + "\\b"),
+            (.atStart, "\\b(?:with|avec)\\s+(?:an?|un|une)\\s+" + letter + "\\b[^.]*?" + atStart),
+            (.atEnd, "\\b(?:with|avec)\\s+(?:an?|un|une)\\s+" + letter + "\\b[^.]*?" + atEnd),
+            (.remove, "\\b(?:without|sans)\\s+(?:the\\s+|de\\s+|d['’])?" + letter + "\\b"),
+            // Bare "with a z", no position and no count. Which letter it
+            // replaces is left to the confusable table: recognition heard
+            // something for the letter actually written, so the one it can be
+            // swapped for is the one that sounds like it. "Elisabeth with a z"
+            // has exactly one candidate, the s.
+            (.swap, "\\b(?:with|avec)\\s+(?:an?|un|une)\\s+" + letter + "\\b"),
+        ]
+    }()
+
+    private static let accentMarks: [(name: String, mark: Character)] = [
+        ("aigu", "\u{0301}"), ("grave", "\u{0300}"), ("circonflexe", "\u{0302}"),
+        ("chapeau", "\u{0302}"), ("tr[ée]ma", "\u{0308}"), ("c[ée]dille", "\u{0327}"),
+    ]
+
+    /// `word` with the change described in `clause` applied, or nil when
+    /// nothing in the clause describes one this can make.
+    static func describedEdit(in clause: String, word: String) -> String? {
+        for (op, pattern) in describedOps {
+            guard let groups = match(pattern, in: clause) else { continue }
+            let letter = groups.count > 1 ? asLetter(groups[1]) : nil
+            switch op {
+            case .join, .hyphen, .strip:
+                break
+            default:
+                if letter == nil { continue }
+            }
+            if let edited = apply(op, letter: letter, word: word, clause: clause),
+               edited.lowercased() != word.lowercased() {
+                return edited
+            }
+        }
+        return nil
+    }
+
+    private static func apply(
+        _ op: DescribedOp, letter: Character?, word: String, clause: String
+    ) -> String? {
+        switch op {
+        case .join:
+            return word.filter { !$0.isWhitespace && $0 != "-" }
+        case .hyphen:
+            return word.split(separator: " ").joined(separator: "-")
+        case .strip:
+            return word.folding(options: .diacriticInsensitive, locale: nil)
+        case .accent:
+            guard let letter else { return nil }
+            let mark = accentMarks.first {
+                clause.range(of: $0.name, options: [.regularExpression, .caseInsensitive]) != nil
+            }?.mark ?? "\u{0301}"
+            // "des accents sur les e" is every e; "un accent sur le e" the first.
+            let every = clause.range(
+                of: "\\b(?:des|les|tous|all)\\b",
+                options: [.regularExpression, .caseInsensitive]
+            ) != nil
+            var out = ""
+            var done = false
+            for character in word.decomposedStringWithCanonicalMapping {
+                out.append(character)
+                if character.lowercased() == String(letter), every || !done {
+                    out.append(mark)
+                    done = true
+                }
+            }
+            return out.precomposedStringWithCanonicalMapping
+        case .double:
+            guard let letter else { return nil }
+            let lowered = Array(word.lowercased())
+            for index in lowered.indices.dropLast()
+            where lowered[index] == letter && lowered[index + 1] == letter {
+                return word  // already doubled; the change is already made
+            }
+            guard let last = lowered.lastIndex(of: letter) else { return nil }
+            var characters = Array(word)
+            characters.insert(characters[last], at: last)
+            return String(characters)
+        case .single:
+            guard let letter else { return nil }
+            var out = ""
+            for character in word {
+                if character.lowercased() == String(letter),
+                   out.last?.lowercased() == String(letter) { continue }
+                out.append(character)
+            }
+            return out
+        case .atStart:
+            guard let letter, let head = word.first else { return nil }
+            let replacement = head.isUppercase
+                ? Character(String(letter).uppercased()) : letter
+            return String(replacement) + word.dropFirst()
+        case .atEnd:
+            guard let letter else { return nil }
+            return word.lowercased().hasSuffix(String(letter)) ? word : word + String(letter)
+        case .remove:
+            guard let letter else { return nil }
+            return word.filter { $0.lowercased() != String(letter) }
+        case .swap:
+            guard let letter, !word.lowercased().contains(letter) else { return nil }
+            for (offset, character) in word.enumerated()
+            where substitutionCost(Character(character.lowercased()), letter) == 0.5 {
+                let replacement = character.isUppercase
+                    ? Character(String(letter).uppercased()) : letter
+                let index = word.index(word.startIndex, offsetBy: offset)
+                return word.replacingCharacters(in: index...index, with: String(replacement))
+            }
+            return nil
+        }
+    }
+
+    /// The utterance split where one correction ends and the next begins.
+    static func clauses(of correction: String) -> [String] {
+        correction
+            .replacingOccurrences(
+                of: "\\b(?:and|et|puis|then|ensuite)\\b|[,;]", with: "\u{0000}",
+                options: [.regularExpression, .caseInsensitive]
+            )
+            .components(separatedBy: "\u{0000}")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    /// The clause one line of the reply came from, so "Anna east spells A N A
+    /// I S and Emmilie takes one m" applies its "one m" to Emmilie and not to
+    /// Anais.
+    static func clause(for span: String, proposed: String, in correction: String) -> String {
+        let parts = clauses(of: correction)
+        guard parts.count > 1 else { return correction }
+
+        var best = correction
+        var score = 0.0
+        for part in parts {
+            let words = part
+                .components(separatedBy: CharacterSet.alphanumerics
+                    .union(CharacterSet(charactersIn: "'-")).inverted)
+                .filter { !$0.isEmpty }
+            for size in 1...2 where words.count >= size {
+                for start in 0...(words.count - size) {
+                    let window = words[start..<(start + size)].joined(separator: " ")
+                    let value = max(
+                        similarity(window, span),
+                        proposed.isEmpty ? 0 : similarity(window, proposed)
+                    )
+                    if value > score {
+                        best = part
+                        score = value
+                    }
+                }
+            }
+        }
+        return best
+    }
+
+    private static func match(_ pattern: String, in text: String) -> [String]? {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive])
+        else { return nil }
+        let subject = text as NSString
+        guard let found = regex.firstMatch(
+            in: text, range: NSRange(location: 0, length: subject.length)
+        ) else { return nil }
+        return (0..<found.numberOfRanges).map { index in
+            let range = found.range(at: index)
+            return range.location == NSNotFound ? "" : subject.substring(with: range)
+        }
+    }
 }

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -41,7 +41,8 @@ enum PanelsCommand {
         correction.tokens[0].replacement = "Tasmeen"
 
         let rule = CorrectionModel()
-        rule.loadRule(heard: "Tasmin", corrected: "Tasmeen")
+        rule.loadRules([(heard: "Tasmin", corrected: "Tasmeen"),
+                        (heard: "Mick", corrected: "Mik")])
 
         let preview = PreviewModel()
         preview.load(
@@ -145,7 +146,8 @@ enum PanelsCommand {
         case "vocabulary":
             correction.show(selection: "Tasmin and Mick")
         case "rule":
-            correction.show(rule: (heard: "Tasmin", corrected: "Tasmeen"))
+            correction.show(rules: [(heard: "Tasmin", corrected: "Tasmeen"),
+                                    (heard: "Mick", corrected: "Mik")])
         case "preview":
             preview.show(
                 prompt: "Grammar",

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -191,13 +191,22 @@ a resumable transfer, and a working app (record-only) until it lands.
 ## Voice corrections
 
 Saying "hey parrot, <name> spells T A S M E E N" adds a replacement rule. A
-local model picks which word in the previous transcript was meant; the spelling
-comes from the letters by regex, never from the model.
+local model picks which words in the previous transcript were meant; the
+spelling comes from the letters by regex, never from the model.
 
 That split is deliberate and measured. Given the whole job the model returns
 the right span but mangles the letters it is copying — "S I O B H A N" came
 back "Sibhan". Given only the span it scores 35/35 on
 `tests/spelling-cases.yaml`.
+
+Two shapes were added later and both stayed on the same side of that split.
+A speaker can describe the change rather than spell it ("Mathieu ne prend
+qu'un seul t", "Jerome with a G at the beginning"), and `describedEdit`
+applies it in code: gemma4:e4b scored 5/10 writing those names itself and
+gemma4:12b 8/10, against 10/10 when the model only names the span. And one
+utterance can carry two corrections joined by "and" or "et", which the panel
+opens as two rows. End to end, English went from 71% to 89% and French from
+89% to 96% on the extended sets.
 
 `scripts/validate-prompt.py <model>` reruns that set in about a minute, and
 `.claude/skills/prompt-iteration/SKILL.md` documents how the prompt was

--- a/scripts/check-spelling.sh
+++ b/scripts/check-spelling.sh
@@ -33,31 +33,39 @@ print(phrases if isinstance(phrases, str) else phrases[0])
 pass=0; total=0; missed=0; wrong=0; invented=0
 started=$(date +%s)
 
-while IFS='|' read -r source correction expect; do
+# One utterance can carry more than one correction, so both the expectation and
+# the answer are lists, joined with "|" and compared sorted — which rule comes
+# out first is not something the app promises.
+while IFS=$'\t' read -r source correction expect; do
   [ -z "$source" ] && continue
   total=$((total + 1))
   out="$("$BIN" --command "$PHRASE, $correction" "$source" 2>/dev/null)"
-  if rule="$(printf '%s' "$out" | sed -n 's/.*action: add rule *//p')"; then :; fi
-  if [ -n "$rule" ]; then
-    got="$(printf '%s' "$rule" | sed 's/ → / => /')"
-  else
-    got="NO MATCH"
-  fi
+  got="$(printf '%s' "$out" \
+    | sed -n 's/.*action: add rule *//p' \
+    | sed 's/ → / => /; s/[[:space:]]*$//' \
+    | sort | paste -sd '|' -)"
+  [ -z "$got" ] && got="NO MATCH"
 
   if [ "$got" = "$expect" ]; then
     pass=$((pass + 1))
     printf '  ✓ %-46s %s\n' "$source" "$got"
   else
-    if   [ "$expect" = "NO MATCH" ]; then invented=$((invented + 1)); mark="invented a rule  ← rewrites every future transcript"
-    elif [ "$got"    = "NO MATCH" ]; then missed=$((missed + 1));     mark="missed it"
-    else wrong=$((wrong + 1));                                        mark="wrong span or spelling"
+    gotn=$(printf '%s' "$got" | tr '|' '\n' | grep -cv '^NO MATCH$')
+    wantn=$(printf '%s' "$expect" | tr '|' '\n' | grep -cv '^NO MATCH$')
+    if   [ "$gotn" -gt "$wantn" ]; then invented=$((invented + 1)); mark="invented a rule  ← rewrites every future transcript"
+    elif [ "$gotn" -lt "$wantn" ]; then missed=$((missed + 1));     mark="missed it"
+    else wrong=$((wrong + 1));                                      mark="wrong span or spelling"
     fi
     printf '  ✗ %-46s got %s, want %s  (%s)\n' "$source" "$got" "$expect" "$mark"
   fi
 done < <(python3 -c '
 import sys, yaml
 for case in yaml.safe_load(open(sys.argv[1]))["cases"]:
-    print("|".join([str(case["source"]), str(case["correction"]), str(case["expect"])]))
+    expect = case["expect"]
+    if not isinstance(expect, list):
+        expect = [expect]
+    print("\t".join([str(case["source"]), str(case["correction"]),
+                     "|".join(sorted(str(rule) for rule in expect))]))
 ' "$ROOT/$CASES")
 
 elapsed=$(( $(date +%s) - started ))

--- a/scripts/validate-prompt.py
+++ b/scripts/validate-prompt.py
@@ -8,37 +8,75 @@
 Prompt variants live in this file so they can be compared directly; the
 winner gets copied into LocalLLM.swift.
 
-Three numbers, because they answer different questions. "pipeline" is the
-model's span plus the regex spelling. "APP" adds interpret()'s snap-to-
-transcript repair, and is the only one that says what a user would see.
+Two numbers, because they answer different questions. "spans" is what the model
+alone got right. "APP" adds the letters, described_edit and interpret()'s
+snap-to-transcript repair, and is the only one that says what a user would see.
 
-Scoreboard (APP). English is tests/spelling-cases.yaml, 44 cases; French is
-tests/french-cases.yaml, 30 cases, where the dictated sentence is French.
-Only the gemma v8/v13/v14 rows below were re-measured after the sets grew and
-spelledOutWord learned the French spelling verbs and stop words; the rest are
-from the 39/25-case sets and are indicative, not comparable.
+Scoreboard (APP). English is tests/spelling-cases.yaml, French is
+tests/french-cases.yaml, where the dictated sentence is French. The sets grew
+twice: the rows marked 62/45 are on the current sets, which added two-in-a-
+breath corrections and described changes; the 44/30 rows are the sets before
+that; anything older is indicative, not comparable.
 
                         English  French  latency  size
-    gemma4:e4b   v14      98%     -       1.15s   9.6GB  <- shipped, English
-    gemma4:e4b   v13       -      93%     1.5s    9.6GB  <- shipped, French
-    gemma4:e4b   v8       98%     87%     1.33s   9.6GB  <- what v14 replaced
+    -- 62 / 45 cases
+    gemma4:e4b   v26      89%      -      1.41s   9.6GB  <- shipped, English
+    gemma4:e4b   v23       -      96%     1.5s    9.6GB  <- shipped, French
+    granite4:3b  v26      89%      -      0.22s   2.1GB  <- level, six times faster
+    granite4:3b  v23       -      69%     0.41s   2.1GB
+    gemma4:e4b   v24      87%      -      1.5s           arrow back on: -2 on spans
+    gemma4:e4b   v28      87%      -      1.4s           v26 + one prose clause
+    gemma4:e4b   v27      85%      -      1.4s           v26 + an extra example
+    gemma4:e4b   v25      85%      -      1.31s          v26 without the described NO MATCH
+    gemma4:e4b   v22      81%      -      1.51s          first attempt at both shapes
+    gemma4:e4b   v14      71%      -      1.17s          what shipped before
+    gemma4:e4b   v13       -      89%     1.46s          what shipped before
+    (no model)            50%     40%       -     <- the control to beat
+    -- 44 / 30 cases
+    gemma4:e4b   v14      98%     -       1.15s   9.6GB
+    gemma4:e4b   v13       -      93%     1.5s    9.6GB
+    gemma4:e4b   v8       98%     87%     1.33s   9.6GB
     gemma4:12b   v8       98%      -      2.96s   7.6GB  <- twice the wait
     gemma4:12b   v13       -      97%     3.29s   7.6GB
     gemma4:e2b   v13       -      80%     1.0s    7.2GB
     gemma4:e2b   v8       86%     60%     0.9s    7.2GB
+    granite4:3b  v8       92%     68%     0.3s    2.1GB
+    granite4:3b  v13       -      48%     0.3s    French prompt HURTS it
+    (no model)            59%     48%       -
+    -- older sets, indicative only
     gemma4:e4b   v4       97%      -      1.4s
     gemma4:e4b   v9       95%      -      1.5s    over-took spans
-    granite4:3b  v8       92%     68%     0.3s    2.1GB  <- best small model
     granite4:3b  v4       90%      -      0.3s
     granite4:3b  v9       87%      -      0.3s
-    granite4:3b  v13       -      48%     0.3s    French prompt HURTS it
     qwen3.5:0.8b v5       62%      -      0.4s    1.0GB
-    (no model)            59%     48%       -     <- the control to beat
     qwen3.5:2b   v8       49%     12%     0.7s    2.7GB
     qwen3.5:0.8b v4       46%      -      0.5s
     qwen3.5:0.8b v7       36%      -      0.4s    correction-first, worse
     qwen3.5:0.8b v6        8%      -      0.4s    by word number: all NONE
     qwen3.5:0.8b v5        8%      -      5.3s    --think: 11x slower, worse
+
+The described changes are the clearest instance yet of the rule that anything
+mechanical belongs in code. "Mathieu ne prend qu'un seul t" has no letters to
+read, so the obvious move is to let the model write the corrected name. On the
+ten described cases in the English set that scores 5/10 on gemma4:e4b and 8/10
+on gemma4:12b, and the failures are not misunderstandings — "Phillip with one
+l" came back "Phill" and "Philp", "Elisabeth with a z" came back "Elizabith".
+described_edit applies the change instead and scores 10/10 on both. A bigger
+model was worth three points here; moving the job out of the model was worth
+five, and it is free.
+
+That change also paid for the prompt. With no spelling for the model to write,
+v25/v26 could go back to answering with the span alone, and the span is where
+the accuracy is: v22 and v24, which restore the arrow, truncate two-word spans
+that v14 got right ("Locks me" to "Locks", "Oluwa shane" to "Oluwa"). Writing
+the name out evidently pulls the model toward the shortest span it can spell.
+French still keeps the arrow, because there it pulls the other way — v19
+measured span-only French and lost ten points to under-trimming.
+
+granite4:3b reaching gemma's English score at a sixth of the latency is new,
+and it is the repair layer doing the work: granite's raw spans score 74%
+against gemma's 89%. The more of the answer that is built from the text, the
+less the model has to be good at.
 
 Latency here is prefill, not generation, and that is the single most useful
 thing on this page. Measured on e4b with v8: 420 prompt tokens in against 6
@@ -987,6 +1025,482 @@ marche => Marc
 source: Cle mence a rejoint l'equipe hier
 correction: Clemence s'ecrit C L E M E N C E
 Cle mence => Clemence""",
+
+# --- Two corrections at once, and corrections that are described ------------
+#
+# v22 is v14 with the right-hand side put back and two capabilities added: an
+# utterance can carry more than one correction, and a correction can describe
+# the change ("with a G at the beginning") instead of spelling it.
+#
+# The right side has to come back. v14 dropped it because the regex rebuilt the
+# spelling from the letters and the model's version was thrown away — but a
+# described change has no letters in it, so for that shape the model's right
+# side is the only spelling there is. It also gives the code something to match
+# the regex candidate against, which is how the two are told apart now:
+# see spelling_segments/choose_spelling below.
+"v22": """Find the words in the source line that the speaker is correcting.
+
+You get a source transcription, and a correction transcription in which the \
+speaker names a word and then says how it is written — either by spelling it \
+letter by letter, or by describing what to change.
+
+Reply with one line per correction, and nothing else:
+<the words exactly as they appear in the source> => <the corrected spelling>
+Or reply NO MATCH.
+
+- Copy the left side from the SOURCE. The correction transcription mishears \
+the name a second time; ignore how it appears there.
+- The source span is often two or three words, because recognition splits \
+names it does not know. Take the whole name, and only the name.
+- When the change is described rather than spelled, apply exactly what was \
+described to the source word and change nothing else about it.
+- One utterance can carry two corrections. Give each its own line.
+- Reply NO MATCH when nothing in the source sounds like the name.
+
+source: I work with Tasmin
+correction: Das mean spells T-A-S-M-E-E-N
+Tasmin => Tasmeen
+
+source: I work with Sarah
+correction: Tasmin spells T-A-S-M-E-E-N
+NO MATCH
+
+source: I like apples
+correction: Oranges spells O-R-A-N-G-E-S
+NO MATCH
+
+source: We deployed to Versal yesterday
+correction: Versoff spells V E R C E L
+Versal => Vercel
+
+source: The Coober netties cluster is down
+correction: Kuber nettis spells K U B E R N E T E S
+Coober netties => Kubernetes
+
+source: When is handling the deploy
+correction: New yen spells N G U Y E N
+When => Nguyen
+
+source: Anna ees joined the design team
+correction: Anna east spells A N A I S
+Anna ees => Anais
+
+source: Steven is reviewing the doc
+correction: Steven with a p h
+Steven => Stephen
+
+source: Matthew and Jon are on the call
+correction: Matthew takes only one t and Jon is spelled with an h
+Matthew => Mathew
+Jon => John""",
+
+# v22's three added examples all had a one-word span, and the model learned
+# exactly that: seven two-word spans that v14 got right came back as their
+# first word ("Say goal enn" as "Say goal", "Locks me" as "Locks"). The
+# examples teach the boundary, and v22's taught the wrong one.
+#
+# So v24 keeps v22's rules and rebuilds the three: a described change over a
+# two-word span, a described change that replaces the first letter, and a
+# two-correction line whose first span is two words. It also gives the removal
+# shape somewhere to be learnt — v22 answered "Phillip with one l" with
+# "Phill", truncating rather than applying the change — and stops "with a G at
+# the beginning" being read as "the name that starts with G", which is how
+# Jerome came back George.
+"v24": """Find the words in the source line that the speaker is correcting.
+
+You get a source transcription, and a correction transcription in which the \
+speaker names a word and then says how it is written — either by spelling it \
+letter by letter, or by describing what to change.
+
+Reply with one line per correction, and nothing else:
+<the words exactly as they appear in the source> => <the corrected spelling>
+Or reply NO MATCH.
+
+- Copy the left side from the SOURCE. The correction transcription mishears \
+the name a second time; ignore how it appears there.
+- The source span is often two or three words, because recognition splits \
+names it does not know. Take the whole name, and only the name.
+- When the change is described rather than spelled, apply exactly what was \
+described to the source word and change nothing else about it.
+- One utterance can carry two corrections. Give each its own line.
+- Reply NO MATCH when nothing in the source sounds like the name.
+
+source: I work with Tasmin
+correction: Das mean spells T-A-S-M-E-E-N
+Tasmin => Tasmeen
+
+source: I work with Sarah
+correction: Tasmin spells T-A-S-M-E-E-N
+NO MATCH
+
+source: I like apples
+correction: Oranges spells O-R-A-N-G-E-S
+NO MATCH
+
+source: We deployed to Versal yesterday
+correction: Versoff spells V E R C E L
+Versal => Vercel
+
+source: The Coober netties cluster is down
+correction: Kuber nettis spells K U B E R N E T E S
+Coober netties => Kubernetes
+
+source: When is handling the deploy
+correction: New yen spells N G U Y E N
+When => Nguyen
+
+source: Anna ees joined the design team
+correction: Anna east spells A N A I S
+Anna ees => Anais
+
+source: The Rabbit em queue broker is down
+correction: Rabbit MQ is one word
+Rabbit em queue => Rabbitmq
+
+source: Katia opened the ticket
+correction: Katia with a C at the beginning
+Katia => Catia
+
+source: Anna ees and Emmilie are on the call
+correction: Anna east spells A N A I S and Emmilie takes one m
+Anna ees => Anais
+Emmilie => Emilie""",
+
+# The right-hand side, deleted again.
+#
+# v14 dropped it and it had to come back for v22, because a described change
+# has no letters and only the model could write the corrected name. Now that
+# described_edit applies the change in code, that reason is gone — and with it
+# the cost, which was measurable: v22 and v24 both truncate two-word spans that
+# v14 got right ("Locks me" to "Locks", "Oluwa shane" to "Oluwa"). Writing the
+# name out evidently pulls the model toward the shortest span it can spell.
+#
+# So v25 is v14's span-only reply, told about the two new shapes. The model
+# names the words; everything to the right of the arrow is now code.
+"v25": """Find the words in the source line that the speaker is correcting.
+
+You get a source transcription, and a correction transcription in which the \
+speaker names a word and then says how it is written — either by spelling it \
+letter by letter, or by describing what to change about it.
+
+Reply with those words copied from the source line, and nothing else. \
+One line per correction. Or reply NO MATCH.
+
+- Copy the words from the SOURCE. The correction transcription mishears the \
+name a second time; ignore how it appears there.
+- The source span is often two or three words, because recognition splits \
+names it does not know. Take the whole name, and only the name.
+- Never write the corrected spelling. Only the words being corrected.
+- One utterance can carry two corrections. Give each its own line.
+- Reply NO MATCH when nothing in the source sounds like the name.
+
+source: I work with Tasmin
+correction: Das mean spells T-A-S-M-E-E-N
+Tasmin
+
+source: I work with Sarah
+correction: Tasmin spells T-A-S-M-E-E-N
+NO MATCH
+
+source: I like apples
+correction: Oranges spells O-R-A-N-G-E-S
+NO MATCH
+
+source: We deployed to Versal yesterday
+correction: Versoff spells V E R C E L
+Versal
+
+source: The Coober netties cluster is down
+correction: Kuber nettis spells K U B E R N E T E S
+Coober netties
+
+source: When is handling the deploy
+correction: New yen spells N G U Y E N
+When
+
+source: Anna ees joined the design team
+correction: Anna east spells A N A I S
+Anna ees
+
+source: The Rabbit em queue broker is down
+correction: Rabbit MQ is one word
+Rabbit em queue
+
+source: Anna ees and Emmilie are on the call
+correction: Anna east spells A N A I S and Emmilie takes one m
+Anna ees
+Emmilie""",
+
+# v25 plus a NO MATCH whose correction describes a change rather than spelling
+# one. Both negative examples in v25 are spelled, and v22/v24/v25 all answer
+# "apples => Oranges" to a case that is in the prompt verbatim as NO MATCH —
+# teaching the described shape evidently made the model readier to find a
+# match in general, and the boundary has to be taught in that shape too. It
+# pairs with the Katia example: same words, opposite answer.
+"v26": """Find the words in the source line that the speaker is correcting.
+
+You get a source transcription, and a correction transcription in which the \
+speaker names a word and then says how it is written — either by spelling it \
+letter by letter, or by describing what to change about it.
+
+Reply with those words copied from the source line, and nothing else. \
+One line per correction. Or reply NO MATCH.
+
+- Copy the words from the SOURCE. The correction transcription mishears the \
+name a second time; ignore how it appears there.
+- The source span is often two or three words, because recognition splits \
+names it does not know. Take the whole name, and only the name.
+- Never write the corrected spelling. Only the words being corrected.
+- One utterance can carry two corrections. Give each its own line.
+- Reply NO MATCH when nothing in the source sounds like the name.
+
+source: I work with Tasmin
+correction: Das mean spells T-A-S-M-E-E-N
+Tasmin
+
+source: I work with Sarah
+correction: Tasmin spells T-A-S-M-E-E-N
+NO MATCH
+
+source: I like apples
+correction: Oranges spells O-R-A-N-G-E-S
+NO MATCH
+
+source: We are shipping on Friday
+correction: Katia with a C at the beginning
+NO MATCH
+
+source: We deployed to Versal yesterday
+correction: Versoff spells V E R C E L
+Versal
+
+source: The Coober netties cluster is down
+correction: Kuber nettis spells K U B E R N E T E S
+Coober netties
+
+source: When is handling the deploy
+correction: New yen spells N G U Y E N
+When
+
+source: Anna ees joined the design team
+correction: Anna east spells A N A I S
+Anna ees
+
+source: Katia opened the ticket
+correction: Katia with a C at the beginning
+Katia
+
+source: The Rabbit em queue broker is down
+correction: Rabbit MQ is one word
+Rabbit em queue
+
+source: Anna ees and Emmilie are on the call
+correction: Anna east spells A N A I S and Emmilie takes one m
+Anna ees
+Emmilie""",
+
+# v26 with one clause added to the span rule, and nothing else. v27 tried
+# teaching the same thing with an extra example and scored two points lower;
+# this is the cheaper half of that change, measured on its own.
+"v28": """Find the words in the source line that the speaker is correcting.
+
+You get a source transcription, and a correction transcription in which the \
+speaker names a word and then says how it is written — either by spelling it \
+letter by letter, or by describing what to change about it.
+
+Reply with those words copied from the source line, and nothing else. \
+One line per correction. Or reply NO MATCH.
+
+- Copy the words from the SOURCE. The correction transcription mishears the \
+name a second time; ignore how it appears there.
+- The source span is often two or three words, because recognition splits \
+names it does not know. Take the whole name, and only the name, even when \
+part of it is an ordinary word.
+- Never write the corrected spelling. Only the words being corrected.
+- One utterance can carry two corrections. Give each its own line.
+- Reply NO MATCH when nothing in the source sounds like the name.
+
+source: I work with Tasmin
+correction: Das mean spells T-A-S-M-E-E-N
+Tasmin
+
+source: I work with Sarah
+correction: Tasmin spells T-A-S-M-E-E-N
+NO MATCH
+
+source: I like apples
+correction: Oranges spells O-R-A-N-G-E-S
+NO MATCH
+
+source: We are shipping on Friday
+correction: Katia with a C at the beginning
+NO MATCH
+
+source: We deployed to Versal yesterday
+correction: Versoff spells V E R C E L
+Versal
+
+source: The Coober netties cluster is down
+correction: Kuber nettis spells K U B E R N E T E S
+Coober netties
+
+source: When is handling the deploy
+correction: New yen spells N G U Y E N
+When
+
+source: Anna ees joined the design team
+correction: Anna east spells A N A I S
+Anna ees
+
+source: Katia opened the ticket
+correction: Katia with a C at the beginning
+Katia
+
+source: The Rabbit em queue broker is down
+correction: Rabbit MQ is one word
+Rabbit em queue
+
+source: Anna ees and Emmilie are on the call
+correction: Anna east spells A N A I S and Emmilie takes one m
+Anna ees
+Emmilie""",
+
+# v26 plus a span whose second word is an ordinary English word. Every
+# multi-word example ends in something that is not a word — "Anna ees", "Coober
+# netties" — and the spans that come back short all end in one that is: "Jang
+# way" as "Jang", "Koval chick" as "Koval", "Graph on a" as "Graph". The model
+# stops where the examples stop.
+"v27": """Find the words in the source line that the speaker is correcting.
+
+You get a source transcription, and a correction transcription in which the \
+speaker names a word and then says how it is written — either by spelling it \
+letter by letter, or by describing what to change about it.
+
+Reply with those words copied from the source line, and nothing else. \
+One line per correction. Or reply NO MATCH.
+
+- Copy the words from the SOURCE. The correction transcription mishears the \
+name a second time; ignore how it appears there.
+- The source span is often two or three words, because recognition splits \
+names it does not know. Take the whole name, and only the name, even when part \
+of it is an ordinary word.
+- Never write the corrected spelling. Only the words being corrected.
+- One utterance can carry two corrections. Give each its own line.
+- Reply NO MATCH when nothing in the source sounds like the name.
+
+source: I work with Tasmin
+correction: Das mean spells T-A-S-M-E-E-N
+Tasmin
+
+source: I work with Sarah
+correction: Tasmin spells T-A-S-M-E-E-N
+NO MATCH
+
+source: I like apples
+correction: Oranges spells O-R-A-N-G-E-S
+NO MATCH
+
+source: We are shipping on Friday
+correction: Katia with a C at the beginning
+NO MATCH
+
+source: We deployed to Versal yesterday
+correction: Versoff spells V E R C E L
+Versal
+
+source: The Coober netties cluster is down
+correction: Kuber nettis spells K U B E R N E T E S
+Coober netties
+
+source: When is handling the deploy
+correction: New yen spells N G U Y E N
+When
+
+source: The Data dog agent is noisy
+correction: Datadog spells D A T A D O G
+Data dog
+
+source: Anna ees joined the design team
+correction: Anna east spells A N A I S
+Anna ees
+
+source: Katia opened the ticket
+correction: Katia with a C at the beginning
+Katia
+
+source: The Rabbit em queue broker is down
+correction: Rabbit MQ is one word
+Rabbit em queue
+
+source: Anna ees and Emmilie are on the call
+correction: Anna east spells A N A I S and Emmilie takes one m
+Anna ees
+Emmilie""",
+
+# v13 with the same two additions, in French. The described-change example
+# carries accents where the rest of the prompt does not: preserving the source
+# word's accents while applying only what was described is exactly the
+# behaviour being taught, and it cannot be taught in an unaccented example.
+"v23": """Associe un nom mal transcrit a l'orthographe que la personne vient d'indiquer.
+
+Tu recois une transcription source, et une transcription de correction dans \
+laquelle la personne dit un nom puis indique comment il s'ecrit — soit en \
+l'epelant lettre par lettre, soit en decrivant ce qu'il faut changer.
+
+Reponds par une ligne par correction, et rien d'autre :
+<les mots exactement comme ils apparaissent dans la source> => <l'orthographe corrigee>
+ou
+NO MATCH
+
+- La partie gauche doit etre copiee caractere par caractere depuis la SOURCE. \
+La transcription de correction se trompe une seconde fois sur le nom ; ignore \
+la facon dont il y apparait.
+- Le nom occupe souvent deux ou trois mots dans la source, parce que la \
+reconnaissance vocale decoupe les noms qu'elle ne connait pas. Prends le nom \
+entier, et rien que le nom.
+- Quand la personne epelle, la partie droite est constituee des lettres \
+epelees, dans l'ordre donne, assemblees avec une majuscule au debut.
+- Quand la personne decrit le changement au lieu de l'epeler, applique \
+exactement ce qui est decrit au mot de la source, et ne change rien d'autre.
+- Une seule phrase peut porter deux corrections. Donne une ligne a chacune.
+- Reponds NO MATCH si rien dans la source ne ressemble au nom.
+
+source: J'ai vu Ni cola hier au bureau
+correction: Nicolas s'ecrit N I C O L A S
+Ni cola => Nicolas
+
+source: J'ai vu Sophie hier au bureau
+correction: Nicolas s'ecrit N I C O L A S
+NO MATCH
+
+source: Il pleut beaucoup en ce moment
+correction: Oranges s'ecrit O R A N G E S
+NO MATCH
+
+source: On utilise Post gres pour les donnees
+correction: Postgresse s'ecrit P O S T G R E S
+Post gres => Postgres
+
+source: Le cluster Elastic serge est lent
+correction: Elastic search s'ecrit E L A S T I C S E A R C H
+Elastic serge => Elasticsearch
+
+source: Il faut que ca marche demain
+correction: Marc s'ecrit M A R C
+marche => Marc
+
+source: Cle mence a rejoint l'equipe hier
+correction: Clemence s'ecrit C L E M E N C E
+Cle mence => Clemence
+
+source: Frederic a relu la maquette
+correction: Frédéric avec des accents sur les e
+Frederic => Frédéric
+
+source: Nathalie et Philipe sont sur l'appel
+correction: Nathalie sans le h et Philipe avec deux p
+Nathalie => Natalie
+Philipe => Philippe""",
 }
 
 # Prompts to use per detected language, English falling back to itself. This is
@@ -994,7 +1508,7 @@ Cle mence => Clemence""",
 BY_LANGUAGE = {"en": "v8", "fr": "v13"}
 
 # Variants whose reply is the span alone, so there is no full line to score.
-SPAN_ONLY = {"v5", "v6", "v7", "v14", "v15", "v16", "v17", "v18", "v19"}
+SPAN_ONLY = {"v5", "v6", "v7", "v14", "v15", "v16", "v17", "v18", "v19", "v25", "v26", "v27", "v28"}
 # Variants that answer with word numbers; the span is rebuilt from the source.
 INDEXED = {"v6"}
 # Variants that read the correction first, so the source is nearest the answer.
@@ -1017,7 +1531,7 @@ def decode(variant, reply, src):
     same outcome the app gives for NO MATCH.
     """
     if variant not in INDEXED:
-        return normalise(reply)
+        return reply
     if re.search(r"\bnone\b|\bno match\b", reply, re.I):
         return "NO MATCH"
     words = src.split()
@@ -1052,12 +1566,36 @@ def ask(model, system, prompt, think, predict, num_ctx=None, meter=None):
         meter["calls"] = meter.get("calls", 0) + 1
     return (d.get("response") or "").strip(), time.time() - t
 
-def normalise(text):
-    text = " ".join(text.split())
-    # "I like apples => NO MATCH" is the right decision, clumsily formatted.
-    if not text or re.search(r"\bno match\b|\bnone\b|\[nothing\]", text, re.I):
-        return "NO MATCH"
-    return text
+NO_MATCH = re.compile(r"\bno match\b|\bnone\b|\[nothing\]", re.I)
+
+def rules_of(value):
+    """A case's `expect`, or a model's reply, as a list of "span => spelling".
+
+    One utterance can now carry more than one correction, so an expectation is
+    a list and NO MATCH is the empty list. A single-rule case keeps the plain
+    string form it always had, which is why nothing above the new groups in the
+    case files had to change.
+    """
+    if isinstance(value, str):
+        value = [line for line in value.splitlines()]
+    out = []
+    for line in value:
+        line = " ".join(str(line).split())
+        if not line or NO_MATCH.search(line):
+            continue
+        # Bullets and numbering, which small models add unasked.
+        line = re.sub(r"^\s*(?:[-*•]|\d+[.)])\s*", "", line)
+        if line:
+            out.append(line)
+    return out
+
+def split_rule(rule):
+    """"span => spelling" as a pair. A reply with no arrow is all span, which
+    is what the span-only variants answer with."""
+    if "=>" in rule:
+        span, spelling = rule.split("=>", 1)
+        return span.strip(), spelling.strip()
+    return rule.strip(), ""
 
 LETTERS = re.compile(r"\b(?:[A-Za-z0-9][\s\-.]+){2,}[A-Za-z0-9]\b")
 # "spells" in English, "ça s'écrit" / "s'épelle" in French. The French forms
@@ -1074,47 +1612,282 @@ TRIGGER = re.compile(
 # stop word, and breaking there would return no spelling at all.
 STOP_WORDS = {"not", "instead", "rather", "but", "no",
               "pas", "non", "plutôt", "plutot", "mais"}
+# What joins two corrections in one breath: "T A S M E E N and Mick spells
+# M I K". Without these the first spelling ran to the end of the sentence and
+# came back "Tasmeenandmickspellsmik".
+#
+# The risk is a spelling that merges INTO the conjunction — "Alexander spells
+# A L E X and er" is a real rendering — so a conjunction only ends a segment
+# when at least two tokens follow it. "and er" does not end one; "and Mick
+# spells M I K" does.
+CONJUNCTIONS = {"and", "et", "puis", "then", "ensuite", "also", "aussi"}
 
-def alnum_tokens(text):
-    """Runs of Unicode alphanumerics, matching Swift's
-    CharacterSet.alphanumerics.inverted. An ASCII-only split turned "plutôt"
-    into "plut", which is how a stop word goes missing on accented input."""
-    out, cur = [], []
+def tokens_with_breaks(text):
+    """(token, punctuation before it), Unicode-alphanumeric runs.
+
+    The punctuation flag is what lets ", Priyanka spells" end a segment when
+    there is no conjunction to break on. An ASCII-only split turned "plutôt"
+    into "plut", which is how a stop word goes missing on accented input.
+    """
+    out, cur, punct = [], [], False
     for ch in text:
         if ch.isalnum():
             cur.append(ch)
-        elif cur:
-            out.append("".join(cur))
-            cur = []
+        else:
+            if cur:
+                out.append(("".join(cur), punct))
+                cur, punct = [], False
+            if ch in ",;:":
+                punct = True
     if cur:
-        out.append("".join(cur))
+        out.append(("".join(cur), punct))
     return out
 
-def spelled_out(correction):
-    """The spelling, taken from the text rather than the model — this is what
-    LocalLLM.swift does, and it is why the model's right side does not matter.
+def spelling_segments(correction):
+    """Every spelling read out in the utterance, in order, as (letters, read
+    out as letters?) — taken from the text rather than from the model.
 
-    Mirrors LocalLLM.spelledOutWord: everything after "spells" is the spelling,
-    however the recogniser chunked it. Matching only runs of single letters
-    loses the tail, because recognition stops treating them as letters partway
-    through — "T A S M Een" gave "Tasm" and "Tas Meen" gave nothing at all.
+    Mirrors LocalLLM.spellingSegments. Everything after a trigger is the
+    spelling, however the recogniser chunked it — matching only runs of single
+    letters loses the tail, because recognition stops treating them as letters
+    partway through ("T A S M Een" gave "Tasm", "Tas Meen" gave nothing).
+
+    What is new is that a trigger no longer runs to the end of the sentence: a
+    second trigger later in the text lets a comma end the segment too, and a
+    conjunction ends it whenever real words follow.
+
+    A described change ("s'écrit avec un G au début") matches a trigger and
+    yields "Avecungaudebut" here. Nothing tries to detect that; choose_spelling
+    below throws it away because it looks nothing like what the model answered.
     """
-    trigger = TRIGGER.search(correction)
-    if trigger:
-        letters = ""
-        for token in alnum_tokens(correction[trigger.end():]):
-            if letters and token.lower() in STOP_WORDS:
+    triggers = list(TRIGGER.finditer(correction))
+    if not triggers:
+        m = LETTERS.search(correction)
+        if not m:
+            return []
+        joined = re.sub(r"[^A-Za-z0-9]", "", m.group(0))
+        if len(joined) < 3:
+            return []
+        return [(joined[:1].upper() + joined[1:].lower(), True)]
+
+    out = []
+    for i, trigger in enumerate(triggers):
+        end = triggers[i + 1].start() if i + 1 < len(triggers) else len(correction)
+        bounded = i + 1 < len(triggers)
+        toks = tokens_with_breaks(correction[trigger.end():end])
+        letters, taken, broke = "", [], False
+        for pos, (token, punct) in enumerate(toks):
+            low = token.lower()
+            # A conjunction always ends a bounded segment: whatever follows it
+            # belongs to the next clause. Unbounded, it has to earn the break
+            # with two real tokens after it, or "A L E X and er" loses its tail.
+            conjunction = low in CONJUNCTIONS and (bounded or len(toks) - pos - 1 >= 2)
+            if letters and (low in STOP_WORDS or conjunction or (punct and bounded)):
+                broke = True
                 break
             letters += token
+            taken.append(token)
+        # Nothing ended it and another clause follows: what is left on the end
+        # is that clause's name ("... M I K" has none, "... and Mick" does).
+        if bounded and not broke and len(taken) > 1:
+            letters = letters[:len(letters) - len(taken[-1])]
+            taken.pop()
         if len(letters) >= 2:
-            return letters[:1].upper() + letters[1:].lower()
+            # Most of a spelled segment arrives as single characters even when
+            # the tail merges into syllables, and no description of a change
+            # does. It is the cheap half of telling the two apart; the
+            # expensive half is agreement with the model, in choose_spelling.
+            singles = sum(1 for t in taken if len(t) == 1)
+            letterish = len(taken) >= 2 and singles / len(taken) >= 0.6
+            out.append((letters[:1].upper() + letters[1:].lower(), letterish))
+    return out
 
-    # No trigger word: fall back to a run of single letters anywhere.
-    m = LETTERS.search(correction)
-    if not m:
+# ---- Changes the speaker describes instead of spelling ---------------------
+#
+# "Mathieu ne prend qu'un seul t" has no letters in it, so the regex that has
+# always built the spelling has nothing to read. The obvious answer is to let
+# the model write the corrected name — and it is the wrong one. Measured on the
+# ten described cases in the English set, gemma4:e4b scores 50% and gemma4:12b
+# 80%, and the failures are not misunderstandings: "Phillip with one l" came
+# back "Phill" and "Philp", "Elisabeth with a z" came back "Elizabith". It is
+# the same weakness the spelled path already routes around — a model asked to
+# copy characters loses some — and the answer is the same. The model finds the
+# span; code applies the change.
+#
+# What is not recognised here falls back to the model, so "Jon is spelled with
+# an h" still works: it needs to know that Jon becomes John, which is knowledge
+# rather than character surgery.
+
+# Letters as recognition renders them when they are dictated on their own —
+# "one t" arrives as "one tea", "un seul t" as "un seul thé". Only ever
+# consulted in a slot the pattern has already decided is a letter, which is
+# what makes it safe to include forms like "en" and "el".
+LETTER_WORDS = {
+    "tea": "t", "tee": "t", "zed": "z", "zee": "z", "see": "c", "sea": "c",
+    "ex": "x", "why": "y", "are": "r", "ar": "r", "you": "u", "jay": "j",
+    "kay": "k", "el": "l", "em": "m", "en": "n", "oh": "o", "pea": "p",
+    "pee": "p", "cue": "q", "queue": "q", "ess": "s", "vee": "v", "bee": "b",
+    "dee": "d", "eff": "f", "gee": "g", "aitch": "h", "eye": "i",
+    "thé": "t", "the": "t", "té": "t", "cé": "c", "dé": "d", "gé": "g",
+    "jé": "j", "pé": "p", "vé": "v", "bé": "b", "zède": "z", "ixe": "x",
+    "ache": "h", "esse": "s", "èsse": "s", "effe": "f", "elle": "l",
+    "emme": "m", "enne": "n", "erre": "r", "ka": "k", "ku": "q",
+}
+
+def as_letter(token):
+    """The letter a slot names, however recognition rendered it."""
+    token = token.strip("'’ ").lower()
+    if len(token) == 1 and token.isalpha():
+        return token
+    return LETTER_WORDS.get(token)
+
+L = r"([^\W\d_]{1,5}['’]?)"          # a letter, or the word for one
+POSITION_FIRST = r"(?:at\s+the\s+(?:beginning|start)|au\s+d[ée]but|en\s+premier)"
+POSITION_LAST = r"(?:at\s+the\s+end|[àa]\s+la\s+fin|en\s+dernier)"
+ACCENTS = {"aigu": "́", "grave": "̀", "circonflexe": "̂",
+           "chapeau": "̂", "tréma": "̈", "trema": "̈",
+           "cédille": "̧", "cedille": "̧"}
+
+# Ordered: "without the h" has to be read before "with ... h", and "one l"
+# before "a G at the beginning", or the looser pattern eats the tighter one.
+DESCRIBED = [
+    ("join",   r"\b(?:in|en)\s+(?:one|a|un)\s+(?:single\s+|seul\s+)?(?:word|mot)\b"),
+    ("join",   r"\b(?:is|est)\s+one\s+word\b"),
+    ("hyphen", r"\b(?:hyphens?|hyphenated|dash|trait\s+d['’ ]?union|tiret)\b"),
+    ("strip",  r"\b(?:without|sans)\s+(?:the\s+)?accents?\b"),
+    ("accent", r"\b(?:accents?|tr[ée]ma|c[ée]dille)\b(?:\s+\w+)*?\s+"
+               r"(?:sur|on)\s+(?:l[ea]s?|the)?\s*" + L),
+    ("double", r"\b(?:two|double|deux)\s+" + L + r"\b"),
+    ("single", r"\b(?:only\s+)?(?:one|a\s+single|un\s+seul|une\s+seule)\s+" + L + r"\b"),
+    ("first",  r"\b(?:with|avec)\s+(?:an?|un|une)\s+" + L + r"\b[^.]*?" + POSITION_FIRST),
+    ("last",   r"\b(?:with|avec)\s+(?:an?|un|une)\s+" + L + r"\b[^.]*?" + POSITION_LAST),
+    ("remove", r"\b(?:without|sans)\s+(?:the\s+|de\s+|d['’])?" + L + r"\b"),
+    # Bare "with a z", no position and no count. Which letter it replaces is
+    # left to the confusable table: recognition heard something for the letter
+    # actually written, so the one it can be swapped for is the one that sounds
+    # like it. "Elisabeth with a z" has exactly one candidate, the s.
+    ("swap",   r"\b(?:with|avec)\s+(?:an?|un|une)\s+" + L + r"\b"),
+]
+
+def described_edit(clause, word):
+    """The word with the described change applied, or None if nothing in the
+    clause describes one this code knows how to make."""
+    for op, pattern in DESCRIBED:
+        m = re.search(pattern, clause, re.I)
+        if not m:
+            continue
+        letter = as_letter(m.group(1)) if m.groups() else None
+        if op in ("accent", "double", "single", "first",
+                  "last", "remove", "swap") and not letter:
+            continue
+        out = apply_described(op, letter, word, clause)
+        if out and out.lower() != word.lower():
+            return out
+    return None
+
+def apply_described(op, letter, word, clause):
+    import unicodedata
+    if op == "join":
+        return re.sub(r"[\s\-]+", "", word)
+    if op == "hyphen":
+        return re.sub(r"\s+", "-", word)
+    if op == "strip":
+        return "".join(c for c in unicodedata.normalize("NFD", word)
+                       if not unicodedata.combining(c))
+    if op == "accent":
+        mark = next((v for k, v in ACCENTS.items() if re.search(k, clause, re.I)), "́")
+        # "des accents sur les e" is every e; "un accent sur le e" is the first.
+        every = re.search(r"\b(?:des|les|tous|all)\b", clause, re.I) is not None
+        out, done = [], False
+        for ch in unicodedata.normalize("NFD", word):
+            out.append(ch)
+            if ch.lower() == letter and (every or not done):
+                out.append(mark)
+                done = True
+        return unicodedata.normalize("NFC", "".join(out))
+    if op == "double":
+        if re.search(letter + letter, word, re.I):
+            return word
+        i = word.lower().rfind(letter)
+        return word[:i] + word[i] + word[i:] if i >= 0 else None
+    if op == "single":
+        return re.sub("(" + letter + ")\\1+", r"\1", word, flags=re.I)
+    if op == "first":
+        if not word:
+            return None
+        head = letter.upper() if word[0].isupper() else letter
+        return head + word[1:]
+    if op == "last":
+        return word if word.lower().endswith(letter) else word + letter
+    if op == "remove":
+        return re.sub(letter, "", word, flags=re.I)
+    if op == "swap":
+        if letter in word.lower():
+            return None
+        for i, ch in enumerate(word):
+            if sub_cost(ch.lower(), letter) == 0.5:
+                swapped = letter.upper() if ch.isupper() else letter
+                return word[:i] + swapped + word[i + 1:]
         return None
-    joined = re.sub(r"[^A-Za-z0-9]", "", m.group(0))
-    return joined[:1].upper() + joined[1:].lower() if len(joined) >= 3 else None
+    return None
+
+def clauses_of(correction):
+    """The utterance split where one correction ends and the next begins."""
+    parts = re.split(r"\b(?:and|et|puis|then|ensuite)\b|[,;]", correction, flags=re.I)
+    return [p.strip() for p in parts if p and p.strip()]
+
+def clause_for(span, proposed, correction):
+    """The clause a given output line came from, so "Anna east spells A N A I S
+    and Emmilie takes one m" applies its "one m" to Emmilie and not to Anais."""
+    parts = clauses_of(correction)
+    if len(parts) < 2:
+        return correction
+    best, score = correction, 0.0
+    for part in parts:
+        words = words_of(part)
+        for size in (1, 2):
+            for start in range(0, len(words) - size + 1):
+                window = " ".join(words[start:start + size])
+                s = max(similarity(window, span),
+                        similarity(window, proposed) if proposed else 0.0)
+                if s > score:
+                    best, score = part, s
+    return best
+
+def choose_spelling(proposed, span, candidates, used, floor=0.55):
+    """The spelling to actually use: the letters when they were read out, the
+    model's own answer when they were not.
+
+    The letters are exact and the model's copy of them is not, so the letters
+    win wherever they exist — that is the whole reason interpret() has never
+    trusted the model's right-hand side. But a described change has no letters,
+    and the trigger regex happily returns "Avecungaudebut" for it. Rather than
+    a list of description words, which would have to grow forever and would
+    misfire on spellings that merge into ordinary words, the two are told apart
+    by agreement: a candidate nothing else corroborates, and that does not read
+    as letters on its own, is not a spelling.
+
+    Corroboration is not only the model's answer. The span is the same name
+    heard once already, so a real spelling resembles it — "Tasmin" against
+    "Tasmeen" — and a description does not: "Jon is spelled with an h" yields
+    "Withanh", which looks nothing like Jon. That matters because the reply may
+    carry no spelling at all to compare against.
+    """
+    best, score = None, 0.0
+    for i, (cand, letterish) in enumerate(candidates):
+        if i in used:
+            continue
+        agreement = max(similarity(cand, proposed) if proposed else 0.0,
+                        similarity(cand, span) if span else 0.0)
+        # Read out as letters. Only which line it belongs to can be wrong, so
+        # the best available agreement still decides the pairing.
+        s = max(agreement, floor) if letterish else agreement
+        if s > score:
+            best, score = i, s
+    if best is not None and score >= floor:
+        used.add(best)
+        return candidates[best][0]
+    return None
 
 # ---- The repair step in LocalLLM.swift, ported so the score reflects it ----
 #
@@ -1183,31 +1956,71 @@ def closest_word(target, transcript):
                 best = (cand, score)
     return best[0] if best and best[1] >= 0.6 else None
 
-def app_outcome(span, correction, source):
-    """The rule VoiceCommand.interpret would actually add, or NO MATCH."""
-    if span == "NO MATCH":
-        return "NO MATCH"
-    corrected = spelled_out(correction)
-    if not corrected:
-        return "NO MATCH"
-    if source and not contains_word(span, source):
-        scored = [(m, similarity(m, cand))
-                  for cand in (corrected, span)
-                  for m in [closest_word(cand, source)] if m]
-        resolved = max(scored, key=lambda t: t[1])[0] if scored else span
-    else:
-        resolved = span
-    # A rule mapping a word to itself is not a rule.
-    if resolved.lower() == corrected.lower():
-        return "NO MATCH"
-    return f"{resolved} => {corrected}"
+def app_rules(reply, correction, source):
+    """The rules VoiceCommand.interpret would actually add, in order.
+
+    A line whose span is neither in the source nor close to anything in it is
+    dropped rather than kept. That is what makes a half-heard utterance —
+    "Kubernetes spells ... and Postgres spells ..." against a source with only
+    Kubernetes in it — produce one rule instead of one rule and one invention.
+    """
+    candidates = spelling_segments(correction)
+    used, rules = set(), []
+    for rule in rules_of(reply):
+        span, proposed = split_rule(rule)
+        if not span:
+            continue
+        # The letters, when they were read out. Nothing else is trusted ahead
+        # of them, because they are the only exact thing in the utterance.
+        letters = choose_spelling(proposed, span, candidates, used)
+        if source and not contains_word(span, source):
+            scored = [(m, similarity(m, cand))
+                      for cand in (letters or proposed, span) if cand
+                      for m in [closest_word(cand, source)] if m]
+            if not scored:
+                continue
+            resolved = max(scored, key=lambda t: t[1])[0]
+        else:
+            resolved = span
+        # No letters: the change was described, so apply it to the source word.
+        # Only if nothing recognisable was described does the model's own
+        # spelling get used.
+        spelling = letters or described_edit(
+            clause_for(span, proposed, correction), resolved) or proposed
+        if not spelling:
+            continue
+        # A rule mapping a word to itself is not a rule.
+        if resolved.lower() == spelling.lower():
+            continue
+        candidate = f"{resolved} => {spelling}"
+        if candidate.lower() not in {r.lower() for r in rules}:
+            rules.append(candidate)
+    return rules
+
+def control_rules(correction, source):
+    """The control: no model at all. Every spelling read out, snapped onto the
+    nearest thing in the transcript. A model that does not beat this line is
+    not earning its place — and it now has to beat it on multi-rule utterances
+    too, where the letters alone carry further than they used to."""
+    rules = []
+    for spelling, _ in spelling_segments(correction):
+        match = closest_word(spelling, source) if source else None
+        if match and match.lower() != spelling.lower():
+            rules.append(f"{match} => {spelling}")
+    return rules
+
+def same(got, want):
+    return sorted(r.lower() for r in got) == sorted(r.lower() for r in want)
+
+def show(rules):
+    return " | ".join(rules) if rules else "NO MATCH"
 
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("model")
-    ap.add_argument("--variant", default="v2", choices=sorted(VARIANTS))
+    ap.add_argument("--variant", default="v22", choices=sorted(VARIANTS))
     ap.add_argument("--think", action="store_true")
-    ap.add_argument("--predict", type=int, default=24)
+    ap.add_argument("--predict", type=int, default=48)
     ap.add_argument("--num-ctx", type=int, default=None,
                     help="KV cache size; unset lets Ollama use the model's own 32k")
     ap.add_argument("--verbose", action="store_true")
@@ -1229,77 +2042,61 @@ def main():
             user_prompt(args.variant, "warm up", "warm up spells W A R M"),
             args.think, args.predict, args.num_ctx)
 
-    passed, total_time, failures = 0, 0.0, []
-    left_passed = [0]
-    pipe_passed = [0]
-    pipe_failures = []
-    app_passed = [0]
-    app_failures = []
+    spans_ok = app_ok = 0
+    invented = missed = wrong = 0
+    total_time = 0.0
+    failures = []
     for case in cases:
+        source, correction = str(case["source"]), str(case["correction"])
+        want = rules_of(case["expect"])
+
         if args.code_only:
-            # The control: what the app gets with no model in the loop, i.e.
-            # the spelled word snapped onto the transcript. A model that does
-            # not beat this line is not earning its place.
-            got_n, dt = spelled_out(case["correction"]) or "NO MATCH", 0.0
+            got, dt = control_rules(correction, source), 0.0
+            model_spans = [split_rule(r)[0] for r in got]
         else:
-            got, dt = ask(args.model, system,
-                          user_prompt(args.variant, case["source"], case["correction"]),
-                          args.think, args.predict, args.num_ctx, meter)
-            got_n = decode(args.variant, got, case["source"])
+            reply, dt = ask(args.model, system,
+                            user_prompt(args.variant, source, correction),
+                            args.think, args.predict, args.num_ctx, meter)
+            reply = decode(args.variant, reply, source)
+            model_spans = [split_rule(r)[0] for r in rules_of(reply)]
+            got = app_rules(reply, correction, source)
         total_time += dt
-        want_n = normalise(case["expect"])
-        ok = got_n.lower() == want_n.lower()
-        passed += ok
-        left_ok = (got_n.split("=>")[0].strip().lower()
-                   == want_n.split("=>")[0].strip().lower())
-        left_passed[0] += left_ok
 
-        # The real pipeline: model picks the span, regex builds the spelling.
-        if got_n == "NO MATCH":
-            span = "NO MATCH"
-            pipeline = "NO MATCH"
-        else:
-            span = got_n.split("=>")[0].strip()
-            spelling = spelled_out(case["correction"])
-            pipeline = f"{span} => {spelling}" if spelling else got_n
-        pipe_ok = pipeline.lower() == want_n.lower()
-        pipe_passed[0] += pipe_ok
-
-        # And what the app would end up doing, repair step included. The span
-        # only — interpret() never sees the model's right side.
-        app = app_outcome(span, case["correction"], case["source"])
-        app_ok = app.lower() == want_n.lower()
-        app_passed[0] += app_ok
-        if not app_ok:
-            app_failures.append((case["source"], app, want_n))
-        if not pipe_ok:
-            pipe_failures.append((case["source"], pipeline, want_n))
+        spans_ok += same(model_spans, [split_rule(r)[0] for r in want])
+        ok = same(got, want)
+        app_ok += ok
         if not ok:
-            failures.append((case["source"], got_n, want_n))
+            # Split by cost. A miss loses one correction; an invented rule is
+            # written into transcription.replacements and rewrites every
+            # transcript from then on.
+            if len(got) > len(want):
+                invented += 1
+            elif len(got) < len(want):
+                missed += 1
+            else:
+                wrong += 1
+            failures.append((source, show(got), show(want)))
         if args.verbose:
-            print(f"  {'✓' if ok else '✗'} {dt:5.2f}s {got_n[:44]!r:46} want {want_n[:34]!r}")
+            print(f"  {'✓' if ok else '✗'} {dt:5.2f}s {show(got)[:46]!r:48} want {show(want)[:36]!r}")
 
-    print(f"\n{args.model}  variant={args.variant}  think={args.think}")
     n = len(cases)
-    if args.variant in SPAN_ONLY:
-        print(f"  full line   n/a — this variant replies with the span alone")
-    else:
-        print(f"  full line   {passed}/{n} = {100*passed/n:.0f}%")
-    print(f"  left side   {left_passed[0]}/{n} = {100*left_passed[0]/n:.0f}%  <- what the model must get right")
-    print(f"  pipeline    {pipe_passed[0]}/{n} = {100*pipe_passed[0]/n:.0f}%  <- model span + regex spelling")
-    print(f"  APP         {app_passed[0]}/{n} = {100*app_passed[0]/n:.0f}%  <- + interpret()'s snap-to-transcript")
+    print(f"\n{args.model}  variant={args.variant}  think={args.think}  ({path.name}, {n} cases)")
+    print(f"  spans       {spans_ok}/{n} = {100*spans_ok/n:.0f}%  <- what the model must get right")
+    print(f"  APP         {app_ok}/{n} = {100*app_ok/n:.0f}%  <- + the letters and interpret()'s repair")
     print(f"  {total_time/n:.2f}s avg")
     if meter.get("calls"):
         c = meter["calls"]
         print(f"  tokens      {meter['prompt_eval_count']/c:.0f} in, {meter['eval_count']/c:.0f} out per call"
               f"  |  prefill {meter['prompt_eval_duration']/c/1e9:.2f}s, generate {meter['eval_duration']/c/1e9:.2f}s")
-    if app_failures:
-        print("  app failures:")
-        for src, got, want in app_failures:
-            print(f"    {src[:40]!r}  got {got!r}  want {want!r}")
-    if failures and not args.verbose:
+    if invented:
+        print(f"  {invented} invented a rule  <- the expensive direction")
+    if wrong:
+        print(f"  {wrong} wrong span or spelling")
+    if missed:
+        print(f"  {missed} missed")
+    if failures:
         print("  failures:")
         for src, got, want in failures:
-            print(f"    {src[:40]!r}\n      got  {got!r}\n      want {want!r}")
+            print(f"    {src[:44]!r}\n      got  {got!r}\n      want {want!r}")
 
 main()

--- a/tests/french-cases.yaml
+++ b/tests/french-cases.yaml
@@ -150,3 +150,93 @@ cases:
   - source: Pass cal a ouvert le ticket
     correction: Pascal s'écrit Pas cal
     expect: Pass cal => Pascal
+
+  # ---- Deux corrections d'un seul souffle ----
+  #
+  # Même forme que dans le jeu anglais : `expect` devient une liste. La jointure
+  # française est "et" ou "puis", et elle doit couper la première épellation,
+  # sinon "T A S M E E N et Mick s'écrit M I K" revient collé en un seul mot.
+
+  - source: Je travaille avec Tasmine et Mick sur la plateforme
+    correction: Das mean s'écrit T A S M E E N et Mick s'écrit M I K
+    expect:
+      - Tasmine => Tasmeen
+      - Mick => Mik
+
+  - source: Versal et Super base sont tombés hier soir
+    correction: Versoff s'écrit V E R C E L et superbees s'écrit S U P A B A S E
+    expect:
+      - Versal => Vercel
+      - Super base => Supabase
+
+  - source: Ghee yome et Tee bo sont sur l'appel
+    correction: Gee ohm s'écrit G U I L L A U M E puis T bow s'écrit T H I B A U L T
+    expect:
+      - Ghee yome => Guillaume
+      - Tee bo => Thibault
+
+  # Un seul des deux noms est dans la source. Inventer un span pour l'autre
+  # écrit une règle qui réécrira toutes les transcriptions suivantes.
+  - source: Le cluster Coober netties est encore en panne
+    correction: Kuber nettis s'écrit K U B E R N E T E S et Postgres s'écrit P O S T G R E S
+    expect: Coober netties => Kubernetes
+
+  # ---- La personne décrit le changement au lieu de l'épeler ----
+  #
+  # "s'écrit avec un G au début" déclenche le même mot-clé qu'une épellation,
+  # mais ce qui suit n'est pas des lettres : la regex en tire "Avecungaudebut".
+  # C'est la seule forme où la partie droite du modèle est tout ce qu'on a.
+  #
+  # Règle : changement minimal. On applique ce qui est décrit au mot de la
+  # source, et rien d'autre. Les accents de la source se conservent, sauf quand
+  # c'est précisément l'accent qu'on décrit.
+
+  - source: Jérôme a poussé le correctif ce matin
+    correction: Jérôme s'écrit avec un G au début
+    expect: Jérôme => Gérôme
+
+  - source: Matthieu s'occupe du déploiement
+    correction: Mathieu ne prend qu'un seul t
+    expect: Matthieu => Mathieu
+
+  - source: Michele a relu la maquette
+    correction: Michele avec deux l
+    expect: Michele => Michelle
+
+  - source: Anais a rejoint l'équipe design
+    correction: Anais avec un tréma sur le i
+    expect: Anais => Anaïs
+
+  - source: Cécile travaille sur le rapport
+    correction: Cécile sans accent
+    expect: Cécile => Cecile
+
+  - source: Philipe a validé le budget
+    correction: Philipe avec deux p
+    expect: Philipe => Philippe
+
+  - source: Jean Luc a envoyé le contrat
+    correction: Jean Luc avec un trait d'union
+    expect: Jean Luc => Jean-Luc
+
+  - source: Le cluster Elastic search est lent
+    correction: Elastic search en un seul mot
+    expect: Elastic search => Elasticsearch
+
+  # La reconnaissance rend la lettre dictée par le mot qui lui ressemble :
+  # "un seul t" revient "un seul thé".
+  - source: Matthieu s'occupe du déploiement
+    correction: Mathieu ne prend qu'un seul thé
+    expect: Matthieu => Mathieu
+
+  # Décrit, et rien à décrire dans la source.
+  - source: Il pleut beaucoup en ce moment
+    correction: Jérôme s'écrit avec un G au début
+    expect: NO MATCH
+
+  # ---- Épelé et décrit dans la même phrase ----
+  - source: Tasmine et Matthieu sont sur la plateforme
+    correction: Das mean s'écrit T A S M E E N et Mathieu ne prend qu'un seul t
+    expect:
+      - Tasmine => Tasmeen
+      - Matthieu => Mathieu

--- a/tests/spelling-cases.yaml
+++ b/tests/spelling-cases.yaml
@@ -206,3 +206,119 @@ cases:
   - source: I work with Sam
     correction: Sam spells S A M
     expect: Sam => Sam
+
+  # ---- Two corrections in one breath ----
+  #
+  # "Das mean spells T A S M E E N and Mick spells M I K" is one utterance and
+  # two rules. `expect` becomes a list; a case with one rule keeps the old
+  # single-string form, so nothing above this line changed.
+  #
+  # The join is the whole difficulty. Everything after "spells" used to be taken
+  # to the end of the sentence, so the first spelling swallowed the second
+  # clause: "Tasmeenandmickspellsmik". Segments break on a conjunction only when
+  # another trigger follows, which is what keeps "Notion spells Not ion" whole.
+
+  - source: I work with Tasmine and Mick on the platform team
+    correction: Das mean spells T A S M E E N and Mick spells M I K
+    expect:
+      - Tasmine => Tasmeen
+      - Mick => Mik
+
+  - source: Versal and Super base are both down
+    correction: Versoff spells V E R C E L and superbees spells S U P A B A S E
+    expect:
+      - Versal => Vercel
+      - Super base => Supabase
+
+  - source: Locks me and Pree anka reviewed the schema
+    correction: Lakshmi spells L A K S H M I, Priyanka spells P R I Y A N K A
+    expect:
+      - Locks me => Lakshmi
+      - Pree anka => Priyanka
+
+  - source: Ghee yome and Tee bo are on the call
+    correction: Gee ohm spells G U I L L A U M E then T bow spells T H I B A U L T
+    expect:
+      - Ghee yome => Guillaume
+      - Tee bo => Thibault
+
+  # Only one of the two is in the source. A partial answer is the honest one;
+  # inventing a span for the other writes a rule that rewrites every future
+  # transcript, which is the failure that costs.
+  - source: The Coober netties cluster is down again
+    correction: Kuber nettis spells K U B E R N E T E S and Postgres spells P O S T G R E S
+    expect: Coober netties => Kubernetes
+
+  # A spelling that merges into the conjunction. "A L E X and er" is what
+  # recognition does with Alexander, and breaking on "and" would yield "Alex".
+  # Safe here because a lone trigger never applies the conjunction rule; with a
+  # second "spells" later in the sentence this case is not winnable, and that
+  # limit is deliberate rather than overlooked.
+  - source: Alex ander opened the incident
+    correction: Alexander spells A L E X and er
+    expect: Alex ander => Alexander
+
+  # ---- The speaker describes the change instead of spelling it ----
+  #
+  # "with a G at the beginning" has no letters in it, so the regex that has
+  # always built the spelling has nothing to build from. This is the one shape
+  # where the model's right-hand side is all there is.
+  #
+  # The rule is minimal change: apply what was described to the word in the
+  # source, and nothing else. Letting the model produce the name it believes was
+  # meant is not checkable by code, and invites it to rewrite what it was asked
+  # to keep.
+
+  - source: Jerome pushed the fix this morning
+    correction: Jerome with a G at the beginning
+    expect: Jerome => Gerome
+
+  - source: Matthew is joining the call
+    correction: Matthew takes only one t
+    expect: Matthew => Mathew
+
+  - source: Sara is reviewing the design doc
+    correction: Sara with an h at the end
+    expect: Sara => Sarah
+
+  - source: Jon owns that service now
+    correction: Jon is spelled with an h
+    expect: Jon => John
+
+  - source: Elisabeth filed the ticket
+    correction: Elisabeth with a z
+    expect: Elisabeth => Elizabeth
+
+  - source: Phillip approved the design doc
+    correction: Phillip with one l
+    expect: Phillip => Philip
+
+  - source: Nathalie runs the standup
+    correction: Nathalie without the h
+    expect: Nathalie => Natalie
+
+  - source: The Elastic search cluster is slow
+    correction: Elastic search is one word
+    expect: Elastic search => Elasticsearch
+
+  - source: Jean Luc sent the contract
+    correction: Jean Luc with a hyphen
+    expect: Jean Luc => Jean-Luc
+
+  # Recognition renders a dictated letter as the word it sounds like, so "one t"
+  # comes back "one tea" and the description is the only thing left to read.
+  - source: Matthew is joining the call
+    correction: Matthew takes only one tea
+    expect: Matthew => Mathew
+
+  # Described, with nothing in the source to describe.
+  - source: The weather is nice today
+    correction: Jerome with a G at the beginning
+    expect: NO MATCH
+
+  # ---- Spelled and described in the same breath ----
+  - source: Tasmine and Matthew are on the platform team
+    correction: Das mean spells T A S M E E N and Matthew takes one t
+    expect:
+      - Tasmine => Tasmeen
+      - Matthew => Mathew


### PR DESCRIPTION
Two shapes the spoken correction could not handle before.

**Two corrections in one utterance.** "Tasmin spells T A S M E E N and Mick spells M I K" is one breath and two rules; the panel opens with a row for each, whether the correction was said after a dictation or inside one.

**Describing the change instead of spelling it**, in either language:

    "hey parrot, Jerome with a G at the beginning"
    "hey parrot, Mathieu ne prend qu'un seul t"
    "hey parrot, Elastic search is one word"
    "hey parrot, Jean Luc avec un trait d'union"

## The interesting part

Both stayed on the **code** side of the split this feature has always had.

The spelled letters were already read from the text rather than from the model, because a model asked to copy characters loses some. A described change looks like a different problem and is the same one: asked to write "Phillip with one l", gemma4:e4b answered "Phill" and gemma4:12b "Philp". On the ten described cases in the English set that is 5/10 and 8/10 — a bigger model buys three points and still fails the same way, which is what said the answer was not a better prompt. `describedEdit` applies the change in code and scores 10/10 on both. The model's only job is still naming which words in the transcript were meant.

That paid for the prompt too. With no spelling left for the model to write, the English prompt went back to answering with the span alone, which is where its accuracy is — the variants that write the corrected name out truncate two-word spans ("Locks me" to "Locks"). French keeps the arrow, where it pulls the other way.

## Scores

End to end, through the shipped binary (`scripts/check-spelling.sh`):

| | English | French |
| --- | --- | --- |
| before (v14 / v13) | 71% | 89% |
| **after (v26 / v23)** | **89%** | **96%** |
| no model at all | 50% | 40% |

`granite4:3b` now matches gemma on English (89%) at a sixth of the latency — its raw spans score 74%, so the more of the answer that is built from the text, the less the model has to be good at.

Known losses, all documented in the code: "Sam spells S A M" (a rule mapping a word to itself is refused on purpose), "Jon is spelled with an h" (knowing Jon becomes John is knowledge, not character surgery), and two spans truncated to their first word.

## What changed

- `tests/spelling-cases.yaml` 44 → 62 cases, `tests/french-cases.yaml` 30 → 45, covering both new shapes and their negatives. `expect` is a list when an utterance carries more than one rule.
- `scripts/validate-prompt.py` scores lists of rules, ports the new deterministic layer, and keeps the rejected variants with their scores (v27, v28 both −2).
- `scripts/check-spelling.sh` compares rule lists through the real binary.
- `.claude/skills/prompt-iteration/SKILL.md` gains the lesson: ask what the model is *for* at every new shape, and use a larger model to tell "wrong prompt" from "no prompt will fix this".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUnWNfi64vX94QqWfUM2qS