### PR TITLE
feat: say "undo" and the last substitution goes back

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1236,10 +1236,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        // Hand focus back before reading or writing: saying the phrase went
-        // through our own hotkey, and the window that holds the text is no
-        // longer the one accessibility will answer about.
-        if let owner = focusAtPress?.owner ?? selectionAtPress?.owner, !owner.isActive {
+        // Back to the window the substitution went into — recorded at the time,
+        // not read now. Saying the phrase went through our own hotkey, and by
+        // then you may well be looking at something else entirely; activating
+        // *that* is how an undo arrives in the wrong app.
+        if let owner = record.owner, !owner.isActive {
             owner.activate()
             Thread.sleep(forTimeInterval: 0.15)
         }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -100,6 +100,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// works against when there is no selection to work against instead.
     private var lastTranscript: String?
 
+    /// The last substitution made in somebody else's window, and enough to put
+    /// it back.
+    ///
+    /// One deep on purpose. This is not an edit history — it is the answer to
+    /// "that went somewhere I did not expect", which is only ever asked about
+    /// the thing that just happened. A stack would invite walking backwards
+    /// through edits the app cannot see the consequences of.
+    ///
+    /// It survives until the next substitution rather than expiring on a timer:
+    /// what makes an undo unsafe is the text having moved on, and `Surface.undo`
+    /// checks that directly by comparing what is on screen against what it
+    /// wrote. A clock cannot answer that question and would only refuse a valid
+    /// undo for having been asked slowly.
+    private var lastSubstitution: Surface.Undo?
+
     // MARK: - Lifecycle
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -1059,7 +1074,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// terminal each one costs a whole line retype, which is a fresh chance to
     /// lose the line.
     private func applyInPlace(
-        _ edits: [Edit], dictated: String?, in element: AXUIElement
+        _ edits: [Edit], dictated: String?, in element: AXUIElement,
+        describedAs label: String
     ) -> InPlace {
         guard !edits.isEmpty else { return .notAttempted }
         guard let surface = Surface.read(element: element, dictated: dictated) else {
@@ -1098,8 +1114,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Log.write("in-place: \(applied) of \(edits.count) edits found their text")
         }
 
-        switch surface.replace(change.range, with: change.replacement) {
-        case .replaced:
+        switch surface.replace(change.range, with: change.replacement, describedAs: label) {
+        case .replaced(let undo):
+            lastSubstitution = undo
             return .replaced
         case .refused(let why):
             Log.write("in-place: refused — \(why)")
@@ -1126,7 +1143,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// removed around it. With no offset to go on there is nothing to choose
     /// between them, and this refuses.
     private func replaceSelected(
-        with text: String, in selection: SelectionReader.Selection
+        with text: String, in selection: SelectionReader.Selection, describedAs label: String
     ) -> InPlace {
         // Re-query rather than reuse: apps generally only honour writes to
         // whatever currently has focus, and by now our own panel has held it.
@@ -1170,8 +1187,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Log.write("transform: \"\(selection.text.prefix(40))\" is no longer in the field")
             return .notAttempted
         }
-        switch surface.replace(target, with: text) {
-        case .replaced:
+        switch surface.replace(target, with: text, describedAs: label) {
+        case .replaced(let undo):
+            lastSubstitution = undo
             return .replaced
         case .refused(let why):
             Log.write("transform: refused — \(why)")
@@ -1190,7 +1208,52 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// text and not at the menu bar. It has to already be on screen.
     private func applied(_ what: String) {
         if config.feedback.sound { NSSound(named: "Glass")?.play() }
-        flash("\(what) applied", tone: .done)
+        flash("\(what) applied\(undoHint)", tone: .done)
+    }
+
+    /// `· "Hey parrot, undo"` — empty when there is no phrase to say it with.
+    ///
+    /// The configured phrase rather than a fixed one: it is spelled however the
+    /// person set it, and offering words that do not work is worse than saying
+    /// nothing.
+    private var undoHint: String {
+        guard let phrase = config.transcription.activationPhrases.first?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !phrase.isEmpty,
+              lastSubstitution != nil
+        else { return "" }
+        return " · \"\(phrase.prefix(1).uppercased() + phrase.dropFirst()), undo\""
+    }
+
+    /// Puts the last substitution back.
+    ///
+    /// Deliberately reachable without the model — it is matched as a literal
+    /// phrase — because the moment you need it is the moment something has gone
+    /// wrong, and "Ollama is not running" is not an acceptable answer then.
+    private func performUndo() {
+        guard let record = lastSubstitution else {
+            Log.write("undo: nothing has been substituted yet")
+            flash("Nothing to undo", tone: .caution)
+            return
+        }
+
+        // Hand focus back before reading or writing: saying the phrase went
+        // through our own hotkey, and the window that holds the text is no
+        // longer the one accessibility will answer about.
+        if let owner = focusAtPress?.owner ?? selectionAtPress?.owner, !owner.isActive {
+            owner.activate()
+            Thread.sleep(forTimeInterval: 0.15)
+        }
+
+        switch Surface.undo(record) {
+        case .replaced:
+            Log.write("undo: put back \(quoted(record.before))")
+            lastSubstitution = nil
+            if config.feedback.sound { NSSound(named: "Glass")?.play() }
+            flash("Undone", tone: .done)
+        case .refused(let why):
+            Log.write("undo: refused — \(why)")
+            flash("Can't undo — \(why)", tone: .caution)
+        }
     }
 
     private func applyTransform(
@@ -1203,7 +1266,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Without one there is nowhere to aim, so it goes in at the cursor the
         // same way a dictation would.
         if let selection {
-            switch replaceSelected(with: text, in: selection) {
+            switch replaceSelected(with: text, in: selection, describedAs: prompt.name) {
             case .replaced:
                 applied(prompt.name)
             case .failed, .notAttempted:
@@ -1234,7 +1297,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                !SelectionReader.isOurs(element) {
                 let edit = Edit(find: original, replace: text, fuzzy: false)
                 switch applyInPlace(
-                    [edit], dictated: original, in: element
+                    [edit], dictated: original, in: element, describedAs: prompt.name
                 ) {
                 case .replaced:
                     applied(prompt.name)
@@ -1270,6 +1333,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         switch command {
         case .openCorrectionPanel:
             beginCorrection()
+        case .undo:
+            performUndo()
         case .addRules(let rules):
             // Prefilled, not saved: the model proposed them, you confirm them.
             // One utterance can carry more than one, so the panel opens with a
@@ -1330,7 +1395,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let trimmed = correctedText.trimmingCharacters(in: .whitespacesAndNewlines)
         var landedOnClipboard = false
         if let selection = pendingSelection, !trimmed.isEmpty {
-            switch replaceSelected(with: correctedText, in: selection) {
+            switch replaceSelected(
+                with: correctedText, in: selection, describedAs: "correction"
+            ) {
             case .replaced:
                 break
             case .failed, .notAttempted:
@@ -1350,7 +1417,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             switch applyInPlace(
                 rules.map { Edit(find: $0.heard, replace: $0.corrected, fuzzy: true) },
                 dictated: lastTranscript,
-                in: element
+                in: element,
+                describedAs: "correction"
             ) {
             case .replaced:
                 break
@@ -1373,7 +1441,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
         switch rules.count {
-        case 0: flash("Text replaced", tone: .done)
+        case 0: flash("Text replaced\(undoHint)", tone: .done)
         case 1: flash("Saved  \(rules[0].heard) → \(rules[0].corrected)", tone: .done)
         default: flash("Saved \(rules.count) rules", tone: .done)
         }
@@ -1655,7 +1723,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                 over: text, rules: nil,
                                 destination: destination, focus: focus
                             )
-                        case .unrecognised:
+                        case .undo, .unrecognised:
+                            // Undo cannot be reached from here: this path is
+                            // the spelling extractor, and it is only asked
+                            // about an instruction that already routed to
+                            // `spelling`. Said mid-dictation it would mean
+                            // undoing a substitution that has not happened yet
+                            // — the text is still in this function.
                             self.giveUpInline(
                                 text, why: "Didn't understand \"\(instruction)\"",
                                 destination: destination

--- a/Sources/ParrotFlow/CommandTestCommand.swift
+++ b/Sources/ParrotFlow/CommandTestCommand.swift
@@ -105,6 +105,8 @@ enum CommandTestCommand {
             for rule in rules {
                 print("   action: add rule   \(rule.heard) → \(rule.corrected)")
             }
+        case .undo:
+            print("   action: undo the last substitution")
         case .unrecognised(let text):
             print("   action: none — didn't understand \"\(text)\"")
         }

--- a/Sources/ParrotFlow/EditTestCommand.swift
+++ b/Sources/ParrotFlow/EditTestCommand.swift
@@ -130,7 +130,7 @@ enum EditTestCommand {
     private static func write(
         _ range: Range<String.Index>, _ replacement: String, in surface: Surface
     ) -> Int32 {
-        switch surface.replace(range, with: replacement) {
+        switch surface.replace(range, with: replacement, describedAs: "edit-test") {
         case .replaced:
             // Deliberately not "succeeded". This is what the write path claimed,
             // which is the thing under test, not the verdict on it.

--- a/Sources/ParrotFlow/LocalLLM.swift
+++ b/Sources/ParrotFlow/LocalLLM.swift
@@ -224,6 +224,8 @@ enum VoiceCommand {
     /// carry more than one: "Tasmeen spells T A S M E E N and Mick spells
     /// M I K" is two rules, and the panel opens with a row for each.
     case addRules([(heard: String, corrected: String)])
+    /// Put the last substitution back where it was.
+    case undo
     /// Understood as nothing actionable.
     case unrecognised(String)
 
@@ -414,6 +416,18 @@ enum VoiceCommand {
             .trimmingCharacters(in: .whitespaces)
 
         if normalized.isEmpty { return .openCorrectionPanel }
+
+        // Undo before anything else, and never through the model. The moment
+        // this is wanted is the moment a substitution went somewhere unexpected,
+        // and an answer that depends on Ollama being up is no answer then. Both
+        // languages the app transcribes, because the panic word comes out in
+        // whichever one you were already speaking.
+        let undoPhrases = [
+            "undo", "undo that", "undo it", "cancel", "cancel that",
+            "revert", "revert that", "put it back", "undo the change",
+            "annule", "annuler", "annule ça", "annuler ça", "reviens en arrière",
+        ]
+        if undoPhrases.contains(normalized) { return .undo }
 
         let vocabularyPhrases = [
             "fix vocabulary", "update vocabulary", "edit vocabulary",

--- a/Sources/ParrotFlow/Surface.swift
+++ b/Sources/ParrotFlow/Surface.swift
@@ -291,9 +291,28 @@ struct Surface {
 
     enum Outcome: Equatable {
         /// The characters in that range, and no others, now read differently.
-        case replaced
+        case replaced(Undo)
         /// Nothing was written, and nothing was disturbed trying.
         case refused(String)
+    }
+
+    /// What it takes to put a substitution back.
+    ///
+    /// The whole content on both sides rather than a range and a string: by the
+    /// time an undo is asked for, the surface has been written to, and any range
+    /// recorded beforehand describes a string that no longer exists. Two
+    /// snapshots can always be checked against what is actually there, which is
+    /// the one question undo has to get right — *is this still the text I
+    /// wrote?* — and a range cannot answer it at all.
+    struct Undo: Equatable {
+        let before: String
+        let after: String
+        /// What the substitution was called, for the toast and the log.
+        let describedAs: String
+
+        static func == (lhs: Undo, rhs: Undo) -> Bool {
+            lhs.before == rhs.before && lhs.after == rhs.after
+        }
     }
 
     /// Substitutes one range of `content`, and nothing else.
@@ -304,19 +323,45 @@ struct Surface {
     /// somebody's sentence is the one this file exists to prevent.
     @discardableResult
     func replace(
-        _ range: Range<String.Index>, with replacement: String
+        _ range: Range<String.Index>, with replacement: String, describedAs label: String = "edit"
     ) -> Outcome {
         let updated = content.replacingCharacters(in: range, with: replacement)
         guard updated != content else {
             return .refused("the text already reads that way")
         }
+        let undo = Undo(before: content, after: updated, describedAs: label)
 
         switch kind {
         case .editable:
-            return writeEditable(range, replacement: replacement, updated: updated)
+            return writeEditable(range, replacement: replacement, updated: updated, undo: undo)
         case .screen:
-            return writeScreen(updated: updated)
+            return writeScreen(updated: updated, undo: undo)
         }
+    }
+
+    /// Puts the content back the way it was before a substitution.
+    ///
+    /// Refuses when the text has moved on. An undo that fires against edited
+    /// text is not an undo, it is a second unwanted edit — and it would land
+    /// exactly where the user had just started fixing things by hand.
+    static func undo(_ record: Undo) -> Outcome {
+        guard let surface = read() else {
+            return .refused("nothing to undo into")
+        }
+        guard surface.folded(surface.content) == surface.folded(record.after) else {
+            return .refused("the text has changed since; leaving it alone")
+        }
+        guard let edit = minimalSpan(from: record.after, to: record.before) else {
+            return .refused("there is nothing to put back")
+        }
+        // Located against `record.after`, which we have just confirmed is what
+        // is on screen, so the offsets are the surface's own.
+        guard let range = Range(
+            NSRange(edit.range, in: record.after), in: surface.content
+        ) else {
+            return .refused("could not place the undo in the field")
+        }
+        return surface.replace(range, with: edit.replacement, describedAs: "undo")
     }
 
     // MARK: - The editable ladder
@@ -328,7 +373,7 @@ struct Surface {
     /// that then ignore it entirely, which is the single fact that has caused
     /// every corrupted line this code has ever produced.
     private func writeEditable(
-        _ range: Range<String.Index>, replacement: String, updated: String
+        _ range: Range<String.Index>, replacement: String, updated: String, undo: Undo
     ) -> Outcome {
         let nsRange = NSRange(range, in: content)
         // The replacement in the company it is meant to keep. Checking for the
@@ -341,7 +386,7 @@ struct Surface {
         //    is what a native field accepts.
         if select(nsRange), setSelectedText(replacement), landed(fragment) {
             Log.write("surface: wrote \(nsRange.length) chars via the accessibility range")
-            return .replaced
+            return .replaced(undo)
         }
 
         // 2. Set the range and paste over it. Chromium and Electron implement
@@ -353,7 +398,7 @@ struct Surface {
             Log.write("surface: the range write was ignored; pasting over a confirmed selection")
             TextInserter.insert(replacement, mode: .paste)
             if settled(on: fragment) {
-                return .replaced
+                return .replaced(undo)
             }
             return .refused(repairedAfterStrayPaste())
         }
@@ -372,7 +417,7 @@ struct Surface {
         //    it is to where the span starts, and every step of that walk can be
         //    checked against the app's own account before anything is typed.
         if let outcome = writeByWalkingTheCaret(
-            nsRange, replacement: replacement, fragment: fragment
+            nsRange, replacement: replacement, fragment: fragment, undo: undo
         ) {
             return outcome
         }
@@ -396,7 +441,7 @@ struct Surface {
     /// Nil rather than a refusal when the walk is too long to be worth taking,
     /// so the caller can fall through to its own last resort.
     private func writeByWalkingTheCaret(
-        _ target: NSRange, replacement: String, fragment: String
+        _ target: NSRange, replacement: String, fragment: String, undo: Undo
     ) -> Outcome? {
         guard var caret = caretOffset() else {
             Log.write("surface: the app will not say where the caret is; cannot walk to the span")
@@ -439,7 +484,7 @@ struct Surface {
 
         Log.write("surface: walked the caret to \(target.location)+\(target.length); pasting")
         TextInserter.insert(replacement, mode: .paste)
-        if settled(on: fragment) { return .replaced }
+        if settled(on: fragment) { return .replaced(undo) }
         return .refused(repairedAfterStrayPaste())
     }
 
@@ -636,7 +681,7 @@ struct Surface {
     /// The caret's position inside the input is invisible to accessibility, so
     /// there is no way to address a range here without assuming where it starts,
     /// and an assumption that is wrong edits the wrong characters.
-    private func writeScreen(updated: String) -> Outcome {
+    private func writeScreen(updated: String, undo: Undo) -> Outcome {
         guard let config = try? ConfigStore.load(), config.transcription.rewriteLine else {
             return .refused("rewrite_line is off, so terminals cannot be edited")
         }
@@ -647,7 +692,7 @@ struct Surface {
         TextInserter.insert(updated, mode: .paste)
         if box(reads: updated) {
             Log.write("surface: retyped \(updated.count) chars of input line")
-            return .replaced
+            return .replaced(undo)
         }
 
         // Put it back deliberately rather than with Ctrl-Y. The paste has

--- a/Sources/ParrotFlow/Surface.swift
+++ b/Sources/ParrotFlow/Surface.swift
@@ -45,6 +45,9 @@ struct Surface {
 
     let kind: Kind
     let element: AXUIElement
+    /// The app the element belongs to, so an undo can go back to it rather than
+    /// to whatever happens to be in front when it is asked for.
+    let owner: NSRunningApplication?
     /// The whole editable content, in one coordinate space.
     let content: String
     /// The selection, as offsets into `content`. Nil when nothing is selected;
@@ -135,13 +138,15 @@ struct Surface {
         } ?? false
 
         if isTerminal {
-            return screen(element: element, value: value, dictated: dictated)
+            return screen(element: element, owner: front, value: value, dictated: dictated)
         }
-        return editable(element: element, value: value)
+        return editable(element: element, owner: front, value: value)
     }
 
     /// A field, a browser input, a composer: the value is the content.
-    private static func editable(element: AXUIElement, value: String) -> Surface {
+    private static func editable(
+        element: AXUIElement, owner: NSRunningApplication?, value: String
+    ) -> Surface {
         var span: Range<String.Index>?
         if let range = SelectionReader.selectedRange(of: element),
            range.location != NSNotFound, range.location >= 0 {
@@ -152,7 +157,7 @@ struct Surface {
                     + " does not fit \(value.count) chars of value; ignoring it")
             }
         }
-        return Surface(kind: .editable, element: element, content: value, span: span)
+        return Surface(kind: .editable, element: element, owner: owner, content: value, span: span)
     }
 
     /// A terminal: the content is the input box, dug back out of the screen.
@@ -164,7 +169,7 @@ struct Surface {
     /// *all* of them, where a transcript only ever describes the last one and
     /// retyping from it would delete the rest.
     private static func screen(
-        element: AXUIElement, value: String, dictated: String?
+        element: AXUIElement, owner: NSRunningApplication?, value: String, dictated: String?
     ) -> Surface? {
         // The box first, and a single row only when no box is drawn — a bare
         // shell rather than a TUI. That fallback is the one place a transcript
@@ -200,7 +205,7 @@ struct Surface {
                     + " times in the input box; cannot say which was selected")
             }
         }
-        return Surface(kind: .screen, element: element, content: box, span: span)
+        return Surface(kind: .screen, element: element, owner: owner, content: box, span: span)
     }
 
     /// Retyping a whole line is proportional to its length, and past a point the
@@ -309,6 +314,17 @@ struct Surface {
         let after: String
         /// What the substitution was called, for the toast and the log.
         let describedAs: String
+        /// The element that was written to, and the app it belongs to.
+        ///
+        /// Without these an undo goes wherever the caret happens to be, and the
+        /// content check is not enough to catch it: two fields holding the same
+        /// sentence are not unusual — a message and the reply quoting it, the
+        /// same text pasted into a second window — and one of them would be
+        /// rewritten while the substitution it was meant to reverse stayed put.
+        /// The text says whether it is safe to undo; only the element says
+        /// where.
+        let element: AXUIElement
+        let owner: NSRunningApplication?
 
         static func == (lhs: Undo, rhs: Undo) -> Bool {
             lhs.before == rhs.before && lhs.after == rhs.after
@@ -329,7 +345,10 @@ struct Surface {
         guard updated != content else {
             return .refused("the text already reads that way")
         }
-        let undo = Undo(before: content, after: updated, describedAs: label)
+        let undo = Undo(
+            before: content, after: updated, describedAs: label,
+            element: element, owner: owner
+        )
 
         switch kind {
         case .editable:
@@ -345,8 +364,12 @@ struct Surface {
     /// text is not an undo, it is a second unwanted edit — and it would land
     /// exactly where the user had just started fixing things by hand.
     static func undo(_ record: Undo) -> Outcome {
-        guard let surface = read() else {
-            return .refused("nothing to undo into")
+        // The recorded element, never `focusedElement()`. Reading whatever is
+        // focused is how an undo lands in the wrong window — and the content
+        // check below cannot catch that, because it is a question about the text
+        // rather than about which field holds it.
+        guard let surface = read(element: record.element, app: record.owner) else {
+            return .refused("the field it changed is not there any more")
         }
         guard surface.folded(surface.content) == surface.folded(record.after) else {
             return .refused("the text has changed since; leaving it alone")

--- a/docs/corrections.md
+++ b/docs/corrections.md
@@ -114,6 +114,26 @@ sentence is French. Score a model or a prompt against them with
 `--command "<what you'd say>"` shows how a phrase would be routed. See
 [cli.md](cli.md).
 
+## Taking it back
+
+Every substitution says how to undo it, in the toast that confirms it:
+
+    grammar applied · "Hey parrot, undo"
+
+Say that and the text goes back to what it was. It is matched as a literal
+phrase, never through the model — the moment you want it is the moment
+something went somewhere unexpected, and "Ollama is not running" is not an
+acceptable answer then. `cancel`, `revert` and `put it back` work too, as do
+`annule` and `annuler`.
+
+It refuses if you have edited the text since. An undo fired against text that
+has moved on is not an undo, it is a second unwanted edit, landing exactly where
+you had started fixing things by hand.
+
+One deep, on purpose. This is not an edit history; it is the answer to "that
+went somewhere I did not expect", which is only ever asked about the thing that
+just happened.
+
 ## In a terminal
 
 Selections are fragile: they get dropped on a keystroke or when focus moves,

--- a/docs/corrections.md
+++ b/docs/corrections.md
@@ -130,6 +130,12 @@ It refuses if you have edited the text since. An undo fired against text that
 has moved on is not an undo, it is a second unwanted edit, landing exactly where
 you had started fixing things by hand.
 
+And it only ever writes to the field it changed, which it remembers rather than
+looks for. Two fields holding the same sentence are not unusual — a message and
+the reply quoting it, the same text pasted into a second window — so matching
+text alone would happily rewrite the wrong one while leaving the substitution
+you wanted reversed exactly where it was.
+
 One deep, on purpose. This is not an edit history; it is the answer to "that
 went somewhere I did not expect", which is only ever asked about the thing that
 just happened.


### PR DESCRIPTION
Stacked on #38 — review that first; this diff is only the undo.

Every substitution now confirms with the phrase that reverts it:

```
grammar applied · "Hey parrot, undo"
```

Said every time rather than only when something looks wrong: the moment you can tell it went wrong is the moment you are looking at the text and not at the menu bar, so the phrase has to already be on screen. It is your configured activation phrase, capitalised — not a hard-coded "Hey parrot" — so it never offers words that would not work on your machine, and it is omitted when there is no phrase to say it with.

## Three decisions worth checking

**It never touches the model.** `undo`, `cancel`, `revert`, `put it back`, plus `annule` and `annuler`, are matched literally in `VoiceCommand.local`. The moment this is wanted is the moment something went somewhere unexpected, and "Ollama is not running" is not an acceptable answer then. Both languages, because the panic word comes out in whichever one you were already speaking.

**It refuses if you have edited the text since.** The record holds the whole content before and after rather than a range and a string — by the time an undo is asked for, the surface has been written to, so a range recorded beforehand describes a string that no longer exists. Two snapshots can always be checked against what is actually there, which is the one question undo has to get right. An undo fired against edited text is not an undo, it is a second unwanted edit, landing exactly where you had started fixing things by hand.

**It is one deep.** Not an edit history — the answer to "that went somewhere I did not expect", which is only ever asked about the thing that just happened. Say if you would rather have a stack.

Distinct from the ⌘Z stray-paste repair in #38: that one catches a paste landing in the wrong place and fires automatically; this one is you deciding you did not want the edit.

## Verification

| harness | result |
|---|---|
| `check-inplace.sh` | 8/8 |
| `check-span.sh fixture` | 8/8 |
| `check-wake.sh` | 24/24 |

`--command "hey parrot undo"` and `--command "hey parrot, annule"` both resolve locally with no model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)