### PR TITLE
feat: the menu says which microphone the next press will use

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -13,6 +13,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private var statusItem: NSStatusItem!
     private var statusInfoItem: NSMenuItem!
+    private var inputDeviceItem: NSMenuItem!
     private var permissionsItem: NSMenuItem!
 
     /// The recording state the menu bar icon was last drawn for.
@@ -1761,6 +1762,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         statusInfoItem.isEnabled = false
         menu.addItem(statusInfoItem)
 
+        // Under the state it qualifies: which microphone the next press will
+        // listen through. Worth a row because the answer is chosen elsewhere —
+        // a headset connects and silently becomes the input for everything.
+        inputDeviceItem = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+        inputDeviceItem.isEnabled = false
+        menu.addItem(inputDeviceItem)
+
         // Above the separator, so it reads as part of the app's state rather
         // than as one more thing you can do. Hidden until there is something
         // to say — a notice at launch is missed, and a setting that quietly
@@ -1999,6 +2007,14 @@ extension AppDelegate: NSMenuDelegate {
     /// than in this app.
     func menuNeedsUpdate(_ menu: NSMenu) {
         permissionsItem.isHidden = !hasPermissionProblem
+
+        // Here rather than in `updateUI`, which runs on a 0.1s timer while
+        // recording: the device is picked in System Settings, so the moment the
+        // menu opens is both the first time the answer can have changed and the
+        // only time anyone can read it.
+        let device = Recorder.inputDeviceName
+        inputDeviceItem.isHidden = device == nil
+        inputDeviceItem.title = device.map { "Microphone  ·  \($0)" } ?? ""
     }
 
     private var hasPermissionProblem: Bool {


### PR DESCRIPTION
Follow-on to #32, which made the input device visible in the log. This makes it visible where you are before you press the key.

## Why

The input is chosen in System Settings, not in this app, so ParrotFlow can be listening through something you did not pick — a headset connects and silently becomes the input for everything. When a dictation then comes back wrong or empty, nothing on screen says the wrong microphone was live. #32 added the device to the launch line and to rebuild lines, but reading a log is not something you do before pressing a key.

## What

A row under the status row, reading `Microphone  ·  <name>`, using the `Recorder.inputDeviceName` that #32 introduced.

It is refreshed in `menuNeedsUpdate`, not in `updateUI`: `updateUI` runs on a 0.1s timer while recording, and the device is picked elsewhere, so menu-open is both the first moment the answer can have changed and the only moment anyone can read it. The row hides itself when the device cannot be named — the same condition the launch line already logs as `none`.

## Testing

- `swift build` clean. The Swift 6 `sendable-closure-captures` warnings in `AppDelegate.swift` are pre-existing on `main` and untouched here.
- **Not exercised in a running app.** The row has not been read on screen, and the switch-device case has not been tried. What the change rests on is that `Recorder.inputDeviceName` is the same accessor #32 already ships in the launch line, and that the item is inert: disabled, no action, nothing reads it — so the blast radius is one line of menu text being wrong or absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)