### PR TITLE
fix: a dictation that is still working says so on screen

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -610,8 +610,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func transcribe(_ recording: Recorder.Recording) {
         transcriptionRun += 1
         let run = transcriptionRun
-        transcriptionLabel = "Transcribing…"
-        updateUI()
+        // On the HUD and not just in the menu. Releasing the key hides the
+        // recording pill, and everything after it — the decoder, then any
+        // prompt stage the pipeline runs — used to report itself only into
+        // `statusInfoItem.title`, a row you have to open the menu bar to read.
+        // A dictation into a mail window spends a second in the `email` prompt
+        // with nothing on screen at all, which reads as the app having dropped
+        // it. Same pair the spoken-command path has used all along.
+        beginProgress("Transcribing…")
 
         let config = self.config
         // Taken at the press, not here: a transcript arrives seconds later and
@@ -644,14 +650,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                             // something on screen to replace.
                             guard let self, self.transcriptionRun == run,
                                   self.transcriptionLabel != nil else { return }
-                            self.transcriptionLabel = label
-                            self.updateUI()
+                            self.beginProgress(label)
                         }
                     }
                 ) ?? ""
                 await MainActor.run {
                     guard let self else { return }
-                    self.transcriptionLabel = nil
+                    // Only if the screen is still ours. Push-to-talk does not
+                    // wait, so a second press while this one was in flight has
+                    // already put its own "Transcribing…" up, and clearing it
+                    // here would leave that dictation running behind a blank
+                    // screen — the bug this is meant to fix, one press later.
+                    // The text is delivered either way: `destination` was
+                    // captured at the press for exactly that reason.
+                    if self.transcriptionRun == run { self.endProgress() }
                     self.finishTranscription(
                         text: text, destination: destination, focus: focus
                     )
@@ -659,7 +671,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             } catch {
                 await MainActor.run {
                     guard let self else { return }
-                    self.transcriptionLabel = nil
+                    if self.transcriptionRun == run { self.endProgress() }
                     Log.write("transcription failed: \(error.localizedDescription)")
                     self.presentAlert(title: "Transcription failed", message: error.localizedDescription)
                     self.updateUI()


### PR DESCRIPTION
Same family as #32 — "the app dropped what I said" — but a different cause. #32 was the hotkey going dead behind a modal alert. This is the pipeline running with nothing on screen.

## The gap after the key comes up

Releasing the key hides the recording pill. Everything after it — the decoder, then whatever prompt stage the config runs — reported itself only into `statusInfoItem.title`, a row you have to open the menu bar to read. A dictation into a mail window spends about a second in the `email` prompt showing nothing at all, which is indistinguishable from the app having thrown the dictation away.

`transcribe` now uses `beginProgress`/`endProgress` — the same pair the spoken-command path has used all along. Two things come with it: the message goes to the HUD as well as the menu bar, and `beginProgress` shows a notice with `duration: nil`, so it stays up until the work ends instead of timing out under a slow stage. Both helpers route through `setLabel`, so `transcriptionLabel` and the existing `transcriptionLabel != nil` guard on the label callback behave exactly as before.

## The clear that belonged to someone else

The teardown was an unconditional `transcriptionLabel = nil`. Push-to-talk does not wait for the previous dictation, so a second press while the first is in flight has already put its own "Transcribing…" up — and the first one finishing wiped it, leaving the newer dictation running behind a blank screen. That is the same bug, one press later. It is now guarded by `transcriptionRun == run`, on both the success and the failure path.

Delivery is untouched: `finishTranscription` still runs unconditionally, and `destination` is captured at the press, which is what makes it safe to skip only the UI teardown.

## What is and is not proven

- `swift build` clean. The Swift 6 `sendable-closure-captures` warnings in `AppDelegate.swift` are pre-existing on `main` and untouched.
- **Not exercised in a running app.** Neither the HUD during a slow prompt stage nor the overlapping-press race has been reproduced or watched on screen; both are reasoned from the code. The reasoning is small — `beginProgress` is an existing, in-use helper, and the guard is the same `run` token the callback three lines above already trusts — but it is reasoning, not a repro.
- No test target covers this; the `scripts/check-*.sh` checks exercise the text pipeline, which this does not touch, so they would not have anything to say either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)