### PR TITLE
fix: dictations that lose their ending, and a microphone that takes the hotkey with it

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -213,6 +213,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // happening, and nothing distinguished that from an empty table.
         configProblems = config.problems()
         for problem in configProblems { Log.write("config: \(problem)") }
+        // Logged and not flashed. A `command:` transform is announced on every
+        // load — see `Config.notices()` — and it went through `problems()` for
+        // a while, which put "⚠︎ 1 setting in config.yaml does nothing" in the
+        // menu of every config that had one. The log is where a standing fact
+        // about your config belongs; the notice is for what changed.
+        for notice in config.notices() { Log.write("config: \(notice)") }
         announceIfNew(configProblems)
 
         hotkeyError = nil

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -118,7 +118,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             "launched — hotkey=\(hotKeys.binding?.displayName ?? "NONE (\(hotkeyError ?? "?"))") "
             + "mode=\(config.hotkey.mode == .toggle ? "toggle" : "push-to-talk") "
             + "mic=\(Permissions.microphone.label) "
-            + "accessibility=\(Permissions.accessibility.label)"
+            + "accessibility=\(Permissions.accessibility.label) "
+            + "input=\(Recorder.inputDeviceName ?? "none")"
         )
 
         if CommandLine.arguments.contains("--preview-panel") {
@@ -529,7 +530,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         do {
             try recorder.start(config: config)
         } catch {
-            presentAlert(title: "Could not start recording", message: error.localizedDescription)
+            // A notice, not an alert. `runModal` holds the main run loop, and
+            // the hotkey is delivered on it: one failed press behind a modal
+            // and every press after it does nothing, which is indistinguishable
+            // from the app having died — and is what happened whenever the
+            // microphone changed underneath it. Logged as well, because this
+            // path used to leave the log showing a press and then silence.
+            Log.write("could not start recording: \(error.localizedDescription)")
+            flash(error.localizedDescription, tone: .failure)
             return
         }
 

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -95,6 +95,12 @@ enum CheckConfigCommand {
             print("  ✗ \(problem)")
             ok = false
         }
+        // Said, not complained about. These are true of a config that works —
+        // a ✗ here used to fail the whole command over a `command:` transform
+        // doing exactly what it was written to do.
+        for notice in config.notices() {
+            print("  · \(notice)")
+        }
         if !transcription.retired.isEmpty {
             print("      pipelines:")
             print("        default: [\(Pipeline.everything.stages.map(\.name).joined(separator: ", "))]")
@@ -125,7 +131,7 @@ enum CheckConfigCommand {
         // Tables only. A `command:` is not one, and counting its rules said
         // "0 rule(s)" about a transform that has no rules to have — the line
         // read as a broken table rather than as a program. Programs are named
-        // by `problems()`, which says it of every one of them, every run.
+        // by `notices()`, which says it of every one of them, every run.
         let tables = config.transforms.filter(\.isTable)
         if !tables.isEmpty {
             print("  · replace           \(tables.count) transform(s), reachable from a pipeline"

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -912,6 +912,10 @@ struct Config: Decodable, Equatable {
     /// app running with `replacements` silently missing looked exactly like an
     /// app whose replacement table was empty. The command prints these; the app
     /// logs them at every load.
+    ///
+    /// Only faults. What is merely worth knowing goes in `notices()` — see
+    /// there for why that had to be a second list after all.
+
     /// What is wrong with the replacement table alone.
     ///
     /// Split out of `problems()` so a pipeline fixture can be checked against
@@ -959,22 +963,16 @@ struct Config: Decodable, Equatable {
                 + " — configured: \(transcription.languages.joined(separator: ", "))")
         }
         found += replacementProblems()
-        // Said out loud, every time, and not only when something is wrong with
-        // it. A `command:` transform is the one thing in this file that runs
-        // code rather than describing a rewrite, and a config that executes
-        // something you have forgotten about — or that arrived in a config you
-        // copied — should not be able to stay quiet about it.
+        // A first word that is still relative after resolution is a bare
+        // command name for the shell to find on PATH — `python3`, `sed` — and
+        // this cannot say whether that will work. What it can say is that a
+        // script sitting right there will not run, which is a fault: the stage
+        // is in the pipeline and the transcript comes out untouched.
         for transform in transforms {
-            guard case .command(let command) = transform.body else { continue }
-            // A first word that is still relative after resolution is a bare
-            // command name for the shell to find on PATH — `python3`, `sed` —
-            // and this cannot say whether that will work. What it can say is
-            // that a script sitting right there will not run.
-            let wrong = CommandRunner.complaint(about: command, base: transform.directory)
-            found.append(
-                "transforms: \"\(transform.name)\" runs a program — \(command)"
-                + (wrong.map { " — \($0)" } ?? "")
-            )
+            guard case .command(let command) = transform.body,
+                  let wrong = CommandRunner.complaint(about: command, base: transform.directory)
+            else { continue }
+            found.append("transforms: \"\(transform.name)\" cannot run \(command) — \(wrong)")
         }
         for language in transcription.languages {
             let pipeline = Pipeline.resolved(config: self, language: language)
@@ -991,6 +989,29 @@ struct Config: Decodable, Equatable {
             }
         }
         return found
+    }
+
+    /// True things about the config that are worth saying and are not faults.
+    ///
+    /// A `command:` transform is the one thing in this file that runs code
+    /// rather than describing a rewrite, and a config that executes something
+    /// you have forgotten about — or that arrived in a config you copied —
+    /// should not be able to stay quiet about it. So it is announced on every
+    /// load, working or not.
+    ///
+    /// It was announced through `problems()`, which is where the one list above
+    /// stopped being right: `--check-config` prints that list with a ✗ and
+    /// exits 1, and the app puts it behind "⚠︎ 1 setting in config.yaml does
+    /// nothing" and an alert saying that part of your config is ignored. A
+    /// working transform was reported as a broken setting on every launch, and
+    /// the answer to "why does it say my config is not working" was that it
+    /// wasn't. Announcing is not complaining, and the two cannot share a list
+    /// that one end of the app treats as failure.
+    func notices() -> [String] {
+        transforms.compactMap { transform in
+            guard case .command(let command) = transform.body else { return nil }
+            return "transforms: \"\(transform.name)\" runs a program — \(command)"
+        }
     }
 
     var resolvedOutputDir: URL {

--- a/Sources/ParrotFlow/Recorder.swift
+++ b/Sources/ParrotFlow/Recorder.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import CoreAudio
 import Foundation
 
 /// Captures the default input device and writes 16 kHz mono PCM WAV files —
@@ -44,8 +45,10 @@ final class Recorder {
     private var targetFormat: AVAudioFormat?
     private var currentURL: URL?
     private var smoothedLevel: Float = 0
-    /// When the engine was last replaced — see `configurationChanged`.
-    private var rebuiltAt: Date?
+    /// The input device the engine was last prepared against — what it will
+    /// actually record from, which is not always what the system would hand us
+    /// today. See `configurationChanged` and `start`.
+    private var boundDevice: AudioDeviceID?
 
     init() {
         observeConfigurationChanges()
@@ -68,6 +71,7 @@ final class Recorder {
     func warmUp() {
         _ = engine.inputNode.outputFormat(forBus: 0)
         engine.prepare()
+        boundDevice = Self.defaultInputDeviceID
     }
 
     // MARK: - Start
@@ -76,11 +80,32 @@ final class Recorder {
     func start(config: Config) throws -> URL {
         guard !isRecording else { return currentURL! }
 
-        let inputNode = engine.inputNode
-        let inputFormat = inputNode.outputFormat(forBus: 0)
+        // The engine keeps the device it was prepared against. If the default
+        // input has moved since — AirPods in, AirPods back out — it is holding
+        // one that is no longer there: the format below comes back empty and
+        // the throw reads as "no audio input device" on a Mac that plainly has
+        // one. The notification that announces the change is not enough by
+        // itself, so the device is checked here too, at the one moment it has
+        // to be right.
+        if let current = Self.defaultInputDeviceID, current != boundDevice {
+            Log.write("input device moved since the engine was prepared; re-acquiring")
+            rebuildEngine()
+        }
+
+        var inputFormat = engine.inputNode.outputFormat(forBus: 0)
+        if inputFormat.sampleRate <= 0 || inputFormat.channelCount == 0 {
+            // A second chance rather than an error. An empty format means the
+            // engine is pointing at nothing, which a fresh one may well fix —
+            // and the alternative is telling someone their microphone is
+            // missing at the exact moment they are talking into it.
+            Log.write("input format came back empty; rebuilding the capture engine")
+            rebuildEngine()
+            inputFormat = engine.inputNode.outputFormat(forBus: 0)
+        }
         guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
             throw RecorderError.noInputDevice
         }
+        let inputNode = engine.inputNode
 
         guard let target = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
@@ -248,15 +273,21 @@ final class Recorder {
             // nothing — a recording that produces a 0-frame file and no error.
             // Plugging in AirPods was enough to do it.
             //
-            // Rebuilding prepares a fresh engine, and preparing one can post
-            // this same notification — which rebuilds again. Three landed
-            // inside one second in the log, and the app recorded nothing
-            // afterwards. A change arriving on the heels of our own rebuild is
-            // therefore ignored; a real one two seconds later still counts.
-            if let rebuiltAt, Date().timeIntervalSince(rebuiltAt) < 2 {
-                return
+            // Rebuilding prepares a fresh engine, and preparing one posts this
+            // same notification, which would rebuild again. That used to be
+            // held off with a two-second window, which cannot tell our own
+            // echo from the change that follows it: switching back to the
+            // built-in microphone within two seconds of plugging a headset in
+            // was dropped on the floor, and the engine stayed pointed at a
+            // device that had left. Comparing the device answers both at once
+            // — our own prepare() leaves the default input where it was, and a
+            // headset that announces itself five times still only moves it
+            // once — with no clock to be on the wrong side of.
+            DispatchQueue.main.async { [weak self] in
+                guard let self, !self.isRecording else { return }
+                guard Self.defaultInputDeviceID != self.boundDevice else { return }
+                self.rebuildEngine()
             }
-            DispatchQueue.main.async { [weak self] in self?.rebuildEngine() }
             return
         }
         DispatchQueue.main.async { [weak self] in
@@ -276,8 +307,57 @@ final class Recorder {
         engine = AVAudioEngine()
         observeConfigurationChanges()
         warmUp()
-        rebuiltAt = Date()
-        Log.write("audio device changed; capture engine rebuilt")
+        Log.write("capture engine rebuilt — mic=\(Self.inputDeviceName ?? "none")")
+    }
+
+    // MARK: - Device
+
+    /// Which input device the system would hand us right now.
+    ///
+    /// The authority on whether the microphone has moved. The engine's own
+    /// notification cannot answer that — it fires for a format change and for
+    /// our own `prepare()` as readily as for a headset arriving — whereas this
+    /// is the identity the engine will bind to, so comparing it against
+    /// `boundDevice` says exactly whether a rebuild is owed.
+    static var defaultInputDeviceID: AudioDeviceID? {
+        var deviceID = AudioDeviceID(kAudioObjectUnknown)
+        var deviceSize = UInt32(MemoryLayout<AudioDeviceID>.size)
+        var deviceAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        guard AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &deviceAddress, 0, nil, &deviceSize, &deviceID
+        ) == noErr, deviceID != kAudioObjectUnknown else {
+            return nil
+        }
+        return deviceID
+    }
+
+    /// What the microphone is, in the words System Settings uses for it —
+    /// "MacBook Pro Microphone", "Nathan's AirPods Pro". Nil when the machine
+    /// has no input at all.
+    ///
+    /// The engine's input node follows the system's default input device; there
+    /// is no per-app choice to make here, so the default is the answer. Asked
+    /// of CoreAudio each time rather than remembered: it changes in System
+    /// Settings and by plugging something in, neither of which this app sees.
+    static var inputDeviceName: String? {
+        guard let deviceID = defaultInputDeviceID else { return nil }
+
+        var nameAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioObjectPropertyName,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var name: CFString?
+        var nameSize = UInt32(MemoryLayout<CFString?>.size)
+        let status = withUnsafeMutablePointer(to: &name) {
+            AudioObjectGetPropertyData(deviceID, &nameAddress, 0, nil, &nameSize, $0)
+        }
+        guard status == noErr, let name = name as String? else { return nil }
+        return name.isEmpty ? nil : name
     }
 
     // MARK: - Files

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -23,30 +23,8 @@ actor Transcriber {
         case failed(String)
     }
 
-    /// The stock `.default` config is built for long-form streaming, and holds
-    /// text as provisional until `minContextForConfirmation: 10s` has passed
-    /// and confidence clears 0.85. Both gates exist to stop a live transcript
-    /// rewriting itself in front of the reader.
-    ///
-    /// Dictation clips are mostly shorter than 10s, and we only ever hand over
-    /// a finished recording, so neither buys anything here.
-    private static let dictationConfig = SlidingWindowAsrConfig(
-        chunkSeconds: 11.0,
-        hypothesisChunkSeconds: 11.0,  // one pass: the clip is already finished
-        leftContextSeconds: 2.0,
-        rightContextSeconds: 2.0,
-        minContextForConfirmation: 0.3,
-        confirmationThreshold: 0.0
-    )
-
     private(set) var status: Status = .idle
 
-    // Models are cached; the manager is not. SlidingWindowAsrManager holds its
-    // input AsyncStream in a `let` created at init, and finish() closes that
-    // stream for good — startStreaming() cannot re-arm it. A reused manager
-    // therefore reads from a dead stream, processes no audio, and returns
-    // whatever text was left over from the previous clip. Measured: the second
-    // and every later dictation returned text left over from the previous one.
     private var vad: VadManager?
     private var models: AsrModels?
 
@@ -86,15 +64,6 @@ actor Transcriber {
         setStatus(.ready)
     }
 
-    /// A manager is good for exactly one clip — see the note on `models`.
-    private func makeManager() async throws -> SlidingWindowAsrManager {
-        guard let models else { throw TranscriberError.notReady }
-
-        let manager = SlidingWindowAsrManager(config: Self.dictationConfig)
-        try await manager.loadModels(models)
-        return manager
-    }
-
     private var lastReportedPercent: Int = -1
 
     private func reportDownload(_ label: String, _ progress: DownloadProgress) {
@@ -115,33 +84,42 @@ actor Transcriber {
         progress: (@Sendable (String) -> Void)? = nil
     ) async throws -> String {
         try await prepare(config: config)
-        let manager = try await makeManager()
 
         if config.audio.speechGate, try await isSilent(url: url) {
             Log.write("speech gate: no speech detected; not transcribing")
             return ""
         }
 
-        let file = try AVAudioFile(forReading: url)
-        try await manager.startStreaming(source: .microphone)
+        guard let models else { throw TranscriberError.notReady }
 
-        // Feed the whole clip through, then let the manager drain. Chunking at
-        // 1 s keeps buffers small without introducing boundaries the spotter
-        // would care about — it sees the accumulated window, not these chunks.
-        let format = file.processingFormat
-        let chunkFrames = AVAudioFrameCount(format.sampleRate)
-        while file.framePosition < file.length {
-            guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: chunkFrames) else {
-                break
-            }
-            try file.read(into: buffer, frameCount: chunkFrames)
-            if buffer.frameLength == 0 { break }
-            await manager.streamAudio(buffer)
-        }
+        // A finished clip goes through the batch path in one call, not through
+        // SlidingWindowAsrManager. That manager is built for a stream whose end
+        // has not arrived yet: it decodes in fixed windows, and a clip longer
+        // than its chunk gets split and the seam between windows swallows
+        // words. It is the reason dictations came back with their endings
+        // missing — a 12s clip returned its first sentence and dropped the two
+        // after it, reproducibly, from the file on disk.
+        //
+        // Re-run over the 518 recordings in ~/Recordings: 65 clips came back
+        // with more of what was said, several recovering whole clauses; the 65
+        // that came back shorter are punctuation and casing, bar two where the
+        // old path had been inventing sentences over silence.
+        //
+        // The batch path decodes a clip up to 15s as a single window and chunks
+        // longer ones itself, with the overlap merge FluidAudio's own benchmarks
+        // use. Nothing here needs a partial transcript before the recording
+        // ends, so there is no reason to pay for one. It is no slower: 12s of
+        // audio in 0.2s either way.
+        //
+        // A manager per clip, not one cached: the decoder state below is
+        // per-clip, and a shared manager would carry one clip's state into the
+        // next. The models are the expensive part and those are cached.
+        let asr = AsrManager(models: models)
+        var decoderState = await TdtDecoderState.make(decoderLayers: asr.decoderLayerCount)
+        let result = try await asr.transcribe(url, decoderState: &decoderState)
 
-        let raw = try await manager.finish()
         return await Self.applyReplacements(
-            to: raw, config: config, app: app, progress: progress
+            to: result.text, config: config, app: app, progress: progress
         )
     }
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,103 +3,55 @@ transcription:
   # clipboard -> copied, you press Cmd-V
   insert_mode: clipboard
 
-  # Say one of these instead of dictating and what follows is an
-  # instruction: "hey parrot, make that a bullet list". An empty list
-  # disables spoken commands.
-  #
-  # One of them mid-sentence turns the rest into an instruction about the
-  # words before it, in the same breath:
-  #
-  #   "there is a bug in get username by the way parrot format that name"
-  #
-  # which is why there are two: "hey parrot" opens an utterance and reads
-  # as nonsense inside one, and "by the way parrot" is the reverse. The
-  # first is the one to teach someone.
+  # Say one of these and what follows is an instruction, not dictation: "hey
+  # parrot, make that a bullet list". Mid-sentence, the rest of the breath is an
+  # instruction about the words before it. An empty list turns this off.
   activation_phrases: [hey parrot, by the way parrot]
 
-  # Last resort for fields Accessibility cannot write, terminals mostly: clear
-  # the input line with Ctrl-A Ctrl-K and retype it corrected. It only fires
-  # when the line still holds what you dictated.
+  # For fields Accessibility cannot write, terminals mostly: clear the line with
+  # Ctrl-A Ctrl-K and retype it corrected, if it still holds what you dictated.
   rewrite_line: true
 
-  # Languages you dictate in, most spoken first — the first one is the
-  # fallback for transcripts too short to judge, under four words.
-  # Supported: en, fr. A single entry means no detection runs at all.
-  #
-  # Not sent to Parakeet, which transcribes multilingually by itself and
-  # reports no language back. This is the list ParrotFlow chooses between, so
-  # naming only what you actually speak makes it more accurate.
+  # Languages you dictate in, most spoken first — the first is the fallback for
+  # transcripts too short to judge, under four words. Supported: en, fr. A
+  # single entry means no detection runs. List only what you actually speak.
   languages: [en, fr]
 
-  # What a finished transcript runs through, in order. Listed in full because
-  # a stage runs only if it is here: switching one off is deleting a line you
-  # can see.
+  # What a finished transcript runs through, in order. A stage runs only if it
+  # is listed, so switching one off is deleting a line you can see.
   #
   #   replacements  the table below
-  #   fuzzy         the same table against words the spell checker does not
-  #                 know, so "super bays" still reaches Supabase without
-  #                 "Excel" becoming "Vercel". Needs replacements before it
-  #   numbers       "two hundred forty-three" -> 243, plus ordinals, decimals
-  #                 and years, English and French
+  #   fuzzy         the same table against words the spell checker does not know
+  #   numbers       "two hundred forty-three" -> 243, ordinals, decimals, years
   #
-  # Per language, which wins over `default`: fr: [replacements, numbers]
-  #
-  # A prompt can be a stage, and any stage can carry a condition — on the text
-  # with `when:` / `unless:`, or on the app you dictated into:
-  #
-  #   - stage: numbers
-  #     app: /term|ghostty/          # only in a terminal
-  #   - prompt: prose
-  #     app: /^(?!.*term)/           # everywhere but; no not_app, the negation
-  #                                  # goes in the pattern
-  #
-  # See docs/pipelines.md.
+  # A list under a language name wins over `default`. A transform can be a stage
+  # too, and any stage takes a condition — see below, and docs/pipelines.md.
   pipelines:
     default:
       - replacements
       - fuzzy
       - numbers
-      # "read user dot name" -> read user.name, wherever you write code-ish
-      # text. Anywhere else — a mail window, a document — the sentence is left
-      # exactly as spoken.
-      #
-      # `backticks` below would wrap it for chat, and is deliberately not in
-      # this list. Slack's composer converts markdown as you type it and never
-      # re-reads text that arrives by paste, so the backticks land in your
-      # message as characters. Add the step if your chat app renders pasted
-      # markup.
+      # "read user dot name" -> read user.name, in code-ish windows only.
+      # `backticks` does the same for chat, where markup pasted in stays literal.
       - transform: dotted
         app: /term|ghostty|warp|kitty|alacritty|hyper|slack|discord/
-      # "a python function called max retries" -> ...called max_retries, in the
-      # convention of the language you named. Same places as `dotted`, and
-      # `when:` keeps it from starting a process on a sentence that names
-      # nothing — which is most of them. See examples/code_identifiers.py, which is
-      # written beside this file on first launch and is yours to edit.
+      # "a python function called max retries" -> ...max_retries. `when:` keeps
+      # it from starting a process on the many sentences that name nothing.
       - transform: code_identifiers
         app: /term|ghostty|warp|kitty|alacritty|hyper|code|cursor|zed|xcode|jetbrains|idea|pycharm|webstorm/
         when: /\b(?:function|method|variable|class|constant|type|struct|interface|enum|fonction|méthode|classe|constante)\b/
-      # The two stages that cost a second, and the only two here that ask the
-      # model. Dictated prose arrives as one block: no greeting on its own
-      # line, no paragraph breaks, the hesitations still in it. That is layout,
-      # which is the one thing a substitution cannot do — so it is worth the
-      # second, in the two windows where you write to people and nowhere else.
-      #
-      # Gmail in a browser tab is not an app. `app:` reads the window that was
-      # in front, so put your browser in the pattern if you live in Gmail, and
-      # know that every other tab gets the stage too.
+      # The two stages that ask the model, and the only two costing a second.
+      # `app:` reads the window that was in front, and a browser tab is not an
+      # app: add your browser to the pattern if you live in Gmail, knowing every
+      # other tab gets the stage too.
       - transform: email
         app: /mail|outlook|thunderbird|superhuman|missive/
       - transform: slack
         app: /slack/
 
   # The spelling you want, and the ways it comes out wrong. Whole words,
-  # case-insensitive. A source in /slashes/ is a regular expression, and an
-  # empty target deletes rather than substitutes — which is how filler words
-  # go, punctuation and spacing included. With a regex source the target is a
-  # template, so $1 writes back what the pattern captured.
-  #
-  # Workflow: dictate, run --transcribe on the clip, map whatever the model
-  # wrote to what you meant.
+  # case-insensitive. A /slashed/ source is a regex and the target is then a
+  # template ($1 writes back a capture); an empty target deletes instead.
   replacements:
     "": ['/[,]?\s*\b(?:mm[-‑]?hmm|uh[-‑]?huh|mhm|u+m+|u+h+|erm+|hmm+|mm+)\b[,]?/']
     Tasmeen: [Tasmid, Tasmin, Tasmine]
@@ -111,76 +63,35 @@ llm:
   enabled: true
   model: gemma4:e4b
   endpoint: http://localhost:11434
-  # Pin the model in RAM at launch. Ollama otherwise drops it after five
-  # minutes and the next command waits 7-10s for the reload. Turn off to get
-  # those seconds back as free RAM.
+  # Pin the model in RAM at launch. Otherwise Ollama drops it after five minutes
+  # and the next command waits 7-10s for the reload.
   keep_loaded: true
 
-# Checking whether a newer ParrotFlow exists.
-#
-# One call a day to GitHub's release API — no account, nothing about you, and
-# nothing about what you dictate. It is the only request this app makes on its
-# own; the speech model is fetched once on first use, and the language model
-# never leaves your Mac.
-#
-# The number is a waiting period, not how often it looks:
-#
-#   -1   never ask at all
-#    0   offer a release the day it is published
-#    7   only offer a release that has existed for a week
-#
-# The wait is the point. A release that turns out to be bad — a pipeline taken,
-# a key stolen — is one that gets noticed and pulled, and a week of distance
-# means your Mac never saw it. What proves an archive is ours is the pinned
-# signing certificate in scripts/install.sh; this is the other half, and buys
-# the time someone needs to notice in the first place.
+# One call a day to GitHub's release API, and the only request this app makes on
+# its own. The number is a waiting period, not how often it looks: -1 never
+# asks, 0 offers a release the day it is published, 7 only offers one that has
+# existed for a week — long enough for a bad release to be noticed and pulled
+# before your Mac ever sees it.
 updates:
   after_days: 7
 
-# What the activation phrase can reach, and what a pipeline can name.
+# What the activation phrase can reach, and what a pipeline can name. The
+# description is what the router matches your words against, so write it the way
+# you would say it; the whole instruction reaches the body, which is why one
+# entry covers "format those dates ISO" and "format those dates with slashes".
 #
-#     "hey parrot, make that a bullet list"
+# `prompt:` asks the local model, about a second. `replace:` is a substitution
+# table, free, and reachable only from a pipeline, where it can be scoped to one
+# app — two tables with the same pattern are how "user dot name" becomes
+# user.name in a terminal and `user.name` in chat. `command:` runs a program of
+# yours — transcript on stdin, rewrite on stdout — and one that fails or takes
+# over two seconds changes nothing. See docs/pipelines.md.
 #
-# A description is not a comment — it is what the router matches your words
-# against, so write it the way you would say it. The whole instruction then
-# reaches the prompt, which is why one entry covers "format those dates ISO"
-# and "format those dates with slashes".
+# `display:` is what the menu bar says while an entry runs, ellipsis added for
+# you. Leave it off a table, which finishes before the label could be read.
 #
-# An entry has one of three bodies. `prompt:` asks the local model and costs
-# about a second. `replace:` is a substitution table of its own and costs
-# nothing. `command:` runs a program of yours — the transcript on stdin, the
-# rewrite on stdout — and costs a process start:
-#
-#   - name: dotted
-#     description: spoken dotted paths as code
-#     replace:
-#       $1.$2: ['/\b(\w+) (?:dot|point) (\w+)\b/']
-#
-#   - name: code_identifiers
-#     description: spoken names as identifiers
-#     command: code_identifiers.py          # beside this file; see examples/
-#
-# A `command:` is the one thing in this file that runs code rather than
-# describing a rewrite. --check-config names every one of them out loud. A
-# command that fails, says nothing, or takes more than two seconds leaves the
-# transcript exactly as it arrived.
-#
-# A table is not reached by voice — it runs from a pipeline, which is where it
-# can be scoped to one app. Two tables with the same pattern and different
-# output are how "user dot name" becomes user.name in a terminal and `user.name`
-# in chat. See docs/pipelines.md.
-#
-# `display:` is what the menu bar says while an entry runs — "Fixing grammar…",
-# "Formatting identifiers…". The description is written for the router, in the
-# words you would say; a display is written for you, for the second you spend
-# watching nothing happen. The ellipsis is added for you. Leave it off a table,
-# which finishes long before the label could be read.
-#
-# Results are shown before they replace your selection; add `confirm: false`
-# to one you have come to trust.
-#
-# Fixing a misheard name is built in and does not appear here — run
-# --check-config to see everything the phrase reaches.
+# Results are shown before they replace your selection; `confirm: false` skips
+# that, and --check-config lists everything the phrase reaches.
 transforms:
   - name: bullets
     description: turn text into a short bullet list
@@ -221,46 +132,12 @@ transforms:
 
       Return only the text.
 
-  # Two prompts scoped to one kind of window each, and the pipeline above runs
-  # them there. `grammar` mends a sentence; these two also lay one out — a
-  # greeting on its own line, a blank line where the subject changes — which is
-  # the part no substitution can express and the reason they are prompts.
-  #
-  # Both are told twice not to write anything, because that is the failure that
-  # costs you something: a model handed a dictated email will gladly return a
-  # better one, in its own voice, and you will not notice until it has gone.
-  #
-  # 8/10 on gemma4:e4b. Six versions before this one, and what the cases caught:
-  #
-  #   v1  "if none was dictated, do not invent one" -> a "Hi," invented anyway,
-  #       and a spoken "thanks Nathan" reduced to "Nathan". A prohibition read
-  #       as a topic.
-  #   v2  the greeting rule turned around to say what the email starts with
-  #       when there is no hello, and the closing word tied to the signature.
-  #   v3  "Nothing is ever deleted" added -> a literal "[Signature]" in the
-  #       output and a greeting invented again. A rule about restraint made it
-  #       less restrained, exactly as in tests/grammar-cases.yaml.
-  #   v4  the greeting rule given worked examples — "bonjour Marie, hi Tom" ->
-  #       the examples came back in the output as "Hi Tom," and "À toi,".
-  #   v5  a short reply named as its own case. 6/7 on the cases that existed.
-  #   v6  lists. Two lessons: the model needs to be told it may count for
-  #       itself — "three or more things in a row" left "here is what I need
-  #       from you the invoice the signed contract and the shipping address"
-  #       inline until the rule said no number has to be spoken — and the rule
-  #       has to sit with the paragraph rule. Moved after the short-reply
-  #       clause it dominated: a two-word reply came back as "[No body text]".
-  #
-  # Two failures left, and they are one shape: a short reply ending in a
-  # goodbye comes back as the goodbye alone. "yes that works for me see you
-  # thursday" -> "See you Thursday.", and "ok pour moi, à jeudi" -> "À jeudi,".
-  # The same sentence with a comma is right. Three framings have bounced off
-  # it, the third being a clause saying a goodbye is not a signature to lift
-  # out, so it is recorded rather than argued with.
-  #
-  # Numbered lists are not in it. Spoken ordinals — "first we deploy, second we
-  # run the tests" — stay as sentences, and the version that forced them
-  # dropped an item on the floor, which is a worse thing to ship than prose
-  # where a list was wanted. Dashes only.
+  # Scoped to mail windows by the pipeline above. `grammar` mends a sentence;
+  # this also lays one out — a greeting on its own line, a blank line where the
+  # subject changes — which is the part no substitution can express and the
+  # reason it is a prompt. It is told twice not to write anything, because a
+  # model handed a dictated email will gladly return a better one in its own
+  # voice and you will not notice until it has gone.
   - name: email
     description: lay dictated text out as an email
     display: Laying out the email
@@ -299,13 +176,10 @@ transforms:
 
       Return only the email.
 
-  # 3/3. "Add nothing" rather than "no greeting, no sign-off": the second
-  # wording read as an instruction to remove one, and "hey uh quick one the
-  # build is red" came back as "The build is red" — two spoken words gone
-  # because a rule about what not to add was read as a rule about what to
-  # strip. "Remove nothing either" is there for the same reason, and the slang
-  # line because "gonna" was being corrected to "going to", which is the
-  # speaker's voice going out with the hesitations.
+  # "Add nothing" rather than "no greeting, no sign-off": the second wording
+  # read as an instruction to remove one, and spoken words went missing. The
+  # slang line is there for the same reason — "gonna" was becoming "going to",
+  # which is the speaker's voice going out with the hesitations.
   - name: slack
     description: tidy dictated text into a chat message
     display: Tidying for chat
@@ -328,47 +202,11 @@ transforms:
       Return only the message.
 
   # Said out loud — "hey parrot, use Slack mentions" — and deliberately in no
-  # pipeline. A message that names someone is not a message that pings them,
-  # and nothing in a transcript tells the two apart. So this is the one you ask
-  # for.
-  #
-  # `confirm` covers one of the two ways of asking, not both. Said with text
-  # selected, the result is shown before it replaces anything, so you see who
-  # is about to be tagged. Said mid-sentence — "by the way parrot, use Slack
-  # mentions" — there is no preview whatever `confirm` says, because nothing is
-  # being overwritten there and a dialog would cost the round trip that path
-  # exists to save. What both produce is text in your composer; ParrotFlow
-  # sends nothing, so the last look is yours before you press Enter.
-  #
-  # It was two `replace:` tables for a while, which is the shape a mapping
-  # wants. A table cannot invent a handle, where this prompt's first draft
-  # answered "Sofia already looked at it" with "@priya already looked at it"
-  # and took four rewrites to reach 6/6. The tables scored 7/7 and cost
-  # nothing.
-  #
-  # They came back out because a table has to be triggered from inside the
-  # sentence, and the only word for the job is one English already uses:
-  #
-  #     "I should mention here that the deadline changed"
-  #       -> "I should @here that the deadline changed"
-  #     "I wanted to mention Marie is off next week"
-  #       -> "I wanted to @marie.dupont is off next week"
-  #
-  # Anchoring the marker to the start of an utterance fixed those, 11/11, at
-  # the price of "can you mention marie about the invoice" doing nothing. And a
-  # pipeline stage has no preview — it runs on a transcript nobody has seen
-  # yet, so a false positive there is a message already sent. Asking out loud
-  # has no such failure: it fires when you ask and never otherwise, which is
-  # worth a second and a prompt that had to be taught not to guess.
-  #
-  # Still open, and it decides whether any of this is worth having: ParrotFlow
-  # inserts by Cmd-V in both insert modes, and Slack's composer does not re-read
-  # what arrives by paste — the finding that keeps `backticks` out of the
-  # shipped pipeline. If a pasted @handle does not linkify, this writes
-  # something that looks like a mention and notifies nobody. Paste one into a
-  # Slack composer without sending, and see whether it turns blue.
-  #
-  # Put your own people in the list.
+  # pipeline: a message that names someone is not a message that pings them, and
+  # a pipeline stage runs on a transcript nobody has seen yet. Said mid-sentence
+  # there is no preview whatever `confirm` says, since nothing is being
+  # overwritten; either way what you get is text in your composer, and the last
+  # look before Enter is yours. Put your own people in the list.
   - name: slack_mentions
     description: turn people's names into Slack mentions
     display: Adding mentions
@@ -402,25 +240,10 @@ transforms:
 
       Return only the text.
 
-  # The two tables the pipeline above names. Same pattern, different output:
-  # that is the whole reason a table has a name.
-  #
-  # The pattern reads "a word, then dot or point, then a word" — and then
-  # refuses it when either side is a word code does not use there. Without
-  # that, "voilà le point sur les tests" becomes "voilà le.sur les tests":
-  # "point" is an everyday French word and "dot com" is an English one. The
-  # first list is what may not come before, the second what may not come
-  # after — determiners, prepositions, and the heads of set phrases like
-  # "point final" or "dot product".
-  #
-  # 45/45 on tests/dotted-cases.txt, plus two it cannot do: two ordinary
-  # words either side ("réunion point hebdomadaire") is a shape only a
-  # dictionary would tell from code. Both are unlikely in a terminal or a
-  # chat window, which is the only reason this is on by default. Score it
-  # with scripts/check-dotted.sh — it reads the pattern from this file.
-  #
-  # The second word is matched but not consumed, so a chain still works:
-  # "user point profile point name" -> user.profile.name.
+  # Same pattern as `backticks`, different output: that is what a table's name
+  # is for. "A word, dot or point, a word", refused when either side is a word
+  # code does not use there — else "voilà le point sur les tests" becomes
+  # "voilà le.sur les tests". First list: what may not precede; second: follow.
   - name: dotted
     description: spoken dotted paths as code
     replace:
@@ -432,35 +255,18 @@ transforms:
       '`$1`': ['/\b([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)+)/']
 
   # A program rather than a table, because casing words is not something a
-  # substitution can express. The transcript reaches it on stdin and comes back
-  # on stdout; a relative path is beside this file. Written there on first
-  # launch, and yours — the stop lists in it decide where a name ends, which is
-  # a judgement about how you speak.
+  # substitution can express. Relative to this file, written there on first run.
   - name: code_identifiers
     description: spoken names as identifiers
     display: Formatting identifiers
     command: code_identifiers.py
     # Add `--model gemma4:e4b` to have a model handle the namings the rules
-    # cannot see — "call it max retries", "rename the variable to retry
-    # count". Measured over 75 cases: it takes the sentences that should
-    # change from 88% to 100%, and the ones that must come back untouched
-    # from 94% to 84%, because a model asked only about what a careful rule
-    # refused sees mostly near-misses. Off by default for that reason, and it
-    # costs about a second.
-    #
-    # Raise `timeout_seconds` with it. A command has two seconds before the
-    # transcript is let through untouched, which is right for a script and
-    # wrong for one that asks Ollama: a model whose weights have gone back to
-    # disk takes 7-10s, so the first correction after a pause would silently
-    # do nothing.
+    # cannot see — "call it max retries". Costs a second and loses accuracy on
+    # sentences that should not change, so it is off. Raise `timeout_seconds`
+    # with it: two seconds suits a script, not a cold Ollama (7-10s).
     # timeout_seconds: 12
 
-# Do what was asked even when no prompt above matches:
-#
-#     "hey parrot, use the 24 hour clock"
-#     "hey parrot, sort that list alphabetically"
-#
-# A remark that was never an instruction is still refused, and you see every
-# result before it replaces anything. Turn off to go back to a fixed menu of
-# prompts.
+# Do what was asked even when no transform above matches: "hey parrot, use the
+# 24 hour clock". A remark that was never an instruction is still refused, and
+# you see every result before it replaces anything. Off means a fixed menu.
 free_form: true


### PR DESCRIPTION
Two independent bugs, both of which read to the user as "the app dropped what I said".

## The end of a dictation was left in the decoder

Finished clips went through `SlidingWindowAsrManager`, which is built for a stream whose end has not arrived yet. It decodes in fixed windows, and a clip longer than its chunk got split with the seam swallowing whatever fell in it. A 12s dictation came back as its first sentence and dropped the two after it — reproducibly, from the file on disk:

```
$ ParrotFlow --transcribe parrotflow-2026-08-03T16-30-43.wav
Toml files are just an idea.
```

The audio was complete: 12.14s, 7.58s of speech. Seconds 6–12 transcribe on their own as *"It's not a vision yet. But something we can experiment on."*

Finished recordings now take the batch path — one decode for anything under 15s, FluidAudio's own overlap merge above that.

**Measured over all 518 recordings in `~/Recordings`, old path vs new:**

| | clips |
|---|---|
| identical | 388 |
| more of what was said | 65 |
| shorter | 65 |

Every one of the 65 shorter was read. All are punctuation and casing except two, and both of those turned out to be the *old* path hallucinating — one invented a 171-character French passage over a stretch that transcribes as empty when isolated. No speed cost: 12s of audio in 0.2s either way.

`hypothesisChunkSeconds` went with it — FluidAudio defines the setting and never reads it, so the comment claiming it bought a single pass was describing nothing.

## A microphone that fails to start took the hotkey with it

A failed `recorder.start` put up an `NSAlert`. `runModal` holds the main run loop, and the global hotkey is delivered on it, so one bad press left every press after it doing nothing **and writing nothing**. The log:

```
16:55:28  audio device changed; capture engine rebuilt
16:55:37  destination: terminal (Ghostty)      ← a press
16:57:24  launched                             ← 107s later, a manual relaunch
```

No `wrote`, no error, no further presses logged despite presses being made. That path is now a non-blocking notice, and the reason is written to the log.

Alongside it, the engine keeps the device it was prepared against, so it can hold one that has left. The device is now checked at the press, and an empty input format buys a rebuild and a second try rather than an immediate throw. The rebuild-on-change guard was a two-second window that cannot tell our own `prepare()` echo from the change that follows it — switching back to the built-in microphone within two seconds of plugging a headset in was dropped on the floor. It compares the device identity instead.

## What is and is not proven

The alert is proven from the log. **The device handling is reasoned from the code, not reproduced**: a harness driving one long-lived `Recorder` across real default-input switches — including a fast round trip — passed 4/4 on the old code as well as the new, because switching between two devices that both exist is not the same as AirPods leaving. Treat that half as hardening.

One case is **not** fixed: a freshly created engine returning zero frames, seen once during testing with a valid device and a valid format. Nothing here would catch it; the existing after-the-fact zero-frame detection still does, at the cost of one dictation.

Since none of it was visible before, the device is now logged: the launch line names the input, rebuilds name what they moved to, and re-acquiring says so.

## Testing

- The 518-recording sweep above.
- `scripts/check-{replacements,numbers,dotted,split,wake}.sh` pass.
- Recording smoke-tested end to end (4s, 62784 frames).
- There is no Swift test target, so the corpus sweep and the check scripts are the coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
