### PR TITLE
fix: stop a sentence about a parrot from being taken as a command

### DIFF
--- a/Sources/ParrotFlow/LocalLLM.swift
+++ b/Sources/ParrotFlow/LocalLLM.swift
@@ -345,11 +345,37 @@ enum VoiceCommand {
         // Take the best-scoring length, not the first above threshold: with
         // "hey parrot fix vocabulary", "hey parrot fix" also clears 0.7 and
         // would swallow the "fix".
+        /// Every word has to look like the word it stands in for.
+        ///
+        /// Without this the distinctive word carries the whole comparison and
+        /// the first word is free to be anything: "my parrot escaped this
+        /// morning" scored as well as "hey parrot fix vocabulary", so a
+        /// sentence about a parrot was taken as a command and never written
+        /// down. Comparing the joined strings cannot tell them apart, because
+        /// "parrot" is most of the characters either way.
+        ///
+        /// Fewer words than the phrase is the clipped case — the start is what
+        /// the audio engine eats while it is still opening the microphone — so
+        /// a short candidate is aligned to the *end* of the phrase. More words
+        /// than the phrase is something said before it, so the phrase is
+        /// aligned to the end of the candidate.
+        ///
+        /// 0.55 per word, measured rather than picked: "ey" for "hey" scores
+        /// 0.67 and has to survive, while "my", "the", "a", "our", "his" and
+        /// "that" all score below 0.5 against "hey".
+        func aligns(_ candidate: ArraySlice<String>) -> Bool {
+            let pairs = candidate.count <= phraseWords.count
+                ? Array(zip(candidate, phraseWords.suffix(candidate.count)))
+                : Array(zip(candidate.suffix(phraseWords.count), phraseWords))
+            return pairs.allSatisfy { similarity($0, $1) >= 0.55 }
+        }
+
         var matchedWords: Int?
         var bestScore = 0.7
         for count in 1...min(phraseWords.count + 1, normalised.count) {
-            let candidate = normalised.prefix(count).joined(separator: " ")
-            let score = similarity(candidate, phrase)
+            let words = normalised.prefix(count)
+            guard aligns(words) else { continue }
+            let score = similarity(words.joined(separator: " "), phrase)
             if score > bestScore {
                 bestScore = score
                 matchedWords = count

--- a/tests/wake-cases.txt
+++ b/tests/wake-cases.txt
@@ -41,20 +41,31 @@ by the way parrot,hey parrot|by the way parrot format the function|format the fu
 # --- no phrases at all is how you turn spoken commands off ---------------
 |hey parrot fix vocabulary|NONE
 
-# --- known, and not fixed here -------------------------------------------
-# The prefix matcher is fuzzy on purpose: the wake phrase is the first thing
-# said and the audio engine is still starting up, so "hey parrot, X" arrives as
-# "parrot, X" or "hey parrots X". The cost is that any sentence beginning with
-# something that sounds like "<word> parrot" is taken as a command and never
-# written down.
-#
-# Found by throwing sentences at it, not by a user losing one. Left failing and
-# counted apart rather than quietly dropped: the fix is a judgement about the
-# 0.7 threshold, which trades these against the clipped audio the fuzziness
-# exists to recover, and that trade wants its own change and its own numbers.
-#
-# `KNOWN:` means "this is the right answer and we do not give it yet". If one
-# starts passing, the runner says so — that is the signal to promote it.
-hey parrot|my parrot escaped this morning|KNOWN:NONE
-hey parrot|the parrot is green|KNOWN:NONE
-hey parrot|a parrot flew past the window|KNOWN:NONE
+# --- clipped and misheard, which the fuzziness exists for ----------------
+# The wake phrase is the first thing said, and the audio engine is still
+# opening the microphone while it is being said. These are what actually
+# arrives, and an exact prefix match would lose all of them.
+hey parrot|hey parrot, fix vocabulary|fix vocabulary
+hey parrot|ey parrot fix vocabulary|fix vocabulary
+hey parrot|hey parot fix vocabulary|fix vocabulary
+hey parrot|hey parrott fix vocabulary|fix vocabulary
+
+# --- a sentence about a parrot is a sentence -----------------------------
+# These were commands until the matcher started checking each word against the
+# word it stands in for. Comparing the joined strings cannot separate them:
+# "parrot" is most of the characters either way, so the first word was free to
+# be anything and "my parrot escaped this morning" was never written down.
+hey parrot|my parrot escaped this morning|NONE
+hey parrot|the parrot is green|NONE
+hey parrot|a parrot flew past the window|NONE
+hey parrot|our parrot talks too much|NONE
+hey parrot|his parrot died last year|NONE
+hey parrot|that parrot needs water|NONE
+hey parrot,by the way parrot|the parrot by the way is green|NONE
+
+# --- what it costs, stated rather than hidden ----------------------------
+# "hey" misheard as an unrelated short word. There is no rule on the phrase
+# alone that keeps this and drops the six above: "a parrot fix vocabulary" and
+# "a parrot flew past the window" are the same shape, and only what follows
+# tells them apart. Six sentences written down beats one command recovered.
+hey parrot|a parrot fix vocabulary|KNOWN:fix vocabulary


### PR DESCRIPTION
The known failure recorded in #19, now with its own numbers.

## The bug

> "my parrot escaped this morning"

was heard as the wake phrase plus an instruction, routed, and **never written
anywhere**. Nothing on screen said why — the sentence simply did not appear.

The matcher compared the candidate and the phrase as joined strings, and
"parrot" is most of the characters either way. That left the first word free to
be anything:

| said | heard as |
|---|---|
| my parrot escaped this morning | command `escaped this morning` |
| the parrot is green | command `is green` |
| a parrot flew past the window | command `flew past the window` |
| our parrot talks too much | command `talks too much` |
| his parrot died last year | command `died last year` |
| that parrot needs water | command `needs water` |

## The fix

Each word is now checked against the word it stands in for.

A candidate **shorter** than the phrase is aligned to the *end* of it, because
the start is what the audio engine eats while it is still opening the
microphone — which is the whole reason this comparison is fuzzy rather than
exact. A longer candidate has the phrase aligned to its end instead.

**0.55 per word, measured rather than picked:** "ey" for "hey" scores 0.67 and
has to survive; the six determiners above are all below 0.5.

Everything the fuzziness exists for still works, and is now in the set rather
than exercised by hand:

```
parrot fix vocabulary      ->  fix vocabulary
ey parrot fix vocabulary   ->  fix vocabulary
hey parot fix vocabulary   ->  fix vocabulary
hey parrott fix vocabulary ->  fix vocabulary
hey parrots fix vocabulary ->  fix vocabulary
```

## What it costs

`a parrot fix vocabulary` is now dictation.

There is no rule on the phrase alone that keeps it and drops the six above:
`a parrot fix vocabulary` and `a parrot flew past the window` are the same
shape, and only what follows tells them apart. Six sentences written down beats
one command recovered.

It stays in the set under `KNOWN:` with that reasoning, rather than being
dropped to round the number up.

## Checks

| set | result |
|---|---|
| `check-wake` | **24/24**, plus 1 known-unfixed — was 13/13 plus 3 |
| `check-routing` | 41/45 — unchanged, the number in the set's own header |
| `check-spelling` | 43/44 — unchanged |
| `check-split` | 14/14 |
| `check-dotted` | 54/54, plus 2 known-unfixable |
| `check-pipeline` | 20/20 |
| `check-replacements` | 23/23 |
| `check-numbers` | 97/97 |
| `check-default-config` | ✓ |

The routing and spelling sets both run through this matcher, which is why they
were re-run with the model rather than assumed unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018L6J1Kw7SVxnoCAJ1Gw4WS