### PR TITLE
feat: the pill shows which app it is about to write into

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -68,6 +68,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// without Accessibility — an app condition has no business needing a
     /// permission that gating a stage by app does not otherwise require.
     private var appAtPress: Pipeline.App?
+    /// That same app's icon, for the pill. Held apart from `appAtPress` because
+    /// `Pipeline.App` is what the pipeline matches on and has no business
+    /// carrying an image around.
+    private var appIconAtPress: NSImage?
 
     private var tickTimer: Timer?
     private var pushToTalkPoll: Timer?
@@ -362,7 +366,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let snapshotStart = Date()
         selectionAtPress = SelectionReader.snapshot()
         focusAtPress = selectionAtPress ?? SelectionReader.focusSnapshot()
-        appAtPress = Self.appInFront()
+        let front = Self.appInFront()
+        appAtPress = front?.app
+        appIconAtPress = front?.icon
         let elapsed = Date().timeIntervalSince(snapshotStart)
         if elapsed > 0.15 {
             Log.write(String(format: "selection snapshot was slow: %.2fs", elapsed))
@@ -491,6 +497,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if config.feedback.overlay {
             overlay.model.elapsed = 0
             overlay.model.level = 0
+            overlay.model.appIcon = appIconAtPress
             overlay.show()
         }
 
@@ -534,14 +541,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Transcription
 
     /// The app in front right now, or nil if there isn't one to name.
-    private static func appInFront() -> Pipeline.App? {
+    ///
+    /// The icon rides along rather than being fetched when the pill is built,
+    /// because those are two different questions asked a moment apart: this one
+    /// is "who was in front when the key went down", and the pill has to show
+    /// the same answer the pipeline will be conditioned on. Reading NSWorkspace
+    /// twice would let them disagree, and the one time they disagree is exactly
+    /// the time the pill is worth having.
+    private static func appInFront() -> (app: Pipeline.App, icon: NSImage?)? {
         guard let front = NSWorkspace.shared.frontmostApplication else { return nil }
         let app = Pipeline.App(
             name: front.localizedName ?? "", bundleID: front.bundleIdentifier ?? ""
         )
         // Both empty is not an app you could write a condition against, and
         // saying so is what makes `app:` fail closed instead of matching "  ".
-        return app.searchable.trimmingCharacters(in: .whitespaces).isEmpty ? nil : app
+        guard !app.searchable.trimmingCharacters(in: .whitespaces).isEmpty else { return nil }
+        return (app, front.icon)
     }
 
     private func transcribe(_ recording: Recorder.Recording) {

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -35,6 +35,15 @@ enum PanelsCommand {
 
         let overlay = OverlayModel()
         overlay.level = 0.75
+        overlay.appIcon = sampleIcon()
+
+        // The pill has two states now and the difference is the whole point of
+        // the slot: with an app in front it holds that app, without one it
+        // holds nothing and is simply narrower. Both are on the sheet because
+        // "it looks wrong with no icon" is the kind of thing that is obvious
+        // side by side and invisible a week apart.
+        let overlayBlind = OverlayModel()
+        overlayBlind.level = 0.75
 
         let correction = CorrectionModel()
         correction.load(selection: "Tasmin and Mick")
@@ -53,7 +62,11 @@ enum PanelsCommand {
 
         let surfaces: [(NSView, NSSize)] = [
             (NSHostingView(rootView: RecordingPill().environmentObject(overlay)),
-             NSSize(width: RecordingMetrics.width, height: RecordingMetrics.height)),
+             NSSize(width: RecordingMetrics.width(hasIcon: overlay.appIcon != nil),
+                    height: RecordingMetrics.height)),
+            (NSHostingView(rootView: RecordingPill().environmentObject(overlayBlind)),
+             NSSize(width: RecordingMetrics.width(hasIcon: false),
+                    height: RecordingMetrics.height)),
             (NSHostingView(rootView: NoticeView().environmentObject(notice)),
              NSSize(width: NoticeMetrics.width(for: notice.message), height: NoticeMetrics.height)),
             (NSHostingView(rootView: NoticeView().environmentObject(thinking)),
@@ -122,6 +135,15 @@ enum PanelsCommand {
         }
     }
 
+    /// Something recognisable to sit in the pill's slot. Mail because that is
+    /// the window the `email` transform was written for, and any Mac has it.
+    private static func sampleIcon() -> NSImage? {
+        guard let url = NSWorkspace.shared.urlForApplication(
+            withBundleIdentifier: "com.apple.mail"
+        ) else { return nil }
+        return NSWorkspace.shared.icon(forFile: url.path)
+    }
+
     static func run(surface: String, seconds: Double) -> Int32 {
         let app = NSApplication.shared
         app.setActivationPolicy(.accessory)
@@ -155,6 +177,7 @@ enum PanelsCommand {
                 after: "I think we should have asked them first — they're going to be annoyed."
             )
         case "pill":
+            overlay.model.appIcon = sampleIcon()
             overlay.show()
             // A meter frozen at zero says nothing about how the meter looks.
             var phase = 0.0

--- a/Sources/ParrotFlow/RecordingOverlay.swift
+++ b/Sources/ParrotFlow/RecordingOverlay.swift
@@ -5,6 +5,10 @@ import SwiftUI
 final class OverlayModel: ObservableObject {
     @Published var level: Float = 0
     @Published var elapsed: TimeInterval = 0
+    /// The icon of the app that was in front when the hotkey went down — the
+    /// one an `app:` condition will be matched against and the one the text
+    /// will land in. Nil when nothing was in front, or when the app has none.
+    @Published var appIcon: NSImage?
 }
 
 /// A small non-interactive pill near the bottom of the screen, so you can tell
@@ -15,6 +19,9 @@ final class RecordingOverlay {
 
     func show() {
         if panel == nil { build() }
+        // Before repositioning, not after: the pill is centred on the screen,
+        // so a width set afterwards would leave it off-centre by half the icon.
+        resize()
         reposition()
         panel?.orderFrontRegardless()
     }
@@ -23,10 +30,28 @@ final class RecordingOverlay {
         panel?.orderOut(nil)
     }
 
+    /// The pill is two widths — with an app icon in it and without — and which
+    /// one applies is only known when a recording starts. Done here rather than
+    /// in the view because the panel is what has to change size; a SwiftUI
+    /// frame inside a fixed panel would centre a narrow pill in a wide
+    /// transparent box and take the shadow with it.
+    private func resize() {
+        guard let panel else { return }
+        let size = NSSize(
+            width: RecordingMetrics.width(hasIcon: model.appIcon != nil),
+            height: RecordingMetrics.height
+        )
+        guard panel.frame.size != size else { return }
+        panel.setContentSize(size)
+        panel.contentView?.frame = NSRect(origin: .zero, size: size)
+    }
+
     private func build() {
         let hosting = NSHostingView(rootView: RecordingPill().environmentObject(model))
         hosting.frame = NSRect(
-            x: 0, y: 0, width: RecordingMetrics.width, height: RecordingMetrics.height
+            x: 0, y: 0,
+            width: RecordingMetrics.width(hasIcon: model.appIcon != nil),
+            height: RecordingMetrics.height
         )
 
         let panel = NSPanel(
@@ -66,41 +91,94 @@ final class RecordingOverlay {
 
 // MARK: - View
 
-/// A red dot and a live meter, and nothing else.
+/// A red light, a live meter, and where the words are going.
 ///
-/// The elapsed time was here to prove the recorder was running, which is the
+/// Left to right that is a sentence: recording, hearing this, into this. The
+/// destination sits at the end because it is the one part you read once and
+/// stop watching — the meter is what moves, and it wants the middle. The
+/// elapsed time was here once to prove the recorder was running, which is the
 /// meter's job — it moves when you speak, which a clock does not. A clock next
 /// to a hot mic only ever reads as pressure to hurry up.
+///
+/// The icon carries no mark of its own. It was tried with a scarlet ring around
+/// it, which read as a red border painted on someone else's artwork and put a
+/// second saturated shape next to the dot for no gain — the dot already says
+/// the mic is hot, and saying it twice is what made the left half heavy.
+///
+/// **With no icon the pill is simply narrower**, back to the dot and the meter
+/// it has always been. An empty slot held open is a hole you have to explain;
+/// the two widths are set in `RecordingMetrics` and applied at `show()`, which
+/// is the only moment either can change.
 struct RecordingPill: View {
     @EnvironmentObject private var model: OverlayModel
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var pulse = false
 
     var body: some View {
-        HStack(spacing: 11) {
+        HStack(spacing: 0) {
             Circle()
                 .fill(Parrot.scarlet)
-                .frame(width: 9, height: 9)
+                .frame(width: RecordingMetrics.dot, height: RecordingMetrics.dot)
                 .shadow(color: Parrot.scarlet.opacity(0.7), radius: 4)
                 .opacity(pulse ? 0.35 : 1)
                 .animation(.easeInOut(duration: 0.7).repeatForever(autoreverses: true), value: pulse)
 
             Meter(level: model.level)
-                .frame(width: 72, height: 16)
+                .frame(width: RecordingMetrics.meter, height: 16)
+                .padding(.leading, RecordingMetrics.gap)
+
+            if let icon = model.appIcon {
+                Image(nsImage: icon)
+                    .resizable()
+                    .interpolation(.high)
+                    .frame(width: RecordingMetrics.icon, height: RecordingMetrics.icon)
+                    .padding(.leading, RecordingMetrics.tuck)
+            }
         }
-        .padding(.horizontal, 17)
-        .frame(width: RecordingMetrics.width, height: RecordingMetrics.height)
+        .padding(.horizontal, RecordingMetrics.padding)
+        .frame(
+            width: RecordingMetrics.width(hasIcon: model.appIcon != nil),
+            height: RecordingMetrics.height
+        )
         .parrotSurface(Capsule())
-        .onAppear { pulse = true }
+        // `initial: true` covers what `onAppear` did; the view stays alive
+        // across recordings, so a Reduce Motion toggle mid-session needs the
+        // same assignment again, not just on the first appearance.
+        .onChange(of: reduceMotion, initial: true) { _, newValue in pulse = !newValue }
     }
 }
 
 enum RecordingMetrics {
-    static let width: CGFloat = 128
+    static let padding: CGFloat = 17
+    static let gap: CGFloat = 11
+    /// The gap on the meter's right, 2pt tighter than the one on its left.
+    ///
+    /// Both were 11 and did not look it. The dot is small, round and spills a
+    /// little glow into its gap; the meter closes on its shortest, dimmest bar
+    /// and the icon has a hard edge — so the eye measures from the last bar it
+    /// can actually see to that edge, and reads that side as wider. Equal
+    /// numbers, unequal gaps. These two are equal to look at.
+    static let tuck: CGFloat = 9
+    static let dot: CGFloat = 9
+    static let icon: CGFloat = 24
+    static let meter: CGFloat = 72
     static let height: CGFloat = 46
+
+    /// 17 + 9 + 11 + 72 + 17, and the icon after the meter when there is one
+    /// to show.
+    static func width(hasIcon: Bool) -> CGFloat {
+        let base = padding * 2 + dot + gap + meter
+        return hasIcon ? base + icon + tuck : base
+    }
 }
 
 /// The bars walk the plumage as they light up, left to right, so a loud sound
 /// fills the pill with the same four colours that ring every other surface.
+///
+/// Against the wheel's direction: sky at the quiet end, scarlet at the loud
+/// one. The last bars are the ones a shout reaches, and the colour arriving
+/// there should be the one that means loud.
 struct Meter: View {
     let level: Float
     private let bars = 12
@@ -120,7 +198,7 @@ struct Meter: View {
     }
 
     private func feather(_ index: Int) -> Color {
-        Parrot.wheel[min(3, index * 4 / bars)]
+        Parrot.wheel[3 - min(3, index * 4 / bars)]
     }
 
     private func height(for index: Int) -> CGFloat {


### PR DESCRIPTION
This is #27, which merged into `feat/release-tail` at 21:52 — thirty-seven minutes after that branch had already gone into `main` via #25. The train had left, so the work never reached `main`. Same content, re-based onto `main` so it can.

`app:` conditions fail closed and say so only in the log, so "why didn't that stage run" had no answer on screen. The app in front is also not reliably the one you assume — `PeekCommand.swift:63-67` already records that NSWorkspace and Accessibility can point at different processes. The icon tells you **before you speak**, while it is still cheap.

Free: `NSRunningApplication.icon`, read at the press in the same NSWorkspace call that fills `appAtPress`. Not a second call — the two questions are asked a moment apart, and the one time they could disagree is exactly the time this is worth having.

## The composition

Dot, meter, icon — left to right that reads as a sentence: recording, hearing this, into this. The destination sits at the end because it is the one part you read once and stop watching; the meter is what moves, and it wants the middle.

A scarlet ring around the icon was tried first and dropped. At 24pt it touched the artwork and stopped reading as a ring at all: it read as a red border painted on someone else's icon.

**The meter walks the wheel backwards** — sky at the quiet end, scarlet at the loud one. Running scarlet-first meant the colour of a shout was sky, the calmest of the four.

**The two gaps are 11 and 9, not 11 and 11.** Equal numbers did not look equal — the dot is round and spills a little glow into its gap, the meter closes on its shortest, dimmest bar, and the icon has a hard edge, so the eye measures from the last bar it can actually see to that edge and reads that side as wider.

**With no app in front the pill is simply narrower**, back to the dot and the meter it has always been. An empty slot held open is a hole you have to explain. The resize happens in `show()` before `reposition()`, or the centred pill would sit off-centre by half an icon.

Both states are on `--panel-sheet`.

## Also

The pulsing dot now respects `accessibilityReduceMotion`, which it did not. `PlumageRim` already did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)