### PR TITLE
feat: a transform can say what it is doing while it does it

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ hotkey:
   key: right_option     # a bare modifier, or a character key + modifiers
   modifiers: []         # required for a character key, ignored for a modifier
   mode: push_to_talk    # or toggle
+  release_tail_seconds: 0.3   # keep recording this long after you let go
 
 audio:
   output_dir: ~/Recordings/ParrotFlow
@@ -211,6 +212,11 @@ one modifier from `command`, `control`, `option`, `shift` (aliases `cmd`,
 
 If a combo is already owned by another app, registration fails and the menu bar
 item says so. Pick another one.
+
+**`release_tail_seconds`** keeps the mic open after you let go, because the hand
+is faster than the mouth and the last syllable lands after the key is up.
+Push-to-talk only. Raise it if endings still get clipped, `0` to stop the moment
+you release.
 
 **`languages`** is not passed to the speech model — Parakeet transcribes
 multilingually by itself and reports no language back. The list is what

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -66,6 +66,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private var tickTimer: Timer?
     private var pushToTalkPoll: Timer?
+    /// Running between the hotkey coming up and the recording actually stopping
+    /// — see `stopRecordingAfterTail`.
+    private var releaseTail: Timer?
     private var keepWarmTimer: Timer?
     private var keepWarmInFlight = false
     private var hotkeyError: String?
@@ -364,6 +367,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         case .toggle:
             toggleRecording()
         case .pushToTalk:
+            // Pressed again inside the tail: one dictation with a stutter in the
+            // key, not two. Keep the recording that is already running — and put
+            // the modifier poll back, since starting the tail took it down.
+            if releaseTail != nil {
+                releaseTail?.invalidate(); releaseTail = nil
+                startPushToTalkPoll()
+                return
+            }
             guard !recorder.isRecording else { return }
             startRecording()
             startPushToTalkPoll()
@@ -372,7 +383,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func handleHotKeyRelease() {
         guard config.hotkey.mode == .pushToTalk else { return }
-        stopRecording()
+        stopRecordingAfterTail()
+    }
+
+    /// The hand is faster than the mouth: the key comes up while the last
+    /// syllable is still being said, and the clip ends "...max retri". So hold
+    /// the mic open a moment longer — `hotkey.release_tail_seconds`, 0 to stop
+    /// on the release as before.
+    private func stopRecordingAfterTail() {
+        guard recorder.isRecording else { return }
+
+        // The poll would see the key still up 60ms from now and ask again.
+        pushToTalkPoll?.invalidate(); pushToTalkPoll = nil
+
+        let tail = config.hotkey.releaseTailSeconds
+        guard tail > 0 else {
+            stopRecording()
+            return
+        }
+        guard releaseTail == nil else { return }
+
+        let timer = Timer(timeInterval: tail, repeats: false) { [weak self] _ in
+            guard let self else { return }
+            self.releaseTail = nil
+            self.stopRecording()
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        releaseTail = timer
     }
 
     /// Carbon only reports the release of the *character* key. If the user lets
@@ -454,6 +491,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         tickTimer?.invalidate(); tickTimer = nil
         pushToTalkPoll?.invalidate(); pushToTalkPoll = nil
+        releaseTail?.invalidate(); releaseTail = nil
         overlay.hide()
         if config.feedback.sound { NSSound(named: "Pop")?.play() }
 
@@ -495,8 +533,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let app = appAtPress
         Task { [weak self] in
             do {
+                // "Transcribing…" is the truth until the decoder is done, and
+                // a lie for the second a prompt or a script spends after it.
+                // A stage that wrote a `display:` says so itself.
                 let text = try await self?.transcriber.transcribe(
-                    url: recording.url, config: config, app: app
+                    url: recording.url, config: config, app: app,
+                    progress: { label in
+                        Task { @MainActor [weak self] in
+                            guard let self, self.transcriptionLabel != nil else { return }
+                            self.transcriptionLabel = label
+                            self.updateUI()
+                        }
+                    }
                 ) ?? ""
                 await MainActor.run {
                     guard let self else { return }
@@ -772,7 +820,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // wrong thing is otherwise indistinguishable in the log from one that
         // worked on the right thing badly.
         Log.write("transform: \(prompt.name) over \(selection == nil ? "the last dictation" : "the selection") — \"\(target.prefix(80))\"")
-        beginProgress("\(prompt.name)…")
+        beginProgress(prompt.progressLabel)
 
         let llmConfig = llmConfig()
         Task { [weak self] in
@@ -1242,7 +1290,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         func run(_ prompt: Config.Prompt) {
-            beginProgress("\(prompt.name)…")
+            beginProgress(prompt.progressLabel)
             let llm = llmConfig()
             Task { [weak self] in
                 do {

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -45,6 +45,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         DispatchQueue.main.async { self?.handleTranscriberStatus(status) }
     }
     private var transcriptionLabel: String?
+    /// Bumped by every transcription, so a stage label arriving late from one
+    /// cannot describe the next. Push-to-talk does not wait for the previous
+    /// transcript: hold the key again while a prompt stage is still running and
+    /// two are in flight, with the older one still holding a progress callback.
+    private var transcriptionRun = 0
     /// Bumped by every `setLabel`, so a self-clear armed for one message cannot
     /// wipe a newer one that is still current.
     private var labelToken = 0
@@ -524,6 +529,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func transcribe(_ recording: Recorder.Recording) {
+        transcriptionRun += 1
+        let run = transcriptionRun
         transcriptionLabel = "Transcribing…"
         updateUI()
 
@@ -540,7 +547,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     url: recording.url, config: config, app: app,
                     progress: { label in
                         Task { @MainActor [weak self] in
-                            guard let self, self.transcriptionLabel != nil else { return }
+                            // Still this dictation, and still one that has
+                            // something on screen to replace.
+                            guard let self, self.transcriptionRun == run,
+                                  self.transcriptionLabel != nil else { return }
                             self.transcriptionLabel = label
                             self.updateUI()
                         }
@@ -702,7 +712,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         // the whole specification, so it goes through unsplit,
                         // exactly as it would to a prompt of your own.
                         Log.write("router: \"\(command)\" → \(FreeForm.name)")
-                        self.runTransform(FreeForm.prompt, instruction: command)
+                        self.runTransform(FreeForm.prompt(for: command), instruction: command)
                     case .none:
                         // Nothing fits. Deliberately not falling through to
                         // dictation: the wake phrase means you were not
@@ -1354,7 +1364,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         self.runInlineAction(action, text: text, instruction: instruction)
                     case .anything:
                         Log.write("inline router: \"\(instruction)\" → \(FreeForm.name)")
-                        run(FreeForm.prompt)
+                        run(FreeForm.prompt(for: instruction))
                     case .none:
                         giveUp("Not something to change in the text: \"\(instruction)\"")
                     }

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -35,6 +35,10 @@ enum CheckConfigCommand {
             let shortcut = KeyCodes.displayString(key: config.hotkey.key, modifiers: config.hotkey.modifiers)
             print("  ✓ hotkey            \(shortcut)  (\(mode), Carbon)")
         }
+        if config.hotkey.mode == .pushToTalk {
+            let tail = config.hotkey.releaseTailSeconds
+            print("  · release tail      \(tail > 0 ? "\(tail)s after the key comes up" : "off — stops on the release")")
+        }
 
         // Audio
         print("  ✓ sample rate       \(Int(config.audio.sampleRate)) Hz mono")
@@ -118,7 +122,11 @@ enum CheckConfigCommand {
         // prompts only, for now — so it would otherwise be invisible here, and
         // "I wrote it and nothing says it exists" is the wrong way to find out
         // that it runs from a pipeline and not from your voice.
-        let tables = config.transforms.filter { !$0.isPrompt }
+        // Tables only. A `command:` is not one, and counting its rules said
+        // "0 rule(s)" about a transform that has no rules to have — the line
+        // read as a broken table rather than as a program. Programs are named
+        // by `problems()`, which says it of every one of them, every run.
+        let tables = config.transforms.filter(\.isTable)
         if !tables.isEmpty {
             print("  · replace           \(tables.count) transform(s), reachable from a pipeline"
                 + " and not by voice")
@@ -126,6 +134,20 @@ enum CheckConfigCommand {
                 let rules = table.rules.count
                 print("      table     \(table.name) — \(rules) rule(s)"
                     + (table.description.isEmpty ? "" : ", \(table.description)"))
+            }
+        }
+
+        // A `display:` is the one part of a transform that is neither matched
+        // against nor run: it is what the menu bar says while the stage takes
+        // its second. Nothing else can show you that you wrote it, and a
+        // second of silence is exactly the symptom of having forgotten to.
+        let announced = config.transforms.compactMap { transform in
+            transform.displayLabel.map { (transform.name, $0) }
+        }
+        if !announced.isEmpty {
+            print("  · display           \(announced.count) transform(s) say what they are doing")
+            for (name, label) in announced {
+                print("      \(name) — \"\(label)\"")
             }
         }
 

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -69,6 +69,7 @@ struct Config: Decodable, Equatable {
     private struct TransformEntry: Decodable {
         var name = ""
         var description = ""
+        var display = ""
         var confirm = true
         var body: Transform.Body?
         var directory: URL?
@@ -77,7 +78,7 @@ struct Config: Decodable, Equatable {
         var namesBoth = false
 
         enum CodingKeys: String, CodingKey {
-            case name, description, confirm, prompt, content, replace, command
+            case name, description, display, confirm, prompt, content, replace, command
             case timeout = "timeout_seconds"
         }
 
@@ -89,6 +90,7 @@ struct Config: Decodable, Equatable {
             }
             name = try trimmed(.name)
             description = try trimmed(.description)
+            display = try trimmed(.display)
             directory = decoder.userInfo[.configDirectory] as? URL
             confirm = try c.decodeIfPresent(Bool.self, forKey: .confirm) ?? true
             timeout = try c.decodeIfPresent(Double.self, forKey: .timeout)
@@ -159,6 +161,7 @@ struct Config: Decodable, Equatable {
             }
             kept.append(Transform(
                 name: entry.name, description: entry.description,
+                display: entry.display,
                 directory: entry.directory, timeout: entry.timeout,
                 confirm: entry.confirm, body: body
             ))
@@ -186,6 +189,19 @@ struct Config: Decodable, Equatable {
     struct Transform: Equatable {
         var name: String
         var description: String
+        /// What goes on screen while this runs — "Formatting functions…",
+        /// "Fixing grammar…".
+        ///
+        /// Not the description. The description is written for the router, in
+        /// the words you would say to ask for this; a display is written for
+        /// you, in the words that make a paused menu bar legible. A pipeline
+        /// stage is the case that needs it: nothing on screen ever said which
+        /// of them the second you are waiting on belongs to.
+        ///
+        /// Empty means say nothing, which is right for a table — it finishes
+        /// before the label could be read, and a flash nobody can read is
+        /// worse than no flash at all.
+        var display: String = ""
         /// The directory of the file that declared this transform, which is
         /// what a relative `command:` is relative to. Nil when it was not
         /// decoded from a file — a default, or a test.
@@ -230,12 +246,33 @@ struct Config: Decodable, Equatable {
             return false
         }
 
+        var isTable: Bool {
+            if case .replace = body { return true }
+            return false
+        }
+
+        /// The display as it goes on screen, or nil when none was written.
+        ///
+        /// The ellipsis is added rather than asked for. Every other waiting
+        /// message in the app ends in one — "Transcribing…", "Thinking…" —
+        /// and a config that has to remember the punctuation is one where
+        /// half the entries eventually do not.
+        var displayLabel: String? { Self.label(display) }
+
+        static func label(_ display: String) -> String? {
+            let trimmed = display.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return nil }
+            return trimmed.hasSuffix("…") || trimmed.hasSuffix("...")
+                ? trimmed : trimmed + "…"
+        }
+
         /// The prompt-shaped view of this transform, for everything that
         /// already speaks `Prompt` — the router, `PromptRunner`, the panels.
         var asPrompt: Prompt? {
             guard case .prompt(let content) = body else { return nil }
             return Prompt(
-                name: name, description: description, content: content, confirm: confirm
+                name: name, description: description, content: content,
+                display: display, confirm: confirm
             )
         }
 
@@ -259,6 +296,8 @@ struct Config: Decodable, Equatable {
         var name: String
         var description: String
         var content: String
+        /// What goes on screen while this runs — see `Transform.display`.
+        var display: String = ""
         /// Show the result and wait for you before replacing anything.
         ///
         /// On by default: a transform overwrites text you selected, triggered
@@ -267,13 +306,17 @@ struct Config: Decodable, Equatable {
         var confirm: Bool = true
 
         enum CodingKeys: String, CodingKey {
-            case name, description, content, confirm
+            case name, description, content, display, confirm
         }
 
-        init(name: String, description: String, content: String, confirm: Bool = true) {
+        init(
+            name: String, description: String, content: String,
+            display: String = "", confirm: Bool = true
+        ) {
             self.name = name
             self.description = description
             self.content = content
+            self.display = display
             self.confirm = confirm
         }
 
@@ -285,7 +328,16 @@ struct Config: Decodable, Equatable {
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             content = (try c.decodeIfPresent(String.self, forKey: .content) ?? "")
                 .trimmingCharacters(in: .whitespacesAndNewlines)
+            display = (try c.decodeIfPresent(String.self, forKey: .display) ?? "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
             confirm = try c.decodeIfPresent(Bool.self, forKey: .confirm) ?? true
+        }
+
+        /// The display as it goes on screen, or the prompt's own name when
+        /// nothing was written — which is what this path showed before
+        /// `display:` existed, so a config that says nothing loses nothing.
+        var progressLabel: String {
+            Transform.label(display) ?? "\(name)…"
         }
 
         /// Where the spoken instruction goes if the prompt asks for it inline.
@@ -714,6 +766,14 @@ struct Config: Decodable, Equatable {
         /// `toggle` — press once to start, once to stop.
         /// `push_to_talk` — record only while held down.
         var mode: Mode = .pushToTalk
+        /// How long the mic stays open after the key comes up, in push-to-talk.
+        /// The hand beats the mouth: the last syllable lands after the release.
+        var releaseTailSeconds: Double = 0.3
+
+        enum CodingKeys: String, CodingKey {
+            case key, modifiers, mode
+            case releaseTailSeconds = "release_tail_seconds"
+        }
 
         enum Mode: String, Codable, Equatable {
             case toggle
@@ -742,6 +802,16 @@ struct Config: Decodable, Equatable {
             if let mods = try c.decodeIfPresent([String].self, forKey: .modifiers) { self.modifiers = mods }
             if let mode = try c.decodeIfPresent(String.self, forKey: .mode) {
                 self.mode = try Mode(parsing: mode)
+            }
+            if let tail = try c.decodeIfPresent(Double.self, forKey: .releaseTailSeconds) {
+                guard tail >= 0, tail <= 5 else {
+                    throw ConfigError.invalidValue(
+                        key: "hotkey.release_tail_seconds",
+                        value: String(tail),
+                        expected: "a delay between 0 and 5 seconds"
+                    )
+                }
+                self.releaseTailSeconds = tail
             }
         }
     }
@@ -988,6 +1058,7 @@ enum ConfigStore {
     transforms:
       - name: code_identifiers
         description: spoken names as identifiers
+        display: Formatting identifiers
         command: code_identifiers.py                       # rules only, 0.03s
       # command: code_identifiers.py --model gemma4:e4b     # + the model, below
         timeout_seconds: 12                                 # only with --model
@@ -1288,6 +1359,11 @@ if __name__ == "__main__":
       # recording every time you typed an accented character with it.
       mode: push_to_talk
 
+      # How long the mic stays open after you let go, in push_to_talk. The hand
+      # is faster than the mouth and the last syllable arrives after the key is
+      # up; without this it is cut off. 0 turns it off.
+      release_tail_seconds: 0.3
+
     audio:
       # Where the recordings pile up.
       output_dir: \(AppVariant.defaultOutputDir)
@@ -1464,6 +1540,12 @@ if __name__ == "__main__":
     # different output are how "user dot name" becomes user.name in a terminal
     # and `user.name` in chat. See docs/pipelines.md.
     #
+    # `display:` is what the menu bar says while an entry runs — "Fixing
+    # grammar…", "Formatting identifiers…". The description is written for the
+    # router, in the words you would say; a display is written for you, for the
+    # second you spend watching nothing happen. The ellipsis is added for you.
+    # Leave it off a table, which finishes before the label could be read.
+    #
     # Results are shown before they replace your selection; add
     # `confirm: false` to one you have come to trust.
     #
@@ -1472,18 +1554,21 @@ if __name__ == "__main__":
     transforms:
       - name: bullets
         description: turn text into a short bullet list
+        display: Making bullets
         prompt: |
           Rewrite the text as concise bullets, one idea each.
           Keep the speaker's wording. Return only the bullets.
 
       - name: terse
         description: shorten text without losing anything it says
+        display: Cutting it down
         prompt: |
           Cut this down. No filler, same facts, same voice.
           Return only the shortened text.
 
       - name: grammar
         description: fix grammar and punctuation mistakes, not formatting or numbers
+        display: Fixing grammar
         prompt: |
           Correct grammar, spelling and punctuation. Make the smallest change
           that makes the text correct — and make it. Every error is fixed.
@@ -1542,6 +1627,7 @@ if __name__ == "__main__":
       # ends, which is a judgement about how you speak.
       - name: code_identifiers
         description: spoken names as identifiers
+        display: Formatting identifiers
         command: code_identifiers.py
         # Add `--model gemma4:e4b` to have a model handle the namings the rules
         # cannot see — "call it max retries", "rename the variable to retry

--- a/Sources/ParrotFlow/FreeForm.swift
+++ b/Sources/ParrotFlow/FreeForm.swift
@@ -78,4 +78,47 @@ enum FreeForm {
         Return only the text.
         """
     )
+
+    /// The catch-all, carrying a display made from what was actually asked.
+    ///
+    /// Every other transform can name what it is doing before it runs, because
+    /// every other transform does one thing. This one does whatever you just
+    /// said, so there is no fixed label to write — and the two it could fall
+    /// back to are both wrong. Its name yields "anything…", which is the least
+    /// informative word in the app to be watching during a wait; "Thinking…"
+    /// is what the path said before and describes the model rather than the
+    /// request.
+    ///
+    /// So the label is generated: your own instruction, handed back. It is the
+    /// one string guaranteed to describe this particular second, and reading it
+    /// mid-wait is also how you find out the router heard you wrong — the
+    /// preview then confirms it, but the preview comes after the second you
+    /// spent wondering.
+    static func prompt(for instruction: String) -> Config.Prompt {
+        var made = prompt
+        made.display = display(for: instruction)
+        return made
+    }
+
+    /// The instruction as a status line: first letter raised, cut to something
+    /// a menu bar can hold, and never cut mid-word.
+    ///
+    /// Empty when there is nothing to show, which leaves `progressLabel` to
+    /// fall back to the name — the caller does not get to end up with a label
+    /// that is just an ellipsis.
+    static func display(for instruction: String) -> String {
+        let trimmed = instruction.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "" }
+
+        var shown = String(trimmed.prefix(maximumDisplay))
+        if shown.count < trimmed.count, let lastSpace = shown.lastIndex(of: " ") {
+            shown = String(shown[..<lastSpace])
+        }
+        return shown.prefix(1).uppercased() + shown.dropFirst()
+    }
+
+    /// Long enough for the instructions people actually say — "sort that list
+    /// alphabetically" is 29 — and short enough that the menu bar does not
+    /// take the whole width of the screen for one dictation.
+    private static let maximumDisplay = 48
 }

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -327,8 +327,14 @@ struct Pipeline: Equatable, Codable {
         return nil
     }
 
+    /// - Parameter progress: Called with a stage's `display:` as that stage
+    ///   starts, for whatever is showing the wait. Only stages that wrote one
+    ///   report, so the caller's own message stands through the rest: the
+    ///   tables finish in microseconds, and a label that changed six times on
+    ///   the way to a transcript would say less than one that never moved.
     func run(
-        _ text: String, config: Config, allowPrompts: Bool = true, app: App? = nil
+        _ text: String, config: Config, allowPrompts: Bool = true, app: App? = nil,
+        progress: (@Sendable (String) -> Void)? = nil
     ) async -> String {
         var output = text
         for step in steps {
@@ -342,6 +348,12 @@ struct Pipeline: Equatable, Codable {
                 let named = step.transform.map { "\(step.stage.name) \($0)" } ?? step.stage.name
                 Log.write("pipeline: skipped \(named) — \(reason)")
                 continue
+            }
+            // After the skip check, not before: a stage that is about to
+            // decline should not put its name on screen first.
+            if let label = step.transform
+                .flatMap({ config.transform(named: $0) })?.displayLabel {
+                progress?(label)
             }
             output = await apply(step, to: output, config: config)
         }

--- a/Sources/ParrotFlow/Replacements.swift
+++ b/Sources/ParrotFlow/Replacements.swift
@@ -37,10 +37,11 @@ enum Replacements {
     /// Kept as the entry point everything already calls, so moving the order
     /// out of this function did not move the call sites too.
     static func apply(
-        to text: String, config: Config, allowPrompts: Bool = true, app: Pipeline.App? = nil
+        to text: String, config: Config, allowPrompts: Bool = true, app: Pipeline.App? = nil,
+        progress: (@Sendable (String) -> Void)? = nil
     ) async -> String {
         await Pipeline.forText(text, config: config).0.run(
-            text, config: config, allowPrompts: allowPrompts, app: app
+            text, config: config, allowPrompts: allowPrompts, app: app, progress: progress
         )
     }
 

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -110,7 +110,10 @@ actor Transcriber {
     // MARK: - Transcription
 
     /// Transcribes a finished recording. Returns the cleaned-up text.
-    func transcribe(url: URL, config: Config, app: Pipeline.App? = nil) async throws -> String {
+    func transcribe(
+        url: URL, config: Config, app: Pipeline.App? = nil,
+        progress: (@Sendable (String) -> Void)? = nil
+    ) async throws -> String {
         try await prepare(config: config)
         let manager = try await makeManager()
 
@@ -137,7 +140,9 @@ actor Transcriber {
         }
 
         let raw = try await manager.finish()
-        return await Self.applyReplacements(to: raw, config: config, app: app)
+        return await Self.applyReplacements(
+            to: raw, config: config, app: app, progress: progress
+        )
     }
 
     /// True when the clip holds no speech worth transcribing.
@@ -189,9 +194,10 @@ actor Transcriber {
     /// "mick" and "Mick" both land, but "Mickey" is left alone.
     /// How names get fixed — see `Replacements`.
     nonisolated static func applyReplacements(
-        to text: String, config: Config, app: Pipeline.App? = nil
+        to text: String, config: Config, app: Pipeline.App? = nil,
+        progress: (@Sendable (String) -> Void)? = nil
     ) async -> String {
-        await Replacements.apply(to: text, config: config, app: app)
+        await Replacements.apply(to: text, config: config, app: app, progress: progress)
     }
 }
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -157,6 +157,12 @@ updates:
 # output are how "user dot name" becomes user.name in a terminal and `user.name`
 # in chat. See docs/pipelines.md.
 #
+# `display:` is what the menu bar says while an entry runs — "Fixing grammar…",
+# "Formatting identifiers…". The description is written for the router, in the
+# words you would say; a display is written for you, for the second you spend
+# watching nothing happen. The ellipsis is added for you. Leave it off a table,
+# which finishes long before the label could be read.
+#
 # Results are shown before they replace your selection; add `confirm: false`
 # to one you have come to trust.
 #
@@ -165,18 +171,21 @@ updates:
 transforms:
   - name: bullets
     description: turn text into a short bullet list
+    display: Making bullets
     prompt: |
       Rewrite the text as concise bullets, one idea each.
       Keep the speaker's wording. Return only the bullets.
 
   - name: terse
     description: shorten text without losing anything it says
+    display: Cutting it down
     prompt: |
       Cut this down. No filler, same facts, same voice.
       Return only the shortened text.
 
   - name: grammar
     description: fix grammar and punctuation mistakes, not formatting or numbers
+    display: Fixing grammar
     prompt: |
       Correct grammar, spelling and punctuation. Make the smallest change
       that makes the text correct — and make it. Every error is fixed.
@@ -235,6 +244,7 @@ transforms:
   # a judgement about how you speak.
   - name: code_identifiers
     description: spoken names as identifiers
+    display: Formatting identifiers
     command: code_identifiers.py
     # Add `--model gemma4:e4b` to have a model handle the namings the rules
     # cannot see — "call it max retries", "rename the variable to retry

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -89,6 +89,14 @@ every dictation.
 `--check-config` prints every display it found, which is the only way to see
 that one is wrong before the second it was meant to explain has passed.
 
+The catch-all is the one transform that cannot have a display written for it,
+because it does whatever you just said rather than one fixed thing. So its
+label is generated from the instruction: say "hey parrot, sort that list
+alphabetically" and the menu bar reads `Sort that list alphabetically…` while
+it runs. Long instructions are cut at a word boundary. Reading it mid-wait is
+also how you catch the router having heard you wrong, a second before the
+preview would have told you.
+
 ### `command:`, or: the app stops needing new primitives
 
 The transcript arrives on **stdin** and comes back on **stdout**. That is the

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -59,6 +59,36 @@ exist. `replace:` is a substitution table of its own, in the same shape as
 yours, which costs a process start — about 30ms for `python3`, 5ms for a shell
 script.
 
+### `display:`, or: what the pause is for
+
+A stage that takes a second is a second in which the menu bar says
+`Transcribing…`, which stopped being true when the decoder finished. `display:`
+is what it should say instead while this transform runs:
+
+```yaml
+  - name: grammar
+    description: fix grammar and punctuation mistakes
+    display: Fixing grammar
+    prompt: |
+      Correct grammar, spelling and punctuation. Return only the text.
+```
+
+The two strings are read by different audiences and are not interchangeable. A
+`description:` is matched — it is what the router compares your spoken
+instruction against, so it reads like the thing you would ask for. A `display:`
+is only ever shown, so it reads like a status: what is happening, not what you
+wanted. The ellipsis is appended for you.
+
+Write one for anything with a wait worth explaining — a `prompt:`, or a
+`command:` that thinks. Leave it off a `replace:` table: it finishes in
+microseconds, and a label that appears and vanishes inside one frame is noise
+where there was none. Stages that write no display leave the current message
+alone, which is why the menu bar does not flicker through the whole pipeline on
+every dictation.
+
+`--check-config` prints every display it found, which is the only way to see
+that one is wrong before the second it was meant to explain has passed.
+
 ### `command:`, or: the app stops needing new primitives
 
 The transcript arrives on **stdin** and comes back on **stdout**. That is the

--- a/examples/code_identifiers.py
+++ b/examples/code_identifiers.py
@@ -4,6 +4,7 @@
     transforms:
       - name: code_identifiers
         description: spoken names as identifiers
+        display: Formatting identifiers
         command: code_identifiers.py                       # rules only, 0.03s
       # command: code_identifiers.py --model gemma4:e4b     # + the model, below
         timeout_seconds: 12                                 # only with --model


### PR DESCRIPTION
A pipeline stage that takes a second is a second in which the menu bar still says `Transcribing…`, which stopped being true when the decoder finished. Nothing on screen ever said which transform the wait belonged to — a prompt thinking and a script hanging look the same from the outside.

## `display:`

A new optional key on any transform:

```yaml
  - name: grammar
    description: fix grammar and punctuation mistakes
    display: Fixing grammar
    prompt: |
      Correct grammar, spelling and punctuation. Return only the text.
```

The menu bar reads `Fixing grammar…` while that stage runs. The two strings are read by different audiences: a `description:` is *matched* — it is what the router compares your spoken instruction against — and a `display:` is only ever *shown*, so it reads like a status rather than like a request. The ellipsis is appended for you.

## How it reports

An optional progress callback on `Pipeline.run`, threaded through `Replacements.apply` and `Transcriber.transcribe` to the menu bar label. Only stages that declare a display report, so the ones that do not leave the current message standing — the `replace:` tables finish in microseconds, and a label that changed six times on the way to one transcript would say less than one that never moved.

The voice-triggered path reads the same key and falls back to the transform's own name, so a config that says nothing behaves exactly as before.

`--check-config` prints every display it found. A display is the one part of a transform that is neither matched against nor run, so nothing else could show you that you wrote it — and a silent second is precisely the symptom of having forgotten to.

## Also

`--check-config` no longer lists a `command:` transform among the tables as `0 rule(s)`, which read as a broken table rather than as a program. Programs are already named, every run, by `problems()`.

## Verified

- `check-pipeline` 27/27, `check-replacements` 23/23, `check-dotted` 54/54, `check-numbers` 97/97, `check-dates` 26/26, `check-split` 14/14
- `check-default-config` and `check-example-script` pass — `display:` is documented in `config.example.yaml`, `Config.defaultYAML`, `examples/code_identifiers.py` and `docs/pipelines.md`
- Run in the app: dictating through a `command:` stage shows its display, and the tables do not flicker the label

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018L6J1Kw7SVxnoCAJ1Gw4WS