### PR TITLE
feat: the harness that scores a rewrite ships with the app

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -117,6 +117,12 @@ jobs:
       - name: A folder per transform
         run: scripts/check-transform-folders.sh
 
+      # The scoring harness itself, against sets built for the purpose. No
+      # model anywhere in it: the numbers have to be the same on a runner and
+      # on a laptop with Ollama up.
+      - name: The eval harness
+        run: scripts/check-eval.sh
+
       # Not a validation set: it checks that the file a new install is written
       # with still teaches everything config.example.yaml documents. That has
       # drifted twice, both times silently.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,15 +22,19 @@ $PF --check-config                                  # what will actually run
 $PF --pipeline <file.yaml> "<text>" --app <name>    # a stage, without a mic
 $PF --replace "<text>"                              # the substitution tables
 $PF --route "<what someone would say>"              # which transform that reaches
+$PF --eval <transform>                              # score it against its set
 ```
 
 `--check-config` reports what survived parsing, which is not what the file
 says. Everything else is in [docs/cli.md](docs/cli.md).
 
-**Never change a prompt or a pattern without scoring it.** Every rewrite in
-this repo has a case set in `tests/` and a runner in `scripts/`. Get the number
-before, change one thing, get it after. "It looks better" is how a change fixes
-the example in front of you and breaks two you are not looking at.
+**Never change a prompt or a pattern without scoring it.** Every rewrite has a
+case set — a transform's in its own folder under `examples/transforms/<name>/`,
+everything else in `tests/` — and a runner, either `$PF --eval <name>` or a
+script in `scripts/`. Get the number before, change one thing, get it after.
+"It looks better" is how a change fixes the example in front of you and breaks
+two you are not looking at. Read both halves: `keep` is the one that decides
+whether a rewrite is usable.
 
 **Fail open.** A stage that errors, times out or finds no model must leave the
 transcript exactly as it arrived. Test it by stopping Ollama and running the

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -85,9 +85,12 @@ struct Config: Decodable, Equatable {
         var namesBoth = false
         /// A `path:` that named a file this could not read, in words.
         var unreadable: String?
+        /// `tests: { path: heldout.yaml }` — the set `--eval` scores by default.
+        var tests: String?
 
         enum CodingKeys: String, CodingKey {
             case name, description, display, confirm, prompt, content, replace, command
+            case tests
             case timeout = "timeout_seconds"
         }
 
@@ -123,6 +126,12 @@ struct Config: Decodable, Equatable {
             }
             confirm = try c.decodeIfPresent(Bool.self, forKey: .confirm) ?? true
             timeout = try c.decodeIfPresent(Double.self, forKey: .timeout)
+            // Written either way, like a body: `tests: heldout.yaml` and
+            // `tests: { path: heldout.yaml }` mean the same thing, because
+            // having to remember which of the two a key takes is the kind of
+            // thing a config format should not ask.
+            let testsWritten = (try? trimmed(.tests)) ?? ""
+            tests = path(.tests) ?? (testsWritten.isEmpty ? nil : testsWritten)
 
             // A body written either way. The mapping is tried first and only
             // succeeds on `{ path: <string> }`, so nothing that decoded before
@@ -263,7 +272,8 @@ struct Config: Decodable, Equatable {
                 name: entry.name, description: entry.description,
                 display: entry.display,
                 folder: entry.folder, timeout: entry.timeout,
-                confirm: entry.confirm, body: body, source: entry.source
+                confirm: entry.confirm, body: body, source: entry.source,
+                tests: entry.tests
             ))
         }
         return (kept, unreadable)
@@ -329,6 +339,10 @@ struct Config: Decodable, Equatable {
         /// folder and beside the config is otherwise invisible, and "which one
         /// is running" is the first question when something is wrong.
         var source: TransformFolder.Resolved?
+        /// The case set `--eval <name>` scores this against, when it is not the
+        /// `cases.yaml` every folder has by convention. Relative to the folder,
+        /// like everything else a transform names.
+        var tests: String?
 
         enum Body: Equatable {
             /// Instructions for the local model.

--- a/Sources/ParrotFlow/EvalCases.swift
+++ b/Sources/ParrotFlow/EvalCases.swift
@@ -1,0 +1,144 @@
+import Foundation
+import Yams
+
+/// A case set, as it is written.
+///
+/// `input` and `expect` are the whole requirement; everything else is
+/// optional. The prose at the top of the file is not parsed and is the most
+/// important part of it — what counts as a case here and what is deliberately
+/// out of scope is the thing you will disagree with yourself about in a week.
+///
+///     cases:
+///       - probe: ambiguity_common
+///         input:  mark it as resolved
+///         expect: mark it as resolved
+struct EvalCases {
+    /// Which transform this scores, when the file is not inside its folder.
+    var transform: String?
+    /// What the speaker said, for a prompt reached by voice — "fix the grammar
+    /// and punctuation". Left out for a prompt that runs as a pipeline stage,
+    /// which is given nothing. The same prompt scores differently under the
+    /// two, so a set that does not say which one it means is a number about a
+    /// use nobody has.
+    var instruction: String?
+    /// A second way to do the same job, without a model — see `Control`.
+    var control: String?
+    var intermediate: Intermediate?
+    /// A `transforms:` section of its own, so a set can state the transform it
+    /// assumes instead of inheriting this machine's config. Decoded by `Config`
+    /// rather than re-read here, the way a `--pipeline` fixture is.
+    var transforms: [Config.Transform] = []
+    var cases: [Case] = []
+
+    /// What the first stage of a two-stage transform should return on its own.
+    ///
+    /// Scoring it separately is what says whether the prompt or the code is at
+    /// fault. On the Slack mentions set the gap between the two ran 25 points,
+    /// and without it every one of those points reads as "the prompt is bad".
+    struct Intermediate {
+        /// The per-case field holding the gold — `spans`, say.
+        var field: String
+        /// Produces it from the input. Optional: without it the gold is still
+        /// checked against itself, which is the half that matters most.
+        var produce: String?
+        /// Turns the gold into what the user sees. Required, because it is
+        /// what checks the gold against itself before anything is scored.
+        var resolve: String
+    }
+
+    /// One case. Every field is read as a string and unknown ones are kept, so
+    /// a set can carry `kind:` or `name:` for its own runner and the gold field
+    /// can be called whatever `intermediate.field` says it is called.
+    struct Case {
+        var fields: [String: String]
+
+        var input: String { fields["input"] ?? "" }
+        /// Absent means "comes back exactly as it went in". Detected, never
+        /// declared: a set that has to remember to say which half a case is in
+        /// is a set that will eventually be wrong about one.
+        var expect: String { fields["expect"] ?? input }
+        /// `category:` is the same idea under the name the older sets in this
+        /// repository use, and refusing to read it would mean editing four
+        /// files to gain nothing.
+        var probe: String { fields["probe"] ?? fields["category"] ?? "" }
+        var name: String { fields["name"] ?? input }
+        /// True when this case must come back byte for byte.
+        var mustNotChange: Bool { expect == input }
+    }
+
+    /// What is wrong with the file, in words, or nothing.
+    func problems() -> [String] {
+        var found: [String] = []
+        if cases.isEmpty { found.append("no cases") }
+        for (index, one) in cases.enumerated() where one.input.isEmpty {
+            found.append("case \(index + 1) has no `input`")
+        }
+        if let intermediate {
+            if intermediate.resolve.isEmpty {
+                found.append("`intermediate:` needs a `resolve:` — it is what checks"
+                    + " the gold against itself")
+            }
+            for one in cases where one.fields[intermediate.field] == nil {
+                found.append("case \"\(one.name)\" has no `\(intermediate.field)`")
+            }
+        }
+        return found
+    }
+}
+
+extension EvalCases: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case transform, instruction, control, intermediate, transforms, cases
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        transform = try c.decodeIfPresent(String.self, forKey: .transform)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        instruction = try c.decodeIfPresent(String.self, forKey: .instruction)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        control = try c.decodeIfPresent(String.self, forKey: .control)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        intermediate = try c.decodeIfPresent(Intermediate.self, forKey: .intermediate)
+        if c.contains(.transforms) {
+            transforms = try Config.transforms(from: try c.superDecoder(forKey: .transforms))
+        }
+        cases = try c.decodeIfPresent([Case].self, forKey: .cases) ?? []
+    }
+}
+
+extension EvalCases.Intermediate: Decodable {
+    enum CodingKeys: String, CodingKey { case field, produce, resolve }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        field = try c.decode(String.self, forKey: .field)
+        produce = try c.decodeIfPresent(String.self, forKey: .produce)
+        resolve = try c.decodeIfPresent(String.self, forKey: .resolve) ?? ""
+    }
+}
+
+extension EvalCases.Case: Decodable {
+    /// Any key at all, because the gold's name is the case file's to choose.
+    private struct AnyKey: CodingKey {
+        var stringValue: String
+        var intValue: Int? { nil }
+        init?(stringValue: String) { self.stringValue = stringValue }
+        init?(intValue: Int) { nil }
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: AnyKey.self)
+        var fields: [String: String] = [:]
+        for key in c.allKeys {
+            // Only the string-valued ones. A set may carry a list or a flag for
+            // a bespoke runner of its own — tests/…/email/cases.yaml carries
+            // `require:` and `forbid:` — and refusing the whole file over a key
+            // this does not read would be this runner deciding what a case set
+            // is allowed to contain.
+            guard let value = try? c.decode(String.self, forKey: key) else { continue }
+            fields[key.stringValue] = value
+        }
+        self.fields = fields
+    }
+}

--- a/Sources/ParrotFlow/EvalCommand.swift
+++ b/Sources/ParrotFlow/EvalCommand.swift
@@ -397,8 +397,9 @@ enum EvalCommand {
         print("")
         let shown = verbose ? scored.failures : Array(scored.failures.prefix(5))
         for failure in shown {
-            let where_ = failure.probe.isEmpty ? failure.half : "\(failure.half), \(failure.probe)"
-            print("  ✗ \(failure.name)  [\(where_)]")
+            let bucket = failure.probe.isEmpty
+                ? failure.half : "\(failure.half), \(failure.probe)"
+            print("  ✗ \(failure.name)  [\(bucket)]")
             if failure.name != failure.input { print("      in    \(failure.input)") }
             print("      got   \(failure.got)")
             print("      want  \(failure.want)")

--- a/Sources/ParrotFlow/EvalCommand.swift
+++ b/Sources/ParrotFlow/EvalCommand.swift
@@ -111,9 +111,12 @@ enum EvalCommand {
                         : " — have: \(config.transforms.map(\.name).joined(separator: ", "))"))
                 return nil
             }
-            guard let found = transform.folder?.resolve(override ?? "cases.yaml") else {
+            // `--cases` wins over the transform's own `tests:`, which wins over
+            // the `cases.yaml` every folder has by convention.
+            let wanted = override ?? transform.tests ?? "cases.yaml"
+            guard let found = transform.folder?.resolve(wanted) else {
                 let folder = transform.folder?.url?.path ?? ConfigStore.directory.path
-                print("✗ no \(override ?? "cases.yaml") for \"\(transform.name)\""
+                print("✗ no \(wanted) for \"\(transform.name)\""
                     + " — expected it in \(short(folder))")
                 print("    a transform's case set lives in its own folder;"
                     + " see docs/authoring.md")

--- a/Sources/ParrotFlow/EvalCommand.swift
+++ b/Sources/ParrotFlow/EvalCommand.swift
@@ -1,0 +1,427 @@
+import Foundation
+import Yams
+
+/// `--eval <transform>` — score a transform against its own case set.
+///
+/// Every rewrite in this repository ships with a case set and a bespoke runner
+/// in `scripts/`. Users get neither, which makes "write a prompt and hope" the
+/// only loop available to anyone who installed the app. This is the loop
+/// docs/authoring.md prescribes, in the binary, against your own config.
+///
+///     ParrotFlow --eval slack_mentions                   transforms/…/cases.yaml
+///     ParrotFlow --eval slack_mentions --cases heldout.yaml
+///     ParrotFlow --eval slack_mentions --verbose --probe ambiguity_common
+///     ParrotFlow --eval path/to/cases.yaml               one-off, outside a folder
+///
+/// The transform is resolved from your real config and **that** is what runs —
+/// not a reimplementation of it. `scripts/validate-slack-mentions.py` imports
+/// the shipped script for the same reason: two copies of an algorithm drift,
+/// and only one of them ships. The note in docs/authoring.md about a runner
+/// drifting from the app is worth 31 points of measured error.
+enum EvalCommand {
+
+    /// The bucket for cases that named no `probe:`.
+    private static let unlabelled = "(no probe)"
+
+    static func run(
+        target: String, cases override: String?, probe: String?, verbose: Bool
+    ) -> Int32 {
+        let config: Config
+        do {
+            config = try ConfigStore.load()
+        } catch {
+            print("✗ \(ConfigStore.fileURL.path): \(CheckConfigCommand.describe(error))")
+            return 1
+        }
+
+        guard let found = locate(target, cases: override, config: config) else { return 1 }
+        let (file, set, transform) = found
+
+        let problems = set.problems()
+        guard problems.isEmpty else {
+            print("✗ \(short(file.path)):")
+            for problem in problems { print("    \(problem)") }
+            return 1
+        }
+
+        print("eval: \(transform.name)")
+        print("  cases    \(short(file.path))  (\(set.cases.count))"
+            + (probe.map { "  — only probe \($0)" } ?? ""))
+        print("  body     \(body(of: transform))")
+
+        // The gold, against itself, before anything is scored. A typo in an
+        // intermediate gold otherwise scores every candidate against a typo,
+        // silently, forever — so this is a refusal and not a warning.
+        if let intermediate = set.intermediate {
+            let wrong = badGold(set, intermediate, transform: transform)
+            guard wrong.isEmpty else {
+                print("")
+                print("  ✗ the gold does not agree with itself."
+                    + " Resolving `\(intermediate.field)` must produce `expect`.")
+                for line in wrong.prefix(10) { print("      \(line)") }
+                if wrong.count > 10 { print("      … and \(wrong.count - 10) more") }
+                print("")
+                print("  Nothing was scored. A set that disagrees with itself scores"
+                    + " every candidate against its own typo.")
+                return 1
+            }
+            print("  gold     \(set.cases.count) cases resolve to their `expect`")
+        }
+
+        let scored = score(set, transform: transform, config: config, probe: probe)
+        report(scored, set: set, probe: probe, verbose: verbose)
+        // 0 means "this was scored", not "this was perfect. A set worth having
+        // keeps its residue in, failing — tests/…/dotted/cases.txt scores 54/54
+        // and carries two more it cannot do — so a number below 100% is an
+        // ordinary result and not an error to report to a shell. What exits 1
+        // is a set that could not be scored at all.
+        return 0
+    }
+
+    // MARK: - Finding what to score
+
+    /// The case file, the set in it, and the transform it belongs to.
+    ///
+    /// Two ways in. A **name** is looked up in your config and its set is
+    /// `transforms/<name>/cases.yaml` by convention. A **path** to a file is
+    /// the one-off: the transform is whatever the file's `transform:` says, or
+    /// failing that the folder it sits in, which is the same answer for a set
+    /// that lives where it belongs.
+    private static func locate(
+        _ target: String, cases override: String?, config: Config
+    ) -> (URL, EvalCases, Config.Transform)? {
+        let path = (target as NSString).expandingTildeInPath
+        let asFile = URL(fileURLWithPath: path).standardizedFileURL
+        var isDirectory: ObjCBool = false
+        let namesAFile = FileManager.default.fileExists(
+            atPath: asFile.path, isDirectory: &isDirectory
+        ) && !isDirectory.boolValue
+
+        let file: URL
+        var name: String
+        if namesAFile {
+            file = asFile
+            name = asFile.deletingLastPathComponent().lastPathComponent
+        } else {
+            name = target
+            guard let transform = config.transform(named: target) else {
+                print("✗ no transform named \"\(target)\""
+                    + (config.transforms.isEmpty
+                        ? " — `transforms:` is empty"
+                        : " — have: \(config.transforms.map(\.name).joined(separator: ", "))"))
+                return nil
+            }
+            guard let found = transform.folder?.resolve(override ?? "cases.yaml") else {
+                let folder = transform.folder?.url?.path ?? ConfigStore.directory.path
+                print("✗ no \(override ?? "cases.yaml") for \"\(transform.name)\""
+                    + " — expected it in \(short(folder))")
+                print("    a transform's case set lives in its own folder;"
+                    + " see docs/authoring.md")
+                return nil
+            }
+            file = found.url
+        }
+
+        let set: EvalCases
+        do {
+            set = try YAMLDecoder().decode(
+                EvalCases.self, from: String(contentsOf: file, encoding: .utf8),
+                userInfo: [.configDirectory: file.deletingLastPathComponent()]
+            )
+        } catch {
+            print("✗ \(short(file.path)): \(CheckConfigCommand.describe(error))")
+            return nil
+        }
+        if let declared = set.transform, !declared.isEmpty { name = declared }
+
+        // The set's own `transforms:` wins, so a case file can carry the
+        // transform it assumes and score the same on any machine.
+        let transform = set.transforms.first {
+            $0.name.caseInsensitiveCompare(name) == .orderedSame
+        } ?? config.transform(named: name)
+        guard let transform else {
+            print("✗ \(short(file.path)) scores \"\(name)\", which is not in your config"
+                + " and not in the file")
+            return nil
+        }
+        return (file, set, transform)
+    }
+
+    // MARK: - Running
+
+    /// One case through the real transform.
+    ///
+    /// A one-step pipeline rather than a switch over the body: that is the code
+    /// the app runs, including the part where every way of failing returns the
+    /// transcript exactly as it arrived.
+    private static func through(
+        _ transform: Config.Transform, _ text: String, config: Config, instruction: String
+    ) -> (output: String, seconds: TimeInterval) {
+        // A prompt reached by voice is given what the speaker actually said,
+        // and the same prompt in a pipeline is given nothing — "format those
+        // dates ISO" and a stage that runs on every transcript are one rule and
+        // two instructions. A set has to be able to say which of the two it is
+        // scoring, or the number describes a use nobody has. Both go through
+        // `PromptRunner`, which is the function both paths in the app call.
+        if !instruction.isEmpty, let prompt = transform.asPrompt {
+            return asked(prompt, text, instruction: instruction, config: config)
+        }
+
+        var config = config
+        // The set's own transform, when it brought one, has to be the one the
+        // pipeline finds by name.
+        if config.transform(named: transform.name) == nil {
+            config.transforms.append(transform)
+        }
+        let pipeline = Pipeline(steps: [Pipeline.Step(stage: .transform, transform: transform.name)])
+        var output = text
+        let started = Date()
+        let done = DispatchSemaphore(value: 0)
+        Task {
+            output = await pipeline.run(text, config: config)
+            done.signal()
+        }
+        done.wait()
+        return (output, Date().timeIntervalSince(started))
+    }
+
+    /// One case through a prompt, with the instruction a speaker would give.
+    ///
+    /// Failing open the way the pipeline does: an unreachable model returns the
+    /// text unchanged rather than an error, so a run without Ollama scores 0 on
+    /// the change half and 100% on the keep half — which is the truth about
+    /// what the app would do, and is legible as such.
+    private static func asked(
+        _ prompt: Config.Prompt, _ text: String, instruction: String, config: Config
+    ) -> (output: String, seconds: TimeInterval) {
+        let llm = LocalLLM.Config(
+            endpoint: config.llm.endpoint, model: config.llm.model,
+            timeout: config.llm.timeoutSeconds, keepLoaded: config.llm.keepLoaded
+        )
+        var output = text
+        let started = Date()
+        let done = DispatchSemaphore(value: 0)
+        Task<Void, Never> {
+            output = (try? await PromptRunner.run(
+                prompt: prompt, instruction: instruction, text: text, config: llm
+            )) ?? text
+            done.signal()
+        }
+        done.wait()
+        return (output.isEmpty ? text : output, Date().timeIntervalSince(started))
+    }
+
+    /// A helper command out of the case file — the control, or an
+    /// intermediate's `produce`/`resolve` — run in the transform's own folder.
+    private static func piped(
+        _ command: String, _ text: String, in transform: Config.Transform
+    ) -> String {
+        CommandRunner.run(
+            command, on: text, in: transform.folder, seconds: transform.timeout
+        ) ?? text
+    }
+
+    // MARK: - Scoring
+
+    struct Tally {
+        var passed = 0
+        var total = 0
+
+        mutating func add(_ correct: Bool) {
+            total += 1
+            if correct { passed += 1 }
+        }
+
+        var percent: Int { total == 0 ? 0 : Int((Double(passed) / Double(total) * 100).rounded()) }
+        /// No percentage of nothing. "0/0 = 0%" reads as a half that failed
+        /// rather than as a half this set does not have.
+        var described: String { total == 0 ? "none in this set" : "\(passed)/\(total) = \(percent)%" }
+    }
+
+    struct Failure {
+        var name: String
+        var probe: String
+        var input: String
+        var got: String
+        var want: String
+        var half: String
+    }
+
+    struct Scored {
+        var overall = Tally()
+        /// Cases that ask for a change.
+        var change = Tally()
+        /// Cases that must come back byte for byte — see `report`.
+        var keep = Tally()
+        var probes: [String: Tally] = [:]
+        var latencies: [TimeInterval] = []
+        var failures: [Failure] = []
+        /// The same three, for the no-model control, when the set declares one.
+        var control: (overall: Tally, change: Tally, keep: Tally)?
+        /// The first stage alone, when the set declares an intermediate gold.
+        var intermediate: Tally?
+    }
+
+    private static func score(
+        _ set: EvalCases, transform: Config.Transform, config: Config, probe: String?
+    ) -> Scored {
+        var scored = Scored()
+        let instruction = set.instruction ?? ""
+        var control = (overall: Tally(), change: Tally(), keep: Tally())
+        var intermediate = Tally()
+
+        // Warm first, and throw the number away. A cold start is 7–10s of
+        // reading weights off a disk and has nothing to say about the thing
+        // being measured; timings that include it send you optimising it.
+        if let first = set.cases.first {
+            _ = through(transform, first.input, config: config, instruction: instruction)
+        }
+
+        for one in set.cases {
+            if let probe, one.probe != probe { continue }
+            let (got, seconds) = through(transform, one.input, config: config, instruction: instruction)
+            let correct = got == one.expect
+            scored.overall.add(correct)
+            scored.latencies.append(seconds)
+            if one.mustNotChange { scored.keep.add(correct) } else { scored.change.add(correct) }
+            // Everything lands in a bucket, including the cases that named no
+            // probe. A grid that silently covers 61 of 75 reads as a complete
+            // breakdown and is not one.
+            scored.probes[one.probe.isEmpty ? unlabelled : one.probe, default: Tally()]
+                .add(correct)
+            if !correct {
+                scored.failures.append(Failure(
+                    name: one.name, probe: one.probe, input: one.input,
+                    got: got, want: one.expect,
+                    half: one.mustNotChange ? "keep" : "change"
+                ))
+            }
+
+            if let command = set.control, !command.isEmpty {
+                let answer = piped(command, one.input, in: transform)
+                let right = answer == one.expect
+                control.overall.add(right)
+                if one.mustNotChange { control.keep.add(right) } else { control.change.add(right) }
+            }
+
+            if let declared = set.intermediate, let produce = declared.produce,
+               let gold = one.fields[declared.field] {
+                intermediate.add(piped(produce, one.input, in: transform) == gold)
+            }
+        }
+
+        if set.control?.isEmpty == false { scored.control = control }
+        if intermediate.total > 0 { scored.intermediate = intermediate }
+        return scored
+    }
+
+    /// The cases whose gold does not resolve to their own `expect`.
+    private static func badGold(
+        _ set: EvalCases, _ intermediate: EvalCases.Intermediate, transform: Config.Transform
+    ) -> [String] {
+        set.cases.compactMap { one in
+            guard let gold = one.fields[intermediate.field] else { return nil }
+            let resolved = piped(intermediate.resolve, gold, in: transform)
+            guard resolved != one.expect else { return nil }
+            return "\(one.name)\n          \(intermediate.field) resolves to  \(resolved)"
+                + "\n          expect is             \(one.expect)"
+        }
+    }
+
+    // MARK: - Reporting
+
+    private static func report(
+        _ scored: Scored, set: EvalCases, probe: String?, verbose: Bool
+    ) {
+        print("")
+        // The two halves, separately and always.
+        //
+        // A rewrite that scores well on `change` and badly on `keep` is not a
+        // rewrite that is 80% there — it is one that makes you proof-read every
+        // dictation, which is the whole thing this app exists to avoid. An
+        // average across the two can hide that completely, so there is no
+        // arrangement of this output in which it is only an average.
+        print("  change   \(scored.change.described)")
+        print("  keep     \(scored.keep.described)"
+            + "   <- must come back byte for byte")
+        print("  overall  \(scored.overall.described)")
+
+        if let control = scored.control {
+            print("")
+            print("  the same set, without a model — is the model earning its place?")
+            print("    change   \(control.change.described)")
+            print("    keep     \(control.keep.described)")
+            print("    overall  \(control.overall.described)")
+        }
+
+        if let intermediate = scored.intermediate {
+            print("")
+            print("  the first stage alone   \(intermediate.described)")
+            print("    above the overall, the code is repairing the model;"
+                + " below it, the code is the fault")
+        }
+
+        // By probe, never only an aggregate: one broken category hides behind
+        // eleven healthy ones for exactly as long as nobody breaks it out.
+        if scored.probes.count > 1 {
+            print("")
+            print("  by probe")
+            let width = scored.probes.keys.map(\.count).max() ?? 0
+            for name in scored.probes.keys.sorted() {
+                guard let tally = scored.probes[name] else { continue }
+                let padded = name.padding(toLength: width, withPad: " ", startingAt: 0)
+                print("    \(padded)  \(tally.passed)/\(tally.total)"
+                    + (tally.passed == tally.total ? "" : "  ←"))
+            }
+        }
+        if scored.probes[unlabelled] != nil, probe == nil {
+            print("")
+            print("  · \(scored.probes[unlabelled]?.total ?? 0) cases name no `probe:`."
+                + " Grouped ones say \"all the two-word cases broke\";"
+                + " ungrouped ones say only that four points went missing.")
+        }
+
+        if !scored.latencies.isEmpty {
+            let sorted = scored.latencies.sorted()
+            let median = sorted[sorted.count / 2]
+            print("")
+            print(String(
+                format: "  latency  %.2fs median, %.2fs worst, warm", median, sorted[sorted.count - 1]
+            ))
+        }
+
+        guard !scored.failures.isEmpty else { return }
+        print("")
+        let shown = verbose ? scored.failures : Array(scored.failures.prefix(5))
+        for failure in shown {
+            let where_ = failure.probe.isEmpty ? failure.half : "\(failure.half), \(failure.probe)"
+            print("  ✗ \(failure.name)  [\(where_)]")
+            if failure.name != failure.input { print("      in    \(failure.input)") }
+            print("      got   \(failure.got)")
+            print("      want  \(failure.want)")
+        }
+        if !verbose, scored.failures.count > shown.count {
+            print("  … and \(scored.failures.count - shown.count) more; --verbose for all")
+        }
+    }
+
+    // MARK: -
+
+    private static func body(of transform: Config.Transform) -> String {
+        let kind: String
+        switch transform.body {
+        case .prompt: kind = "prompt "
+        case .replace: kind = "replace"
+        case .command: kind = "command"
+        }
+        if let found = transform.resolvedSource { return "\(kind)  \(short(found.path))" }
+        if case .command(let command) = transform.body { return "\(kind)  \(command) — on PATH" }
+        return "\(kind)  inline"
+    }
+
+    private static func short(_ path: String) -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        guard path.hasPrefix(home + "/") else { return path }
+        return "~" + path.dropFirst(home.count)
+    }
+}

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -134,6 +134,26 @@ if let index = arguments.firstIndex(of: "--prompt") {
     ))
 }
 
+if let index = arguments.firstIndex(of: "--eval") {
+    guard arguments.indices.contains(index + 1), !arguments[index + 1].hasPrefix("--") else {
+        print("usage: ParrotFlow --eval <transform|cases.yaml>"
+            + " [--cases <file>] [--probe <name>] [--verbose]")
+        exit(2)
+    }
+    func value(_ flag: String) -> String? {
+        arguments.firstIndex(of: flag).flatMap { at in
+            arguments.indices.contains(at + 1) && !arguments[at + 1].hasPrefix("--")
+                ? arguments[at + 1] : nil
+        }
+    }
+    exit(EvalCommand.run(
+        target: arguments[index + 1],
+        cases: value("--cases"),
+        probe: value("--probe"),
+        verbose: arguments.contains("--verbose")
+    ))
+}
+
 if let index = arguments.firstIndex(of: "--pipeline") {
     guard arguments.indices.contains(index + 1) else {
         print("usage: ParrotFlow --pipeline <file.yaml> [\"<text>\"]"

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -35,8 +35,8 @@ including how to build a validation set that can tell you which one you need.
 ## The loop
 
 ```
-1. write the cases            tests/<thing>-cases.yaml
-2. score what exists now      scripts/check-<thing>.sh        <- the baseline
+1. write the cases            transforms/<name>/cases.yaml
+2. score what exists now      $PF --eval <name>               <- the baseline
 3. change one thing
 4. score again                same command, same set
 5. keep it only if the number went up and no category collapsed
@@ -46,6 +46,17 @@ Steps 1 and 2 are not optional overhead. Tuning by eye fixes the example in
 front of you and silently breaks one you are not looking at — which is why
 every rewrite in this repo ships with a set, and why the sets keep their
 failures in rather than dropping them to make a number look better.
+
+`--eval` is that loop in the binary, against your own config, so it is
+available to anyone who installed the app and not only to this repository. It
+runs the transform your config actually names — not a copy of it — and always
+reports the must-not-change half and the per-probe grid separately. The full
+format and every optional key is in [cli.md](cli.md#scoring-a-transform---eval).
+
+The sets in this repository that predate it still have bespoke runners in
+`scripts/`, and some of them always will: a custom gate — "a handle belonging
+to someone who was not named must be zero" — is not something a generic runner
+can express, and should not try to.
 
 ## Recipe: a substitution
 
@@ -210,6 +221,20 @@ $PF --pipeline my-test.yaml "on en a vingt et un" --lang fr
 
 ## Writing the case set
 
+It goes in the transform's own folder, called `cases.yaml`, which is where
+`--eval <name>` looks:
+
+```yaml
+# The contract, in prose — see below.
+cases:
+  - probe: language-said
+    input:  add a python function called max retries
+    expect: add a python function called max_retries
+  - probe: prose
+    input:  we should discuss the retry count tomorrow    # no expect: —
+                                                          # it must not change
+```
+
 Twenty to forty cases. Fewer and you cannot tell a real change from noise; more
 and you stop running it.
 
@@ -232,19 +257,33 @@ and you stop running it.
 - **Write the contract at the top of the file**, in prose: what counts as a
   case for this feature and what is deliberately out of scope. It is the thing
   you will disagree with yourself about in a week.
-- **Group by category**, so a regression reads as "all the two-word ones broke"
-  rather than an unattributable drop of four points.
+- **Group by `probe:`**, so a regression reads as "all the two-word ones broke"
+  rather than an unattributable drop of four points. `--eval` prints the grid.
+- **Run the control.** If the job can be done without a model, `control:` in
+  the case file scores that too, on the same cases. It is the only thing that
+  answers "is the model earning its place", and twice in this repo the answer
+  was no.
 
-The sets that exist: `spelling` (62) and `french` (45) for corrections,
-`numbers` (97), `routing` (45), `dotted` (56), `code-identifier` (75),
-`grammar` (17), `wake` (25), `split` (14), `generic`, `dates`, `inplace`,
-`pipeline`, `replacement`. Each has a runner in `scripts/`.
+The sets that exist. A transform's set lives in its folder; the ones belonging
+to a built-in stage or to the router have nowhere else to be and stay in
+`tests/`:
+
+| Where | Sets |
+|---|---|
+| `examples/transforms/<name>/` | `code_identifiers` (75), `dotted` (56), `grammar` (17), `email` (26) |
+| `tests/` | `spelling` (62), `french` (45), `numbers` (97), `routing` (45), `wake` (25), `split` (14), `generic`, `dates`, `inplace`, `pipeline`, `replacement` |
+
+Each has a runner in `scripts/`; the transform sets can also be scored with
+`--eval`. `examples/transforms/` is a byte-for-byte mirror of what a first
+launch writes into `~/.config/parrotflow/transforms/`, kept honest by
+`scripts/check-seeded-transform.sh`.
 
 ## Before you call it done
 
-- [ ] `--check-config` is clean, and names every `command:` transform you added
-- [ ] the check script for what you touched still passes, and you know its
-      number before and after
+- [ ] `--check-config` is clean, names every `command:` transform you added, and
+      the resolved path it prints for each is the one you meant
+- [ ] `--eval <name>`, or the check script for what you touched, still passes —
+      and you know its number before and after, on both halves
 - [ ] any stage costing a model call has a `when:`, an `unless:` or an `app:`
 - [ ] failure leaves the transcript alone — kill the model, run it again, see
       the sentence come through untouched

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -21,6 +21,7 @@ means it did what it says**, so these compose into scripts — which is what
 | `--pipeline <file.yaml> "<text>"` | What does this pipeline do to this sentence? |
 | `--replace "<text>"` | What do my replacement rules do to this sentence? |
 | `--route "<what you'd say>"` | Which transform does this instruction reach? |
+| `--eval <transform>` | How does it score against its own case set? |
 | `--seed-config` | What does a first launch write, and what did it leave alone? |
 
 Every one of them reads `~/.config/parrotflow/`. Set `PARROTFLOW_CONFIG_DIR` to
@@ -91,6 +92,62 @@ so a case file states the setup it assumes instead of inheriting this machine's.
 - `--quiet` prints only the result, for scripts.
 - `--lang en,fr` stands in for the configured `languages:`, so a case file does
   not depend on how this Mac is set up.
+
+## Scoring a transform: `--eval`
+
+One sentence tells you a rewrite is wrong. Only a set tells you a change made
+it better rather than moved the failure.
+
+```sh
+$PF --eval code_identifiers                        # transforms/…/cases.yaml
+$PF --eval slack_mentions --cases heldout.yaml     # another set in the folder
+$PF --eval grammar --probe restraint --verbose
+$PF --eval ~/scratch/my-cases.yaml                 # one-off, outside a folder
+```
+
+It resolves the transform from your config and runs **that** — the same code
+the app runs, including the part where every way of failing leaves the text
+alone. A runner that reimplements the thing it scores drifts from it, and the
+number then describes code nobody ships.
+
+```yaml
+# The contract, in prose: what counts as a case here and what is deliberately
+# out of scope. It is what you will disagree with yourself about in a week.
+cases:
+  - probe: ambiguity_common        # optional; groups the breakdown
+    input:  mark it as resolved
+    expect: mark it as resolved
+```
+
+`input` and `expect` are the whole requirement. **`expect` left out means "comes
+back exactly as it went in"**, and those cases are reported as their own half —
+detected, never declared. A rewrite that scores well on `change` and badly on
+`keep` is not 80% of the way there; it is one that makes you proof-read every
+dictation.
+
+Four optional keys, each earning its place:
+
+| | |
+|---|---|
+| `probe:` on a case | the breakdown. One broken category hides behind eleven healthy ones for exactly as long as nobody breaks it out |
+| `instruction:` | what the speaker said, for a prompt reached by voice. The same prompt scores differently as a pipeline stage, which is given nothing |
+| `control:` | a command doing the same job without a model. The only thing that answers "is the model earning its place" — on Slack mentions it scored the same and the model was dropped |
+| `intermediate:` | `field:`, `resolve:` and optionally `produce:`, for a two-stage transform. Scores what the model alone returns, separately, so you can tell whether the prompt or the code is at fault |
+
+Where an intermediate gold exists it is **checked against itself before
+anything is scored**: resolving it must produce `expect`. A typo in a gold
+otherwise scores every candidate against the typo, silently, for as long as the
+set exists — so that is a refusal, not a warning.
+
+Latency is reported warm, after a throwaway first call. A cold start is Ollama
+reading weights off a disk and has nothing to say about the thing you changed.
+
+`--eval` exits 0 whenever it managed to score, whatever the number: a set worth
+having keeps its residue in, failing. It exits 1 when it could not score at all.
+
+Custom gates — "a handle belonging to someone who was not named must be zero" —
+do not generalise and stay in a script of your own. See
+[authoring.md](authoring.md).
 
 ## Testing a spoken instruction
 
@@ -192,7 +249,8 @@ scripts/check-routing.sh           scripts/check-wake.sh
 scripts/check-split.sh             scripts/check-grammar.sh
 scripts/check-dates.sh             scripts/check-inplace.sh
 scripts/check-default-config.sh    scripts/check-seeded-transform.sh
-scripts/check-transform-folders.sh scripts/check-span.sh
+scripts/check-transform-folders.sh scripts/check-eval.sh
+scripts/check-span.sh              # a composer-shaped page, or Slack, or Outlook
 
 PF_VIEWPORT=Ghostty scripts/check-inplace.sh   # the same set, in another terminal
 $PF --peek 3 --via-copy                        # what Select All + Copy hands back

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -82,6 +82,7 @@ transforms:
   - name: slack_mentions
     description: turn people's names into Slack mentions
     command: slack_mentions.py          # transforms/slack_mentions/…
+    tests: { path: heldout.yaml }       # what --eval scores; default cases.yaml
 ```
 
 A scalar stays a scalar: an inline `prompt: |` is unchanged, and a three-line

--- a/docs/proposals/transform-folders.md
+++ b/docs/proposals/transform-folders.md
@@ -1,8 +1,8 @@
 # Proposal: a folder per transform, and one harness for everyone
 
-**Status.** Phase 1 is built — this change. Phase 2 is specified below and
-built in the change that follows it. Kept as the record of what was decided and
-why, which the code cannot hold.
+**Status.** Built, both phases. Kept as the record of what was decided and why,
+which the code cannot hold. Where the implementation departed from the text
+below it is noted inline as **[built]**.
 
 **Goal.** A transform is a directory. Everything belonging to it — the prompt
 or script, its case set, its data — lives inside, so it can be written, tested
@@ -196,8 +196,25 @@ it — a shipped example that comes with its own set is the whole argument of
 | `config.example.yaml`, `docs/configuration.md`, `docs/pipelines.md`, `docs/authoring.md` | the layout, the rule, the `path:` form |
 | `scripts/check-default-config.sh` | reads the real file; will need the new shape |
 
-**Note:** `Config.swift` had uncommitted changes from another session on
-2026-08-04. Check `git status` and coordinate before starting.
+**[built]** Two things were added that the text above does not ask for, both
+because they are what makes the acceptance below checkable rather than
+assertable:
+
+- `PARROTFLOW_CONFIG_DIR` points any command at a config directory of its own,
+  so `scripts/check-transform-folders.sh` and `scripts/check-eval.sh` score the
+  real binary against a config in `/tmp` instead of inheriting this machine's.
+- `--seed-config` runs `createIfMissing` and reports what it wrote and what it
+  left alone. What a first launch gets was otherwise only answerable by
+  deleting your own config.
+
+And one bug came out on the way: `expandingTildeInPath` also standardises, so
+`command: sed -e s/quick/slow/` lost its trailing slash before the shell saw it.
+It is expanded only when there is a tilde now.
+
+The repository moved too, which the text above does not cover: the sets
+belonging to a shipped transform live in `examples/transforms/<name>/`, a
+byte-for-byte mirror of what is seeded. The sets belonging to a built-in stage
+or to the router have no folder to own them and stay in `tests/`.
 
 ### Acceptance
 
@@ -247,6 +264,16 @@ from the app is worth 31 points of measured error.
 
 ### Case file format
 
+**[built]** with two additions: `instruction:`, because a prompt asked for by
+voice is given what the speaker said and the same prompt as a pipeline stage is
+given nothing — `grammar` scores 16/17 and 15/17 under the two, and a set that
+cannot say which one it means reports a number for a use nobody has. And
+`transforms:`, so a set can carry the transform it assumes the way a
+`--pipeline` fixture does, which is what lets `scripts/check-eval.sh` mean the
+same thing on any machine. `category:` is read as an alias for `probe:`, and a
+case with no `expect:` is the must-not-change half — both so the sets that
+predate this need no editing.
+
 ```yaml
 # Contract prose at the top: what counts as a case here, what is deliberately
 # out of scope. It is what you will disagree with yourself about in a week.
@@ -272,11 +299,16 @@ something real.
    behind eleven healthy ones.
 3. **Report latency per case**, warm. Cold-start timings send you optimising
    the wrong thing.
-4. **A no-model control**, when the transform can run without one. On this task
+4. **A no-model control**, when the transform can run without one. **[built]**
+   as `control:` in the case file, naming a command: the app cannot infer how
+   to run someone's script without its model, and inferring it would be
+   guessing at the one number that exists to be trusted. On this task
    it scored the same as the model and the model was dropped; on spoken
    identifiers the control won outright. It is the only thing that answers
    "is the model earning its place".
-5. **Optional intermediate gold** for two-stage transforms — a second field
+5. **Optional intermediate gold** for two-stage transforms. **[built]** as
+   `intermediate:` with `field:`, `resolve:` and an optional `produce:` —
+   `resolve:` is what requirement 6 needs and is therefore not optional. — a second field
    holding what the model alone should return. Scoring it separately says
    whether the prompt or the code is at fault. The gap ran 25 points on this
    task.

--- a/examples/transforms/grammar/cases.yaml
+++ b/examples/transforms/grammar/cases.yaml
@@ -48,6 +48,13 @@
 # *examples* did not (v4a, 15/17). Elsewhere here examples beat rules. It is
 # worth trying both rather than assuming which way it will go.
 
+# What the speaker said, because this prompt is asked for by voice rather than
+# run as a pipeline stage — and the same prompt scores differently under the
+# two. `--eval grammar` reproduces scripts/check-grammar.sh only with it, at
+# 16/17; without it the prompt is given the text and nothing else and comes
+# back at 15/17, which is the number for a use this transform does not have.
+instruction: fix the grammar and punctuation
+
 cases:
   # --- real errors, minimally fixed ---------------------------------------
   - input: the panel dont show up sometimes

--- a/scripts/check-eval.sh
+++ b/scripts/check-eval.sh
@@ -185,6 +185,26 @@ check "a case with no expect: is detected as must-not-change" \
      | grep -E '^  keep' | sed 's/ <-.*//;s/  */ /g;s/^ //;s/ $//')" \
   "keep 1/1 = 100%"
 
+# --- `tests:` on the transform ----------------------------------------------
+#
+# A transform whose default set is not cases.yaml says so once, in the config,
+# rather than in every command anyone runs against it.
+cp "$WORK/transforms/shout/cases.yaml" "$WORK/transforms/shout/heldout.yaml"
+cat >> "$WORK/config.yaml" <<'YAML'
+  - name: shout_heldout
+    description: the same transform, scored against a set of its own
+    command: shout.py
+    tests: { path: heldout.yaml }
+YAML
+mkdir -p "$WORK/transforms/shout_heldout"
+ln -s ../shout/heldout.yaml "$WORK/transforms/shout_heldout/heldout.yaml"
+ln -s ../shout/shout.py "$WORK/transforms/shout_heldout/shout.py"
+ln -s ../shout/roster.json "$WORK/transforms/shout_heldout/roster.json"
+
+check "tests: names the set --eval scores by default" \
+  "$("$BIN" --eval shout_heldout 2>/dev/null | grep -c 'heldout.yaml')" \
+  "1"
+
 # --- a set that names a file that is not there ------------------------------
 check "a missing set names where it looked" \
   "$("$BIN" --eval shout --cases nowhere.yaml 2>&1 | grep -c 'no nowhere.yaml')" \

--- a/scripts/check-eval.sh
+++ b/scripts/check-eval.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Checks the --eval harness against sets built for the purpose.
+#
+#   scripts/check-eval.sh
+#
+# Six things --eval has to do, each of which came from building
+# scripts/validate-slack-mentions.py and each of which caught something real:
+#
+#   1  split the must-not-change half out and report it separately
+#   2  break out by probe, never only an aggregate
+#   3  report latency per case, warm
+#   4  a no-model control, when the transform can run without one
+#   5  score an intermediate gold separately, for two-stage transforms
+#   6  check the gold against itself before scoring anything
+#
+# Everything runs against a config directory built in /tmp, so this scores the
+# real binary and says nothing about — and does nothing to — the config on this
+# machine. Nothing here calls a model: the numbers have to be the same on a
+# laptop with Ollama running and one without.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/release/ParrotFlow"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+
+WORK="$(mktemp -d -t parrotflow-eval)"
+trap 'rm -rf "$WORK"' EXIT
+export PARROTFLOW_CONFIG_DIR="$WORK"
+
+pass=0; total=0; failed=""
+
+check() {  # check <name> <got> <want>
+  total=$((total + 1))
+  if [ "$2" = "$3" ]; then
+    pass=$((pass + 1)); printf '  ✓ %s\n' "$1"
+  else
+    failed="$failed
+      $1"
+    printf '  ✗ %s\n      got   %s\n      want  %s\n' "$1" "$2" "$3"
+  fi
+}
+
+# --- a transform with two stages, and no model anywhere ---------------------
+#
+# `shout.py` marks the words to change and resolves the marks, in one pass or
+# either half on demand — which is what lets one set exercise the control, the
+# intermediate gold and the gold's own self-check without asking Ollama for
+# anything. The rule it applies is deliberately trivial: a word in the roster
+# comes back in capitals.
+mkdir -p "$WORK/transforms/shout"
+cat > "$WORK/transforms/shout/shout.py" <<'PY'
+#!/usr/bin/env python3
+"""Roster words in capitals. --mark stops after marking, --resolve starts there."""
+import json, pathlib, re, sys
+
+roster = set(json.loads(pathlib.Path("roster.json").read_text()))
+text = sys.stdin.read().rstrip("\n")
+
+if "--resolve" not in sys.argv:
+    text = re.sub(r"\b\w+\b", lambda m: "[[%s]]" % m.group(0)
+                  if m.group(0).lower() in roster else m.group(0), text)
+if "--mark" not in sys.argv:
+    text = re.sub(r"\[\[(\w+)\]\]", lambda m: m.group(1).upper(), text)
+print(text)
+PY
+chmod +x "$WORK/transforms/shout/shout.py"
+printf '["mark", "tess"]\n' > "$WORK/transforms/shout/roster.json"
+
+cat > "$WORK/config.yaml" <<'YAML'
+transforms:
+  - name: shout
+    description: roster words in capitals
+    command: shout.py
+  - name: quiet
+    description: a table, so a replace body is scored too
+    replace:
+      hush: [shout]
+YAML
+
+cat > "$WORK/transforms/shout/cases.yaml" <<'YAML'
+# Half the set must come back byte for byte. That is not padding: the expensive
+# failure is shouting a word that was never on the roster.
+control: shout.py
+intermediate:
+  field: marks
+  produce: shout.py --mark
+  resolve: shout.py --resolve
+cases:
+  - probe: roster
+    input: ask mark about it
+    marks: ask [[mark]] about it
+    expect: ask MARK about it
+  - probe: roster
+    input: tess knows
+    marks: '[[tess]] knows'
+    expect: TESS knows
+  - probe: bystander
+    input: leave it alone
+    marks: leave it alone
+    expect: leave it alone
+  - probe: bystander
+    input: nothing to see
+    marks: nothing to see
+    expect: nothing to see
+YAML
+
+out="$("$BIN" --eval shout 2>/dev/null)"
+line() { printf '%s\n' "$out" | grep -E "^  $1" | sed 's/  */ /g;s/^ //;s/ $//'; }
+
+# 1 — the two halves, separately and always.
+check "the must-not-change half is reported on its own" \
+  "$(line change)$(line keep | sed 's/ <-.*//')" \
+  "change 2/2 = 100%keep 2/2 = 100%"
+
+# 2 — the per-probe grid.
+check "the per-probe grid is printed" \
+  "$(printf '%s\n' "$out" | grep -cE '^    (roster|bystander) +2/2')" \
+  "2"
+
+# 3 — latency, warm.
+check "latency is reported" \
+  "$(printf '%s\n' "$out" | grep -c 'latency.*warm')" \
+  "1"
+
+# 4 — the control.
+check "the no-model control is scored" \
+  "$(printf '%s\n' "$out" | grep -c 'without a model')" \
+  "1"
+
+# 5 — the first stage on its own.
+check "the intermediate gold is scored separately" \
+  "$(printf '%s\n' "$out" | grep -E 'first stage alone' | grep -c '4/4')" \
+  "1"
+
+check "a passing set exits 0" "$("$BIN" --eval shout > /dev/null 2>&1; echo $?)" "0"
+
+# 6 — a gold that does not agree with itself stops everything.
+#
+# A typo here otherwise scores every candidate against the typo, silently and
+# for as long as the set exists. So it is a refusal before any case is run,
+# and the proof that nothing was run is that no score is printed.
+cp "$WORK/transforms/shout/cases.yaml" "$WORK/transforms/shout/typo.yaml"
+sed -i '' 's/marks: ask \[\[mark\]\] about it/marks: ask [[tess]] about it/' \
+  "$WORK/transforms/shout/typo.yaml"
+bad="$("$BIN" --eval shout --cases typo.yaml 2>/dev/null)"
+
+check "a bad gold is refused" \
+  "$(printf '%s\n' "$bad" | grep -c 'does not agree with itself')" \
+  "1"
+
+check "and nothing is scored before it is" \
+  "$(printf '%s\n' "$bad" | grep -cE '^  overall')" \
+  "0"
+
+check "and it exits 1" \
+  "$("$BIN" --eval shout --cases typo.yaml > /dev/null 2>&1; echo $?)" \
+  "1"
+
+# --- a set that carries its own transform ----------------------------------
+#
+# So a case file can state what it assumes rather than inherit this machine's
+# config — the same reason `--pipeline` takes a fixture.
+mkdir -p "$WORK/elsewhere"
+cat > "$WORK/elsewhere/table-cases.yaml" <<'YAML'
+transform: quiet
+transforms:
+  - name: quiet
+    description: a table carried by the set itself
+    replace:
+      hush: [shout]
+cases:
+  - input: please shout about it
+    expect: please hush about it
+  - input: nothing to change here
+YAML
+
+check "a replace: body scores, from a set that carries its own transform" \
+  "$("$BIN" --eval "$WORK/elsewhere/table-cases.yaml" 2>/dev/null \
+     | grep -E '^  overall' | sed 's/  */ /g;s/^ //')" \
+  "overall 2/2 = 100%"
+
+# `expect` absent means "comes back exactly as it went in", and that case
+# belongs to the keep half without anyone having to say so.
+check "a case with no expect: is detected as must-not-change" \
+  "$("$BIN" --eval "$WORK/elsewhere/table-cases.yaml" 2>/dev/null \
+     | grep -E '^  keep' | sed 's/ <-.*//;s/  */ /g;s/^ //;s/ $//')" \
+  "keep 1/1 = 100%"
+
+# --- a set that names a file that is not there ------------------------------
+check "a missing set names where it looked" \
+  "$("$BIN" --eval shout --cases nowhere.yaml 2>&1 | grep -c 'no nowhere.yaml')" \
+  "1"
+
+echo
+echo "  $pass/$total$failed"
+[ "$pass" = "$total" ]


### PR DESCRIPTION
Stacked on #41 — review that first; this diff is only `--eval`. GitHub retargets this to `main` when #41 merges.

Every rewrite in this repository has a case set and a bespoke runner in `scripts/`. Nobody who installed the app has either, which leaves "write a prompt and hope" as the only loop available to them. This is the loop `docs/authoring.md` prescribes, in the binary, against your own config.

```sh
$PF --eval code_identifiers                        # transforms/…/cases.yaml
$PF --eval slack_mentions --cases heldout.yaml     # another set in the folder
$PF --eval grammar --probe restraint --verbose
$PF --eval ~/scratch/my-cases.yaml                 # one-off, outside a folder
```

It resolves the transform from your config and runs **that** — a one-step `Pipeline` and `PromptRunner`, the same code the app runs, including the part where every way of failing leaves the text alone. A runner that reimplements the thing it scores drifts from it, and the number then describes code nobody ships.

## The format

`input` and `expect` are the whole requirement.

```yaml
# The contract, in prose: what counts as a case here and what is deliberately
# out of scope. It is what you will disagree with yourself about in a week.
cases:
  - probe: ambiguity_common
    input:  mark it as resolved
    expect: mark it as resolved
```

**`expect` left out means "comes back exactly as it went in"** — detected, never declared, and reported as its own half. A rewrite that scores well on `change` and badly on `keep` is not 80% of the way there; it is one that makes you proof-read every dictation.

Four optional keys, each of which caught something real while building `scripts/validate-slack-mentions.py`:

| | |
|---|---|
| `probe:` | the breakdown. One broken category hides behind eleven healthy ones for exactly as long as nobody breaks it out |
| `instruction:` | what the speaker said, for a prompt reached by voice — see below |
| `control:` | the same set without a model. The only thing that answers "is the model earning its place" |
| `intermediate:` | `field:`, `resolve:`, optionally `produce:`. Scores what the first stage alone returns, so you can tell whether the prompt or the code is at fault |

Where an intermediate gold exists it is **checked against itself before anything is scored**: resolving it must produce `expect`. A typo in a gold otherwise scores every candidate against the typo, silently, for as long as the set exists — so that is a refusal, not a warning.

Every case lands in a probe bucket including the ones that name none, because a grid that silently covers 61 of 75 reads as a complete breakdown and is not one. Latency is warm, after a throwaway first call.

## Both shipped examples agree with the runners they replace

| | `--eval` | the bespoke runner |
|---|---|---|
| `code_identifiers`, 75 cases | 38/43 change, 30/32 keep, **68/75** | `validate-code-identifiers.py --code-only`: identical |
| `slack_mentions`, 76 cases | 40/40, 36/36, **76/76** | `validate-slack-mentions.py --code-only`: identical |
| `slack_mentions`, held out | 10/10, 13/14, **23/24** | identical, same single failure |
| `grammar`, 17 cases | 7/7, 9/10, **16/17** | `check-grammar.sh`: identical |

`grammar` only matches **with** `instruction:` in its set. Run as a pipeline stage the same prompt is given no instruction and comes back at 15/17 — a real number for a use that transform does not have. That is why the key exists, and it is now recorded in the case file rather than in a runner's argv.

## Two decisions worth checking

**`--eval` exits 0 whenever it managed to score, whatever the number.** A set worth having keeps its residue in, failing — `dotted` scores 54/54 and carries two more it cannot do. A number below 100% is an ordinary result, not something to report to a shell. It exits 1 when it could not score at all: no such transform, no case file, a bad gold.

**Custom gates stay bespoke.** The Slack set counts wrong handles and false `@channel` separately and both must be zero; that does not generalise, and a generic runner that tried would be guessing at the one number that exists to be trusted.

## Verification

`scripts/check-eval.sh` is new — 13 cases, no model anywhere in it, so the numbers are the same on a runner and on a laptop with Ollama up. It covers all six scoring requirements, both halves, the per-probe grid, the control, the intermediate, and the bad-gold refusal, including that **nothing is scored before the refusal**.

| harness | result |
|---|---|
| `check-eval.sh` (new) | 13/13 |
| `check-transform-folders.sh` | 12/12 |
| `check-pipeline.sh` | 27/27 |
| the other seven deterministic sets | unchanged |
| `swiftlint` | 0 errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)