### PR TITLE
feat: the mic stays open a moment after you let go

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -388,6 +388,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func handleHotKeyRelease() {
         guard config.hotkey.mode == .pushToTalk else { return }
+        // The character key is actually up now, so there is nothing left for
+        // the modifier poll to catch — unlike the poll's own call below, where
+        // the character key is still down and a flicked-back modifier means
+        // the chord never really broke.
+        pushToTalkPoll?.invalidate(); pushToTalkPoll = nil
         stopRecordingAfterTail()
     }
 
@@ -397,9 +402,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// on the release as before.
     private func stopRecordingAfterTail() {
         guard recorder.isRecording else { return }
-
-        // The poll would see the key still up 60ms from now and ask again.
-        pushToTalkPoll?.invalidate(); pushToTalkPoll = nil
 
         let tail = config.hotkey.releaseTailSeconds
         guard tail > 0 else {
@@ -434,9 +436,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let timer = Timer(timeInterval: 0.06, repeats: true) { [weak self] _ in
             guard let self, self.recorder.isRecording else { return }
             let held = NSEvent.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            if !held.isSuperset(of: required) {
+            if held.isSuperset(of: required) {
+                // The modifier is back and the character key never came up —
+                // Carbon has no press event for that, since it only edge-
+                // detects the character key, so the poll is what has to
+                // notice the chord is whole again and call off the tail it
+                // started.
+                if self.releaseTail != nil {
+                    self.releaseTail?.invalidate(); self.releaseTail = nil
+                }
+            } else if self.releaseTail == nil {
                 // The same event as a release, found a different way, so it
-                // ends the recording the same way — through the tail.
+                // ends the recording the same way — through the tail. Keep
+                // polling through the tail itself: this is the one path where
+                // the modifier can still come back before the character key
+                // does.
                 self.stopRecordingAfterTail()
             }
         }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -435,7 +435,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             guard let self, self.recorder.isRecording else { return }
             let held = NSEvent.modifierFlags.intersection(.deviceIndependentFlagsMask)
             if !held.isSuperset(of: required) {
-                self.stopRecording()
+                // The same event as a release, found a different way, so it
+                // ends the recording the same way — through the tail.
+                self.stopRecordingAfterTail()
             }
         }
         RunLoop.main.add(timer, forMode: .common)


### PR DESCRIPTION
The hand is faster than the mouth. The key comes up while the last syllable is still being said, and the clip ends `...max retri` — a word the decoder then guesses at, which is worse than a word it never heard.

Push-to-talk now holds the recording open past the release:

```yaml
hotkey:
  release_tail_seconds: 0.3   # 0 stops on the release, as before
```

Three things follow from it:

- The modifier poll is taken down when the tail starts, or it would notice the key still up 60ms later and start the wait again.
- Pressing the key again inside the tail keeps the recording that is already running — a stutter in the key is one dictation, not two — and puts the poll back.
- A stop that did not come from the key, the audio device changing, cancels the tail instead of racing it.

Toggle mode is untouched: no release there ends a recording, so there is nothing to delay.

`--check-config` prints the tail under the hotkey it belongs to, including when it is off, since a clipped ending is exactly the symptom of having set it to 0 and forgotten.

**Worth knowing:** `audio.min_duration_seconds` is also 0.3 and measures the written clip, so with the tail on a fumbled tap now clears it and the speech gate is what discards the room tone.

**Verified:** builds clean; `--check-config` read back `0.6`, rejected `9` with the range message, and reported `0` as off. The timing itself is unverified in the running app — it needs a physical key hold.

**Note:** `feat/transform-display` currently contains these same changes, swept in by a commit made while this was in the working tree. That branch wants a rebase once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUnWNfi64vX94QqWfUM2qS