### PR TITLE
feat: one permission per screen, explained before it is asked

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -130,12 +130,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         warmUpLLM()
 
-        // First run: open the walk, and ask for nothing yet. The prompt used to
-        // fire here, the moment the window appeared — a system dialog on top of
-        // the window explaining it, before either had been read. The window
-        // asks when its button is pressed and not before.
-        if Permissions.microphone == .notDetermined {
-            permissions.show(.installing)
+        // Anything still missing opens the walk, and nothing is asked for yet.
+        // The prompt used to fire here, the moment the window appeared — a
+        // system dialog on top of the window explaining it, before either had
+        // been read. The window asks when its button is pressed and not before.
+        //
+        // Both permissions, not just the microphone: a launch with the
+        // microphone already answered and accessibility still missing is
+        // exactly the install that fails later, at the moment someone holds the
+        // key and nothing is written.
+        //
+        // Which walk it is turns on whether the microphone has ever been
+        // answered. An unanswered one is a first run and the install is still
+        // happening, so the way out is to cancel it. Once there is an answer on
+        // record the app has been opened before, and offering to cancel an
+        // installation that finished is a threat about something that already
+        // happened — same reasoning as the hotkey path below.
+        if Permissions.microphone != .granted || Permissions.accessibility != .granted {
+            permissions.show(Permissions.microphone == .notDetermined ? .installing : .revisiting)
         }
     }
 

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -130,13 +130,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         warmUpLLM()
 
-        // First run: get the microphone prompt out of the way immediately,
-        // rather than at the moment the user first tries to dictate.
+        // First run: open the walk, and ask for nothing yet. The prompt used to
+        // fire here, the moment the window appeared — a system dialog on top of
+        // the window explaining it, before either had been read. The window
+        // asks when its button is pressed and not before.
         if Permissions.microphone == .notDetermined {
-            permissions.show()
-            Permissions.requestMicrophone { [weak self] _ in
-                self?.permissions.model.refresh()
-            }
+            permissions.show(.installing)
         }
     }
 
@@ -480,7 +479,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 if granted {
                     self.startRecording()
                 } else {
-                    self.permissions.show()
+                    // Not `.installing`: the app has been running for a while
+                    // by the time someone presses the hotkey, and a refusal
+                    // here should not offer to cancel an install that finished
+                    // days ago.
+                    self.permissions.show(.revisiting)
                 }
             }
             return
@@ -1805,7 +1808,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc private func openPermissions() {
-        permissions.show()
+        permissions.show(.revisiting)
     }
 
     @objc private func showAbout() {

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -39,9 +39,9 @@ enum PanelsCommand {
 
         // The pill has two states now and the difference is the whole point of
         // the slot: with an app in front it holds that app, without one it
-        // holds nothing and is simply narrower. Both are on the sheet because
-        // "it looks wrong with no icon" is the kind of thing that is obvious
-        // side by side and invisible a week apart.
+        // holds nothing and stays exactly as wide. Both are on the sheet
+        // because "the ring looks wrong empty" is the kind of thing that is
+        // obvious side by side and invisible a week apart.
         let overlayBlind = OverlayModel()
         overlayBlind.level = 0.75
 
@@ -60,25 +60,46 @@ enum PanelsCommand {
             after: "I think we should have asked them first — they're going to be annoyed."
         )
 
-        let surfaces: [(NSView, NSSize)] = [
+        // The third element is the appearance to draw in. Every floating
+        // surface is dark whatever the system is set to — that is decided in
+        // `adoptParrotAppearance` and is not a preference. The permissions
+        // window is the exception and the reason this is a column at all: it is
+        // an ordinary titled window, it follows the system, and it has to be
+        // legible both ways. So it appears twice, once each.
+        let surfaces: [(NSView, NSSize, NSAppearance.Name)] = [
             (NSHostingView(rootView: RecordingPill().environmentObject(overlay)),
              NSSize(width: RecordingMetrics.width(hasIcon: overlay.appIcon != nil),
-                    height: RecordingMetrics.height)),
+                    height: RecordingMetrics.height), .darkAqua),
             (NSHostingView(rootView: RecordingPill().environmentObject(overlayBlind)),
              NSSize(width: RecordingMetrics.width(hasIcon: false),
-                    height: RecordingMetrics.height)),
+                    height: RecordingMetrics.height), .darkAqua),
+            // The one real window the app has, and the first thing anyone sees.
+            // On the sheet for the same reason as the rest: it is looked at,
+            // not asserted on, and two screens that drift apart are obvious
+            // side by side and invisible a week apart.
+            //
+            // One of each context, because the second button is the difference
+            // between them and it is the part worth being able to see: setting
+            // up says "Cancel installation", revisiting says "Not now".
+            (NSHostingView(rootView: PermissionsView()
+                .environmentObject(PermissionsModel.showing(.microphone))),
+             NSSize(width: PermissionMetrics.width, height: PermissionMetrics.height), .aqua),
+            (NSHostingView(rootView: PermissionsView()
+                .environmentObject(PermissionsModel.showing(
+                    .accessibility, asked: true, context: .revisiting))),
+             NSSize(width: PermissionMetrics.width, height: PermissionMetrics.height), .darkAqua),
             (NSHostingView(rootView: NoticeView().environmentObject(notice)),
-             NSSize(width: NoticeMetrics.width(for: notice.message), height: NoticeMetrics.height)),
+             NSSize(width: NoticeMetrics.width(for: notice.message), height: NoticeMetrics.height), .darkAqua),
             (NSHostingView(rootView: NoticeView().environmentObject(thinking)),
-             NSSize(width: NoticeMetrics.width(for: thinking.message), height: NoticeMetrics.height)),
+             NSSize(width: NoticeMetrics.width(for: thinking.message), height: NoticeMetrics.height), .darkAqua),
             (NSHostingView(rootView: NoticeView().environmentObject(caution)),
-             NSSize(width: NoticeMetrics.width(for: caution.message), height: NoticeMetrics.height)),
+             NSSize(width: NoticeMetrics.width(for: caution.message), height: NoticeMetrics.height), .darkAqua),
             (NSHostingView(rootView: CorrectionView().environmentObject(correction)),
-             NSSize(width: CorrectionMetrics.width, height: CorrectionMetrics.height(forRows: 2))),
+             NSSize(width: CorrectionMetrics.width, height: CorrectionMetrics.height(forRows: 2)), .darkAqua),
             (NSHostingView(rootView: CorrectionView().environmentObject(rule)),
-             NSSize(width: CorrectionMetrics.width, height: CorrectionMetrics.height(forRows: 1))),
+             NSSize(width: CorrectionMetrics.width, height: CorrectionMetrics.height(forRows: 1)), .darkAqua),
             (NSHostingView(rootView: PreviewView().environmentObject(preview)),
-             NSSize(width: PreviewMetrics.width, height: PreviewMetrics.height(forCharacters: 70))),
+             NSSize(width: PreviewMetrics.width, height: PreviewMetrics.height(forCharacters: 70)), .darkAqua),
         ]
 
         let margin: CGFloat = 36
@@ -106,8 +127,8 @@ enum PanelsCommand {
             NSRect(x: left, y: 0, width: column, height: size.height).fill()
 
             var top = size.height - margin
-            for (view, natural) in surfaces {
-                view.appearance = NSAppearance(named: .darkAqua)
+            for (view, natural, appearance) in surfaces {
+                view.appearance = NSAppearance(named: appearance)
                 view.frame = NSRect(origin: .zero, size: natural)
                 view.layoutSubtreeIfNeeded()
                 guard let rep = view.bitmapImageRepForCachingDisplay(in: view.bounds) else { continue }

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -460,10 +460,21 @@ private struct StepPane: View {
 
                 Spacer()
 
-                Button(asked ? "Ask again" : step.actionTitle, action: onAsk)
+                Button(actionTitle, action: onAsk)
                     .keyboardShortcut(.defaultAction)
             }
         }
+    }
+
+    /// Named for where pressing it lands, which a refusal changes.
+    ///
+    /// macOS prompts once. After that `requestMicrophone` opens the pane
+    /// instead, so a button still offering to ask is a button that does
+    /// something else than it says — and it would say it directly under the
+    /// line explaining that Settings is now the only way back.
+    private var actionTitle: String {
+        if status == .denied { return "Open System Settings" }
+        return asked ? "Ask again" : step.actionTitle
     }
 
     /// Three states, three words for them, in the order they happen.

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -1,20 +1,166 @@
 import AppKit
 import SwiftUI
 
+/// The two things macOS will not let this app do without being asked.
+///
+/// Both are required, and the walk is not skippable: the only way past a screen
+/// is to grant it, and the only other button quits. The microphone is what the
+/// app hears with, accessibility is what it writes and reads selections with,
+/// and an install missing either is one that fails later, quietly, at the
+/// moment someone is trying to use it — which is a worse place to find out.
+/// Why the window is open, which decides what the second button says and does.
+///
+/// The same screen means two different things at two moments. During setup a
+/// permission is a condition of having the app at all, and the way out is to
+/// stop installing it. Afterwards the app is installed, running, and in the
+/// menu bar — "cancel installation" there would be a threat about something
+/// that already happened, and pressing it would quit an app the user opened a
+/// window from. So the way out becomes a skip, and the window gets its close
+/// button back.
+enum PermissionsContext {
+    case installing
+    case revisiting
+}
+
+enum PermissionStep: CaseIterable {
+    case microphone
+    case accessibility
+
+    var title: String {
+        switch self {
+        case .microphone: return "Microphone"
+        case .accessibility: return "Accessibility"
+        }
+    }
+
+    /// What it is for, and why this app is the one asking. Two sentences at
+    /// most: this is read once, standing between someone and the thing they
+    /// just installed.
+    var reason: String {
+        switch self {
+        case .microphone:
+            return "Hold the hotkey and ParrotFlow records. The recording becomes "
+                + "text on this Mac, and never leaves it."
+        case .accessibility:
+            return "This is what puts the text into the app you are already in, and "
+                + "reads the words you select so you can fix them out loud. Both "
+                + "halves of ParrotFlow need it."
+        }
+    }
+
+    /// Named for what pressing it does, not for what it is for. Neither button
+    /// grants anything: one makes macOS ask, the other opens the pane where you
+    /// answer. Saying "Allow" would take credit for a decision this app does
+    /// not get to make, and then the system dialog would read as a second ask.
+    var actionTitle: String {
+        switch self {
+        case .microphone: return "Show the macOS prompt"
+        case .accessibility: return "Open System Settings"
+        }
+    }
+
+    /// The same on both screens, and different in the two contexts. Setting up
+    /// has one way out and it does what it says: the app quits. Both
+    /// permissions are required, and a requirement you can walk past is not
+    /// one. Revisiting has no installation left to cancel.
+    func declineTitle(in context: PermissionsContext) -> String {
+        context == .installing ? "Cancel installation" : "Not now"
+    }
+
+    /// Shown after the ask, while the answer is somewhere else.
+    var waiting: String {
+        switch self {
+        case .microphone:
+            return "Answer the prompt macOS just put up."
+        case .accessibility:
+            return "Find ParrotFlow in the list and tick it. This window updates itself."
+        }
+    }
+}
+
 final class PermissionsModel: ObservableObject {
     @Published var micStatus: Permissions.Status = .notDetermined
     @Published var axStatus: Permissions.Status = .notGranted
     @Published var axBlocker: String?
+
+    /// What is left to ask for, fixed when the window opens.
+    ///
+    /// Fixed rather than recomputed so "1 of 2" does not become "1 of 1" under
+    /// the reader the moment they grant the first one — a counter that changes
+    /// its own total reads as the app losing count.
+    @Published private(set) var steps: [PermissionStep] = []
+    @Published private(set) var index = 0
+    /// The system has been asked and the answer is not here yet.
+    @Published private(set) var asked = false
+    @Published private(set) var context: PermissionsContext = .installing
+
+    var current: PermissionStep? { steps.indices.contains(index) ? steps[index] : nil }
+
+    func status(of step: PermissionStep) -> Permissions.Status {
+        switch step {
+        case .microphone: return micStatus
+        case .accessibility: return axStatus
+        }
+    }
 
     func refresh() {
         micStatus = Permissions.microphone
         axStatus = Permissions.accessibility
         axBlocker = Permissions.accessibilityBlocker
     }
+
+    /// Start the walk. Anything already granted is not a screen — nobody needs
+    /// to be told about a permission they have given.
+    func begin(context: PermissionsContext) {
+        self.context = context
+        refresh()
+        steps = PermissionStep.allCases.filter { status(of: $0) != .granted }
+        index = 0
+        asked = false
+    }
+
+    func markAsked() { asked = true }
+
+    /// Only reachable when revisiting — during setup the button that would
+    /// call this quits instead.
+    func skip() {
+        guard index < steps.count else { return }
+        index += 1
+        asked = false
+    }
+
+    /// Parked on one step, for `--panel-sheet`. The statuses are left at their
+    /// defaults, which is what a first launch actually shows.
+    static func showing(
+        _ step: PermissionStep, asked: Bool = false, context: PermissionsContext = .installing
+    ) -> PermissionsModel {
+        let model = PermissionsModel()
+        model.context = context
+        model.steps = PermissionStep.allCases
+        model.index = PermissionStep.allCases.firstIndex(of: step) ?? 0
+        model.asked = asked
+        return model
+    }
+
+    /// Move past anything that has been granted since the last look. Called on
+    /// the poll, so the screen advances itself the moment the box is ticked
+    /// rather than waiting to be dismissed.
+    func advancePastGranted() {
+        while let step = current, status(of: step) == .granted {
+            index += 1
+            asked = false
+        }
+    }
 }
 
-/// Single plain window — no preferences tabs, no toolbar. It exists to answer
-/// "is this thing actually allowed to hear me, and to type what it hears?".
+/// A single plain window that walks one permission at a time.
+///
+/// It used to show both at once, each with its own Request button, and fire the
+/// microphone prompt on first launch the instant it appeared — a system dialog
+/// on top of a window explaining the system dialog, before anyone had read
+/// either. One screen, one permission, one button: the explanation is finished
+/// being read before anything is asked.
+///
 /// Everything else the app can be told lives in config.yaml, which the Settings
 /// menu item opens.
 final class PermissionsWindowController {
@@ -25,7 +171,7 @@ final class PermissionsWindowController {
 
     init() {
         accessibilityObserver = Permissions.observeAccessibilityChanges { [weak self] in
-            self?.model.refresh()
+            self?.poll()
         }
     }
 
@@ -35,28 +181,41 @@ final class PermissionsWindowController {
         }
     }
 
-    func show() {
-        model.refresh()
+    func show(_ context: PermissionsContext = .revisiting) {
+        model.begin(context: context)
 
         if window == nil { build() }
+        // Set per showing, not at build: the same window is both, and which
+        // one it is now decides whether the title bar offers a third way out.
+        window?.styleMask = context == .installing ? [.titled] : [.titled, .closable]
         NSApp.activate(ignoringOtherApps: true)
         window?.makeKeyAndOrderFront(nil)
         window?.center()
 
         timer?.invalidate()
         timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            self?.model.refresh()
+            self?.poll()
         }
     }
 
+    private func poll() {
+        model.refresh()
+        model.advancePastGranted()
+    }
+
     private func build() {
-        let view = PermissionsView().environmentObject(model)
+        let view = PermissionsView(
+            onAsk: { [weak self] step in self?.ask(step) },
+            onDecline: { [weak self] in self?.decline() },
+            onClose: { [weak self] in self?.window?.close() }
+        ).environmentObject(model)
+
         let hosting = NSHostingController(rootView: view)
         let window = NSWindow(contentViewController: hosting)
         window.title = "\(AppVariant.displayName) Permissions"
-        window.styleMask = [.titled, .closable, .miniaturizable]
+        window.styleMask = [.titled]
         window.isReleasedWhenClosed = false
-        window.setContentSize(NSSize(width: 460, height: 320))
+        window.setContentSize(NSSize(width: PermissionMetrics.width, height: PermissionMetrics.height))
         self.window = window
 
         NotificationCenter.default.addObserver(
@@ -68,106 +227,311 @@ final class PermissionsWindowController {
             self?.timer = nil
         }
     }
+
+    /// Leaving. During setup that means the app — a button reading "cancel
+    /// installation" that quietly moved to the next screen would be the kind of
+    /// wording nobody trusts twice. Revisiting, it is a skip, and the walk ends
+    /// on the screen that says what is still missing.
+    private func decline() {
+        guard model.context == .installing else {
+            model.skip()
+            return
+        }
+        window?.close()
+        NSApp.terminate(nil)
+    }
+
+    private func ask(_ step: PermissionStep) {
+        model.markAsked()
+        switch step {
+        case .microphone:
+            Permissions.requestMicrophone { [weak self] _ in self?.poll() }
+        case .accessibility:
+            // Request before opening Settings, always. It is
+            // AXIsProcessTrustedWithOptions that registers this binary with
+            // TCC — open the pane first and the app may not be in the list to
+            // tick, which reads as the instructions being wrong.
+            Permissions.requestAccessibility()
+            Permissions.openAccessibilitySettings()
+        }
+    }
 }
 
 // MARK: - View
 
-private struct PermissionsView: View {
+enum PermissionMetrics {
+    static let width: CGFloat = 460
+    static let height: CGFloat = 328
+}
+
+struct PermissionsView: View {
     @EnvironmentObject private var model: PermissionsModel
 
-    var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 14) {
-                PermissionRow(
-                    icon: "mic.fill",
-                    title: "Microphone",
-                    detail: "Required to record.",
-                    status: model.micStatus,
-                    actionTitle: model.micStatus == .notDetermined ? "Request" : "Open Settings",
-                    action: {
-                        if model.micStatus == .notDetermined {
-                            Permissions.requestMicrophone { _ in model.refresh() }
-                        } else {
-                            Permissions.openMicrophoneSettings()
-                        }
-                    }
-                )
+    var onAsk: (PermissionStep) -> Void = { _ in }
+    var onDecline: () -> Void = {}
+    var onClose: () -> Void = {}
 
-                PermissionRow(
-                    icon: "keyboard.fill",
-                    title: "Accessibility",
-                    detail: "Not needed to record — it's what lets ParrotFlow type the transcript into the app you're using.",
-                    status: model.axStatus,
-                    // "Request" must come first: AXIsProcessTrustedWithOptions
-                    // is what registers this binary with TCC. Merely opening
-                    // Settings shows a list this app may not be in yet.
-                    actionTitle: "Request",
-                    action: { Permissions.requestAccessibility() },
-                    secondaryTitle: "Open Settings",
-                    secondaryAction: { Permissions.openAccessibilitySettings() },
-                    footnote: model.axBlocker
-                        ?? "Ticked the box already? Relaunch so the running process picks it up."
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 8) {
+                PlumageMark()
+                Text(AppVariant.displayName.uppercased())
+                    .foregroundStyle(Parrot.action)
+                Spacer()
+                if model.steps.count > 1, let step = model.current,
+                   let position = model.steps.firstIndex(of: step) {
+                    Text("\(position + 1) of \(model.steps.count)".uppercased())
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .font(.system(size: 9, weight: .semibold, design: .rounded))
+            .kerning(0.9)
+
+            if let step = model.current {
+                StepPane(
+                    step: step,
+                    status: model.status(of: step),
+                    asked: model.asked,
+                    context: model.context,
+                    blocker: step == .accessibility ? model.axBlocker : nil,
+                    onAsk: { onAsk(step) },
+                    onDecline: onDecline
+                )
+            } else {
+                DonePane(
+                    micStatus: model.micStatus, axStatus: model.axStatus, onClose: onClose
                 )
             }
-            .padding(24)
         }
-        .frame(minWidth: 460, minHeight: 320)
+        .padding(28)
+        .frame(width: PermissionMetrics.width, height: PermissionMetrics.height)
+        // Stated rather than inherited. In the app this is the window's own
+        // background and setting it changes nothing; drawn on `--panel-sheet`
+        // there is no window to inherit from, and without this the pane came
+        // out with light chrome and white text on it.
+        .background(Color(nsColor: .windowBackgroundColor))
     }
 }
 
-private struct PermissionRow: View {
-    let icon: String
-    let title: String
-    let detail: String
-    let status: Permissions.Status
-    let actionTitle: String
-    let action: () -> Void
-    var secondaryTitle: String? = nil
-    var secondaryAction: (() -> Void)? = nil
-    /// Shown only while the permission is still missing.
-    var footnote: String? = nil
+/// The piece of the app this permission switches on, drawn with the app's own
+/// parts rather than illustrated.
+///
+/// A microphone glyph says "microphone", which the heading already says. The
+/// recording pill says what is about to appear at the bottom of the screen
+/// every time you hold the key — so the screen that asks for the microphone is
+/// also the only place anyone is told what the pill is before it turns up over
+/// their work. That is the whole argument for it: the illustration is the
+/// feature, at the size it will really be.
+private struct Instrument: View {
+    let step: PermissionStep
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(alignment: .top, spacing: 12) {
-                Image(systemName: icon)
-                    .font(.system(size: 14))
-                    .foregroundStyle(.secondary)
-                    .frame(width: 18)
+        ZStack {
+            RoundedRectangle(cornerRadius: 13, style: .continuous)
+                .fill(Color.primary.opacity(0.045))
 
-                VStack(alignment: .leading, spacing: 3) {
-                    HStack(spacing: 7) {
-                        Text(title).font(.system(size: 13, weight: .medium))
-                        StatusBadge(status: status)
-                    }
-                    Text(detail)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                Spacer(minLength: 8)
-
-                if status != .granted {
-                    VStack(alignment: .trailing, spacing: 6) {
-                        Button(actionTitle, action: action)
-                        if let secondaryTitle, let secondaryAction {
-                            Button(secondaryTitle, action: secondaryAction)
-                        }
-                    }
-                }
-            }
-
-            if status != .granted, let footnote {
-                Text(footnote)
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .padding(.leading, 30)
+            switch step {
+            case .microphone:
+                // The real view, at its real size. It carries its own dark
+                // glass, which is what it will look like over your document.
+                RecordingPill().environmentObject(Instrument.hearing)
+            case .accessibility:
+                Landing()
             }
         }
-        .padding(12)
-        .background(Color.secondary.opacity(0.07), in: RoundedRectangle(cornerRadius: 9))
+        .frame(height: 88)
+    }
+
+    /// Mid-sentence, so the meter has something to show.
+    private static let hearing: OverlayModel = {
+        let model = OverlayModel()
+        model.level = 0.62
+        return model
+    }()
+}
+
+/// The four feathers, then a field with the words already in it and the caret
+/// after them. `PlumageMark` is documented as the pill once it has heard you,
+/// which makes it exactly the right mark to show arriving somewhere.
+private struct Landing: View {
+    var body: some View {
+        HStack(spacing: 12) {
+            // Scaled up rather than redrawn: it is the app's mark at label size
+            // everywhere else, and this is the one place it is the subject of
+            // the picture rather than a label on one.
+            PlumageMark()
+                .scaleEffect(1.5)
+                .frame(width: 18)
+
+            Image(systemName: "arrow.right")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 2) {
+                Text("hold the hotkey and talk")
+                    .font(.system(size: 13, design: .rounded))
+                    .foregroundStyle(.primary)
+                RoundedRectangle(cornerRadius: 1)
+                    .fill(Parrot.action)
+                    .frame(width: 2, height: 16)
+            }
+            .padding(.horizontal, 11)
+            .padding(.vertical, 9)
+            .background(
+                Color.primary.opacity(0.07),
+                in: RoundedRectangle(cornerRadius: Parrot.fieldRadius, style: .continuous)
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: Parrot.fieldRadius, style: .continuous)
+                    .strokeBorder(Parrot.action.opacity(0.55), lineWidth: 1.5)
+            }
+        }
+    }
+}
+
+private struct StepPane: View {
+    let step: PermissionStep
+    let status: Permissions.Status
+    let asked: Bool
+    let context: PermissionsContext
+    let blocker: String?
+    let onAsk: () -> Void
+    let onDecline: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Instrument(step: step)
+                .padding(.top, 20)
+                .padding(.bottom, 18)
+
+            // Says what kind of screen this is before the heading says which
+            // one. "Microphone" on its own is a subject, not a request — and
+            // someone who has just installed a dictation app and been handed a
+            // window with a picture on it is owed the word "permission" before
+            // they are asked to press anything.
+            //
+            // Amber, which is what a permission that is not granted already
+            // wears on the last screen. One colour, one meaning, both places.
+            Text(eyebrow)
+                .font(.system(size: 9, weight: .semibold, design: .rounded))
+                .kerning(0.9)
+                .foregroundStyle(status == .denied ? Parrot.scarlet : Parrot.amber)
+                .padding(.bottom, 6)
+
+            Text(step.title)
+                .font(.system(size: 19, weight: .semibold, design: .rounded))
+                .padding(.bottom, 7)
+
+            Text(step.reason)
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .lineSpacing(2)
+
+            // Only after the ask. Before it, the screen has one thing to say
+            // and one button to press, and a line about what happens next is a
+            // second thing to read first.
+            if asked {
+                Text(status == .denied ? deniedNote : step.waiting)
+                    .font(.system(size: 11))
+                    .foregroundStyle(
+                        status == .denied
+                            ? AnyShapeStyle(Parrot.amber) : AnyShapeStyle(.tertiary)
+                    )
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.top, 12)
+            }
+
+            if asked, let blocker {
+                Text(blocker)
+                    .font(.system(size: 10))
+                    .foregroundStyle(.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.top, 8)
+            }
+
+            Spacer(minLength: 16)
+
+            HStack(spacing: 10) {
+                Button(step.declineTitle(in: context), action: onDecline)
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.tertiary)
+                    .font(.system(size: 12))
+
+                Spacer()
+
+                Button(asked ? "Ask again" : step.actionTitle, action: onAsk)
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+    }
+
+    /// Three states, three words for them, in the order they happen.
+    private var eyebrow: String {
+        if status == .denied { return "PERMISSION REFUSED" }
+        return asked ? "WAITING FOR YOU" : "PERMISSION NEEDED"
+    }
+
+    /// macOS prompts once. After a refusal the only way back is the pane.
+    private var deniedNote: String {
+        step == .microphone
+            ? "macOS only asks once. Turn it on for ParrotFlow in System Settings, under Privacy & Security."
+            : "Tick ParrotFlow under Privacy & Security → Accessibility."
+    }
+}
+
+private struct DonePane: View {
+    let micStatus: Permissions.Status
+    let axStatus: Permissions.Status
+    let onClose: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Spacer(minLength: 20)
+
+            Text(everything ? "Ready" : "Something was switched off")
+                .font(.system(size: 19, weight: .semibold, design: .rounded))
+                .padding(.bottom, 7)
+
+            // Reachable two ways now: a permission revoked in System Settings
+            // while this window is open, or a skip from the menu bar. Either
+            // way what is true is that something is missing, which it says
+            // rather than pretending the app is fine.
+            Text(everything
+                ? "Hold your hotkey, say something, let go."
+                : "ParrotFlow needs both. Reopen this window from the menu bar when you want to "
+                    + "finish, or check what is missing below.")
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.bottom, 18)
+
+            StatusLine(title: "Microphone", status: micStatus)
+            StatusLine(title: "Accessibility", status: axStatus)
+
+            Spacer(minLength: 16)
+
+            HStack {
+                Spacer()
+                Button("Done", action: onClose).keyboardShortcut(.defaultAction)
+            }
+        }
+    }
+
+    private var everything: Bool { micStatus == .granted && axStatus == .granted }
+}
+
+private struct StatusLine: View {
+    let title: String
+    let status: Permissions.Status
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(title).font(.system(size: 12))
+            StatusBadge(status: status)
+            Spacer()
+        }
+        .padding(.vertical, 3)
     }
 }
 
@@ -185,9 +549,9 @@ private struct StatusBadge: View {
 
     private var color: Color {
         switch status {
-        case .granted: return .green
-        case .denied: return .red
-        case .notDetermined, .notGranted: return .orange
+        case .granted: return Parrot.leaf
+        case .denied: return Parrot.scarlet
+        case .notDetermined, .notGranted: return Parrot.amber
         }
     }
 }


### PR DESCRIPTION
> Stacked on #27 — review that one first. This diff is permissions only.

The window used to show both permissions at once, each with its own Request button, and fire the microphone prompt on first launch the instant it appeared: a system dialog on top of the window explaining the system dialog, before anyone had read either. Now it is one screen, one permission, one button, and nothing is asked until that button is pressed.

## Each screen shows the piece of the app it switches on

Drawn with the app's own parts rather than illustrated. A microphone glyph says "microphone", which the heading already says.

- **Microphone** holds the real `RecordingPill`, at its real size. It is also the only place anyone learns what that pill is before it turns up over their work.
- **Accessibility** shows `PlumageMark` — documented in `ParrotStyle.swift` as the pill once it has heard you — landing in a focused field, using the sky ring from `parrotField(focused:)`.

## Wording

An amber eyebrow says what kind of screen this is before the heading says which one: `PERMISSION NEEDED` → `WAITING FOR YOU` once asked → `PERMISSION REFUSED`. Amber is the colour a not-granted permission already wears on the status screen.

Buttons are named for what pressing them does, not for what they are for — "Show the macOS prompt", "Open System Settings". Neither grants anything, and a button saying "Allow" would take credit for a decision this app does not get to make, after which the system dialog would read as a second ask.

## Required, and what that had to mean

Both permissions are required during setup, so the only other button is **Cancel installation** and it quits. A requirement you can walk past is not one — which is also why the title bar has no close button during setup: it would have been a third way out.

Reopened from the menu bar afterwards there is no installation left to cancel, so the same button becomes **Not now** and the close button comes back. `PermissionsContext` decides this, not the screen. The hotkey-refusal path (`AppDelegate.swift:463`) is `.revisiting` too — the app has been running for a while by then.

## Sheet

Both screens are on `--panel-sheet`, one per context and one per appearance. This is the only surface that follows the system rather than being dark either way, so the sheet now carries an appearance per surface instead of forcing `darkAqua` on all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUnWNfi64vX94QqWfUM2qS