### PR TITLE
feat: the words go to the clipboard when there is nowhere to type them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ dist/
 
 # The runner imports examples/code_identifiers.py, which leaves this behind.
 __pycache__/
+
+# Where Claude Code puts a git worktree it makes: a checkout of this repository,
+# inside this repository. Untracked it turns every `git status` into a warning
+# about a directory that is already under version control by another route.
+.claude/worktrees/

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ your cursor is.
 Set `transcription.insert_mode: clipboard` to have it copied instead of typed —
 that mode needs no Accessibility permission, but you press ⌘V yourself.
 
+**With no cursor in a field, nothing is typed.** A Finder window, a video, a
+page you are reading — they are frontmost and they have nowhere to put a
+sentence, and a ⌘V sent there does whatever that window makes of it. So the
+pill leaves the app icon out while you talk, which is the warning, and when the
+transcript arrives it goes to your clipboard with a notice saying where it went.
+Terminals are the exception: what they show macOS is a screen rather than a
+field, so they are recognised by name and always counted as somewhere to write.
+
 Audio is kept in `~/Recordings/ParrotFlow` and every transcript is logged to
 `~/Library/Logs/ParrotFlow.log`.
 
@@ -352,6 +360,7 @@ entry in place, which is why re-ticking it never helps.
 | Menu bar & wiring | `AppDelegate.swift` | |
 | Logging | `Log.swift` | `~/Library/Logs/ParrotFlow.log` — a menu bar app has no console |
 | Recording pill | `RecordingOverlay.swift` | Borderless non-activating `NSPanel` |
+| Where the words go | `Destination.swift` | Asks the focused element whether it takes text, at the press — decides the pill's icon and whether the transcript is typed or copied |
 
 Two wrinkles worth knowing about push-to-talk:
 

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -596,6 +596,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // press's verdict: copied when it had a field to go in, or pasted into a
         // window that has nothing to put it in.
         let destination = destinationAtPress
+        // And where it was being typed, for the same reason. The inline
+        // correction panel hands focus back to this app before writing, and it
+        // can be left open for as long as it takes to think about a spelling —
+        // longer than any other wait in the app, and long enough to start
+        // another dictation somewhere else while it sits there.
+        let focus = focusAtPress
         Task { [weak self] in
             do {
                 // "Transcribing…" is the truth until the decoder is done, and
@@ -617,7 +623,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 await MainActor.run {
                     guard let self else { return }
                     self.transcriptionLabel = nil
-                    self.finishTranscription(text: text, destination: destination)
+                    self.finishTranscription(
+                        text: text, destination: destination, focus: focus
+                    )
                 }
             } catch {
                 await MainActor.run {
@@ -1301,7 +1309,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `destination` is where this dictation was aimed when its hotkey went
     /// down — passed along rather than looked up, so a second press landing
     /// mid-transcription cannot redirect this one. See `transcribe`.
-    private func finishTranscription(text: String, destination: Destination) {
+    private func finishTranscription(
+        text: String, destination: Destination, focus: SelectionReader.Selection?
+    ) {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
 
         if let command = commandAfterWakePhrase(trimmed) {
@@ -1325,7 +1335,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Log.write("inline: \"\(split.instruction)\" over \"\(split.text)\"")
             lastTranscript = split.text
             runInline(
-                text: split.text, instruction: split.instruction, destination: destination
+                text: split.text, instruction: split.instruction,
+                destination: destination, focus: focus
             )
             return
         }
@@ -1350,7 +1361,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// being overwritten here, and a dialog in the middle would give back the
     /// second round trip this exists to remove. The rewrite goes to the log
     /// with its before and after, as pipeline transforms do.
-    private func runInline(text: String, instruction: String, destination: Destination) {
+    private func runInline(
+        text: String, instruction: String, destination: Destination,
+        focus: SelectionReader.Selection?
+    ) {
         let catalogue = Catalogue(prompts: config.prompts)
 
         /// Write what was said, and say why it is not what was asked for.
@@ -1400,7 +1414,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             case .transform(let prompt): run(prompt)
             case .action(let action):
                 runInlineAction(
-                    action, text: text, instruction: instruction, destination: destination
+                    action, text: text, instruction: instruction,
+                    destination: destination, focus: focus
                 )
             }
             return
@@ -1429,7 +1444,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     case .matched(.action(let action)):
                         self.runInlineAction(
                             action, text: text, instruction: instruction,
-                            destination: destination
+                            destination: destination, focus: focus
                         )
                     case .anything:
                         Log.write("inline router: \"\(instruction)\" → \(FreeForm.name)")
@@ -1458,7 +1473,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// mind about a rule.
     private func runInlineAction(
         _ action: Capability.Action, text: String, instruction: String,
-        destination: Destination
+        destination: Destination, focus: SelectionReader.Selection?
     ) {
         switch action {
         case .vocabulary:
@@ -1466,7 +1481,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // panel opens on the sentence itself and you correct it by hand.
             endProgress()
             Log.write("inline: correction panel over \"\(text)\"")
-            showInlineCorrection(over: text, rules: nil, destination: destination)
+            showInlineCorrection(
+                over: text, rules: nil, destination: destination, focus: focus
+            )
 
         case .spelling:
             // "…by the way parrot, Tasmin spells T A S M E E N" — the rule has
@@ -1503,11 +1520,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                 Log.write("inline: proposed rule \(rule.heard) -> \(rule.corrected)")
                             }
                             self.showInlineCorrection(
-                                over: text, rules: rules, destination: destination
+                                over: text, rules: rules,
+                                destination: destination, focus: focus
                             )
                         case .openCorrectionPanel:
                             self.showInlineCorrection(
-                                over: text, rules: nil, destination: destination
+                                over: text, rules: nil,
+                                destination: destination, focus: focus
                             )
                         case .unrecognised:
                             self.giveUpInline(
@@ -1532,14 +1551,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// The correction panel, with the dictated text waiting behind it.
     ///
-    /// `pendingSelection` and `focusAtPress` are deliberately cleared: they are
-    /// how `saveCorrections` decides to write into a field somewhere else, and
-    /// here the only place the text should land is where a dictation would put
-    /// it. Leaving them set would rewrite whatever happened to be selected when
-    /// the hotkey went down.
+    /// `pendingSelection` is deliberately cleared: it is how `saveCorrections`
+    /// decides to write into a field somewhere else, and here the only place
+    /// the text should land is where a dictation would put it. Leaving it set
+    /// would rewrite whatever happened to be selected when the hotkey went down.
+    ///
+    /// `focus` is passed in rather than read off `focusAtPress` when the panel
+    /// closes. This panel is the longest wait in the app — it is open for as
+    /// long as someone takes to think about a spelling — and a dictation
+    /// started somewhere else in the meantime moves that field. Reading it late
+    /// would hand focus to the newer app and paste this sentence into it.
     private func showInlineCorrection(
         over text: String, rules: [(heard: String, corrected: String)]?,
-        destination: Destination
+        destination: Destination, focus: SelectionReader.Selection?
     ) {
         pendingSelection = nil
 
@@ -1552,7 +1576,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         /// showed a rule proposed and then nothing at all. `applyTransform`
         /// learned this the same way and does the same thing.
         func handBack() {
-            guard let owner = focusAtPress?.owner, !owner.isActive else { return }
+            guard let owner = focus?.owner, !owner.isActive else { return }
             owner.activate()
             // Let it come forward before the keystroke is posted.
             Thread.sleep(forTimeInterval: 0.15)
@@ -1592,7 +1616,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             ).isEmpty ? correctedText : corrected
             self.lastTranscript = final
             handBack()
-            Log.write("inline: writing into \(self.focusAtPress?.owner?.localizedName ?? "the frontmost app")")
+            Log.write("inline: writing into \(focus?.owner?.localizedName ?? "the frontmost app")")
             self.insertDictation(final, to: destination)
         }
         correctionPanel.onCancel = { [weak self] in

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -73,8 +73,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// carrying an image around.
     private var appIconAtPress: NSImage?
     /// Whether there was anywhere to type when the hotkey went down — see
-    /// `Destination`. Decides both whether the pill shows the icon and, a few
-    /// seconds later, whether the transcript is typed or copied.
+    /// `Destination`. Decides whether the pill shows the icon, and is handed to
+    /// the transcription it belongs to so that the same press decides, a few
+    /// seconds later, whether the words are typed or copied.
+    ///
+    /// Read exactly once after the press, in `transcribe`, for the same reason
+    /// `appAtPress` is: two dictations can be in flight at once, and this field
+    /// only ever holds the newest.
     ///
     /// Starts at nothing, which is only read if a transcript ever arrives
     /// without a press behind it — and one that did not come from a press has
@@ -583,6 +588,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Taken at the press, not here: a transcript arrives seconds later and
         // the window you dictated into may not be the one in front by then.
         let app = appAtPress
+        // Carried down the chain from here for the same reason, plus one of its
+        // own. Push-to-talk does not wait for the previous transcript — hold the
+        // key again while a prompt stage is still running and two are in flight,
+        // which is what `transcriptionRun` exists to survive. Read off `self` at
+        // the end instead, the older dictation would be delivered by the newer
+        // press's verdict: copied when it had a field to go in, or pasted into a
+        // window that has nothing to put it in.
+        let destination = destinationAtPress
         Task { [weak self] in
             do {
                 // "Transcribing…" is the truth until the decoder is done, and
@@ -604,7 +617,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 await MainActor.run {
                     guard let self else { return }
                     self.transcriptionLabel = nil
-                    self.finishTranscription(text: text)
+                    self.finishTranscription(text: text, destination: destination)
                 }
             } catch {
                 await MainActor.run {
@@ -1285,7 +1298,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    private func finishTranscription(text: String) {
+    /// `destination` is where this dictation was aimed when its hotkey went
+    /// down — passed along rather than looked up, so a second press landing
+    /// mid-transcription cannot redirect this one. See `transcribe`.
+    private func finishTranscription(text: String, destination: Destination) {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
 
         if let command = commandAfterWakePhrase(trimmed) {
@@ -1308,13 +1324,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         ) {
             Log.write("inline: \"\(split.instruction)\" over \"\(split.text)\"")
             lastTranscript = split.text
-            runInline(text: split.text, instruction: split.instruction)
+            runInline(
+                text: split.text, instruction: split.instruction, destination: destination
+            )
             return
         }
 
         Log.write("transcribed: \(trimmed)")
         lastTranscript = trimmed
-        insertDictation(trimmed)
+        insertDictation(trimmed, to: destination)
     }
 
     /// An instruction found inside a dictation: route it, run it over the words
@@ -1332,14 +1350,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// being overwritten here, and a dialog in the middle would give back the
     /// second round trip this exists to remove. The rewrite goes to the log
     /// with its before and after, as pipeline transforms do.
-    private func runInline(text: String, instruction: String) {
+    private func runInline(text: String, instruction: String, destination: Destination) {
         let catalogue = Catalogue(prompts: config.prompts)
 
         /// Write what was said, and say why it is not what was asked for.
         func giveUp(_ why: String, tone: NoticeTone = .caution) {
             endProgress()
             Log.write("inline: \(why); wrote the text as dictated")
-            insertDictation(text)
+            insertDictation(text, to: destination)
             notice.show(why, tone: tone, duration: 7)
             setLabel(why, clearAfter: 7)
         }
@@ -1366,7 +1384,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                             Log.write("    after:  \(cleaned)")
                         }
                         self.lastTranscript = cleaned
-                        self.insertDictation(cleaned)
+                        self.insertDictation(cleaned, to: destination)
                     }
                 } catch {
                     await MainActor.run {
@@ -1380,7 +1398,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Log.write("inline router: \"\(instruction)\" named \(capability.name) outright")
             switch capability {
             case .transform(let prompt): run(prompt)
-            case .action(let action): runInlineAction(action, text: text, instruction: instruction)
+            case .action(let action):
+                runInlineAction(
+                    action, text: text, instruction: instruction, destination: destination
+                )
             }
             return
         }
@@ -1406,7 +1427,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         Log.write("inline router: \"\(instruction)\" → \(prompt.name)")
                         run(prompt)
                     case .matched(.action(let action)):
-                        self.runInlineAction(action, text: text, instruction: instruction)
+                        self.runInlineAction(
+                            action, text: text, instruction: instruction,
+                            destination: destination
+                        )
                     case .anything:
                         Log.write("inline router: \"\(instruction)\" → \(FreeForm.name)")
                         run(FreeForm.prompt(for: instruction))
@@ -1433,7 +1457,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// because a panel was dismissed would lose the sentence over a change of
     /// mind about a rule.
     private func runInlineAction(
-        _ action: Capability.Action, text: String, instruction: String
+        _ action: Capability.Action, text: String, instruction: String,
+        destination: Destination
     ) {
         switch action {
         case .vocabulary:
@@ -1441,14 +1466,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // panel opens on the sentence itself and you correct it by hand.
             endProgress()
             Log.write("inline: correction panel over \"\(text)\"")
-            showInlineCorrection(over: text, rules: nil)
+            showInlineCorrection(over: text, rules: nil, destination: destination)
 
         case .spelling:
             // "…by the way parrot, Tasmin spells T A S M E E N" — the rule has
             // to be read out of the instruction first, which is a model call of
             // its own and not part of routing.
             guard config.llm.enabled else {
-                giveUpInline(text, why: "\"\(instruction)\" needs the local model to read the spelling")
+                giveUpInline(
+                    text,
+                    why: "\"\(instruction)\" needs the local model to read the spelling",
+                    destination: destination
+                )
                 return
             }
             beginProgress("Thinking…")
@@ -1473,18 +1502,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                             for rule in rules {
                                 Log.write("inline: proposed rule \(rule.heard) -> \(rule.corrected)")
                             }
-                            self.showInlineCorrection(over: text, rules: rules)
+                            self.showInlineCorrection(
+                                over: text, rules: rules, destination: destination
+                            )
                         case .openCorrectionPanel:
-                            self.showInlineCorrection(over: text, rules: nil)
+                            self.showInlineCorrection(
+                                over: text, rules: nil, destination: destination
+                            )
                         case .unrecognised:
-                            self.giveUpInline(text, why: "Didn't understand \"\(instruction)\"")
+                            self.giveUpInline(
+                                text, why: "Didn't understand \"\(instruction)\"",
+                                destination: destination
+                            )
                         }
                     }
                 } catch {
                     await MainActor.run {
                         guard let self else { return }
                         self.endProgress()
-                        self.giveUpInline(text, why: error.localizedDescription, tone: .failure)
+                        self.giveUpInline(
+                            text, why: error.localizedDescription, tone: .failure,
+                            destination: destination
+                        )
                     }
                 }
             }
@@ -1499,7 +1538,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// it. Leaving them set would rewrite whatever happened to be selected when
     /// the hotkey went down.
     private func showInlineCorrection(
-        over text: String, rules: [(heard: String, corrected: String)]?
+        over text: String, rules: [(heard: String, corrected: String)]?,
+        destination: Destination
     ) {
         pendingSelection = nil
 
@@ -1553,13 +1593,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self.lastTranscript = final
             handBack()
             Log.write("inline: writing into \(self.focusAtPress?.owner?.localizedName ?? "the frontmost app")")
-            self.insertDictation(final)
+            self.insertDictation(final, to: destination)
         }
         correctionPanel.onCancel = { [weak self] in
             guard let self else { return }
             Log.write("inline: correction dismissed; wrote the text as dictated")
             handBack()
-            self.insertDictation(text)
+            self.insertDictation(text, to: destination)
         }
 
         if let rules {
@@ -1570,10 +1610,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     /// Write what was said, and say why it is not what was asked for.
-    private func giveUpInline(_ text: String, why: String, tone: NoticeTone = .caution) {
+    private func giveUpInline(
+        _ text: String, why: String, tone: NoticeTone = .caution,
+        destination: Destination
+    ) {
         endProgress()
         Log.write("inline: \(why); wrote the text as dictated")
-        insertDictation(text)
+        insertDictation(text, to: destination)
         notice.show(why, tone: tone, duration: 7)
         setLabel(why, clearAfter: 7)
     }
@@ -1585,7 +1628,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// selection can fail with nothing but a message, because the words are
     /// already on screen — here they have never been written, and a toast is
     /// not somewhere you can copy them back out of.
-    private func insertDictation(_ text: String) {
+    ///
+    /// `destination` is where *this* text was aimed when its hotkey went down,
+    /// carried in rather than read off `self` — by the time an inline prompt
+    /// and a correction panel have both had their turn, the field may be
+    /// holding a newer press's answer.
+    private func insertDictation(_ text: String, to destination: Destination) {
         // Nowhere to type: the pill said so by leaving its icon out, and this is
         // the other half of that. Pasting anyway is the bad outcome — a ⌘V into
         // a Finder window or a video player does whatever that window makes of
@@ -1605,7 +1653,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // been saying so in the menu bar for as long as it has existed — see the
         // `.clipboardOnly` branch below.
         if config.transcription.insertMode == .paste,
-           case .nowhere(let reason) = destinationAtPress, reason != .noAccessibility {
+           case .nowhere(let reason) = destination, reason != .noAccessibility {
             TextInserter.insert(text, mode: .clipboard)
             if config.feedback.sound { NSSound(named: "Glass")?.play() }
             Log.write("nothing to type into (\(reason.described)); copied instead")

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -72,6 +72,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `Pipeline.App` is what the pipeline matches on and has no business
     /// carrying an image around.
     private var appIconAtPress: NSImage?
+    /// Whether there was anywhere to type when the hotkey went down — see
+    /// `Destination`. Decides both whether the pill shows the icon and, a few
+    /// seconds later, whether the transcript is typed or copied.
+    ///
+    /// Starts at nothing, which is only read if a transcript ever arrives
+    /// without a press behind it — and one that did not come from a press has
+    /// no window it was aimed at either, so the clipboard is the honest answer.
+    private var destinationAtPress: Destination = .nowhere(.nothingFocused)
 
     private var tickTimer: Timer?
     private var pushToTalkPoll: Timer?
@@ -368,7 +376,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         focusAtPress = selectionAtPress ?? SelectionReader.focusSnapshot()
         let front = Self.appInFront()
         appAtPress = front?.app
-        appIconAtPress = front?.icon
+        // The icon is a promise that the words are going to land in that app,
+        // so it is only made when they will. Off the element the snapshot above
+        // already fetched — the answer costs two more attribute reads on a
+        // reference we are holding, not another walk of the tree.
+        destinationAtPress = Destination.at(app: front?.app, focus: focusAtPress?.element)
+        appIconAtPress = destinationAtPress.acceptsText ? front?.icon : nil
+        Log.write("destination: \(destinationAtPress.described)")
         let elapsed = Date().timeIntervalSince(snapshotStart)
         if elapsed > 0.15 {
             Log.write(String(format: "selection snapshot was slow: %.2fs", elapsed))
@@ -1572,6 +1586,34 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// already on screen — here they have never been written, and a toast is
     /// not somewhere you can copy them back out of.
     private func insertDictation(_ text: String) {
+        // Nowhere to type: the pill said so by leaving its icon out, and this is
+        // the other half of that. Pasting anyway is the bad outcome — a ⌘V into
+        // a Finder window or a video player does whatever that window makes of
+        // it, and the sentence is gone, because a dictation exists nowhere but
+        // here until it is written down.
+        //
+        // The clipboard is the one destination that always exists, so this one
+        // is said out loud rather than logged. "It went to the clipboard" is
+        // only true if you know it: unsaid, it is indistinguishable from the
+        // dictation having failed, and you say the whole thing again.
+        //
+        // Two cases are deliberately not this one. `insert_mode: clipboard` is
+        // someone who has already decided every transcript is copied, and a
+        // notice each time would be telling them what they configured. A
+        // missing Accessibility grant lands on the clipboard too, but it is a
+        // permission to grant rather than a window to click into, and it has
+        // been saying so in the menu bar for as long as it has existed — see the
+        // `.clipboardOnly` branch below.
+        if config.transcription.insertMode == .paste,
+           case .nowhere(let reason) = destinationAtPress, reason != .noAccessibility {
+            TextInserter.insert(text, mode: .clipboard)
+            if config.feedback.sound { NSSound(named: "Glass")?.play() }
+            Log.write("nothing to type into (\(reason.described)); copied instead")
+            flash("Nowhere to type — the transcription is on your clipboard", tone: .done)
+            updateUI()
+            return
+        }
+
         switch TextInserter.insert(text, mode: config.transcription.insertMode) {
         case .pasted:
             if config.feedback.sound { NSSound(named: "Glass")?.play() }

--- a/Sources/ParrotFlow/Destination.swift
+++ b/Sources/ParrotFlow/Destination.swift
@@ -1,0 +1,155 @@
+import AppKit
+import ApplicationServices
+
+/// Whether the dictation has anywhere to land, decided at the press.
+///
+/// The pill shows the icon of the app the words are about to be typed into, and
+/// "the app in front" is not that claim. A Finder window, a browser reading an
+/// article, a full-screen video — all frontmost, none of them with a caret in
+/// it. The paste still happens: ⌘V lands in whatever that window makes of it,
+/// which is usually nothing and occasionally something nobody asked for, and
+/// either way the sentence is gone, because it existed nowhere else.
+///
+/// So the question asked at the press is not who is in front but whether
+/// anything in front has keyboard focus and takes text. The answer drives two
+/// things that have to agree: the icon is drawn only when there is somewhere to
+/// write, and when there is not, the transcript is copied and said out loud
+/// instead of being fired into a window that will swallow it.
+enum Destination: Equatable {
+
+    /// Something with keyboard focus that will accept typed text, named by the
+    /// accessibility role it reported — the log line is the only way to tell
+    /// afterwards why a surface was accepted or refused.
+    case field(role: String)
+
+    /// A terminal, which is the one place the question cannot be asked.
+    ///
+    /// Its focused element is a view of the screen rather than a field: the
+    /// value is the whole visible buffer and is read-only, so an editable-field
+    /// test says no about the one surface in the system that is nothing but an
+    /// input. `SelectionReader` has known this for as long as it has been
+    /// writing corrections — a terminal takes keystrokes and refuses
+    /// everything else, which is precisely what a paste is. So terminals are
+    /// named rather than examined.
+    case terminal(name: String)
+
+    /// Nothing focused that would take text. The transcript goes to the
+    /// clipboard instead.
+    ///
+    /// Spelled `nowhere` rather than `none` so that a `Destination?` never has
+    /// two meanings for `.none`.
+    case nowhere(Reason)
+
+    /// Why there was nowhere to write. Carried apart from the message because
+    /// one of these is not like the others: without the grant nothing can be
+    /// typed anywhere, which the app has always reported in its own way.
+    enum Reason: Equatable {
+        case noAccessibility
+        case nothingFocused
+        case notAField(role: String)
+
+        var described: String {
+            switch self {
+            case .noAccessibility: return "accessibility is not granted"
+            case .nothingFocused: return "nothing has keyboard focus"
+            case .notAField(let role): return "\(role) does not take text"
+            }
+        }
+    }
+
+    /// True when the words can be typed where they were aimed.
+    var acceptsText: Bool {
+        if case .nowhere = self { return false }
+        return true
+    }
+
+    var described: String {
+        switch self {
+        case .field(let role): return "field (\(role))"
+        case .terminal(let name): return "terminal (\(name))"
+        case .nowhere(let reason): return "nowhere — \(reason.described)"
+        }
+    }
+
+    /// What the press found.
+    ///
+    /// `focus` is the element `SelectionReader` captured a moment earlier in the
+    /// same handler, so this asks accessibility nothing it has not already been
+    /// asked — the snapshot is on the main thread against apps that can be slow
+    /// to answer, and a second traversal for a second opinion is how a hotkey
+    /// starts feeling late.
+    static func at(app: Pipeline.App?, focus: AXUIElement?) -> Destination {
+        // First, and ahead of the terminals, because without the grant there is
+        // no focused element to inspect *and* no paste to aim: `TextInserter`
+        // leaves the text on the clipboard whatever this says, terminal or not.
+        // Answering honestly here is what keeps the pill's icon from promising
+        // something the app cannot do.
+        guard Permissions.accessibility == .granted else {
+            return .nowhere(.noAccessibility)
+        }
+
+        if let app, let name = terminalName(of: app) { return .terminal(name: name) }
+
+        guard let focus else { return .nowhere(.nothingFocused) }
+        let role = SelectionReader.role(of: focus) ?? "an unnamed element"
+        guard SelectionReader.acceptsTypedText(focus) else {
+            return .nowhere(.notAField(role: role))
+        }
+        return .field(role: role)
+    }
+
+    /// The terminal in front, by name, or nil for anything else.
+    ///
+    /// A list rather than a test, because there is nothing to test: what makes a
+    /// terminal a terminal is on the far side of a pty, and everything the
+    /// accessibility API can see is a grid of characters — the same shape
+    /// whether it is showing a shell prompt or the output of `cat`.
+    ///
+    /// Both halves are checked because one terminal is several bundles. Warp
+    /// ships stable, preview and nightly under three identifiers, Alacritty has
+    /// been `io.` and `org.` in living memory, and anything built from source
+    /// signs itself however the build did — while the name in the menu bar
+    /// stays what you call it. A list that only knew identifiers would silently
+    /// stop recognising a terminal on the day its author renamed one.
+    ///
+    /// The exception is deliberately narrow either way: being wrong here costs
+    /// a paste into a window that ignores it, which is what happened before any
+    /// of this existed.
+    private static func terminalName(of app: Pipeline.App) -> String? {
+        let bundle = app.bundleID.lowercased()
+        let name = app.name.lowercased()
+        if terminalBundleIDs.contains(bundle) || terminalNames.contains(name) {
+            return app.described
+        }
+        return nil
+    }
+
+    private static let terminalBundleIDs: Set<String> = [
+        "com.apple.terminal",
+        "com.googlecode.iterm2",
+        "com.mitchellh.ghostty",
+        "net.kovidgoyal.kitty",
+        "com.github.wez.wezterm",
+        "io.alacritty",
+        "org.alacritty",
+        "dev.warp.warp-stable",
+        "dev.warp.warp-preview",
+        "co.zeit.hyper",
+        "com.raphaelamorim.rio",
+        "org.tabby",
+    ]
+
+    private static let terminalNames: Set<String> = [
+        "terminal",
+        "iterm",
+        "iterm2",
+        "ghostty",
+        "kitty",
+        "wezterm",
+        "alacritty",
+        "warp",
+        "hyper",
+        "rio",
+        "tabby",
+    ]
+}

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -38,10 +38,11 @@ enum PanelsCommand {
         overlay.appIcon = sampleIcon()
 
         // The pill has two states now and the difference is the whole point of
-        // the slot: with an app in front it holds that app, without one it
-        // holds nothing and is simply narrower. Both are on the sheet because
-        // "it looks wrong with no icon" is the kind of thing that is obvious
-        // side by side and invisible a week apart.
+        // the slot: with somewhere to type it holds that app's icon, with
+        // nowhere it holds nothing and is simply narrower — which is how you
+        // are told the words are going to the clipboard instead. Both are on
+        // the sheet because "it looks wrong with no icon" is the kind of thing
+        // that is obvious side by side and invisible a week apart.
         let overlayBlind = OverlayModel()
         overlayBlind.level = 0.75
 

--- a/Sources/ParrotFlow/PeekCommand.swift
+++ b/Sources/ParrotFlow/PeekCommand.swift
@@ -80,6 +80,19 @@ enum PeekCommand {
         AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &role)
         report("role      \((role as? String) ?? "unknown")")
 
+        // What a dictation would do with this window before a single word of it
+        // is transcribed: `nowhere` is the pill with no icon in it and a
+        // transcript that ends up on the clipboard. Reported here because this
+        // is where a verdict that looks wrong gets checked — an app that plainly
+        // has a caret in it and reads as `nowhere` is a role this does not know.
+        let destination = Destination.at(
+            app: front.map {
+                Pipeline.App(name: $0.localizedName ?? "", bundleID: $0.bundleIdentifier ?? "")
+            },
+            focus: element
+        )
+        report("dictation \(destination.described)")
+
         let value = SelectionReader.visibleText(of: element)
         if let value {
             let lines = value.components(separatedBy: "\n").count

--- a/Sources/ParrotFlow/RecordingOverlay.swift
+++ b/Sources/ParrotFlow/RecordingOverlay.swift
@@ -5,9 +5,13 @@ import SwiftUI
 final class OverlayModel: ObservableObject {
     @Published var level: Float = 0
     @Published var elapsed: TimeInterval = 0
-    /// The icon of the app that was in front when the hotkey went down — the
-    /// one an `app:` condition will be matched against and the one the text
-    /// will land in. Nil when nothing was in front, or when the app has none.
+    /// The icon of the app the text is going to land in — the one an `app:`
+    /// condition will be matched against.
+    ///
+    /// Nil when nothing was in front, when the app has no icon, and when there
+    /// was nothing in it to type into: the icon is a promise about where the
+    /// words are going, and a window with no caret in it is not somewhere they
+    /// can go. See `Destination`.
     @Published var appIcon: NSImage?
 }
 
@@ -109,6 +113,14 @@ final class RecordingOverlay {
 /// it has always been. An empty slot held open is a hole you have to explain;
 /// the two widths are set in `RecordingMetrics` and applied at `show()`, which
 /// is the only moment either can change.
+///
+/// The narrow pill is also the warning. The icon appears when there is a field
+/// with keyboard focus to write into — not merely when an app is in front — so
+/// its absence says the words have nowhere to go and will be copied instead.
+/// That is a thing worth knowing while you are still talking, and it is told by
+/// the shape of the pill rather than by a second word on it: the pill is read in
+/// peripheral vision, and something being missing is the one difference that
+/// registers there.
 struct RecordingPill: View {
     @EnvironmentObject private var model: OverlayModel
 

--- a/Sources/ParrotFlow/SelectionReader.swift
+++ b/Sources/ParrotFlow/SelectionReader.swift
@@ -639,6 +639,60 @@ enum SelectionReader {
         return (element as! AXUIElement)
     }
 
+    /// The accessibility role of an element — `AXTextArea`, `AXWebArea`, and so
+    /// on — or nil when it will not say.
+    static func role(of element: AXUIElement) -> String? {
+        AXUIElementSetMessagingTimeout(element, 0.25)
+        var role: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            element, kAXRoleAttribute as CFString, &role
+        ) == .success else { return nil }
+        return role as? String
+    }
+
+    /// Whether an element would take text typed into it.
+    ///
+    /// Settability first, role second, and that order is the point. A role is
+    /// what an app calls its own view, and the apps that matter call theirs
+    /// whatever the page said — an Electron composer and a browser field are
+    /// `AXTextArea` on a good day and something invented on the others. What
+    /// every real input has in common is that its text can be written, and
+    /// `AXUIElementIsAttributeSettable` answers that about a custom role as
+    /// readily as about a stock one.
+    ///
+    /// The role check stays as a fallback rather than as the test, because the
+    /// two mistakes are not the same size. A field wrongly called uneditable
+    /// sends the dictation to the clipboard, which is the sentence not landing;
+    /// a read-only text area wrongly called editable gets a ⌘V it ignores,
+    /// which is what already happens today.
+    static func acceptsTypedText(_ element: AXUIElement) -> Bool {
+        AXUIElementSetMessagingTimeout(element, 0.25)
+        if isSettable(kAXValueAttribute as CFString, of: element) { return true }
+        if isSettable(kAXSelectedTextAttribute as CFString, of: element) { return true }
+        guard let role = role(of: element) else { return false }
+        return editableRoles.contains(role)
+    }
+
+    /// Roles that are a text input whatever they answer about settability.
+    ///
+    /// `AXWebArea` is deliberately absent: it is the page itself, which is what
+    /// a browser reports when you are reading rather than typing — the case
+    /// this whole check exists to catch.
+    private static let editableRoles: Set<String> = [
+        kAXTextFieldRole as String,
+        kAXTextAreaRole as String,
+        kAXComboBoxRole as String,
+        "AXSearchField",
+    ]
+
+    private static func isSettable(_ attribute: CFString, of element: AXUIElement) -> Bool {
+        var settable: DarwinBoolean = false
+        guard AXUIElementIsAttributeSettable(
+            element, attribute, &settable
+        ) == .success else { return false }
+        return settable.boolValue
+    }
+
     static func selectedText(of element: AXUIElement) -> String? {
         AXUIElementSetMessagingTimeout(element, 0.25)
         var selected: CFTypeRef?


### PR DESCRIPTION
The pill has shown the icon of the app in front since #29, and "the app in
front" is not the claim that icon makes. A Finder window, a video, a page being
read — all frontmost, none of them with a caret in it. The paste happened
anyway: ⌘V lands in whatever that window makes of it, usually nothing, and the
sentence is gone, because a dictation exists nowhere but in the app until it is
written down.

So the question asked at the press is no longer who is in front but whether
anything in front takes text, and the two halves of the answer have to agree.

**No field, no icon.** The narrow pill is the warning, given while you are still
talking rather than after.

**And the transcript is copied, out loud.** "On your clipboard" is only true if
you know it — unsaid, it is indistinguishable from the dictation having failed,
which is a sentence you say twice.

### How the question is asked

Settability, not role. `AXTextField` and `AXTextArea` cover the Cocoa cases and
miss the ones that matter — Electron and web fields answer with whatever the
page called them — while every real input has a value that can be written, and
`AXUIElementIsAttributeSettable` says so outright. The role list stays behind it
as a fallback because the two mistakes are different sizes: a field wrongly
called uneditable loses the paste, a read-only text area wrongly called editable
gets a ⌘V it ignores, which is today's behaviour.

It costs no extra traversal — the answer is read off the focused element
`SelectionReader` already snapshotted in the same handler.

### Terminals are exempt

Named rather than examined. A terminal's focused element is a view of the
screen: the value is the whole visible buffer and is read-only, so the
settability test says no about the one surface in the system that is nothing but
an input. Both the bundle identifier and the app's own name are matched — Warp
ships three bundles, Alacritty has been `io.` and `org.`, and anything built
from source signs itself however the build did.

### Two clipboard cases deliberately left alone

`insert_mode: clipboard` is someone who already decided every transcript is
copied, and a notice each time would be reciting their config back at them. A
missing Accessibility grant lands on the clipboard too, but it is a permission
to grant rather than a window to click into, and it has been saying so in the
menu bar all along.

### Diagnosing it

`--peek` now reports the verdict next to the role it read it from, and every
press writes a `destination:` line to the log. An app that plainly has a caret
in it and reads as `nowhere` is a role the list does not know, and that is where
you find out.

### Not checked here

The build and the deterministic sets run in CI, but this path needs a real
screen, an installed app and the Accessibility grant — the same reason
`check-inplace` cannot run in a pipe. Worth trying by hand against a Finder
window, a browser reading a page, a terminal, and an Electron composer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1NJxiqVWXVnicesUhZsgt)_