### PR TITLE
fix: a transform you can run is a transform you can ask for

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -917,10 +917,32 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         case .replace:
             return Replacements.applyExact(to: text, rules: transform.rules)
         case .command(let command):
-            // Nil is every way a program can fail, and it means keep the text.
-            return CommandRunner.run(
+            // Nil is every way a program can fail, and in a pipeline it means
+            // keep the text — a stage that fails must not cost you a sentence.
+            //
+            // Asked for by name it means something else. You said "use slack
+            // handles", the script did not run, and returning the text
+            // unchanged makes that indistinguishable from a script that ran
+            // and found nothing to do: the selection path then says "nothing
+            // to change" and the inline path says nothing at all. Both are
+            // describing a transform that worked. So this throws, and the
+            // failure paths both callers already have get to do their job.
+            guard let result = CommandRunner.run(
                 command, on: text, in: transform.folder, seconds: transform.timeout
-            ) ?? text
+            ) else { throw CommandDidNotRun(name: transform.name) }
+            return result
+        }
+    }
+
+    /// A `command:` transform that produced no rewrite, asked for by name.
+    ///
+    /// The log already carries which of the ways it went wrong — could not
+    /// start, exited non-zero, took too long, said nothing — and that is more
+    /// than fits on screen. What belongs on screen is that it did not run.
+    private struct CommandDidNotRun: LocalizedError {
+        let name: String
+        var errorDescription: String? {
+            "\(name) did not run — the log says what it said"
         }
     }
 

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -785,7 +785,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // being kept warm is Ollama's prompt cache, and a system prompt that
         // differs by one line is a cache miss and the 3.5s this exists to avoid.
         let system = Router.prompt(
-            for: Catalogue(prompts: config.prompts), freeForm: config.freeForm
+            for: Catalogue(transforms: config.transforms), freeForm: config.freeForm
         )
         keepWarmInFlight = true
         Task.detached(priority: .background) { [weak self] in
@@ -807,7 +807,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func handleVoiceCommand(_ command: String) {
-        let catalogue = Catalogue(prompts: config.prompts)
+        let catalogue = Catalogue(transforms: config.transforms)
 
         // Deterministic phrases first: no model needed, and they work when
         // Ollama is not running. This also covers the wake phrase said on its
@@ -850,7 +850,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         // the whole specification, so it goes through unsplit,
                         // exactly as it would to a prompt of your own.
                         Log.write("router: \"\(command)\" → \(FreeForm.name)")
-                        self.runTransform(FreeForm.prompt(for: command), instruction: command)
+                        self.runTransform(FreeForm.prompt(for: command).asTransform, instruction: command)
                     case .none:
                         // Nothing fits. Deliberately not falling through to
                         // dictation: the wake phrase means you were not
@@ -887,8 +887,40 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             beginCorrection()
         case .action(.spelling):
             interpretSpelling(instruction)
-        case .transform(let prompt):
-            runTransform(prompt, instruction: instruction)
+        case .transform(let transform):
+            runTransform(transform, instruction: instruction)
+        }
+    }
+
+    /// Runs any of the three bodies over text and gives back the result.
+    ///
+    /// The one place that knows how a transform is made, so the two paths that
+    /// reach one by voice — over your selection, and inline in a dictation —
+    /// cannot disagree about what running it means. It mirrors
+    /// `Pipeline.runTransform`, which does the same job for a stage.
+    ///
+    /// The spoken instruction reaches a `prompt:` and nothing else. A script
+    /// and a table take text on one side and give text on the other; there is
+    /// nowhere to put "in French" and no honest way to invent one. Saying it
+    /// anyway is harmless — the words are consumed by the routing and the
+    /// transform runs — and is the reason `--check-config` names what each
+    /// capability is made of.
+    private func perform(
+        _ transform: Config.Transform, instruction: String, on text: String
+    ) async throws -> String {
+        switch transform.body {
+        case .prompt:
+            guard let prompt = transform.asPrompt else { return text }
+            return try await PromptRunner.run(
+                prompt: prompt, instruction: instruction, text: text, config: llmConfig()
+            )
+        case .replace:
+            return Replacements.applyExact(to: text, rules: transform.rules)
+        case .command(let command):
+            // Nil is every way a program can fail, and it means keep the text.
+            return CommandRunner.run(
+                command, on: text, in: transform.folder, seconds: transform.timeout
+            ) ?? text
         }
     }
 
@@ -938,7 +970,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// The selection is taken from the snapshot made when the hotkey went down,
     /// not read now — by the time this runs, our own panel may hold focus, and
     /// reading then returns nothing or something of ours.
-    private func runTransform(_ prompt: Config.Prompt, instruction: String) {
+    private func runTransform(_ transform: Config.Transform, instruction: String) {
         // Never the clipboard. `read()` falls back to it for the correction
         // panel, where you see the words before anything happens and can
         // cancel; a transform gets no such look. The clipboard holds whatever
@@ -967,19 +999,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // The text itself, not just its length: a transform that worked on the
         // wrong thing is otherwise indistinguishable in the log from one that
         // worked on the right thing badly.
-        Log.write("transform: \(prompt.name) over \(selection == nil ? "the last dictation" : "the selection") — \"\(target.prefix(80))\"")
-        beginProgress(prompt.progressLabel)
+        Log.write("transform: \(transform.name) over \(selection == nil ? "the last dictation" : "the selection") — \"\(target.prefix(80))\"")
+        beginProgress(transform.progressLabel)
 
-        let llmConfig = llmConfig()
         Task { [weak self] in
             do {
-                let result = try await PromptRunner.run(
-                    prompt: prompt, instruction: instruction,
-                    text: target, config: llmConfig
-                )
+                guard let result = try await self?.perform(
+                    transform, instruction: instruction, on: target
+                ) else { return }
                 await MainActor.run {
                     self?.finishTransform(
-                        prompt: prompt, selection: selection,
+                        transform: transform, selection: selection,
                         before: target, after: result
                     )
                 }
@@ -994,7 +1024,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func finishTransform(
-        prompt: Config.Prompt,
+        transform: Config.Transform,
         selection: SelectionReader.Selection?,
         before: String,
         after: String
@@ -1003,8 +1033,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let cleaned = after.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !cleaned.isEmpty else {
-            Log.write("transform: \(prompt.name) returned nothing")
-            flash("\(prompt.name) returned nothing from \(quoted(before))", tone: .caution)
+            Log.write("transform: \(transform.name) returned nothing")
+            flash("\(transform.name) returned nothing from \(quoted(before))", tone: .caution)
             return
         }
         // Saying so beats replacing text with itself and calling it done, which
@@ -1016,23 +1046,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // failed — and telling them apart took reading the log. Showing what it
         // looked at answers the first two at a glance.
         guard cleaned != before.trimmingCharacters(in: .whitespacesAndNewlines) else {
-            Log.write("transform: \(prompt.name) changed nothing")
-            flash("\(prompt.name): nothing to change in \(quoted(before))", tone: .plain)
+            Log.write("transform: \(transform.name) changed nothing")
+            flash("\(transform.name): nothing to change in \(quoted(before))", tone: .plain)
             return
         }
 
-        guard prompt.confirm else {
-            applyTransform(cleaned, to: selection, replacing: before, prompt: prompt)
+        guard transform.confirm else {
+            applyTransform(cleaned, to: selection, replacing: before, transform: transform)
             return
         }
 
         previewPanel.onApply = { [weak self] edited in
-            self?.applyTransform(edited, to: selection, replacing: before, prompt: prompt)
+            self?.applyTransform(edited, to: selection, replacing: before, transform: transform)
         }
         previewPanel.onCancel = {
-            Log.write("transform: \(prompt.name) discarded")
+            Log.write("transform: \(transform.name) discarded")
         }
-        previewPanel.show(prompt: prompt.name, before: before, after: cleaned)
+        previewPanel.show(prompt: transform.name, before: before, after: cleaned)
     }
 
     /// One edit to make to text that is already in the field.
@@ -1261,20 +1291,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         _ text: String,
         to selection: SelectionReader.Selection?,
         replacing replaced: String,
-        prompt: Config.Prompt
+        transform: Config.Transform
     ) {
         // Replacing the selection puts it back exactly where it came from.
         // Without one there is nowhere to aim, so it goes in at the cursor the
         // same way a dictation would.
         if let selection {
-            switch replaceSelected(with: text, in: selection, describedAs: prompt.name) {
+            switch replaceSelected(with: text, in: selection, describedAs: transform.name) {
             case .replaced:
-                applied(prompt.name)
+                applied(transform.name)
             case .failed, .notAttempted:
                 Log.write("transform: this app would not accept the rewrite; left on the clipboard")
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(text, forType: .string)
-                flash("\(prompt.name) copied — this app won't let me edit it", tone: .caution)
+                flash("\(transform.name) copied — this app won't let me edit it", tone: .caution)
             }
         } else {
             // Hand focus back first. Showing the preview called NSApp.activate
@@ -1298,17 +1328,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                !SelectionReader.isOurs(element) {
                 let edit = Edit(find: original, replace: text, fuzzy: false)
                 switch applyInPlace(
-                    [edit], dictated: original, in: element, describedAs: prompt.name
+                    [edit], dictated: original, in: element, describedAs: transform.name
                 ) {
                 case .replaced:
-                    applied(prompt.name)
+                    applied(transform.name)
                     lastTranscript = text
                     return
                 case .failed:
                     Log.write("transform: the line would not take the rewrite; left on the clipboard")
                     NSPasteboard.general.clearContents()
                     NSPasteboard.general.setString(text, forType: .string)
-                    flash("\(prompt.name) copied — this app won't let me edit it", tone: .caution)
+                    flash("\(transform.name) copied — this app won't let me edit it", tone: .caution)
                     lastTranscript = text
                     return
                 case .notAttempted:
@@ -1319,9 +1349,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             switch TextInserter.insert(text, mode: config.transcription.insertMode) {
             case .pasted, .copied:
                 if config.feedback.sound { NSSound(named: "Glass")?.play() }
-                flash("\(prompt.name) applied", tone: .done)
+                flash("\(transform.name) applied", tone: .done)
             case .clipboardOnly:
-                flash("\(prompt.name) copied — grant Accessibility to paste", tone: .caution)
+                flash("\(transform.name) copied — grant Accessibility to paste", tone: .caution)
             }
         }
         lastTranscript = text
@@ -1561,7 +1591,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         text: String, instruction: String, destination: Destination,
         focus: SelectionReader.Selection?
     ) {
-        let catalogue = Catalogue(prompts: config.prompts)
+        let catalogue = Catalogue(transforms: config.transforms)
 
         /// Write what was said, and say why it is not what was asked for.
         func giveUp(_ why: String, tone: NoticeTone = .caution) {
@@ -1572,24 +1602,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             setLabel(why, clearAfter: 7)
         }
 
-        func run(_ prompt: Config.Prompt) {
-            beginProgress(prompt.progressLabel)
-            let llm = llmConfig()
+        func run(_ transform: Config.Transform) {
+            beginProgress(transform.progressLabel)
             Task { [weak self] in
                 do {
-                    let result = try await PromptRunner.run(
-                        prompt: prompt, instruction: instruction, text: text, config: llm
-                    )
+                    guard let result = try await self?.perform(
+                        transform, instruction: instruction, on: text
+                    ) else { return }
                     await MainActor.run {
                         guard let self else { return }
                         self.endProgress()
                         let cleaned = result.trimmingCharacters(in: .whitespacesAndNewlines)
                         guard !cleaned.isEmpty else {
-                            giveUp("\(prompt.name) returned nothing", tone: .failure)
+                            giveUp("\(transform.name) returned nothing", tone: .failure)
                             return
                         }
                         if cleaned != text {
-                            Log.write("inline: \(prompt.name) rewrote the transcript")
+                            Log.write("inline: \(transform.name) rewrote the transcript")
                             Log.write("    before: \(text)")
                             Log.write("    after:  \(cleaned)")
                         }
@@ -1607,7 +1636,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if let capability = Router.local(instruction: instruction, catalogue: catalogue) {
             Log.write("inline router: \"\(instruction)\" named \(capability.name) outright")
             switch capability {
-            case .transform(let prompt): run(prompt)
+            case .transform(let transform): run(transform)
             case .action(let action):
                 runInlineAction(
                     action, text: text, instruction: instruction,
@@ -1634,9 +1663,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 await MainActor.run {
                     guard let self else { return }
                     switch decision {
-                    case .matched(.transform(let prompt)):
-                        Log.write("inline router: \"\(instruction)\" → \(prompt.name)")
-                        run(prompt)
+                    case .matched(.transform(let transform)):
+                        Log.write("inline router: \"\(instruction)\" → \(transform.name)")
+                        run(transform)
                     case .matched(.action(let action)):
                         self.runInlineAction(
                             action, text: text, instruction: instruction,
@@ -1644,7 +1673,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         )
                     case .anything:
                         Log.write("inline router: \"\(instruction)\" → \(FreeForm.name)")
-                        run(FreeForm.prompt(for: instruction))
+                        run(FreeForm.prompt(for: instruction).asTransform)
                     case .none:
                         giveUp("Not something to change in the text: \"\(instruction)\"")
                     }

--- a/Sources/ParrotFlow/Capability.swift
+++ b/Sources/ParrotFlow/Capability.swift
@@ -3,16 +3,25 @@ import Foundation
 /// Everything "hey parrot" can reach, in one list.
 ///
 /// Two kinds, because not everything worth saying is a text rewrite. A
-/// **transform** is text in, text out, and comes from `prompts:` in the config.
-/// An **action** runs Swift — fixing a spelling opens a panel and writes a YAML
-/// rule, which no prompt can express.
+/// **transform** is text in, text out, and comes from `transforms:` in the
+/// config. An **action** runs Swift — fixing a spelling opens a panel and
+/// writes a YAML rule, which no prompt can express.
 ///
 /// Keeping both in one catalogue is the point: the router sees a flat list of
 /// names and descriptions and does not care which kind it picked, while the
 /// config stays honest by only ever holding transforms.
+///
+/// It carries a `Transform` and not a `Prompt`, which it did until a transform
+/// stopped always being a prompt. `asPrompt` returns nil for a `command:` body,
+/// so building this from `config.prompts` quietly dropped every script from the
+/// list the router chooses between — and a router given nine of your ten tools
+/// does not fail, it picks the nearest of the nine. Measured: "use slack
+/// handles" reached `slack`, the chat-tidying prompt, and tidied a sentence
+/// instead of turning a name into a handle. Nothing said so, because from the
+/// outside that is what a wrong route and a right route both look like.
 enum Capability: Equatable {
     case action(Action)
-    case transform(Config.Prompt)
+    case transform(Config.Transform)
 
     /// The built-ins. Registered here rather than in the config so they cannot
     /// be deleted by editing a file, and so they keep working when `prompts:`
@@ -36,14 +45,30 @@ enum Capability: Equatable {
     var name: String {
         switch self {
         case .action(let action): return action.rawValue
-        case .transform(let prompt): return prompt.name
+        case .transform(let transform): return transform.name
         }
     }
 
     var describedAs: String {
         switch self {
         case .action(let action): return action.describedAs
-        case .transform(let prompt): return prompt.description
+        case .transform(let transform): return transform.description
+        }
+    }
+
+    /// Which of the three bodies it is, for anything printing the catalogue.
+    /// The router never sees this: what a tool is made of is not a reason to
+    /// pick it, and putting it in the listing would be one more thing for the
+    /// model to weigh.
+    var kind: String {
+        switch self {
+        case .action: return "built-in"
+        case .transform(let transform):
+            switch transform.body {
+            case .prompt: return "prompt "
+            case .replace: return "table  "
+            case .command: return "program"
+            }
         }
     }
 
@@ -57,24 +82,39 @@ enum Capability: Equatable {
 struct Catalogue {
     let capabilities: [Capability]
 
-    /// Built-ins first, then the config's prompts.
+    /// Built-ins first, then everything in `transforms:`.
     ///
-    /// A prompt naming a built-in is dropped rather than allowed to shadow it.
-    /// Shadowing `spelling` would silently disable the one command that has a
-    /// validation set behind it, and the failure would look like the router
+    /// **All three bodies.** A `prompt:` costs a model call, a `command:` a
+    /// process start and a `replace:` nothing at all, and none of that is a
+    /// reason you cannot ask for one out loud. What decides whether something
+    /// belongs here is whether it has a `description` worth matching spoken
+    /// words against — which is the same question for all three.
+    ///
+    /// The cost is a longer list for the router to choose between, and a longer
+    /// list is measurably harder to choose from. That is the trade: a tool that
+    /// is not in the list is not merely unreachable, it makes its neighbours
+    /// wrong, because the router answers with the nearest thing it was shown
+    /// rather than admitting the right one is missing.
+    ///
+    /// A transform naming a built-in is dropped rather than allowed to shadow
+    /// it. Shadowing `spelling` would silently disable the one command that has
+    /// a validation set behind it, and the failure would look like the router
     /// misbehaving rather than like a name collision.
-    init(prompts: [Config.Prompt]) {
+    init(transforms: [Config.Transform]) {
         var seen = Set(Capability.Action.allCases.map { $0.rawValue.lowercased() })
         var list: [Capability] = Capability.Action.allCases.map { .action($0) }
 
-        for prompt in prompts {
-            let key = prompt.name.lowercased()
+        for transform in transforms {
+            let key = transform.name.lowercased()
             guard !seen.contains(key) else {
-                Log.write("prompts: \"\(prompt.name)\" collides with an existing name; skipped")
+                Log.write("transforms: \"\(transform.name)\" collides with an existing name; skipped")
                 continue
             }
+            // Nothing to match spoken words against. It still runs from a
+            // pipeline, where the name is written down rather than said.
+            guard !transform.description.isEmpty else { continue }
             seen.insert(key)
-            list.append(.transform(prompt))
+            list.append(.transform(transform))
         }
         capabilities = list
     }

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -128,11 +128,23 @@ enum CheckConfigCommand {
         // What "hey parrot" can reach. Printed even when `prompts:` is empty,
         // because the built-ins are the answer to "why did it do that" as
         // often as a prompt of your own is.
-        let catalogue = Catalogue(prompts: config.prompts)
+        let catalogue = Catalogue(transforms: config.transforms)
         print("  ✓ capabilities      \(catalogue.capabilities.count) reachable by \"\(transcription.activationPhrase)\"")
+        // What each one is made of, because the three cost wildly different
+        // things — a model call, a process start, nothing at all — and because
+        // a program reachable by voice is a program run by saying a sentence,
+        // which this file says out loud everywhere else it happens.
         for capability in catalogue.capabilities {
-            let kind = capability.isTransform ? "prompt " : "built-in"
-            print("      \(kind)  \(capability.name) — \(capability.describedAs)")
+            print("      \(capability.kind)  \(capability.name) — \(capability.describedAs)")
+        }
+        // A transform with no description cannot be routed to, so it is not in
+        // the list above. It still runs from a pipeline, where the name is
+        // written down rather than said — which is the difference worth naming,
+        // since "I wrote it and it does not answer" is otherwise a mystery.
+        let unroutable = config.transforms.filter { $0.description.isEmpty }
+        if !unroutable.isEmpty {
+            print("  · not by voice      \(unroutable.map(\.name).joined(separator: ", "))"
+                + " — no description to match spoken words against")
         }
         // Not one of the capabilities above — the router reaches it by
         // answering ANY, not by picking it off the list — so it is printed
@@ -143,18 +155,19 @@ enum CheckConfigCommand {
             print("  · free_form         off — an instruction no prompt covers is refused")
         }
 
-        // A `replace:` transform is not in the catalogue — the router reaches
-        // prompts only, for now — so it would otherwise be invisible here, and
-        // "I wrote it and nothing says it exists" is the wrong way to find out
-        // that it runs from a pipeline and not from your voice.
-        // Tables only. A `command:` is not one, and counting its rules said
-        // "0 rule(s)" about a transform that has no rules to have — the line
-        // read as a broken table rather than as a program. Programs are named
-        // by `notices()`, which says it of every one of them, every run.
+        // How many rules each table holds, which nothing else says. The
+        // catalogue above now lists tables like everything else — the router
+        // reaches all three bodies — so this is no longer where you find out
+        // that a `replace:` transform exists at all; it is where you find out
+        // whether it has anything in it. A table that reads "0 rule(s)" is a
+        // table whose pattern did not survive parsing.
+        //
+        // Tables only. A `command:` has no rules to count, and counting them
+        // said "0 rule(s)" about a program — a line that read as a broken
+        // table rather than as a script.
         let tables = config.transforms.filter(\.isTable)
         if !tables.isEmpty {
-            print("  · replace           \(tables.count) transform(s), reachable from a pipeline"
-                + " and not by voice")
+            print("  · replace           \(tables.count) transform(s)")
             for table in tables {
                 let rules = table.rules.count
                 print("      table     \(table.name) — \(rules) rule(s)"

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -406,6 +406,12 @@ struct Config: Decodable, Equatable {
                 ? trimmed : trimmed + "…"
         }
 
+        /// What the menu bar says while this runs, or the transform's own name
+        /// when nothing was written — see `Prompt.progressLabel`.
+        var progressLabel: String {
+            Self.label(display) ?? "\(name)…"
+        }
+
         /// The prompt-shaped view of this transform, for everything that
         /// already speaks `Prompt` — the router, `PromptRunner`, the panels.
         var asPrompt: Prompt? {
@@ -494,6 +500,16 @@ struct Config: Decodable, Equatable {
         /// `display:` existed, so a config that says nothing loses nothing.
         var progressLabel: String {
             Transform.label(display) ?? "\(name)…"
+        }
+
+        /// The transform-shaped view, for the catalogue — which now holds
+        /// transforms rather than prompts, and has to be able to hold the
+        /// free-form one too. It is a prompt that no config declares.
+        var asTransform: Transform {
+            Transform(
+                name: name, description: description, display: display,
+                confirm: confirm, body: .prompt(content)
+            )
         }
 
         /// Where the spoken instruction goes if the prompt asks for it inline.

--- a/Sources/ParrotFlow/RouteTestCommand.swift
+++ b/Sources/ParrotFlow/RouteTestCommand.swift
@@ -15,7 +15,7 @@ enum RouteTestCommand {
             return 1
         }
 
-        let catalogue = Catalogue(prompts: config.prompts)
+        let catalogue = Catalogue(transforms: config.transforms)
         let phrases = config.transcription.activationPhrases
 
         // The wake phrase is stripped first, exactly as the app does it, so a

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -434,11 +434,12 @@ pattern if you live in Gmail, and accept that every other tab gets the stage
 too. There is no narrower answer available: the condition is a window, not a
 URL.
 
-**They cost the router something, and it is measured.** Both are prompts, so
-both join the catalogue the activation phrase reaches, and every description
-added is another way for an idle sentence to find a tool.
-`tests/routing-cases.yaml` was rerun and grew: 41/45 on three prompts, 50/54 on
-six. One new failure appeared and it is the expensive class, the one the
+**They cost the router something, and it is measured.** Both join the catalogue
+the activation phrase reaches — as every transform with a description now does,
+whatever its body — and each description added is another way for an idle
+sentence to find a tool. `tests/routing-cases.yaml` was rerun and grew: 41/45 on
+three prompts, 50/54 on six, and 50/54 again when the tables and scripts joined
+the list. One new failure appeared and it is the expensive class, the one the
 negative half of that set exists for:
 
 ```
@@ -523,11 +524,29 @@ a decimal and it is `numbers` that consumes that word. Swap the two and `dotted`
 gets there first: "three one.four". The `DECIMAL` cases in the set exist to fail
 if anyone reorders them.
 
-Transforms with a `prompt:` body are also what the activation phrase reaches:
-"hey parrot, tidy that up" routes on the same `description`. A `replace:`
-transform is not routable by voice today — it runs from a pipeline only, and
-`--check-config` lists it apart from the catalogue so that is visible rather
-than surprising.
+Transforms are also what the activation phrase reaches: "hey parrot, tidy that
+up" routes on the same `description`. **All three bodies**, because what a
+transform is made of is not a reason you cannot ask for it out loud — a table
+costs nothing and a script costs a process start, and both answer to a
+description exactly as a prompt does.
+
+It was prompts only until it became a real bug. The catalogue was built from
+`config.prompts`, which drops every `command:` body, so a transform that became
+a script left the list silently — and a router shown nine of your ten tools
+does not report the tenth missing, it picks the nearest of the nine. Measured:
+"use slack handles" reached `slack`, the chat-tidying prompt, which tidied the
+sentence and left the name alone. `--check-config` now prints what each
+capability is made of, so a program answering your voice is visible rather than
+implied.
+
+An entry with **no `description:`** is not in the catalogue — there is nothing
+to match spoken words against. It still runs from a pipeline, where the name is
+written down rather than said, and `--check-config` names it apart so that is
+visible rather than surprising.
+
+The spoken instruction reaches a `prompt:` and nothing else. A script and a
+table take text in and give text back; there is nowhere to put "in French" and
+no honest way to invent one.
 
 `prompts:` is the older name for this section and still reads, `content:`
 alongside `prompt:` with it. `- prompt: <name>` still works as a pipeline step.


### PR DESCRIPTION
Found by dictating into Slack and watching it go somewhere else.

```
inline router: "use slack handles." → slack
inline: slack rewrote the transcript
```

`slack` is the chat-tidying prompt. It tidied the sentence and left the name exactly as spoken, while `slack_mentions` — which scores 76/76 on its own set and turns that name into `@Alex MacLure` — sat unreachable.

## Why a missing tool is worse than it sounds

The catalogue the router chooses from was built from `config.prompts`, which is `transforms.compactMap(\.asPrompt)` — and `asPrompt` returns nil for a `command:` body. So a transform that became a script left the list without a word, and a `replace:` table was never in it at all.

That is not a tool going quiet. **A router shown nine of your ten tools does not report the tenth missing; it answers with the nearest of the nine.** From the outside a wrong route and a right route look identical: something happened, text came back. Which is why this survived being scored — every set in the repo measured the tools that were in the list.

## What changed

`Capability.transform` carries a `Config.Transform` rather than a `Config.Prompt`, and the catalogue is built from every transform that has a `description` to match spoken words against — **all three bodies**. What a transform is made of is not a reason you cannot ask for it out loud: a table costs nothing, a script costs a process start, and both answer to a description exactly as a prompt does.

An entry with no `description:` is not in the catalogue and `--check-config` names it apart, because there is nothing to match spoken words against. It still runs from a pipeline, where the name is written down rather than said.

One place now knows how to run a body — `perform` — so the two paths that reach a transform by voice, over a selection and inline in a dictation, cannot disagree about what running one means. It makes the same call `Pipeline.runTransform` does.

The spoken instruction still reaches a `prompt:` and nothing else. A script takes text on one side and gives text on the other; there is nowhere to put "in French" and no honest way to invent one.

## The cost, measured rather than assumed

A longer list is measurably harder to choose from — that is stated in `docs/pipelines.md` with numbers, and this makes the list longer. `tests/routing-cases.yaml` holds at **50/54**, unchanged, with four more capabilities in it.

`--check-config` prints what each capability is made of, because a program that answers your voice is a program run by saying a sentence, and this file says that out loud everywhere else it happens:

```
built-in  spelling — fix a name or word the speaker just spelled out letter by letter
prompt    slack — tidy dictated text into a chat message
program   slack_mentions — turn people's names into Slack mentions
table     backticks — wrap dotted paths in backticks, for chat
```

## Verification

| | |
|---|---|
| `check-routing.sh` | 50/54, the same as before |
| `--route "use slack handles"` | `slack_mentions` |
| `--route "turn the names into mentions"` | `slack_mentions` |
| `--route "wrap that in backticks"` | `backticks` |
| the eleven deterministic sets | unchanged |
| `swiftlint` | 0 errors |

`perform` makes the same `CommandRunner.run(in: transform.folder, …)` call the pipeline does, and `--eval slack_mentions` scores 76/76 through that path — so a script reached by voice runs where a script reached by a pipeline runs. The voice dispatch itself is the one thing no harness reaches; it has been installed and is being exercised by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)