### PR TITLE
fix: a substitution replaces the words instead of landing after them

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1020,21 +1020,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         previewPanel.show(prompt: prompt.name, before: before, after: cleaned)
     }
 
-    /// Puts a transformed phrase where the phrase it replaces is sitting.
-    ///
-    /// The accessibility write first, because it disturbs nothing. A terminal
-    /// refuses it — its value is a picture of a screen — and there the only
-    /// thing that writes is keystrokes, which stays behind `rewrite_line`
-    /// because it clears the line to do it.
-    /// Three outcomes, not two.
-    ///
-    /// "It did not happen" and "it was tried and rolled back" call for opposite
-    /// things afterwards. Treating them alike is what produced
-    /// "Fifty cents.50 cents.": the retype had already put text on the line and
-    /// taken it off again, and the caller, seeing only false, pasted on top of
-    /// the result.
-    private enum InPlace { case replaced, notAttempted, failed }
-
     /// One edit to make to text that is already in the field.
     struct Edit {
         let find: String
@@ -1050,86 +1035,133 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let fuzzy: Bool
     }
 
-    /// Makes edits to text where it already sits, by whichever means the app
-    /// in front will accept.
+    /// Three outcomes, not two.
     ///
-    /// The one ladder for both callers. Corrections and transforms want the
-    /// same thing — the field says X, make it say Y — and having each keep its
-    /// own version of this meant a fix for one silently left the other behind.
+    /// "It did not happen" and "it was tried and rolled back" call for opposite
+    /// things afterwards. Treating them alike is what produced
+    /// "Fifty cents.50 cents.": the retype had already put text on the line and
+    /// taken it off again, and the caller, seeing only false, pasted on top of
+    /// the result.
+    private enum InPlace { case replaced, notAttempted, failed }
+
+    /// Turns edits into a span and hands it to `Surface`.
     ///
-    /// The accessibility write first, per edit, because it disturbs nothing. A
-    /// terminal refuses it, and there the only thing that writes is keystrokes,
-    /// which stays behind `rewrite_line` because it clears the line to do it —
-    /// and which is done once for all the edits rather than once each, since
-    /// every retype is a chance to lose the line.
+    /// The two halves of an in-place edit are *where* and *how*, and only the
+    /// first one belongs here. Locating is this app's problem — a rule learned
+    /// by ear names a word that may be spelled differently on screen, and
+    /// resolving that needs the fuzzy match below. Writing is the surface's
+    /// problem, and it is the same problem in every app, which is why there is
+    /// one ladder rather than one per caller.
+    ///
+    /// All the edits are applied to the content first and the result handed over
+    /// as a single substitution. Done one at a time, the second edit would be
+    /// located against a string that the first had already changed — and in a
+    /// terminal each one costs a whole line retype, which is a fresh chance to
+    /// lose the line.
     private func applyInPlace(
         _ edits: [Edit], dictated: String?, in element: AXUIElement
     ) -> InPlace {
         guard !edits.isEmpty else { return .notAttempted }
+        guard let surface = Surface.read(element: element, dictated: dictated) else {
+            return .notAttempted
+        }
 
-        var written = 0
+        var updated = surface.content
+        var applied = 0
         for edit in edits {
-            if SelectionReader.replaceLastOccurrence(
-                of: edit.find, with: edit.replace, in: element
+            let before = updated
+            if edit.fuzzy {
+                // A rule, so every occurrence on the line: a name you have just
+                // taught the app to spell is misspelled everywhere it appears,
+                // not only the last time you said it. `applying` also falls back
+                // to the closest word, because the word on screen and the word
+                // in the rule are two hearings of one name.
+                updated = SelectionReader.applying(
+                    [(heard: edit.find, corrected: edit.replace)], to: updated
+                )
+            } else if let found = updated.range(
+                of: edit.find, options: [.caseInsensitive, .backwards]
             ) {
-                written += 1
-                continue
+                // A phrase, so the last occurrence only: this is the sentence
+                // dictated a moment ago being replaced by its rewritten form,
+                // and there is exactly one of it.
+                updated = updated.replacingCharacters(in: found, with: edit.replace)
             }
-            guard edit.fuzzy,
-                  let text = SelectionReader.visibleText(of: element),
-                  let nearest = VoiceCommand.closestWord(to: edit.replace, in: text),
-                  nearest.lowercased() != edit.replace.lowercased(),
-                  SelectionReader.replaceLastOccurrence(
-                      of: nearest, with: edit.replace, in: element
-                  )
-            else { continue }
-            written += 1
+            if updated != before { applied += 1 }
         }
-        if written == edits.count {
-            Log.write("rewrote \(written) occurrence(s) in the focused field")
+
+        guard applied > 0, let change = Surface.minimalSpan(from: surface.content, to: updated) else {
+            Log.write("in-place: nothing on the line matches \(edits.map(\.find))")
+            return .notAttempted
+        }
+        if applied < edits.count {
+            Log.write("in-place: \(applied) of \(edits.count) edits found their text")
+        }
+
+        switch surface.replace(change.range, with: change.replacement) {
+        case .replaced:
             return .replaced
+        case .refused(let why):
+            Log.write("in-place: refused — \(why)")
+            return .failed
+        }
+    }
+
+    /// Substitutes the text that was selected when the hotkey went down.
+    ///
+    /// The recorded range is a hint, not an address. It was read before the
+    /// panel opened and before focus moved, and a field that has scrolled or
+    /// been typed into since will happily hand back a range that now covers
+    /// something else — so it is used only when the characters sitting there are
+    /// still the ones that were selected. Otherwise the text is found again by
+    /// its content, which is the thing that was actually pointed at.
+    private func replaceSelected(
+        with text: String, in selection: SelectionReader.Selection
+    ) -> InPlace {
+        // Re-query rather than reuse: apps generally only honour writes to
+        // whatever currently has focus, and by now our own panel has held it.
+        let element = SelectionReader.refocusedElement(in: selection.owner)
+            ?? selection.element.flatMap { SelectionReader.isOurs($0) ? nil : $0 }
+        guard let element,
+              let surface = Surface.read(
+                  element: element, app: selection.owner, dictated: selection.text
+              )
+        else { return .notAttempted }
+
+        var target: Range<String.Index>?
+        if let recorded = selection.range,
+           recorded.location >= 0, recorded.length > 0,
+           let range = Range(
+               NSRange(location: recorded.location, length: recorded.length),
+               in: surface.content
+           ), surface.content[range] == selection.text {
+            target = range
+        } else if let found = surface.range(of: selection.text) {
+            Log.write("transform: the recorded range moved; found the selection by its text")
+            target = found
         }
 
-        // Some but not all. Reporting success here said the whole batch had
-        // landed while one of the corrections had quietly not been made, and
-        // the clipboard fallback the caller keeps for exactly that never ran —
-        // so a rule you confirmed was neither in the field nor anywhere you
-        // could reach it. Two rules in one breath is what made this reachable;
-        // with one edit there was no partial state to be wrong about.
-        if written > 0 {
-            Log.write("rewrite: \(written) of \(edits.count) landed in the field;"
-                + " retyping the line so the rest do too")
+        guard let target else {
+            Log.write("transform: \"\(selection.text.prefix(40))\" is no longer in the field")
+            return .notAttempted
         }
+        switch surface.replace(target, with: text) {
+        case .replaced:
+            return .replaced
+        case .refused(let why):
+            Log.write("transform: refused — \(why)")
+            return .failed
+        }
+    }
 
-        guard config.transcription.rewriteLine else {
-            Log.write("rewrite: rewrite_line is off; not retyping")
-            // A partial write is not "nothing happened". The caller treats both
-            // the same today, but saying `failed` keeps the log and the return
-            // value telling the same story.
-            return written > 0 ? .failed : .notAttempted
-        }
-        Log.write("rewrite: retyping the line via keystrokes")
-        let retyped = SelectionReader.rewriteCurrentLine(dictated: dictated, in: element) { line in
-            // Fuzzy edits go through the rule machinery, which matches on word
-            // boundaries and falls back to the closest spelling. Literal ones
-            // cannot: a phrase may end in a full stop, and \b will not match
-            // past it, so "Sixty Euros." found nothing and was pasted alongside.
-            var output = SelectionReader.applying(
-                edits.filter(\.fuzzy).map { (heard: $0.find, corrected: $0.replace) },
-                to: line
-            )
-            for edit in edits where !edit.fuzzy {
-                guard let found = output.range(
-                    of: edit.find, options: [.caseInsensitive, .backwards]
-                ) else { continue }
-                output = output.replacingCharacters(in: found, with: edit.replace)
-            }
-            return output
-        }
-        // The retype found its line and acted on it either way; if it came back
-        // false it has already put the line back, and the text belongs on the
-        // clipboard rather than on top of what it restored.
-        return retyped ? .replaced : .failed
+    /// The toast after a substitution, and the phrase that takes it back.
+    ///
+    /// Said every time rather than only when something looks wrong, because the
+    /// moment you can tell it went wrong is the moment you are looking at the
+    /// text and not at the menu bar. It has to already be on screen.
+    private func applied(_ what: String) {
+        if config.feedback.sound { NSSound(named: "Glass")?.play() }
+        flash("\(what) applied", tone: .done)
     }
 
     private func applyTransform(
@@ -1142,21 +1174,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Without one there is nowhere to aim, so it goes in at the cursor the
         // same way a dictation would.
         if let selection {
-            switch SelectionReader.replaceSelection(with: text, in: selection) {
-            case .written, .pasted:
-                if config.feedback.sound { NSSound(named: "Glass")?.play() }
-                flash("\(prompt.name) applied", tone: .done)
-            case .clipboardOnly:
+            switch replaceSelected(with: text, in: selection) {
+            case .replaced:
+                applied(prompt.name)
+            case .failed, .notAttempted:
                 Log.write("transform: this app would not accept the rewrite; left on the clipboard")
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(text, forType: .string)
                 flash("\(prompt.name) copied — this app won't let me edit it", tone: .caution)
             }
         } else {
             // Hand focus back first. Showing the preview called NSApp.activate
             // to put the panel in front, so by the time Apply is pressed we are
             // the frontmost app and Cmd-V lands in our own window — which is
-            // how "digits applied" appeared over a TUI that never changed. The
-            // other branch never had this problem because replaceSelection
-            // activates the owner itself.
+            // how "digits applied" appeared over a TUI that never changed.
             if let owner = focusAtPress?.owner, !owner.isActive {
                 owner.activate()
                 // Let it come forward before the keystroke is posted.
@@ -1173,10 +1204,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                let element = SelectionReader.focusedElement(),
                !SelectionReader.isOurs(element) {
                 let edit = Edit(find: original, replace: text, fuzzy: false)
-                switch applyInPlace([edit], dictated: original, in: element) {
+                switch applyInPlace(
+                    [edit], dictated: original, in: element
+                ) {
                 case .replaced:
-                    if config.feedback.sound { NSSound(named: "Glass")?.play() }
-                    flash("\(prompt.name) applied", tone: .done)
+                    applied(prompt.name)
                     lastTranscript = text
                     return
                 case .failed:
@@ -1267,9 +1299,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Put the corrected phrase back where it came from, whether or not any
         // rules were saved — the user may just be fixing this one instance.
         let trimmed = correctedText.trimmingCharacters(in: .whitespacesAndNewlines)
-        var outcome: SelectionReader.ReplaceOutcome?
+        var landedOnClipboard = false
         if let selection = pendingSelection, !trimmed.isEmpty {
-            outcome = SelectionReader.replaceSelection(with: correctedText, in: selection)
+            switch replaceSelected(with: correctedText, in: selection) {
+            case .replaced:
+                break
+            case .failed, .notAttempted:
+                Log.write("field would not accept the correction; it is on the clipboard")
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(correctedText, forType: .string)
+                landedOnClipboard = true
+            }
         } else if !rules.isEmpty, let focus = focusAtPress,
                   let element = SelectionReader.refocusedElement(in: focus.owner)
                       ?? focus.element.flatMap({ SelectionReader.isOurs($0) ? nil : $0 }) {
@@ -1284,12 +1324,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 in: element
             ) {
             case .replaced:
-                outcome = .written
+                break
             case .notAttempted, .failed:
                 Log.write("field would not accept the rewrite; correction is on the clipboard")
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(rules[0].corrected, forType: .string)
-                outcome = .clipboardOnly
+                landedOnClipboard = true
             }
         } else if !trimmed.isEmpty {
             NSPasteboard.general.clearContents()
@@ -1299,7 +1339,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         focusAtPress = nil
 
         if config.feedback.sound { NSSound(named: "Glass")?.play() }
-        if outcome == .clipboardOnly {
+        if landedOnClipboard {
             flash("Rule saved · \"\(rules.first?.corrected ?? "")\" copied — this app won't let me edit it", tone: .caution)
             return
         }
@@ -1619,8 +1659,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// long as someone takes to think about a spelling — and a dictation
     /// started somewhere else in the meantime moves that field. Reading it late
     /// would hand focus to the newer app and paste this sentence into it.
+    ///
+    /// `proposed` is named apart from the panel's own `rules` on purpose. Both
+    /// used to be called `rules`, and the closure's parameter shadowed this one
+    /// — so the test for "was the panel opened on the sentence rather than on
+    /// proposed rules" compared a non-optional array against nil, was always
+    /// false, and silently threw away text the speaker had typed into the panel
+    /// by hand. The two are genuinely different questions: what the model
+    /// proposed on the way in, and what was confirmed on the way out.
     private func showInlineCorrection(
-        over text: String, rules: [(heard: String, corrected: String)]?,
+        over text: String, rules proposed: [(heard: String, corrected: String)]?,
         destination: Destination, focus: SelectionReader.Selection?
     ) {
         pendingSelection = nil
@@ -1672,7 +1720,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // The panel edits words, not the sentence, when it was opened on
             // proposed rules — so its text is only the target when it was
             // opened on the sentence itself.
-            let final = rules == nil && !correctedText.trimmingCharacters(
+            let final = proposed == nil && !correctedText.trimmingCharacters(
                 in: .whitespacesAndNewlines
             ).isEmpty ? correctedText : corrected
             self.lastTranscript = final
@@ -1687,8 +1735,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self.insertDictation(text, to: destination)
         }
 
-        if let rules {
-            correctionPanel.show(rules: rules)
+        if let proposed {
+            correctionPanel.show(rules: proposed)
         } else {
             correctionPanel.show(selection: text)
         }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1115,6 +1115,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// something else — so it is used only when the characters sitting there are
     /// still the ones that were selected. Otherwise the text is found again by
     /// its content, which is the thing that was actually pointed at.
+    ///
+    /// Finding it again is where this can go wrong, and the recorded range earns
+    /// its keep a second time. A field reading "Jerry and Jerry" gives two
+    /// answers to "where is Jerry", and taking either one on its own merits
+    /// rewrites a word the speaker was not pointing at — selecting the first and
+    /// having the last one changed is worse than nothing happening. So a
+    /// repeated selection is resolved by *where* it was: the occurrence nearest
+    /// the offset originally recorded, which survives text being inserted or
+    /// removed around it. With no offset to go on there is nothing to choose
+    /// between them, and this refuses.
     private func replaceSelected(
         with text: String, in selection: SelectionReader.Selection
     ) -> InPlace {
@@ -1136,9 +1146,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                in: surface.content
            ), surface.content[range] == selection.text {
             target = range
-        } else if let found = surface.range(of: selection.text) {
-            Log.write("transform: the recorded range moved; found the selection by its text")
-            target = found
+        } else {
+            let matches = surface.ranges(of: selection.text)
+            if matches.count == 1 {
+                Log.write("transform: the recorded range moved; found the selection by its text")
+                target = matches[0]
+            } else if matches.count > 1, let recorded = selection.range, recorded.location >= 0 {
+                // Nearest the offset it was read at, not nearest the end.
+                target = matches.min {
+                    abs(offset(of: $0, in: surface.content) - recorded.location)
+                        < abs(offset(of: $1, in: surface.content) - recorded.location)
+                }
+                Log.write("transform: \(matches.count) copies of the selection;"
+                    + " taking the one nearest where it was read")
+            } else if matches.count > 1 {
+                Log.write("transform: \(matches.count) copies of the selection and nothing"
+                    + " says which was meant; not guessing")
+                return .notAttempted
+            }
         }
 
         guard let target else {
@@ -1152,6 +1177,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Log.write("transform: refused — \(why)")
             return .failed
         }
+    }
+
+    private func offset(of range: Range<String.Index>, in text: String) -> Int {
+        NSRange(range, in: text).location
     }
 
     /// The toast after a substitution, and the phrase that takes it back.

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1417,9 +1417,10 @@ if __name__ == "__main__":
       # first is the one to teach someone.
       activation_phrases: [hey parrot, by the way parrot]
 
-      # Last resort for fields Accessibility cannot write, terminals mostly:
-      # clear the input line with Ctrl-A Ctrl-K and retype it corrected. It
-      # only fires when the line still holds what you dictated.
+      # Terminals only. Their accessibility value is a picture of a screen, so
+      # the only thing that writes there is keystrokes: clear the input line
+      # with Ctrl-A Ctrl-K and retype it corrected. Everywhere else — a field,
+      # a browser, Slack, Outlook — edits the range directly and ignores this.
       rewrite_line: true
 
       # Languages you dictate in, most spoken first — the first one is the

--- a/Sources/ParrotFlow/Destination.swift
+++ b/Sources/ParrotFlow/Destination.swift
@@ -115,7 +115,7 @@ enum Destination: Equatable {
     /// The exception is deliberately narrow either way: being wrong here costs
     /// a paste into a window that ignores it, which is what happened before any
     /// of this existed.
-    private static func terminalName(of app: Pipeline.App) -> String? {
+    static func terminalName(of app: Pipeline.App) -> String? {
         let bundle = app.bundleID.lowercased()
         let name = app.name.lowercased()
         if terminalBundleIDs.contains(bundle) || terminalNames.contains(name) {

--- a/Sources/ParrotFlow/EditTestCommand.swift
+++ b/Sources/ParrotFlow/EditTestCommand.swift
@@ -4,21 +4,26 @@ import ApplicationServices
 /// `--edit-test <needle> <replacement> --find <sentinel>` — performs one real
 /// in-place edit against the frontmost app and reports which branch took it.
 ///
+/// `--span-test <start> <length> <replacement> --find <sentinel>` does the same
+/// thing to a character range instead of to a word, which is the only way to
+/// exercise the layer as the app now uses it: a caller that knows exactly which
+/// characters it wants changed says so, and nothing searches for anything.
+///
 /// The counterpart to `--peek`, and the reason that command cannot be the whole
 /// harness. A read can say whether there is a selection and whether the value
 /// looks like a field, but it cannot say whether a write will land: setting a
-/// range returns `.success` in terminals that then ignore it, so the only way
-/// to learn what a surface really does is to write to it and look.
+/// range returns `.success` in surfaces that then ignore it, so the only way to
+/// learn what one really does is to write to it and look.
 ///
 /// Looking is not this command's job. It says what it attempted and what the
 /// accessibility API claimed; whether the text actually changed is answered by
-/// something outside this process — `tmux capture-pane` reading the pane
-/// through the pty, which owes nothing to the API being tested.
+/// something outside this process — `tmux capture-pane` reading a pane through
+/// the pty, or the fixture page reporting its own DOM — which owes nothing to
+/// the API being tested.
 ///
-/// `--find` is required, not optional. This synthesises keystrokes into
-/// whichever window happens to be frontmost, and a harness that mis-fires types
-/// into somebody's document. The sentinel is the proof that the window in front
-/// is the fixture and not a real one.
+/// `--find` is required, not optional. This writes into whichever window happens
+/// to be frontmost, and a harness that mis-fires types into somebody's document.
+/// The sentinel is the proof that the window in front is the fixture.
 enum EditTestCommand {
 
     private static func report(_ line: String) {
@@ -26,10 +31,43 @@ enum EditTestCommand {
         Log.write("edit-test: \(line)")
     }
 
-    /// `dictated` selects the route. Absent, this exercises the accessibility
-    /// write — the one a terminal refuses. Present, it exercises the keystroke
-    /// retype, which needs to be told what it put on the line because that is
-    /// the whole point of it: nothing is read back off the screen.
+    /// Everything both modes need before either is allowed to write.
+    private static func surface(
+        sentinel: String, dictated: String?, seconds: Double
+    ) -> Surface? {
+        // Same reason as PeekCommand: launched through LaunchServices this is an
+        // ordinary app until it says otherwise, and an ordinary app wins
+        // activation — then writes to its own empty focus.
+        NSApplication.shared.setActivationPolicy(.accessory)
+
+        guard Permissions.accessibility == .granted else {
+            report("✗ accessibility is not granted to this binary")
+            return nil
+        }
+
+        if seconds > 0 {
+            print("focus the fixture window — writing in \(Int(seconds))s")
+            Thread.sleep(forTimeInterval: seconds)
+        }
+
+        guard let surface = Surface.read(dictated: dictated) else {
+            report("✗ nothing readable is focused")
+            return nil
+        }
+        guard surface.content.contains(sentinel) else {
+            report("✗ sentinel \"\(sentinel)\" not in the content — refusing to write")
+            report("  content: \"\(surface.content.prefix(120))\"")
+            return nil
+        }
+        report("surface   \(surface.kind), \(surface.content.count) chars"
+            + (surface.span.map { _ in ", selection present" } ?? ""))
+        return surface
+    }
+
+    /// `literal` selects how the needle is found, which is the only thing the
+    /// two modes of this command disagree about. A transform's needle is a whole
+    /// phrase, punctuation and all, which a word-boundary rule cannot match; a
+    /// correction's is a word that may be spelled differently on screen.
     static func run(
         needle: String,
         replacement: String,
@@ -39,70 +77,68 @@ enum EditTestCommand {
         seconds: Double
     ) -> Int32 {
         defer { Log.flush() }
+        guard let surface = surface(
+            sentinel: sentinel, dictated: dictated, seconds: seconds
+        ) else { return 2 }
 
-        // Same reason as PeekCommand: launched through LaunchServices this is an
-        // ordinary app until it says otherwise, and an ordinary app wins
-        // activation — then writes to its own empty focus.
-        NSApplication.shared.setActivationPolicy(.accessory)
-
-        guard Permissions.accessibility == .granted else {
-            report("✗ accessibility is not granted to this binary")
-            return 1
-        }
-
-        if seconds > 0 {
-            print("focus the fixture window — writing in \(Int(seconds))s")
-            Thread.sleep(forTimeInterval: seconds)
-        }
-
-        guard let element = SelectionReader.focusedElement() else {
-            report("✗ nothing focused")
-            return 2
-        }
-        guard !SelectionReader.isOurs(element) else {
-            report("✗ focused element is ParrotFlow's own")
-            return 2
-        }
-        guard let value = SelectionReader.visibleText(of: element) else {
-            report("✗ focused element has no readable value")
-            return 2
-        }
-        guard value.contains(sentinel) else {
-            report("✗ sentinel \"\(sentinel)\" not in the focused element — refusing to write")
-            return 2
-        }
-        guard value.contains(needle) else {
-            report("✗ \"\(needle)\" is not on screen — nothing to replace")
-            return 2
-        }
-
-        let landed: Bool
-        if let dictated, literal {
-            // The route a transform takes: a whole phrase, punctuation and all,
-            // which a word-boundary rule cannot match.
-            report("retyping the line literally, \"\(needle)\" → \"\(replacement)\"")
-            landed = SelectionReader.rewriteCurrentLine(dictated: dictated, in: element) { line in
-                guard let found = line.range(
-                    of: needle, options: [.caseInsensitive, .backwards]
-                ) else { return line }
-                return line.replacingCharacters(in: found, with: replacement)
+        // The same order as `applyInPlace`, and for the same reason. A rule
+        // applies to every occurrence on the line; a phrase is the one sentence
+        // just dictated, and only its last occurrence is that sentence.
+        var updated = surface.content
+        if literal {
+            if let found = updated.range(of: needle, options: [.caseInsensitive, .backwards]) {
+                updated = updated.replacingCharacters(in: found, with: replacement)
             }
-        } else if let dictated {
-            report("retyping the line, \"\(needle)\" → \"\(replacement)\"")
-            landed = SelectionReader.rewriteCurrentLine(
-                applying: [(heard: needle, corrected: replacement)],
-                dictated: dictated,
-                in: element
-            )
         } else {
-            report("writing \"\(needle)\" → \"\(replacement)\"")
-            landed = SelectionReader.replaceLastOccurrence(
-                of: needle, with: replacement, in: element
+            updated = SelectionReader.applying(
+                [(heard: needle, corrected: replacement)], to: updated
             )
         }
-        // Deliberately not "succeeded". This is what the accessibility API said,
-        // which is the claim under test, not the verdict on it.
-        report(landed ? "claimed: written" : "claimed: refused")
-        return landed ? 0 : 3
+        guard let change = Surface.minimalSpan(from: surface.content, to: updated) else {
+            report("✗ \"\(needle)\" is not in the content — nothing to replace")
+            return 2
+        }
+
+        report("replacing \"\(surface.content[change.range])\" with \"\(change.replacement)\"")
+        return write(change.range, change.replacement, in: surface)
+    }
+
+    /// The span mode: a range, given rather than searched for.
+    static func runSpan(
+        start: Int, length: Int,
+        replacement: String,
+        sentinel: String,
+        dictated: String?,
+        seconds: Double
+    ) -> Int32 {
+        defer { Log.flush() }
+        guard let surface = surface(
+            sentinel: sentinel, dictated: dictated, seconds: seconds
+        ) else { return 2 }
+
+        guard start >= 0, length >= 0,
+              let range = Range(NSRange(location: start, length: length), in: surface.content)
+        else {
+            report("✗ \(start)+\(length) is not a range of \(surface.content.count) chars")
+            return 2
+        }
+
+        report("replacing \(start)+\(length) — \"\(surface.content[range])\" → \"\(replacement)\"")
+        return write(range, replacement, in: surface)
+    }
+
+    private static func write(
+        _ range: Range<String.Index>, _ replacement: String, in surface: Surface
+    ) -> Int32 {
+        switch surface.replace(range, with: replacement) {
+        case .replaced:
+            // Deliberately not "succeeded". This is what the write path claimed,
+            // which is the thing under test, not the verdict on it.
+            report("claimed: written")
+            return 0
+        case .refused(let why):
+            report("claimed: refused — \(why)")
+            return 3
+        }
     }
 }

--- a/Sources/ParrotFlow/PeekCommand.swift
+++ b/Sources/ParrotFlow/PeekCommand.swift
@@ -281,4 +281,3 @@ enum PeekCommand {
         text.suffix(80).replacingOccurrences(of: "\n", with: "⏎")
     }
 }
-

--- a/Sources/ParrotFlow/PeekCommand.swift
+++ b/Sources/ParrotFlow/PeekCommand.swift
@@ -36,7 +36,9 @@ enum PeekCommand {
     /// a harness seeds a sentinel through tmux and names it here: if it is not
     /// in the value, accessibility and the pane are not looking at the same
     /// place and every measurement after this point is fiction.
-    static func run(seconds: Double, expecting sentinel: String? = nil) -> Int32 {
+    static func run(
+        seconds: Double, expecting sentinel: String? = nil, viaCopy: Bool = false
+    ) -> Int32 {
         defer { Log.flush() }
 
         // Declare ourselves an accessory before anything else. Launched through
@@ -123,6 +125,25 @@ enum PeekCommand {
         report("selected  \(selected.map { "\"\(preview($0))\"" } ?? "none")")
         report("range     \(rangeDescription(of: element))")
 
+        // What the write path will actually be handed. Everything above is raw
+        // accessibility; this is the one coordinate space the app edits in, and
+        // when the two disagree it is this line that decides what happens.
+        if let surface = Surface.read(element: element) {
+            report("")
+            report("as a surface:")
+            report("  kind    \(surface.kind)")
+            report("  content \(surface.content.count) chars — \"\(preview(surface.content))\"")
+            if let span = surface.span {
+                let range = NSRange(span, in: surface.content)
+                report("  span    \(range.location)+\(range.length) — \"\(preview(String(surface.content[span])))\"")
+            } else {
+                report("  span    none")
+            }
+        } else {
+            report("")
+            report("as a surface: unreadable — nothing here can be edited in place")
+        }
+
         if let sentinel {
             guard let value, value.contains(sentinel) else {
                 report("sentinel  \"\(sentinel)\" NOT in the focused element — wrong window")
@@ -133,42 +154,98 @@ enum PeekCommand {
 
         report("")
         report("a write here would:")
-        describeBranches(value: value, selected: selected)
+        describeBranches()
+
+        if viaCopy { reportSelectAllCopy() }
         return 0
     }
 
-    /// Mirrors the branch order in `SelectionReader.replaceSelection` and
-    /// `rewriteCurrentLine`. Held in step with them by hand — when this and the
-    /// write path disagree, this command is the one lying, and the harness
-    /// built on top of it is measuring nothing.
-    private static func describeBranches(value: String?, selected: String?) {
-        // The direct range write is the only branch that cannot be predicted
-        // from a read: setting a range returns .success in terminals that then
-        // ignore it, which is exactly the lie the write path exists to survive.
-        // So this reports what is knowable and says plainly what is not.
-        report("  1. try the accessibility range write — unknowable without writing;")
-        report("     terminals report success here and change nothing")
+    /// Asks the app for its own text with Select All and Copy.
+    ///
+    /// Opt-in because it borrows the clipboard and leaves a selection on screen.
+    /// The question it answers is whether a surface that publishes nothing to
+    /// accessibility — Ghostty, iTerm — will still hand over its contents
+    /// through the one path every Mac app implements. ⌘-keys are handled by the
+    /// application, never forwarded to a pty, so this cannot disturb a shell.
+    private static func reportSelectAllCopy() {
+        let pasteboard = NSPasteboard.general
+        let saved = pasteboard.string(forType: .string)
+        let before = pasteboard.changeCount
 
-        if let selected, !selected.isEmpty {
-            report("  2. fall back to pasting over the live selection — available")
-        } else {
-            report("  2. fall back to pasting over the live selection — refused,")
-            report("     no selection to confirm, so it will not paste blind")
+        report("")
+        report("via Select All + Copy:")
+        postCommandKey(0x00)   // A
+        Thread.sleep(forTimeInterval: 0.4)
+        postCommandKey(0x08)   // C
+
+        let deadline = Date().addingTimeInterval(1.5)
+        while Date() < deadline, pasteboard.changeCount == before {
+            Thread.sleep(forTimeInterval: 0.05)
         }
 
-        guard let value else {
-            report("  3. retyping the input line — unavailable, value unreadable")
+        if pasteboard.changeCount == before {
+            report("  nothing — the clipboard never changed")
+        } else if let text = pasteboard.string(forType: .string) {
+            let rows = text.components(separatedBy: "\n")
+            report("  \(text.count) chars, \(rows.count) row(s)")
+            let borders = rows.filter { SelectionReader.isBorder($0) }.count
+            report("  \(borders) row(s) look like a rule the TUI drew")
+            if let box = SelectionReader.joinedInputBox(in: text) {
+                report("  input box: \(box.count) chars — \"\(preview(box))\"")
+            } else {
+                report("  input box: none found between the last two rules")
+            }
+            report("  tail: \"\(preview(text))\"")
+        }
+
+        if let saved {
+            pasteboard.clearContents()
+            pasteboard.setString(saved, forType: .string)
+        }
+    }
+
+    private static func postCommandKey(_ key: CGKeyCode) {
+        let source = CGEventSource(stateID: .combinedSessionState)
+        guard let down = CGEvent(keyboardEventSource: source, virtualKey: key, keyDown: true),
+              let up = CGEvent(keyboardEventSource: source, virtualKey: key, keyDown: false)
+        else { return }
+        down.flags = .maskCommand
+        up.flags = .maskCommand
+        down.post(tap: .cghidEventTap)
+        up.post(tap: .cghidEventTap)
+    }
+
+    /// Mirrors the branch order in `Surface.replace`. Held in step with it by
+    /// hand — when this and the write path disagree, this command is the one
+    /// lying, and the harness built on top of it is measuring nothing.
+    private static func describeBranches() {
+        guard let surface = Surface.read() else {
+            report("  nothing — the surface is unreadable, so no branch is reachable")
             return
         }
-        if (try? ConfigStore.load())?.transcription.rewriteLine != true {
-            report("  3. retyping the input line — refused, rewrite_line is off")
-        } else if value.contains("\n") {
-            report("  3. retyping the input line — refused, value is \(value.count) chars")
-            report("     of screen, not one field; a terminal never passes this gate")
-        } else if value.count > 2000 {
-            report("  3. retyping the input line — refused, \(value.count) chars is too long")
-        } else {
-            report("  3. retyping the input line — available (Ctrl-A, Ctrl-K, paste)")
+
+        switch surface.kind {
+        case .editable:
+            // Neither of these can be predicted from a read. Setting a range
+            // returns .success in surfaces that then ignore it, which is exactly
+            // the lie the write path exists to survive, so this says plainly
+            // what is unknowable rather than guessing at it.
+            report("  1. set the range, write the text into it — unknowable without")
+            report("     writing; a native field takes this one")
+            report("  2. set the range, confirm what came back, paste over it —")
+            report("     unknowable without writing; this is the branch that carries")
+            report("     the web, where selecting works and writing does not")
+            report("  3. otherwise refused, and the text goes to the clipboard")
+
+        case .screen:
+            if (try? ConfigStore.load())?.transcription.rewriteLine != true {
+                report("  retyping the input line — refused, rewrite_line is off")
+                return
+            }
+            report("  retyping the input line (Ctrl-A, Ctrl-K, paste) — the only")
+            report("  branch here; a terminal takes keystrokes and refuses the rest")
+            report("  content is \(surface.content.count) chars of input box, and")
+            report("  the clear is checked between presses rather than assumed")
         }
     }
 
@@ -204,3 +281,4 @@ enum PeekCommand {
         text.suffix(80).replacingOccurrences(of: "\n", with: "⏎")
     }
 }
+

--- a/Sources/ParrotFlow/SelectionReader.swift
+++ b/Sources/ParrotFlow/SelectionReader.swift
@@ -58,149 +58,6 @@ enum SelectionReader {
         )
     }
 
-    /// Rewrites the last occurrence of `needle` in a text element.
-    ///
-    /// Last rather than first: the word being corrected was dictated a moment
-    /// ago, so the most recent occurrence is the one meant. Replaces just that
-    /// range instead of rewriting the whole field, which would lose the caret
-    /// and clobber anything typed since.
-    @discardableResult
-    static func replaceLastOccurrence(
-        of needle: String,
-        with replacement: String,
-        in element: AXUIElement
-    ) -> Bool {
-        AXUIElementSetMessagingTimeout(element, 0.5)
-
-        var role: CFTypeRef?
-        _ = AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &role)
-        let roleName = (role as? String) ?? "unknown"
-
-        var value: CFTypeRef?
-        let readStatus = AXUIElementCopyAttributeValue(
-            element, kAXValueAttribute as CFString, &value
-        )
-        guard readStatus == .success, let text = value as? String, !text.isEmpty else {
-            Log.write("rewrite: can't read \(roleName) value (AXError \(readStatus.rawValue))")
-            return false
-        }
-        Log.write("rewrite: \(roleName), \(text.count) chars, looking for \"\(needle)\"")
-
-        guard let found = text.range(of: needle, options: [.caseInsensitive, .backwards]) else {
-            let preview = text.suffix(160).replacingOccurrences(of: "\n", with: "⏎")
-            Log.write("rewrite: \"\(needle)\" not in \(roleName); tail = \"\(preview)\"")
-            return false
-        }
-
-        // The replacement in the company it is supposed to keep. Checking for
-        // the replacement on its own would accept an append — "…the
-        // storethey're" contains "they're" quite happily — so the surrounding
-        // characters are what make this a check rather than a formality.
-        let context = 12
-        let fragment = String(text[..<found.lowerBound].suffix(context))
-            + replacement
-            + String(text[found.upperBound...].prefix(context))
-
-        let nsRange = NSRange(found, in: text)
-        var range = CFRange(location: nsRange.location, length: nsRange.length)
-        guard let axRange = AXValueCreate(.cfRange, &range) else { return false }
-
-        let selectStatus = AXUIElementSetAttributeValue(
-            element, kAXSelectedTextRangeAttribute as CFString, axRange
-        )
-        guard selectStatus == .success else {
-            Log.write("rewrite: \(roleName) refused the selection (AXError \(selectStatus.rawValue))")
-            return false
-        }
-
-        let writeStatus = AXUIElementSetAttributeValue(
-            element, kAXSelectedTextAttribute as CFString, replacement as CFTypeRef
-        )
-        if writeStatus == .success, landed(element, expecting: fragment) {
-            return true
-        }
-
-        // Everything past here is the paste fallback, which is only safe where
-        // the value is an editable buffer. A terminal's is a view of its
-        // screen: setting the range really does select the characters drawn
-        // there, but the program on the other side of the pty never hears
-        // about it, so Cmd-V arrives at the input caret and appends —
-        // "…the storethey're", the same shape as "Versalailles.Tasmeen".
-        //
-        // The guard below used to be the only one, and it could not catch that,
-        // because it asked whether the selection existed. It did: we had just
-        // made it two lines earlier. Confirming your own action is not
-        // evidence, so the check passed every time while the paste corrupted
-        // the line. What rules a terminal out is the shape of the value.
-        guard !text.contains("\n"), text.count <= 2000 else {
-            Log.write("rewrite: \(roleName) is a screen, not a field — its selection is of output, not input; not pasting")
-            return false
-        }
-
-        guard let selected = selectedText(of: element),
-              selected.compare(needle, options: .caseInsensitive) == .orderedSame else {
-            Log.write("rewrite: \(roleName) ignored the range; not pasting blind")
-            return false
-        }
-
-        Log.write("rewrite: \(roleName) ignored the direct write, pasting over the confirmed selection")
-        TextInserter.insert(replacement, mode: .paste)
-        Thread.sleep(forTimeInterval: 0.2)
-
-        if landed(element, expecting: fragment) { return true }
-        Log.write("rewrite: \(roleName) would not accept either method")
-        return false
-    }
-
-    /// Clears the current input line with readline keys and types a corrected
-    /// version, checking between the two that the clear actually happened.
-    ///
-    /// The last resort for surfaces the accessibility API cannot write —
-    /// terminals, mostly, whose AX value is a read-only view of the screen.
-    /// Keystrokes work there because accepting keystrokes is what a terminal
-    /// is for.
-    ///
-    /// Ctrl-A then Ctrl-K is the readline idiom for "clear this line", and it
-    /// works on the logical line, so a wrapped one is handled correctly.
-    ///
-    /// The keystrokes are blind, but their effect is not: reading the field
-    /// back after the kill turns this from a hope into a check. If the text is
-    /// still there the kill did not land, and nothing is typed — Ctrl-A alone
-    /// only moved the caret, so bailing costs nothing. Pasting at that point
-    /// is what appends "…Versalailles.Tasmeen" to the end of a line.
-    /// Clears the input line, works out what was in it from what disappeared,
-    /// and types back a corrected version.
-    ///
-    /// The last resort for surfaces the accessibility API cannot write —
-    /// terminals, whose AX value is a read-only view of the screen. Keystrokes
-    /// work there because accepting keystrokes is what a terminal is.
-    ///
-    /// Identifying "the current line" inside a screen-shaped value is not
-    /// reliable: a wrapped line arrives split across newlines, and the text may
-    /// have been edited since we dictated it. So the line is not identified in
-    /// advance at all — it is killed, and the difference between the screen
-    /// before and after says exactly what was there. That text is authoritative
-    /// because the terminal just gave it to us.
-    ///
-    /// If nothing was killed, nothing is typed. If something was, it is always
-    /// typed back — corrected when a rule applies, verbatim when none does —
-    /// so the line is never left emptied.
-    /// Clears the input line, works out what was in it from what disappeared,
-    /// and types back a corrected version — restoring it if anything is unclear.
-    ///
-    /// The last resort for surfaces the accessibility API cannot write.
-    /// Keystrokes work in a terminal because accepting keystrokes is what a
-    /// terminal is.
-    ///
-    /// The line is not identified in advance: it is killed, and the difference
-    /// between the screen before and after says what was there. But that read
-    /// cannot be trusted to prove the kill happened — a terminal's AX value can
-    /// report the line unchanged while the screen shows it gone, which once
-    /// left an input emptied because we concluded there was nothing to restore.
-    ///
-    /// So the safety net is readline's own: Ctrl-K pushes to the kill ring and
-    /// Ctrl-Y yanks it back. Any uncertainty ends in Ctrl-Y, which puts the
-    /// line back whatever the accessibility API believes.
     /// Applies rules to a line, falling back to the closest match.
     ///
     /// The word on screen and the word in the rule are two hearings of the
@@ -245,119 +102,6 @@ enum SelectionReader {
         return output
     }
 
-    /// Retypes the input line corrected, when the field's value is readable
-    /// and is the line itself rather than a screenful of terminal.
-    ///
-    /// The last resort for surfaces that refuse accessibility writes but accept
-    /// keystrokes. Reading works in those; only writing does not.
-    ///
-    /// An earlier version killed the line and diffed the screen before and
-    /// after to learn what had been there. That cannot work against a live TUI:
-    /// Claude Code redrew its status bar between the two reads and the diff
-    /// swept up 140 characters of chrome for an 18 character line, which then
-    /// got typed into the input.
-    ///
-    /// So no diffing, and nothing is read out of a screen. In a plain field the
-    /// value is the line and can be used directly. In a terminal it cannot be,
-    /// but it does not need to be: the line was dictated there a moment ago and
-    /// we still have what we typed. The corrected text is known exactly before
-    /// a single key is pressed, and the screen is asked one question only —
-    /// whether the line is still ours alone — which is weak enough that it can
-    /// answer honestly.
-    @discardableResult
-    static func rewriteCurrentLine(
-        applying rules: [(heard: String, corrected: String)],
-        dictated: String? = nil,
-        in element: AXUIElement
-    ) -> Bool {
-        rewriteCurrentLine(dictated: dictated, in: element) { applying(rules, to: $0) }
-    }
-
-    /// The same retype, told what to do to the line rather than which rules to
-    /// run over it.
-    ///
-    /// Rules match on word boundaries, which is right for correcting a word and
-    /// wrong for replacing a phrase: `\b` will not match after the full stop in
-    /// "Sixty Euros.", so a transform asked to rewrite that found nothing and
-    /// its result was pasted alongside instead.
-    @discardableResult
-    static func rewriteCurrentLine(
-        dictated: String?,
-        in element: AXUIElement,
-        correcting: (String) -> String
-    ) -> Bool {
-        guard let value = visibleText(of: element) else { return false }
-
-        let line: String
-        if !value.contains("\n"), value.count <= 2000 {
-            line = value
-        } else if let located = inputLine(anchoredBy: dictated, in: value) {
-            Log.write("rewrite: value is a screen; using the input box")
-            line = located
-        } else {
-            Log.write("rewrite: \(value.count) chars of screen and the line is not ours alone; not retyping")
-            return false
-        }
-
-        let corrected = correcting(line)
-        guard corrected != line else {
-            Log.write("rewrite: nothing to change on the line; leaving it alone")
-            return false
-        }
-
-        guard clearedInput(of: element) else {
-            Log.write("rewrite: could not empty the line; not retyping over what is left")
-            return false
-        }
-        TextInserter.insert(corrected, mode: .paste)
-
-        // Poll, rather than read once after a guessed delay. The terminal
-        // services the paste asynchronously and repaints when it is ready, and
-        // a single read at 0.2s arrived before the repaint: the line was
-        // already right, the check said it was not, and the restore below
-        // undid a correction that had worked. `viaCopy` learned this first.
-        if appeared(corrected, in: element, within: 1.5) {
-            Log.write("rewrite: retyped \(line.count) chars")
-            return true
-        }
-
-        // Put it back deliberately rather than with Ctrl-Y. The paste has
-        // already happened by now, so yanking inserts what Ctrl-K took *after*
-        // whatever landed and leaves you holding both — which is how a
-        // truncated correction became a duplicated line. We still have the text
-        // that was there, so type that instead and depend on nothing.
-        Log.write("rewrite: line did not come back as expected; restoring what was there")
-        _ = clearedInput(of: element)
-        TextInserter.insert(line, mode: .paste)
-        Thread.sleep(forTimeInterval: 0.20)
-        return false
-    }
-
-    /// Waits for text to show up on screen, or gives up.
-    ///
-    /// The wait is the point: everything this class writes is written by
-    /// posting a keystroke, and a keystroke is a request. Reading back before
-    /// the app has serviced it does not measure the write, it measures the
-    /// delay — and concluding failure from that is worse than not checking,
-    /// because the recovery then destroys work that was fine.
-    private static func appeared(
-        _ text: String, in element: AXUIElement, within seconds: TimeInterval
-    ) -> Bool {
-        let deadline = Date().addingTimeInterval(seconds)
-        repeat {
-            if let value = visibleText(of: element) {
-                // The raw screen first, then the input box put back together.
-                // A corrected line long enough to wrap is drawn across several
-                // rows and never appears whole in the value — which reported a
-                // retype that had plainly worked as a failure, and undid it.
-                if value.contains(text) { return true }
-                if let joined = joinedInputBox(in: value), joined.contains(text) { return true }
-            }
-            Thread.sleep(forTimeInterval: 0.05)
-        } while Date() < deadline
-        return false
-    }
-
     /// The input line, located by text we know we put on it.
     ///
     /// The transcript answers "which row", never "what is on it". Those are
@@ -371,7 +115,7 @@ enum SelectionReader {
     /// before and after and swept up 140 characters of status bar for an 18
     /// character line. This reads one row, and only ever the row that already
     /// contains text we placed there.
-    private static func inputLine(anchoredBy dictated: String?, in screen: String) -> String? {
+    static func inputLine(anchoredBy dictated: String?, in screen: String) -> String? {
         let rows = screen.components(separatedBy: "\n")
 
         // The input box: what lies between the last two rules the TUI draws.
@@ -439,43 +183,6 @@ enum SelectionReader {
         return stripPrompt(row)
     }
 
-    /// Empties the input line, checking between presses rather than assuming.
-    ///
-    /// Ctrl-K kills to the end of the *visual row* in this TUI, not the end of
-    /// the logical line, so a single press leaves behind everything a wrap
-    /// pushed onto the rows below — and the retype then landed on top of the
-    /// remainder: "…certainly wrapsthis line past the width…". Pressing until
-    /// the box reads empty is the only version of this that survives a line
-    /// that wrapped.
-    ///
-    /// Only where the box can be read. In a plain field there is nothing to
-    /// check against, and a loop that cannot see what it is doing would keep
-    /// killing; there, one press is what it always was.
-    private static func clearedInput(of element: AXUIElement) -> Bool {
-        func boxIsEmpty() -> Bool? {
-            guard let value = visibleText(of: element),
-                  let box = joinedInputBox(in: value) else { return nil }
-            return box.isEmpty
-        }
-
-        guard boxIsEmpty() != nil else {
-            postControlKey(0x00)   // Ctrl-A, start of line
-            Thread.sleep(forTimeInterval: 0.06)
-            postControlKey(0x28)   // Ctrl-K, kill to end of line
-            Thread.sleep(forTimeInterval: 0.10)
-            return true
-        }
-
-        for _ in 0..<12 {
-            if boxIsEmpty() == true { return true }
-            postControlKey(0x00)
-            Thread.sleep(forTimeInterval: 0.06)
-            postControlKey(0x28)
-            Thread.sleep(forTimeInterval: 0.12)
-        }
-        return boxIsEmpty() == true
-    }
-
     /// The input box put back into one line, needing no anchor to find it.
     ///
     /// Between the last two rules the TUI draws, joined with the single space
@@ -512,7 +219,7 @@ enum SelectionReader {
         return String(line).trimmingCharacters(in: .whitespaces)
     }
 
-    private static func postControlKey(_ key: CGKeyCode) {
+    static func postControlKey(_ key: CGKeyCode) {
         let source = CGEventSource(stateID: .combinedSessionState)
         guard let down = CGEvent(keyboardEventSource: source, virtualKey: key, keyDown: true),
               let up = CGEvent(keyboardEventSource: source, virtualKey: key, keyDown: false)
@@ -533,34 +240,6 @@ enum SelectionReader {
             element, kAXValueAttribute as CFString, &value
         ) == .success, let text = value as? String else { return nil }
         return text
-    }
-
-    /// True when the correction is where it was asked to go.
-    ///
-    /// This used to ask whether the value had changed at all, which is not the
-    /// same question and answered yes far too easily. A live TUI changes on its
-    /// own — a clock in a status bar is enough — so a paste that appended
-    /// "…the storethey're" and a paste that did nothing both reported success.
-    /// What matters is that the text now reads the way it would have if the
-    /// substitution had happened, in the place it was meant to happen, and an
-    /// append does not.
-    private static func landed(_ element: AXUIElement, expecting fragment: String) -> Bool {
-        var after: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(
-            element, kAXValueAttribute as CFString, &after
-        ) == .success, let updated = after as? String else { return false }
-        return folded(updated).contains(folded(fragment))
-    }
-
-    /// Typographic substitution is not a failed write. Most apps turn a
-    /// straight apostrophe curly as it arrives, so "they're" comes back as
-    /// "they’re" — the correction landed, and a literal comparison would call
-    /// it a refusal and send the text to the clipboard instead.
-    private static func folded(_ text: String) -> String {
-        text.replacingOccurrences(of: "\u{2019}", with: "'")
-            .replacingOccurrences(of: "\u{2018}", with: "'")
-            .replacingOccurrences(of: "\u{201C}", with: "\"")
-            .replacingOccurrences(of: "\u{201D}", with: "\"")
     }
 
     /// Full read, in descending order of politeness. `snapshot` is preferred
@@ -704,7 +383,7 @@ enum SelectionReader {
         return selected as? String
     }
 
-    private static func selectedRange(of element: AXUIElement) -> CFRange? {
+    static func selectedRange(of element: AXUIElement) -> CFRange? {
         var value: CFTypeRef?
         guard AXUIElementCopyAttributeValue(
             element,
@@ -740,70 +419,7 @@ enum SelectionReader {
         return nil
     }
 
-    enum ReplaceOutcome {
-        /// Written straight into the range that was selected.
-        case written
-        /// Pasted over a selection we confirmed still existed.
-        case pasted
-        /// Nothing was safe to do; the text is on the clipboard instead.
-        case clipboardOnly
-    }
-
-    /// Puts the corrected text back, or refuses.
-    ///
-    /// Pasting blind is how you corrupt someone's document: if the selection
-    /// has collapsed to a caret — which is what a terminal does the moment it
-    /// loses focus — Cmd-V inserts instead of replacing, and you get
-    /// "and TasTasmeen.min." out of "and Tasmin.". So: write to the recorded
-    /// range if the element supports it, else paste only after confirming a
-    /// selection is genuinely still there, else leave it on the clipboard.
-    @discardableResult
-    static func replaceSelection(with text: String, in selection: Selection) -> ReplaceOutcome {
-        if let element = selection.element, writeDirectly(text, to: element, range: selection.range) {
-            Log.write("correction written via accessibility range")
-            return .written
-        }
-
-        selection.owner?.activate()
-        // Let the app come forward before asking what it has selected.
-        Thread.sleep(forTimeInterval: 0.15)
-
-        if let element = focusedElement(),
-           let current = selectedText(of: element), !current.isEmpty {
-            Log.write("correction pasted over live selection")
-            TextInserter.insert(text, mode: .paste)
-            return .pasted
-        }
-
-        Log.write("selection gone; correction left on the clipboard")
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(text, forType: .string)
-        return .clipboardOnly
-    }
-
-    /// Restores the recorded range, then replaces its contents. No keystrokes,
-    /// no dependence on the app having kept its selection visible.
-    private static func writeDirectly(
-        _ text: String,
-        to element: AXUIElement,
-        range: CFRange?
-    ) -> Bool {
-        if var range {
-            guard let value = AXValueCreate(.cfRange, &range) else { return false }
-            guard AXUIElementSetAttributeValue(
-                element,
-                kAXSelectedTextRangeAttribute as CFString,
-                value
-            ) == .success else { return false }
-        }
-        return AXUIElementSetAttributeValue(
-            element,
-            kAXSelectedTextAttribute as CFString,
-            text as CFTypeRef
-        ) == .success
-    }
-
-    private static func postCommandKey(_ key: CGKeyCode) {
+    static func postCommandKey(_ key: CGKeyCode) {
         let source = CGEventSource(stateID: .combinedSessionState)
         guard let down = CGEvent(keyboardEventSource: source, virtualKey: key, keyDown: true),
               let up = CGEvent(keyboardEventSource: source, virtualKey: key, keyDown: false)

--- a/Sources/ParrotFlow/Surface.swift
+++ b/Sources/ParrotFlow/Surface.swift
@@ -1,0 +1,691 @@
+import AppKit
+import ApplicationServices
+
+/// The editable thing in front of you, as one string and one span into it.
+///
+/// Everything that edits text in place used to ask its own question. One path
+/// searched the accessibility value for a needle, another reconstructed a
+/// terminal's input box and retyped the whole line, a third read
+/// `kAXSelectedTextRange` — three coordinate systems, none of which could be
+/// handed to the next. So a caller that knew exactly which characters it wanted
+/// changed had no way to say so, and expressed it as "find this text" instead,
+/// which is a different and much weaker request.
+///
+/// This is the one answer: `content` is the whole editable text, `span` is the
+/// selection as offsets *into that string*, and `replace` substitutes a range of
+/// it and nothing else. What a prompt then does with the content and the span is
+/// somebody else's problem — this layer only has to be right about where the
+/// characters are and whether they moved.
+///
+/// ## Two kinds, and why there are not more
+///
+/// The tempting split is by app: a native field, an Electron composer, a
+/// browser, a terminal. Three of those four are the same thing — the value is
+/// the content and the offsets address it — and they differ only in which write
+/// they will accept, which `replace` discovers by writing and reading back. A
+/// classification made in advance would be a guess dressed as a fact; the ladder
+/// finds out instead.
+///
+/// The terminal is genuinely different, and not by degree. Its value is a
+/// picture of a screen: the input box has to be read back out of it, the
+/// offsets in that reconstruction address nothing the app can write, and setting
+/// a range there *succeeds* while changing nothing — the lie this whole file
+/// exists to survive. So that one is named rather than examined, the same way
+/// `Destination` names it, and it gets a write path that touches only keystrokes.
+struct Surface {
+
+    enum Kind {
+        /// The accessibility value is the content, and its offsets address it.
+        /// A native field, a browser input, an Electron composer.
+        case editable
+        /// The value is a terminal screen. `content` is the input box read out
+        /// of it, and no offset into that addresses anything writable.
+        case screen
+    }
+
+    let kind: Kind
+    let element: AXUIElement
+    /// The whole editable content, in one coordinate space.
+    let content: String
+    /// The selection, as offsets into `content`. Nil when nothing is selected;
+    /// an empty range is a caret.
+    let span: Range<String.Index>?
+
+    var selectedText: String? { span.map { String(content[$0]) } }
+
+    // MARK: - Reading
+
+    /// What is in front, read once.
+    ///
+    /// Nil rather than an empty surface when there is nothing to edit: a caller
+    /// that cannot tell "an empty field" from "no field" writes into neither
+    /// safely.
+    /// `dictated` is used for one thing only, and only in a terminal that draws
+    /// no box: finding *which row* the input is on. It never says what is on
+    /// that row. The distinction is load-bearing — a field can hold several
+    /// dictations and whatever was typed between them, so treating the last
+    /// transcript as the content would quietly delete the rest.
+    ///
+    /// Retried briefly, for the same reason every write in this file is polled:
+    /// activating a window is a request, and the accessibility tree settles a
+    /// beat after it. Ghostty in particular reports the *window* as the focused
+    /// element for a few hundred milliseconds after coming forward, and hands
+    /// back its text view only once focus has landed — read once and
+    /// immediately, that is indistinguishable from a terminal that publishes
+    /// nothing at all, and it was misread exactly that way. Two cases in the
+    /// Ghostty run failed on it and neither corrupted anything; they simply read
+    /// an empty screen and declined.
+    static func read(
+        element: AXUIElement? = nil,
+        app: NSRunningApplication? = nil,
+        dictated: String? = nil
+    ) -> Surface? {
+        let deadline = Date().addingTimeInterval(0.6)
+        var attempt = 0
+        while true {
+            if let surface = readOnce(element: element, app: app, dictated: dictated) {
+                if attempt > 0 {
+                    Log.write("surface: readable on attempt \(attempt + 1)")
+                }
+                return surface
+            }
+            attempt += 1
+            guard Date() < deadline else { return nil }
+            Thread.sleep(forTimeInterval: 0.08)
+        }
+    }
+
+    private static func readOnce(
+        element: AXUIElement? = nil,
+        app: NSRunningApplication? = nil,
+        dictated: String? = nil
+    ) -> Surface? {
+        guard Permissions.accessibility == .granted else {
+            Log.write("surface: accessibility is not granted")
+            return nil
+        }
+        guard let element = element ?? SelectionReader.focusedElement() else {
+            Log.write("surface: nothing focused")
+            return nil
+        }
+        guard !SelectionReader.isOurs(element) else {
+            Log.write("surface: the focused element is our own")
+            return nil
+        }
+        guard let value = SelectionReader.visibleText(of: element) else {
+            // Ghostty and iTerm land here and always will: they focus the
+            // window, render their screen with Metal, and publish nothing but
+            // chrome to accessibility. Walking down from the window finds their
+            // tab title — 44 characters where the screen is two thousand — and
+            // treating that as the input line would retype chrome into the pty.
+            // So this refuses, and the text goes to the clipboard.
+            Log.write("surface: the focused element has no readable value")
+            return nil
+        }
+
+        let front = app ?? NSWorkspace.shared.frontmostApplication
+        let isTerminal = front.map {
+            Destination.terminalName(of: Pipeline.App(
+                name: $0.localizedName ?? "", bundleID: $0.bundleIdentifier ?? ""
+            )) != nil
+        } ?? false
+
+        if isTerminal {
+            return screen(element: element, value: value, dictated: dictated)
+        }
+        return editable(element: element, value: value)
+    }
+
+    /// A field, a browser input, a composer: the value is the content.
+    private static func editable(element: AXUIElement, value: String) -> Surface {
+        var span: Range<String.Index>?
+        if let range = SelectionReader.selectedRange(of: element),
+           range.location != NSNotFound, range.location >= 0 {
+            let nsRange = NSRange(location: range.location, length: max(0, range.length))
+            span = Range(nsRange, in: value)
+            if span == nil {
+                Log.write("surface: selected range \(range.location)+\(range.length)"
+                    + " does not fit \(value.count) chars of value; ignoring it")
+            }
+        }
+        return Surface(kind: .editable, element: element, content: value, span: span)
+    }
+
+    /// A terminal: the content is the input box, dug back out of the screen.
+    ///
+    /// The box is found by the rules the TUI draws around it, never by
+    /// recognising text we believe we put there. That distinction is the whole
+    /// reason several sentences dictated into one box survive being edited: the
+    /// box is authoritative about its contents and it is authoritative about
+    /// *all* of them, where a transcript only ever describes the last one and
+    /// retyping from it would delete the rest.
+    private static func screen(
+        element: AXUIElement, value: String, dictated: String?
+    ) -> Surface? {
+        // The box first, and a single row only when no box is drawn — a bare
+        // shell rather than a TUI. That fallback is the one place a transcript
+        // is consulted, and it still reads the whole row it lands on.
+        guard let box = SelectionReader.joinedInputBox(in: value)
+            ?? SelectionReader.inputLine(anchoredBy: dictated, in: value) else {
+            Log.write("surface: terminal, but nothing identifies the input line")
+            return nil
+        }
+        // An empty box is nothing to substitute into, so nil is the honest
+        // answer either way — and it lets the retry above tell a screen that has
+        // not finished being drawn from one that is genuinely empty.
+        guard !box.isEmpty else { return nil }
+        guard box.count <= maxScreenContent else {
+            Log.write("surface: the input box holds \(box.count) chars; too much to retype")
+            return nil
+        }
+
+        // A terminal's selection is of its *output* — the whole screen is
+        // selectable and none of it is the input. So a selection only means
+        // something here when it lands unambiguously inside the box, and
+        // "unambiguously" has to mean exactly one occurrence: a word that
+        // appears twice gives no way to tell which one was highlighted, and
+        // guessing puts the edit on the wrong half of the line.
+        var span: Range<String.Index>?
+        if let selected = SelectionReader.selectedText(of: element),
+           !selected.isEmpty {
+            let matches = occurrences(of: selected, in: box)
+            if matches.count == 1 {
+                span = matches[0]
+            } else {
+                Log.write("surface: \"\(selected.prefix(40))\" appears \(matches.count)"
+                    + " times in the input box; cannot say which was selected")
+            }
+        }
+        return Surface(kind: .screen, element: element, content: box, span: span)
+    }
+
+    /// Retyping a whole line is proportional to its length, and past a point the
+    /// clipboard is the kinder answer.
+    private static let maxScreenContent = 2000
+
+    private static func occurrences(of needle: String, in haystack: String) -> [Range<String.Index>] {
+        var found: [Range<String.Index>] = []
+        var from = haystack.startIndex
+        while let next = haystack.range(of: needle, range: from..<haystack.endIndex) {
+            found.append(next)
+            from = next.upperBound
+            if found.count > 1 { break }
+        }
+        return found
+    }
+
+    // MARK: - Locating
+
+    /// The smallest range of `before` whose replacement turns it into `after`.
+    ///
+    /// Common prefix, common suffix, and whatever is left in the middle. Exact
+    /// rather than clever: no tokenising, no similarity, nothing that can
+    /// disagree with itself on a second run.
+    ///
+    /// This is what lets a whole-text rewrite become an in-place substitution.
+    /// A prompt handed a sentence returns a sentence, and pasting that over the
+    /// field is what loses the caret and everything typed since; the difference
+    /// between the two is usually one word, and this finds it.
+    ///
+    /// Nil when the strings are equal, which is a caller asking to change
+    /// nothing and is worth being told about rather than performing.
+    static func minimalSpan(
+        from before: String, to after: String
+    ) -> (range: Range<String.Index>, replacement: String)? {
+        guard before != after else { return nil }
+
+        var start = before.startIndex
+        var afterStart = after.startIndex
+        while start < before.endIndex, afterStart < after.endIndex,
+              before[start] == after[afterStart] {
+            start = before.index(after: start)
+            afterStart = after.index(after: afterStart)
+        }
+
+        var end = before.endIndex
+        var afterEnd = after.endIndex
+        while end > start, afterEnd > afterStart,
+              before[before.index(before: end)] == after[after.index(before: afterEnd)] {
+            end = before.index(before: end)
+            afterEnd = after.index(before: afterEnd)
+        }
+
+        return (start..<end, String(after[afterStart..<afterEnd]))
+    }
+
+    /// The range holding `needle`, nearest the end.
+    ///
+    /// Last rather than first: the word being corrected was dictated a moment
+    /// ago, so the most recent occurrence is the one meant.
+    func range(of needle: String) -> Range<String.Index>? {
+        content.range(of: needle, options: [.caseInsensitive, .backwards])
+    }
+
+    // MARK: - Writing
+
+    enum Outcome: Equatable {
+        /// The characters in that range, and no others, now read differently.
+        case replaced
+        /// Nothing was written, and nothing was disturbed trying.
+        case refused(String)
+    }
+
+    /// Substitutes one range of `content`, and nothing else.
+    ///
+    /// Every branch below either changes exactly those characters or changes
+    /// nothing at all. There is no branch that writes and hopes: the two failures
+    /// are not the same size, and the one that appends a correction to the end of
+    /// somebody's sentence is the one this file exists to prevent.
+    @discardableResult
+    func replace(
+        _ range: Range<String.Index>, with replacement: String
+    ) -> Outcome {
+        let updated = content.replacingCharacters(in: range, with: replacement)
+        guard updated != content else {
+            return .refused("the text already reads that way")
+        }
+
+        switch kind {
+        case .editable:
+            return writeEditable(range, replacement: replacement, updated: updated)
+        case .screen:
+            return writeScreen(updated: updated)
+        }
+    }
+
+    // MARK: - The editable ladder
+
+    /// Three attempts, each verified by reading back, then a refusal.
+    ///
+    /// The order is by how little each disturbs. Nothing here trusts a return
+    /// value: setting an accessibility attribute reports `.success` in surfaces
+    /// that then ignore it entirely, which is the single fact that has caused
+    /// every corrupted line this code has ever produced.
+    private func writeEditable(
+        _ range: Range<String.Index>, replacement: String, updated: String
+    ) -> Outcome {
+        let nsRange = NSRange(range, in: content)
+        // The replacement in the company it is meant to keep. Checking for the
+        // replacement alone would accept an append — "…the storethey're"
+        // contains "they're" quite happily — so the surrounding characters are
+        // what make this a check rather than a formality.
+        let fragment = self.fragment(around: range, replacement: replacement)
+
+        // 1. Set the range, then write the text into it. Disturbs nothing, and
+        //    is what a native field accepts.
+        if select(nsRange), setSelectedText(replacement), landed(fragment) {
+            Log.write("surface: wrote \(nsRange.length) chars via the accessibility range")
+            return .replaced
+        }
+
+        // 2. Set the range and paste over it. Chromium and Electron implement
+        //    selecting but not writing, so this is the branch that carries the
+        //    web — and the read-back is what makes it safe. Skipping the
+        //    question is what turns a paste into an append.
+        if select(nsRange),
+           confirmedSelection(matches: String(content[range]), range: nsRange) {
+            Log.write("surface: the range write was ignored; pasting over a confirmed selection")
+            TextInserter.insert(replacement, mode: .paste)
+            if settled(on: fragment) {
+                return .replaced
+            }
+            return .refused(repairedAfterStrayPaste())
+        }
+
+        // 3. Walk the caret to the span with arrow keys and select it by hand.
+        //
+        //    Measured, not guessed: Chromium accepts `AXSelectedTextRange` on a
+        //    contenteditable, returns `.success`, and leaves the selection
+        //    exactly where it was — asked for 14+10 it went on reporting 43+0.
+        //    That rules out both branches above for every browser and every
+        //    Electron app, which is most of the places anyone writes prose.
+        //
+        //    What the same measurement gives back is the way through. Chromium
+        //    will not *move* the selection on request, but it reports where the
+        //    caret is perfectly honestly — so the caret can be walked from where
+        //    it is to where the span starts, and every step of that walk can be
+        //    checked against the app's own account before anything is typed.
+        if let outcome = writeByWalkingTheCaret(
+            nsRange, replacement: replacement, fragment: fragment
+        ) {
+            return outcome
+        }
+
+        return .refused("this app would not let me edit it")
+    }
+
+    /// Selects a range the way a person would, and pastes over it.
+    ///
+    /// The branch that carries the web. Everything before it asks the app to
+    /// move the selection; this one moves it with the same keystrokes a person
+    /// would use, which is the one instruction a text surface cannot decline
+    /// without ceasing to be one.
+    ///
+    /// It is not blind, which is what separates it from the retype that used to
+    /// live here. Arrow keys change no text, so every step up to the paste is
+    /// free to fail — and each one is checked against the range the app reports
+    /// before the next is taken. By the time anything is written, the app has
+    /// said in its own words that exactly the intended characters are selected.
+    ///
+    /// Nil rather than a refusal when the walk is too long to be worth taking,
+    /// so the caller can fall through to its own last resort.
+    private func writeByWalkingTheCaret(
+        _ target: NSRange, replacement: String, fragment: String
+    ) -> Outcome? {
+        guard var caret = caretOffset() else {
+            Log.write("surface: the app will not say where the caret is; cannot walk to the span")
+            return nil
+        }
+
+        let end = target.location + target.length
+        let distance = abs(end - caret) + target.length
+        guard distance <= Surface.maxCaretTravel else {
+            Log.write("surface: the span is \(distance) keystrokes away; too far to walk")
+            return nil
+        }
+
+        // Collapse an existing selection first, so the caret is somewhere
+        // arithmetic can be done about. Right rather than left, which puts it at
+        // the end of what was selected — the same place a person's caret ends up.
+        if let current = SelectionReader.selectedRange(of: element), current.length > 0 {
+            post(arrowRight)
+            guard let collapsed = caretOffset() else { return nil }
+            caret = collapsed
+        }
+
+        let step = end > caret ? arrowRight : arrowLeft
+        post(step, times: abs(end - caret))
+        guard let landed = caretOffset(), landed == end else {
+            Log.write("surface: walked to \(end) but the caret reports"
+                + " \(caretOffset().map(String.init) ?? "nothing") — not typing")
+            return nil
+        }
+
+        post(arrowLeft, times: target.length, flags: .maskShift)
+        let got = SelectionReader.selectedRange(of: element)
+        guard let selected = got,
+              selected.location == target.location, selected.length == target.length else {
+            let reported = got.map { "\($0.location)+\($0.length)" } ?? "nothing"
+            Log.write("surface: selected \(reported), wanted"
+                + " \(target.location)+\(target.length) — not typing")
+            return nil
+        }
+
+        Log.write("surface: walked the caret to \(target.location)+\(target.length); pasting")
+        TextInserter.insert(replacement, mode: .paste)
+        if settled(on: fragment) { return .replaced }
+        return .refused(repairedAfterStrayPaste())
+    }
+
+    /// Where the caret is, or nil when the app will not say. A selection counts
+    /// as a caret at its start for this purpose; the caller collapses it first.
+    private func caretOffset() -> Int? {
+        guard let range = SelectionReader.selectedRange(of: element),
+              range.location != NSNotFound, range.location >= 0 else { return nil }
+        return range.location
+    }
+
+    /// Past this it is cheaper and safer to hand over the clipboard. Each step
+    /// is one synthesised key event, and a walk long enough to be slow is also
+    /// long enough for something else to move the caret underneath it — which
+    /// the check afterwards would catch, but only after a visible crawl.
+    private static let maxCaretTravel = 400
+
+    private let arrowLeft: CGKeyCode = 123
+    private let arrowRight: CGKeyCode = 124
+
+    private func post(_ key: CGKeyCode, times: Int = 1, flags: CGEventFlags = []) {
+        guard times > 0 else { return }
+        let source = CGEventSource(stateID: .combinedSessionState)
+        for _ in 0..<times {
+            guard let down = CGEvent(keyboardEventSource: source, virtualKey: key, keyDown: true),
+                  let up = CGEvent(keyboardEventSource: source, virtualKey: key, keyDown: false)
+            else { return }
+            down.flags = flags
+            up.flags = flags
+            down.post(tap: .cghidEventTap)
+            up.post(tap: .cghidEventTap)
+        }
+        // One wait for the batch rather than one per key: the app services these
+        // in order, and the only moment the result matters is after the last.
+        Thread.sleep(forTimeInterval: 0.05 + Double(times) * 0.004)
+    }
+
+    /// Undoes a paste that went somewhere other than where it was aimed.
+    ///
+    /// Cmd-Z rather than another accessibility write, because the surface has
+    /// just demonstrated that it does not honour those, and a repair built on
+    /// the mechanism that failed is not a repair. A paste is an ordinary edit in
+    /// every app this branch reaches — a browser, a composer, a mail body — and
+    /// undoing an ordinary edit is what their own history is for.
+    ///
+    /// Only when something actually changed. If the value still reads exactly as
+    /// it did, the paste landed nowhere and there is nothing of ours to take
+    /// back — pressing Cmd-Z then would undo whatever the person did before we
+    /// arrived, which is a far worse outcome than the failed correction.
+    private func repairedAfterStrayPaste() -> String {
+        guard let now = SelectionReader.visibleText(of: element),
+              folded(now) != folded(content) else {
+            Log.write("surface: the paste changed nothing; leaving the field alone")
+            return "this app would not let me edit it"
+        }
+
+        Log.write("surface: the paste landed somewhere unintended; undoing it")
+        SelectionReader.postCommandKey(0x06)   // Cmd-Z
+
+        let deadline = Date().addingTimeInterval(1.0)
+        repeat {
+            if let value = SelectionReader.visibleText(of: element),
+               folded(value) == folded(content) {
+                Log.write("surface: the stray paste is undone; the text is as it was")
+                return "this app would not let me edit it"
+            }
+            Thread.sleep(forTimeInterval: 0.05)
+        } while Date() < deadline
+
+        // Said as loudly as a log line can. Everything else in this file exists
+        // to make this branch unreachable.
+        Log.write("surface: ⚠︎ the stray paste would not undo — the field may hold the wrong text")
+        return "the edit went wrong and would not undo — check the text"
+    }
+
+    /// True once the value reads the way it would if the substitution had
+    /// happened — polled, because a paste is a request and the app services it
+    /// when it is ready.
+    ///
+    /// Reading once after a guessed delay measures the delay, not the write, and
+    /// concluding failure from that is worse than not checking at all: the
+    /// recovery then destroys work that was fine.
+    private func settled(on fragment: String) -> Bool {
+        let deadline = Date().addingTimeInterval(1.0)
+        repeat {
+            if landed(fragment) { return true }
+            Thread.sleep(forTimeInterval: 0.05)
+        } while Date() < deadline
+        return false
+    }
+
+    /// The replacement with up to 12 characters of its surroundings on each
+    /// side — the shape the value must take for the edit to have happened in
+    /// the place it was asked to happen. An append does not produce it.
+    private func fragment(around range: Range<String.Index>, replacement: String) -> String {
+        let context = 12
+        return String(content[..<range.lowerBound].suffix(context))
+            + replacement
+            + String(content[range.upperBound...].prefix(context))
+    }
+
+    private func landed(_ fragment: String) -> Bool {
+        guard let value = SelectionReader.visibleText(of: element) else { return false }
+        return folded(value).contains(folded(fragment))
+    }
+
+    /// Typographic substitution is not a failed write. Most apps turn a straight
+    /// apostrophe curly as it arrives, so "they're" comes back as "they’re" — the
+    /// edit landed, and a literal comparison would call it a refusal.
+    private func folded(_ text: String) -> String {
+        text.replacingOccurrences(of: "\u{2019}", with: "'")
+            .replacingOccurrences(of: "\u{2018}", with: "'")
+            .replacingOccurrences(of: "\u{201C}", with: "\"")
+            .replacingOccurrences(of: "\u{201D}", with: "\"")
+    }
+
+    private func select(_ range: NSRange) -> Bool {
+        var cfRange = CFRange(location: range.location, length: range.length)
+        guard let value = AXValueCreate(.cfRange, &cfRange) else { return false }
+        return AXUIElementSetAttributeValue(
+            element, kAXSelectedTextRangeAttribute as CFString, value
+        ) == .success
+    }
+
+    private func setSelectedText(_ text: String) -> Bool {
+        AXUIElementSetAttributeValue(
+            element, kAXSelectedTextAttribute as CFString, text as CFTypeRef
+        ) == .success
+    }
+
+    /// Whether the app agrees that what is selected is what we aimed at.
+    ///
+    /// Its own function because it is the only thing standing between a paste
+    /// and somebody's document. Confirming our own action is not evidence — we
+    /// set the range a moment ago, so asking "is there a selection" answers yes
+    /// whatever happened. The question has to be one the app answers out of its
+    /// own state.
+    ///
+    /// Two ways it can answer, because the surfaces that matter answer
+    /// differently. A native field hands back the selected *text*, which is the
+    /// stronger evidence and is tried first. Chromium hands back `""` for the
+    /// selected text of a contenteditable however the selection was made — by
+    /// hand, by us, at all — so insisting on text refuses every browser and
+    /// every Electron app on earth. What it does report honestly is the
+    /// *range*, and a range that reads back as the one we asked for, when the
+    /// one before it was different, is the app saying it moved the selection.
+    ///
+    /// Neither answer is taken as proof that the write worked. They only decide
+    /// whether pasting is safe to attempt; what happened afterwards is settled
+    /// by reading the value back, and by the repair below when it went wrong.
+    /// Polled, and that is not a detail. Setting a selection is a request, and
+    /// Chromium services it a beat later — read once and immediately, it reports
+    /// the caret exactly where it was, which reads identically to "this app
+    /// ignores range writes". That misreading is what sent the first version of
+    /// this file off building a keystroke walk for a branch that already worked.
+    /// The same mistake, in the same shape, is recorded twice more in this file
+    /// about pastes: reading before the app has serviced the request measures
+    /// the delay, not the write.
+    private func confirmedSelection(matches expected: String, range: NSRange) -> Bool {
+        var lastSeen = "nothing"
+        let deadline = Date().addingTimeInterval(0.6)
+        repeat {
+            if let selected = SelectionReader.selectedText(of: element), !selected.isEmpty {
+                if folded(selected).compare(
+                    folded(expected), options: .caseInsensitive
+                ) == .orderedSame {
+                    return true
+                }
+                lastSeen = "\"\(selected.prefix(40))\""
+            } else if let echoed = SelectionReader.selectedRange(of: element) {
+                // Chromium reports `""` for the selected text of a
+                // contenteditable however the selection was made — by hand, by
+                // us, at all — so insisting on text refuses every browser and
+                // every Electron app. The range it does report honestly.
+                if echoed.location == range.location, echoed.length == range.length {
+                    return true
+                }
+                lastSeen = "\(echoed.location)+\(echoed.length)"
+            }
+            Thread.sleep(forTimeInterval: 0.03)
+        } while Date() < deadline
+
+        Log.write("surface: asked to select \(range.location)+\(range.length),"
+            + " the app still reports \(lastSeen); not pasting")
+        return false
+    }
+
+    // MARK: - The screen path
+
+    /// A terminal takes keystrokes and refuses everything else, so the input
+    /// line is cleared and retyped whole — computed from the span, but written
+    /// as one line because that is the only unit a terminal exposes.
+    ///
+    /// The caret's position inside the input is invisible to accessibility, so
+    /// there is no way to address a range here without assuming where it starts,
+    /// and an assumption that is wrong edits the wrong characters.
+    private func writeScreen(updated: String) -> Outcome {
+        guard let config = try? ConfigStore.load(), config.transcription.rewriteLine else {
+            return .refused("rewrite_line is off, so terminals cannot be edited")
+        }
+        guard clearedBox() else {
+            return .refused("could not empty the line; not retyping over what is left")
+        }
+
+        TextInserter.insert(updated, mode: .paste)
+        if box(reads: updated) {
+            Log.write("surface: retyped \(updated.count) chars of input line")
+            return .replaced
+        }
+
+        // Put it back deliberately rather than with Ctrl-Y. The paste has
+        // already happened, so yanking inserts what Ctrl-K took *after*
+        // whatever landed and leaves you holding both — which is how a truncated
+        // correction became a duplicated line. We still have the text that was
+        // there, so type that and depend on nothing.
+        Log.write("surface: the line did not come back as expected; restoring it")
+        _ = clearedBox()
+        TextInserter.insert(content, mode: .paste)
+        Thread.sleep(forTimeInterval: 0.20)
+        return .refused("the terminal would not take the rewrite")
+    }
+
+    /// Empties the input line, checking between presses rather than assuming.
+    ///
+    /// Ctrl-K kills to the end of the *visual row* in this TUI, not the end of
+    /// the logical line, so one press leaves behind everything a wrap pushed
+    /// onto the rows below — and the retype then lands on top of the remainder.
+    /// Pressing until the box reads empty is the only version of this that
+    /// survives a line that wrapped.
+    ///
+    /// There is no blind branch. There used to be: when the box could not be
+    /// read this pressed the keys anyway and returned `true`, which on any
+    /// surface that does not implement readline meant nothing was cleared and
+    /// the caller pasted onto the end of the line. That is the append.
+    private func clearedBox() -> Bool {
+        for _ in 0..<12 {
+            switch boxIsEmpty() {
+            case true: return true
+            case false: break
+            case nil:
+                Log.write("surface: cannot read the input box back; refusing to clear blind")
+                return false
+            }
+            SelectionReader.postControlKey(0x00)   // Ctrl-A, start of line
+            Thread.sleep(forTimeInterval: 0.06)
+            SelectionReader.postControlKey(0x28)   // Ctrl-K, kill to end of line
+            Thread.sleep(forTimeInterval: 0.12)
+        }
+        return boxIsEmpty() == true
+    }
+
+    private func boxIsEmpty() -> Bool? {
+        guard let value = SelectionReader.visibleText(of: element),
+              let box = SelectionReader.joinedInputBox(in: value) else { return nil }
+        return box.isEmpty
+    }
+
+    /// Whether the box now holds exactly the text we retyped.
+    ///
+    /// Equality, not containment. A box reading "Jery is on vacationJerry is on
+    /// vacation" *contains* the corrected line, and containment is what reported
+    /// that append as a clean retype for as long as this bug existed.
+    private func box(reads expected: String) -> Bool {
+        let deadline = Date().addingTimeInterval(1.5)
+        repeat {
+            if let value = SelectionReader.visibleText(of: element),
+               let box = SelectionReader.joinedInputBox(in: value),
+               folded(box) == folded(expected) {
+                return true
+            }
+            Thread.sleep(forTimeInterval: 0.05)
+        } while Date() < deadline
+        return false
+    }
+}

--- a/Sources/ParrotFlow/Surface.swift
+++ b/Sources/ParrotFlow/Surface.swift
@@ -672,10 +672,14 @@ struct Surface {
     /// the caller pasted onto the end of the line. That is the append.
     private func clearedBox() -> Bool {
         for _ in 0..<12 {
+            // Spelled `.some`/`.none` rather than `true`/`false`/`nil`. Both
+            // read the same, and only this one is exhaustive to every compiler
+            // that has to build it — Swift 6.3 accepts the literals, the 6.0 on
+            // the CI runner asks for `.some(_)` and fails the build.
             switch boxIsEmpty() {
-            case true: return true
-            case false: break
-            case nil:
+            case .some(true): return true
+            case .some(false): break
+            case .none:
                 Log.write("surface: cannot read the input box back; refusing to clear blind")
                 return false
             }

--- a/Sources/ParrotFlow/Surface.swift
+++ b/Sources/ParrotFlow/Surface.swift
@@ -113,12 +113,16 @@ struct Surface {
             return nil
         }
         guard let value = SelectionReader.visibleText(of: element) else {
-            // Ghostty and iTerm land here and always will: they focus the
-            // window, render their screen with Metal, and publish nothing but
-            // chrome to accessibility. Walking down from the window finds their
-            // tab title — 44 characters where the screen is two thousand — and
-            // treating that as the input line would retype chrome into the pty.
-            // So this refuses, and the text goes to the clipboard.
+            // A window that has not finished handing over its text view lands
+            // here too, which is why `read` retries rather than taking this as
+            // final. Ghostty and iTerm both answer this way for a few hundred
+            // milliseconds after coming forward, and reading them once was
+            // enough to write them up as terminals that publish nothing at all.
+            //
+            // Walking down from the window to find *some* text was tried and
+            // taken out again: it reaches the tab title long before the screen,
+            // and retyping that into a pty is worse than declining. Waiting is
+            // the fix; searching is not.
             Log.write("surface: the focused element has no readable value")
             return nil
         }

--- a/Sources/ParrotFlow/Surface.swift
+++ b/Sources/ParrotFlow/Surface.swift
@@ -261,6 +261,28 @@ struct Surface {
         content.range(of: needle, options: [.caseInsensitive, .backwards])
     }
 
+    /// Every range holding `needle`, in the order they appear.
+    ///
+    /// For callers that have to know whether the text is ambiguous before they
+    /// pick one. "Nearest the end" is a fine answer when the word was dictated a
+    /// moment ago and a bad one when the caller is pointing at a specific
+    /// occurrence — and the difference between those is not visible from a
+    /// single range.
+    func ranges(of needle: String) -> [Range<String.Index>] {
+        var found: [Range<String.Index>] = []
+        var from = content.startIndex
+        while let next = content.range(
+            of: needle, options: [.caseInsensitive], range: from..<content.endIndex
+        ) {
+            found.append(next)
+            from = next.lowerBound < next.upperBound
+                ? next.upperBound
+                : content.index(after: next.lowerBound)
+            if from >= content.endIndex { break }
+        }
+        return found
+    }
+
     // MARK: - Writing
 
     enum Outcome: Equatable {

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -170,7 +170,36 @@ if let index = arguments.firstIndex(of: "--peek") {
     let sentinel = arguments.firstIndex(of: "--find").flatMap { found in
         arguments.indices.contains(found + 1) ? arguments[found + 1] : nil
     }
-    exit(PeekCommand.run(seconds: seconds ?? 3, expecting: sentinel))
+    exit(PeekCommand.run(
+        seconds: seconds ?? 3, expecting: sentinel,
+        viaCopy: arguments.contains("--via-copy")
+    ))
+}
+
+if let index = arguments.firstIndex(of: "--span-test") {
+    guard arguments.indices.contains(index + 3),
+          let start = Int(arguments[index + 1]), let length = Int(arguments[index + 2]) else {
+        print("usage: ParrotFlow --span-test <start> <length> <replacement> --find <sentinel> [--after <seconds>]")
+        exit(2)
+    }
+    guard let found = arguments.firstIndex(of: "--find"),
+          arguments.indices.contains(found + 1) else {
+        print("✗ --find <sentinel> is required; it is what stops this writing into a real window")
+        exit(2)
+    }
+    let seconds = arguments.firstIndex(of: "--after").flatMap { after in
+        arguments.indices.contains(after + 1) ? Double(arguments[after + 1]) : nil
+    }
+    let dictated = arguments.firstIndex(of: "--dictated").flatMap { said in
+        arguments.indices.contains(said + 1) ? arguments[said + 1] : nil
+    }
+    exit(EditTestCommand.runSpan(
+        start: start, length: length,
+        replacement: arguments[index + 3],
+        sentinel: arguments[found + 1],
+        dictated: dictated,
+        seconds: seconds ?? 3
+    ))
 }
 
 if let index = arguments.firstIndex(of: "--edit-test") {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -8,8 +8,10 @@ transcription:
   # instruction about the words before it. An empty list turns this off.
   activation_phrases: [hey parrot, by the way parrot]
 
-  # For fields Accessibility cannot write, terminals mostly: clear the line with
-  # Ctrl-A Ctrl-K and retype it corrected, if it still holds what you dictated.
+  # Terminals only. Their accessibility value is a picture of a screen, so
+  # the only thing that writes there is keystrokes: clear the input line
+  # with Ctrl-A Ctrl-K and retype it corrected. Everywhere else — a field,
+  # a browser, Slack, Outlook — edits the range directly and ignores this.
   rewrite_line: true
 
   # Languages you dictate in, most spoken first — the first is the fallback for

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,7 @@
 | Config | `Config.swift` | Yams + a `DispatchSource` file watcher for live reload |
 | Permissions | `Permissions.swift` | `AVCaptureDevice` for mic, `AXIsProcessTrusted` for Accessibility |
 | Text insertion | `TextInserter.swift`, `SelectionReader.swift` | Paste-via-clipboard, then the pasteboard is put back |
+| Editing in place | `Surface.swift` | The field as one string plus one span, and the ladder that substitutes a range of it — [below](#editing-text-that-is-already-there) |
 | Where the words go | `Destination.swift` | Asks the focused element whether it takes text, at the press — decides the pill's icon and whether the transcript is typed or copied |
 | Menu bar & wiring | `AppDelegate.swift` | |
 | Logging | `Log.swift` | `~/Library/Logs/ParrotFlow.log` — a menu bar app has no console |
@@ -34,6 +35,95 @@ prompt — a steep price when a bare modifier types nothing on its own, so there
 is nothing to swallow. Polling `CGEventSource.flagsState` every 25 ms needs no
 permission at all. The trade is ~25 ms of latency and no way to stop the key
 also reaching the frontmost app.
+
+## Editing text that is already there
+
+Dictation writes at the caret. Everything else — a correction, a transform over
+a selection, a rewrite of the sentence you just said — has to change text that
+is already on screen without disturbing the rest of it. That is `Surface`.
+
+It answers two questions and nothing else. **What is in the field**, as one
+string, and **what is selected**, as offsets into that same string. A caller
+that knows which characters it wants changed says so; nothing searches for
+anything.
+
+    let surface = Surface.read()
+    surface.content        // the whole editable text
+    surface.span           // the selection, as offsets into it
+    surface.replace(range, with: "Jerry")
+
+Two kinds, because only one distinction survives contact with real apps:
+
+| Kind | What `content` is | How it is written |
+| --- | --- | --- |
+| `editable` | the accessibility value itself | a range write, else a selection plus a paste, else the caret is walked to the span |
+| `screen` | the input box, read back out of a terminal's picture of itself | the line is cleared and retyped whole |
+
+A native field, a browser, an Electron composer and a webview are all
+`editable`. They are not told apart in advance, because the thing that
+distinguishes them cannot be read — it can only be discovered by writing and
+looking. A terminal is named rather than examined, the same way `Destination`
+names it.
+
+### The three rules that keep this safe
+
+**Nothing is trusted to have worked because it returned success.** Setting an
+accessibility attribute reports `.success` in surfaces that ignore it entirely.
+Every branch reads the value back and looks for the replacement *with the
+characters that should surround it* — an append produces the replacement but
+never the neighbourhood, which is the difference between "Jerry is on vacation"
+and "Jery is on vacationJerry is on vacation".
+
+**Nothing is written blind.** The old retype pressed ⌃A ⌃K and typed whatever
+happened next, which in anything that is not a terminal cleared nothing and
+appended everything. A clear that cannot be verified is now a refusal.
+
+**A request is not an action.** Selecting a range, pasting, and killing a line
+are all things you ask an app to do and it does when it is ready. Reading back
+immediately measures the delay, not the write. Every check here polls — and the
+one place that did not is why the caret-walking branch below exists at all.
+
+### What each surface actually does
+
+Measured with `--peek` and `--span-test`, not assumed:
+
+- **A native field** takes the range write, the first and cheapest branch.
+- **Chromium** — so Slack, the new Outlook, and every browser — accepts
+  `AXSelectedTextRange`, returns `.success`, and applies it *a beat later*. Read
+  immediately it reports the caret exactly where it was, which is
+  indistinguishable from refusing. Polling for half a second is the whole fix.
+  It reports `""` for the selected text of a contenteditable however the
+  selection was made, so the range it echoes back is the evidence, not the text.
+- **A terminal** — Terminal.app, Ghostty and iTerm all behave the same way —
+  refuses everything but keystrokes, so the line is cleared and retyped, and the
+  clear is checked between presses because ⌃K kills to the end of a *visual* row
+  and a wrapped line takes several. The full case set scores 8/8 in each of the
+  three.
+- **Ghostty hands back the window for a moment after it comes forward**, and its
+  text view only once focus has landed. Peeked in that gap it reports no value
+  at all, which reads exactly like a terminal that publishes nothing — it was
+  misread that way here, and written up as an app that could not be edited
+  before the harness was pointed at it and scored 6/8 rather than 0. The two
+  failures were empty reads, not bad writes. Retrying the read for 0.6 s makes
+  it 8/8. Nothing about Ghostty needed working around; the read simply had to
+  wait, which is the same lesson as every poll in this file.
+
+The caret-walking branch is the last resort for an `editable` that will not move
+its selection on request: the caret is stepped to the span with arrow keys and
+the span selected with ⇧←, checking the app's own reported range at every step.
+Arrow keys change no text, so everything up to the paste is free to fail.
+
+### When it goes wrong anyway
+
+A paste that lands somewhere unintended is undone with ⌘Z — the app's own edit
+history, which is the one mechanism guaranteed to work in a surface that has
+just proved it does not honour accessibility writes. Only when the value
+actually changed: if the paste landed nowhere, ⌘Z would undo whatever the person
+did before we arrived.
+
+And every substitution leaves an undo record, which is what `"hey parrot, undo"`
+puts back. It compares what is on screen against what it wrote and refuses if
+the text has moved on, because an undo fired against edited text is not an undo.
 
 ## Where the time goes
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -131,13 +131,23 @@ $PF --transcribe /tmp/t.wav
 ```sh
 $PF --peek 3 [--find <sentinel>]
 $PF --edit-test <needle> <replacement> --find <sentinel> [--after 3] [--literal]
+$PF --span-test <start> <length> <replacement> --find <sentinel> [--after 3]
 ```
 
-`--peek` reads the selection the way the app would. `--edit-test` performs a
-real in-place edit in the frontmost window after a delay, which is why
-`--find <sentinel>` is **required**: without it this writes into whatever
-happens to be in front, which during a test run is as likely to be a real
-window as the scratch one you meant.
+`--peek` reads the surface the way the app would — the value, the selection, and
+then the same thing as `Surface` sees it: the content as one string and the span
+as offsets into it. That last block is the one that decides what a write does;
+when it and the raw accessibility lines above it disagree, the surface block is
+the one that matters.
+
+`--edit-test` performs a real in-place edit after a delay, finding the text by
+searching for it. `--span-test` does the same to a character range given
+outright, which is how the app itself now works — a caller that knows which
+characters it wants changed says so, and nothing searches for anything.
+
+`--find <sentinel>` is **required** for both: without it these write into
+whatever happens to be in front, which during a test run is as likely to be a
+real window as the scratch one you meant.
 
 ## Looking at the floating surfaces
 
@@ -170,6 +180,10 @@ scripts/check-routing.sh           scripts/check-wake.sh
 scripts/check-split.sh             scripts/check-grammar.sh
 scripts/check-dates.sh             scripts/check-inplace.sh
 scripts/check-default-config.sh    scripts/check-example-script.sh
+scripts/check-span.sh              # a composer-shaped page, or Slack, or Outlook
+
+PF_VIEWPORT=Ghostty scripts/check-inplace.sh   # the same set, in another terminal
+$PF --peek 3 --via-copy                        # what Select All + Copy hands back
 
 scripts/validate-prompt.py gemma4:e4b        # spelling + French correction sets
 scripts/validate-code-identifiers.py         # the identifier transform

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -126,9 +126,17 @@ before it, in the same breath — which is why there are two. See
 
 ## `transcription.rewrite_line`
 
-Last resort for fields Accessibility cannot write, terminals mostly: clear the
-input line with ⌃A ⌃K and retype it corrected. Destructive by nature, so it only
-fires when the line still holds what you dictated.
+Terminals only. Their accessibility value is a picture of a screen rather than
+an editable buffer, so the only thing that writes there is keystrokes: the input
+line is cleared with ⌃A ⌃K and retyped corrected. Destructive by nature, which is
+why it is a setting — but it is checked rather than hoped, and a clear that
+cannot be read back is a refusal rather than a guess.
+
+Everywhere else — a field, a browser, Slack, Outlook — edits a range directly and
+never touches this. It used to be the fallback for those too, which is how a
+correction ended up appended to the end of a line instead of replacing a word in
+it: ⌃K clears nothing in a composer, and the paste that followed landed on the
+end of what was still there.
 
 ## `transcription.replacements`
 

--- a/docs/corrections.md
+++ b/docs/corrections.md
@@ -63,6 +63,22 @@ and a rule for "Das mean" matches nothing you will ever say. Since the target
 spelling is already known from the letters, the closest match to it in the last
 transcript is the word that needs fixing.
 
+## In Slack, in a browser, in Outlook
+
+These all work the same way and are not told apart: what a correction needs is
+the field's text and the characters to change, and a composer, a webview and a
+mail body all supply both.
+
+The one that took measuring is Chromium — Slack, the new Outlook, every browser
+tab. It accepts a request to move the selection, answers `.success`, and does it
+a moment later; asked what it has selected in a contenteditable it says `""`
+whatever is highlighted. Read too early, that is indistinguishable from an app
+that ignores the request, and it was misread that way for a while. Waiting for
+the answer is the whole of the fix.
+
+`scripts/check-span.sh` scores this against a local fixture page that behaves
+like a composer, and against Slack or Outlook directly if you focus one.
+
 ## What it needs
 
 Ollama running with the model in `llm.model` (`ollama pull gemma4:e4b`), and

--- a/scripts/check-inplace.sh
+++ b/scripts/check-inplace.sh
@@ -29,6 +29,13 @@ BIN="$APP/Contents/MacOS/ParrotFlow"
 SESSION="${PF_CHECK_SESSION:-pfcheck}"
 CLAUDE="$(command -v claude || echo "$HOME/.local/bin/claude")"
 SCRATCH="${TMPDIR:-/tmp}/pf-check-inplace"
+# Which terminal hosts the fixture. Terminal.app by default because it is on
+# every Mac; the point of the switch is that "does in-place editing work in a
+# terminal" has a different answer per terminal, and the only way to know is to
+# run the set in each one.
+#
+#   PF_VIEWPORT=Ghostty scripts/check-inplace.sh
+VIEWPORT="${PF_VIEWPORT:-Terminal}"
 
 [ -x "$TMUX" ]  || { echo "tmux not found"; exit 1; }
 [ -d "$APP" ]   || { echo "install the dev app first: make install"; exit 1; }
@@ -70,7 +77,7 @@ start_fixture() {
   chmod +x "$SCRATCH/attach.command"
   # A freshly opened window is frontmost without anyone having to click, which
   # is what lets this run unattended.
-  open -a Terminal "$SCRATCH/attach.command"
+  open -a "$VIEWPORT" "$SCRATCH/attach.command"
   sleep 4
 }
 
@@ -81,7 +88,7 @@ pass=0; total=0; refused=0; corrupted=0; skipped=0; wrongpath=0
 start_fixture
 trap '"$TMUX" kill-session -t "$SESSION" 2>/dev/null' EXIT
 
-while IFS='|' read -r name id dictated line heard corrected expect literal want_log; do
+while IFS='|' read -r name id dictated line heard corrected expect literal want_log span; do
   [ -z "$name" ] && continue
   total=$((total + 1))
 
@@ -96,9 +103,23 @@ while IFS='|' read -r name id dictated line heard corrected expect literal want_
   [ "$expect" = "unchanged" ] && want="$line" || want="$expect"
 
   mark=$(grep -c "" "$LOG" 2>/dev/null || echo 0)
-  open -a Terminal; sleep 2
-  open -g -na ParrotFlowDev --args \
-    --edit-test "$heard" "$corrected" --find "$id" --dictated "$dictated" $literal --after 3
+  open -a "$VIEWPORT"; sleep 2
+  # A span case names the range; the offsets come from the seeded line, which
+  # the check above has just confirmed is what is on screen. Computed here
+  # rather than written into the case file, so they cannot drift from the text.
+  if [ -n "$span" ]; then
+    read -r start length < <(python3 -c '
+import sys
+line, heard = sys.argv[1], sys.argv[2]
+i = line.index(heard)
+print(i, len(heard))
+' "$line" "$heard")
+    open -g -na ParrotFlowDev --args \
+      --span-test "$start" "$length" "$corrected" --find "$id" --dictated "$dictated" --after 3
+  else
+    open -g -na ParrotFlowDev --args \
+      --edit-test "$heard" "$corrected" --find "$id" --dictated "$dictated" $literal --after 3
+  fi
   sleep 7
 
   got="$(input_region)"
@@ -130,7 +151,8 @@ for c in yaml.safe_load(open(sys.argv[1]))["cases"]:
     print("|".join(str(c[k]) for k in
         ("name", "id", "dictated", "line", "heard", "corrected", "expect"))
           + "|" + ("--literal" if c.get("literal") else "")
-          + "|" + str(c.get("log", "")))
+          + "|" + str(c.get("log", ""))
+          + "|" + ("span" if c.get("span") else ""))
 ' "$ROOT/tests/inplace-cases.yaml")
 
 echo

--- a/scripts/check-span.sh
+++ b/scripts/check-span.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Scores span substitution against a real surface, from tests/span-cases.yaml.
+#
+#   scripts/check-span.sh              # the local fixture in Chrome, unattended
+#   scripts/check-span.sh slack        # you focus Slack's composer, it scores
+#   scripts/check-span.sh outlook      # you focus an Outlook message body
+#
+# The oracle is never the accessibility API, because the accessibility API is
+# what is on trial — it has reported a corrupting paste as a clean write. So:
+#
+#   fixture   the page publishes its own DOM in document.title, read with
+#             AppleScript. Owes nothing to accessibility and needs no typing.
+#   an app    the text is read back with a synthetic Cmd-A Cmd-C and pbpaste,
+#             which goes through the app's own copy implementation rather than
+#             through the attribute the write used.
+#
+# Two counters, because the failures are not equally bad. A substitution that
+# does not happen costs a trip to the clipboard. One that happens to the wrong
+# characters costs the text, and that is the one this exists to prevent.
+#
+# Requires the dev app installed (`make install`) with Accessibility granted.
+# The fixture mode also needs Chrome, and macOS will ask once for permission to
+# control it.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP="/Applications/ParrotFlowDev.app"
+TARGET="${1:-fixture}"
+FIXTURE="$ROOT/tests/fixtures/composer.html"
+LOG="$HOME/Library/Logs/ParrotFlow-Dev.log"
+
+[ -d "$APP" ] || { echo "install the dev app first: make install"; exit 1; }
+
+# --- the two oracles ---------------------------------------------------------
+
+read_fixture() {
+  osascript -e 'tell application "Google Chrome" to get title of active tab of front window' 2>/dev/null \
+    | sed -n 's/^PFBOX|//p'
+}
+
+read_app() {
+  osascript -e 'tell application "System Events" to keystroke "a" using command down' 2>/dev/null
+  sleep 0.3
+  osascript -e 'tell application "System Events" to keystroke "c" using command down' 2>/dev/null
+  sleep 0.4
+  pbpaste | tr '\n' ' ' | sed 's/[[:space:]]*$//'
+}
+
+seed_fixture() {
+  local text="$1"
+  local encoded
+  encoded="$(python3 -c 'import sys,urllib.parse; print(urllib.parse.quote(sys.argv[1]))' "$text")"
+  osascript >/dev/null 2>&1 <<OSA
+tell application "Google Chrome"
+  activate
+  if (count of windows) = 0 then make new window
+  set URL of active tab of front window to "file://$FIXTURE#$encoded"
+end tell
+OSA
+  # Long enough for the navigation to settle and the page to take focus back
+  # from the omnibox. Short of this the app reads the address bar instead of the
+  # composer, refuses correctly, and the case scores a refusal that says nothing
+  # about the write path.
+  sleep 2
+}
+
+seed_app() {
+  local text="$1"
+  # Clear whatever is there, then type the seed. Typing rather than pasting:
+  # a paste is the mechanism under test, and seeding with it would let a broken
+  # paste hide behind a broken seed.
+  osascript -e 'tell application "System Events" to keystroke "a" using command down' 2>/dev/null
+  sleep 0.2
+  osascript -e 'tell application "System Events" to key code 51' 2>/dev/null
+  sleep 0.3
+  osascript -e "tell application \"System Events\" to keystroke \"$text\"" 2>/dev/null
+  sleep 0.8
+}
+
+case "$TARGET" in
+  fixture) READ=read_fixture; SEED=seed_fixture ;;
+  *)       READ=read_app;     SEED=seed_app ;;
+esac
+
+if [ "$TARGET" != "fixture" ]; then
+  echo "Focus the $TARGET composer you want scored. Starting in 8s."
+  echo "Everything in it will be selected and replaced — use a scratch message."
+  sleep 8
+fi
+
+# --- the run -----------------------------------------------------------------
+
+pass=0; total=0; refused=0; corrupted=0; skipped=0
+
+while IFS='|' read -r name id seed target replacement expect; do
+  [ -z "$name" ] && continue
+  total=$((total + 1))
+
+  $SEED "$seed"
+  got="$($READ)"
+  if [ "$got" != "$seed" ]; then
+    printf '  ⊘ %s — seed did not land (read back "%s")\n' "$name" "$got"
+    skipped=$((skipped + 1)); continue
+  fi
+
+  # Offsets computed from the seed we just confirmed is there, so the span is a
+  # fact about the content rather than a number written by hand into the cases.
+  read -r start length < <(python3 -c '
+import sys
+seed, target = sys.argv[1], sys.argv[2]
+i = seed.index(target)
+print(i, len(target))
+' "$seed" "$target")
+
+  [ "$expect" = "unchanged" ] && want="$seed" || want="$expect"
+
+  open -g -na ParrotFlowDev --args \
+    --span-test "$start" "$length" "$replacement" --find "$id" --after 2
+  sleep 6
+
+  got="$($READ)"
+  # Curly quotes are not a failed write — most composers substitute them on the
+  # way in, and the app folds them for exactly this reason.
+  norm() { printf '%s' "$1" | sed "s/[’‘]/'/g; s/[“”]/\"/g"; }
+  if [ "$(norm "$got")" = "$(norm "$want")" ]; then
+    pass=$((pass + 1)); printf '  ✓ %s\n' "$name"
+  elif [ "$(norm "$got")" = "$(norm "$seed")" ]; then
+    refused=$((refused + 1))
+    printf '  ✗ %s\n      refused — the text is untouched but should have changed\n' "$name"
+  else
+    corrupted=$((corrupted + 1))
+    printf '  ✗ %s\n      got  %s\n      want %s\n      (altered into something neither)\n' \
+      "$name" "$got" "$want"
+  fi
+done < <(python3 -c '
+import sys, yaml
+for c in yaml.safe_load(open(sys.argv[1]))["cases"]:
+    print("|".join(str(c[k]) for k in
+        ("name", "id", "seed", "target", "replacement", "expect")))
+' "$ROOT/tests/span-cases.yaml")
+
+echo
+printf '  %d/%d  (%s)\n' "$pass" "$total" "$TARGET"
+[ "$refused"   -gt 0 ] && printf '    %d refused when it should have substituted\n' "$refused"
+[ "$corrupted" -gt 0 ] && printf '    %d altered the text  ← the one that costs you your words\n' "$corrupted"
+[ "$skipped"   -gt 0 ] && printf '    %d skipped — the surface was not in a known state\n' "$skipped"
+[ "$pass" = "$total" ]

--- a/tests/fixtures/composer.html
+++ b/tests/fixtures/composer.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>PFBOX|</title>
+<style>
+  body { font: 15px/1.5 -apple-system, sans-serif; margin: 0; padding: 40px; background: #1a1d21; color: #d1d2d3; }
+  h1 { font-size: 13px; font-weight: 600; color: #868686; margin: 0 0 12px; letter-spacing: .04em; text-transform: uppercase; }
+  #composer { min-height: 96px; padding: 12px 14px; border: 1px solid #565856; border-radius: 8px; background: #222529; outline: none; white-space: pre-wrap; }
+  #composer:focus { border-color: #1d9bd1; }
+  p { color: #868686; font-size: 12px; margin: 14px 0 0; }
+</style>
+</head>
+<body>
+
+<!--
+  A composer shaped like the ones that break in-place editing.
+
+  Not a <textarea>. A textarea is a native control and macOS gives it a real
+  accessibility implementation for free, which is exactly the case that already
+  worked — so testing against one would prove nothing about Slack, about the new
+  Outlook, or about any of the web. A contenteditable div is what those actually
+  are, and what makes the accessibility API answer questions about a tree of
+  nodes rather than about a string.
+
+  The oracle is the page's own DOM, published in document.title, where AppleScript
+  can read it without going anywhere near the API under test. That independence
+  is the entire point of this file: the write path reports its own success through
+  accessibility, and accessibility is what is on trial. A verdict has to come from
+  somewhere else.
+
+  Seeded through the URL fragment rather than by typing, so a case starts from an
+  exact known string:
+
+      file://…/composer.html#PFCHK-301%20Jery%20is%20on%20vacation
+-->
+
+<h1>ParrotFlow span fixture</h1>
+<div id="composer" contenteditable="true" spellcheck="false"></div>
+<p>The title mirrors this box. <code>PFBOX|&lt;contents&gt;</code></p>
+
+<script>
+  var composer = document.getElementById('composer');
+
+  // innerText rather than textContent: a contenteditable turns a wrapped line
+  // into separate nodes, and textContent would run the pieces together with no
+  // separator — reporting "onvacation" for a box plainly reading "on vacation"
+  // and failing every case for a reason that has nothing to do with the write.
+  function publish() {
+    document.title = 'PFBOX|' + composer.innerText.replace(/ /g, ' ').replace(/\n+$/, '');
+  }
+
+  function seed() {
+    var text = decodeURIComponent(location.hash.slice(1));
+    composer.textContent = text;
+    publish();
+    composer.focus();
+    // Caret to the end, where a composer leaves it after you type — a test that
+    // started from a collapsed selection at position 0 would be starting from a
+    // state no real use produces.
+    var range = document.createRange();
+    range.selectNodeContents(composer);
+    range.collapse(false);
+    var selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+
+  composer.addEventListener('input', publish);
+  window.addEventListener('hashchange', seed);
+
+  // Navigating by setting the URL leaves Chrome's focus in the omnibox often
+  // enough to make the harness flaky — the app then reads the address bar,
+  // finds no composer, and refuses. It refuses correctly, which is the point,
+  // but a fixture that measures Chrome's focus behaviour is not measuring the
+  // thing under test. So the box takes focus back whenever the window gets it.
+  window.addEventListener('focus', function () { composer.focus(); });
+  document.addEventListener('visibilitychange', function () {
+    if (!document.hidden) composer.focus();
+  });
+
+  seed();
+  // Once more after the navigation has fully settled, for the same reason.
+  setTimeout(seed, 250);
+</script>
+
+</body>
+</html>

--- a/tests/inplace-cases.yaml
+++ b/tests/inplace-cases.yaml
@@ -85,3 +85,36 @@ cases:
     corrected: Georgy
     expect: PFCHK-206 I saw a movie with Georgy.So Georgy.
     log: retyped
+
+  # --- spans, addressed rather than searched for ---------------------------
+  #
+  # Everything above says "the line reads X, make it read Y" and lets the app
+  # find the words. These name a range instead, which is what the app now does
+  # internally and what a prompt handed the content plus a selection will
+  # produce. `span: true` computes the offsets from `heard` inside `line`, so
+  # the case file stays readable and the numbers stay honest.
+
+  # The worry this whole layer exists for: several dictated sentences in one
+  # box, and the word to fix is in the first. Retyping from the last transcript
+  # would delete the rest of the line.
+  - name: a span in the earlier of two sentences
+    id: PFCHK-210
+    dictated: PFCHK-210 Jery is on vacation. I will ask him Monday.
+    line: PFCHK-210 Jery is on vacation. I will ask him Monday.
+    heard: Jery
+    corrected: Jerry
+    expect: PFCHK-210 Jerry is on vacation. I will ask him Monday.
+    span: true
+    log: retyped
+
+  # Only the named occurrence moves. A find-and-replace cannot express this;
+  # the point of a span is that it says which one.
+  - name: a span over the second of two identical words
+    id: PFCHK-211
+    dictated: PFCHK-211 Jery said Jery is away
+    line: PFCHK-211 Jery said Jery is away
+    heard: Jery is
+    corrected: Jerry is
+    expect: PFCHK-211 Jery said Jerry is away
+    span: true
+    log: retyped

--- a/tests/span-cases.yaml
+++ b/tests/span-cases.yaml
@@ -1,0 +1,85 @@
+# Cases for scripts/check-span.sh — substituting a character range in place.
+#
+# The question here is narrower than tests/inplace-cases.yaml asks. That one
+# starts from "the field says X, make it say Y" and lets the app find the words.
+# This starts from a range that is already known — the caller says *these
+# characters*, and the only thing under test is whether exactly those change.
+#
+#   seed         what is in the composer when the substitution fires
+#   target       the substring whose offsets become the span; found once, exactly
+#   replacement  what those characters become
+#   expect       the whole content afterwards, or `unchanged` where refusing is right
+#
+# Refusing is a passing result wherever the write cannot be verified. A
+# substitution that does not happen costs a trip to the clipboard; one that
+# happens to the wrong characters costs the text.
+cases:
+  # The bug that started this. In a surface where the range write is ignored,
+  # the old code cleared nothing and pasted, and the result contained the
+  # corrected text — so the check passed while the line read both versions.
+  - name: one word, mid-sentence
+    id: PFCHK-301
+    seed: PFCHK-301 Jery is on vacation
+    target: Jery
+    replacement: Jerry
+    expect: PFCHK-301 Jerry is on vacation
+
+  # The same word twice, and only the named range moves. A find-and-replace
+  # cannot express this and would have to pick one by rule; a span says which.
+  - name: the second of two identical words
+    id: PFCHK-302
+    seed: PFCHK-302 Jery said Jery is away
+    target: Jery is
+    replacement: Jerry is
+    expect: PFCHK-302 Jery said Jerry is away
+
+  # The user's case: several dictated sentences in one box, and the word to fix
+  # is in the first. Retyping from the last transcript would delete the rest.
+  - name: a word in the earlier of two sentences
+    id: PFCHK-303
+    seed: PFCHK-303 Jery is on vacation. I will ask him on Monday.
+    target: Jery
+    replacement: Jerry
+    expect: PFCHK-303 Jerry is on vacation. I will ask him on Monday.
+
+  # Punctuation immediately after the span. A word-boundary rule cannot match
+  # past a full stop, which is how "Sixty Euros." became "Sixty Euros.60 Euros."
+  - name: a phrase ending in punctuation
+    id: PFCHK-304
+    seed: PFCHK-304 It costs Sixty Euros.
+    target: Sixty Euros.
+    replacement: 60 Euros.
+    expect: PFCHK-304 It costs 60 Euros.
+
+  # The span at the very end, where an append and a correct substitution produce
+  # strings that differ only in what was left behind.
+  - name: the last word in the box
+    id: PFCHK-305
+    seed: PFCHK-305 send it to Tasmin
+    target: Tasmin
+    replacement: Tasmeen
+    expect: PFCHK-305 send it to Tasmeen
+
+  # Growing and shrinking the content, so the offsets after the span move.
+  - name: a replacement longer than what it replaces
+    id: PFCHK-306
+    seed: PFCHK-306 the DB is down and the DB is slow
+    target: DB is down
+    replacement: database is completely down
+    expect: PFCHK-306 the database is completely down and the DB is slow
+
+  - name: a replacement shorter than what it replaces
+    id: PFCHK-307
+    seed: PFCHK-307 please review the pull request today
+    target: the pull request
+    replacement: it
+    expect: PFCHK-307 please review it today
+
+  # An apostrophe, which most composers turn curly on the way in. The check
+  # folds them, because a typographic substitution is not a failed write.
+  - name: a replacement carrying an apostrophe
+    id: PFCHK-308
+    seed: PFCHK-308 their going to the store
+    target: their
+    replacement: they're
+    expect: PFCHK-308 they're going to the store


### PR DESCRIPTION
Asking for a word to be corrected appended the correction to the end of the line instead — `"Jery is on vacationJerry is on vacation"`. Reported in Slack; reproducible anywhere that is not a terminal.

## The bug

Two verification holes let a blind paste report success:

- **`clearedInput`** pressed ⌃A ⌃K blind and returned `true` whenever it could not read the input box back — which is every surface that is not a TUI. In a Slack composer ⌃K is not a kill-line, so nothing was cleared.
- **`appeared`** then asked whether the value *contained* the corrected text. A line holding both versions contains it quite happily, so it logged `retyped` and moved on.

The correct check already existed eight functions away — `landed` compares a ±12-character context fragment, which an append fails — and its own comment describes this exact failure. It had never been applied to the retype path. `writeDirectly` returning `true` on an unverified `.success` was the same shape and went with them.

## The layer underneath

Three write paths become one. `Surface` answers two questions — what is in the field, as one string, and what is selected, as offsets into that same string — and substitutes a range of it:

```swift
let surface = Surface.read()
surface.content                     // the whole editable text
surface.span                        // the selection, as offsets into it
surface.replace(range, with: "Jerry")
```

Callers that know which characters they want changed can now say so. Before, they could only say "find this text", and a whole-line retype stood in for the difference. `SelectionReader` loses 392 lines to it.

## What each surface actually does

Measured with `--peek` and `--span-test`, not assumed:

| surface | behaviour |
|---|---|
| native field | takes the range write, first and cheapest branch |
| Chromium (Slack, new Outlook, any browser) | accepts the range write, answers `.success`, applies it **a beat later** |
| terminal | keystrokes only — clear the line and retype, checking between presses |

Chromium read immediately reports the caret exactly where it was — asked for `14+10` it kept saying `43+0` — which is indistinguishable from refusing. Polling for 0.6 s took the web fixture from 0/8 to 8/8. It also reports `""` for the selected text of a contenteditable however the selection was made, so the *range* it echoes back is the evidence, not the text.

Ghostty and iTerm hand back the window rather than the text view for a few hundred milliseconds after coming forward. Read once, that looks like a terminal publishing nothing at all — it was written up that way here before the harness said otherwise. The read retries; all three terminals pass.

## When it goes wrong anyway

A paste that lands somewhere unintended is undone with ⌘Z — the app's own edit history, the one mechanism still working in a surface that has just proved it ignores accessibility writes. Only when the value actually changed, since otherwise ⌘Z would undo whatever the person did before we arrived.

## Verification

Neither harness trusts the API under test.

| harness | oracle | result |
|---|---|---|
| `check-inplace.sh` | `tmux capture-pane`, through the pty | **8/8** in Terminal.app, Ghostty and iTerm |
| `check-span.sh fixture` | the page's own DOM via `document.title` | **8/8** |
| wake / split / replacements / numbers / dotted / default-config | text in, text out | unchanged |

`check-inplace.sh` gained `PF_VIEWPORT=` so the set runs in any terminal, plus two span cases. `check-span.sh` is new and can be pointed at Slack or Outlook by hand.

Not run: `check-span.sh slack` / `outlook`, which type into a real window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)