### PR TITLE
feat: keep what the decoder knew, not just what it said

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -651,7 +651,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 // decoder: the stages that follow write into the same record,
                 // and the line is appended even if one of them throws.
                 let text = try await Trace.record(
-                    wav: recording.url.lastPathComponent, source: .live, app: app?.name
+                    wav: recording.url.lastPathComponent, source: .live,
+                    app: app.map { Trace.App(name: $0.name, bundleID: $0.bundleID) }
                 ) {
                     let text = try await self?.transcriber.transcribe(
                         url: recording.url, config: config, app: app,
@@ -1254,6 +1255,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             do {
                 try ConfigWriter.addReplacement(heard: rule.heard, corrected: rule.corrected)
                 Log.write("learned replacement: \(rule.heard) -> \(rule.corrected)")
+                Trace.correction(heard: rule.heard, corrected: rule.corrected, via: "command")
             } catch {
                 presentAlert(title: "Could not save the rule", message: error.localizedDescription)
                 pendingSelection = nil
@@ -1642,6 +1644,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 do {
                     try ConfigWriter.addReplacement(heard: rule.heard, corrected: rule.corrected)
                     Log.write("learned replacement: \(rule.heard) -> \(rule.corrected)")
+                    Trace.correction(
+                        heard: rule.heard, corrected: rule.corrected, via: "panel"
+                    )
                 } catch {
                     self.presentAlert(
                         title: "Could not save the rule", message: error.localizedDescription

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -652,7 +652,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 // and the line is appended even if one of them throws.
                 let text = try await Trace.record(
                     wav: recording.url.lastPathComponent, source: .live,
-                    app: app.map { Trace.App(name: $0.name, bundleID: $0.bundleID) }
+                    app: app.map { Trace.App(name: $0.name, bundleID: $0.bundleID) },
+                    beside: recording.url.deletingLastPathComponent()
                 ) {
                     let text = try await self?.transcriber.transcribe(
                         url: recording.url, config: config, app: app,

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -213,6 +213,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // which the app never runs. A mistyped stage name used to vanish at
         // decode time with no trace anywhere: replacements simply stopped
         // happening, and nothing distinguished that from an empty table.
+        // Beside the recordings, and re-read here because `output_dir` can move
+        // on any save of config.yaml.
+        Trace.directory = config.resolvedOutputDir
+
         configProblems = config.problems()
         for problem in configProblems { Log.write("config: \(problem)") }
         // Logged and not flashed. A `command:` transform is announced on every
@@ -643,18 +647,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 // "Transcribing…" is the truth until the decoder is done, and
                 // a lie for the second a prompt or a script spends after it.
                 // A stage that wrote a `display:` says so itself.
-                let text = try await self?.transcriber.transcribe(
-                    url: recording.url, config: config, app: app,
-                    progress: { label in
-                        Task { @MainActor [weak self] in
-                            // Still this dictation, and still one that has
-                            // something on screen to replace.
-                            guard let self, self.transcriptionRun == run,
-                                  self.transcriptionLabel != nil else { return }
-                            self.beginProgress(label)
+                // The trace is opened around the whole chain, not just the
+                // decoder: the stages that follow write into the same record,
+                // and the line is appended even if one of them throws.
+                let text = try await Trace.record(
+                    wav: recording.url.lastPathComponent, source: .live, app: app?.name
+                ) {
+                    let text = try await self?.transcriber.transcribe(
+                        url: recording.url, config: config, app: app,
+                        progress: { label in
+                            Task { @MainActor [weak self] in
+                                // Still this dictation, and still one that has
+                                // something on screen to replace.
+                                guard let self, self.transcriptionRun == run,
+                                      self.transcriptionLabel != nil else { return }
+                                self.beginProgress(label)
+                            }
                         }
-                    }
-                ) ?? ""
+                    ) ?? ""
+                    Trace.current?.recordFinal(text)
+                    return text
+                }
                 await MainActor.run {
                     guard let self else { return }
                     // Only if the screen is still ours. Push-to-talk does not

--- a/Sources/ParrotFlow/LearnCommand.swift
+++ b/Sources/ParrotFlow/LearnCommand.swift
@@ -8,6 +8,7 @@ enum LearnCommand {
     static func run(heard: String, corrected: String) -> Int32 {
         do {
             try ConfigWriter.addReplacement(heard: heard, corrected: corrected)
+            Trace.correction(heard: heard, corrected: corrected, via: "learn")
             print("✓ \(heard) → \(corrected)")
             return 0
         } catch {

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -275,9 +275,20 @@ struct Pipeline: Equatable, Codable {
     /// nothing about the wake-phrase guard, so a prompt the pipeline had
     /// skipped was reported as having "ran, changed nothing". A diagnostic that
     /// disagrees with the thing it is diagnosing is worse than none.
+    /// Why a stage did not run, in both registers.
+    ///
+    /// `described` names the actual pattern, which is what you need to fix a
+    /// condition. `code` is the category, which is what you need to count —
+    /// and the prose cannot be counted, because every branch below phrases it
+    /// differently and two of them interpolate a regex.
+    struct Skip {
+        let code: String
+        let described: String
+    }
+
     static func skipReason(
         for step: Step, text: String, config: Config, allowPrompts: Bool, app: App? = nil
-    ) -> String? {
+    ) -> Skip? {
         if step.stage == .transform {
             // Only the prompt-bodied ones. `allowPrompts` is there to keep
             // `--replace` off the network, and a `replace:` transform is a
@@ -290,7 +301,7 @@ struct Pipeline: Equatable, Codable {
             // become a way onto the network.
             let named = step.transform.flatMap { config.transform(named: $0) }
             if !allowPrompts, named?.isPrompt ?? true {
-                return "prompts are off on this path"
+                return Skip(code: "prompts_off", described: "prompts are off on this path")
             }
             // Either position. A phrase at the front means the whole utterance
             // is an instruction; one in the middle means the instruction is
@@ -300,10 +311,10 @@ struct Pipeline: Equatable, Codable {
             // document.
             let phrases = config.transcription.activationPhrases
             if VoiceCommand.commandAfterWakePhrase(text, phrases: phrases) != nil {
-                return "this is a spoken command"
+                return Skip(code: "spoken_command", described: "this is a spoken command")
             }
             if VoiceCommand.inlineInstruction(text, phrases: phrases) != nil {
-                return "this carries an instruction of its own"
+                return Skip(code: "inline_instruction", described: "this carries an instruction of its own")
             }
         }
         if let wanted = step.app {
@@ -312,17 +323,23 @@ struct Pipeline: Equatable, Codable {
             // a terminal-only stage in your editor, which is the one outcome
             // asking for `app:` was meant to prevent.
             guard let app else {
-                return "app \(wanted) cannot be checked — nothing was in front"
+                return Skip(
+                    code: "app_unknown",
+                    described: "app \(wanted) cannot be checked — nothing was in front"
+                )
             }
             if !step.matches(app.searchable, wanted) {
-                return "app \(wanted) did not match \(app.described)"
+                return Skip(
+                    code: "app_mismatch",
+                    described: "app \(wanted) did not match \(app.described)"
+                )
             }
         }
         if let unless = step.unless, step.matches(text, unless) {
-            return "unless \(unless) matched"
+            return Skip(code: "unless_matched", described: "unless \(unless) matched")
         }
         if let when = step.when, !step.matches(text, when) {
-            return "when \(when) did not match"
+            return Skip(code: "when_unmatched", described: "when \(when) did not match")
         }
         return nil
     }
@@ -346,8 +363,8 @@ struct Pipeline: Equatable, Codable {
                 // indistinguishable from one that ran and found nothing, and
                 // only one of those is answerable by editing a condition.
                 let named = step.transform.map { "\(step.stage.name) \($0)" } ?? step.stage.name
-                Log.write("pipeline: skipped \(named) — \(reason)")
-                Trace.current?.recordSkip(named, reason: reason)
+                Log.write("pipeline: skipped \(named) — \(reason.described)")
+                Trace.current?.recordSkip(named, code: reason.code, reason: reason.described)
                 continue
             }
             // After the skip check, not before: a stage that is about to

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -347,6 +347,7 @@ struct Pipeline: Equatable, Codable {
                 // only one of those is answerable by editing a condition.
                 let named = step.transform.map { "\(step.stage.name) \($0)" } ?? step.stage.name
                 Log.write("pipeline: skipped \(named) — \(reason)")
+                Trace.current?.recordSkip(named, reason: reason)
                 continue
             }
             // After the skip check, not before: a stage that is about to
@@ -355,7 +356,18 @@ struct Pipeline: Equatable, Codable {
                 .flatMap({ config.transform(named: $0) })?.displayLabel {
                 progress?(label)
             }
+            // Timed here rather than inside each kind of stage, so the number
+            // covers the same span for a table, a script and a model call —
+            // the three costs `AGENTS.md` asks you to choose between, finally
+            // measured on your own sentences instead of quoted from a README.
+            let before = output
+            let started = CFAbsoluteTimeGetCurrent()
             output = await apply(step, to: output, config: config)
+            Trace.current?.recordStage(
+                step.transform.map { "\(step.stage.name) \($0)" } ?? step.stage.name,
+                before: before, after: output,
+                seconds: CFAbsoluteTimeGetCurrent() - started
+            )
         }
         return output
     }

--- a/Sources/ParrotFlow/PipelineCommand.swift
+++ b/Sources/ParrotFlow/PipelineCommand.swift
@@ -162,7 +162,7 @@ enum PipelineCommand {
                 for: step, text: current, config: config,
                 allowPrompts: allowPrompts, app: front
             ) {
-                print("  ⊘ \(step.stage.name)  — skipped, \(reason)")
+                print("  ⊘ \(step.stage.name)  — skipped, \(reason.described)")
                 continue
             }
             var after = current

--- a/Sources/ParrotFlow/Replacements.swift
+++ b/Sources/ParrotFlow/Replacements.swift
@@ -40,7 +40,12 @@ enum Replacements {
         to text: String, config: Config, allowPrompts: Bool = true, app: Pipeline.App? = nil,
         progress: (@Sendable (String) -> Void)? = nil
     ) async -> String {
-        await Pipeline.forText(text, config: config).0.run(
+        let (pipeline, language) = Pipeline.forText(text, config: config)
+        // The verdict that picked the stages, which until now was computed here
+        // and discarded on the same line. Parakeet reports no language of its
+        // own, so this is the only one there is to write down.
+        Trace.current?.recordLanguage(language)
+        return await pipeline.run(
             text, config: config, allowPrompts: allowPrompts, app: app, progress: progress
         )
     }

--- a/Sources/ParrotFlow/Trace.swift
+++ b/Sources/ParrotFlow/Trace.swift
@@ -118,7 +118,14 @@ enum Trace {
         body: () async throws -> T
     ) async rethrows -> T {
         let collector = Collector(wav: wav, source: source)
-        defer { append(collector.record(at: stamp(), app: app)) }
+        // The destination is fixed when the dictation starts, not when it ends.
+        // `output_dir` can change on any save of config.yaml — the file is
+        // watched and reloaded live — and a save while a prompt stage is
+        // running would otherwise file the record in the new directory while
+        // the clip it names sits in the old one. `wav` is a bare filename, so
+        // the two being separated is the one thing that breaks the join.
+        let directory = Self.directory
+        defer { append(collector.record(at: stamp(), app: app), to: directory) }
         return try await $current.withValue(collector) { try await body() }
     }
 
@@ -135,7 +142,25 @@ enum Trace {
     /// that write here are handed a transcript and nothing else.
     nonisolated(unsafe) static var directory: URL?
 
-    private static func append(_ record: Record) {
+    /// Appends one line, atomically against every other writer of this file.
+    ///
+    /// Two processes write here by design: the menu bar app, and a
+    /// `--transcribe` sweep over the archive — which `cli.md` recommends
+    /// running, and which nobody is going to quit the app before starting.
+    /// Seeking to the end and then writing is two steps, and both processes
+    /// can take the first before either takes the second, which loses a line
+    /// or splices two into something no longer parseable as JSONL.
+    ///
+    /// `O_APPEND` collapses those two steps into one the kernel does not
+    /// interleave, which `FileHandle(forWritingTo:)` does not ask for. The
+    /// serial queue still orders this process's own writes and keeps them off
+    /// the caller's thread; it just cannot say anything about the other
+    /// process.
+    ///
+    /// Deliberately no size cap. This is the corpus, not a debug buffer: a year
+    /// of heavy use is a few megabytes, and the whole point is being able to
+    /// ask a question of every dictation you have ever given.
+    private static func append(_ record: Record, to directory: URL?) {
         guard let directory else { return }
         let url = directory.appendingPathComponent("trace.jsonl")
 
@@ -145,18 +170,18 @@ enum Trace {
         data.append(0x0A)  // one object per line, so `jq -c` and friends work
 
         queue.async {
-            let fm = FileManager.default
-            if let handle = try? FileHandle(forWritingTo: url) {
-                defer { try? handle.close() }
-                // Deliberately no size cap. This is the corpus, not a debug
-                // buffer: a year of heavy use is a few megabytes, and the whole
-                // point is being able to ask a question of every dictation you
-                // have ever given.
-                _ = try? handle.seekToEnd()
-                try? handle.write(contentsOf: data)
-            } else {
-                try? fm.createDirectory(at: directory, withIntermediateDirectories: true)
-                try? data.write(to: url)
+            try? FileManager.default.createDirectory(
+                at: directory, withIntermediateDirectories: true
+            )
+            let fd = open(url.path, O_WRONLY | O_APPEND | O_CREAT, 0o644)
+            guard fd >= 0 else { return }
+            defer { close(fd) }
+            data.withUnsafeBytes { buffer in
+                guard let base = buffer.baseAddress else { return }
+                // One call, so the append stays the single atomic act O_APPEND
+                // promises. A short write would mean a torn line, and there is
+                // nothing useful to do about it but stop.
+                _ = write(fd, base, buffer.count)
             }
         }
     }

--- a/Sources/ParrotFlow/Trace.swift
+++ b/Sources/ParrotFlow/Trace.swift
@@ -170,18 +170,30 @@ enum Trace {
     ///
     /// Writes the line whether or not the body threw: a dictation that failed
     /// halfway is the one you most want the decoder's numbers for.
+    /// - Parameter beside: the directory to write the line into. Pass the one
+    ///   holding the clip; the global is only a fallback for callers that have
+    ///   no clip on disk to point at.
     static func record<T>(
-        wav: String, source: Source, app: App? = nil,
+        wav: String, source: Source, app: App? = nil, beside: URL? = nil,
         body: () async throws -> T
     ) async rethrows -> T {
         let collector = Collector(wav: wav, source: source)
-        // The destination is fixed when the dictation starts, not when it ends.
+        // Taken from where the clip actually is, not from the global, and not
+        // snapshotted at a moment chosen for being early.
+        //
         // `output_dir` can change on any save of config.yaml — the file is
-        // watched and reloaded live — and a save while a prompt stage is
-        // running would otherwise file the record in the new directory while
-        // the clip it names sits in the old one. `wav` is a bare filename, so
-        // the two being separated is the one thing that breaks the join.
-        let directory = Self.directory
+        // watched and reloaded live — so any read of the global is a read at
+        // some particular instant, and there is no instant late enough to be
+        // right and early enough to be safe. Reading it when the record is
+        // finished loses to a save during a prompt stage. Reading it when the
+        // dictation starts loses to a save between the clip being written and
+        // this task being scheduled. Both file the line in one directory while
+        // the clip it names sits in the other, and `wav` is a bare filename, so
+        // that separation is the one thing that breaks the join.
+        //
+        // The clip's own URL has no such instant: it is where the file went,
+        // whatever the config said at the time or says now.
+        let directory = beside ?? Self.directory
         defer { append(collector.record(at: stamp(), app: app), to: directory) }
         return try await $current.withValue(collector) { try await body() }
     }

--- a/Sources/ParrotFlow/Trace.swift
+++ b/Sources/ParrotFlow/Trace.swift
@@ -24,6 +24,14 @@ import Foundation
 /// the sake of a debug artefact.
 enum Trace {
 
+    /// The shape of a line. Records written before this existed have no `v` at
+    /// all, which reads as 1 — two of them, from the afternoon this was built.
+    ///
+    /// One field, and the only moment it is free is before there is anything to
+    /// migrate. A reader three months from now needs to know which shape it is
+    /// holding without inferring it from which keys happen to be present.
+    static let version = 2
+
     /// The dictation being traced right now, if any. Nil on every path that
     /// did not ask for a trace — nothing here runs unless a collector is bound.
     @TaskLocal static var current: Collector?
@@ -33,6 +41,35 @@ enum Trace {
     enum Source: String {
         case live
         case cli
+    }
+
+    /// Which kind of line this is. Corrections are not dictations — they arrive
+    /// minutes later, from a panel or the terminal — but they belong in the same
+    /// file, because the question they answer is about the dictation they
+    /// followed. `jq 'select(.kind == "correction")'` separates them.
+    enum Kind: String {
+        case dictation
+        case correction
+    }
+
+    /// The app a dictation was spoken into.
+    ///
+    /// Both halves, because they answer different questions: the bundle id is
+    /// what survives a rename and what a query should group on, and the name is
+    /// what a human reads. Until now only the name was kept, while `app:`
+    /// conditions were matching against both.
+    ///
+    /// Deliberately *not* the window title. It is the highest-yield field on
+    /// offer and the one that leaks hardest — document names, client names,
+    /// ticket subjects — and nothing here needs it.
+    struct App: Encodable {
+        let name: String
+        let bundleID: String
+
+        enum CodingKeys: String, CodingKey {
+            case name
+            case bundleID = "bundle_id"
+        }
     }
 
     // MARK: - Collecting
@@ -51,15 +88,30 @@ enum Trace {
         private var vad: VAD?
         private var stages: [Stage] = []
         private var final: String?
+        private var lang: String?
 
         init(wav: String, source: Source) {
             self.wav = wav
             self.source = source
         }
 
-        func recordASR(_ result: ASRResult) {
+        /// Which language the pipeline was chosen for.
+        ///
+        /// Ours, not Parakeet's — `ASRResult` carries no language and
+        /// `TokenLanguageFilter` takes a hint rather than reporting one, so
+        /// there is nothing to log from the model. This is the verdict that
+        /// actually selected the stages, which makes it the more useful of the
+        /// two anyway. `Pipeline.forText` has always computed it and
+        /// `Replacements.apply` has always thrown it away.
+        func recordLanguage(_ language: String) {
+            lock.lock(); defer { lock.unlock() }
+            lang = language
+        }
+
+        func recordASR(_ result: ASRResult, model: String) {
             lock.lock(); defer { lock.unlock() }
             asr = ASR(
+                model: model,
                 text: result.text,
                 confidence: result.confidence,
                 duration: result.duration,
@@ -76,9 +128,13 @@ enum Trace {
             )
         }
 
-        func recordSkip(_ name: String, reason: String) {
+        /// - Parameter code: the category, for grouping. The prose beside it
+        ///   names the actual pattern that did or did not match, which is what
+        ///   you need to fix a condition — and which is useless for counting,
+        ///   because every stage phrases it differently.
+        func recordSkip(_ name: String, code: String, reason: String) {
             lock.lock(); defer { lock.unlock() }
-            stages.append(Stage(name: name, skipped: reason))
+            stages.append(Stage(name: name, skipCode: code, skipped: reason))
         }
 
         /// Every stage that ran, including the ones that changed nothing —
@@ -98,10 +154,11 @@ enum Trace {
             final = text
         }
 
-        fileprivate func record(at: String, app: String?) -> Record {
+        fileprivate func record(at: String, app: App?) -> Record {
             lock.lock(); defer { lock.unlock() }
             return Record(
-                at: at, wav: wav, source: source.rawValue, app: app,
+                v: Trace.version, kind: Kind.dictation.rawValue,
+                at: at, wav: wav, source: source.rawValue, app: app, lang: lang,
                 asr: asr, vad: vad, stages: stages, final: final
             )
         }
@@ -114,7 +171,7 @@ enum Trace {
     /// Writes the line whether or not the body threw: a dictation that failed
     /// halfway is the one you most want the decoder's numbers for.
     static func record<T>(
-        wav: String, source: Source, app: String? = nil,
+        wav: String, source: Source, app: App? = nil,
         body: () async throws -> T
     ) async rethrows -> T {
         let collector = Collector(wav: wav, source: source)
@@ -127,6 +184,24 @@ enum Trace {
         let directory = Self.directory
         defer { append(collector.record(at: stamp(), app: app), to: directory) }
         return try await $current.withValue(collector) { try await body() }
+    }
+
+    /// Writes down a rule someone taught the app.
+    ///
+    /// Its own line rather than a field on a dictation: a correction arrives
+    /// minutes after the transcript it is about, from a panel or the terminal,
+    /// long past the task that carried the collector. Joining the two is a
+    /// question for whoever reads the file, and `at` is enough to do it.
+    ///
+    /// - Parameter via: which path taught it — `panel`, `inline` or `learn`.
+    static func correction(heard: String, corrected: String, via: String) {
+        append(
+            Correction(
+                v: version, kind: Kind.correction.rawValue, at: stamp(),
+                heard: heard, corrected: corrected, via: via
+            ),
+            to: directory
+        )
     }
 
     private static let queue = DispatchQueue(label: "com.parrotflow.trace")
@@ -160,7 +235,7 @@ enum Trace {
     /// Deliberately no size cap. This is the corpus, not a debug buffer: a year
     /// of heavy use is a few megabytes, and the whole point is being able to
     /// ask a question of every dictation you have ever given.
-    private static func append(_ record: Record, to directory: URL?) {
+    private static func append<Line: Encodable>(_ record: Line, to directory: URL?) {
         guard let directory else { return }
         let url = directory.appendingPathComponent("trace.jsonl")
 
@@ -241,17 +316,46 @@ enum Trace {
     }
 
     fileprivate struct Record: Encodable {
+        let v: Int
+        let kind: String
         let at: String
         let wav: String
         let source: String
-        let app: String?
+        let app: App?
+        let lang: String?
         let asr: ASR?
         let vad: VAD?
         let stages: [Stage]
         let final: String?
     }
 
+    /// A rule someone taught the app, on its own line.
+    ///
+    /// The one free source of human labels in the whole system: a correction is
+    /// a person saying, in real distribution and unprompted, that the decoder
+    /// got a word wrong and what the right one was. It cannot be reconstructed
+    /// afterwards from anything else on disk.
+    ///
+    /// These are the corrections ParrotFlow already mediates — the panel, an
+    /// inline instruction, `--learn` — and nothing more. Watching the field
+    /// after the text lands would catch more of them, and would mean reading
+    /// another app's content back out through Accessibility after we have given
+    /// focus away. That is a different thing to be, and not one this file needs.
+    fileprivate struct Correction: Encodable {
+        let v: Int
+        let kind: String
+        let at: String
+        let heard: String
+        let corrected: String
+        let via: String
+    }
+
     fileprivate struct ASR: Encodable {
+        /// Which model produced this. Without it there is no telling a prompt
+        /// regression from a model that changed under you between two runs.
+        /// The repository id is all FluidAudio exposes — there is no revision
+        /// to log, so none is invented.
+        let model: String
         let text: String
         let confidence: Float
         let duration: Double
@@ -274,13 +378,21 @@ enum Trace {
 
     fileprivate struct Stage: Encodable {
         let name: String
+        var skipCode: String?
         var skipped: String?
         var before: String?
         var after: String?
         var seconds: Double?
 
-        init(name: String, skipped: String) {
+        enum CodingKeys: String, CodingKey {
+            case name
+            case skipCode = "skip_reason"
+            case skipped, before, after, seconds
+        }
+
+        init(name: String, skipCode: String, skipped: String) {
             self.name = name
+            self.skipCode = skipCode
             self.skipped = skipped
         }
 

--- a/Sources/ParrotFlow/Trace.swift
+++ b/Sources/ParrotFlow/Trace.swift
@@ -1,0 +1,269 @@
+import FluidAudio
+import Foundation
+
+/// One JSON object per dictation, appended to `trace.jsonl` beside the
+/// recordings it describes.
+///
+/// `ParrotFlow.log` is for reading over someone's shoulder while something is
+/// going wrong: prose, second resolution, and a rolling buffer that throws the
+/// oldest away. That makes it the wrong place to keep what the decoder
+/// actually said. The interesting questions here are asked over hundreds of
+/// dictations at once — which words does the model get least sure about, does
+/// a dropped ending come from the decoder or the speech gate, what does a
+/// prompt stage really cost — and none of them survive a file that truncates
+/// itself, or a format you have to parse back out of English.
+///
+/// So: one line per dictation, never rotated, joined to its audio by
+/// `wav`. The decoder already computes every number in here and we used to
+/// drop it on the floor one line after it arrived.
+///
+/// Collected through a task local rather than an extra parameter on nine
+/// functions. A dictation is one task from the decoder to the last pipeline
+/// stage, which is exactly the scope a task local has; the alternative was
+/// threading a collector through `Pipeline.run`, `apply` and `runPrompt` for
+/// the sake of a debug artefact.
+enum Trace {
+
+    /// The dictation being traced right now, if any. Nil on every path that
+    /// did not ask for a trace — nothing here runs unless a collector is bound.
+    @TaskLocal static var current: Collector?
+
+    /// Where a trace comes from, so a sweep re-run over the archive can be told
+    /// apart from the dictations someone actually spoke.
+    enum Source: String {
+        case live
+        case cli
+    }
+
+    // MARK: - Collecting
+
+    /// Gathers one dictation's record as it happens.
+    ///
+    /// A class with a lock rather than an actor: every writer here is a
+    /// synchronous call sitting next to an existing `Log.write`, and making
+    /// them all `await` would have been the whole invasive change again.
+    final class Collector: @unchecked Sendable {
+        private let lock = NSLock()
+
+        private let wav: String
+        private let source: Source
+        private var asr: ASR?
+        private var vad: VAD?
+        private var stages: [Stage] = []
+        private var final: String?
+
+        init(wav: String, source: Source) {
+            self.wav = wav
+            self.source = source
+        }
+
+        func recordASR(_ result: ASRResult) {
+            lock.lock(); defer { lock.unlock() }
+            asr = ASR(
+                text: result.text,
+                confidence: result.confidence,
+                duration: result.duration,
+                processing: result.processingTime,
+                words: Trace.words(from: result.tokenTimings ?? [])
+            )
+        }
+
+        func recordVAD(speech: Double, total: Double, segments: [(Double, Double)]) {
+            lock.lock(); defer { lock.unlock() }
+            vad = VAD(
+                speech: speech, total: total,
+                segments: segments.map { [$0.0, $0.1] }
+            )
+        }
+
+        func recordSkip(_ name: String, reason: String) {
+            lock.lock(); defer { lock.unlock() }
+            stages.append(Stage(name: name, skipped: reason))
+        }
+
+        /// Every stage that ran, including the ones that changed nothing —
+        /// "ran and found nothing" and "was skipped" are different answers and
+        /// only the log conflates them.
+        func recordStage(_ name: String, before: String, after: String, seconds: Double) {
+            lock.lock(); defer { lock.unlock() }
+            stages.append(
+                Stage(name: name, before: before, after: after, seconds: seconds)
+            )
+        }
+
+        /// What was actually delivered. Left nil by a dictation that threw on
+        /// the way there, which is worth being able to see.
+        func recordFinal(_ text: String) {
+            lock.lock(); defer { lock.unlock() }
+            final = text
+        }
+
+        fileprivate func record(at: String, app: String?) -> Record {
+            lock.lock(); defer { lock.unlock() }
+            return Record(
+                at: at, wav: wav, source: source.rawValue, app: app,
+                asr: asr, vad: vad, stages: stages, final: final
+            )
+        }
+    }
+
+    // MARK: - Writing
+
+    /// Runs `body` with a collector bound, then appends what it gathered.
+    ///
+    /// Writes the line whether or not the body threw: a dictation that failed
+    /// halfway is the one you most want the decoder's numbers for.
+    static func record<T>(
+        wav: String, source: Source, app: String? = nil,
+        body: () async throws -> T
+    ) async rethrows -> T {
+        let collector = Collector(wav: wav, source: source)
+        defer { append(collector.record(at: stamp(), app: app)) }
+        return try await $current.withValue(collector) { try await body() }
+    }
+
+    private static let queue = DispatchQueue(label: "com.parrotflow.trace")
+
+    /// Waits for queued writes to reach the file. Same reason as `Log.flush` —
+    /// a CLI process exits before the queue drains.
+    static func flush() {
+        queue.sync {}
+    }
+
+    /// Where `trace.jsonl` goes — the recordings directory, so a clip and its
+    /// trace live together. Set from the config at launch, because the stages
+    /// that write here are handed a transcript and nothing else.
+    nonisolated(unsafe) static var directory: URL?
+
+    private static func append(_ record: Record) {
+        guard let directory else { return }
+        let url = directory.appendingPathComponent("trace.jsonl")
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.withoutEscapingSlashes]
+        guard var data = try? encoder.encode(record) else { return }
+        data.append(0x0A)  // one object per line, so `jq -c` and friends work
+
+        queue.async {
+            let fm = FileManager.default
+            if let handle = try? FileHandle(forWritingTo: url) {
+                defer { try? handle.close() }
+                // Deliberately no size cap. This is the corpus, not a debug
+                // buffer: a year of heavy use is a few megabytes, and the whole
+                // point is being able to ask a question of every dictation you
+                // have ever given.
+                _ = try? handle.seekToEnd()
+                try? handle.write(contentsOf: data)
+            } else {
+                try? fm.createDirectory(at: directory, withIntermediateDirectories: true)
+                try? data.write(to: url)
+            }
+        }
+    }
+
+    // MARK: - Words
+
+    /// Sub-word tokens grouped into words, keeping the confidence FluidAudio's
+    /// own `buildWordTimings` drops.
+    ///
+    /// Confidence is the reason this file exists — a word the decoder was
+    /// unsure of is a candidate for `transcription.replacements`, and ranking
+    /// those beats guessing at them. The word keeps its *lowest* token's
+    /// confidence: a name that came through as one solid piece and one shaky
+    /// one is a shaky name, and averaging hides exactly that.
+    static func words(from timings: [TokenTiming]) -> [Word] {
+        var words: [Word] = []
+        var text = ""
+        var start = 0.0
+        var end = 0.0
+        var confidence = Float.greatestFiniteMagnitude
+
+        func flush() {
+            let trimmed = text.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { return }
+            words.append(
+                Word(word: trimmed, start: start, end: end, confidence: confidence)
+            )
+        }
+
+        for timing in timings {
+            let token = timing.token
+            if token.isEmpty || token == "<blank>" || token == "<pad>" { continue }
+
+            // SentencePiece marks a word's first piece with `▁`; the tokenizer
+            // hands some of them back already rendered as a leading space.
+            if token.hasPrefix("\u{2581}") || token.hasPrefix(" ") || text.isEmpty {
+                if !text.isEmpty { flush() }
+                text = token.replacingOccurrences(of: "\u{2581}", with: "")
+                start = timing.startTime
+                confidence = timing.confidence
+            } else {
+                text += token
+                confidence = min(confidence, timing.confidence)
+            }
+            end = timing.endTime
+        }
+        flush()
+        return words
+    }
+
+    // MARK: - Shape on disk
+
+    private static func stamp() -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.string(from: Date())
+    }
+
+    fileprivate struct Record: Encodable {
+        let at: String
+        let wav: String
+        let source: String
+        let app: String?
+        let asr: ASR?
+        let vad: VAD?
+        let stages: [Stage]
+        let final: String?
+    }
+
+    fileprivate struct ASR: Encodable {
+        let text: String
+        let confidence: Float
+        let duration: Double
+        let processing: Double
+        let words: [Word]
+    }
+
+    fileprivate struct VAD: Encodable {
+        let speech: Double
+        let total: Double
+        let segments: [[Double]]
+    }
+
+    struct Word: Encodable {
+        let word: String
+        let start: Double
+        let end: Double
+        let confidence: Float
+    }
+
+    fileprivate struct Stage: Encodable {
+        let name: String
+        var skipped: String?
+        var before: String?
+        var after: String?
+        var seconds: Double?
+
+        init(name: String, skipped: String) {
+            self.name = name
+            self.skipped = skipped
+        }
+
+        init(name: String, before: String, after: String, seconds: Double) {
+            self.name = name
+            self.before = before
+            self.after = after
+            self.seconds = seconds
+        }
+    }
+}

--- a/Sources/ParrotFlow/TranscribeCommand.swift
+++ b/Sources/ParrotFlow/TranscribeCommand.swift
@@ -45,8 +45,20 @@ enum TranscribeCommand {
                 try await transcriber.prepare(config: config)
                 let loadElapsed = Date().timeIntervalSince(loadStart)
 
+                // Traced like a real dictation, marked `cli` so a sweep over
+                // the archive can be told apart from what was actually spoken.
+                // This is the path that makes the trace worth having: re-run
+                // the recordings after a change and the two sets of numbers sit
+                // in the same file, joined to the same clips.
+                Trace.directory = config.resolvedOutputDir
                 let started = Date()
-                let text = try await transcriber.transcribe(url: url, config: config)
+                let text = try await Trace.record(
+                    wav: url.lastPathComponent, source: .cli
+                ) {
+                    let text = try await transcriber.transcribe(url: url, config: config)
+                    Trace.current?.recordFinal(text)
+                    return text
+                }
                 let elapsed = Date().timeIntervalSince(started)
 
                 print("\r\u{1B}[K", terminator: "")

--- a/Sources/ParrotFlow/TranscribeCommand.swift
+++ b/Sources/ParrotFlow/TranscribeCommand.swift
@@ -50,10 +50,21 @@ enum TranscribeCommand {
                 // This is the path that makes the trace worth having: re-run
                 // the recordings after a change and the two sets of numbers sit
                 // in the same file, joined to the same clips.
-                Trace.directory = config.resolvedOutputDir
+                //
+                // The line goes to the recordings directory even when the clip
+                // does not live there, because one corpus in one place is the
+                // point and a `--transcribe /tmp/t.wav` should not leave a
+                // `trace.jsonl` behind in /tmp. That costs the bare-filename
+                // join, so a clip from anywhere else is named by its full path
+                // instead — the join stays exact either way.
+                let directory = config.resolvedOutputDir
+                Trace.directory = directory
+                let isInCorpus = url.deletingLastPathComponent().standardizedFileURL.path
+                    == directory.standardizedFileURL.path
                 let started = Date()
                 let text = try await Trace.record(
-                    wav: url.lastPathComponent, source: .cli
+                    wav: isInCorpus ? url.lastPathComponent : url.standardizedFileURL.path,
+                    source: .cli, beside: directory
                 ) {
                     let text = try await transcriber.transcribe(url: url, config: config)
                     Trace.current?.recordFinal(text)

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -117,7 +117,7 @@ actor Transcriber {
         let asr = AsrManager(models: models)
         var decoderState = await TdtDecoderState.make(decoderLayers: asr.decoderLayerCount)
         let result = try await asr.transcribe(url, decoderState: &decoderState)
-        Trace.current?.recordASR(result)
+        Trace.current?.recordASR(result, model: Repo.parakeetV3.rawValue)
 
         return await Self.applyReplacements(
             to: result.text, config: config, app: app, progress: progress

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -117,6 +117,7 @@ actor Transcriber {
         let asr = AsrManager(models: models)
         var decoderState = await TdtDecoderState.make(decoderLayers: asr.decoderLayerCount)
         let result = try await asr.transcribe(url, decoderState: &decoderState)
+        Trace.current?.recordASR(result)
 
         return await Self.applyReplacements(
             to: result.text, config: config, app: app, progress: progress
@@ -162,6 +163,13 @@ actor Transcriber {
             format: "speech gate: %.2fs speech in %.2fs (%d segment(s))",
             speech, total, segments.count
         ))
+        // The boundaries, not just the totals: "the ending was cut off" is
+        // answered by where the last segment stops against where the words
+        // stop, and the log line above cannot tell you either.
+        Trace.current?.recordVAD(
+            speech: speech, total: total,
+            segments: segments.map { ($0.startTime, $0.endTime) }
+        )
         return segments.isEmpty
     }
 

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -14,7 +14,7 @@ let arguments = CommandLine.arguments
 // flush and the rest did not, so `--replace` was dropping the very lines that
 // explain what the pipeline did — a stage saying it skipped, and why. Doing it
 // here covers every path, including the ones added later.
-atexit { Log.flush() }
+atexit { Log.flush(); Trace.flush() }
 
 /// `--lang fr` or `--lang en,fr`. One entry pins a grammar; several stand in
 /// for the configured list, so a case file can state the environment it assumes

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -16,6 +16,13 @@ let arguments = CommandLine.arguments
 // here covers every path, including the ones added later.
 atexit { Log.flush(); Trace.flush() }
 
+// Where `trace.jsonl` goes, for every command below that writes one. The app
+// sets this again from `applyConfig`, which is the copy that follows a live
+// edit of `output_dir`; this is only so a terminal command has somewhere to
+// write before any of that has run. Silent when the config will not load —
+// a trace is a debug artefact and must not be the reason a command fails.
+Trace.directory = (try? ConfigStore.load())?.resolvedOutputDir
+
 /// `--lang fr` or `--lang en,fr`. One entry pins a grammar; several stand in
 /// for the configured list, so a case file can state the environment it assumes
 /// instead of inheriting this machine's.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,6 +18,7 @@
 | Where the words go | `Destination.swift` | Asks the focused element whether it takes text, at the press — decides the pill's icon and whether the transcript is typed or copied |
 | Menu bar & wiring | `AppDelegate.swift` | |
 | Logging | `Log.swift` | `~/Library/Logs/ParrotFlow.log` — a menu bar app has no console |
+| The record | `Trace.swift` | `trace.jsonl` beside the recordings — one line per dictation, with word timings and confidences the log cannot hold |
 | Floating surfaces | `RecordingOverlay.swift`, `PreviewPanel.swift`, `NoticeHUD.swift`, `ParrotStyle.swift` | Borderless non-activating `NSPanel`s, one look between them |
 | Variants | `AppVariant.swift` | Dev and released builds are separate apps — [development.md](development.md) |
 

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -206,7 +206,10 @@ and you stop running it.
 - **Use real inputs.** These come out of speech recognition, so the test inputs
   must be mangled the way speech recognition mangles them. A set built from
   tidy sentences measures nothing, because tidy sentences were never the
-  problem.
+  problem. `trace.jsonl` beside your recordings is where they are: every
+  dictation you have given, with the decoder's own confidence on each word, so
+  the ones it struggled with can be pulled out rather than invented — see
+  [cli.md](cli.md#the-trace).
 - **Include negatives — a lot of them.** Roughly one in five, and closer to
   half for anything that runs on every transcript rather than on demand. Models
   are strongly biased toward producing output, and a confident wrong answer

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -206,7 +206,7 @@ Ask a question of more than one dictation and you want the trace instead.
 tail -1 ~/Recordings/ParrotFlow/trace.jsonl | jq .
 ```
 
-One JSON object per dictation, appended and never rotated, beside the clips it
+One JSON object per line, appended and never rotated, beside the clips it
 describes. It holds what the decoder actually returned before anything touched
 it — the raw text, its confidence, and **every word with its start, end and
 confidence** — plus the speech gate's segment boundaries, then each pipeline
@@ -217,6 +217,32 @@ sweep over the archive does not read as a day of dictation.
 
 The decoder computed all of it either way. It used to be dropped one line after
 it arrived.
+
+`kind` says which sort of line you are holding.
+
+- **`dictation`** — the shape above.
+- **`correction`** — `heard`, `corrected`, and `via` (`panel`, `command` or
+  `learn`). Written whenever a rule is taught, which is minutes after the
+  transcript it is about and from a different place entirely, so it gets its
+  own line rather than a field on one. These are the only human labels in the
+  system, and nothing else on disk can reconstruct them.
+
+`v` is the schema version — records written before it existed have no `v` and
+should be read as 1.
+
+A note on what is **not** here. `lang` is ParrotFlow's own verdict, the one that
+picked the pipeline; Parakeet reports no language of its own, so there is
+nothing else to log. `app` carries the name and the bundle id and deliberately
+not the window title, which is the highest-yield field available and the one
+that leaks document names, client names and ticket subjects. And a correction is
+only recorded when ParrotFlow mediates it — reading the field back after the
+text has landed would catch more of them and would mean looking at another app's
+content after focus has been given away, which is a different thing to be.
+
+Nothing derived is stored: pause gaps, filled pauses, confidence dips and
+whether a gate would have fired are all computable from `asr.words` and
+`vad.segments`, and baking them in would mean recomputing history every time a
+threshold moves.
 
 The questions it answers, which the log cannot:
 
@@ -235,13 +261,21 @@ jq -r 'select(.asr.words|length > 0) |
        [.wav, (.vad.segments[-1][1]), (.asr.words[-1].end), .vad.total] | @tsv' trace.jsonl
 
 # What each stage really costs on your own sentences.
-jq -r '.stages[] | select(.seconds) | [.name, .seconds] | @tsv' trace.jsonl |
+jq -r '.stages[]? | select(.seconds) | [.name, .seconds] | @tsv' trace.jsonl |
   awk '{n[$1]++; s[$1]+=$2} END {for (k in n) printf "%-28s %6.3fs  ×%d\n", k, s[k]/n[k], n[k]}' |
   sort -k2 -rn
 
 # Every dictation a prompt stage rewrote, and into what.
-jq -r '.stages[] | select(.before and .before != .after) |
+jq -r '.stages[]? | select(.before and .before != .after) |
        [.name, .before, .after] | @tsv' trace.jsonl
+
+# Which stage conditions are doing the skipping, by category rather than by
+# whichever regex happened to be written into the prose.
+jq -r '.stages[]? | select(.skip_reason) | .skip_reason' trace.jsonl |
+  sort | uniq -c | sort -rn
+
+# Every rule you have ever taught, and from where.
+jq -r 'select(.kind == "correction") | [.via, .heard, .corrected] | @tsv' trace.jsonl
 ```
 
 `--transcribe` writes a trace line too, which is what makes it worth having:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -225,7 +225,9 @@ cd ~/Recordings/ParrotFlow
 
 # Which words is the model least sure of? Candidates for the replacement
 # table, ranked instead of guessed at.
-jq -r '.asr.words[] | select(.confidence < 0.5) | .word' trace.jsonl |
+# `[]?` because a dictation that failed before the decoder returned is still
+# written down, with a null `asr` — and iterating that aborts jq outright.
+jq -r '.asr.words[]? | select(.confidence < 0.5) | .word' trace.jsonl |
   sort | uniq -c | sort -rn | head -20
 
 # A dictation whose ending went missing: did the decoder stop, or the gate?

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -257,7 +257,9 @@ jq -r '.asr.words[]? | select(.confidence < 0.5) | .word' trace.jsonl |
   sort | uniq -c | sort -rn | head -20
 
 # A dictation whose ending went missing: did the decoder stop, or the gate?
-jq -r 'select(.asr.words|length > 0) |
+# Both halves are guarded: `vad` is absent whenever the speech gate is off or
+# its detector would not load, and a record can have every word and no segments.
+jq -r 'select((.asr.words|length > 0) and (.vad.segments|length > 0)) |
        [.wav, (.vad.segments[-1][1]), (.asr.words[-1].end), .vad.total] | @tsv' trace.jsonl
 
 # What each stage really costs on your own sentences.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -195,3 +195,57 @@ that was skipped and why, and the before-and-after of every rewrite a model
 made. A stage that silently does not run looks exactly like one that ran and
 found nothing — only one of those is answerable by editing a condition, so the
 log distinguishes them.
+
+It is for reading over your own shoulder while something goes wrong: prose,
+second resolution, and a rolling buffer that throws the oldest away at 1 MB.
+Ask a question of more than one dictation and you want the trace instead.
+
+## The trace
+
+```sh
+tail -1 ~/Recordings/ParrotFlow/trace.jsonl | jq .
+```
+
+One JSON object per dictation, appended and never rotated, beside the clips it
+describes. It holds what the decoder actually returned before anything touched
+it — the raw text, its confidence, and **every word with its start, end and
+confidence** — plus the speech gate's segment boundaries, then each pipeline
+stage with its before, its after and what it cost in seconds, and finally the
+text that was delivered. `wav` joins a line to its recording; `source` is
+`live` for something you spoke and `cli` for a `--transcribe` re-run, so a
+sweep over the archive does not read as a day of dictation.
+
+The decoder computed all of it either way. It used to be dropped one line after
+it arrived.
+
+The questions it answers, which the log cannot:
+
+```sh
+cd ~/Recordings/ParrotFlow
+
+# Which words is the model least sure of? Candidates for the replacement
+# table, ranked instead of guessed at.
+jq -r '.asr.words[] | select(.confidence < 0.5) | .word' trace.jsonl |
+  sort | uniq -c | sort -rn | head -20
+
+# A dictation whose ending went missing: did the decoder stop, or the gate?
+jq -r 'select(.asr.words|length > 0) |
+       [.wav, (.vad.segments[-1][1]), (.asr.words[-1].end), .vad.total] | @tsv' trace.jsonl
+
+# What each stage really costs on your own sentences.
+jq -r '.stages[] | select(.seconds) | [.name, .seconds] | @tsv' trace.jsonl |
+  awk '{n[$1]++; s[$1]+=$2} END {for (k in n) printf "%-28s %6.3fs  ×%d\n", k, s[k]/n[k], n[k]}' |
+  sort -k2 -rn
+
+# Every dictation a prompt stage rewrote, and into what.
+jq -r '.stages[] | select(.before and .before != .after) |
+       [.name, .before, .after] | @tsv' trace.jsonl
+```
+
+`--transcribe` writes a trace line too, which is what makes it worth having:
+change a table, re-run the clips, and both sets of numbers sit in one file
+joined to the same audio.
+
+```sh
+for f in ~/Recordings/ParrotFlow/*.wav; do ParrotFlow --transcribe "$f" >/dev/null; done
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,6 +51,7 @@ feedback:
 |---|---|
 | Config | `~/.config/parrotflow/config.yaml` |
 | Recordings | `~/Recordings/ParrotFlow` |
+| Trace | `~/Recordings/ParrotFlow/trace.jsonl` |
 | Log | `~/Library/Logs/ParrotFlow.log` |
 | The example script | `~/.config/parrotflow/code_identifiers.py`, written on first launch and never overwritten |
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,6 +11,7 @@ separate applications**. Both can be installed, and both can run at once.
 | Config | `~/.config/parrotflow/` | `~/.config/parrotflow-dev/` |
 | Log | `ParrotFlow.log` | `ParrotFlow-Dev.log` |
 | Recordings | `~/Recordings/ParrotFlow` | `~/Recordings/ParrotFlow Dev` |
+| Trace | `~/Recordings/ParrotFlow/trace.jsonl` | `~/Recordings/ParrotFlow Dev/trace.jsonl` |
 | Menu bar | `mic` | `mic.circle` |
 
 This is not tidiness. macOS grants microphone and Accessibility **per bundle


### PR DESCRIPTION
The audio has been on disk since the first version and the log has held the
transcript. Everything in between was thrown away one line after it arrived —
Parakeet returns a start, an end and a confidence for every token, and we took
`result.text` and dropped the rest.

This adds `trace.jsonl` beside the recordings: one JSON object per dictation,
appended, never rotated, joined to its clip by `wav`.

```json
{"at":"2026-08-04T07:59:55Z","wav":"parrotflow-2026-08-04T09-39-12.wav","source":"cli",
 "asr":{"text":"If no can we do this?","confidence":0.848,"duration":1.69,"processing":0.26,
        "words":[{"word":"If","start":0.16,"end":0.32,"confidence":0.582},
                 {"word":"this?","start":1.04,"end":1.28,"confidence":0.345}]},
 "vad":{"speech":1.53,"total":1.69,"segments":[[0.16,1.686]]},
 "stages":[{"name":"replacements","before":"…","after":"…","seconds":0.0014},
           {"name":"transform email","skipped":"app /mail|…/ did not match Ghostty"}],
 "final":"If no can we do this?"}
```

New beyond what the log had: the raw ASR text **before** substitutions, per-word
spans and confidences, the speech gate's segment boundaries rather than its
totals, per-stage cost in seconds, and every stage that ran — including the ones
that changed nothing, which the log conflates with "skipped".

## Why a second file

The log is for reading over your own shoulder while something goes wrong: prose,
second resolution, and a rolling buffer that truncates to zero at 1 MB. The
questions worth asking here are asked over hundreds of dictations at once — which
words is the model least sure of, does a missing ending come from the decoder or
the gate, what does a prompt stage really cost on your own sentences — and none
of them survive a file that throws the oldest away. **No size cap on this one**,
deliberately: a year of heavy use is a few megabytes.

`docs/cli.md` carries a `jq` recipe for each of those questions.

## Decisions worth arguing with

- **No config key.** Recordings are kept unconditionally and a clip is strictly
  more revealing than its transcript, so a switch on the trace alone protects
  nothing.
- **A task local, not a parameter.** Threading a collector through
  `Pipeline.run`, `apply` and `runPrompt` for a debug artefact was the invasive
  version; a dictation is one task from the decoder to the last stage, which is
  exactly the scope a task local has.
- **A word keeps its lowest token's confidence, not the mean.** A name that came
  through as one solid piece and one shaky one is a shaky name. FluidAudio's own
  `buildWordTimings` drops confidence entirely, so the grouping is ours.
- **`--transcribe` writes a line too**, tagged `cli` against `live`. This is what
  makes the file worth keeping: change a table, re-run the archive, and both sets
  of numbers sit together joined to the same audio.

## Verification

Run over real clips — word timings and confidences populate, and every `jq`
recipe in `cli.md` was run against the file before being written down.

```
check-pipeline       27/27
check-replacements   23/23
check-numbers        97/97
check-dotted         54/54
```

Unchanged, and the check scripts bind no collector, so `--pipeline` runs leave
the corpus clean. The 188 pre-existing Swift 6 sendability warnings are untouched.

**Not yet verified:** the live hotkey path. It builds and runs, but confirming it
needs someone to press the key and check
`~/Recordings/ParrotFlow\ Dev/trace.jsonl`.

## Left alone

`Log.swift`'s 1 MB cap, which truncates the whole log to zero rather than
rotating. Out of scope here, but worth a follow-up.

---

The first line this wrote was already a finding: a clip with 1.22s of speech
across one VAD segment that decoded to nothing at confidence 0.1. The log showed
the speech, and then silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)