### PR TITLE
fix: the span harness stops racing its own fixture

### DIFF
--- a/scripts/check-span.sh
+++ b/scripts/check-span.sh
@@ -56,11 +56,24 @@ tell application "Google Chrome"
   set URL of active tab of front window to "file://$FIXTURE#$encoded"
 end tell
 OSA
-  # Long enough for the navigation to settle and the page to take focus back
-  # from the omnibox. Short of this the app reads the address bar instead of the
-  # composer, refuses correctly, and the case scores a refusal that says nothing
-  # about the write path.
-  sleep 2
+  # Wait for the box to actually read the seed, and to keep reading it — not for
+  # a guessed interval. Two things race here and a fixed sleep loses to both:
+  # the navigation has to settle and the page has to take focus back from the
+  # omnibox, and a paste from the *previous* case can still be in flight and land
+  # on top of the fresh seed. That is not hypothetical — it appended 46
+  # characters to a 27 character seed, the title had not caught up when the
+  # harness looked, and the case scored as corruption by the app rather than as
+  # the harness racing itself.
+  #
+  # So: settled means the same text twice, a beat apart.
+  local previous="" current=""
+  for _ in $(seq 1 30); do
+    current="$(read_fixture)"
+    [ -n "$current" ] && [ "$current" = "$previous" ] && [ "$current" = "$text" ] && return 0
+    previous="$current"
+    sleep 0.25
+  done
+  return 1
 }
 
 seed_app() {
@@ -95,10 +108,8 @@ while IFS='|' read -r name id seed target replacement expect; do
   [ -z "$name" ] && continue
   total=$((total + 1))
 
-  $SEED "$seed"
-  got="$($READ)"
-  if [ "$got" != "$seed" ]; then
-    printf '  ⊘ %s — seed did not land (read back "%s")\n' "$name" "$got"
+  if ! $SEED "$seed"; then
+    printf '  ⊘ %s — seed did not settle (read back "%s")\n' "$name" "$($READ)"
     skipped=$((skipped + 1)); continue
   fi
 
@@ -112,6 +123,21 @@ print(i, len(target))
 ' "$seed" "$target")
 
   [ "$expect" = "unchanged" ] && want="$seed" || want="$expect"
+
+  # Bring the fixture back to the front immediately before the write. An
+  # unattended run shares the machine, and something else taking focus for a
+  # moment — a chat app raising its window was the observed case — means the app
+  # reads that window instead. The sentinel stops it writing there, so the harm
+  # is a refusal rather than somebody's message being edited, but a refusal that
+  # says nothing about the write path is still a wasted case.
+  if [ "$TARGET" = "fixture" ]; then
+    osascript -e 'tell application "Google Chrome" to activate' >/dev/null 2>&1
+    sleep 0.6
+    if [ "$(read_fixture)" != "$seed" ]; then
+      printf '  ⊘ %s — the box changed between seeding and writing\n' "$name"
+      skipped=$((skipped + 1)); continue
+    fi
+  fi
 
   open -g -na ParrotFlowDev --args \
     --span-test "$start" "$length" "$replacement" --find "$id" --after 2


### PR DESCRIPTION
Follow-up to #38 — harness only, no product code.

## What went wrong

Two runs reported the app **corrupting text**, which is the counter that is supposed to mean "this cost you your words". It had not.

```
edit-test: surface   editable, 73 chars, selection present
edit-test: replacing 21+6 — "Tasmin" → "Tasmeen"
```

The case seeds `PFCHK-305 send it to Tasmin` — 27 characters. The app read 73. A paste from the *previous* case was still in flight and landed on top of the fresh seed, and `document.title` had not caught up when the harness checked it. The app then applied the offsets it was handed, exactly and correctly, to a box that was no longer what the harness believed.

A separate run lost four cases to refusals because Slack raised its window mid-run and the app read `"Write a message…"` instead of the fixture. The sentinel did its job — it refused to write into Slack — but a refusal that says nothing about the write path is a wasted case, and four of them together read as a regression.

## What changed

**Seeding waits for the box to settle** instead of sleeping two seconds: the same text twice, a quarter-second apart, and equal to the seed. A late paste cannot fake that.

**The fixture is raised and re-read immediately before the write.** If the box no longer holds the seed the case is skipped as `⊘ the box changed between seeding and writing`, which is honest, rather than being scored against the app.

Both failure modes now surface as skips with a reason, so a red run means the write path and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)