### PR TITLE
feat: writing prompts, and a permissions walk that explains itself

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -388,6 +388,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func handleHotKeyRelease() {
         guard config.hotkey.mode == .pushToTalk else { return }
+        // The character key is actually up now, so there is nothing left for
+        // the modifier poll to catch — unlike the poll's own call below, where
+        // the character key is still down and a flicked-back modifier means
+        // the chord never really broke.
+        pushToTalkPoll?.invalidate(); pushToTalkPoll = nil
         stopRecordingAfterTail()
     }
 
@@ -397,9 +402,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// on the release as before.
     private func stopRecordingAfterTail() {
         guard recorder.isRecording else { return }
-
-        // The poll would see the key still up 60ms from now and ask again.
-        pushToTalkPoll?.invalidate(); pushToTalkPoll = nil
 
         let tail = config.hotkey.releaseTailSeconds
         guard tail > 0 else {
@@ -434,9 +436,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let timer = Timer(timeInterval: 0.06, repeats: true) { [weak self] _ in
             guard let self, self.recorder.isRecording else { return }
             let held = NSEvent.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            if !held.isSuperset(of: required) {
+            if held.isSuperset(of: required) {
+                // The modifier is back and the character key never came up —
+                // Carbon has no press event for that, since it only edge-
+                // detects the character key, so the poll is what has to
+                // notice the chord is whole again and call off the tail it
+                // started.
+                if self.releaseTail != nil {
+                    self.releaseTail?.invalidate(); self.releaseTail = nil
+                }
+            } else if self.releaseTail == nil {
                 // The same event as a release, found a different way, so it
-                // ends the recording the same way — through the tail.
+                // ends the recording the same way — through the tail. Keep
+                // polling through the tail itself: this is the one path where
+                // the modifier can still come back before the character key
+                // does.
                 self.stopRecordingAfterTail()
             }
         }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -130,13 +130,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         warmUpLLM()
 
-        // First run: get the microphone prompt out of the way immediately,
-        // rather than at the moment the user first tries to dictate.
-        if Permissions.microphone == .notDetermined {
-            permissions.show()
-            Permissions.requestMicrophone { [weak self] _ in
-                self?.permissions.model.refresh()
-            }
+        // Anything still missing opens the walk, and nothing is asked for yet.
+        // The prompt used to fire here, the moment the window appeared — a
+        // system dialog on top of the window explaining it, before either had
+        // been read. The window asks when its button is pressed and not before.
+        //
+        // Both permissions, not just the microphone: a launch with the
+        // microphone already answered and accessibility still missing is
+        // exactly the install that fails later, at the moment someone holds the
+        // key and nothing is written.
+        //
+        // Which walk it is turns on whether the microphone has ever been
+        // answered. An unanswered one is a first run and the install is still
+        // happening, so the way out is to cancel it. Once there is an answer on
+        // record the app has been opened before, and offering to cancel an
+        // installation that finished is a threat about something that already
+        // happened — same reasoning as the hotkey path below.
+        if Permissions.microphone != .granted || Permissions.accessibility != .granted {
+            permissions.show(Permissions.microphone == .notDetermined ? .installing : .revisiting)
         }
     }
 
@@ -480,7 +491,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 if granted {
                     self.startRecording()
                 } else {
-                    self.permissions.show()
+                    // Not `.installing`: the app has been running for a while
+                    // by the time someone presses the hotkey, and a refusal
+                    // here should not offer to cancel an install that finished
+                    // days ago.
+                    self.permissions.show(.revisiting)
                 }
             }
             return
@@ -1805,7 +1820,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc private func openPermissions() {
-        permissions.show()
+        permissions.show(.revisiting)
     }
 
     @objc private func showAbout() {

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -68,6 +68,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// without Accessibility — an app condition has no business needing a
     /// permission that gating a stage by app does not otherwise require.
     private var appAtPress: Pipeline.App?
+    /// That same app's icon, for the pill. Held apart from `appAtPress` because
+    /// `Pipeline.App` is what the pipeline matches on and has no business
+    /// carrying an image around.
+    private var appIconAtPress: NSImage?
 
     private var tickTimer: Timer?
     private var pushToTalkPoll: Timer?
@@ -362,7 +366,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let snapshotStart = Date()
         selectionAtPress = SelectionReader.snapshot()
         focusAtPress = selectionAtPress ?? SelectionReader.focusSnapshot()
-        appAtPress = Self.appInFront()
+        let front = Self.appInFront()
+        appAtPress = front?.app
+        appIconAtPress = front?.icon
         let elapsed = Date().timeIntervalSince(snapshotStart)
         if elapsed > 0.15 {
             Log.write(String(format: "selection snapshot was slow: %.2fs", elapsed))
@@ -491,6 +497,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if config.feedback.overlay {
             overlay.model.elapsed = 0
             overlay.model.level = 0
+            overlay.model.appIcon = appIconAtPress
             overlay.show()
         }
 
@@ -534,14 +541,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Transcription
 
     /// The app in front right now, or nil if there isn't one to name.
-    private static func appInFront() -> Pipeline.App? {
+    ///
+    /// The icon rides along rather than being fetched when the pill is built,
+    /// because those are two different questions asked a moment apart: this one
+    /// is "who was in front when the key went down", and the pill has to show
+    /// the same answer the pipeline will be conditioned on. Reading NSWorkspace
+    /// twice would let them disagree, and the one time they disagree is exactly
+    /// the time the pill is worth having.
+    private static func appInFront() -> (app: Pipeline.App, icon: NSImage?)? {
         guard let front = NSWorkspace.shared.frontmostApplication else { return nil }
         let app = Pipeline.App(
             name: front.localizedName ?? "", bundleID: front.bundleIdentifier ?? ""
         )
         // Both empty is not an app you could write a condition against, and
         // saying so is what makes `app:` fail closed instead of matching "  ".
-        return app.searchable.trimmingCharacters(in: .whitespaces).isEmpty ? nil : app
+        guard !app.searchable.trimmingCharacters(in: .whitespaces).isEmpty else { return nil }
+        return (app, front.icon)
     }
 
     private func transcribe(_ recording: Recorder.Recording) {

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -435,7 +435,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             guard let self, self.recorder.isRecording else { return }
             let held = NSEvent.modifierFlags.intersection(.deviceIndependentFlagsMask)
             if !held.isSuperset(of: required) {
-                self.stopRecording()
+                // The same event as a release, found a different way, so it
+                // ends the recording the same way — through the tail.
+                self.stopRecordingAfterTail()
             }
         }
         RunLoop.main.add(timer, forMode: .common)

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1457,6 +1457,12 @@ if __name__ == "__main__":
           - transform: code_identifiers
             app: /term|ghostty|warp|kitty|alacritty|hyper|code|cursor|zed|xcode|jetbrains|idea|pycharm|webstorm/
             when: /\\b(?:function|method|variable|class|constant|type|struct|interface|enum|fonction|méthode|classe|constante)\\b/
+          # `email` and `slack` below lay dictated prose out for one kind of
+          # window each, and are deliberately not in this list. Every stage
+          # here is free and needs nothing running; those two cost about a
+          # second and stop dead without Ollama, which is not a default. Wire
+          # them up behind `app:` when you want them — config.example.yaml
+          # shows how.
 
       # The spelling you want, and the ways it comes out wrong. Whole words,
       # case-insensitive. A source in /slashes/ is a regular expression, and an
@@ -1588,6 +1594,145 @@ if __name__ == "__main__":
 
           A phrase before the main clause takes a comma after it. A trailing
           please or thanks does not.
+
+          Return only the text.
+
+      # Two prompts scoped to one kind of window each. `grammar` mends a
+      # sentence; these two also lay one out — a greeting on its own line, a
+      # blank line where the subject changes — which is the part no
+      # substitution can express and the reason they are prompts.
+      #
+      # Both are told twice not to write anything, because that is the failure
+      # that costs you something: a model handed a dictated email will gladly
+      # return a better one, in its own voice, and you will not notice until it
+      # has gone.
+      #
+      # 8/10 on gemma4:e4b, and the six versions before it are written down in
+      # config.example.yaml beside the same prompt. The short version: a
+      # prohibition ("do not invent a greeting") read as a topic and produced
+      # one; "nothing is ever deleted" produced a literal "[Signature]";
+      # worked examples for the greeting came back in the output; and the list
+      # rule has to sit with the paragraph rule, because after the short-reply
+      # clause it turned a two-word reply into "[No body text]".
+      #
+      # The two still failing are one shape — a short reply ending in a goodbye
+      # comes back as the goodbye alone. Numbered lists are deliberately absent:
+      # the version that forced them from spoken ordinals dropped an item.
+      - name: email
+        description: lay dictated text out as an email
+        display: Laying out the email
+        prompt: |
+          Lay the text out as an email, in the language it was dictated in.
+          Fix the writing; do not write it.
+
+          Correct grammar, spelling and punctuation, and drop the hesitations
+          — um, uh, euh, well, you know, I mean. Every other word survives:
+          the wording, the order and the tone are the speaker's.
+
+          If the text opens with a greeting, it goes on its own line, with a
+          comma after it and a blank line under it. If it does not, the email
+          starts with the first sentence. Never add a greeting nobody spoke.
+
+          Break the body into paragraphs where the subject changes, a blank
+          line between them. Add no headings and no emphasis.
+
+          Three or more things listed in a row never stay inline. Whatever
+          joined them — commas, "and", nothing at all — the words introducing
+          them take a colon and each thing goes on a line of its own behind a
+          dash. No number has to be said for this: "here is what I need from
+          you", "the steps are", "we should" all open a list as surely as
+          "there are three things" does. Two things are a sentence and stay
+          one.
+
+          A name at the end is a signature: a blank line, then the name on
+          its own line, and a closing word said just before it — thanks,
+          merci — on the line above. No name at the end means no signature:
+          the last thing said is the last line of the body, wherever it
+          sounds like a goodbye.
+
+          A short reply is not an email with parts. One or two sentences and
+          no hello in front of them come back as one or two sentences,
+          corrected, with no line put anywhere.
+
+          Return only the email.
+
+      # 3/3. "Add nothing" rather than "no greeting, no sign-off": the second
+      # wording read as an instruction to remove one, and "hey uh quick one the
+      # build is red" came back as "The build is red". The slang line is there
+      # because "gonna" was being corrected to "going to", which is the
+      # speaker's voice going out with the hesitations.
+      - name: slack
+        description: tidy dictated text into a chat message
+        display: Tidying for chat
+        prompt: |
+          Tidy the text into a chat message, in the language it was dictated
+          in. Fix the writing; do not write it.
+
+          Correct grammar, spelling and punctuation, and drop the hesitations
+          — um, uh, euh, well, you know, I mean. Every other word survives.
+          Slang and contractions are the speaker's voice rather than
+          mistakes: gonna stays gonna, ouais stays ouais.
+
+          Add nothing: no greeting, no sign-off, no heading, no bullet, no
+          bold, no backtick. Slack's composer renders none of that when text
+          arrives by paste, so it would land in the message as characters.
+          Remove nothing either: a spoken "hey" is part of the message.
+
+          One paragraph, unless the text plainly holds two.
+
+          Return only the message.
+
+      # Said out loud — "hey parrot, use Slack mentions" — and deliberately in
+      # no pipeline. A message that names someone is not a message that pings
+      # them, and nothing in a transcript tells the two apart. So this is the
+      # one you ask for.
+      #
+      # `confirm` covers one of the two ways of asking. With text selected the
+      # result is shown first; mid-sentence there is no preview whatever
+      # `confirm` says. Either way what lands is text in your composer, and
+      # ParrotFlow sends nothing.
+      #
+      # It was two `replace:` tables for a while — a table cannot invent a
+      # handle, where this prompt's first draft answered "Sofia already looked
+      # at it" with "@priya already looked at it". They came back out because a
+      # table has to be triggered from inside the sentence, and "mention" is a
+      # word English already uses: "I should mention here that the deadline
+      # changed" became "I should @here that the deadline changed". A pipeline
+      # stage has no preview, so a false positive there is a message already
+      # sent. Asking out loud fires when you ask and never otherwise. The whole
+      # excursion is written up in config.example.yaml.
+      #
+      # Put your own people in the list.
+      - name: slack_mentions
+        description: turn people's names into Slack mentions
+        display: Adding mentions
+        prompt: |
+          Return the text word for word, with one kind of change and no
+          other: a name that appears in this list becomes its handle.
+
+            Marie   -> @marie.dupont
+            Thomas  -> @tleroy
+            Priya   -> @priya
+
+          Every occurrence, including where the message is about that person
+          rather than to them.
+
+          A name that is not in the list is left exactly as it was. Sofia
+          stays Sofia. Never give a name a handle that belongs to someone
+          else, and never invent one.
+
+          Two group mentions are a judgement rather than a lookup. "everyone
+          here", "whoever is around" -> @here, which pings the people who are
+          online. "the whole channel", "everyone", "all of them" -> @channel,
+          which pings the ones who are away too. Only where the text means
+          the people: "the file is here" is a place, and stays.
+
+          A mention replaces the words that name the person or the group, and
+          not one word more: "heads up to the whole channel" comes back as
+          "heads up to @channel".
+
+          Nothing is ever deleted. Every other word, the order and the
+          punctuation come back as they went in.
 
           Return only the text.
 

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -35,6 +35,15 @@ enum PanelsCommand {
 
         let overlay = OverlayModel()
         overlay.level = 0.75
+        overlay.appIcon = sampleIcon()
+
+        // The pill has two states now and the difference is the whole point of
+        // the slot: with an app in front it holds that app, without one it
+        // holds nothing and is simply narrower. Both are on the sheet because
+        // "it looks wrong with no icon" is the kind of thing that is obvious
+        // side by side and invisible a week apart.
+        let overlayBlind = OverlayModel()
+        overlayBlind.level = 0.75
 
         let correction = CorrectionModel()
         correction.load(selection: "Tasmin and Mick")
@@ -53,7 +62,11 @@ enum PanelsCommand {
 
         let surfaces: [(NSView, NSSize)] = [
             (NSHostingView(rootView: RecordingPill().environmentObject(overlay)),
-             NSSize(width: RecordingMetrics.width, height: RecordingMetrics.height)),
+             NSSize(width: RecordingMetrics.width(hasIcon: overlay.appIcon != nil),
+                    height: RecordingMetrics.height)),
+            (NSHostingView(rootView: RecordingPill().environmentObject(overlayBlind)),
+             NSSize(width: RecordingMetrics.width(hasIcon: false),
+                    height: RecordingMetrics.height)),
             (NSHostingView(rootView: NoticeView().environmentObject(notice)),
              NSSize(width: NoticeMetrics.width(for: notice.message), height: NoticeMetrics.height)),
             (NSHostingView(rootView: NoticeView().environmentObject(thinking)),
@@ -122,6 +135,15 @@ enum PanelsCommand {
         }
     }
 
+    /// Something recognisable to sit in the pill's slot. Mail because that is
+    /// the window the `email` transform was written for, and any Mac has it.
+    private static func sampleIcon() -> NSImage? {
+        guard let url = NSWorkspace.shared.urlForApplication(
+            withBundleIdentifier: "com.apple.mail"
+        ) else { return nil }
+        return NSWorkspace.shared.icon(forFile: url.path)
+    }
+
     static func run(surface: String, seconds: Double) -> Int32 {
         let app = NSApplication.shared
         app.setActivationPolicy(.accessory)
@@ -155,6 +177,7 @@ enum PanelsCommand {
                 after: "I think we should have asked them first — they're going to be annoyed."
             )
         case "pill":
+            overlay.model.appIcon = sampleIcon()
             overlay.show()
             // A meter frozen at zero says nothing about how the meter looks.
             var phase = 0.0

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -39,9 +39,9 @@ enum PanelsCommand {
 
         // The pill has two states now and the difference is the whole point of
         // the slot: with an app in front it holds that app, without one it
-        // holds nothing and is simply narrower. Both are on the sheet because
-        // "it looks wrong with no icon" is the kind of thing that is obvious
-        // side by side and invisible a week apart.
+        // holds nothing and stays exactly as wide. Both are on the sheet
+        // because "the ring looks wrong empty" is the kind of thing that is
+        // obvious side by side and invisible a week apart.
         let overlayBlind = OverlayModel()
         overlayBlind.level = 0.75
 
@@ -60,25 +60,46 @@ enum PanelsCommand {
             after: "I think we should have asked them first — they're going to be annoyed."
         )
 
-        let surfaces: [(NSView, NSSize)] = [
+        // The third element is the appearance to draw in. Every floating
+        // surface is dark whatever the system is set to — that is decided in
+        // `adoptParrotAppearance` and is not a preference. The permissions
+        // window is the exception and the reason this is a column at all: it is
+        // an ordinary titled window, it follows the system, and it has to be
+        // legible both ways. So it appears twice, once each.
+        let surfaces: [(NSView, NSSize, NSAppearance.Name)] = [
             (NSHostingView(rootView: RecordingPill().environmentObject(overlay)),
              NSSize(width: RecordingMetrics.width(hasIcon: overlay.appIcon != nil),
-                    height: RecordingMetrics.height)),
+                    height: RecordingMetrics.height), .darkAqua),
             (NSHostingView(rootView: RecordingPill().environmentObject(overlayBlind)),
              NSSize(width: RecordingMetrics.width(hasIcon: false),
-                    height: RecordingMetrics.height)),
+                    height: RecordingMetrics.height), .darkAqua),
+            // The one real window the app has, and the first thing anyone sees.
+            // On the sheet for the same reason as the rest: it is looked at,
+            // not asserted on, and two screens that drift apart are obvious
+            // side by side and invisible a week apart.
+            //
+            // One of each context, because the second button is the difference
+            // between them and it is the part worth being able to see: setting
+            // up says "Cancel installation", revisiting says "Not now".
+            (NSHostingView(rootView: PermissionsView()
+                .environmentObject(PermissionsModel.showing(.microphone))),
+             NSSize(width: PermissionMetrics.width, height: PermissionMetrics.height), .aqua),
+            (NSHostingView(rootView: PermissionsView()
+                .environmentObject(PermissionsModel.showing(
+                    .accessibility, asked: true, context: .revisiting))),
+             NSSize(width: PermissionMetrics.width, height: PermissionMetrics.height), .darkAqua),
             (NSHostingView(rootView: NoticeView().environmentObject(notice)),
-             NSSize(width: NoticeMetrics.width(for: notice.message), height: NoticeMetrics.height)),
+             NSSize(width: NoticeMetrics.width(for: notice.message), height: NoticeMetrics.height), .darkAqua),
             (NSHostingView(rootView: NoticeView().environmentObject(thinking)),
-             NSSize(width: NoticeMetrics.width(for: thinking.message), height: NoticeMetrics.height)),
+             NSSize(width: NoticeMetrics.width(for: thinking.message), height: NoticeMetrics.height), .darkAqua),
             (NSHostingView(rootView: NoticeView().environmentObject(caution)),
-             NSSize(width: NoticeMetrics.width(for: caution.message), height: NoticeMetrics.height)),
+             NSSize(width: NoticeMetrics.width(for: caution.message), height: NoticeMetrics.height), .darkAqua),
             (NSHostingView(rootView: CorrectionView().environmentObject(correction)),
-             NSSize(width: CorrectionMetrics.width, height: CorrectionMetrics.height(forRows: 2))),
+             NSSize(width: CorrectionMetrics.width, height: CorrectionMetrics.height(forRows: 2)), .darkAqua),
             (NSHostingView(rootView: CorrectionView().environmentObject(rule)),
-             NSSize(width: CorrectionMetrics.width, height: CorrectionMetrics.height(forRows: 1))),
+             NSSize(width: CorrectionMetrics.width, height: CorrectionMetrics.height(forRows: 1)), .darkAqua),
             (NSHostingView(rootView: PreviewView().environmentObject(preview)),
-             NSSize(width: PreviewMetrics.width, height: PreviewMetrics.height(forCharacters: 70))),
+             NSSize(width: PreviewMetrics.width, height: PreviewMetrics.height(forCharacters: 70)), .darkAqua),
         ]
 
         let margin: CGFloat = 36
@@ -106,8 +127,8 @@ enum PanelsCommand {
             NSRect(x: left, y: 0, width: column, height: size.height).fill()
 
             var top = size.height - margin
-            for (view, natural) in surfaces {
-                view.appearance = NSAppearance(named: .darkAqua)
+            for (view, natural, appearance) in surfaces {
+                view.appearance = NSAppearance(named: appearance)
                 view.frame = NSRect(origin: .zero, size: natural)
                 view.layoutSubtreeIfNeeded()
                 guard let rep = view.bitmapImageRepForCachingDisplay(in: view.bounds) else { continue }

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -1,20 +1,166 @@
 import AppKit
 import SwiftUI
 
+/// The two things macOS will not let this app do without being asked.
+///
+/// Both are required, and the walk is not skippable: the only way past a screen
+/// is to grant it, and the only other button quits. The microphone is what the
+/// app hears with, accessibility is what it writes and reads selections with,
+/// and an install missing either is one that fails later, quietly, at the
+/// moment someone is trying to use it — which is a worse place to find out.
+/// Why the window is open, which decides what the second button says and does.
+///
+/// The same screen means two different things at two moments. During setup a
+/// permission is a condition of having the app at all, and the way out is to
+/// stop installing it. Afterwards the app is installed, running, and in the
+/// menu bar — "cancel installation" there would be a threat about something
+/// that already happened, and pressing it would quit an app the user opened a
+/// window from. So the way out becomes a skip, and the window gets its close
+/// button back.
+enum PermissionsContext {
+    case installing
+    case revisiting
+}
+
+enum PermissionStep: CaseIterable {
+    case microphone
+    case accessibility
+
+    var title: String {
+        switch self {
+        case .microphone: return "Microphone"
+        case .accessibility: return "Accessibility"
+        }
+    }
+
+    /// What it is for, and why this app is the one asking. Two sentences at
+    /// most: this is read once, standing between someone and the thing they
+    /// just installed.
+    var reason: String {
+        switch self {
+        case .microphone:
+            return "Hold the hotkey and ParrotFlow records. The recording becomes "
+                + "text on this Mac, and never leaves it."
+        case .accessibility:
+            return "This is what puts the text into the app you are already in, and "
+                + "reads the words you select so you can fix them out loud. Both "
+                + "halves of ParrotFlow need it."
+        }
+    }
+
+    /// Named for what pressing it does, not for what it is for. Neither button
+    /// grants anything: one makes macOS ask, the other opens the pane where you
+    /// answer. Saying "Allow" would take credit for a decision this app does
+    /// not get to make, and then the system dialog would read as a second ask.
+    var actionTitle: String {
+        switch self {
+        case .microphone: return "Show the macOS prompt"
+        case .accessibility: return "Open System Settings"
+        }
+    }
+
+    /// The same on both screens, and different in the two contexts. Setting up
+    /// has one way out and it does what it says: the app quits. Both
+    /// permissions are required, and a requirement you can walk past is not
+    /// one. Revisiting has no installation left to cancel.
+    func declineTitle(in context: PermissionsContext) -> String {
+        context == .installing ? "Cancel installation" : "Not now"
+    }
+
+    /// Shown after the ask, while the answer is somewhere else.
+    var waiting: String {
+        switch self {
+        case .microphone:
+            return "Answer the prompt macOS just put up."
+        case .accessibility:
+            return "Find ParrotFlow in the list and tick it. This window updates itself."
+        }
+    }
+}
+
 final class PermissionsModel: ObservableObject {
     @Published var micStatus: Permissions.Status = .notDetermined
     @Published var axStatus: Permissions.Status = .notGranted
     @Published var axBlocker: String?
+
+    /// What is left to ask for, fixed when the window opens.
+    ///
+    /// Fixed rather than recomputed so "1 of 2" does not become "1 of 1" under
+    /// the reader the moment they grant the first one — a counter that changes
+    /// its own total reads as the app losing count.
+    @Published private(set) var steps: [PermissionStep] = []
+    @Published private(set) var index = 0
+    /// The system has been asked and the answer is not here yet.
+    @Published private(set) var asked = false
+    @Published private(set) var context: PermissionsContext = .installing
+
+    var current: PermissionStep? { steps.indices.contains(index) ? steps[index] : nil }
+
+    func status(of step: PermissionStep) -> Permissions.Status {
+        switch step {
+        case .microphone: return micStatus
+        case .accessibility: return axStatus
+        }
+    }
 
     func refresh() {
         micStatus = Permissions.microphone
         axStatus = Permissions.accessibility
         axBlocker = Permissions.accessibilityBlocker
     }
+
+    /// Start the walk. Anything already granted is not a screen — nobody needs
+    /// to be told about a permission they have given.
+    func begin(context: PermissionsContext) {
+        self.context = context
+        refresh()
+        steps = PermissionStep.allCases.filter { status(of: $0) != .granted }
+        index = 0
+        asked = false
+    }
+
+    func markAsked() { asked = true }
+
+    /// Only reachable when revisiting — during setup the button that would
+    /// call this quits instead.
+    func skip() {
+        guard index < steps.count else { return }
+        index += 1
+        asked = false
+    }
+
+    /// Parked on one step, for `--panel-sheet`. The statuses are left at their
+    /// defaults, which is what a first launch actually shows.
+    static func showing(
+        _ step: PermissionStep, asked: Bool = false, context: PermissionsContext = .installing
+    ) -> PermissionsModel {
+        let model = PermissionsModel()
+        model.context = context
+        model.steps = PermissionStep.allCases
+        model.index = PermissionStep.allCases.firstIndex(of: step) ?? 0
+        model.asked = asked
+        return model
+    }
+
+    /// Move past anything that has been granted since the last look. Called on
+    /// the poll, so the screen advances itself the moment the box is ticked
+    /// rather than waiting to be dismissed.
+    func advancePastGranted() {
+        while let step = current, status(of: step) == .granted {
+            index += 1
+            asked = false
+        }
+    }
 }
 
-/// Single plain window — no preferences tabs, no toolbar. It exists to answer
-/// "is this thing actually allowed to hear me, and to type what it hears?".
+/// A single plain window that walks one permission at a time.
+///
+/// It used to show both at once, each with its own Request button, and fire the
+/// microphone prompt on first launch the instant it appeared — a system dialog
+/// on top of a window explaining the system dialog, before anyone had read
+/// either. One screen, one permission, one button: the explanation is finished
+/// being read before anything is asked.
+///
 /// Everything else the app can be told lives in config.yaml, which the Settings
 /// menu item opens.
 final class PermissionsWindowController {
@@ -25,7 +171,7 @@ final class PermissionsWindowController {
 
     init() {
         accessibilityObserver = Permissions.observeAccessibilityChanges { [weak self] in
-            self?.model.refresh()
+            self?.poll()
         }
     }
 
@@ -35,28 +181,41 @@ final class PermissionsWindowController {
         }
     }
 
-    func show() {
-        model.refresh()
+    func show(_ context: PermissionsContext = .revisiting) {
+        model.begin(context: context)
 
         if window == nil { build() }
+        // Set per showing, not at build: the same window is both, and which
+        // one it is now decides whether the title bar offers a third way out.
+        window?.styleMask = context == .installing ? [.titled] : [.titled, .closable]
         NSApp.activate(ignoringOtherApps: true)
         window?.makeKeyAndOrderFront(nil)
         window?.center()
 
         timer?.invalidate()
         timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            self?.model.refresh()
+            self?.poll()
         }
     }
 
+    private func poll() {
+        model.refresh()
+        model.advancePastGranted()
+    }
+
     private func build() {
-        let view = PermissionsView().environmentObject(model)
+        let view = PermissionsView(
+            onAsk: { [weak self] step in self?.ask(step) },
+            onDecline: { [weak self] in self?.decline() },
+            onClose: { [weak self] in self?.window?.close() }
+        ).environmentObject(model)
+
         let hosting = NSHostingController(rootView: view)
         let window = NSWindow(contentViewController: hosting)
         window.title = "\(AppVariant.displayName) Permissions"
-        window.styleMask = [.titled, .closable, .miniaturizable]
+        window.styleMask = [.titled]
         window.isReleasedWhenClosed = false
-        window.setContentSize(NSSize(width: 460, height: 320))
+        window.setContentSize(NSSize(width: PermissionMetrics.width, height: PermissionMetrics.height))
         self.window = window
 
         NotificationCenter.default.addObserver(
@@ -68,106 +227,322 @@ final class PermissionsWindowController {
             self?.timer = nil
         }
     }
+
+    /// Leaving. During setup that means the app — a button reading "cancel
+    /// installation" that quietly moved to the next screen would be the kind of
+    /// wording nobody trusts twice. Revisiting, it is a skip, and the walk ends
+    /// on the screen that says what is still missing.
+    private func decline() {
+        guard model.context == .installing else {
+            model.skip()
+            return
+        }
+        window?.close()
+        NSApp.terminate(nil)
+    }
+
+    private func ask(_ step: PermissionStep) {
+        model.markAsked()
+        switch step {
+        case .microphone:
+            Permissions.requestMicrophone { [weak self] _ in self?.poll() }
+        case .accessibility:
+            // Request before opening Settings, always. It is
+            // AXIsProcessTrustedWithOptions that registers this binary with
+            // TCC — open the pane first and the app may not be in the list to
+            // tick, which reads as the instructions being wrong.
+            Permissions.requestAccessibility()
+            Permissions.openAccessibilitySettings()
+        }
+    }
 }
 
 // MARK: - View
 
-private struct PermissionsView: View {
+enum PermissionMetrics {
+    static let width: CGFloat = 460
+    static let height: CGFloat = 328
+}
+
+struct PermissionsView: View {
     @EnvironmentObject private var model: PermissionsModel
 
-    var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 14) {
-                PermissionRow(
-                    icon: "mic.fill",
-                    title: "Microphone",
-                    detail: "Required to record.",
-                    status: model.micStatus,
-                    actionTitle: model.micStatus == .notDetermined ? "Request" : "Open Settings",
-                    action: {
-                        if model.micStatus == .notDetermined {
-                            Permissions.requestMicrophone { _ in model.refresh() }
-                        } else {
-                            Permissions.openMicrophoneSettings()
-                        }
-                    }
-                )
+    var onAsk: (PermissionStep) -> Void = { _ in }
+    var onDecline: () -> Void = {}
+    var onClose: () -> Void = {}
 
-                PermissionRow(
-                    icon: "keyboard.fill",
-                    title: "Accessibility",
-                    detail: "Not needed to record — it's what lets ParrotFlow type the transcript into the app you're using.",
-                    status: model.axStatus,
-                    // "Request" must come first: AXIsProcessTrustedWithOptions
-                    // is what registers this binary with TCC. Merely opening
-                    // Settings shows a list this app may not be in yet.
-                    actionTitle: "Request",
-                    action: { Permissions.requestAccessibility() },
-                    secondaryTitle: "Open Settings",
-                    secondaryAction: { Permissions.openAccessibilitySettings() },
-                    footnote: model.axBlocker
-                        ?? "Ticked the box already? Relaunch so the running process picks it up."
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 8) {
+                PlumageMark()
+                Text(AppVariant.displayName.uppercased())
+                    .foregroundStyle(Parrot.action)
+                Spacer()
+                if model.steps.count > 1, let step = model.current,
+                   let position = model.steps.firstIndex(of: step) {
+                    Text("\(position + 1) of \(model.steps.count)".uppercased())
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .font(.system(size: 9, weight: .semibold, design: .rounded))
+            .kerning(0.9)
+
+            if let step = model.current {
+                StepPane(
+                    step: step,
+                    status: model.status(of: step),
+                    asked: model.asked,
+                    context: model.context,
+                    blocker: step == .accessibility ? model.axBlocker : nil,
+                    onAsk: { onAsk(step) },
+                    onDecline: onDecline
+                )
+            } else {
+                DonePane(
+                    micStatus: model.micStatus, axStatus: model.axStatus, onClose: onClose
                 )
             }
-            .padding(24)
         }
-        .frame(minWidth: 460, minHeight: 320)
+        .padding(28)
+        .frame(width: PermissionMetrics.width, height: PermissionMetrics.height)
+        // Stated rather than inherited. In the app this is the window's own
+        // background and setting it changes nothing; drawn on `--panel-sheet`
+        // there is no window to inherit from, and without this the pane came
+        // out with light chrome and white text on it.
+        .background(Color(nsColor: .windowBackgroundColor))
     }
 }
 
-private struct PermissionRow: View {
-    let icon: String
-    let title: String
-    let detail: String
-    let status: Permissions.Status
-    let actionTitle: String
-    let action: () -> Void
-    var secondaryTitle: String? = nil
-    var secondaryAction: (() -> Void)? = nil
-    /// Shown only while the permission is still missing.
-    var footnote: String? = nil
+/// The piece of the app this permission switches on, drawn with the app's own
+/// parts rather than illustrated.
+///
+/// A microphone glyph says "microphone", which the heading already says. The
+/// recording pill says what is about to appear at the bottom of the screen
+/// every time you hold the key — so the screen that asks for the microphone is
+/// also the only place anyone is told what the pill is before it turns up over
+/// their work. That is the whole argument for it: the illustration is the
+/// feature, at the size it will really be.
+private struct Instrument: View {
+    let step: PermissionStep
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(alignment: .top, spacing: 12) {
-                Image(systemName: icon)
-                    .font(.system(size: 14))
-                    .foregroundStyle(.secondary)
-                    .frame(width: 18)
+        ZStack {
+            RoundedRectangle(cornerRadius: 13, style: .continuous)
+                .fill(Color.primary.opacity(0.045))
 
-                VStack(alignment: .leading, spacing: 3) {
-                    HStack(spacing: 7) {
-                        Text(title).font(.system(size: 13, weight: .medium))
-                        StatusBadge(status: status)
-                    }
-                    Text(detail)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                Spacer(minLength: 8)
-
-                if status != .granted {
-                    VStack(alignment: .trailing, spacing: 6) {
-                        Button(actionTitle, action: action)
-                        if let secondaryTitle, let secondaryAction {
-                            Button(secondaryTitle, action: secondaryAction)
-                        }
-                    }
-                }
-            }
-
-            if status != .granted, let footnote {
-                Text(footnote)
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .padding(.leading, 30)
+            switch step {
+            case .microphone:
+                // The real view, at its real size. It carries its own dark
+                // glass, which is what it will look like over your document.
+                RecordingPill().environmentObject(Instrument.hearing)
+            case .accessibility:
+                Landing()
             }
         }
-        .padding(12)
-        .background(Color.secondary.opacity(0.07), in: RoundedRectangle(cornerRadius: 9))
+        .frame(height: 88)
+    }
+
+    /// Mid-sentence, so the meter has something to show.
+    private static let hearing: OverlayModel = {
+        let model = OverlayModel()
+        model.level = 0.62
+        return model
+    }()
+}
+
+/// The four feathers, then a field with the words already in it and the caret
+/// after them. `PlumageMark` is documented as the pill once it has heard you,
+/// which makes it exactly the right mark to show arriving somewhere.
+private struct Landing: View {
+    var body: some View {
+        HStack(spacing: 12) {
+            // Scaled up rather than redrawn: it is the app's mark at label size
+            // everywhere else, and this is the one place it is the subject of
+            // the picture rather than a label on one.
+            PlumageMark()
+                .scaleEffect(1.5)
+                .frame(width: 18)
+
+            Image(systemName: "arrow.right")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 2) {
+                Text("hold the hotkey and talk")
+                    .font(.system(size: 13, design: .rounded))
+                    .foregroundStyle(.primary)
+                RoundedRectangle(cornerRadius: 1)
+                    .fill(Parrot.action)
+                    .frame(width: 2, height: 16)
+            }
+            .padding(.horizontal, 11)
+            .padding(.vertical, 9)
+            .background(
+                Color.primary.opacity(0.07),
+                in: RoundedRectangle(cornerRadius: Parrot.fieldRadius, style: .continuous)
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: Parrot.fieldRadius, style: .continuous)
+                    .strokeBorder(Parrot.action.opacity(0.55), lineWidth: 1.5)
+            }
+        }
+    }
+}
+
+private struct StepPane: View {
+    let step: PermissionStep
+    let status: Permissions.Status
+    let asked: Bool
+    let context: PermissionsContext
+    let blocker: String?
+    let onAsk: () -> Void
+    let onDecline: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Instrument(step: step)
+                .padding(.top, 20)
+                .padding(.bottom, 18)
+
+            // Says what kind of screen this is before the heading says which
+            // one. "Microphone" on its own is a subject, not a request — and
+            // someone who has just installed a dictation app and been handed a
+            // window with a picture on it is owed the word "permission" before
+            // they are asked to press anything.
+            //
+            // Amber, which is what a permission that is not granted already
+            // wears on the last screen. One colour, one meaning, both places.
+            Text(eyebrow)
+                .font(.system(size: 9, weight: .semibold, design: .rounded))
+                .kerning(0.9)
+                .foregroundStyle(status == .denied ? Parrot.scarlet : Parrot.amber)
+                .padding(.bottom, 6)
+
+            Text(step.title)
+                .font(.system(size: 19, weight: .semibold, design: .rounded))
+                .padding(.bottom, 7)
+
+            Text(step.reason)
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .lineSpacing(2)
+
+            // Only after the ask. Before it, the screen has one thing to say
+            // and one button to press, and a line about what happens next is a
+            // second thing to read first.
+            if asked {
+                Text(status == .denied ? deniedNote : step.waiting)
+                    .font(.system(size: 11))
+                    .foregroundStyle(
+                        status == .denied
+                            ? AnyShapeStyle(Parrot.amber) : AnyShapeStyle(.tertiary)
+                    )
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.top, 12)
+            }
+
+            if asked, let blocker {
+                Text(blocker)
+                    .font(.system(size: 10))
+                    .foregroundStyle(.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.top, 8)
+            }
+
+            Spacer(minLength: 16)
+
+            HStack(spacing: 10) {
+                Button(step.declineTitle(in: context), action: onDecline)
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.tertiary)
+                    .font(.system(size: 12))
+
+                Spacer()
+
+                Button(actionTitle, action: onAsk)
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+    }
+
+    /// Named for where pressing it lands, which a refusal changes.
+    ///
+    /// macOS prompts once. After that `requestMicrophone` opens the pane
+    /// instead, so a button still offering to ask is a button that does
+    /// something else than it says — and it would say it directly under the
+    /// line explaining that Settings is now the only way back.
+    private var actionTitle: String {
+        if status == .denied { return "Open System Settings" }
+        return asked ? "Ask again" : step.actionTitle
+    }
+
+    /// Three states, three words for them, in the order they happen.
+    private var eyebrow: String {
+        if status == .denied { return "PERMISSION REFUSED" }
+        return asked ? "WAITING FOR YOU" : "PERMISSION NEEDED"
+    }
+
+    /// macOS prompts once. After a refusal the only way back is the pane.
+    private var deniedNote: String {
+        step == .microphone
+            ? "macOS only asks once. Turn it on for ParrotFlow in System Settings, under Privacy & Security."
+            : "Tick ParrotFlow under Privacy & Security → Accessibility."
+    }
+}
+
+private struct DonePane: View {
+    let micStatus: Permissions.Status
+    let axStatus: Permissions.Status
+    let onClose: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Spacer(minLength: 20)
+
+            Text(everything ? "Ready" : "Something was switched off")
+                .font(.system(size: 19, weight: .semibold, design: .rounded))
+                .padding(.bottom, 7)
+
+            // Reachable two ways now: a permission revoked in System Settings
+            // while this window is open, or a skip from the menu bar. Either
+            // way what is true is that something is missing, which it says
+            // rather than pretending the app is fine.
+            Text(everything
+                ? "Hold your hotkey, say something, let go."
+                : "ParrotFlow needs both. Reopen this window from the menu bar when you want to "
+                    + "finish, or check what is missing below.")
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.bottom, 18)
+
+            StatusLine(title: "Microphone", status: micStatus)
+            StatusLine(title: "Accessibility", status: axStatus)
+
+            Spacer(minLength: 16)
+
+            HStack {
+                Spacer()
+                Button("Done", action: onClose).keyboardShortcut(.defaultAction)
+            }
+        }
+    }
+
+    private var everything: Bool { micStatus == .granted && axStatus == .granted }
+}
+
+private struct StatusLine: View {
+    let title: String
+    let status: Permissions.Status
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(title).font(.system(size: 12))
+            StatusBadge(status: status)
+            Spacer()
+        }
+        .padding(.vertical, 3)
     }
 }
 
@@ -185,9 +560,9 @@ private struct StatusBadge: View {
 
     private var color: Color {
         switch status {
-        case .granted: return .green
-        case .denied: return .red
-        case .notDetermined, .notGranted: return .orange
+        case .granted: return Parrot.leaf
+        case .denied: return Parrot.scarlet
+        case .notDetermined, .notGranted: return Parrot.amber
         }
     }
 }

--- a/Sources/ParrotFlow/RecordingOverlay.swift
+++ b/Sources/ParrotFlow/RecordingOverlay.swift
@@ -5,6 +5,10 @@ import SwiftUI
 final class OverlayModel: ObservableObject {
     @Published var level: Float = 0
     @Published var elapsed: TimeInterval = 0
+    /// The icon of the app that was in front when the hotkey went down — the
+    /// one an `app:` condition will be matched against and the one the text
+    /// will land in. Nil when nothing was in front, or when the app has none.
+    @Published var appIcon: NSImage?
 }
 
 /// A small non-interactive pill near the bottom of the screen, so you can tell
@@ -15,6 +19,9 @@ final class RecordingOverlay {
 
     func show() {
         if panel == nil { build() }
+        // Before repositioning, not after: the pill is centred on the screen,
+        // so a width set afterwards would leave it off-centre by half the icon.
+        resize()
         reposition()
         panel?.orderFrontRegardless()
     }
@@ -23,10 +30,28 @@ final class RecordingOverlay {
         panel?.orderOut(nil)
     }
 
+    /// The pill is two widths — with an app icon in it and without — and which
+    /// one applies is only known when a recording starts. Done here rather than
+    /// in the view because the panel is what has to change size; a SwiftUI
+    /// frame inside a fixed panel would centre a narrow pill in a wide
+    /// transparent box and take the shadow with it.
+    private func resize() {
+        guard let panel else { return }
+        let size = NSSize(
+            width: RecordingMetrics.width(hasIcon: model.appIcon != nil),
+            height: RecordingMetrics.height
+        )
+        guard panel.frame.size != size else { return }
+        panel.setContentSize(size)
+        panel.contentView?.frame = NSRect(origin: .zero, size: size)
+    }
+
     private func build() {
         let hosting = NSHostingView(rootView: RecordingPill().environmentObject(model))
         hosting.frame = NSRect(
-            x: 0, y: 0, width: RecordingMetrics.width, height: RecordingMetrics.height
+            x: 0, y: 0,
+            width: RecordingMetrics.width(hasIcon: model.appIcon != nil),
+            height: RecordingMetrics.height
         )
 
         let panel = NSPanel(
@@ -66,41 +91,94 @@ final class RecordingOverlay {
 
 // MARK: - View
 
-/// A red dot and a live meter, and nothing else.
+/// A red light, a live meter, and where the words are going.
 ///
-/// The elapsed time was here to prove the recorder was running, which is the
+/// Left to right that is a sentence: recording, hearing this, into this. The
+/// destination sits at the end because it is the one part you read once and
+/// stop watching — the meter is what moves, and it wants the middle. The
+/// elapsed time was here once to prove the recorder was running, which is the
 /// meter's job — it moves when you speak, which a clock does not. A clock next
 /// to a hot mic only ever reads as pressure to hurry up.
+///
+/// The icon carries no mark of its own. It was tried with a scarlet ring around
+/// it, which read as a red border painted on someone else's artwork and put a
+/// second saturated shape next to the dot for no gain — the dot already says
+/// the mic is hot, and saying it twice is what made the left half heavy.
+///
+/// **With no icon the pill is simply narrower**, back to the dot and the meter
+/// it has always been. An empty slot held open is a hole you have to explain;
+/// the two widths are set in `RecordingMetrics` and applied at `show()`, which
+/// is the only moment either can change.
 struct RecordingPill: View {
     @EnvironmentObject private var model: OverlayModel
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var pulse = false
 
     var body: some View {
-        HStack(spacing: 11) {
+        HStack(spacing: 0) {
             Circle()
                 .fill(Parrot.scarlet)
-                .frame(width: 9, height: 9)
+                .frame(width: RecordingMetrics.dot, height: RecordingMetrics.dot)
                 .shadow(color: Parrot.scarlet.opacity(0.7), radius: 4)
                 .opacity(pulse ? 0.35 : 1)
                 .animation(.easeInOut(duration: 0.7).repeatForever(autoreverses: true), value: pulse)
 
             Meter(level: model.level)
-                .frame(width: 72, height: 16)
+                .frame(width: RecordingMetrics.meter, height: 16)
+                .padding(.leading, RecordingMetrics.gap)
+
+            if let icon = model.appIcon {
+                Image(nsImage: icon)
+                    .resizable()
+                    .interpolation(.high)
+                    .frame(width: RecordingMetrics.icon, height: RecordingMetrics.icon)
+                    .padding(.leading, RecordingMetrics.tuck)
+            }
         }
-        .padding(.horizontal, 17)
-        .frame(width: RecordingMetrics.width, height: RecordingMetrics.height)
+        .padding(.horizontal, RecordingMetrics.padding)
+        .frame(
+            width: RecordingMetrics.width(hasIcon: model.appIcon != nil),
+            height: RecordingMetrics.height
+        )
         .parrotSurface(Capsule())
-        .onAppear { pulse = true }
+        // `initial: true` covers what `onAppear` did; the view stays alive
+        // across recordings, so a Reduce Motion toggle mid-session needs the
+        // same assignment again, not just on the first appearance.
+        .onChange(of: reduceMotion, initial: true) { _, newValue in pulse = !newValue }
     }
 }
 
 enum RecordingMetrics {
-    static let width: CGFloat = 128
+    static let padding: CGFloat = 17
+    static let gap: CGFloat = 11
+    /// The gap on the meter's right, 2pt tighter than the one on its left.
+    ///
+    /// Both were 11 and did not look it. The dot is small, round and spills a
+    /// little glow into its gap; the meter closes on its shortest, dimmest bar
+    /// and the icon has a hard edge — so the eye measures from the last bar it
+    /// can actually see to that edge, and reads that side as wider. Equal
+    /// numbers, unequal gaps. These two are equal to look at.
+    static let tuck: CGFloat = 9
+    static let dot: CGFloat = 9
+    static let icon: CGFloat = 24
+    static let meter: CGFloat = 72
     static let height: CGFloat = 46
+
+    /// 17 + 9 + 11 + 72 + 17, and the icon after the meter when there is one
+    /// to show.
+    static func width(hasIcon: Bool) -> CGFloat {
+        let base = padding * 2 + dot + gap + meter
+        return hasIcon ? base + icon + tuck : base
+    }
 }
 
 /// The bars walk the plumage as they light up, left to right, so a loud sound
 /// fills the pill with the same four colours that ring every other surface.
+///
+/// Against the wheel's direction: sky at the quiet end, scarlet at the loud
+/// one. The last bars are the ones a shout reaches, and the colour arriving
+/// there should be the one that means loud.
 struct Meter: View {
     let level: Float
     private let bars = 12
@@ -120,7 +198,7 @@ struct Meter: View {
     }
 
     private func feather(_ index: Int) -> Color {
-        Parrot.wheel[min(3, index * 4 / bars)]
+        Parrot.wheel[3 - min(3, index * 4 / bars)]
     }
 
     private func height(for index: Int) -> CGFloat {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -78,6 +78,19 @@ transcription:
       - transform: code_identifiers
         app: /term|ghostty|warp|kitty|alacritty|hyper|code|cursor|zed|xcode|jetbrains|idea|pycharm|webstorm/
         when: /\b(?:function|method|variable|class|constant|type|struct|interface|enum|fonction|méthode|classe|constante)\b/
+      # The two stages that cost a second, and the only two here that ask the
+      # model. Dictated prose arrives as one block: no greeting on its own
+      # line, no paragraph breaks, the hesitations still in it. That is layout,
+      # which is the one thing a substitution cannot do — so it is worth the
+      # second, in the two windows where you write to people and nowhere else.
+      #
+      # Gmail in a browser tab is not an app. `app:` reads the window that was
+      # in front, so put your browser in the pattern if you live in Gmail, and
+      # know that every other tab gets the stage too.
+      - transform: email
+        app: /mail|outlook|thunderbird|superhuman|missive/
+      - transform: slack
+        app: /slack/
 
   # The spelling you want, and the ways it comes out wrong. Whole words,
   # case-insensitive. A source in /slashes/ is a regular expression, and an
@@ -205,6 +218,187 @@ transforms:
 
       A phrase before the main clause takes a comma after it. A trailing
       please or thanks does not.
+
+      Return only the text.
+
+  # Two prompts scoped to one kind of window each, and the pipeline above runs
+  # them there. `grammar` mends a sentence; these two also lay one out — a
+  # greeting on its own line, a blank line where the subject changes — which is
+  # the part no substitution can express and the reason they are prompts.
+  #
+  # Both are told twice not to write anything, because that is the failure that
+  # costs you something: a model handed a dictated email will gladly return a
+  # better one, in its own voice, and you will not notice until it has gone.
+  #
+  # 8/10 on gemma4:e4b. Six versions before this one, and what the cases caught:
+  #
+  #   v1  "if none was dictated, do not invent one" -> a "Hi," invented anyway,
+  #       and a spoken "thanks Nathan" reduced to "Nathan". A prohibition read
+  #       as a topic.
+  #   v2  the greeting rule turned around to say what the email starts with
+  #       when there is no hello, and the closing word tied to the signature.
+  #   v3  "Nothing is ever deleted" added -> a literal "[Signature]" in the
+  #       output and a greeting invented again. A rule about restraint made it
+  #       less restrained, exactly as in tests/grammar-cases.yaml.
+  #   v4  the greeting rule given worked examples — "bonjour Marie, hi Tom" ->
+  #       the examples came back in the output as "Hi Tom," and "À toi,".
+  #   v5  a short reply named as its own case. 6/7 on the cases that existed.
+  #   v6  lists. Two lessons: the model needs to be told it may count for
+  #       itself — "three or more things in a row" left "here is what I need
+  #       from you the invoice the signed contract and the shipping address"
+  #       inline until the rule said no number has to be spoken — and the rule
+  #       has to sit with the paragraph rule. Moved after the short-reply
+  #       clause it dominated: a two-word reply came back as "[No body text]".
+  #
+  # Two failures left, and they are one shape: a short reply ending in a
+  # goodbye comes back as the goodbye alone. "yes that works for me see you
+  # thursday" -> "See you Thursday.", and "ok pour moi, à jeudi" -> "À jeudi,".
+  # The same sentence with a comma is right. Three framings have bounced off
+  # it, the third being a clause saying a goodbye is not a signature to lift
+  # out, so it is recorded rather than argued with.
+  #
+  # Numbered lists are not in it. Spoken ordinals — "first we deploy, second we
+  # run the tests" — stay as sentences, and the version that forced them
+  # dropped an item on the floor, which is a worse thing to ship than prose
+  # where a list was wanted. Dashes only.
+  - name: email
+    description: lay dictated text out as an email
+    display: Laying out the email
+    prompt: |
+      Lay the text out as an email, in the language it was dictated in.
+      Fix the writing; do not write it.
+
+      Correct grammar, spelling and punctuation, and drop the hesitations
+      — um, uh, euh, well, you know, I mean. Every other word survives:
+      the wording, the order and the tone are the speaker's.
+
+      If the text opens with a greeting, it goes on its own line, with a
+      comma after it and a blank line under it. If it does not, the email
+      starts with the first sentence. Never add a greeting nobody spoke.
+
+      Break the body into paragraphs where the subject changes, a blank
+      line between them. Add no headings and no emphasis.
+
+      Three or more things listed in a row never stay inline. Whatever
+      joined them — commas, "and", nothing at all — the words introducing
+      them take a colon and each thing goes on a line of its own behind a
+      dash. No number has to be said for this: "here is what I need from
+      you", "the steps are", "we should" all open a list as surely as
+      "there are three things" does. Two things are a sentence and stay
+      one.
+
+      A name at the end is a signature: a blank line, then the name on
+      its own line, and a closing word said just before it — thanks,
+      merci — on the line above. No name at the end means no signature:
+      the last thing said is the last line of the body, wherever it
+      sounds like a goodbye.
+
+      A short reply is not an email with parts. One or two sentences and
+      no hello in front of them come back as one or two sentences,
+      corrected, with no line put anywhere.
+
+      Return only the email.
+
+  # 3/3. "Add nothing" rather than "no greeting, no sign-off": the second
+  # wording read as an instruction to remove one, and "hey uh quick one the
+  # build is red" came back as "The build is red" — two spoken words gone
+  # because a rule about what not to add was read as a rule about what to
+  # strip. "Remove nothing either" is there for the same reason, and the slang
+  # line because "gonna" was being corrected to "going to", which is the
+  # speaker's voice going out with the hesitations.
+  - name: slack
+    description: tidy dictated text into a chat message
+    display: Tidying for chat
+    prompt: |
+      Tidy the text into a chat message, in the language it was dictated
+      in. Fix the writing; do not write it.
+
+      Correct grammar, spelling and punctuation, and drop the hesitations
+      — um, uh, euh, well, you know, I mean. Every other word survives.
+      Slang and contractions are the speaker's voice rather than
+      mistakes: gonna stays gonna, ouais stays ouais.
+
+      Add nothing: no greeting, no sign-off, no heading, no bullet, no
+      bold, no backtick. Slack's composer renders none of that when text
+      arrives by paste, so it would land in the message as characters.
+      Remove nothing either: a spoken "hey" is part of the message.
+
+      One paragraph, unless the text plainly holds two.
+
+      Return only the message.
+
+  # Said out loud — "hey parrot, use Slack mentions" — and deliberately in no
+  # pipeline. A message that names someone is not a message that pings them,
+  # and nothing in a transcript tells the two apart. So this is the one you ask
+  # for.
+  #
+  # `confirm` covers one of the two ways of asking, not both. Said with text
+  # selected, the result is shown before it replaces anything, so you see who
+  # is about to be tagged. Said mid-sentence — "by the way parrot, use Slack
+  # mentions" — there is no preview whatever `confirm` says, because nothing is
+  # being overwritten there and a dialog would cost the round trip that path
+  # exists to save. What both produce is text in your composer; ParrotFlow
+  # sends nothing, so the last look is yours before you press Enter.
+  #
+  # It was two `replace:` tables for a while, which is the shape a mapping
+  # wants. A table cannot invent a handle, where this prompt's first draft
+  # answered "Sofia already looked at it" with "@priya already looked at it"
+  # and took four rewrites to reach 6/6. The tables scored 7/7 and cost
+  # nothing.
+  #
+  # They came back out because a table has to be triggered from inside the
+  # sentence, and the only word for the job is one English already uses:
+  #
+  #     "I should mention here that the deadline changed"
+  #       -> "I should @here that the deadline changed"
+  #     "I wanted to mention Marie is off next week"
+  #       -> "I wanted to @marie.dupont is off next week"
+  #
+  # Anchoring the marker to the start of an utterance fixed those, 11/11, at
+  # the price of "can you mention marie about the invoice" doing nothing. And a
+  # pipeline stage has no preview — it runs on a transcript nobody has seen
+  # yet, so a false positive there is a message already sent. Asking out loud
+  # has no such failure: it fires when you ask and never otherwise, which is
+  # worth a second and a prompt that had to be taught not to guess.
+  #
+  # Still open, and it decides whether any of this is worth having: ParrotFlow
+  # inserts by Cmd-V in both insert modes, and Slack's composer does not re-read
+  # what arrives by paste — the finding that keeps `backticks` out of the
+  # shipped pipeline. If a pasted @handle does not linkify, this writes
+  # something that looks like a mention and notifies nobody. Paste one into a
+  # Slack composer without sending, and see whether it turns blue.
+  #
+  # Put your own people in the list.
+  - name: slack_mentions
+    description: turn people's names into Slack mentions
+    display: Adding mentions
+    prompt: |
+      Return the text word for word, with one kind of change and no
+      other: a name that appears in this list becomes its handle.
+
+        Marie   -> @marie.dupont
+        Thomas  -> @tleroy
+        Priya   -> @priya
+
+      Every occurrence, including where the message is about that person
+      rather than to them.
+
+      A name that is not in the list is left exactly as it was. Sofia
+      stays Sofia. Never give a name a handle that belongs to someone
+      else, and never invent one.
+
+      Two group mentions are a judgement rather than a lookup. "everyone
+      here", "whoever is around" -> @here, which pings the people who are
+      online. "the whole channel", "everyone", "all of them" -> @channel,
+      which pings the ones who are away too. Only where the text means
+      the people: "the file is here" is a place, and stays.
+
+      A mention replaces the words that name the person or the group, and
+      not one word more: "heads up to the whole channel" comes back as
+      "heads up to @channel".
+
+      Nothing is ever deleted. Every other word, the order and the
+      punctuation come back as they went in.
 
       Return only the text.
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -298,6 +298,171 @@ Add the step if your chat app renders pasted markup. Getting this to work
 properly means putting rich text on the clipboard rather than markdown
 characters, which is a different feature.
 
+### Writing to people: `email` and `slack`
+
+Two prompts scoped to one kind of window each, and the first stages that ask
+the model from a pipeline rather than from the activation phrase:
+
+```yaml
+- transform: email
+  app: /mail|outlook|thunderbird|superhuman|missive/
+- transform: slack
+  app: /slack/
+```
+
+`grammar` mends a sentence. These two also **lay one out**, which is the part
+no substitution can express: dictated prose arrives as a single block with the
+greeting run into the first sentence, no paragraph breaks, and the hesitations
+still in it. A comma and a newline after "Bonjour Marie" is not a rewrite of
+your words, and it is not something a table can be taught.
+
+`email` puts the greeting on its own line with a blank line under it, breaks
+the body where the subject changes, and treats a name at the end as a
+signature. `slack` does almost none of that — no greeting, no sign-off, one
+paragraph — and is explicitly told to emit no markup at all, for the reason
+`backticks` is not in the shipped pipeline: Slack's composer does not render
+markdown that arrives by paste, so bold or bullets land in the message as
+characters.
+
+Both are told twice not to write anything. That is the failure worth spending
+tokens on: a model handed a dictated email will gladly return a better one, in
+its own voice, and nothing on screen says it happened — a pipeline stage runs
+on a transcript nobody has seen yet, so `confirm` does not apply to it.
+
+**8/10 and 3/3 on gemma4:e4b**, and the versions in between are written into
+config.example.yaml beside each prompt, because what they cost is the useful
+part. Four findings, all of them the prompt making things worse before better:
+
+| Wording | What it did |
+|---|---|
+| "If none was dictated, do not invent one" | invented a greeting anyway — a prohibition read as a topic |
+| "Nothing is ever deleted" | answered with a literal `[Signature]` placeholder |
+| the greeting rule given examples | put the examples in the output: "Hi Tom," and "À toi," |
+| the list rule moved after the short-reply clause | a two-word reply came back as "[No body text]" |
+
+The first is the lesson `tests/grammar-cases.yaml` already records — a rule
+about restraint making the model less restrained. The third is that file's
+other lesson running the opposite way: elsewhere here examples beat rules, and
+in a prompt whose output is the same shape as its examples they get copied.
+
+What fixed the greeting was turning the prohibition around and saying what the
+email starts with when there is no hello. What fixed a dropped `thanks` was
+tying the closing word to the signature instead of listing it among the things
+not to add. And `slack` says "Add nothing" rather than "No greeting, no
+sign-off", because the second wording was read as an instruction to *remove*
+one: "hey uh quick one the build is red" came back as "The build is red".
+
+`email` also sets out lists, which is the one place it adds structure rather
+than removing it. Three or more things in a row take a colon and a dash each.
+The rule has to say that **no number needs to have been spoken** — "three or
+more things in a row" on its own left `here is what I need from you the invoice
+the signed contract and the shipping address` inline, because the model was
+waiting to be told there were three.
+
+**Numbered lists are deliberately absent.** Spoken ordinals — "first we deploy,
+second we run the tests" — stay as sentences. The version that forced them to
+1. 2. 3. dropped an item on the floor, and prose where a list was wanted is a
+better thing to ship than a list missing a line.
+
+The two cases still failing are one shape: a short reply ending in a goodbye
+comes back as the goodbye alone — `yes that works for me see you thursday` →
+`See you Thursday.`, and `ok pour moi, à jeudi` → `À jeudi,`. The same sentence
+with a comma is right. Three framings have bounced off it, so it is recorded
+rather than argued with.
+
+**Neither is in the shipped default pipeline.** Every stage a new install gets
+is free and needs nothing running; these cost about a second and do nothing at
+all without Ollama. Same rule as the `--model` switch on `code_identifiers`,
+which ships off for the same reason. config.example.yaml has them wired up.
+
+**Gmail in a browser tab is not an app.** `app:` reads the window that was in
+front, which is `Google Chrome com.google.Chrome` — so name your browser in the
+pattern if you live in Gmail, and accept that every other tab gets the stage
+too. There is no narrower answer available: the condition is a window, not a
+URL.
+
+**They cost the router something, and it is measured.** Both are prompts, so
+both join the catalogue the activation phrase reaches, and every description
+added is another way for an idle sentence to find a tool.
+`tests/routing-cases.yaml` was rerun and grew: 41/45 on three prompts, 50/54 on
+six. One new failure appeared and it is the expensive class, the one the
+negative half of that set exists for:
+
+```
+I sent her an email yesterday  ->  email
+```
+
+A sentence, not an instruction, sent to a prompt that would rewrite your
+selection. Four descriptions were measured against it and all four routed it
+identically, so it is recorded there rather than tuned away.
+
+### `slack_mentions`, which you have to ask for
+
+Said out loud — "hey parrot, use Slack mentions" — and deliberately in no
+pipeline. A message that names someone is not a message that pings them, and
+nothing in a transcript tells the two apart. So it is the one you ask for.
+
+**`confirm` covers one of the two ways of asking, not both.** Said with text
+selected, the result is shown before it replaces anything and you see who is
+about to be tagged. Said mid-sentence — "by the way parrot, use Slack mentions"
+— there is no preview whatever `confirm` says: nothing is being overwritten
+there, and a dialog in the middle would give back the round trip that path
+exists to remove. That is the rule for every inline transform, not this one —
+see *An instruction inside a dictation* below.
+
+What both produce is text in your composer. ParrotFlow never sends a message,
+so the last look before anyone is notified is yours.
+
+**The mapping lives in the prompt**, which is the opposite of the rule
+everywhere else here, and it was tried the other way round. The tables are
+worth reading about because of what they cost, not because they failed:
+
+```yaml
+- name: slack_handles
+  replace:
+    '@marie.dupont': ['/\bmention(?:ne)? marie\b/']
+```
+
+A table cannot invent. This prompt's first draft answered "the config file is
+here, Sofia already looked at it" with "…@priya already looked at it" — a handle
+made up for a name it had never been given, which in Slack is a message sent to
+the wrong person — and it took four rewrites and three load-bearing sentences to
+reach 6/6. The tables reached **7/7** on the same cases, for free, with nothing
+running. On the mapping alone the table wins outright.
+
+**What it lost on was the trigger.** A table has to fire from inside the
+sentence, and the only natural word for it is one English already uses as a
+verb:
+
+```
+"I should mention here that the deadline changed"
+  ->  "I should @here that the deadline changed"
+"I wanted to mention Marie is off next week"
+  ->  "I wanted to @marie.dupont is off next week"
+```
+
+Anchoring the marker to the start of an utterance or to a `.` `!` `?` `;` or
+comma fixed those — **11/11**, five prose sentences that must not ping and six
+deliberate forms that must — at the price of "can you mention marie about the
+invoice" doing nothing at all. But a pipeline stage has **no preview**: it runs
+on a transcript nobody has seen yet, so `confirm` does not reach it and a false
+positive is a message that has already gone.
+
+Asking out loud has no such failure. It fires when you ask and never otherwise,
+which is worth a second and a prompt that had to be taught not to guess. The
+table is the better mapping; the voice command is the better trigger, and the
+trigger is where the expensive mistakes live.
+
+**One thing is still open, and it decides whether any of this is worth having.**
+`TextInserter` puts the text on the pasteboard and synthesises ⌘V — in both
+insert modes, so everything ParrotFlow writes arrives in Slack by paste. And
+Slack's composer does not re-read what arrives by paste: that is the finding
+that keeps `backticks` out of the shipped pipeline, tested on a real Slack. If a
+pasted `@handle` does not linkify either, this writes something that looks like
+a mention and notifies nobody, which is worse than not having it — you would
+believe you had told someone. Paste one into a Slack composer without sending
+and see whether it turns blue.
+
 ### Order matters, and only one set notices
 
 `numbers` runs before `dotted`, because English says "three point one four" for

--- a/tests/routing-cases.yaml
+++ b/tests/routing-cases.yaml
@@ -5,9 +5,12 @@
 # longer request, because that is the case the router has to get right.
 #
 # The expectations assume the catalogue in config.example.yaml: bullets, terse,
-# grammar, and the built-ins. `--route` reads your own config, so a machine with
-# extra prompts will disagree with this set, and rightly — it is scoring a
-# router against a list, and the list is part of the question.
+# grammar, email, slack, slack_mentions, and the built-ins.
+#
+# `--route` reads your own config, so a machine with a different list will
+# disagree with this set,
+# and rightly — it is scoring a router against a list, and the list is part of
+# the question.
 #
 # Three answers since free_form, and the third is what made the first two
 # honest. NONE used to carry two meanings, "no tool does this" and "that was
@@ -20,26 +23,39 @@
 # to a prompt that rewrites your selection. That risk went up when ANY arrived,
 # not down, which is why there are more of them now than tools.
 #
-# 41/45 on gemma4:e4b, and the shape matters more than the number: nothing
-# routed something idle. Both cases that used to — "I bought a box of bullets"
-# and "her grammar is better than mine", the two Router.swift recorded as the
-# model's floor — pass with the third answer present. Splitting "not an edit"
-# off from "no tool for it" turned out to help the question it did not ask.
+# 50/54 on gemma4:e4b, on a catalogue of six prompts. It was 41/45 on three.
 #
-# The four that fail all fail cheaply, which is the only reason they are left
-# standing rather than argued with:
+# Three of the four that fail fail cheaply, which is why they are left standing
+# rather than argued with:
 #
 #     format those dates ISO                     -> grammar
 #     fix the numbers                            -> grammar
 #     fix the numbers but leave the years alone  -> grammar
-#     use the 24 hour clock                      -> NONE
 #
-# The first three are the residue of removing `dates` and `digits`: grammar is
-# now the only entry that mends anything, so "fix the ..." lands on it. It runs
-# a prompt whose every rule is against touching a number, so the cost is a
-# no-op you can see in the preview, not a rewrite. The fourth is a refusal —
-# you say it again. Five descriptions and a second ANY example were measured
-# against these; the notes are in Router.swift.
+# They are the residue of removing `dates` and `digits`: grammar is now the
+# only entry that mends anything, so "fix the ..." lands on it. It runs a prompt
+# whose every rule is against touching a number, so the cost is a no-op you can
+# see in the preview, not a rewrite. Five descriptions and a second ANY example
+# were measured against these; the notes are in Router.swift.
+#
+# This family moves with the size of the list rather than with any one entry in
+# it. "format those dates with slashes" passes with six prompts in the
+# catalogue and failed with five, twice measured in both directions, and
+# nothing about dates changed in between — worth knowing before reading a
+# one-case swing here as a regression in whatever was added or removed that
+# day.
+#
+# The fourth is the expensive kind and is new:
+#
+#     I sent her an email yesterday              -> email
+#
+# A sentence, not an instruction, routed to a prompt that would rewrite your
+# selection. It is the trap "I bought a box of bullets" and "her grammar is
+# better than mine" set for the older entries, and those two pass — so this is
+# a gap this catalogue opened, not a floor the model always had. Four
+# descriptions were measured against it and every one routed it the same way,
+# which says the description is not what decides it. The preview is what stands
+# between this and a lost selection.
 
 cases:
   # --- named outright: should never reach the model -----------------------
@@ -162,3 +178,33 @@ cases:
     expect: NONE
   - instruction: her grammar is better than mine
     expect: NONE
+  # Same trap, for the three window-scoped prompts. The first one fails: it is
+  # routed to `email`, and it is a sentence, not an instruction. Four
+  # descriptions were tried against it — "lay dictated text out as an email",
+  # "format the selected text as an email", "lay this out as an email, greeting
+  # and paragraphs", "put this into email shape" — and all four routed it
+  # identically, so the description is not what decides this one. Left failing.
+  - instruction: I sent her an email yesterday
+    expect: NONE
+  - instruction: did you see my slack message
+    expect: NONE
+  - instruction: he never mentions it
+    expect: NONE
+
+  # --- the three prompts scoped to a window --------------------------------
+  # `email` and `slack` run from a pipeline behind `app:`, but they are prompts,
+  # so the phrase reaches them too. `slack_mentions` is only ever reached this
+  # way. The two neighbours worth watching are terse and slack — "shorten this"
+  # against "tidy that up for chat" — and they hold.
+  - instruction: write an email
+    expect: email
+  - instruction: make that an email
+    expect: email
+  - instruction: make that a slack message
+    expect: slack
+  - instruction: tidy that up for chat
+    expect: slack
+  - instruction: use Slack mentions
+    expect: slack_mentions
+  - instruction: turn the names into mentions
+    expect: slack_mentions


### PR DESCRIPTION
What is left on `feat/release-tail` that `main` does not have. The pill (#27/#29) and the release tail itself (#25) already landed; this is #26 and #28.

## Prompts for writing to people (#26)

`email` and `slack` lay dictated prose out for one kind of window each, behind `app:`. `slack_mentions` is said out loud and is in no pipeline — a message that names someone is not a message that pings them.

Measured on gemma4:e4b, with every version in between written down beside the prompt:

| | | |
|---|---|---|
| `email` | 8/10 | a prohibition read as a topic and invented a greeting; "nothing is ever deleted" produced a literal `[Signature]`; worked examples came back in the output; the list rule had to sit with the paragraph rule or a two-word reply became `[No body text]` |
| `slack` | 3/3 | "no greeting" read as an instruction to *remove* one |
| `slack_mentions` | 6/6 | first draft was 2/6 and invented a handle for a name it had never been given |

Lists are set out with a dash each. Numbered lists are deliberately absent — the version that forced them from spoken ordinals dropped an item.

**The mapping was two `replace:` tables for a while and came back out.** A table cannot invent a handle and scored 7/7 for free, but it has to fire from inside the sentence, and "mention" is a word English already uses as a verb: `"I should mention here that the deadline changed"` → `"I should @here that…"`. Anchoring the marker fixed the known cases (11/11) but left the class open, and a pipeline stage has no preview. The table was the better mapping and the worse trigger, and the trigger is where the expensive mistakes live. The excursion is kept in the config comment rather than deleted.

Routing rescored against the larger catalogue: 41/45 on three prompts, **50/54 on six**. One new failure, and it is the expensive class — `"I sent her an email yesterday"` routes to `email`. Four descriptions were measured against it and all four routed it identically.

## One permission per screen (#28)

The window used to show both at once and fire the microphone prompt the instant it appeared — a system dialog on top of the window explaining it. Now nothing is asked until the button is pressed.

Each screen shows the piece of the app the permission switches on, drawn with the app's own parts: the real `RecordingPill` at its real size, and `PlumageMark` landing in a focused field.

Both permissions are required during setup, so the only other button is **Cancel installation** and it quits; there is no close button in the title bar, because a requirement you can dismiss is not one. Reopened from the menu bar there is no installation left to cancel, so it becomes **Not now**.

## Still open

Everything ParrotFlow writes reaches Slack by ⌘V, and Slack's composer does not re-read pasted text — the finding that keeps `backticks` out of the shipped pipeline. If a pasted `@handle` does not linkify, `slack_mentions` writes something that looks like a mention and notifies nobody. Recorded in the config comment and the docs with the ten-second test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUnWNfi64vX94QqWfUM2qS