### PR TITLE
feat: prompts for writing an email and a Slack message

### DIFF
--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1680,57 +1680,54 @@ if __name__ == "__main__":
 
           Return only the message.
 
-      # Two tables rather than one prompt, and the marker word is why they can be.
+      # Said out loud — "hey parrot, use Slack mentions" — and deliberately in
+      # no pipeline. A message that names someone is not a message that pings
+      # them, and nothing in a transcript tells the two apart. So this is the
+      # one you ask for, and `confirm` shows you who is about to be tagged
+      # before anything is replaced.
       #
-      # A name is a lookup. The prompt that used to do this got to 6/6 after four
-      # rewrites, and its first draft answered "Sofia already looked at it" with
-      # "@priya already looked at it" — a handle invented for a name it had never
-      # been given, which in Slack is a message sent to the wrong person. A table
-      # cannot do that. It substitutes what is in it, leaves the rest alone, costs
-      # nothing, and needs no model running.
+      # It was two `replace:` tables for a while — a table cannot invent a
+      # handle, where this prompt's first draft answered "Sofia already looked
+      # at it" with "@priya already looked at it". They came back out because a
+      # table has to be triggered from inside the sentence, and "mention" is a
+      # word English already uses: "I should mention here that the deadline
+      # changed" became "I should @here that the deadline changed". A pipeline
+      # stage has no preview, so a false positive there is a message already
+      # sent. Asking out loud fires when you ask and never otherwise. The whole
+      # excursion is written up in config.example.yaml.
       #
-      # `mention` is the safety, not the syntax. Without a marker the table would
-      # turn every "Marie" into a ping, and a message that names someone is not a
-      # message that pings them. It is said in the same breath, so unlike the voice
-      # command this replaces it costs no round trip:
-      #
-      #     "mention marie can you look at this"
-      #     -> "@marie.dupont can you look at this"
-      #
-      # Two tables and not one, so the group pings can go without the handles going
-      # with them: those are the two that wake people up, and @channel reaches the
-      # ones who are away.
-      #
-      #
-      # The marker has to open the message or follow a pause, and that is the half
-      # of the safety the first version of this table did not have. "mention" is an
-      # ordinary English verb: "I should mention here that the deadline changed"
-      # came back as "I should @here that the deadline changed", and "I wanted to
-      # mention Marie is off next week" pinged Marie. Neither is a message anyone
-      # meant to send, and a pipeline stage has no preview to catch it — it runs on
-      # a transcript nobody has seen yet.
-      #
-      # So the word counts only at the start of the utterance or straight after
-      # . ! ? ; or a comma, which is where it lands when you mean it and almost
-      # never where the verb does. Same shape as the stop lists on `dotted`, for
-      # the same reason: that pattern has to tell code from prose, this one has to
-      # tell an instruction from a verb. The cost is that "can you mention marie
-      # about the invoice" does nothing — a ping you did not get rather than one
-      # you did not mean, which is the direction to fail in.
-      # To fill this in, hand Claude Code your team's names and handles and ask it
-      # to update this table. The shape is regular and the names are yours.
-      - name: slack_handles
-        description: spoken names as Slack handles
-        replace:
-          '$1@marie.dupont': ['/(^|[.!?;,]\\s*)mention(?:ne)? marie\\b/']
-          '$1@tleroy': ['/(^|[.!?;,]\\s*)mention(?:ne)? thomas\\b/']
-          '$1@priya': ['/(^|[.!?;,]\\s*)mention(?:ne)? priya\\b/']
-
+      # Put your own people in the list.
       - name: slack_mentions
-        description: spoken group mentions as @here and @channel
-        replace:
-          '$1@here': ['/(^|[.!?;,]\\s*)mention(?:ne)? (?:everyone here|here)\\b/']
-          '$1@channel': ['/(^|[.!?;,]\\s*)mention(?:ne)? (?:the )?(?:whole )?channel\\b/']
+        description: turn people's names into Slack mentions
+        prompt: |
+          Return the text word for word, with one kind of change and no
+          other: a name that appears in this list becomes its handle.
+
+            Marie   -> @marie.dupont
+            Thomas  -> @tleroy
+            Priya   -> @priya
+
+          Every occurrence, including where the message is about that person
+          rather than to them.
+
+          A name that is not in the list is left exactly as it was. Sofia
+          stays Sofia. Never give a name a handle that belongs to someone
+          else, and never invent one.
+
+          Two group mentions are a judgement rather than a lookup. "everyone
+          here", "whoever is around" -> @here, which pings the people who are
+          online. "the whole channel", "everyone", "all of them" -> @channel,
+          which pings the ones who are away too. Only where the text means
+          the people: "the file is here" is a place, and stays.
+
+          A mention replaces the words that name the person or the group, and
+          not one word more: "heads up to the whole channel" comes back as
+          "heads up to @channel".
+
+          Nothing is ever deleted. Every other word, the order and the
+          punctuation come back as they went in.
+
+          Return only the text.
 
       # The two tables the pipeline above names. Same pattern, different output:
       # that is the whole reason a table has a name.

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1607,13 +1607,17 @@ if __name__ == "__main__":
       # return a better one, in its own voice, and you will not notice until it
       # has gone.
       #
-      # 6/7 on gemma4:e4b, and the versions in between are written down in
+      # 8/10 on gemma4:e4b, and the six versions before it are written down in
       # config.example.yaml beside the same prompt. The short version: a
       # prohibition ("do not invent a greeting") read as a topic and produced
-      # one; "nothing is ever deleted" produced a literal "[Signature]"; and
-      # giving the greeting rule worked examples put those examples in the
-      # output. The one case still failing runs two clauses together with no
-      # comma and comes back as the second one.
+      # one; "nothing is ever deleted" produced a literal "[Signature]";
+      # worked examples for the greeting came back in the output; and the list
+      # rule has to sit with the paragraph rule, because after the short-reply
+      # clause it turned a two-word reply into "[No body text]".
+      #
+      # The two still failing are one shape — a short reply ending in a goodbye
+      # comes back as the goodbye alone. Numbered lists are deliberately absent:
+      # the version that forced them from spoken ordinals dropped an item.
       - name: email
         description: lay dictated text out as an email
         prompt: |
@@ -1629,7 +1633,15 @@ if __name__ == "__main__":
           starts with the first sentence. Never add a greeting nobody spoke.
 
           Break the body into paragraphs where the subject changes, a blank
-          line between them. Add no headings, no bullets and no emphasis.
+          line between them. Add no headings and no emphasis.
+
+          Three or more things listed in a row never stay inline. Whatever
+          joined them — commas, "and", nothing at all — the words introducing
+          them take a colon and each thing goes on a line of its own behind a
+          dash. No number has to be said for this: "here is what I need from
+          you", "the steps are", "we should" all open a list as surely as
+          "there are three things" does. Two things are a sentence and stay
+          one.
 
           A name at the end is a signature: a blank line, then the name on
           its own line, and a closing word said just before it — thanks,

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1701,20 +1701,36 @@ if __name__ == "__main__":
       # with them: those are the two that wake people up, and @channel reaches the
       # ones who are away.
       #
+      #
+      # The marker has to open the message or follow a pause, and that is the half
+      # of the safety the first version of this table did not have. "mention" is an
+      # ordinary English verb: "I should mention here that the deadline changed"
+      # came back as "I should @here that the deadline changed", and "I wanted to
+      # mention Marie is off next week" pinged Marie. Neither is a message anyone
+      # meant to send, and a pipeline stage has no preview to catch it — it runs on
+      # a transcript nobody has seen yet.
+      #
+      # So the word counts only at the start of the utterance or straight after
+      # . ! ? ; or a comma, which is where it lands when you mean it and almost
+      # never where the verb does. Same shape as the stop lists on `dotted`, for
+      # the same reason: that pattern has to tell code from prose, this one has to
+      # tell an instruction from a verb. The cost is that "can you mention marie
+      # about the invoice" does nothing — a ping you did not get rather than one
+      # you did not mean, which is the direction to fail in.
       # To fill this in, hand Claude Code your team's names and handles and ask it
       # to update this table. The shape is regular and the names are yours.
       - name: slack_handles
         description: spoken names as Slack handles
         replace:
-          '@marie.dupont': ['/\\bmention(?:ne)? marie\\b/']
-          '@tleroy': ['/\\bmention(?:ne)? thomas\\b/']
-          '@priya': ['/\\bmention(?:ne)? priya\\b/']
+          '$1@marie.dupont': ['/(^|[.!?;,]\\s*)mention(?:ne)? marie\\b/']
+          '$1@tleroy': ['/(^|[.!?;,]\\s*)mention(?:ne)? thomas\\b/']
+          '$1@priya': ['/(^|[.!?;,]\\s*)mention(?:ne)? priya\\b/']
 
       - name: slack_mentions
         description: spoken group mentions as @here and @channel
         replace:
-          '@here': ['/\\bmention(?:ne)? (?:everyone here|here)\\b/']
-          '@channel': ['/\\bmention(?:ne)? (?:the )?(?:whole )?channel\\b/']
+          '$1@here': ['/(^|[.!?;,]\\s*)mention(?:ne)? (?:everyone here|here)\\b/']
+          '$1@channel': ['/(^|[.!?;,]\\s*)mention(?:ne)? (?:the )?(?:whole )?channel\\b/']
 
       # The two tables the pipeline above names. Same pattern, different output:
       # that is the whole reason a table has a name.

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1685,8 +1685,12 @@ if __name__ == "__main__":
       # Said out loud — "hey parrot, use Slack mentions" — and deliberately in
       # no pipeline. A message that names someone is not a message that pings
       # them, and nothing in a transcript tells the two apart. So this is the
-      # one you ask for, and `confirm` shows you who is about to be tagged
-      # before anything is replaced.
+      # one you ask for.
+      #
+      # `confirm` covers one of the two ways of asking. With text selected the
+      # result is shown first; mid-sentence there is no preview whatever
+      # `confirm` says. Either way what lands is text in your composer, and
+      # ParrotFlow sends nothing.
       #
       # It was two `replace:` tables for a while — a table cannot invent a
       # handle, where this prompt's first draft answered "Sofia already looked

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1457,6 +1457,12 @@ if __name__ == "__main__":
           - transform: code_identifiers
             app: /term|ghostty|warp|kitty|alacritty|hyper|code|cursor|zed|xcode|jetbrains|idea|pycharm|webstorm/
             when: /\\b(?:function|method|variable|class|constant|type|struct|interface|enum|fonction|méthode|classe|constante)\\b/
+          # `email` and `slack` below lay dictated prose out for one kind of
+          # window each, and are deliberately not in this list. Every stage
+          # here is free and needs nothing running; those two cost about a
+          # second and stop dead without Ollama, which is not a default. Wire
+          # them up behind `app:` when you want them — config.example.yaml
+          # shows how.
 
       # The spelling you want, and the ways it comes out wrong. Whole words,
       # case-insensitive. A source in /slashes/ is a regular expression, and an
@@ -1588,6 +1594,127 @@ if __name__ == "__main__":
 
           A phrase before the main clause takes a comma after it. A trailing
           please or thanks does not.
+
+          Return only the text.
+
+      # Two prompts scoped to one kind of window each. `grammar` mends a
+      # sentence; these two also lay one out — a greeting on its own line, a
+      # blank line where the subject changes — which is the part no
+      # substitution can express and the reason they are prompts.
+      #
+      # Both are told twice not to write anything, because that is the failure
+      # that costs you something: a model handed a dictated email will gladly
+      # return a better one, in its own voice, and you will not notice until it
+      # has gone.
+      #
+      # 6/7 on gemma4:e4b, and the versions in between are written down in
+      # config.example.yaml beside the same prompt. The short version: a
+      # prohibition ("do not invent a greeting") read as a topic and produced
+      # one; "nothing is ever deleted" produced a literal "[Signature]"; and
+      # giving the greeting rule worked examples put those examples in the
+      # output. The one case still failing runs two clauses together with no
+      # comma and comes back as the second one.
+      - name: email
+        description: lay dictated text out as an email
+        prompt: |
+          Lay the text out as an email, in the language it was dictated in.
+          Fix the writing; do not write it.
+
+          Correct grammar, spelling and punctuation, and drop the hesitations
+          — um, uh, euh, well, you know, I mean. Every other word survives:
+          the wording, the order and the tone are the speaker's.
+
+          If the text opens with a greeting, it goes on its own line, with a
+          comma after it and a blank line under it. If it does not, the email
+          starts with the first sentence. Never add a greeting nobody spoke.
+
+          Break the body into paragraphs where the subject changes, a blank
+          line between them. Add no headings, no bullets and no emphasis.
+
+          A name at the end is a signature: a blank line, then the name on
+          its own line, and a closing word said just before it — thanks,
+          merci — on the line above. No name at the end means no signature:
+          the last thing said is the last line of the body, wherever it
+          sounds like a goodbye.
+
+          A short reply is not an email with parts. One or two sentences and
+          no hello in front of them come back as one or two sentences,
+          corrected, with no line put anywhere.
+
+          Return only the email.
+
+      # 3/3. "Add nothing" rather than "no greeting, no sign-off": the second
+      # wording read as an instruction to remove one, and "hey uh quick one the
+      # build is red" came back as "The build is red". The slang line is there
+      # because "gonna" was being corrected to "going to", which is the
+      # speaker's voice going out with the hesitations.
+      - name: slack
+        description: tidy dictated text into a chat message
+        prompt: |
+          Tidy the text into a chat message, in the language it was dictated
+          in. Fix the writing; do not write it.
+
+          Correct grammar, spelling and punctuation, and drop the hesitations
+          — um, uh, euh, well, you know, I mean. Every other word survives.
+          Slang and contractions are the speaker's voice rather than
+          mistakes: gonna stays gonna, ouais stays ouais.
+
+          Add nothing: no greeting, no sign-off, no heading, no bullet, no
+          bold, no backtick. Slack's composer renders none of that when text
+          arrives by paste, so it would land in the message as characters.
+          Remove nothing either: a spoken "hey" is part of the message.
+
+          One paragraph, unless the text plainly holds two.
+
+          Return only the message.
+
+      # Asked for out loud — "hey parrot, use Slack mentions" — and
+      # deliberately not in a pipeline. A message that names someone is not a
+      # message that pings them, and nothing in a transcript tells the two
+      # apart. So this one you say, and `confirm` shows you who is about to be
+      # tagged before anything is replaced.
+      #
+      # The mapping lives in the prompt rather than in a `replace:` table
+      # because a table is not reachable by voice — it runs from a pipeline
+      # only, and a pipeline is where this must not be. It is also the better
+      # half of the trade: names are a lookup a table would do exactly, but
+      # "let everyone here know" -> @here is a judgement, and a pattern that
+      # turned every "here" into @here is one you would switch off after a
+      # single message.
+      #
+      # Put your own people in the list. 6/6 as written; the first draft was
+      # 2/6 and failed in the direction that costs the most, answering "Sofia
+      # already looked at it" with "@priya already looked at it" — a handle
+      # invented for a name it had never been given.
+      - name: slack_mentions
+        description: turn people's names into Slack mentions
+        prompt: |
+          Return the text word for word, with one kind of change and no
+          other: a name that appears in this list becomes its handle.
+
+            Marie   -> @marie.dupont
+            Thomas  -> @tleroy
+            Priya   -> @priya
+
+          Every occurrence, including where the message is about that person
+          rather than to them.
+
+          A name that is not in the list is left exactly as it was. Sofia
+          stays Sofia. Never give a name a handle that belongs to someone
+          else, and never invent one.
+
+          Two group mentions are a judgement rather than a lookup. "everyone
+          here", "whoever is around" -> @here, which pings the people who are
+          online. "the whole channel", "everyone", "all of them" -> @channel,
+          which pings the ones who are away too. Only where the text means
+          the people: "the file is here" is a place, and stays.
+
+          A mention replaces the words that name the person or the group, and
+          not one word more: "heads up to the whole channel" comes back as
+          "heads up to @channel".
+
+          Nothing is ever deleted. Every other word, the order and the
+          punctuation come back as they went in.
 
           Return only the text.
 

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1668,55 +1668,41 @@ if __name__ == "__main__":
 
           Return only the message.
 
-      # Asked for out loud — "hey parrot, use Slack mentions" — and
-      # deliberately not in a pipeline. A message that names someone is not a
-      # message that pings them, and nothing in a transcript tells the two
-      # apart. So this one you say, and `confirm` shows you who is about to be
-      # tagged before anything is replaced.
+      # Two tables rather than one prompt, and the marker word is why they can be.
       #
-      # The mapping lives in the prompt rather than in a `replace:` table
-      # because a table is not reachable by voice — it runs from a pipeline
-      # only, and a pipeline is where this must not be. It is also the better
-      # half of the trade: names are a lookup a table would do exactly, but
-      # "let everyone here know" -> @here is a judgement, and a pattern that
-      # turned every "here" into @here is one you would switch off after a
-      # single message.
+      # A name is a lookup. The prompt that used to do this got to 6/6 after four
+      # rewrites, and its first draft answered "Sofia already looked at it" with
+      # "@priya already looked at it" — a handle invented for a name it had never
+      # been given, which in Slack is a message sent to the wrong person. A table
+      # cannot do that. It substitutes what is in it, leaves the rest alone, costs
+      # nothing, and needs no model running.
       #
-      # Put your own people in the list. 6/6 as written; the first draft was
-      # 2/6 and failed in the direction that costs the most, answering "Sofia
-      # already looked at it" with "@priya already looked at it" — a handle
-      # invented for a name it had never been given.
+      # `mention` is the safety, not the syntax. Without a marker the table would
+      # turn every "Marie" into a ping, and a message that names someone is not a
+      # message that pings them. It is said in the same breath, so unlike the voice
+      # command this replaces it costs no round trip:
+      #
+      #     "mention marie can you look at this"
+      #     -> "@marie.dupont can you look at this"
+      #
+      # Two tables and not one, so the group pings can go without the handles going
+      # with them: those are the two that wake people up, and @channel reaches the
+      # ones who are away.
+      #
+      # To fill this in, hand Claude Code your team's names and handles and ask it
+      # to update this table. The shape is regular and the names are yours.
+      - name: slack_handles
+        description: spoken names as Slack handles
+        replace:
+          '@marie.dupont': ['/\\bmention(?:ne)? marie\\b/']
+          '@tleroy': ['/\\bmention(?:ne)? thomas\\b/']
+          '@priya': ['/\\bmention(?:ne)? priya\\b/']
+
       - name: slack_mentions
-        description: turn people's names into Slack mentions
-        prompt: |
-          Return the text word for word, with one kind of change and no
-          other: a name that appears in this list becomes its handle.
-
-            Marie   -> @marie.dupont
-            Thomas  -> @tleroy
-            Priya   -> @priya
-
-          Every occurrence, including where the message is about that person
-          rather than to them.
-
-          A name that is not in the list is left exactly as it was. Sofia
-          stays Sofia. Never give a name a handle that belongs to someone
-          else, and never invent one.
-
-          Two group mentions are a judgement rather than a lookup. "everyone
-          here", "whoever is around" -> @here, which pings the people who are
-          online. "the whole channel", "everyone", "all of them" -> @channel,
-          which pings the ones who are away too. Only where the text means
-          the people: "the file is here" is a place, and stays.
-
-          A mention replaces the words that name the person or the group, and
-          not one word more: "heads up to the whole channel" comes back as
-          "heads up to @channel".
-
-          Nothing is ever deleted. Every other word, the order and the
-          punctuation come back as they went in.
-
-          Return only the text.
+        description: spoken group mentions as @here and @channel
+        replace:
+          '@here': ['/\\bmention(?:ne)? (?:everyone here|here)\\b/']
+          '@channel': ['/\\bmention(?:ne)? (?:the )?(?:whole )?channel\\b/']
 
       # The two tables the pipeline above names. Same pattern, different output:
       # that is the whole reason a table has a name.

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1620,6 +1620,7 @@ if __name__ == "__main__":
       # the version that forced them from spoken ordinals dropped an item.
       - name: email
         description: lay dictated text out as an email
+        display: Laying out the email
         prompt: |
           Lay the text out as an email, in the language it was dictated in.
           Fix the writing; do not write it.
@@ -1662,6 +1663,7 @@ if __name__ == "__main__":
       # speaker's voice going out with the hesitations.
       - name: slack
         description: tidy dictated text into a chat message
+        display: Tidying for chat
         prompt: |
           Tidy the text into a chat message, in the language it was dictated
           in. Fix the writing; do not write it.
@@ -1699,6 +1701,7 @@ if __name__ == "__main__":
       # Put your own people in the list.
       - name: slack_mentions
         description: turn people's names into Slack mentions
+        display: Adding mentions
         prompt: |
           Return the text word for word, with one kind of change and no
           other: a name that appears in this list becomes its handle.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -89,6 +89,13 @@ transcription:
       # know that every other tab gets the stage too.
       - transform: email
         app: /mail|outlook|thunderbird|superhuman|missive/
+      # Free and exact, and ahead of the prompt on purpose: a handle is a token
+      # a model leaves alone, where "mention marie" is a phrase it might tidy
+      # away. Measured — the handles come through `slack` untouched.
+      - transform: slack_handles
+        app: /slack/
+      - transform: slack_mentions
+        app: /slack/
       - transform: slack
         app: /slack/
 
@@ -308,58 +315,41 @@ transforms:
 
       Return only the message.
 
-  # Asked for out loud — "hey parrot, use Slack mentions" — and deliberately
-  # not in the pipeline above. A message that names someone is not a message
-  # that pings them, and nothing in a transcript tells the two apart. So this
-  # one you say, and `confirm` shows you who is about to be tagged before
-  # anything is replaced.
+  # Two tables rather than one prompt, and the marker word is why they can be.
   #
-  # The mapping lives in the prompt rather than in a `replace:` table because a
-  # table is not reachable by voice — it runs from a pipeline only, and a
-  # pipeline is where this must not be. It is also the better half of the trade:
-  # names are a lookup a table would do exactly, but "let everyone here know"
-  # -> @here is a judgement, and a pattern that turned every "here" into @here
-  # is one you would switch off after a single message.
+  # A name is a lookup. The prompt that used to do this got to 6/6 after four
+  # rewrites, and its first draft answered "Sofia already looked at it" with
+  # "@priya already looked at it" — a handle invented for a name it had never
+  # been given, which in Slack is a message sent to the wrong person. A table
+  # cannot do that. It substitutes what is in it, leaves the rest alone, costs
+  # nothing, and needs no model running.
   #
-  # Put your own people in the list. 6/6 as written, and the first draft was
-  # 2/6 in the direction that costs the most — it answered "Sofia already
-  # looked at it" with "@priya already looked at it", inventing a handle for a
-  # name it had never been given, and it swallowed the words in front of the
-  # first mention ("heads up to the whole channel" -> "@channel,"). Three
-  # sentences fixed both and all three are load-bearing: the one naming a name
-  # off the list, the one saying a mention replaces the words that name the
-  # person and not one more, and "nothing is ever deleted".
+  # `mention` is the safety, not the syntax. Without a marker the table would
+  # turn every "Marie" into a ping, and a message that names someone is not a
+  # message that pings them. It is said in the same breath, so unlike the voice
+  # command this replaces it costs no round trip:
+  #
+  #     "mention marie can you look at this"
+  #     -> "@marie.dupont can you look at this"
+  #
+  # Two tables and not one, so the group pings can go without the handles going
+  # with them: those are the two that wake people up, and @channel reaches the
+  # ones who are away.
+  #
+  # To fill this in, hand Claude Code your team's names and handles and ask it
+  # to update this table. The shape is regular and the names are yours.
+  - name: slack_handles
+    description: spoken names as Slack handles
+    replace:
+      '@marie.dupont': ['/\bmention(?:ne)? marie\b/']
+      '@tleroy': ['/\bmention(?:ne)? thomas\b/']
+      '@priya': ['/\bmention(?:ne)? priya\b/']
+
   - name: slack_mentions
-    description: turn people's names into Slack mentions
-    prompt: |
-      Return the text word for word, with one kind of change and no
-      other: a name that appears in this list becomes its handle.
-
-        Marie   -> @marie.dupont
-        Thomas  -> @tleroy
-        Priya   -> @priya
-
-      Every occurrence, including where the message is about that person
-      rather than to them.
-
-      A name that is not in the list is left exactly as it was. Sofia
-      stays Sofia. Never give a name a handle that belongs to someone
-      else, and never invent one.
-
-      Two group mentions are a judgement rather than a lookup. "everyone
-      here", "whoever is around" -> @here, which pings the people who are
-      online. "the whole channel", "everyone", "all of them" -> @channel,
-      which pings the ones who are away too. Only where the text means
-      the people: "the file is here" is a place, and stays.
-
-      A mention replaces the words that name the person or the group, and
-      not one word more: "heads up to the whole channel" comes back as
-      "heads up to @channel".
-
-      Nothing is ever deleted. Every other word, the order and the
-      punctuation come back as they went in.
-
-      Return only the text.
+    description: spoken group mentions as @here and @channel
+    replace:
+      '@here': ['/\bmention(?:ne)? (?:everyone here|here)\b/']
+      '@channel': ['/\bmention(?:ne)? (?:the )?(?:whole )?channel\b/']
 
   # The two tables the pipeline above names. Same pattern, different output:
   # that is the whole reason a table has a name.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -237,28 +237,37 @@ transforms:
   # costs you something: a model handed a dictated email will gladly return a
   # better one, in its own voice, and you will not notice until it has gone.
   #
-  # 6/7 on gemma4:e4b, and every version in between is in the failure, not the
-  # number. What the seven cases caught, in the order they were caught:
+  # 8/10 on gemma4:e4b. Six versions before this one, and what the cases caught:
   #
   #   v1  "if none was dictated, do not invent one" -> a "Hi," invented anyway,
   #       and a spoken "thanks Nathan" reduced to "Nathan". A prohibition read
   #       as a topic.
   #   v2  the greeting rule turned around to say what the email starts with
   #       when there is no hello, and the closing word tied to the signature.
-  #       Both fixed. 5/7.
-  #   v3  "Nothing is ever deleted" added -> the model answered with a literal
-  #       "[Signature]" placeholder and went back to inventing a greeting. A
-  #       rule about restraint made it less restrained, exactly as it did in
-  #       tests/grammar-cases.yaml.
-  #   v4  the greeting rule given examples — "bonjour Marie, hi Tom" -> the
-  #       examples came back in the output as "Hi Tom," and "À toi,". Elsewhere
-  #       here examples beat rules; not here.
-  #   v5  a short reply named as its own case, no line put anywhere. 6/7.
+  #   v3  "Nothing is ever deleted" added -> a literal "[Signature]" in the
+  #       output and a greeting invented again. A rule about restraint made it
+  #       less restrained, exactly as in tests/grammar-cases.yaml.
+  #   v4  the greeting rule given worked examples — "bonjour Marie, hi Tom" ->
+  #       the examples came back in the output as "Hi Tom," and "À toi,".
+  #   v5  a short reply named as its own case. 6/7 on the cases that existed.
+  #   v6  lists. Two lessons: the model needs to be told it may count for
+  #       itself — "three or more things in a row" left "here is what I need
+  #       from you the invoice the signed contract and the shipping address"
+  #       inline until the rule said no number has to be spoken — and the rule
+  #       has to sit with the paragraph rule. Moved after the short-reply
+  #       clause it dominated: a two-word reply came back as "[No body text]".
   #
-  # The one that fails is "yes that works for me see you thursday", which comes
-  # back as "See you Thursday." — two clauses run together with no comma read
-  # as one goodbye. The same sentence with the comma is right. It is left in
-  # the set failing rather than argued with.
+  # Two failures left, and they are one shape: a short reply ending in a
+  # goodbye comes back as the goodbye alone. "yes that works for me see you
+  # thursday" -> "See you Thursday.", and "ok pour moi, à jeudi" -> "À jeudi,".
+  # The same sentence with a comma is right. Three framings have bounced off
+  # it, the third being a clause saying a goodbye is not a signature to lift
+  # out, so it is recorded rather than argued with.
+  #
+  # Numbered lists are not in it. Spoken ordinals — "first we deploy, second we
+  # run the tests" — stay as sentences, and the version that forced them
+  # dropped an item on the floor, which is a worse thing to ship than prose
+  # where a list was wanted. Dashes only.
   - name: email
     description: lay dictated text out as an email
     prompt: |
@@ -274,7 +283,15 @@ transforms:
       starts with the first sentence. Never add a greeting nobody spoke.
 
       Break the body into paragraphs where the subject changes, a blank
-      line between them. Add no headings, no bullets and no emphasis.
+      line between them. Add no headings and no emphasis.
+
+      Three or more things listed in a row never stay inline. Whatever
+      joined them — commas, "and", nothing at all — the words introducing
+      them take a colon and each thing goes on a line of its own behind a
+      dash. No number has to be said for this: "here is what I need from
+      you", "the steps are", "we should" all open a list as surely as
+      "there are three things" does. Two things are a sentence and stay
+      one.
 
       A name at the end is a signature: a blank line, then the name on
       its own line, and a closing word said just before it — thanks,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -263,6 +263,7 @@ transforms:
   # where a list was wanted. Dashes only.
   - name: email
     description: lay dictated text out as an email
+    display: Laying out the email
     prompt: |
       Lay the text out as an email, in the language it was dictated in.
       Fix the writing; do not write it.
@@ -307,6 +308,7 @@ transforms:
   # speaker's voice going out with the hesitations.
   - name: slack
     description: tidy dictated text into a chat message
+    display: Tidying for chat
     prompt: |
       Tidy the text into a chat message, in the language it was dictated
       in. Fix the writing; do not write it.
@@ -362,6 +364,7 @@ transforms:
   # Put your own people in the list.
   - name: slack_mentions
     description: turn people's names into Slack mentions
+    display: Adding mentions
     prompt: |
       Return the text word for word, with one kind of change and no
       other: a name that appears in this list becomes its handle.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -353,20 +353,36 @@ transforms:
   # with them: those are the two that wake people up, and @channel reaches the
   # ones who are away.
   #
+  #
+  # The marker has to open the message or follow a pause, and that is the half
+  # of the safety the first version of this table did not have. "mention" is an
+  # ordinary English verb: "I should mention here that the deadline changed"
+  # came back as "I should @here that the deadline changed", and "I wanted to
+  # mention Marie is off next week" pinged Marie. Neither is a message anyone
+  # meant to send, and a pipeline stage has no preview to catch it — it runs on
+  # a transcript nobody has seen yet.
+  #
+  # So the word counts only at the start of the utterance or straight after
+  # . ! ? ; or a comma, which is where it lands when you mean it and almost
+  # never where the verb does. Same shape as the stop lists on `dotted`, for
+  # the same reason: that pattern has to tell code from prose, this one has to
+  # tell an instruction from a verb. The cost is that "can you mention marie
+  # about the invoice" does nothing — a ping you did not get rather than one
+  # you did not mean, which is the direction to fail in.
   # To fill this in, hand Claude Code your team's names and handles and ask it
   # to update this table. The shape is regular and the names are yours.
   - name: slack_handles
     description: spoken names as Slack handles
     replace:
-      '@marie.dupont': ['/\bmention(?:ne)? marie\b/']
-      '@tleroy': ['/\bmention(?:ne)? thomas\b/']
-      '@priya': ['/\bmention(?:ne)? priya\b/']
+      '$1@marie.dupont': ['/(^|[.!?;,]\s*)mention(?:ne)? marie\b/']
+      '$1@tleroy': ['/(^|[.!?;,]\s*)mention(?:ne)? thomas\b/']
+      '$1@priya': ['/(^|[.!?;,]\s*)mention(?:ne)? priya\b/']
 
   - name: slack_mentions
     description: spoken group mentions as @here and @channel
     replace:
-      '@here': ['/\bmention(?:ne)? (?:everyone here|here)\b/']
-      '@channel': ['/\bmention(?:ne)? (?:the )?(?:whole )?channel\b/']
+      '$1@here': ['/(^|[.!?;,]\s*)mention(?:ne)? (?:everyone here|here)\b/']
+      '$1@channel': ['/(^|[.!?;,]\s*)mention(?:ne)? (?:the )?(?:whole )?channel\b/']
 
   # The two tables the pipeline above names. Same pattern, different output:
   # that is the whole reason a table has a name.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -89,13 +89,6 @@ transcription:
       # know that every other tab gets the stage too.
       - transform: email
         app: /mail|outlook|thunderbird|superhuman|missive/
-      # Free and exact, and ahead of the prompt on purpose: a handle is a token
-      # a model leaves alone, where "mention marie" is a phrase it might tidy
-      # away. Measured — the handles come through `slack` untouched.
-      - transform: slack_handles
-        app: /slack/
-      - transform: slack_mentions
-        app: /slack/
       - transform: slack
         app: /slack/
 
@@ -332,57 +325,72 @@ transforms:
 
       Return only the message.
 
-  # Two tables rather than one prompt, and the marker word is why they can be.
+  # Said out loud — "hey parrot, use Slack mentions" — and deliberately in no
+  # pipeline. A message that names someone is not a message that pings them,
+  # and nothing in a transcript tells the two apart. So this is the one you ask
+  # for, and `confirm` shows you who is about to be tagged before anything is
+  # replaced.
   #
-  # A name is a lookup. The prompt that used to do this got to 6/6 after four
-  # rewrites, and its first draft answered "Sofia already looked at it" with
-  # "@priya already looked at it" — a handle invented for a name it had never
-  # been given, which in Slack is a message sent to the wrong person. A table
-  # cannot do that. It substitutes what is in it, leaves the rest alone, costs
-  # nothing, and needs no model running.
+  # It was two `replace:` tables for a while, which is the shape a mapping
+  # wants. A table cannot invent a handle, where this prompt's first draft
+  # answered "Sofia already looked at it" with "@priya already looked at it"
+  # and took four rewrites to reach 6/6. The tables scored 7/7 and cost
+  # nothing.
   #
-  # `mention` is the safety, not the syntax. Without a marker the table would
-  # turn every "Marie" into a ping, and a message that names someone is not a
-  # message that pings them. It is said in the same breath, so unlike the voice
-  # command this replaces it costs no round trip:
+  # They came back out because a table has to be triggered from inside the
+  # sentence, and the only word for the job is one English already uses:
   #
-  #     "mention marie can you look at this"
-  #     -> "@marie.dupont can you look at this"
+  #     "I should mention here that the deadline changed"
+  #       -> "I should @here that the deadline changed"
+  #     "I wanted to mention Marie is off next week"
+  #       -> "I wanted to @marie.dupont is off next week"
   #
-  # Two tables and not one, so the group pings can go without the handles going
-  # with them: those are the two that wake people up, and @channel reaches the
-  # ones who are away.
+  # Anchoring the marker to the start of an utterance fixed those, 11/11, at
+  # the price of "can you mention marie about the invoice" doing nothing. And a
+  # pipeline stage has no preview — it runs on a transcript nobody has seen
+  # yet, so a false positive there is a message already sent. Asking out loud
+  # has no such failure: it fires when you ask and never otherwise, which is
+  # worth a second and a prompt that had to be taught not to guess.
   #
+  # Still open, and it decides whether any of this is worth having: ParrotFlow
+  # inserts by Cmd-V in both insert modes, and Slack's composer does not re-read
+  # what arrives by paste — the finding that keeps `backticks` out of the
+  # shipped pipeline. If a pasted @handle does not linkify, this writes
+  # something that looks like a mention and notifies nobody. Paste one into a
+  # Slack composer without sending, and see whether it turns blue.
   #
-  # The marker has to open the message or follow a pause, and that is the half
-  # of the safety the first version of this table did not have. "mention" is an
-  # ordinary English verb: "I should mention here that the deadline changed"
-  # came back as "I should @here that the deadline changed", and "I wanted to
-  # mention Marie is off next week" pinged Marie. Neither is a message anyone
-  # meant to send, and a pipeline stage has no preview to catch it — it runs on
-  # a transcript nobody has seen yet.
-  #
-  # So the word counts only at the start of the utterance or straight after
-  # . ! ? ; or a comma, which is where it lands when you mean it and almost
-  # never where the verb does. Same shape as the stop lists on `dotted`, for
-  # the same reason: that pattern has to tell code from prose, this one has to
-  # tell an instruction from a verb. The cost is that "can you mention marie
-  # about the invoice" does nothing — a ping you did not get rather than one
-  # you did not mean, which is the direction to fail in.
-  # To fill this in, hand Claude Code your team's names and handles and ask it
-  # to update this table. The shape is regular and the names are yours.
-  - name: slack_handles
-    description: spoken names as Slack handles
-    replace:
-      '$1@marie.dupont': ['/(^|[.!?;,]\s*)mention(?:ne)? marie\b/']
-      '$1@tleroy': ['/(^|[.!?;,]\s*)mention(?:ne)? thomas\b/']
-      '$1@priya': ['/(^|[.!?;,]\s*)mention(?:ne)? priya\b/']
-
+  # Put your own people in the list.
   - name: slack_mentions
-    description: spoken group mentions as @here and @channel
-    replace:
-      '$1@here': ['/(^|[.!?;,]\s*)mention(?:ne)? (?:everyone here|here)\b/']
-      '$1@channel': ['/(^|[.!?;,]\s*)mention(?:ne)? (?:the )?(?:whole )?channel\b/']
+    description: turn people's names into Slack mentions
+    prompt: |
+      Return the text word for word, with one kind of change and no
+      other: a name that appears in this list becomes its handle.
+
+        Marie   -> @marie.dupont
+        Thomas  -> @tleroy
+        Priya   -> @priya
+
+      Every occurrence, including where the message is about that person
+      rather than to them.
+
+      A name that is not in the list is left exactly as it was. Sofia
+      stays Sofia. Never give a name a handle that belongs to someone
+      else, and never invent one.
+
+      Two group mentions are a judgement rather than a lookup. "everyone
+      here", "whoever is around" -> @here, which pings the people who are
+      online. "the whole channel", "everyone", "all of them" -> @channel,
+      which pings the ones who are away too. Only where the text means
+      the people: "the file is here" is a place, and stays.
+
+      A mention replaces the words that name the person or the group, and
+      not one word more: "heads up to the whole channel" comes back as
+      "heads up to @channel".
+
+      Nothing is ever deleted. Every other word, the order and the
+      punctuation come back as they went in.
+
+      Return only the text.
 
   # The two tables the pipeline above names. Same pattern, different output:
   # that is the whole reason a table has a name.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -330,8 +330,15 @@ transforms:
   # Said out loud — "hey parrot, use Slack mentions" — and deliberately in no
   # pipeline. A message that names someone is not a message that pings them,
   # and nothing in a transcript tells the two apart. So this is the one you ask
-  # for, and `confirm` shows you who is about to be tagged before anything is
-  # replaced.
+  # for.
+  #
+  # `confirm` covers one of the two ways of asking, not both. Said with text
+  # selected, the result is shown before it replaces anything, so you see who
+  # is about to be tagged. Said mid-sentence — "by the way parrot, use Slack
+  # mentions" — there is no preview whatever `confirm` says, because nothing is
+  # being overwritten there and a dialog would cost the round trip that path
+  # exists to save. What both produce is text in your composer; ParrotFlow
+  # sends nothing, so the last look is yours before you press Enter.
   #
   # It was two `replace:` tables for a while, which is the shape a mapping
   # wants. A table cannot invent a handle, where this prompt's first draft

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -78,6 +78,19 @@ transcription:
       - transform: code_identifiers
         app: /term|ghostty|warp|kitty|alacritty|hyper|code|cursor|zed|xcode|jetbrains|idea|pycharm|webstorm/
         when: /\b(?:function|method|variable|class|constant|type|struct|interface|enum|fonction|méthode|classe|constante)\b/
+      # The two stages that cost a second, and the only two here that ask the
+      # model. Dictated prose arrives as one block: no greeting on its own
+      # line, no paragraph breaks, the hesitations still in it. That is layout,
+      # which is the one thing a substitution cannot do — so it is worth the
+      # second, in the two windows where you write to people and nowhere else.
+      #
+      # Gmail in a browser tab is not an app. `app:` reads the window that was
+      # in front, so put your browser in the pattern if you live in Gmail, and
+      # know that every other tab gets the stage too.
+      - transform: email
+        app: /mail|outlook|thunderbird|superhuman|missive/
+      - transform: slack
+        app: /slack/
 
   # The spelling you want, and the ways it comes out wrong. Whole words,
   # case-insensitive. A source in /slashes/ is a regular expression, and an
@@ -205,6 +218,146 @@ transforms:
 
       A phrase before the main clause takes a comma after it. A trailing
       please or thanks does not.
+
+      Return only the text.
+
+  # Two prompts scoped to one kind of window each, and the pipeline above runs
+  # them there. `grammar` mends a sentence; these two also lay one out — a
+  # greeting on its own line, a blank line where the subject changes — which is
+  # the part no substitution can express and the reason they are prompts.
+  #
+  # Both are told twice not to write anything, because that is the failure that
+  # costs you something: a model handed a dictated email will gladly return a
+  # better one, in its own voice, and you will not notice until it has gone.
+  #
+  # 6/7 on gemma4:e4b, and every version in between is in the failure, not the
+  # number. What the seven cases caught, in the order they were caught:
+  #
+  #   v1  "if none was dictated, do not invent one" -> a "Hi," invented anyway,
+  #       and a spoken "thanks Nathan" reduced to "Nathan". A prohibition read
+  #       as a topic.
+  #   v2  the greeting rule turned around to say what the email starts with
+  #       when there is no hello, and the closing word tied to the signature.
+  #       Both fixed. 5/7.
+  #   v3  "Nothing is ever deleted" added -> the model answered with a literal
+  #       "[Signature]" placeholder and went back to inventing a greeting. A
+  #       rule about restraint made it less restrained, exactly as it did in
+  #       tests/grammar-cases.yaml.
+  #   v4  the greeting rule given examples — "bonjour Marie, hi Tom" -> the
+  #       examples came back in the output as "Hi Tom," and "À toi,". Elsewhere
+  #       here examples beat rules; not here.
+  #   v5  a short reply named as its own case, no line put anywhere. 6/7.
+  #
+  # The one that fails is "yes that works for me see you thursday", which comes
+  # back as "See you Thursday." — two clauses run together with no comma read
+  # as one goodbye. The same sentence with the comma is right. It is left in
+  # the set failing rather than argued with.
+  - name: email
+    description: lay dictated text out as an email
+    prompt: |
+      Lay the text out as an email, in the language it was dictated in.
+      Fix the writing; do not write it.
+
+      Correct grammar, spelling and punctuation, and drop the hesitations
+      — um, uh, euh, well, you know, I mean. Every other word survives:
+      the wording, the order and the tone are the speaker's.
+
+      If the text opens with a greeting, it goes on its own line, with a
+      comma after it and a blank line under it. If it does not, the email
+      starts with the first sentence. Never add a greeting nobody spoke.
+
+      Break the body into paragraphs where the subject changes, a blank
+      line between them. Add no headings, no bullets and no emphasis.
+
+      A name at the end is a signature: a blank line, then the name on
+      its own line, and a closing word said just before it — thanks,
+      merci — on the line above. No name at the end means no signature:
+      the last thing said is the last line of the body, wherever it
+      sounds like a goodbye.
+
+      A short reply is not an email with parts. One or two sentences and
+      no hello in front of them come back as one or two sentences,
+      corrected, with no line put anywhere.
+
+      Return only the email.
+
+  # 3/3. "Add nothing" rather than "no greeting, no sign-off": the second
+  # wording read as an instruction to remove one, and "hey uh quick one the
+  # build is red" came back as "The build is red" — two spoken words gone
+  # because a rule about what not to add was read as a rule about what to
+  # strip. "Remove nothing either" is there for the same reason, and the slang
+  # line because "gonna" was being corrected to "going to", which is the
+  # speaker's voice going out with the hesitations.
+  - name: slack
+    description: tidy dictated text into a chat message
+    prompt: |
+      Tidy the text into a chat message, in the language it was dictated
+      in. Fix the writing; do not write it.
+
+      Correct grammar, spelling and punctuation, and drop the hesitations
+      — um, uh, euh, well, you know, I mean. Every other word survives.
+      Slang and contractions are the speaker's voice rather than
+      mistakes: gonna stays gonna, ouais stays ouais.
+
+      Add nothing: no greeting, no sign-off, no heading, no bullet, no
+      bold, no backtick. Slack's composer renders none of that when text
+      arrives by paste, so it would land in the message as characters.
+      Remove nothing either: a spoken "hey" is part of the message.
+
+      One paragraph, unless the text plainly holds two.
+
+      Return only the message.
+
+  # Asked for out loud — "hey parrot, use Slack mentions" — and deliberately
+  # not in the pipeline above. A message that names someone is not a message
+  # that pings them, and nothing in a transcript tells the two apart. So this
+  # one you say, and `confirm` shows you who is about to be tagged before
+  # anything is replaced.
+  #
+  # The mapping lives in the prompt rather than in a `replace:` table because a
+  # table is not reachable by voice — it runs from a pipeline only, and a
+  # pipeline is where this must not be. It is also the better half of the trade:
+  # names are a lookup a table would do exactly, but "let everyone here know"
+  # -> @here is a judgement, and a pattern that turned every "here" into @here
+  # is one you would switch off after a single message.
+  #
+  # Put your own people in the list. 6/6 as written, and the first draft was
+  # 2/6 in the direction that costs the most — it answered "Sofia already
+  # looked at it" with "@priya already looked at it", inventing a handle for a
+  # name it had never been given, and it swallowed the words in front of the
+  # first mention ("heads up to the whole channel" -> "@channel,"). Three
+  # sentences fixed both and all three are load-bearing: the one naming a name
+  # off the list, the one saying a mention replaces the words that name the
+  # person and not one more, and "nothing is ever deleted".
+  - name: slack_mentions
+    description: turn people's names into Slack mentions
+    prompt: |
+      Return the text word for word, with one kind of change and no
+      other: a name that appears in this list becomes its handle.
+
+        Marie   -> @marie.dupont
+        Thomas  -> @tleroy
+        Priya   -> @priya
+
+      Every occurrence, including where the message is about that person
+      rather than to them.
+
+      A name that is not in the list is left exactly as it was. Sofia
+      stays Sofia. Never give a name a handle that belongs to someone
+      else, and never invent one.
+
+      Two group mentions are a judgement rather than a lookup. "everyone
+      here", "whoever is around" -> @here, which pings the people who are
+      online. "the whole channel", "everyone", "all of them" -> @channel,
+      which pings the ones who are away too. Only where the text means
+      the people: "the file is here" is a place, and stays.
+
+      A mention replaces the words that name the person or the group, and
+      not one word more: "heads up to the whole channel" comes back as
+      "heads up to @channel".
+
+      Nothing is ever deleted. Every other word, the order and the
+      punctuation come back as they went in.
 
       Return only the text.
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -384,8 +384,8 @@ URL.
 **They cost the router something, and it is measured.** Both are prompts, so
 both join the catalogue the activation phrase reaches, and every description
 added is another way for an idle sentence to find a tool.
-`tests/routing-cases.yaml` was rerun and grew: 41/45 on three prompts, 47/52 on
-five. One new failure appeared and it is the expensive class, the one the
+`tests/routing-cases.yaml` was rerun and grew: 41/45 on three prompts, 50/54 on
+six. One new failure appeared and it is the expensive class, the one the
 negative half of that set exists for:
 
 ```
@@ -396,49 +396,33 @@ A sentence, not an instruction, sent to a prompt that would rewrite your
 selection. Four descriptions were measured against it and all four routed it
 identically, so it is recorded there rather than tuned away.
 
-### `slack_handles` and `slack_mentions`, which are tables
+### `slack_mentions`, which you have to ask for
+
+Said out loud — "hey parrot, use Slack mentions" — and deliberately in no
+pipeline. A message that names someone is not a message that pings them, and
+nothing in a transcript tells the two apart. So it is the one you ask for, and
+`confirm` shows you who is about to be tagged before anything is replaced.
+
+**The mapping lives in the prompt**, which is the opposite of the rule
+everywhere else here, and it was tried the other way round. The tables are
+worth reading about because of what they cost, not because they failed:
 
 ```yaml
 - name: slack_handles
-  description: spoken names as Slack handles
   replace:
     '@marie.dupont': ['/\bmention(?:ne)? marie\b/']
-
-- name: slack_mentions
-  description: spoken group mentions as @here and @channel
-  replace:
-    '@here': ['/\bmention(?:ne)? (?:everyone here|here)\b/']
 ```
 
-Both run from the Slack pipeline, ahead of the `slack` prompt.
+A table cannot invent. This prompt's first draft answered "the config file is
+here, Sofia already looked at it" with "…@priya already looked at it" — a handle
+made up for a name it had never been given, which in Slack is a message sent to
+the wrong person — and it took four rewrites and three load-bearing sentences to
+reach 6/6. The tables reached **7/7** on the same cases, for free, with nothing
+running. On the mapping alone the table wins outright.
 
-**This was a prompt first, and it was the wrong tool.** A name is a lookup, and
-the thing a lookup must never do is answer with something that was not in it.
-The prompt did exactly that: its first draft turned "the config file is here,
-Sofia already looked at it" into "…@priya already looked at it" — a handle
-invented for a name it had never been given, which in Slack is a message sent
-to the wrong person. It took four rewrites and three load-bearing sentences to
-reach 6/6, and it still cost a second per message and a model being up.
-
-A table cannot invent. It substitutes what is in it and leaves everything else,
-in microseconds, with nothing running. **7/7 on the same cases, and the two that
-mattered — "Sofia" and a bare "Marie" — are not failures it passes but shapes it
-has no way to produce.**
-
-**The marker is the safety, and it is what makes a table possible here.** The
-prompt was reachable only by voice — "hey parrot, use Slack mentions" — because
-a table in a pipeline would have turned every "Marie" into a ping, and a message
-that names someone is not a message that pings them. `mention` in front of the
-name is the same opt-in, said in the same breath, and it costs no round trip:
-
-```
-"mention marie can you look at this"  ->  "@marie.dupont can you look at this"
-"mention everyone here"               ->  "@here"
-```
-
-**It has to open the message or follow a pause**, and the first version of this
-table did not say so. `mention` is an ordinary English verb, and it read as an
-instruction wherever it appeared:
+**What it lost on was the trigger.** A table has to fire from inside the
+sentence, and the only natural word for it is one English already uses as a
+verb:
 
 ```
 "I should mention here that the deadline changed"
@@ -447,36 +431,27 @@ instruction wherever it appeared:
   ->  "I wanted to @marie.dupont is off next week"
 ```
 
-Neither is a message anyone meant to send, and a pipeline stage has no preview
-to catch it — it runs on a transcript nobody has seen yet, so `confirm` does not
-apply. The pattern therefore counts the word only at the start of the utterance
-or straight after `.` `!` `?` `;` or a comma:
+Anchoring the marker to the start of an utterance or to a `.` `!` `?` `;` or
+comma fixed those — **11/11**, five prose sentences that must not ping and six
+deliberate forms that must — at the price of "can you mention marie about the
+invoice" doing nothing at all. But a pipeline stage has **no preview**: it runs
+on a transcript nobody has seen yet, so `confirm` does not reach it and a false
+positive is a message that has already gone.
 
-```
-/(^|[.!?;,]\s*)mention(?:ne)? marie\b/  ->  $1@marie.dupont
-```
+Asking out loud has no such failure. It fires when you ask and never otherwise,
+which is worth a second and a prompt that had to be taught not to guess. The
+table is the better mapping; the voice command is the better trigger, and the
+trigger is where the expensive mistakes live.
 
-Which is the same shape as the stop lists on `dotted`, for the same reason: that
-pattern has to tell code from prose, and this one has to tell an instruction
-from a verb. **11/11** — five prose sentences that must not ping, six deliberate
-forms that must. The cost is that "can you mention marie about the invoice" does
-nothing, which is the direction to fail in: a ping you did not get rather than
-one you did not mean.
-
-That also removes the argument for keeping a mapping inside a prompt, which was
-the one place in this file where a lookup was not a table.
-
-**Two tables rather than one**, so the group pings can be deleted without the
-handles going with them: `@here` and `@channel` are the two that wake people up.
-
-**They run before the `slack` prompt** because a handle is a token a model
-leaves alone, where "mention marie" is a phrase it might tidy away. Measured
-rather than assumed — the handles come through the prompt untouched, 3/3.
-
-**Filling it in.** The shape is regular and the contents are your colleagues, so
-hand your team's names and handles to Claude Code and ask it to update the
-table. That is the maintenance path, the same way `replacements:` is filled from
-`--transcribe` output.
+**One thing is still open, and it decides whether any of this is worth having.**
+`TextInserter` puts the text on the pasteboard and synthesises ⌘V — in both
+insert modes, so everything ParrotFlow writes arrives in Slack by paste. And
+Slack's composer does not re-read what arrives by paste: that is the finding
+that keeps `backticks` out of the shipped pipeline, tested on a real Slack. If a
+pasted `@handle` does not linkify either, this writes something that looks like
+a mention and notifies nobody, which is worse than not having it — you would
+believe you had told someone. Paste one into a Slack composer without sending
+and see whether it turns blue.
 
 ### Order matters, and only one set notices
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -298,6 +298,130 @@ Add the step if your chat app renders pasted markup. Getting this to work
 properly means putting rich text on the clipboard rather than markdown
 characters, which is a different feature.
 
+### Writing to people: `email` and `slack`
+
+Two prompts scoped to one kind of window each, and the first stages that ask
+the model from a pipeline rather than from the activation phrase:
+
+```yaml
+- transform: email
+  app: /mail|outlook|thunderbird|superhuman|missive/
+- transform: slack
+  app: /slack/
+```
+
+`grammar` mends a sentence. These two also **lay one out**, which is the part
+no substitution can express: dictated prose arrives as a single block with the
+greeting run into the first sentence, no paragraph breaks, and the hesitations
+still in it. A comma and a newline after "Bonjour Marie" is not a rewrite of
+your words, and it is not something a table can be taught.
+
+`email` puts the greeting on its own line with a blank line under it, breaks
+the body where the subject changes, and treats a name at the end as a
+signature. `slack` does almost none of that — no greeting, no sign-off, one
+paragraph — and is explicitly told to emit no markup at all, for the reason
+`backticks` is not in the shipped pipeline: Slack's composer does not render
+markdown that arrives by paste, so bold or bullets land in the message as
+characters.
+
+Both are told twice not to write anything. That is the failure worth spending
+tokens on: a model handed a dictated email will gladly return a better one, in
+its own voice, and nothing on screen says it happened — a pipeline stage runs
+on a transcript nobody has seen yet, so `confirm` does not apply to it.
+
+**6/7 and 3/3 on gemma4:e4b**, and the versions in between are written into
+config.example.yaml beside each prompt, because what they cost is the useful
+part. Three findings, all of them the prompt making things worse before better:
+
+| Wording | What it did |
+|---|---|
+| "If none was dictated, do not invent one" | invented a greeting anyway — a prohibition read as a topic |
+| "Nothing is ever deleted" | answered with a literal `[Signature]` placeholder |
+| the greeting rule given examples | put the examples in the output: "Hi Tom," and "À toi," |
+
+The first is the lesson `tests/grammar-cases.yaml` already records — a rule
+about restraint making the model less restrained. The third is that file's
+other lesson running the opposite way: elsewhere here examples beat rules, and
+in a prompt whose output is the same shape as its examples they get copied.
+
+What fixed the greeting was turning the prohibition around and saying what the
+email starts with when there is no hello. What fixed a dropped `thanks` was
+tying the closing word to the signature instead of listing it among the things
+not to add. And `slack` says "Add nothing" rather than "No greeting, no
+sign-off", because the second wording was read as an instruction to *remove*
+one: "hey uh quick one the build is red" came back as "The build is red".
+
+The case still failing is `yes that works for me see you thursday`, which comes
+back as `See you Thursday.` — two clauses run together with no comma read as
+one goodbye. With the comma it is right. It is left failing rather than argued
+with.
+
+**Neither is in the shipped default pipeline.** Every stage a new install gets
+is free and needs nothing running; these cost about a second and do nothing at
+all without Ollama. Same rule as the `--model` switch on `code_identifiers`,
+which ships off for the same reason. config.example.yaml has them wired up.
+
+**Gmail in a browser tab is not an app.** `app:` reads the window that was in
+front, which is `Google Chrome com.google.Chrome` — so name your browser in the
+pattern if you live in Gmail, and accept that every other tab gets the stage
+too. There is no narrower answer available: the condition is a window, not a
+URL.
+
+**They cost the router something, and it is measured.** Both are prompts, so
+both join the catalogue the activation phrase reaches, and every description
+added is another way for an idle sentence to find a tool. `tests/routing-cases.
+yaml` went from 41/45 on three prompts to 50/54 on six — one old failure
+started passing, and one new one appeared: "I sent her an email yesterday"
+routes to `email`. That is the expensive class, the one the negative half of
+that set exists for. Four descriptions were measured against it and all four
+routed it identically, so it is recorded there rather than tuned away.
+
+### `slack_mentions`, which you have to ask for
+
+```yaml
+- name: slack_mentions
+  description: turn people's names into Slack mentions
+  prompt: |
+    Replace people's names with their Slack handle. Use only this list:
+
+      Marie   -> @marie.dupont
+      ...
+```
+
+Said out loud — "hey parrot, use Slack mentions" — and deliberately in no
+pipeline. A message that names someone is not a message that pings them, and
+nothing in a transcript tells the two apart. So it is the one you ask for, and
+`confirm` shows you who is about to be tagged before anything is replaced.
+
+**The mapping is in the prompt rather than in a `replace:` table**, which is
+the opposite of the rule everywhere else here. Two reasons, and only the first
+is forced: a table is not reachable by voice — it runs from a pipeline only,
+and a pipeline is exactly where this must not be. The second is that it is the
+better half of the trade anyway. Names are a mapping and a table would do them
+exactly; `@here` is a judgement — "let everyone here know" wants it and "the
+file is here" does not, and a pattern cannot see the difference. The generic
+mentions are the part worth a model, and having them in the same place as the
+names is what keeps it one step rather than two.
+
+**6/6, and the first draft was 2/6 in the expensive direction.** It answered
+"the config file is here, Sofia already looked at it" with "…@priya already
+looked at it" — a handle invented for a name it had never been given, which in
+Slack is a message sent to the wrong person. It also ate the words in front of
+the first mention: "heads up to the whole channel" came back as "@channel,".
+
+Three sentences fixed both, and all three are load-bearing:
+
+- a name off the list is left as it was, with one named — "Sofia stays Sofia"
+- a mention replaces the words that name the person or the group, *and not one
+  word more*, with the failing input as the worked example
+- nothing is ever deleted
+
+The second is the interesting one. The model was not substituting, it was
+summarising a span — and telling it where the span ends is a different
+instruction from telling it what to do. Note also that here the worked example
+helped where the same technique hurt `email`: it names an input, not an output
+shape, so there is nothing to copy.
+
 ### Order matters, and only one set notices
 
 `numbers` runs before `dotted`, because English says "three point one four" for

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -436,6 +436,33 @@ name is the same opt-in, said in the same breath, and it costs no round trip:
 "mention everyone here"               ->  "@here"
 ```
 
+**It has to open the message or follow a pause**, and the first version of this
+table did not say so. `mention` is an ordinary English verb, and it read as an
+instruction wherever it appeared:
+
+```
+"I should mention here that the deadline changed"
+  ->  "I should @here that the deadline changed"
+"I wanted to mention Marie is off next week"
+  ->  "I wanted to @marie.dupont is off next week"
+```
+
+Neither is a message anyone meant to send, and a pipeline stage has no preview
+to catch it — it runs on a transcript nobody has seen yet, so `confirm` does not
+apply. The pattern therefore counts the word only at the start of the utterance
+or straight after `.` `!` `?` `;` or a comma:
+
+```
+/(^|[.!?;,]\s*)mention(?:ne)? marie\b/  ->  $1@marie.dupont
+```
+
+Which is the same shape as the stop lists on `dotted`, for the same reason: that
+pattern has to tell code from prose, and this one has to tell an instruction
+from a verb. **11/11** — five prose sentences that must not ping, six deliberate
+forms that must. The cost is that "can you mention marie about the invoice" does
+nothing, which is the direction to fail in: a ping you did not get rather than
+one you did not mean.
+
 That also removes the argument for keeping a mapping inside a prompt, which was
 the one place in this file where a lookup was not a table.
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -369,58 +369,73 @@ URL.
 
 **They cost the router something, and it is measured.** Both are prompts, so
 both join the catalogue the activation phrase reaches, and every description
-added is another way for an idle sentence to find a tool. `tests/routing-cases.
-yaml` went from 41/45 on three prompts to 50/54 on six — one old failure
-started passing, and one new one appeared: "I sent her an email yesterday"
-routes to `email`. That is the expensive class, the one the negative half of
-that set exists for. Four descriptions were measured against it and all four
-routed it identically, so it is recorded there rather than tuned away.
+added is another way for an idle sentence to find a tool.
+`tests/routing-cases.yaml` was rerun and grew: 41/45 on three prompts, 47/52 on
+five. One new failure appeared and it is the expensive class, the one the
+negative half of that set exists for:
 
-### `slack_mentions`, which you have to ask for
-
-```yaml
-- name: slack_mentions
-  description: turn people's names into Slack mentions
-  prompt: |
-    Replace people's names with their Slack handle. Use only this list:
-
-      Marie   -> @marie.dupont
-      ...
+```
+I sent her an email yesterday  ->  email
 ```
 
-Said out loud — "hey parrot, use Slack mentions" — and deliberately in no
-pipeline. A message that names someone is not a message that pings them, and
-nothing in a transcript tells the two apart. So it is the one you ask for, and
-`confirm` shows you who is about to be tagged before anything is replaced.
+A sentence, not an instruction, sent to a prompt that would rewrite your
+selection. Four descriptions were measured against it and all four routed it
+identically, so it is recorded there rather than tuned away.
 
-**The mapping is in the prompt rather than in a `replace:` table**, which is
-the opposite of the rule everywhere else here. Two reasons, and only the first
-is forced: a table is not reachable by voice — it runs from a pipeline only,
-and a pipeline is exactly where this must not be. The second is that it is the
-better half of the trade anyway. Names are a mapping and a table would do them
-exactly; `@here` is a judgement — "let everyone here know" wants it and "the
-file is here" does not, and a pattern cannot see the difference. The generic
-mentions are the part worth a model, and having them in the same place as the
-names is what keeps it one step rather than two.
+### `slack_handles` and `slack_mentions`, which are tables
 
-**6/6, and the first draft was 2/6 in the expensive direction.** It answered
-"the config file is here, Sofia already looked at it" with "…@priya already
-looked at it" — a handle invented for a name it had never been given, which in
-Slack is a message sent to the wrong person. It also ate the words in front of
-the first mention: "heads up to the whole channel" came back as "@channel,".
+```yaml
+- name: slack_handles
+  description: spoken names as Slack handles
+  replace:
+    '@marie.dupont': ['/\bmention(?:ne)? marie\b/']
 
-Three sentences fixed both, and all three are load-bearing:
+- name: slack_mentions
+  description: spoken group mentions as @here and @channel
+  replace:
+    '@here': ['/\bmention(?:ne)? (?:everyone here|here)\b/']
+```
 
-- a name off the list is left as it was, with one named — "Sofia stays Sofia"
-- a mention replaces the words that name the person or the group, *and not one
-  word more*, with the failing input as the worked example
-- nothing is ever deleted
+Both run from the Slack pipeline, ahead of the `slack` prompt.
 
-The second is the interesting one. The model was not substituting, it was
-summarising a span — and telling it where the span ends is a different
-instruction from telling it what to do. Note also that here the worked example
-helped where the same technique hurt `email`: it names an input, not an output
-shape, so there is nothing to copy.
+**This was a prompt first, and it was the wrong tool.** A name is a lookup, and
+the thing a lookup must never do is answer with something that was not in it.
+The prompt did exactly that: its first draft turned "the config file is here,
+Sofia already looked at it" into "…@priya already looked at it" — a handle
+invented for a name it had never been given, which in Slack is a message sent
+to the wrong person. It took four rewrites and three load-bearing sentences to
+reach 6/6, and it still cost a second per message and a model being up.
+
+A table cannot invent. It substitutes what is in it and leaves everything else,
+in microseconds, with nothing running. **7/7 on the same cases, and the two that
+mattered — "Sofia" and a bare "Marie" — are not failures it passes but shapes it
+has no way to produce.**
+
+**The marker is the safety, and it is what makes a table possible here.** The
+prompt was reachable only by voice — "hey parrot, use Slack mentions" — because
+a table in a pipeline would have turned every "Marie" into a ping, and a message
+that names someone is not a message that pings them. `mention` in front of the
+name is the same opt-in, said in the same breath, and it costs no round trip:
+
+```
+"mention marie can you look at this"  ->  "@marie.dupont can you look at this"
+"mention everyone here"               ->  "@here"
+```
+
+That also removes the argument for keeping a mapping inside a prompt, which was
+the one place in this file where a lookup was not a table.
+
+**Two tables rather than one**, so the group pings can be deleted without the
+handles going with them: `@here` and `@channel` are the two that wake people up.
+
+**They run before the `slack` prompt** because a handle is a token a model
+leaves alone, where "mention marie" is a phrase it might tidy away. Measured
+rather than assumed — the handles come through the prompt untouched, 3/3.
+
+**Filling it in.** The shape is regular and the contents are your colleagues, so
+hand your team's names and handles to Claude Code and ask it to update the
+table. That is the maintenance path, the same way `replacements:` is filled from
+`--transcribe` output.
 
 ### Order matters, and only one set notices
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -400,8 +400,18 @@ identically, so it is recorded there rather than tuned away.
 
 Said out loud — "hey parrot, use Slack mentions" — and deliberately in no
 pipeline. A message that names someone is not a message that pings them, and
-nothing in a transcript tells the two apart. So it is the one you ask for, and
-`confirm` shows you who is about to be tagged before anything is replaced.
+nothing in a transcript tells the two apart. So it is the one you ask for.
+
+**`confirm` covers one of the two ways of asking, not both.** Said with text
+selected, the result is shown before it replaces anything and you see who is
+about to be tagged. Said mid-sentence — "by the way parrot, use Slack mentions"
+— there is no preview whatever `confirm` says: nothing is being overwritten
+there, and a dialog in the middle would give back the round trip that path
+exists to remove. That is the rule for every inline transform, not this one —
+see *An instruction inside a dictation* below.
+
+What both produce is text in your composer. ParrotFlow never sends a message,
+so the last look before anyone is notified is yours.
 
 **The mapping lives in the prompt**, which is the opposite of the rule
 everywhere else here, and it was tried the other way round. The tables are

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -329,15 +329,16 @@ tokens on: a model handed a dictated email will gladly return a better one, in
 its own voice, and nothing on screen says it happened — a pipeline stage runs
 on a transcript nobody has seen yet, so `confirm` does not apply to it.
 
-**6/7 and 3/3 on gemma4:e4b**, and the versions in between are written into
+**8/10 and 3/3 on gemma4:e4b**, and the versions in between are written into
 config.example.yaml beside each prompt, because what they cost is the useful
-part. Three findings, all of them the prompt making things worse before better:
+part. Four findings, all of them the prompt making things worse before better:
 
 | Wording | What it did |
 |---|---|
 | "If none was dictated, do not invent one" | invented a greeting anyway — a prohibition read as a topic |
 | "Nothing is ever deleted" | answered with a literal `[Signature]` placeholder |
 | the greeting rule given examples | put the examples in the output: "Hi Tom," and "À toi," |
+| the list rule moved after the short-reply clause | a two-word reply came back as "[No body text]" |
 
 The first is the lesson `tests/grammar-cases.yaml` already records — a rule
 about restraint making the model less restrained. The third is that file's
@@ -351,10 +352,23 @@ not to add. And `slack` says "Add nothing" rather than "No greeting, no
 sign-off", because the second wording was read as an instruction to *remove*
 one: "hey uh quick one the build is red" came back as "The build is red".
 
-The case still failing is `yes that works for me see you thursday`, which comes
-back as `See you Thursday.` — two clauses run together with no comma read as
-one goodbye. With the comma it is right. It is left failing rather than argued
-with.
+`email` also sets out lists, which is the one place it adds structure rather
+than removing it. Three or more things in a row take a colon and a dash each.
+The rule has to say that **no number needs to have been spoken** — "three or
+more things in a row" on its own left `here is what I need from you the invoice
+the signed contract and the shipping address` inline, because the model was
+waiting to be told there were three.
+
+**Numbered lists are deliberately absent.** Spoken ordinals — "first we deploy,
+second we run the tests" — stay as sentences. The version that forced them to
+1. 2. 3. dropped an item on the floor, and prose where a list was wanted is a
+better thing to ship than a list missing a line.
+
+The two cases still failing are one shape: a short reply ending in a goodbye
+comes back as the goodbye alone — `yes that works for me see you thursday` →
+`See you Thursday.`, and `ok pour moi, à jeudi` → `À jeudi,`. The same sentence
+with a comma is right. Three framings have bounced off it, so it is recorded
+rather than argued with.
 
 **Neither is in the shipped default pipeline.** Every stage a new install gets
 is free and needs nothing running; these cost about a second and do nothing at

--- a/tests/routing-cases.yaml
+++ b/tests/routing-cases.yaml
@@ -5,10 +5,7 @@
 # longer request, because that is the case the router has to get right.
 #
 # The expectations assume the catalogue in config.example.yaml: bullets, terse,
-# grammar, email, slack, and the built-ins. `slack_handles` and `slack_mentions`
-# are tables, so they reach the router not at all — what selects them is the
-# word "mention" inside a sentence, which is a substitution, not a routing
-# decision.
+# grammar, email, slack, slack_mentions, and the built-ins.
 #
 # `--route` reads your own config, so a machine with a different list will
 # disagree with this set,
@@ -26,13 +23,12 @@
 # to a prompt that rewrites your selection. That risk went up when ANY arrived,
 # not down, which is why there are more of them now than tools.
 #
-# 47/52 on gemma4:e4b, on a catalogue of five prompts. It was 41/45 on three.
+# 50/54 on gemma4:e4b, on a catalogue of six prompts. It was 41/45 on three.
 #
-# Four of the five that fail fail cheaply, which is why they are left standing
+# Three of the four that fail fail cheaply, which is why they are left standing
 # rather than argued with:
 #
 #     format those dates ISO                     -> grammar
-#     format those dates with slashes            -> grammar
 #     fix the numbers                            -> grammar
 #     fix the numbers but leave the years alone  -> grammar
 #
@@ -43,10 +39,11 @@
 # were measured against these; the notes are in Router.swift.
 #
 # This family moves with the size of the list rather than with any one entry in
-# it. "format those dates with slashes" passed with six prompts in the
-# catalogue and fails with five, and nothing about dates changed in between —
-# worth knowing before reading a one-case swing here as a regression in
-# whatever was added or removed that day.
+# it. "format those dates with slashes" passes with six prompts in the
+# catalogue and failed with five, twice measured in both directions, and
+# nothing about dates changed in between — worth knowing before reading a
+# one-case swing here as a regression in whatever was added or removed that
+# day.
 #
 # The fourth is the expensive kind and is new:
 #
@@ -196,11 +193,9 @@ cases:
 
   # --- the three prompts scoped to a window --------------------------------
   # `email` and `slack` run from a pipeline behind `app:`, but they are prompts,
-  # so the phrase reaches them too. `slack_handles` and `slack_mentions` are
-  # tables and are reachable no way but a pipeline, so they are not in here —
-  # what routes them is the word "mention" inside the sentence, which is not a
-  # routing question at all. The two neighbours worth watching are terse and
-  # slack — "shorten this" against "tidy that up for chat" — and they hold.
+  # so the phrase reaches them too. `slack_mentions` is only ever reached this
+  # way. The two neighbours worth watching are terse and slack — "shorten this"
+  # against "tidy that up for chat" — and they hold.
   - instruction: write an email
     expect: email
   - instruction: make that an email
@@ -209,3 +204,7 @@ cases:
     expect: slack
   - instruction: tidy that up for chat
     expect: slack
+  - instruction: use Slack mentions
+    expect: slack_mentions
+  - instruction: turn the names into mentions
+    expect: slack_mentions

--- a/tests/routing-cases.yaml
+++ b/tests/routing-cases.yaml
@@ -5,8 +5,13 @@
 # longer request, because that is the case the router has to get right.
 #
 # The expectations assume the catalogue in config.example.yaml: bullets, terse,
-# grammar, email, slack, slack_mentions, and the built-ins. `--route` reads your
-# own config, so a machine with a different list will disagree with this set,
+# grammar, email, slack, and the built-ins. `slack_handles` and `slack_mentions`
+# are tables, so they reach the router not at all — what selects them is the
+# word "mention" inside a sentence, which is a substitution, not a routing
+# decision.
+#
+# `--route` reads your own config, so a machine with a different list will
+# disagree with this set,
 # and rightly — it is scoring a router against a list, and the list is part of
 # the question.
 #
@@ -21,15 +26,13 @@
 # to a prompt that rewrites your selection. That risk went up when ANY arrived,
 # not down, which is why there are more of them now than tools.
 #
-# 50/54 on gemma4:e4b. It was 41/45 on a catalogue of three prompts; adding
-# email, slack and slack_mentions took the same 45 cases to 42 — one of the
-# four known failures, "use the 24 hour clock", started passing — and the nine
-# cases added with them cost one.
+# 47/52 on gemma4:e4b, on a catalogue of five prompts. It was 41/45 on three.
 #
-# Three of the four that fail fail cheaply, which is why they are left standing
+# Four of the five that fail fail cheaply, which is why they are left standing
 # rather than argued with:
 #
 #     format those dates ISO                     -> grammar
+#     format those dates with slashes            -> grammar
 #     fix the numbers                            -> grammar
 #     fix the numbers but leave the years alone  -> grammar
 #
@@ -38,6 +41,12 @@
 # whose every rule is against touching a number, so the cost is a no-op you can
 # see in the preview, not a rewrite. Five descriptions and a second ANY example
 # were measured against these; the notes are in Router.swift.
+#
+# This family moves with the size of the list rather than with any one entry in
+# it. "format those dates with slashes" passed with six prompts in the
+# catalogue and fails with five, and nothing about dates changed in between —
+# worth knowing before reading a one-case swing here as a regression in
+# whatever was added or removed that day.
 #
 # The fourth is the expensive kind and is new:
 #
@@ -187,9 +196,11 @@ cases:
 
   # --- the three prompts scoped to a window --------------------------------
   # `email` and `slack` run from a pipeline behind `app:`, but they are prompts,
-  # so the phrase reaches them too. `slack_mentions` is only ever reached this
-  # way. The two neighbours worth watching are terse and slack — "shorten this"
-  # against "tidy that up for chat" — and they hold.
+  # so the phrase reaches them too. `slack_handles` and `slack_mentions` are
+  # tables and are reachable no way but a pipeline, so they are not in here —
+  # what routes them is the word "mention" inside the sentence, which is not a
+  # routing question at all. The two neighbours worth watching are terse and
+  # slack — "shorten this" against "tidy that up for chat" — and they hold.
   - instruction: write an email
     expect: email
   - instruction: make that an email
@@ -198,7 +209,3 @@ cases:
     expect: slack
   - instruction: tidy that up for chat
     expect: slack
-  - instruction: use Slack mentions
-    expect: slack_mentions
-  - instruction: turn the names into mentions
-    expect: slack_mentions

--- a/tests/routing-cases.yaml
+++ b/tests/routing-cases.yaml
@@ -5,9 +5,10 @@
 # longer request, because that is the case the router has to get right.
 #
 # The expectations assume the catalogue in config.example.yaml: bullets, terse,
-# grammar, and the built-ins. `--route` reads your own config, so a machine with
-# extra prompts will disagree with this set, and rightly — it is scoring a
-# router against a list, and the list is part of the question.
+# grammar, email, slack, slack_mentions, and the built-ins. `--route` reads your
+# own config, so a machine with a different list will disagree with this set,
+# and rightly — it is scoring a router against a list, and the list is part of
+# the question.
 #
 # Three answers since free_form, and the third is what made the first two
 # honest. NONE used to carry two meanings, "no tool does this" and "that was
@@ -20,26 +21,35 @@
 # to a prompt that rewrites your selection. That risk went up when ANY arrived,
 # not down, which is why there are more of them now than tools.
 #
-# 41/45 on gemma4:e4b, and the shape matters more than the number: nothing
-# routed something idle. Both cases that used to — "I bought a box of bullets"
-# and "her grammar is better than mine", the two Router.swift recorded as the
-# model's floor — pass with the third answer present. Splitting "not an edit"
-# off from "no tool for it" turned out to help the question it did not ask.
+# 50/54 on gemma4:e4b. It was 41/45 on a catalogue of three prompts; adding
+# email, slack and slack_mentions took the same 45 cases to 42 — one of the
+# four known failures, "use the 24 hour clock", started passing — and the nine
+# cases added with them cost one.
 #
-# The four that fail all fail cheaply, which is the only reason they are left
-# standing rather than argued with:
+# Three of the four that fail fail cheaply, which is why they are left standing
+# rather than argued with:
 #
 #     format those dates ISO                     -> grammar
 #     fix the numbers                            -> grammar
 #     fix the numbers but leave the years alone  -> grammar
-#     use the 24 hour clock                      -> NONE
 #
-# The first three are the residue of removing `dates` and `digits`: grammar is
-# now the only entry that mends anything, so "fix the ..." lands on it. It runs
-# a prompt whose every rule is against touching a number, so the cost is a
-# no-op you can see in the preview, not a rewrite. The fourth is a refusal —
-# you say it again. Five descriptions and a second ANY example were measured
-# against these; the notes are in Router.swift.
+# They are the residue of removing `dates` and `digits`: grammar is now the
+# only entry that mends anything, so "fix the ..." lands on it. It runs a prompt
+# whose every rule is against touching a number, so the cost is a no-op you can
+# see in the preview, not a rewrite. Five descriptions and a second ANY example
+# were measured against these; the notes are in Router.swift.
+#
+# The fourth is the expensive kind and is new:
+#
+#     I sent her an email yesterday              -> email
+#
+# A sentence, not an instruction, routed to a prompt that would rewrite your
+# selection. It is the trap "I bought a box of bullets" and "her grammar is
+# better than mine" set for the older entries, and those two pass — so this is
+# a gap this catalogue opened, not a floor the model always had. Four
+# descriptions were measured against it and every one routed it the same way,
+# which says the description is not what decides it. The preview is what stands
+# between this and a lost selection.
 
 cases:
   # --- named outright: should never reach the model -----------------------
@@ -162,3 +172,33 @@ cases:
     expect: NONE
   - instruction: her grammar is better than mine
     expect: NONE
+  # Same trap, for the three window-scoped prompts. The first one fails: it is
+  # routed to `email`, and it is a sentence, not an instruction. Four
+  # descriptions were tried against it — "lay dictated text out as an email",
+  # "format the selected text as an email", "lay this out as an email, greeting
+  # and paragraphs", "put this into email shape" — and all four routed it
+  # identically, so the description is not what decides this one. Left failing.
+  - instruction: I sent her an email yesterday
+    expect: NONE
+  - instruction: did you see my slack message
+    expect: NONE
+  - instruction: he never mentions it
+    expect: NONE
+
+  # --- the three prompts scoped to a window --------------------------------
+  # `email` and `slack` run from a pipeline behind `app:`, but they are prompts,
+  # so the phrase reaches them too. `slack_mentions` is only ever reached this
+  # way. The two neighbours worth watching are terse and slack — "shorten this"
+  # against "tidy that up for chat" — and they hold.
+  - instruction: write an email
+    expect: email
+  - instruction: make that an email
+    expect: email
+  - instruction: make that a slack message
+    expect: slack
+  - instruction: tidy that up for chat
+    expect: slack
+  - instruction: use Slack mentions
+    expect: slack_mentions
+  - instruction: turn the names into mentions
+    expect: slack_mentions


### PR DESCRIPTION
Three transforms. `email` and `slack` lay dictated prose out for one kind of window each and run from the pipeline behind `app:`; `slack_mentions` is said out loud and is deliberately in no pipeline — a message that names someone is not a message that pings them, and nothing in a transcript tells the two apart.

## Measured on gemma4:e4b

| | score | what the failures taught |
|---|---|---|
| `email` | 6/7 | "do not invent a greeting" read as a topic and produced one; "nothing is ever deleted" produced a literal `[Signature]`; giving the greeting rule worked examples put those examples in the output |
| `slack` | 3/3 | "no greeting" read as an instruction to *remove* one — "hey uh quick one the build is red" came back as "The build is red" |
| `slack_mentions` | 6/6 | the first draft was **2/6** and invented a handle for a name it had never been given: "Sofia already looked at it" → "@priya already looked at it" |

Every version in between is written down beside the prompt, because what they cost is the useful part. The one case still failing is `yes that works for me see you thursday` → `See you Thursday.` — two clauses run together with no comma read as one goodbye. It is left failing rather than argued with.

## Not in the shipped default pipeline

Every stage a new install gets is free and needs nothing running. These cost about a second and do nothing at all without Ollama — the same rule that keeps `--model` off `code_identifiers` by default. `config.example.yaml` has them wired up.

## Routing was rescored

Adding three descriptions changes the catalogue the router sees, so `tests/routing-cases.yaml` was rerun and grew nine cases: **41/45 on three prompts → 50/54 on six.** One old failure started passing. One new one appeared and is the expensive class:

```
I sent her an email yesterday  ->  email
```

A sentence, not an instruction, routed to a prompt that would rewrite your selection. Four descriptions were measured against it and all four routed it identically, so the description is not what decides it. Recorded in the case file rather than tuned away.

## Known gap

Gmail in a browser tab is not an app — `app:` reads the window in front, which is `Google Chrome com.google.Chrome`. Named in the config comment and the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUnWNfi64vX94QqWfUM2qS