### PR TITLE
feat: a stage can tell the next one what it just did

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,12 @@ rewrite a sentence and 8/8 asked only to identify which words matter, with a
 script doing the rest. Split the job before reaching for a bigger prompt.
 
 **A stage that costs a model call needs a condition.** `when:`, `unless:` or
-`app:`, so it is skipped on the transcripts that never needed it.
+`app:`, so it is skipped on the transcripts that never needed it. A condition
+between slashes is a regular expression; anything else is an expression over
+what the stages above published — `code_identifiers.count == 0`,
+`asr.confidence < 0.7`, `!grammar.changed`. `--pipeline <file> "<text>" --vars`
+prints the whole scope, and a skipped stage names the values that decided it.
+See [docs/pipelines.md](docs/pipelines.md#variables).
 
 **Say out loud what executes.** A `command:` transform makes `config.yaml` run
 a program. If you add one, tell the person whose machine it runs on, in the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,21 @@
 See [AGENTS.md](AGENTS.md) — the entry point for any agent working in this
 repository, and the map to the documentation in [docs/](docs/README.md).
+
+## How to write
+
+Write in simplified technical English. This applies to **every** natural
+language output: chat replies, explanations, commit messages, pull request
+descriptions, issues, review comments, and documentation.
+
+- Short sentences. One idea per sentence.
+- Plain words. Say "use", not "leverage". Say "so", not "which is why".
+- Explain things simply. Assume the reader is smart but in a hurry.
+- No long sub-clauses, no em-dash chains, no rhetorical build-up.
+- Lead with the point. Then give the reason.
+- Keep it concrete: names, numbers, file paths.
+
+This is about the prose, not the work. Be just as precise and just as thorough.
+Say the same things — say them in fewer, simpler words.
+
+Code comments in this repository follow the surrounding style, which explains
+*why* a thing is the way it is. Keep that habit, but keep the sentences short.

--- a/Sources/ParrotFlow/CommandRunner.swift
+++ b/Sources/ParrotFlow/CommandRunner.swift
@@ -43,6 +43,85 @@ enum CommandRunner {
     /// that already runs on every transcript.
     static let timeout: TimeInterval = 2
 
+    /// What a command handed back.
+    ///
+    /// `text` is optional and that is the whole difference between the two
+    /// protocols. A bare command's stdout *is* the text, so it always has one. A
+    /// `returns: json` command may return only variables — "I looked, I found
+    /// three, I changed nothing" — and an absent `text` says that in a way an
+    /// echoed copy of the input cannot.
+    struct Output: Equatable {
+        var text: String?
+        var vars: [String: Scope.Value] = [:]
+    }
+
+    /// What a structured command is told about the transcript besides the
+    /// transcript.
+    ///
+    /// Read-only from the script's side, and deliberately not the same shape as
+    /// what comes back: a command receives the whole accumulated scope and
+    /// returns only its own contribution. It has no way to spell "and everything
+    /// else, unchanged", so it has no way to drop it. Carrying is the pipeline's
+    /// job — a `sed` one-liner could never have echoed a namespace, and a
+    /// contract only some bodies can honour is not one.
+    struct Context: Encodable {
+        let scope: Scope
+        let language: String
+
+        /// The bare names go at the top and the namespaced ones nest under
+        /// `vars`, so a script reads `ctx["vars"]["numbers"]["count"]` rather
+        /// than splitting a dotted string itself. The flat storage inside
+        /// `Scope` is an implementation detail of the evaluator, and pushing it
+        /// through the interface would make every script a parser.
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: Key.self)
+            var nested: [String: [String: Scope.Value]] = [:]
+            for path in scope.paths {
+                guard let value = scope[path] else { continue }
+                guard let dot = path.firstIndex(of: ".") else {
+                    try container.encode(value, forKey: Key(path))
+                    continue
+                }
+                let namespace = String(path[path.startIndex..<dot])
+                let name = String(path[path.index(after: dot)...])
+                nested[namespace, default: [:]][name] = value
+            }
+            try container.encode(language, forKey: Key("language"))
+            try container.encode(nested, forKey: Key("vars"))
+        }
+
+        struct Key: CodingKey {
+            let stringValue: String
+            var intValue: Int? { nil }
+            init(_ value: String) { stringValue = value }
+            init?(stringValue value: String) { stringValue = value }
+            init?(intValue: Int) { return nil }
+        }
+    }
+
+    /// What goes in on stdin when a transform declares `returns: json`.
+    private struct Envelope: Encodable {
+        let text: String
+        let ctx: Context
+    }
+
+    /// What must come back. Both keys optional, because a script that only
+    /// contributes variables and a script that only rewrites text are both
+    /// ordinary — and `text: null` is how the first one says so without echoing
+    /// a string it never looked at.
+    private struct Reply: Decodable {
+        var text: String?
+        var vars: [String: Scope.Value] = [:]
+
+        enum CodingKeys: String, CodingKey { case text, vars }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            text = try c.decodeIfPresent(String.self, forKey: .text)
+            vars = try c.decodeIfPresent([String: Scope.Value].self, forKey: .vars) ?? [:]
+        }
+    }
+
     /// stdout, or nil if the program could not run, failed, took too long, or
     /// said nothing. Nil means "keep the transcript".
     ///
@@ -53,6 +132,28 @@ enum CommandRunner {
         _ command: String, on text: String, in folder: TransformFolder?,
         seconds: TimeInterval? = nil
     ) -> String? {
+        run(command, on: text, in: folder, seconds: seconds, structured: false, context: nil)?
+            .text
+    }
+
+    /// The same run, in whichever of the two protocols the transform declared.
+    ///
+    /// `structured` is read from the config rather than sniffed from the output,
+    /// and that is a decision worth defending. The obvious rule — "if stdout
+    /// parses as an object with a `text` key, it is structured" — breaks on
+    /// exactly the transcript this app is most likely to be handed by somebody
+    /// who dictates code: one that *is* a JSON object. Sniffing also means a
+    /// script's protocol depends on its output, so a stage silently changes
+    /// contract on the one sentence that happens to look like a map.
+    ///
+    /// Nil still means "keep the transcript", and now also means "and record
+    /// that this stage did not work" — the caller turns it into `ok: false`, so
+    /// a later condition can tell a stage that failed from a stage that ran and
+    /// found nothing.
+    static func run(
+        _ command: String, on text: String, in folder: TransformFolder?,
+        seconds: TimeInterval?, structured: Bool, context: Context?
+    ) -> Output? {
         let timeout = seconds ?? Self.timeout
         let folder = folder ?? TransformFolder(configDirectory: ConfigStore.directory, name: "")
         if let complaint = complaint(about: command, in: folder) {
@@ -71,6 +172,20 @@ enum CommandRunner {
         // The folder, so a script opens `roster.json` as a bare relative path
         // and the whole transform is one directory you can copy.
         process.currentDirectoryURL = folder.workingDirectory
+        if structured {
+            // So `returns: json` stays the only place the protocol is declared.
+            // The script has to know too — it is reading stdin — and the
+            // alternative was a flag in the `command:` line that means the same
+            // thing as the key above it and can disagree with it.
+            //
+            // It also keeps a script runnable by hand. `echo "text" | ./x.py`
+            // has no variable set, so the script takes the old path, which is
+            // what every harness in scripts/ does and what anybody debugging one
+            // will type.
+            var environment = ProcessInfo.processInfo.environment
+            environment["PARROTFLOW_PROTOCOL"] = "json"
+            process.environment = environment
+        }
 
         let input = Pipe()
         let output = Pipe()
@@ -109,7 +224,21 @@ enum CommandRunner {
             return nil
         }
 
-        input.fileHandleForWriting.write(Data(text.utf8))
+        // The transcript on its own, or the transcript wrapped in what the
+        // pipeline knows about it. An encoding failure falls back to the bare
+        // text rather than to nothing: a script that then cannot parse its input
+        // fails in its own way and the transcript survives, which is a better
+        // outcome than this returning nil for a reason nobody can see.
+        var payload = Data(text.utf8)
+        if structured, let context {
+            let encoder = JSONEncoder()
+            if let encoded = try? encoder.encode(Envelope(text: text, ctx: context)) {
+                payload = encoded
+            } else {
+                Log.write("command: \"\(command)\" could not be given its context; sent bare text")
+            }
+        }
+        input.fileHandleForWriting.write(payload)
         try? input.fileHandleForWriting.close()
 
         if exited.wait(timeout: .now() + timeout) == .timedOut {
@@ -141,7 +270,24 @@ enum CommandRunner {
         // is not this app's business, and `print` adds exactly one newline.
         var result = String(data: collected.value, encoding: .utf8) ?? ""
         if result.hasSuffix("\n") { result.removeLast() }
-        return result.isEmpty ? nil : result
+        guard !result.isEmpty else { return nil }
+
+        guard structured else { return Output(text: result) }
+
+        guard let reply = try? JSONDecoder().decode(Reply.self, from: Data(result.utf8)) else {
+            // Loud, and then harmless. A transform that declared `returns: json`
+            // and printed something else is a script bug rather than a config
+            // one, so it cannot be caught by `--check-config` and has to be
+            // caught here — but the transcript still comes through untouched,
+            // because the alternative is losing a sentence over a stray
+            // `print()` somebody left in.
+            Log.write(
+                "command: \"\(command)\" declares returns: json but printed"
+                + " \(result.prefix(120)); kept the transcript"
+            )
+            return nil
+        }
+        return Output(text: reply.text, vars: reply.vars)
     }
 
     /// SIGTERM, then SIGKILL if that was not enough.

--- a/Sources/ParrotFlow/CommandRunner.swift
+++ b/Sources/ParrotFlow/CommandRunner.swift
@@ -66,13 +66,19 @@ enum CommandRunner {
     /// contract only some bodies can honour is not one.
     struct Context: Encodable {
         let scope: Scope
-        let language: String
 
         /// The bare names go at the top and the namespaced ones nest under
         /// `vars`, so a script reads `ctx["vars"]["numbers"]["count"]` rather
         /// than splitting a dotted string itself. The flat storage inside
         /// `Scope` is an implementation detail of the evaluator, and pushing it
         /// through the interface would make every script a parser.
+        ///
+        /// Everything comes from the scope and nothing is passed in beside it.
+        /// `language` used to be its own parameter, taken from the first
+        /// configured language — which is not the detected one, and which was
+        /// then encoded *over* the correct value the scope already held, under
+        /// the same key. Two sources for one field is how they disagree; there
+        /// is now one.
         func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: Key.self)
             var nested: [String: [String: Scope.Value]] = [:]
@@ -86,7 +92,6 @@ enum CommandRunner {
                 let name = String(path[path.index(after: dot)...])
                 nested[namespace, default: [:]][name] = value
             }
-            try container.encode(language, forKey: Key("language"))
             try container.encode(nested, forKey: Key("vars"))
         }
 

--- a/Sources/ParrotFlow/Condition.swift
+++ b/Sources/ParrotFlow/Condition.swift
@@ -1,0 +1,547 @@
+import Foundation
+
+/// The expression language a `when:` or `unless:` is written in when it is not
+/// a regular expression.
+///
+/// A regex could ask one question — "does the text say this" — and once stages
+/// could publish facts about themselves there was a second kind of question with
+/// no way to spell it: `code_identifiers.count == 0`. This is that spelling.
+///
+/// It is a **subset of CEL**, deliberately, and the subset matters more than the
+/// choice. Nothing here needs a standard: the evaluator is three hundred lines
+/// and any small grammar would have run. What a standard buys is a second
+/// implementation that agrees with this one without anybody writing a
+/// specification — if the pipeline is ever rewritten in Python or Go, the config
+/// files people have already written keep meaning what they meant, because
+/// `cel-python` and `cel-go` implement the same operators. Inventing `=~` and
+/// `and` instead would have cost nothing today and that agreement forever.
+///
+/// What is in: dotted paths, string/number/bool literals, `&&` `||` `!`, the six
+/// comparisons, and four string methods — `matches`, `contains`, `startsWith`,
+/// `endsWith`, all of which are CEL standard-library functions rather than
+/// extensions of ours. What is out: macros (`all`, `exists`, `map`), lists,
+/// maps, durations, timestamps, arithmetic. A routing condition needs none of
+/// them, and each one is a type in `Scope.Value` and a rule in whatever
+/// implements this next.
+///
+/// Two divergences from CEL worth knowing. `matches` here is ICU through
+/// `NSRegularExpression`, not RE2 — so lookahead works, where a real CEL would
+/// refuse it. And it is case-insensitive, because every condition in this app
+/// has always been: `when: /term/` matching "Terminal" is the behaviour people
+/// already have, and a language that quietly stopped doing it would break
+/// configs while parsing them perfectly.
+enum Condition {
+
+    struct Failure: LocalizedError, Equatable {
+        let message: String
+        var errorDescription: String? { message }
+    }
+
+    // MARK: - Syntax
+
+    indirect enum Node: Equatable {
+        case literal(Scope.Value)
+        /// A dotted name — `text`, `numbers.count`, `asr.confidence`.
+        case path(String)
+        case not(Node)
+        case and(Node, Node)
+        case or(Node, Node)
+        case compare(Node, Comparison, Node)
+        /// `receiver.method(arguments)`, the only call shape there is.
+        case call(Node, String, [Node])
+    }
+
+    enum Comparison: String, Equatable {
+        case equal = "=="
+        case notEqual = "!="
+        case less = "<"
+        case lessOrEqual = "<="
+        case greater = ">"
+        case greaterOrEqual = ">="
+    }
+
+    /// The methods a string will answer to. Named here rather than in the
+    /// evaluator so that a misspelling is caught while parsing — `startswith`
+    /// is the one people write, and finding out at parse time means
+    /// `--check-config` says so instead of a stage quietly never running.
+    static let methods: Set<String> = ["matches", "contains", "startsWith", "endsWith"]
+
+    // MARK: - Tokens
+
+    private enum Token: Equatable {
+        case identifier(String)
+        case string(String)
+        case number(Scope.Value)
+        case boolean(Bool)
+        case symbol(String)
+    }
+
+    private static func tokenize(_ source: String) throws -> [Token] {
+        var tokens: [Token] = []
+        let characters = Array(source)
+        var index = 0
+
+        func peek(_ offset: Int = 0) -> Character? {
+            let position = index + offset
+            return position < characters.count ? characters[position] : nil
+        }
+
+        while index < characters.count {
+            let character = characters[index]
+
+            if character.isWhitespace { index += 1; continue }
+
+            // A string literal. Both quote styles, because CEL takes both and a
+            // pattern full of double quotes is easier to write in single ones —
+            // which matters here, where most string literals are regexes.
+            if character == "\"" || character == "'" {
+                let quote = character
+                index += 1
+                var literal = ""
+                var closed = false
+                while index < characters.count {
+                    let next = characters[index]
+                    if next == "\\", let escaped = peek(1) {
+                        // Only the escapes a quoted string needs. A regex is
+                        // full of backslashes that mean something to the regex
+                        // engine and nothing here — `\b`, `\d`, `\.` — and
+                        // consuming those would leave the pattern mangled by the
+                        // time it was compiled. So an unrecognised escape keeps
+                        // both characters.
+                        switch escaped {
+                        case quote: literal.append(quote)
+                        case "\\": literal.append("\\")
+                        case "n": literal.append("\n")
+                        case "t": literal.append("\t")
+                        default: literal.append(next); literal.append(escaped)
+                        }
+                        index += 2
+                        continue
+                    }
+                    if next == quote { closed = true; index += 1; break }
+                    literal.append(next)
+                    index += 1
+                }
+                guard closed else {
+                    throw Failure(message: "a string is never closed — add the missing \(quote)")
+                }
+                tokens.append(.string(literal))
+                continue
+            }
+
+            if character.isNumber {
+                var literal = ""
+                var isDouble = false
+                while let next = peek(), next.isNumber || next == "." {
+                    // A dot only continues a number when a digit follows it, so
+                    // `1.5` is a double while `count.1` would end the number and
+                    // let the parser complain about the rest.
+                    if next == "." {
+                        guard let after = peek(1), after.isNumber, !isDouble else { break }
+                        isDouble = true
+                    }
+                    literal.append(next)
+                    index += 1
+                }
+                if isDouble, let value = Double(literal) {
+                    tokens.append(.number(.double(value)))
+                } else if let value = Int(literal) {
+                    tokens.append(.number(.int(value)))
+                } else {
+                    throw Failure(message: "\"\(literal)\" is not a number")
+                }
+                continue
+            }
+
+            if character.isLetter || character == "_" {
+                var name = ""
+                while let next = peek(), next.isLetter || next.isNumber || next == "_" {
+                    name.append(next)
+                    index += 1
+                }
+                switch name {
+                case "true": tokens.append(.boolean(true))
+                case "false": tokens.append(.boolean(false))
+                default: tokens.append(.identifier(name))
+                }
+                continue
+            }
+
+            // Two-character operators before one-character ones, or `!=` lexes
+            // as `!` and the parser sees a negation with nothing to negate.
+            if let next = peek(1) {
+                let pair = String([character, next])
+                if ["&&", "||", "==", "!=", "<=", ">="].contains(pair) {
+                    tokens.append(.symbol(pair))
+                    index += 2
+                    continue
+                }
+            }
+            if "!<>().,".contains(character) {
+                tokens.append(.symbol(String(character)))
+                index += 1
+                continue
+            }
+            // Named rather than skipped. A `&` where `&&` was meant, or the `=~`
+            // somebody used to write, should say what is wrong with it.
+            if character == "&" || character == "|" {
+                throw Failure(
+                    message: "\"\(character)\" on its own is not an operator — write"
+                        + " \(character)\(character)"
+                )
+            }
+            throw Failure(message: "\"\(character)\" is not part of this language")
+        }
+        return tokens
+    }
+
+    // MARK: - Parsing
+
+    private struct Parser {
+        let tokens: [Token]
+        var index = 0
+
+        var current: Token? { index < tokens.count ? tokens[index] : nil }
+
+        mutating func match(_ symbol: String) -> Bool {
+            guard current == .symbol(symbol) else { return false }
+            index += 1
+            return true
+        }
+
+        mutating func expression() throws -> Node {
+            var left = try conjunction()
+            while match("||") {
+                left = .or(left, try conjunction())
+            }
+            return left
+        }
+
+        mutating func conjunction() throws -> Node {
+            var left = try unary()
+            while match("&&") {
+                left = .and(left, try unary())
+            }
+            return left
+        }
+
+        mutating func unary() throws -> Node {
+            if match("!") { return .not(try unary()) }
+            return try comparison()
+        }
+
+        mutating func comparison() throws -> Node {
+            let left = try primary()
+            guard case .symbol(let symbol) = current ?? .symbol(""),
+                  let operation = Comparison(rawValue: symbol) else { return left }
+            index += 1
+            return .compare(left, operation, try primary())
+        }
+
+        mutating func primary() throws -> Node {
+            guard let token = current else {
+                throw Failure(message: "the expression ends where a value was expected")
+            }
+            index += 1
+
+            switch token {
+            case .string(let value): return .literal(.string(value))
+            case .number(let value): return .literal(value)
+            case .boolean(let value): return .literal(.bool(value))
+
+            case .symbol("("):
+                let inner = try expression()
+                guard match(")") else {
+                    throw Failure(message: "a ( is never closed")
+                }
+                return inner
+
+            case .identifier(let first):
+                // A dotted name, which may end in a method call. The split
+                // cannot be decided until the `(` is seen: `numbers.count` is a
+                // path and `text.matches` is a receiver and a method, and they
+                // look identical until the next token.
+                var components = [first]
+                var node = Node.path(first)
+                while current == .symbol(".") {
+                    index += 1
+                    guard case .identifier(let next)? = current else {
+                        throw Failure(message: "a name is expected after \".\"")
+                    }
+                    index += 1
+                    if current == .symbol("(") {
+                        index += 1
+                        guard Condition.methods.contains(next) else {
+                            throw Failure(
+                                message: "\"\(next)\" is not a method — have: "
+                                    + Condition.methods.sorted().joined(separator: ", ")
+                            )
+                        }
+                        var arguments: [Node] = []
+                        if !match(")") {
+                            repeat {
+                                arguments.append(try expression())
+                            } while match(",")
+                            guard match(")") else {
+                                throw Failure(message: "a ( is never closed")
+                            }
+                        }
+                        guard arguments.count == 1 else {
+                            throw Failure(
+                                message: "\(next)() takes one argument, not \(arguments.count)"
+                            )
+                        }
+                        node = .call(node, next, arguments)
+                        // A method result is a boolean, and nothing here has a
+                        // method on a boolean — so the path is finished.
+                        return node
+                    }
+                    components.append(next)
+                    node = .path(components.joined(separator: "."))
+                }
+                return node
+
+            default:
+                throw Failure(message: "\"\(describe(token))\" cannot start a value")
+            }
+        }
+
+        func describe(_ token: Token) -> String {
+            switch token {
+            case .identifier(let name): return name
+            case .string(let value): return "\"\(value)\""
+            case .number(let value): return value.described
+            case .boolean(let value): return value ? "true" : "false"
+            case .symbol(let symbol): return symbol
+            }
+        }
+    }
+
+    /// Parsed once per condition, then kept. A pipeline runs on every transcript
+    /// and re-parsing the same six conditions each time is work nobody asked
+    /// for. Locked for the same reason `Pipeline.Step.expression` is: a prompt
+    /// stage suspends for seconds, so a second transcript's pipeline reaches
+    /// this while the first is still waiting, and a Swift Dictionary written
+    /// from two threads corrupts.
+    private static var cache: [String: Result<Node, Failure>] = [:]
+    private static let cacheLock = NSLock()
+
+    static func parse(_ source: String) throws -> Node {
+        cacheLock.lock()
+        if let cached = cache[source] {
+            cacheLock.unlock()
+            return try cached.get()
+        }
+        cacheLock.unlock()
+
+        let outcome: Result<Node, Failure>
+        do {
+            var parser = Parser(tokens: try tokenize(source))
+            let node = try parser.expression()
+            guard parser.index == parser.tokens.count else {
+                throw Failure(
+                    message: "\"\(parser.describe(parser.tokens[parser.index]))\" is left over"
+                        + " at the end of the expression"
+                )
+            }
+            outcome = .success(node)
+        } catch let failure as Failure {
+            outcome = .failure(failure)
+        }
+
+        cacheLock.lock()
+        cache[source] = outcome
+        cacheLock.unlock()
+        return try outcome.get()
+    }
+
+    // MARK: - Evaluating
+
+    static func evaluate(_ source: String, in scope: Scope) throws -> Bool {
+        let value = try value(of: try parse(source), in: scope)
+        guard case .bool(let answer) = value else {
+            throw Failure(
+                message: "a condition has to be true or false, and this one is \(value.described)"
+            )
+        }
+        return answer
+    }
+
+    private static func value(of node: Node, in scope: Scope) throws -> Scope.Value {
+        switch node {
+        case .literal(let value):
+            return value
+
+        case .path(let path):
+            guard let found = scope[path] else {
+                throw Failure(message: unknown(path, in: scope))
+            }
+            return found
+
+        case .not(let inner):
+            guard case .bool(let value) = try self.value(of: inner, in: scope) else {
+                throw Failure(message: "! takes something true or false")
+            }
+            return .bool(!value)
+
+        case .and(let left, let right):
+            // Short-circuit, which is not only speed: it is what lets
+            // `numbers.ran && numbers.count > 0` be written at all, since the
+            // right half would throw on a stage that never ran.
+            guard case .bool(let a) = try value(of: left, in: scope) else {
+                throw Failure(message: "&& takes something true or false")
+            }
+            if !a { return .bool(false) }
+            guard case .bool(let b) = try value(of: right, in: scope) else {
+                throw Failure(message: "&& takes something true or false")
+            }
+            return .bool(b)
+
+        case .or(let left, let right):
+            guard case .bool(let a) = try value(of: left, in: scope) else {
+                throw Failure(message: "|| takes something true or false")
+            }
+            if a { return .bool(true) }
+            guard case .bool(let b) = try value(of: right, in: scope) else {
+                throw Failure(message: "|| takes something true or false")
+            }
+            return .bool(b)
+
+        case .compare(let left, let operation, let right):
+            return .bool(try compare(
+                try value(of: left, in: scope), operation, try value(of: right, in: scope)
+            ))
+
+        case .call(let receiver, let method, let arguments):
+            guard case .string(let subject) = try value(of: receiver, in: scope) else {
+                throw Failure(message: "\(method)() only works on text")
+            }
+            guard case .string(let argument) = try value(of: arguments[0], in: scope) else {
+                throw Failure(message: "\(method)() takes a string")
+            }
+            return .bool(try apply(method, subject, argument))
+        }
+    }
+
+    private static func compare(
+        _ left: Scope.Value, _ operation: Comparison, _ right: Scope.Value
+    ) throws -> Bool {
+        // Numbers first, so an int and a double compare as the numbers they
+        // are. A script returning 1 and one returning 1.0 have said the same
+        // thing, and a condition that disagreed would be reporting the script's
+        // JSON encoder rather than its answer.
+        if let a = left.asDouble, let b = right.asDouble {
+            switch operation {
+            case .equal: return a == b
+            case .notEqual: return a != b
+            case .less: return a < b
+            case .lessOrEqual: return a <= b
+            case .greater: return a > b
+            case .greaterOrEqual: return a >= b
+            }
+        }
+        if case .string(let a) = left, case .string(let b) = right {
+            switch operation {
+            case .equal: return a == b
+            case .notEqual: return a != b
+            case .less: return a < b
+            case .lessOrEqual: return a <= b
+            case .greater: return a > b
+            case .greaterOrEqual: return a >= b
+            }
+        }
+        if case .bool(let a) = left, case .bool(let b) = right {
+            switch operation {
+            case .equal: return a == b
+            case .notEqual: return a != b
+            default:
+                throw Failure(message: "true and false can only be compared with == and !=")
+            }
+        }
+        throw Failure(
+            message: "\(left.described) and \(right.described) are different kinds of thing"
+                + " and cannot be compared"
+        )
+    }
+
+    private static func apply(_ method: String, _ subject: String, _ argument: String) throws -> Bool {
+        switch method {
+        case "contains":
+            return subject.range(of: argument, options: .caseInsensitive) != nil
+        case "startsWith":
+            return subject.lowercased().hasPrefix(argument.lowercased())
+        case "endsWith":
+            return subject.lowercased().hasSuffix(argument.lowercased())
+        case "matches":
+            guard let expression = try? NSRegularExpression(
+                pattern: argument, options: [.caseInsensitive]
+            ) else {
+                throw Failure(message: "\"\(argument)\" is not a valid regular expression")
+            }
+            return expression.firstMatch(
+                in: subject, range: NSRange(subject.startIndex..., in: subject)
+            ) != nil
+        default:
+            throw Failure(message: "\"\(method)\" is not a method")
+        }
+    }
+
+    // MARK: - Diagnostics
+
+    /// Why a name resolved to nothing, said in the way most likely to be the
+    /// actual mistake.
+    ///
+    /// Three of them, and the order is by likelihood rather than by severity.
+    /// The first is the migration: `when: genre` used to mean "the word genre
+    /// appears", and now parses as a variable nobody defined. Reading it as
+    /// false would have been the silent failure this whole design refuses, and
+    /// reading it as an error is only useful if the error says what to write
+    /// instead.
+    private static func unknown(_ path: String, in scope: Scope) -> String {
+        if !path.contains(".") {
+            return "\"\(path)\" is not a variable. If you meant the word \"\(path)\" in the"
+                + " text, write it as a pattern: /\(path)/"
+        }
+        let namespace = String(path.prefix(while: { $0 != "." }))
+        let known = Set(scope.paths.compactMap { path -> String? in
+            guard path.contains(".") else { return nil }
+            return String(path.prefix(while: { $0 != "." }))
+        })
+        if !known.contains(namespace) && !Scope.reserved.contains(namespace) {
+            return "no stage called \"\(namespace)\" has run yet, so \"\(path)\" has no value."
+                + " A condition can only read a stage above it in the pipeline."
+        }
+        let inside = scope.namespace(namespace).keys.sorted()
+        return "\"\(path)\" is not something \"\(namespace)\" reports"
+            + (inside.isEmpty ? "" : " — it reports: \(inside.joined(separator: ", "))")
+    }
+
+    /// Every name an expression reads, for the check that runs before anything
+    /// does. `validate()` uses it to refuse a condition that reads a stage
+    /// declared below it, which is the failure no runtime error can catch in
+    /// time: by then the transcript is already halfway through the pipeline.
+    static func roots(of source: String) -> Set<String> {
+        guard let node = try? parse(source) else { return [] }
+        var found: Set<String> = []
+        collect(node, into: &found)
+        return found
+    }
+
+    private static func collect(_ node: Node, into found: inout Set<String>) {
+        switch node {
+        case .literal:
+            return
+        case .path(let path):
+            found.insert(path)
+        case .not(let inner):
+            collect(inner, into: &found)
+        case .and(let a, let b), .or(let a, let b):
+            collect(a, into: &found); collect(b, into: &found)
+        case .compare(let a, _, let b):
+            collect(a, into: &found); collect(b, into: &found)
+        case .call(let receiver, _, let arguments):
+            collect(receiver, into: &found)
+            for argument in arguments { collect(argument, into: &found) }
+        }
+    }
+}

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -75,6 +75,7 @@ struct Config: Decodable, Equatable {
         var description = ""
         var display = ""
         var confirm = true
+        var returnsJSON = false
         var body: Transform.Body?
         var folder: TransformFolder?
         var timeout: Double?
@@ -90,7 +91,7 @@ struct Config: Decodable, Equatable {
 
         enum CodingKeys: String, CodingKey {
             case name, description, display, confirm, prompt, content, replace, command
-            case tests
+            case tests, returns
             case timeout = "timeout_seconds"
         }
 
@@ -126,6 +127,20 @@ struct Config: Decodable, Equatable {
             }
             confirm = try c.decodeIfPresent(Bool.self, forKey: .confirm) ?? true
             timeout = try c.decodeIfPresent(Double.self, forKey: .timeout)
+            // `returns: json`, spelled as a word rather than as `returns_json:
+            // true`, because the thing being named is a protocol and there may
+            // one day be a second one. Anything else is refused rather than
+            // read as false: `returns: JSON` and `returns: text` both look like
+            // they say something, and a key that quietly means nothing is how a
+            // script ends up talking past the app that runs it.
+            if let declared = try c.decodeIfPresent(String.self, forKey: .returns) {
+                let written = declared.trimmingCharacters(in: .whitespacesAndNewlines)
+                    .lowercased()
+                returnsJSON = written == "json"
+                if !returnsJSON, written != "text" {
+                    unreadable = "returns: \(declared) — write `returns: json`, or leave it out"
+                }
+            }
             // Written either way — `tests: heldout.yaml` and
             // `tests: { path: heldout.yaml }` mean the same thing — and
             // refused when it is neither. A mapping
@@ -289,7 +304,8 @@ struct Config: Decodable, Equatable {
                 name: entry.name, description: entry.description,
                 display: entry.display,
                 folder: entry.folder, timeout: entry.timeout,
-                confirm: entry.confirm, body: body, source: entry.source,
+                confirm: entry.confirm, returnsJSON: entry.returnsJSON,
+                body: body, source: entry.source,
                 tests: entry.tests
             ))
         }
@@ -347,6 +363,20 @@ struct Config: Decodable, Equatable {
         /// when a transform is run over your selection — a pipeline stage runs
         /// on a transcript nobody has seen yet, so there is nothing to confirm.
         var confirm: Bool = true
+        /// Whether a `command:` speaks the structured protocol — `{text, ctx}`
+        /// in, `{text?, vars?}` out — rather than plain text on stdin and stdout.
+        ///
+        /// Declared rather than detected. Reading the output to decide would
+        /// break on the one transcript most likely to arrive in a folder with a
+        /// `code_identifiers` stage in it: a sentence that *is* a JSON object.
+        /// It would also make a script's protocol depend on its answer, so a
+        /// stage would change contract on one sentence in a thousand and nowhere
+        /// else.
+        ///
+        /// Off by default, and off is the whole of the old contract: stdout is
+        /// the transcript, `sed` is still a transform, and nothing anybody has
+        /// already written has to change.
+        var returnsJSON: Bool = false
         var body: Body
         /// Where the body was read from, when it was read from a file at all —
         /// `prompt: { path: slack.md }`. Nil for an inline body, and nil for a
@@ -1876,6 +1906,7 @@ they say where a name ends, and that boundary is a judgement about how you
 speak, not a fact.
 """
 import json
+import os
 import re
 import sys
 import urllib.request
@@ -1947,7 +1978,14 @@ def cased(words, style):
     return words[0].lower() + "".join(word.capitalize() for word in words[1:])
 
 
-def convert(text):
+def convert(text, converted=None):
+    """The rewrite. `converted`, if given, is appended one entry per name taken.
+
+    An out-parameter rather than a second return value because
+    `scripts/validate-code-identifiers.py` calls this as `shipped.convert` and
+    compares its result to a string — a tuple would have changed what the
+    scoreboard measures in order to add a number nothing there reads.
+    """
     out = text
     # Right to left, so an earlier rewrite cannot move a later match.
     for match in list(TRIGGER.finditer(text))[::-1]:
@@ -1969,6 +2007,8 @@ def convert(text):
             continue
         if span in out:
             out = out.replace(span, cased(words, style_for(text, text[:match.start()])), 1)
+            if converted is not None:
+                converted.append(span)
     return out
 
 
@@ -2074,13 +2114,46 @@ if __name__ == "__main__":
         index = sys.argv.index("--model")
         model = sys.argv[index + 1] if len(sys.argv) > index + 1 else None
 
-    text = sys.stdin.read().rstrip("\n")
-    out = convert(text)
+    # Two protocols, and which one is in force is decided by the config rather
+    # than by anything here: ParrotFlow sets PARROTFLOW_PROTOCOL=json when the
+    # transform declares `returns: json`, and leaves it unset otherwise.
+    #
+    # Reading the environment rather than taking a flag keeps `returns:` the
+    # single declaration — a flag in the `command:` line would say the same
+    # thing one line lower and could disagree with it. It also keeps this
+    # runnable by hand: `echo "a python function called max retries" |
+    # ./code_identifiers.py` takes the plain path, which is what every harness
+    # in scripts/ does and what anybody debugging one will type.
+    structured = os.environ.get("PARROTFLOW_PROTOCOL") == "json"
+
+    raw = sys.stdin.read()
+    if structured:
+        text = json.loads(raw)["text"]
+    else:
+        text = raw.rstrip("\n")
+
+    converted = []
+    out = convert(text, converted)
+    asked = False
     # The model is asked only about what the rules declined. On a sentence with
     # a marker in it — the common case — nothing is paid at all.
     if model and out == text:
+        asked = True
         out = place(ask(model, text), text)
-    sys.stdout.write(out)
+
+    if not structured:
+        sys.stdout.write(out)
+        raise SystemExit(0)
+
+    # `count` is what a later stage wants: `dotted` should stand down when this
+    # already took the sentence, and until now the only way to ask was to
+    # re-derive the judgement from the words. `asked` is for the log rather than
+    # for a condition — it is the difference between a stage that cost nothing
+    # and one that cost a second, and it was previously invisible.
+    sys.stdout.write(json.dumps({
+        "text": out,
+        "vars": {"count": len(converted), "asked_model": asked},
+    }))
 """#
 
     /// Reads and decodes the config. Missing keys fall back to the struct defaults.

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -2082,9 +2082,16 @@ def ask(model, text, endpoint="http://localhost:11434"):
         return ""
 
 
-def place(reply, text):
+def place(reply, text, converted=None):
     """The extraction applied — the deterministic half, sharing `cased` and
-    `style_for` with the rules above so there is one algorithm and not two."""
+    `style_for` with the rules above so there is one algorithm and not two.
+
+    `converted` is appended one entry per name taken, exactly as `convert` does
+    — the two paths produce the same kind of rewrite and have to report it the
+    same way. A model conversion that did not count would publish `count: 0` on
+    a sentence this stage had just rewritten, and the stage below, told to stand
+    down when the count is zero, would run anyway.
+    """
     language, names = None, []
     for line in reply.splitlines():
         line = line.strip()
@@ -2105,6 +2112,8 @@ def place(reply, text):
         start = out.lower().index(span.lower())
         out = (out[:start] + cased(words, style_for(out, out[:start], language))
                + out[start + len(span):])
+        if converted is not None:
+            converted.append(span)
     return out
 
 
@@ -2137,9 +2146,14 @@ if __name__ == "__main__":
     asked = False
     # The model is asked only about what the rules declined. On a sentence with
     # a marker in it — the common case — nothing is paid at all.
+    #
+    # `converted` is passed on rather than reset: the branch is only reached
+    # when the rules took nothing, so it is empty here — but threading it keeps
+    # `count` meaning "names this stage converted" regardless of which half did
+    # it, which is the only reading a condition below can rely on.
     if model and out == text:
         asked = True
-        out = place(ask(model, text), text)
+        out = place(ask(model, text), text, converted)
 
     if not structured:
         sys.stdout.write(out)

--- a/Sources/ParrotFlow/Numbers.swift
+++ b/Sources/ParrotFlow/Numbers.swift
@@ -82,13 +82,32 @@ enum Numbers {
     /// "vingt et un", two of the commonest things anyone dictates, would be
     /// handed the wrong grammar and come back untouched.
     static func apply(to text: String, languages: [String]) -> String {
+        read(text, languages: languages).text
+    }
+
+    /// The same pass, saying which grammar it was that read the numbers.
+    ///
+    /// That verdict has always been computed here and thrown away, and it is not
+    /// the same answer as the pipeline's own language: the rule above is "try the
+    /// detected one, then the others, and let a candidate win only on real
+    /// evidence", so a French number inside an English sentence is read by the
+    /// French grammar while the pipeline is still an English one. The pipeline
+    /// publishes it as `numbers.language`, which is the first time anything has
+    /// been able to see which grammar actually fired.
+    ///
+    /// When nothing changed there is no winner, and the detected language is
+    /// reported — that is the grammar that was asked and declined, which is the
+    /// useful answer to "why did this not become a digit".
+    static func read(
+        _ text: String, languages: [String]
+    ) -> (text: String, language: String) {
         let fallback = languages.first ?? "en"
         let detected = DictationLanguage.detect(
             text, allowed: languages, fallback: fallback
         )
 
         let primary = apply(to: text, grammar: .named(detected))
-        if primary != text { return primary }
+        if primary != text { return (primary, detected) }
 
         let identifiable = text.split(whereSeparator: { $0.isWhitespace }).count
             >= DictationLanguage.minimumWords && languages.count > 1
@@ -98,9 +117,9 @@ enum Numbers {
             let output = apply(to: text, grammar: grammar)
             guard output != text else { continue }
             if identifiable, !hasPlainNumberWord(text, grammar) { continue }
-            return output
+            return (output, language)
         }
-        return text
+        return (text, detected)
     }
 
     /// Whether the text contains a word this grammar reads as a unit, a teen or

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -551,6 +551,15 @@ struct Pipeline: Equatable, Codable {
             scope.set("app", .string(app.name))
             scope.set("bundle_id", .string(app.bundleID))
         }
+        // Only when the caller did not already resolve it. `Replacements.apply`
+        // detects the language to choose the pipeline and seeds it on the way
+        // in, so the live path costs nothing here; a caller that reaches this
+        // type directly — `--eval` does — would otherwise leave `language`
+        // absent from a condition and from a script's context. Absent is better
+        // than wrong, and present-and-right is better than either.
+        if scope["language"] == nil {
+            scope.set("language", .string(Pipeline.forText(output, config: config).1))
+        }
 
         for step in steps {
             let named = step.transform.map { "\(step.stage.name) \($0)" } ?? step.stage.name
@@ -694,9 +703,7 @@ struct Pipeline: Equatable, Codable {
             let outcome = CommandRunner.run(
                 command, on: text, in: transform.folder, seconds: transform.timeout,
                 structured: transform.returnsJSON,
-                context: transform.returnsJSON
-                    ? CommandRunner.Context(scope: scope, language: config.transcription.languages.first ?? "en")
-                    : nil
+                context: transform.returnsJSON ? CommandRunner.Context(scope: scope) : nil
             )
             guard let result = outcome else {
                 return StageResult(text: text, vars: ["ok": .bool(false)])

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -104,14 +104,32 @@ struct Pipeline: Equatable, Codable {
         /// rather than leaving to run everywhere in silence.
         var app: String?
 
-        /// Same convention as `replacements`, so there is one thing to learn:
-        /// between slashes it is a regular expression, otherwise it is a word,
-        /// matched on word boundaries. Case-insensitive either way.
+        /// Whether a condition is a pattern rather than an expression.
+        ///
+        /// Between slashes it is a regular expression — the form every condition
+        /// in this app has ever been written in. Anything else is now read as an
+        /// expression over the pipeline's variables, which is the only way
+        /// `code_identifiers.count == 0` could be spelled at all.
+        ///
+        /// That does take a form away. A bare word used to mean "this word
+        /// appears, on word boundaries", and now parses as a variable nobody
+        /// defined. It was documented and never used — not in the default
+        /// config, not in an example, not in a fixture — and the alternative was
+        /// two condition languages in one key forever. `validate` refuses the
+        /// old form by name and says what to write instead, so a config that
+        /// used it fails at `--check-config` rather than at the moment a stage
+        /// quietly stops running.
+        static func isPattern(_ condition: String) -> Bool {
+            let trimmed = condition.trimmingCharacters(in: .whitespaces)
+            return trimmed.count >= 2 && trimmed.hasPrefix("/") && trimmed.hasSuffix("/")
+        }
+
+        /// The regular expression inside the slashes. A condition that is not a
+        /// pattern has none, and asking is a programming error rather than a
+        /// config one — `isPattern` decides first, everywhere.
         static func pattern(for condition: String) -> String {
             let trimmed = condition.trimmingCharacters(in: .whitespaces)
-            guard trimmed.count >= 2, trimmed.hasPrefix("/"), trimmed.hasSuffix("/") else {
-                return "\\b\(NSRegularExpression.escapedPattern(for: trimmed))\\b"
-            }
+            guard isPattern(trimmed) else { return trimmed }
             return String(trimmed.dropFirst().dropLast())
         }
 
@@ -120,6 +138,23 @@ struct Pipeline: Equatable, Codable {
             return expression.firstMatch(
                 in: text, range: NSRange(text.startIndex..., in: text)
             ) != nil
+        }
+
+        /// Whether a condition holds, whichever of the two forms it is in.
+        ///
+        /// `subject` is what a *pattern* is matched against — the text for
+        /// `when:` and `unless:`, the app for `app:`. An expression ignores it
+        /// and reads the scope, where the same things are available by name.
+        ///
+        /// Throws only for an expression, and only for the mistakes that have no
+        /// sensible false: a name nothing defines, a comparison between a string
+        /// and a number. Returning false for those is the silent failure this
+        /// design exists to remove — a stage that never runs looks exactly like
+        /// a stage that is broken, and only one of them is answerable by editing
+        /// a line.
+        func holds(_ condition: String, subject: String, scope: Scope) throws -> Bool {
+            guard !Step.isPattern(condition) else { return matches(subject, condition) }
+            return try Condition.evaluate(condition, in: scope)
         }
 
         /// Compiled once per pattern. A pipeline runs on every transcript, and
@@ -225,11 +260,30 @@ struct Pipeline: Equatable, Codable {
         for step in steps where step.stage == .transform && (step.transform ?? "").isEmpty {
             problems.append("a prompt stage names no prompt — write `- prompt: <name>`")
         }
+        // Which namespaces a condition on this step is allowed to read: the
+        // seeds, plus every stage *above* it. Built as the list is walked, which
+        // is what makes the ordering check possible at all — a condition reading
+        // a stage declared below it has no value to read, and at run time that
+        // is indistinguishable from the stage having reported nothing.
+        var available = Scope.reserved
         for step in steps {
+            if step.stage == .transform, let name = step.transform,
+               Scope.reserved.contains(name) {
+                problems.append(
+                    "a transform called \"\(name)\" would file its variables where"
+                        + " \(name) already is — rename it"
+                )
+            }
             for (label, condition) in [
                 ("when", step.when), ("unless", step.unless), ("app", step.app)
             ] {
                 guard let condition else { continue }
+                guard Step.isPattern(condition) else {
+                    problems += expressionProblems(
+                        condition, label: label, step: step, available: available
+                    )
+                    continue
+                }
                 if Step.expression(for: condition) == nil {
                     // Otherwise the stage simply never runs, which looks
                     // exactly like the stage being broken.
@@ -242,6 +296,10 @@ struct Pipeline: Equatable, Codable {
                 // "Terminal" and the stage runs everywhere it was meant to be
                 // kept out of. Nothing about that failure is visible — the
                 // stage does not error, it just runs — so it is refused here.
+                //
+                // An expression does not need this and does not get it: `!` is
+                // a real negation, so exclusion is `!app.matches("term")` and
+                // the anchor nobody remembers stops existing.
                 if Step.pattern(for: condition).hasPrefix("(?!") {
                     problems.append(
                         "\(step.stage.name): \(label) \"\(condition)\" is an unanchored negative"
@@ -249,6 +307,7 @@ struct Pipeline: Equatable, Codable {
                     )
                 }
             }
+            available.insert(Pipeline.namespace(of: step))
         }
         if let fuzzy = stages.firstIndex(of: .fuzzy) {
             guard let exact = stages.firstIndex(of: .replacements) else {
@@ -257,6 +316,66 @@ struct Pipeline: Equatable, Codable {
             }
             if fuzzy < exact {
                 problems.append("fuzzy runs before replacements; it needs the exact pass to have run first")
+            }
+        }
+        return problems
+    }
+
+    /// What is wrong with an expression, before a transcript ever reaches it.
+    ///
+    /// Two kinds of thing, and the second is the one worth having. A parse error
+    /// would surface on the first dictation anyway; **reading a stage that runs
+    /// later** would not, because at run time "the stage below has not published
+    /// anything yet" and "the stage published nothing" are the same absence.
+    /// Only the pipeline as a whole knows the order, so only here can the
+    /// difference be seen — which is the same argument that already refuses
+    /// `fuzzy` before `replacements`.
+    private func expressionProblems(
+        _ condition: String, label: String, step: Step, available: Set<String>
+    ) -> [String] {
+        let named = step.transform.map { "\(step.stage.name) \($0)" } ?? step.stage.name
+        do {
+            _ = try Condition.parse(condition)
+        } catch {
+            let message = (error as? Condition.Failure)?.message ?? error.localizedDescription
+            return ["\(named): \(label) \"\(condition)\" — \(message)"]
+        }
+
+        var problems: [String] = []
+        for path in Condition.roots(of: condition).sorted() {
+            // A bare name is either a seed or the old word-boundary form. The
+            // second is why this branch says what to write instead: `when: genre`
+            // meant something for as long as this app has had conditions, and a
+            // config carrying one should be told, not silently re-read.
+            guard path.contains(".") else {
+                if !Scope.reserved.contains(path) {
+                    problems.append(
+                        "\(named): \(label) \"\(condition)\" reads \"\(path)\", which is not a"
+                            + " variable. If you meant the word \"\(path)\" in the text, write it"
+                            + " as a pattern: /\(path)/"
+                    )
+                }
+                continue
+            }
+            let namespace = String(path.prefix(while: { $0 != "." }))
+            guard available.contains(namespace) else {
+                let later = steps.contains { Pipeline.namespace(of: $0) == namespace }
+                problems.append(
+                    "\(named): \(label) \"\(condition)\" reads \"\(path)\", but "
+                        + (later
+                            ? "\"\(namespace)\" runs *after* this stage — a condition can only"
+                                + " read a stage above it"
+                            : "nothing in this pipeline is called \"\(namespace)\"")
+                )
+                continue
+            }
+            // `text.matches(…)` and friends: `text` is a seed and a namespace
+            // prefix is not, so a path under a stage is only ever a variable.
+            if Scope.reserved.contains(namespace), namespace != "asr", namespace != "vad" {
+                problems.append(
+                    "\(named): \(label) \"\(condition)\" reads \"\(path)\", but \"\(namespace)\""
+                        + " is text rather than a group of variables"
+                )
             }
         }
         return problems
@@ -287,7 +406,8 @@ struct Pipeline: Equatable, Codable {
     }
 
     static func skipReason(
-        for step: Step, text: String, config: Config, allowPrompts: Bool, app: App? = nil
+        for step: Step, text: String, config: Config, allowPrompts: Bool, app: App? = nil,
+        scope: Scope = Scope()
     ) -> Skip? {
         if step.stage == .transform {
             // Only the prompt-bodied ones. `allowPrompts` is there to keep
@@ -328,20 +448,71 @@ struct Pipeline: Equatable, Codable {
                     described: "app \(wanted) cannot be checked — nothing was in front"
                 )
             }
-            if !step.matches(app.searchable, wanted) {
-                return Skip(
-                    code: "app_mismatch",
-                    described: "app \(wanted) did not match \(app.described)"
-                )
+            do {
+                if try !step.holds(wanted, subject: app.searchable, scope: scope) {
+                    return Skip(
+                        code: "app_mismatch",
+                        described: "app \(wanted) did not match \(app.described)"
+                    )
+                }
+            } catch {
+                return broken("app", wanted, error, scope)
             }
         }
-        if let unless = step.unless, step.matches(text, unless) {
-            return Skip(code: "unless_matched", described: "unless \(unless) matched")
+        do {
+            if let unless = step.unless,
+               try step.holds(unless, subject: text, scope: scope) {
+                return Skip(
+                    code: "unless_matched",
+                    described: "unless \(unless) matched\(evidence(unless, scope))"
+                )
+            }
+        } catch {
+            return broken("unless", step.unless ?? "", error, scope)
         }
-        if let when = step.when, !step.matches(text, when) {
-            return Skip(code: "when_unmatched", described: "when \(when) did not match")
+        do {
+            if let when = step.when,
+               try !step.holds(when, subject: text, scope: scope) {
+                return Skip(
+                    code: "when_unmatched",
+                    described: "when \(when) did not match\(evidence(when, scope))"
+                )
+            }
+        } catch {
+            return broken("when", step.when ?? "", error, scope)
         }
         return nil
+    }
+
+    /// A condition that could not be answered at all.
+    ///
+    /// Skipping is the safe direction and the only one available: the question
+    /// "should this stage run" has no answer, and running a stage on a condition
+    /// nobody could evaluate is how a terminal-only rewrite ends up in an email.
+    /// The transcript passes through untouched, which is what every other
+    /// failure in this file does too.
+    private static func broken(
+        _ label: String, _ condition: String, _ error: Error, _ scope: Scope
+    ) -> Skip {
+        Skip(
+            code: "condition_error",
+            described: "\(label) \(condition) could not be answered — "
+                + ((error as? Condition.Failure)?.message ?? error.localizedDescription)
+        )
+    }
+
+    /// The values that decided an expression, appended to the reason it gives.
+    ///
+    /// Naming the condition was enough while a condition was a regex and the
+    /// text was right there on the line above. An expression is not: "when
+    /// code_identifiers.count == 0 did not match" leaves the one question you
+    /// actually have unanswered, and the answer is already in the scope.
+    private static func evidence(_ condition: String, _ scope: Scope) -> String {
+        guard !Step.isPattern(condition) else { return "" }
+        let read = Condition.roots(of: condition)
+            .sorted()
+            .compactMap { path in scope[path].map { "\(path) = \($0.described)" } }
+        return read.isEmpty ? "" : " (\(read.joined(separator: ", ")))"
     }
 
     /// - Parameter progress: Called with a stage's `display:` as that stage
@@ -351,20 +522,55 @@ struct Pipeline: Equatable, Codable {
     ///   the way to a transcript would say less than one that never moved.
     func run(
         _ text: String, config: Config, allowPrompts: Bool = true, app: App? = nil,
-        progress: (@Sendable (String) -> Void)? = nil
+        seed: Scope = Scope(), progress: (@Sendable (String) -> Void)? = nil
     ) async -> String {
+        await runCollectingScope(
+            text, config: config, allowPrompts: allowPrompts, app: app,
+            seed: seed, progress: progress
+        ).text
+    }
+
+    /// The same run, handing back the variables as well as the sentence.
+    ///
+    /// Separate from `run` because almost nothing wants the scope — the app
+    /// wants a string to type — and a caller that only needs the text should not
+    /// have to say `.text` to get it. `--pipeline` and the case sets want both,
+    /// and they are the reason the scope is reachable at all: a variable nothing
+    /// can print is a variable nobody can debug.
+    func runCollectingScope(
+        _ text: String, config: Config, allowPrompts: Bool = true, app: App? = nil,
+        seed: Scope = Scope(), progress: (@Sendable (String) -> Void)? = nil
+    ) async -> (text: String, scope: Scope) {
         var output = text
+        var scope = seed
+        // Seeded here rather than by the caller so that every path through the
+        // app agrees about what a condition can read. `--pipeline` and a live
+        // dictation differ only in what they know, never in what they call it.
+        scope.set("text", .string(output))
+        if let app {
+            scope.set("app", .string(app.name))
+            scope.set("bundle_id", .string(app.bundleID))
+        }
+
         for step in steps {
+            let named = step.transform.map { "\(step.stage.name) \($0)" } ?? step.stage.name
+            let namespace = Pipeline.namespace(of: step)
+
             if let reason = Pipeline.skipReason(
                 for: step, text: output, config: config,
-                allowPrompts: allowPrompts, app: app
+                allowPrompts: allowPrompts, app: app, scope: scope
             ) {
                 // Said out loud: a stage that silently does not run is
                 // indistinguishable from one that ran and found nothing, and
                 // only one of those is answerable by editing a condition.
-                let named = step.transform.map { "\(step.stage.name) \($0)" } ?? step.stage.name
                 Log.write("pipeline: skipped \(named) — \(reason.described)")
                 Trace.current?.recordSkip(named, code: reason.code, reason: reason.described)
+                // `ran` and nothing else. A stage that did not run has no `ok`
+                // and no `changed` to report, and inventing them would let
+                // `grammar.ok` read true for a stage that never happened. The
+                // way to ask is `grammar.ran && grammar.ok`, which is what `&&`
+                // short-circuits for.
+                scope.merge(["ran": .bool(false)], under: namespace)
                 continue
             }
             // After the skip check, not before: a stage that is about to
@@ -379,20 +585,57 @@ struct Pipeline: Equatable, Codable {
             // measured on your own sentences instead of quoted from a README.
             let before = output
             let started = CFAbsoluteTimeGetCurrent()
-            output = await apply(step, to: output, config: config)
+            let result = await apply(step, to: output, config: config, scope: scope)
+            let seconds = CFAbsoluteTimeGetCurrent() - started
+            output = result.text
+
+            // Derived, never claimed. `changed` is the comparison this loop just
+            // made, and a stage cannot get it wrong by forgetting to report it
+            // or by reporting it about the wrong string. Written *before* the
+            // stage's own contribution so that a stage which insists on
+            // publishing `ms` is allowed to — nothing here is worth overruling a
+            // script that knows better about itself.
+            scope.merge([
+                "ran": .bool(true),
+                "ok": .bool(result.vars["ok"] != .bool(false)),
+                "changed": .bool(output != before),
+                "ms": .double((seconds * 1000).rounded()),
+            ], under: namespace)
+            scope.merge(result.vars, under: namespace)
+            // The one bare name that moves. A condition reads the text as it
+            // stands at that point in the pipeline — that has always been true
+            // of a `when:` pattern, and an expression asking `text.matches(…)`
+            // has to mean the same thing.
+            scope.set("text", .string(output))
+
             Trace.current?.recordStage(
-                step.transform.map { "\(step.stage.name) \($0)" } ?? step.stage.name,
-                before: before, after: output,
-                seconds: CFAbsoluteTimeGetCurrent() - started
+                named, before: before, after: output, seconds: seconds,
+                vars: scope.namespace(namespace)
             )
         }
-        return output
+        return (output, scope)
     }
 
-    private func apply(_ step: Step, to text: String, config: Config) async -> String {
+    /// Which name a stage's facts are filed under.
+    ///
+    /// The transform's name for a `transform` stage, the stage's own name for
+    /// everything else — so a condition says `code_identifiers.count` rather
+    /// than `transform.count`, and two transforms in one pipeline do not share
+    /// a namespace. Two steps naming the *same* transform do share one, and the
+    /// later run wins; that is the reading a list executed top to bottom
+    /// invites, and refusing it would rule out running `replacements` both
+    /// before and after a rewrite.
+    static func namespace(of step: Step) -> String {
+        step.transform ?? step.stage.name
+    }
+
+    private func apply(
+        _ step: Step, to text: String, config: Config, scope: Scope
+    ) async -> StageResult {
         switch step.stage {
         case .replacements:
-            return Replacements.applyExact(to: text, rules: config.transcription.rules)
+            let done = Replacements.exact(to: text, rules: config.transcription.rules)
+            return StageResult(text: done.text, vars: ["count": .int(done.count)])
         case .fuzzy:
             // From the rules, not from the table's keys. Fuzzy matching
             // compares spellings, so a target is only a candidate if it is one
@@ -403,11 +646,12 @@ struct Pipeline: Equatable, Codable {
             let targets = Set(
                 config.transcription.rules.filter(\.isFuzzyCandidate).map(\.replacement)
             )
-            return Replacements.applyFuzzy(to: text, targets: Array(targets))
+            return StageResult(text: Replacements.applyFuzzy(to: text, targets: Array(targets)))
         case .numbers:
-            return Numbers.apply(to: text, languages: config.transcription.languages)
+            let done = Numbers.read(text, languages: config.transcription.languages)
+            return StageResult(text: done.text, vars: ["language": .string(done.language)])
         case .transform:
-            return await runTransform(step, on: text, config: config)
+            return await runTransform(step, on: text, config: config, scope: scope)
         }
     }
 
@@ -416,14 +660,16 @@ struct Pipeline: Equatable, Codable {
     /// A missing one returns the transcript rather than emptying it, same as
     /// every other way this stage declines — the name may be a typo, and
     /// `--check-config` is where that gets said.
-    private func runTransform(_ step: Step, on text: String, config: Config) async -> String {
+    private func runTransform(
+        _ step: Step, on text: String, config: Config, scope: Scope
+    ) async -> StageResult {
         guard let name = step.transform else {
             Log.write("pipeline: a transform stage names no transform; skipped")
-            return text
+            return StageResult(text: text, vars: ["ok": .bool(false)])
         }
         guard let transform = config.transform(named: name) else {
             Log.write("pipeline: no transform named \"\(name)\"; skipped")
-            return text
+            return StageResult(text: text, vars: ["ok": .bool(false)])
         }
         switch transform.body {
         case .prompt:
@@ -432,28 +678,40 @@ struct Pipeline: Equatable, Codable {
             // Exact and free, so there is nothing to guard and nothing to
             // report beyond what the table did — the log line is the same one
             // `replacements` writes, with the name that asked for it.
-            let result = Replacements.applyExact(to: text, rules: transform.rules)
-            if result != text {
+            let done = Replacements.exact(to: text, rules: transform.rules)
+            if done.text != text {
                 Log.write("pipeline: transform \(name) rewrote the transcript")
                 Log.write("    before: \(text)")
-                Log.write("    after:  \(result)")
+                Log.write("    after:  \(done.text)")
             }
-            return result
+            return StageResult(text: done.text, vars: ["count": .int(done.count)])
         case .command(let command):
             // Someone else's program, so this is the second stage that can
             // fail and the second that must not fail loudly. `run` returns nil
             // for every way it can go wrong, and nil means keep the
             // transcript. Logged either way: a stage you wrote yourself is
             // exactly the one whose before and after you want on the record.
-            guard let result = CommandRunner.run(
-                command, on: text, in: transform.folder, seconds: transform.timeout
-            ) else { return text }
-            if result != text {
+            let outcome = CommandRunner.run(
+                command, on: text, in: transform.folder, seconds: transform.timeout,
+                structured: transform.returnsJSON,
+                context: transform.returnsJSON
+                    ? CommandRunner.Context(scope: scope, language: config.transcription.languages.first ?? "en")
+                    : nil
+            )
+            guard let result = outcome else {
+                return StageResult(text: text, vars: ["ok": .bool(false)])
+            }
+            // A structured body that returned no `text` key has said "I did not
+            // touch the sentence", which is not the same as returning the same
+            // string — but it lands in the same place, and `changed` is derived
+            // from the comparison either way.
+            let after = result.text ?? text
+            if after != text {
                 Log.write("pipeline: transform \(name) rewrote the transcript")
                 Log.write("    before: \(text)")
-                Log.write("    after:  \(result)")
+                Log.write("    after:  \(after)")
             }
-            return result
+            return StageResult(text: after, vars: result.vars)
         }
     }
 
@@ -467,14 +725,14 @@ struct Pipeline: Equatable, Codable {
     /// nothing on screen will ever show you it happened.
     private func runPrompt(
         _ step: Step, named name: String, on text: String, config: Config
-    ) async -> String {
+    ) async -> StageResult {
         guard config.llm.enabled else {
             Log.write("pipeline: skipped prompt \(name) — llm.enabled is false")
-            return text
+            return StageResult(text: text, vars: ["ok": .bool(false)])
         }
         guard let prompt = config.transform(named: name)?.asPrompt else {
             Log.write("pipeline: no prompt named \"\(name)\"; skipped")
-            return text
+            return StageResult(text: text, vars: ["ok": .bool(false)])
         }
 
         do {
@@ -491,18 +749,22 @@ struct Pipeline: Equatable, Codable {
             )
             guard !result.isEmpty else {
                 Log.write("pipeline: prompt \(name) returned nothing; kept the transcript")
-                return text
+                return StageResult(text: text, vars: ["ok": .bool(false)])
             }
             if result != text {
                 Log.write("pipeline: prompt \(name) rewrote the transcript")
                 Log.write("    before: \(text)")
                 Log.write("    after:  \(result)")
             }
-            return result
+            // Which model wrote this. A prompt stage is the one whose output
+            // nobody sees happen, and "was that the model I think it was" is
+            // the first question when its answers change shape between two
+            // runs — the same question `Trace` logs `asr.model` to answer.
+            return StageResult(text: result, vars: ["model": .string(config.llm.model)])
         } catch {
             Log.write("pipeline: prompt \(name) failed (\(error.localizedDescription));"
                 + " kept the transcript")
-            return text
+            return StageResult(text: text, vars: ["ok": .bool(false)])
         }
     }
 }

--- a/Sources/ParrotFlow/PipelineCommand.swift
+++ b/Sources/ParrotFlow/PipelineCommand.swift
@@ -72,9 +72,15 @@ enum PipelineCommand {
     /// `--no-prompts` mirrors what `--replace` does, the only other caller that
     /// turns them off. Without it, "a table still runs when prompts are off" is
     /// a claim no fixture can make — and it was wrong until something ran it.
+    /// `--vars` prints the scope when the pipeline is done: every variable, by
+    /// full path, sorted. It is how a case set asserts on something other than
+    /// the finished string — a stage that publishes `count: 3` and changes no
+    /// text is invisible to `expect:` and is exactly the kind of stage worth
+    /// testing. Printed before the output line so that `--quiet | tail -1` still
+    /// means what it has always meant.
     static func run(
         path: String, text: String?, quiet: Bool = false, app: String? = nil,
-        allowPrompts: Bool = true
+        allowPrompts: Bool = true, showVars: Bool = false
     ) -> Int32 {
         let named = (app ?? "").trimmingCharacters(in: .whitespaces)
         let front = named.isEmpty ? nil : Pipeline.App(name: named, bundleID: "")
@@ -138,12 +144,22 @@ enum PipelineCommand {
             return 0
         }
 
+        // The same seed a live dictation gets from `Replacements.apply`. Without
+        // it a condition reading `language` would work in the app and fail here,
+        // and a fixture that cannot reproduce the app is not a fixture.
+        // `Pipeline.forText` is asked rather than `DictationLanguage` directly,
+        // so the answer is the one that would have selected the stages.
+        var seed = Scope()
+        seed.set("language", .string(Pipeline.forText(text, config: config).1))
+
         let done = DispatchSemaphore(value: 0)
         if quiet {
             Task {
-                print(await pipeline.run(
-                    text, config: config, allowPrompts: allowPrompts, app: front
-                ))
+                let result = await pipeline.runCollectingScope(
+                    text, config: config, allowPrompts: allowPrompts, app: front, seed: seed
+                )
+                if showVars { printVars(result.scope) }
+                print(result.text)
                 done.signal()
             }
             done.wait()
@@ -163,33 +179,70 @@ enum PipelineCommand {
         print("in:   \(text)")
         if let front { print("app:  \(front.described)") }
         var current = text
+        // Threaded, not restarted. Each step is still run on its own so that its
+        // own before and after can be printed, but the scope it inherits is the
+        // one the steps above it built — otherwise a condition reading
+        // `code_identifiers.count` would find nothing here while working
+        // perfectly in the pipeline this is supposed to be a view of, and a
+        // diagnostic that disagrees with the thing it diagnoses is worse than
+        // none.
+        var scope = seed
         for step in steps {
+            let namespace = Pipeline.namespace(of: step)
+            var after = current
+            let stepDone = DispatchSemaphore(value: 0)
+            Task {
+                let result = await Pipeline(steps: [step]).runCollectingScope(
+                    current, config: config, allowPrompts: allowPrompts, app: front,
+                    seed: scope
+                )
+                after = result.text
+                scope = result.scope
+                stepDone.signal()
+            }
+            stepDone.wait()
+
+            // Asked of the same scope the step was given, so the reason printed
+            // is the reason that fired. `skipReason` is called a second time
+            // rather than reported back out of `run` because the run above has
+            // already decided — this only needs the words.
             if let reason = Pipeline.skipReason(
                 for: step, text: current, config: config,
-                allowPrompts: allowPrompts, app: front
+                allowPrompts: allowPrompts, app: front, scope: scope
             ) {
                 print("  ⊘ \(step.stage.name)  — skipped, \(reason.described)")
                 continue
             }
-            var after = current
-            let stepDone = DispatchSemaphore(value: 0)
-            Task {
-                after = await Pipeline(steps: [step]).run(
-                    current, config: config, allowPrompts: allowPrompts, app: front
-                )
-                stepDone.signal()
-            }
-            stepDone.wait()
             if after == current {
                 print("  · \(step.stage.name)  — ran, changed nothing")
             } else {
                 print("  → \(step.stage.name)")
                 print("      \(after)")
             }
+            let published = scope.namespace(namespace)
+                .filter { $0.key != "ran" && $0.key != "ok" && $0.key != "ms" }
+            if !published.isEmpty {
+                print("      " + published.keys.sorted()
+                    .map { "\(namespace).\($0) = \(published[$0]!.described)" }
+                    .joined(separator: "  "))
+            }
             current = after
         }
+        if showVars { printVars(scope) }
         print("out:  \(current)")
         problems = []
         return 0
+    }
+
+    /// Every variable, by full path, one per line.
+    ///
+    /// `text` is left out: it is the sentence, it is printed twice already, and
+    /// a multi-line email in the middle of a variable listing makes the listing
+    /// unreadable for the one value nobody needed it for.
+    private static func printVars(_ scope: Scope) {
+        for path in scope.paths where path != "text" {
+            guard let value = scope[path] else { continue }
+            print("var   \(path) = \(value.described)")
+        }
     }
 }

--- a/Sources/ParrotFlow/Replacements.swift
+++ b/Sources/ParrotFlow/Replacements.swift
@@ -38,15 +38,18 @@ enum Replacements {
     /// out of this function did not move the call sites too.
     static func apply(
         to text: String, config: Config, allowPrompts: Bool = true, app: Pipeline.App? = nil,
-        progress: (@Sendable (String) -> Void)? = nil
+        seed: Scope = Scope(), progress: (@Sendable (String) -> Void)? = nil
     ) async -> String {
         let (pipeline, language) = Pipeline.forText(text, config: config)
         // The verdict that picked the stages, which until now was computed here
         // and discarded on the same line. Parakeet reports no language of its
         // own, so this is the only one there is to write down.
         Trace.current?.recordLanguage(language)
+        var seed = seed
+        seed.set("language", .string(language))
         return await pipeline.run(
-            text, config: config, allowPrompts: allowPrompts, app: app, progress: progress
+            text, config: config, allowPrompts: allowPrompts, app: app,
+            seed: seed, progress: progress
         )
     }
 
@@ -55,8 +58,26 @@ enum Replacements {
     /// Literal on word boundaries, or a regular expression when the source is
     /// wrapped in slashes. Case-insensitive either way.
     static func applyExact(to text: String, rules: [Config.Transcription.Rule]) -> String {
+        exact(to: text, rules: rules).text
+    }
+
+    /// The same pass, with how many rules actually fired.
+    ///
+    /// Split out rather than folded in because the count is only wanted by the
+    /// pipeline, which publishes it as `replacements.count` so a later stage can
+    /// ask whether this one already did the job. Every other caller wants the
+    /// string and nothing else, and `applyExact` above is still exactly what
+    /// they were calling.
+    ///
+    /// Counted per *rule*, not per substitution: "two rules fired" is the
+    /// question a condition is asking, and a rule that replaced the same word
+    /// four times did one thing, not four.
+    static func exact(
+        to text: String, rules: [Config.Transcription.Rule]
+    ) -> (text: String, count: Int) {
         var output = text
         var deleted = false
+        var fired = 0
 
         for rule in rules {
             guard let pattern = try? NSRegularExpression(
@@ -71,10 +92,13 @@ enum Replacements {
                 range: NSRange(output.startIndex..., in: output),
                 withTemplate: rule.template
             )
-            if rule.isDeletion, output != before { deleted = true }
+            if output != before {
+                fired += 1
+                if rule.isDeletion { deleted = true }
+            }
         }
 
-        return deleted ? tidy(output) : output
+        return (deleted ? tidy(output) : output, fired)
     }
 
     /// Closes the gaps a deletion leaves — doubled spaces, a space before a

--- a/Sources/ParrotFlow/Scope.swift
+++ b/Sources/ParrotFlow/Scope.swift
@@ -1,0 +1,190 @@
+import Foundation
+
+/// What a pipeline knows about the transcript in flight, beyond the transcript.
+///
+/// Every stage used to be `String -> String`, which meant the only thing one
+/// stage could tell the next was the sentence itself. A condition could ask
+/// "does the text still say `function`" and nothing else — so a stage that had
+/// already done the work had no way to say so, and the stage after it re-derived
+/// the same judgement from the same words, or ran when it should not have.
+///
+/// A scope is the other channel. A stage contributes facts about *what it did*;
+/// later conditions read them. The rules are deliberately narrow, because the
+/// failure this design invites is a variable that outlives the text it described:
+///
+///   - A stage writes only under its **own name**. The namespace is supplied by
+///     the runner, never by the stage, so one stage cannot reach into another's
+///     facts by accident or on purpose. Cross-namespace clobbering is not
+///     guarded against here; it is unrepresentable.
+///   - Everything else **carries through untouched**. A stage contributing
+///     nothing erases nothing — carrying is the loop's job, not a courtesy each
+///     script has to remember. A `sed` one-liner cannot echo a namespace, and a
+///     contract only some stages can honour is not a contract.
+///   - A name is a fact about the stage, not a claim about the text.
+///     `code_identifiers.count` stays true after a later stage rewrites the
+///     sentence; `has_identifier` would not. The namespace makes the first
+///     reading the natural one, which is the whole reason facts are filed under
+///     the stage that produced them rather than merged flat.
+struct Scope: Equatable {
+
+    /// One value a condition can read.
+    ///
+    /// Scalars only, and four of them. The ceiling is not shyness: the predicate
+    /// language that reads these has to be implementable twice — once here, once
+    /// wherever a pipeline runner is written next — and every type added to this
+    /// enum is a comparison, a coercion and a parse rule in both. Four scalars
+    /// and one level of namespace is the largest domain that stays a few hundred
+    /// lines rather than a type system.
+    enum Value: Equatable {
+        case string(String)
+        case int(Int)
+        case double(Double)
+        case bool(Bool)
+
+        /// How it reads in a log line or a `--pipeline` listing.
+        var described: String {
+            switch self {
+            case .string(let s): return "\"\(s)\""
+            case .int(let i): return String(i)
+            case .double(let d): return String(d)
+            case .bool(let b): return b ? "true" : "false"
+            }
+        }
+
+        /// The number this is, for `<`, `>` and friends. Ints and doubles
+        /// compare with each other — a script that returns `1` and one that
+        /// returns `1.0` have said the same thing, and a condition that treats
+        /// them differently would be reporting the script's JSON encoder rather
+        /// than its answer.
+        var asDouble: Double? {
+            switch self {
+            case .int(let i): return Double(i)
+            case .double(let d): return d
+            default: return nil
+            }
+        }
+    }
+
+    /// Keyed by the whole dotted path — `numbers.count`, `asr.confidence`,
+    /// `text`. Flat storage rather than nested dictionaries because every
+    /// question asked of it is "what is at this path", and one level of nesting
+    /// would be a tree walk to answer a lookup.
+    private(set) var values: [String: Value] = [:]
+
+    /// The namespaces a stage may not be filed under, because something else is
+    /// already there. A transform called `asr` would put `asr.confidence` in
+    /// reach of two writers and leave no way to tell which one a condition read.
+    ///
+    /// `text` is here because it is a bare name rather than a namespace: a
+    /// stage called `text` would contribute `text.count` while `text` itself is
+    /// a string, and a path that is both a value and a prefix has no sensible
+    /// answer.
+    static let reserved: Set<String> = [
+        "text", "app", "bundle_id", "language", "asr", "vad",
+    ]
+
+    init(values: [String: Value] = [:]) {
+        self.values = values
+    }
+
+    subscript(path: String) -> Value? { values[path] }
+
+    /// Set a bare, un-namespaced name — the seeds the runner puts in before any
+    /// stage runs, and `text`, which it rewrites after each one.
+    mutating func set(_ name: String, _ value: Value) {
+        values[name] = value
+    }
+
+    mutating func set(_ name: String, _ value: Value?) {
+        guard let value else { return }
+        values[name] = value
+    }
+
+    /// File a stage's contribution under its own name.
+    ///
+    /// Keys already present under this namespace are replaced and keys under
+    /// every other namespace are left alone — which is the whole of "carry
+    /// through unless overridden", enforced in the one place that knows both
+    /// halves.
+    ///
+    /// A stage that appears twice in a pipeline writes the same namespace twice,
+    /// and the second run wins. That is the reading a person expects from a list
+    /// executed top to bottom, and the alternative — refusing the pipeline —
+    /// would rule out running `replacements` before and after a rewrite, which
+    /// is a thing people legitimately do. A condition between the two sees the
+    /// first run's facts; one after them sees the second's.
+    mutating func merge(_ contribution: [String: Value], under namespace: String) {
+        for (key, value) in contribution {
+            values["\(namespace).\(key)"] = value
+        }
+    }
+
+    /// Everything filed under one namespace, with the prefix taken back off.
+    /// For printing a stage's contribution, which is a question about one stage
+    /// rather than about the scope.
+    func namespace(_ name: String) -> [String: Value] {
+        let prefix = name + "."
+        var found: [String: Value] = [:]
+        for (path, value) in values where path.hasPrefix(prefix) {
+            found[String(path.dropFirst(prefix.count))] = value
+        }
+        return found
+    }
+
+    /// Every path, sorted, for a deterministic listing. `--pipeline` prints
+    /// these and a case set compares them, and a dictionary's own order is
+    /// neither stable nor meaningful.
+    var paths: [String] { values.keys.sorted() }
+}
+
+/// What a stage hands back.
+///
+/// The asymmetry with what a stage is *given* is deliberate and is the reason
+/// carry-through cannot be forgotten. A stage receives the whole scope and
+/// returns only its own contribution: it has no way to express "and here is
+/// everything else, unchanged", so it has no way to get that wrong. The runner,
+/// which is the only thing holding the accumulated scope, is the only thing that
+/// can drop a namespace — and it never does.
+struct StageResult: Equatable {
+    var text: String
+    var vars: [String: Scope.Value] = [:]
+
+    init(text: String, vars: [String: Scope.Value] = [:]) {
+        self.text = text
+        self.vars = vars
+    }
+}
+
+// MARK: - JSON
+
+/// Decoded straight from a script's stdout, and encoded into the context a
+/// script is given. Kept next to the type rather than in `CommandRunner` because
+/// the shape is the interface: a body written in any language is conforming
+/// exactly when it round-trips through this.
+extension Scope.Value: Codable {
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        // Bool first. `JSONDecoder` will decode `true` as an `Int` 1 on some
+        // platforms if asked in the wrong order, and a script that returned a
+        // flag would find its condition comparing numbers.
+        if let b = try? container.decode(Bool.self) { self = .bool(b); return }
+        if let i = try? container.decode(Int.self) { self = .int(i); return }
+        if let d = try? container.decode(Double.self) { self = .double(d); return }
+        if let s = try? container.decode(String.self) { self = .string(s); return }
+        throw DecodingError.dataCorruptedError(
+            in: container,
+            debugDescription: "a variable must be a string, number or boolean"
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let s): try container.encode(s)
+        case .int(let i): try container.encode(i)
+        case .double(let d): try container.encode(d)
+        case .bool(let b): try container.encode(b)
+        }
+    }
+}

--- a/Sources/ParrotFlow/Trace.swift
+++ b/Sources/ParrotFlow/Trace.swift
@@ -140,10 +140,13 @@ enum Trace {
         /// Every stage that ran, including the ones that changed nothing —
         /// "ran and found nothing" and "was skipped" are different answers and
         /// only the log conflates them.
-        func recordStage(_ name: String, before: String, after: String, seconds: Double) {
+        func recordStage(
+            _ name: String, before: String, after: String, seconds: Double,
+            vars: [String: Scope.Value] = [:]
+        ) {
             lock.lock(); defer { lock.unlock() }
             stages.append(
-                Stage(name: name, before: before, after: after, seconds: seconds)
+                Stage(name: name, before: before, after: after, seconds: seconds, vars: vars)
             )
         }
 
@@ -395,11 +398,19 @@ enum Trace {
         var before: String?
         var after: String?
         var seconds: Double?
+        /// What the stage published about itself — `count`, `language`, and the
+        /// `ran`/`ok`/`changed`/`ms` the pipeline derives for every stage.
+        ///
+        /// Worth a column of its own rather than folding into the prose: this is
+        /// the file a sweep runs over, and "which transcripts did
+        /// code_identifiers actually fire on" is a `jq` query when the numbers
+        /// are numbers and a regex over English when they are not.
+        var vars: [String: Scope.Value]?
 
         enum CodingKeys: String, CodingKey {
             case name
             case skipCode = "skip_reason"
-            case skipped, before, after, seconds
+            case skipped, before, after, seconds, vars
         }
 
         init(name: String, skipCode: String, skipped: String) {
@@ -408,11 +419,15 @@ enum Trace {
             self.skipped = skipped
         }
 
-        init(name: String, before: String, after: String, seconds: Double) {
+        init(
+            name: String, before: String, after: String, seconds: Double,
+            vars: [String: Scope.Value]
+        ) {
             self.name = name
             self.before = before
             self.after = after
             self.seconds = seconds
+            self.vars = vars.isEmpty ? nil : vars
         }
     }
 }

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -161,8 +161,23 @@ actor Transcriber {
         }
         Trace.current?.recordASR(result, model: Repo.parakeetV3.rawValue)
 
+        // The same numbers the trace records, handed to the pipeline as well.
+        //
+        // Not read back off `Trace`, deliberately. The collector is bound only
+        // when somebody asked for a trace — `Trace.current` is nil the rest of
+        // the time — and a condition reading `asr.confidence` must not work on
+        // the runs you are watching and quietly stop on the runs you are not.
+        // So the trace consumes these; it does not own them.
         return await Self.applyReplacements(
-            to: result.text, config: config, app: app, progress: progress
+            to: result.text, config: config, app: app,
+            seed: Scope(values: [
+                "asr.model": .string(Repo.parakeetV3.rawValue),
+                "asr.confidence": .double(Double(result.confidence)),
+                "asr.duration": .double(result.duration),
+                "asr.processing": .double(result.processingTime),
+                "asr.words": .int(result.tokenTimings?.count ?? 0),
+            ]),
+            progress: progress
         )
     }
 
@@ -420,9 +435,12 @@ actor Transcriber {
     /// How names get fixed — see `Replacements`.
     nonisolated static func applyReplacements(
         to text: String, config: Config, app: Pipeline.App? = nil,
+        seed: Scope = Scope(),
         progress: (@Sendable (String) -> Void)? = nil
     ) async -> String {
-        await Replacements.apply(to: text, config: config, app: app, progress: progress)
+        await Replacements.apply(
+            to: text, config: config, app: app, seed: seed, progress: progress
+        )
     }
 }
 

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -165,7 +165,8 @@ if let index = arguments.firstIndex(of: "--pipeline") {
     exit(PipelineCommand.run(
         path: arguments[index + 1], text: text,
         quiet: arguments.contains("--quiet"), app: appArgument,
-        allowPrompts: !arguments.contains("--no-prompts")
+        allowPrompts: !arguments.contains("--no-prompts"),
+        showVars: arguments.contains("--vars")
     ))
 }
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -42,6 +42,24 @@ transcription:
       - transform: code_identifiers
         app: /term|ghostty|warp|kitty|alacritty|hyper|code|cursor|zed|xcode|jetbrains|idea|pycharm|webstorm/
         when: /\b(?:function|method|variable|class|constant|type|struct|interface|enum|fonction|méthode|classe|constante)\b/
+      #
+      # A `when:` that is not a pattern is an expression over what the stages
+      # above published — `code_identifiers.count`, `replacements.count`,
+      # `numbers.language`, `asr.confidence`, and `<stage>.ran` / `.ok` /
+      # `.changed` / `.ms` for every stage. So a stage can stand down because
+      # another one already took the sentence, rather than re-deciding from the
+      # same words:
+      #
+      #   - transform: code_identifiers
+      #   - stage: transform
+      #     transform: dotted
+      #     when: code_identifiers.count == 0
+      #
+      # Reading a variable needs the stage that publishes it to declare
+      # `returns: json` and to speak that protocol — see docs/authoring.md.
+      # Both halves, in that order: a transform folder is never overwritten, so
+      # a config that asks for it before the script understands it turns that
+      # stage off. `--pipeline <file> "<text>" --vars` shows the whole scope.
       # The two stages that ask the model, and the only two costing a second.
       # `app:` reads the window that was in front, and a browser tab is not an
       # app: add your browser to the pattern if you live in Gmail, knowing every

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -200,6 +200,77 @@ file does. `--check-config` names every `command:` transform out loud, every
 time — a config that runs something you have forgotten about, or that arrived
 in a config you copied from somewhere, should not be able to stay quiet.
 
+## Recipe: a program that reports what it did
+
+Text in, text out cannot say anything except the text — so a stage that
+*looked* and found nothing is indistinguishable from one that ran and changed
+nothing, and the stage below has to re-derive the judgement from the same
+words. Adding `returns: json` swaps the plumbing for one that carries
+variables. See [pipelines.md](pipelines.md#variables) for what a condition can
+then do with them.
+
+```yaml
+  - name: code_identifiers
+    description: spoken names as identifiers
+    command: code_identifiers.py
+    returns: json
+```
+
+**In**, on stdin:
+
+```json
+{ "text": "a python function called max retries",
+  "ctx": { "app": "Ghostty", "bundle_id": "com.mitchellh.ghostty",
+           "language": "en",
+           "vars": { "asr": { "confidence": 0.91, "duration": 4.2 },
+                     "replacements": { "ran": true, "count": 1,
+                                       "changed": true, "ms": 0.4 } } } }
+```
+
+**Out**, on stdout — and only what this stage contributes:
+
+```json
+{ "text": "a python function called max_retries",
+  "vars": { "count": 1, "asked_model": false } }
+```
+
+- **Both keys are optional.** No `text` means "I looked and left the sentence
+  alone", which is not the same as echoing the input back and is not a failure.
+  No `vars` means the stage published nothing this time.
+- **Never echo the context back.** You cannot erase another stage's variables
+  by leaving them out, because carrying them is the pipeline's job. The reply
+  is a contribution, not a replacement.
+- Values are strings, numbers or booleans. One level, no nesting.
+- Print something that is not JSON and the transcript comes through untouched
+  with `<stage>.ok` set false, and the log says what was printed. That is a
+  script bug rather than a config one, so `--check-config` cannot catch it.
+
+The app sets **`PARROTFLOW_PROTOCOL=json`** in the environment when — and only
+when — the transform declares `returns: json`. Read that rather than taking a
+flag, so `returns:` stays the single declaration and the script is still
+runnable by hand:
+
+```python
+structured = os.environ.get("PARROTFLOW_PROTOCOL") == "json"
+raw = sys.stdin.read()
+text = json.loads(raw)["text"] if structured else raw.rstrip("\n")
+...
+if structured:
+    sys.stdout.write(json.dumps({"text": out, "vars": {"count": n}}))
+else:
+    sys.stdout.write(out)
+```
+
+That branch is worth keeping. Every harness in `scripts/` pipes plain text, and
+so will you the first time a stage misbehaves.
+
+> **Upgrading an existing transform.** A transform folder is written on first
+> launch and **never overwritten**, so adding `returns: json` to a config whose
+> script predates it means the script prints bare text, the app cannot read it,
+> and the stage silently stops doing anything. Edit the script first, then the
+> config. `--pipeline <fixture> "<text>" --vars` is how you check, before it
+> matters.
+
 ## Recipe: a language
 
 `pipelines:` takes a key per language, and a language's own list wins over

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -90,8 +90,36 @@ so a case file states the setup it assumes instead of inheriting this machine's.
 - `--no-prompts` skips the stages that would call the model, so a run stays
   deterministic and fast.
 - `--quiet` prints only the result, for scripts.
+- `--vars` prints the whole variable scope when the run is done, one line per
+  path, before the output line — so `--quiet --vars | tail -1` is still the
+  result. It is how a stage whose only contribution is a fact gets scored at
+  all, and the first thing to reach for when a condition is not deciding what
+  you expected. See [pipelines.md](pipelines.md#variables).
 - `--lang en,fr` stands in for the configured `languages:`, so a case file does
   not depend on how this Mac is set up.
+
+```
+$ $PF --pipeline tests/pipelines/vars-shipped.yaml \
+      "a python function called max retries" --vars
+in:   a python function called max retries
+  → transform
+      a python function called max_retries
+      code_identifiers.asked_model = false  code_identifiers.changed = true  code_identifiers.count = 1
+  ⊘ transform  — skipped, when code_identifiers.count == 0 did not match (code_identifiers.count = 1)
+var   code_identifiers.asked_model = false
+var   code_identifiers.changed = true
+var   code_identifiers.count = 1
+var   code_identifiers.ms = 69.0
+var   code_identifiers.ok = true
+var   code_identifiers.ran = true
+var   dotted.ran = false
+var   language = "en"
+out:  a python function called max_retries
+```
+
+The line under a stage is what *that* stage contributed; the `var` block at the
+end is the whole scope. A skipped stage names the values that decided it, which
+is the question you actually have.
 
 ## Scoring a transform: `--eval`
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -572,13 +572,136 @@ stages above — so a cheap stage can make an expensive one unnecessary rather
 than merely earlier. Both may be set and `unless` wins, because a reason not to
 run is a stronger statement than a reason to.
 
-The pattern is written like a replacement source: between slashes it is a
-regular expression, otherwise a word matched on word boundaries.
-Case-insensitive either way.
+Between slashes it is a regular expression, matched case-insensitively.
+Anything else is an **expression** — see [Variables](#variables) below.
+
+> A bare word used to mean "this word appears, on word boundaries". It now
+> parses as a variable, and `--check-config` refuses it by name rather than
+> letting a stage quietly stop running: `when: genre` is told to become
+> `when: /genre/`.
 
 A skipped stage says so in the log. A stage that silently does not run looks
 exactly like one that ran and found nothing, and only one of those is
 answerable by editing a condition.
+
+## Variables
+
+A regex can ask one thing: does the text say this. It cannot ask whether the
+stage above already did the job — so a stage had to re-derive that judgement
+from the same words, or run when it should not have.
+
+Every stage publishes facts about itself, under its own name, and a condition
+can read them:
+
+```yaml
+pipelines:
+  default:
+    - replacements
+    - transform: code_identifiers
+    - stage: transform
+      transform: dotted
+      when: code_identifiers.count == 0     # only if nothing else took it
+```
+
+Four are derived for every stage, whatever it is and whether or not it knows
+any of this exists:
+
+| | |
+|---|---|
+| `<stage>.ran` | false when a condition skipped it |
+| `<stage>.ok` | false when it errored, timed out, or returned nothing |
+| `<stage>.changed` | whether the text differs from what went in |
+| `<stage>.ms` | how long it took |
+
+They are **derived, never claimed**. A stage cannot forget to report `changed`,
+and cannot report it about the wrong string.
+
+Stages add their own on top. The built-in ones publish `replacements.count`,
+`numbers.language` — which grammar actually read the numbers, and not the same
+answer as the pipeline's language — and, for a prompt stage, `model`. A
+`command:` transform publishes whatever it likes; see
+[docs/authoring.md](authoring.md#recipe-a-program-that-reports-what-it-did).
+
+Before any stage runs, the scope already holds `text`, `app`, `bundle_id`,
+`language`, and what transcription measured — `asr.confidence`, `asr.duration`,
+`asr.processing`, `asr.words`. So a stage can stand down on a recording the
+recogniser was not sure about:
+
+```yaml
+    - stage: transform
+      transform: disfluency
+      when: asr.confidence < 0.7 && asr.duration > 3.0
+```
+
+### The rules
+
+**A stage writes under its own name and nowhere else.** The namespace comes
+from the pipeline, not from the stage, so one stage reaching into another's
+facts is not guarded against — it is unspellable.
+
+**Everything else carries through.** A stage contributing nothing erases
+nothing. Carrying is the pipeline's job, not something each script has to
+remember; a `sed` one-liner could never have echoed a namespace back.
+
+**A name is a fact about the stage, not a claim about the text.**
+`code_identifiers.count` — how many names it converted — stays true after a
+later stage rewrites the sentence. A variable called `has_identifier` would
+not. The namespace makes the first reading the natural one.
+
+**The same stage twice writes the same namespace, and the later run wins.** A
+condition between the two sees the earlier facts. Keys the second run does not
+mention survive it.
+
+**A skipped stage gets `ran: false` and nothing else** — no `ok`, no `changed`.
+Inventing them would let `grammar.ok` read true for a stage that never
+happened. Ask `grammar.ran && grammar.ok`; `&&` short-circuits, so the second
+half is never evaluated on a stage that has no `ok`.
+
+### The expression language
+
+A subset of [CEL](https://cel.dev), which is chosen for the spec rather than
+for any library: if the pipeline is ever rewritten in another language, the
+configs people have written keep meaning what they meant.
+
+```
+paths          text, numbers.count, asr.confidence
+literals       "a string", 12, 1.5, true, false
+operators      &&  ||  !  ==  !=  <  <=  >  >=
+methods        matches(re)  contains(s)  startsWith(s)  endsWith(s)
+```
+
+Strings compare and match case-insensitively, and `matches` is ICU — the same
+engine `/…/` conditions use, so a pattern moved from one form to the other
+behaves identically.
+
+`!` is a real negation, which is why the anchored negative lookahead below is
+not needed in an expression:
+
+```yaml
+      app: /^(?!.*(term|ghostty))/          # a pattern needs the anchor
+      when: '!app.matches("term|ghostty")'  # an expression does not
+```
+
+**An unknown name is an error, not false.** Silently reading false is how a
+condition stops working without anything saying so. Two of the three cases are
+caught at load, by `--check-config`, before a transcript ever reaches them:
+
+- a name nothing defines — `when: genre`, the old bare-word form
+- a stage that runs *later* in the pipeline than the condition reading it,
+  which no runtime error can catch in time: by then the transcript is already
+  halfway through, and "has not run yet" and "reported nothing" are the same
+  absence
+
+The third — a variable a script stopped publishing — can only be seen at run
+time. The stage is skipped, and the log says why.
+
+`--pipeline … --vars` prints the whole scope, and a skipped stage names the
+values that decided it:
+
+```
+  ⊘ transform  — skipped, when code_identifiers.count == 0 did not match
+                 (code_identifiers.count = 1)
+```
 
 ## Apps
 

--- a/examples/transforms/code_identifiers/code_identifiers.py
+++ b/examples/transforms/code_identifiers/code_identifiers.py
@@ -234,9 +234,16 @@ def ask(model, text, endpoint="http://localhost:11434"):
         return ""
 
 
-def place(reply, text):
+def place(reply, text, converted=None):
     """The extraction applied — the deterministic half, sharing `cased` and
-    `style_for` with the rules above so there is one algorithm and not two."""
+    `style_for` with the rules above so there is one algorithm and not two.
+
+    `converted` is appended one entry per name taken, exactly as `convert` does
+    — the two paths produce the same kind of rewrite and have to report it the
+    same way. A model conversion that did not count would publish `count: 0` on
+    a sentence this stage had just rewritten, and the stage below, told to stand
+    down when the count is zero, would run anyway.
+    """
     language, names = None, []
     for line in reply.splitlines():
         line = line.strip()
@@ -257,6 +264,8 @@ def place(reply, text):
         start = out.lower().index(span.lower())
         out = (out[:start] + cased(words, style_for(out, out[:start], language))
                + out[start + len(span):])
+        if converted is not None:
+            converted.append(span)
     return out
 
 
@@ -289,9 +298,14 @@ if __name__ == "__main__":
     asked = False
     # The model is asked only about what the rules declined. On a sentence with
     # a marker in it — the common case — nothing is paid at all.
+    #
+    # `converted` is passed on rather than reset: the branch is only reached
+    # when the rules took nothing, so it is empty here — but threading it keeps
+    # `count` meaning "names this stage converted" regardless of which half did
+    # it, which is the only reading a condition below can rely on.
     if model and out == text:
         asked = True
-        out = place(ask(model, text), text)
+        out = place(ask(model, text), text, converted)
 
     if not structured:
         sys.stdout.write(out)

--- a/examples/transforms/code_identifiers/code_identifiers.py
+++ b/examples/transforms/code_identifiers/code_identifiers.py
@@ -58,6 +58,7 @@ they say where a name ends, and that boundary is a judgement about how you
 speak, not a fact.
 """
 import json
+import os
 import re
 import sys
 import urllib.request
@@ -129,7 +130,14 @@ def cased(words, style):
     return words[0].lower() + "".join(word.capitalize() for word in words[1:])
 
 
-def convert(text):
+def convert(text, converted=None):
+    """The rewrite. `converted`, if given, is appended one entry per name taken.
+
+    An out-parameter rather than a second return value because
+    `scripts/validate-code-identifiers.py` calls this as `shipped.convert` and
+    compares its result to a string — a tuple would have changed what the
+    scoreboard measures in order to add a number nothing there reads.
+    """
     out = text
     # Right to left, so an earlier rewrite cannot move a later match.
     for match in list(TRIGGER.finditer(text))[::-1]:
@@ -151,6 +159,8 @@ def convert(text):
             continue
         if span in out:
             out = out.replace(span, cased(words, style_for(text, text[:match.start()])), 1)
+            if converted is not None:
+                converted.append(span)
     return out
 
 
@@ -256,10 +266,43 @@ if __name__ == "__main__":
         index = sys.argv.index("--model")
         model = sys.argv[index + 1] if len(sys.argv) > index + 1 else None
 
-    text = sys.stdin.read().rstrip("\n")
-    out = convert(text)
+    # Two protocols, and which one is in force is decided by the config rather
+    # than by anything here: ParrotFlow sets PARROTFLOW_PROTOCOL=json when the
+    # transform declares `returns: json`, and leaves it unset otherwise.
+    #
+    # Reading the environment rather than taking a flag keeps `returns:` the
+    # single declaration — a flag in the `command:` line would say the same
+    # thing one line lower and could disagree with it. It also keeps this
+    # runnable by hand: `echo "a python function called max retries" |
+    # ./code_identifiers.py` takes the plain path, which is what every harness
+    # in scripts/ does and what anybody debugging one will type.
+    structured = os.environ.get("PARROTFLOW_PROTOCOL") == "json"
+
+    raw = sys.stdin.read()
+    if structured:
+        text = json.loads(raw)["text"]
+    else:
+        text = raw.rstrip("\n")
+
+    converted = []
+    out = convert(text, converted)
+    asked = False
     # The model is asked only about what the rules declined. On a sentence with
     # a marker in it — the common case — nothing is paid at all.
     if model and out == text:
+        asked = True
         out = place(ask(model, text), text)
-    sys.stdout.write(out)
+
+    if not structured:
+        sys.stdout.write(out)
+        raise SystemExit(0)
+
+    # `count` is what a later stage wants: `dotted` should stand down when this
+    # already took the sentence, and until now the only way to ask was to
+    # re-derive the judgement from the words. `asked` is for the log rather than
+    # for a condition — it is the difference between a stage that cost nothing
+    # and one that cost a second, and it was previously invisible.
+    sys.stdout.write(json.dumps({
+        "text": out,
+        "vars": {"count": len(converted), "asked_model": asked},
+    }))

--- a/scripts/check-pipeline.sh
+++ b/scripts/check-pipeline.sh
@@ -110,6 +110,26 @@ while IFS='|' read -r name fixture problem; do
   total=$((total + 1))
   path="$ROOT/tests/pipelines/refused/$fixture.yaml"
 
+  # An entry with no `expect_problem` is refused rather than run. `grep -F ""`
+  # matches every line, so a case with nothing to look for passed on any
+  # failure at all — and that is exactly what happened to four cases appended
+  # to the wrong section of the file: they named no problem, the fixture did
+  # not exist, the binary failed to load it, and the empty pattern called that
+  # a pass. A test that cannot fail is worse than no test.
+  if [ -z "$problem" ]; then
+    failed="$failed
+      $name"
+    printf '  ✗ %s  [%s]\n      no expect_problem — a refused case must say what it is looking for\n' \
+      "$name" "$fixture"
+    continue
+  fi
+  if [ ! -f "$path" ]; then
+    failed="$failed
+      $name"
+    printf '  ✗ %s\n      no such fixture: tests/pipelines/refused/%s.yaml\n' "$name" "$fixture"
+    continue
+  fi
+
   if out="$("$BIN" --pipeline "$path" "anything at all" --app "" --quiet 2>&1)"; then
     failed="$failed
       $name"

--- a/scripts/check-pipeline.sh
+++ b/scripts/check-pipeline.sh
@@ -19,7 +19,7 @@ BIN="$ROOT/.build/release/ParrotFlow"
 
 pass=0; total=0; failed=""
 
-while IFS='|' read -r name fixture app noprompts input expect; do
+while IFS='|' read -r name fixture app noprompts input expect vars; do
   [ -z "$name" ] && continue
   total=$((total + 1))
   [ "$expect" = "unchanged" ] && want="$input" || want="$expect"
@@ -40,23 +40,93 @@ while IFS='|' read -r name fixture app noprompts input expect; do
     continue
   fi
 
-  got="$("$BIN" --pipeline "$path" "$input" --app "$app" $off --quiet 2>/dev/null | tail -1)"
+  # `--vars` prints `var <path> = <value>` for the whole scope before the output
+  # line, so the text comparison below is still `tail -1` and a case that says
+  # nothing about variables costs nothing to run.
+  full="$("$BIN" --pipeline "$path" "$input" --app "$app" $off --quiet --vars 2>/dev/null)"
+  got="$(printf '%s' "$full" | tail -1)"
 
-  if [ "$got" = "$want" ]; then
+  # Every `expect_vars` entry has to appear, verbatim, in that listing. Absence
+  # is a failure and so is a different value — the two are the same question
+  # asked of a variable, and a stage that stopped publishing one is exactly the
+  # regression this is here to catch.
+  missing=""
+  if [ -n "$vars" ]; then
+    old="$IFS"; IFS=';'
+    for pair in $vars; do
+      [ -z "$pair" ] && continue
+      printf '%s\n' "$full" | grep -qxF "var   $pair" || missing="$missing
+      $pair"
+    done
+    IFS="$old"
+  fi
+
+  if [ "$got" = "$want" ] && [ -z "$missing" ]; then
     pass=$((pass + 1))
     printf '  ✓ %-52s [%s]\n' "$name" "$fixture"
   else
     failed="$failed
       $name"
-    printf '  ✗ %s  [%s]\n      in    %s\n      got   %s\n      want  %s\n' \
-      "$name" "$fixture" "$input" "$got" "$want"
-    "$BIN" --pipeline "$path" "$input" --app "$app" $off 2>/dev/null | sed 's/^/        /'
+    if [ "$got" != "$want" ]; then
+      printf '  ✗ %s  [%s]\n      in    %s\n      got   %s\n      want  %s\n' \
+        "$name" "$fixture" "$input" "$got" "$want"
+    else
+      printf '  ✗ %s  [%s]\n      in    %s\n      variables not as expected:%s\n' \
+        "$name" "$fixture" "$input" "$missing"
+    fi
+    "$BIN" --pipeline "$path" "$input" --app "$app" $off --vars 2>/dev/null | sed 's/^/        /'
   fi
 done < <(python3 -c '
 import sys, yaml
+
+def printed(value):
+    """A value as `Scope.Value.described` writes it, so the two can be compared
+    as strings. Strings are quoted there and bare in YAML, which is the only
+    difference that matters — and the one a case author would otherwise have to
+    remember by writing '"'"'"en"'"'"' in a YAML file."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, str):
+        return "\"%s\"" % value
+    return str(value)
+
 for c in yaml.safe_load(open(sys.argv[1]))["cases"]:
-    print("|".join(str(c.get(k, "")) for k in
-                   ("name", "pipeline", "app", "no_prompts", "input", "expect")))
+    fields = [str(c.get(k, "")) for k in
+              ("name", "pipeline", "app", "no_prompts", "input", "expect")]
+    fields.append(";".join("%s = %s" % (path, printed(value))
+                           for path, value in (c.get("expect_vars") or {}).items()))
+    print("|".join(fields))
+' "$ROOT/tests/pipeline-cases.yaml")
+
+# --- pipelines that must be refused -----------------------------------------
+#
+# A config error is only useful if it arrives before a transcript does, so these
+# are scored on `--check-config`'s half of `--pipeline`: the fixture is loaded,
+# `validate` runs, and the pipeline must be rejected with a message that names
+# the actual mistake. A wrong-but-present message fails as loudly as a missing
+# one — "it said something" is not the property being tested.
+while IFS='|' read -r name fixture problem; do
+  [ -z "$name" ] && continue
+  total=$((total + 1))
+  path="$ROOT/tests/pipelines/refused/$fixture.yaml"
+
+  if out="$("$BIN" --pipeline "$path" "anything at all" --app "" --quiet 2>&1)"; then
+    failed="$failed
+      $name"
+    printf '  ✗ %s  [%s]\n      was accepted; it should have been refused\n' "$name" "$fixture"
+  elif printf '%s' "$out" | grep -qF "$problem"; then
+    pass=$((pass + 1))
+    printf '  ✓ %-52s [%s]\n' "$name" "$fixture"
+  else
+    failed="$failed
+      $name"
+    printf '  ✗ %s  [%s]\n      want  %s\n      got   %s\n' \
+      "$name" "$fixture" "$problem" "$out"
+  fi
+done < <(python3 -c '
+import sys, yaml
+for c in yaml.safe_load(open(sys.argv[1])).get("refused", []):
+    print("|".join(str(c.get(k, "")) for k in ("name", "pipeline", "expect_problem")))
 ' "$ROOT/tests/pipeline-cases.yaml")
 
 echo

--- a/tests/pipeline-cases.yaml
+++ b/tests/pipeline-cases.yaml
@@ -415,6 +415,43 @@ cases:
       quiet.ok: true
       quiet.changed: true
 
+  # The language a structured command is handed is the detected one, not the
+  # first entry in `languages:`. Scored from what the script reports back,
+  # because what Swift believes it sent is not the question.
+  - name: a structured command is told the detected language
+    pipeline: vars-language
+    input: on en a vingt et un dans le tableau
+    expect: unchanged
+    expect_vars:
+      first.saw: fr
+
+  - name: and the configured order does not decide it
+    pipeline: vars-language
+    input: there are twenty one rows in the table
+    expect: unchanged
+    expect_vars:
+      first.saw: en
+
+  # The shipped script, speaking the protocol, with the stage below it gated on
+  # what it published. A sentence it takes:
+  - name: the shipped transform publishes what it converted
+    pipeline: vars-shipped
+    input: a python function called max retries
+    expect: a python function called max_retries
+    expect_vars:
+      code_identifiers.count: 1
+      code_identifiers.asked_model: false
+      dotted.ran: false
+  # And one it declines, which is what lets the stage below it have a turn.
+  - name: and stands aside for the next stage when it converted nothing
+    pipeline: vars-shipped
+    input: read user dot name
+    expect: read user.name
+    expect_vars:
+      code_identifiers.count: 0
+      dotted.ran: true
+      dotted.changed: true
+
 # Pipelines that must not load at all.
 #
 # Scored separately because the property is different: these never reach a
@@ -441,24 +478,3 @@ refused:
   - name: a transform named after the transcription metadata is refused
     pipeline: reserved-name
     expect_problem: would file its variables where asr already is
-
-  # The shipped script, speaking the protocol, with the stage below it gated on
-  # what it published. A sentence it takes:
-  - name: the shipped transform publishes what it converted
-    pipeline: vars-shipped
-    input: a python function called max retries
-    expect: a python function called max_retries
-    expect_vars:
-      code_identifiers.count: 1
-      code_identifiers.asked_model: false
-      dotted.ran: false
-
-  # And one it declines, which is what lets the stage below it have a turn.
-  - name: and stands aside for the next stage when it converted nothing
-    pipeline: vars-shipped
-    input: read user dot name
-    expect: read user.name
-    expect_vars:
-      code_identifiers.count: 0
-      dotted.ran: true
-      dotted.changed: true

--- a/tests/pipeline-cases.yaml
+++ b/tests/pipeline-cases.yaml
@@ -245,3 +245,220 @@ cases:
     pipeline: command-patient
     input: read user dot name
     expect: READ USER DOT NAME
+
+  # --- variables ------------------------------------------------------------
+  #
+  # `expect_vars` asserts on the scope rather than on the sentence, which is the
+  # only way to score a stage whose whole contribution is a fact. Each entry has
+  # to appear in the `--vars` listing with that exact value; a case that names no
+  # variables is unaffected.
+  #
+  # What is being scored here is the machinery, not the stages — the fixtures use
+  # a script that publishes whatever its flags say, so a failure is about the
+  # carrying and never about whether some transform changed its mind.
+
+  # Every namespace present at the end, including the two that ran before the
+  # ones that published last. This is carry-through in its plainest form: four
+  # stages, and the first one's facts are still readable after the other three.
+  - name: every stage's variables survive the stages after it
+    pipeline: vars
+    input: super base has vingt et un users
+    expect: Supabase has 21 users
+    expect_vars:
+      replacements.count: 1
+      replacements.changed: true
+      numbers.language: fr
+      numbers.changed: true
+      first.count: 2
+      second.count: 7
+      second.label: kept
+
+  # The same run, read from the far side of a pipe. `first` reports what it found
+  # at `replacements.count` and `second` reports what it found at `first.count`,
+  # so a pass here means the scope reached two separate scripts — not merely that
+  # it survived in Swift, which every other case in this section would also show.
+  - name: a script sees what the stages above it published
+    pipeline: vars
+    input: super base has vingt et un users
+    expect: Supabase has 21 users
+    expect_vars:
+      first.saw: 1
+      second.saw: 2
+
+  # And the same pipeline on a sentence the table does not touch, so the numbers
+  # a script reads are the ones this run produced rather than any run's.
+  - name: what a script sees is this transcript's, not the last one's
+    pipeline: vars
+    input: nothing here matches
+    expect: unchanged
+    expect_vars:
+      replacements.count: 0
+      first.saw: 0
+      second.saw: 2
+
+  # Both halves of the rule, in one pipeline. `counter` runs twice: `count` is
+  # republished and the later value wins; `label` is written only by the first
+  # run and has to survive the second one saying nothing about it.
+  - name: a stage run twice overrides its own variables
+    pipeline: vars-override
+    input: read user dot name
+    expect: unchanged
+    expect_vars:
+      counter.count: 2
+      counter.label: first-run
+
+  # The stage in between is untouched by either run of `counter`, and its own
+  # namespace is untouched by them. A stage writes under its own name and
+  # nowhere else — there is no way to spell otherwise, which is the point.
+  - name: one stage's variables do not reach another's namespace
+    pipeline: vars-override
+    input: read user dot name
+    expect: unchanged
+    expect_vars:
+      quiet.count: 9
+      quiet.changed: false
+
+  # A condition reading a variable rather than the text. The table fires, so
+  # `replacements.count` is 1, so the stage gated on it being 0 stands down.
+  - name: a stage stands down because an earlier stage already did the work
+    pipeline: vars-conditions
+    app: Ghostty
+    input: super base is down
+    expect: Supabase is down
+    expect_vars:
+      first.saw: 1
+      second.ran: false
+
+  # The same pipeline, the other branch. Nothing for the table to do, so the
+  # gated stage runs.
+  - name: and runs when the earlier stage found nothing to do
+    pipeline: vars-conditions
+    app: Ghostty
+    input: nothing here matches
+    expect: unchanged
+    expect_vars:
+      first.saw: 0
+      second.ran: true
+      second.count: 42
+
+  # `app` and `language` are in the scope before any stage runs, so a condition
+  # can read them by name. Ghostty, so the stage that excludes terminals stands
+  # down — written as a real negation rather than as the anchored negative
+  # lookahead the `app:` key would have needed.
+  - name: a condition reads the seeded app and language
+    pipeline: vars-conditions
+    app: Ghostty
+    input: nothing here matches
+    expect: unchanged
+    expect_vars:
+      third.ran: false
+
+  - name: and the same condition lets it run in an editor
+    pipeline: vars-conditions
+    app: Zed
+    input: nothing here matches
+    expect: unchanged
+    expect_vars:
+      third.ran: true
+      third.count: 7
+
+  # The three ways a structured stage does not work. All three keep the
+  # transcript; all three stay distinguishable afterwards.
+  - name: a stage that printed prose is marked as having failed
+    pipeline: vars-failure
+    input: read user dot name
+    expect: unchanged
+    expect_vars:
+      broken.ok: false
+      broken.changed: false
+
+  - name: a stage that exited non-zero is marked the same way
+    pipeline: vars-failure
+    input: read user dot name
+    expect: unchanged
+    expect_vars:
+      second.ok: false
+
+  # Returning no `text` is not a failure. It is a stage saying it looked and
+  # left the sentence alone, which is why `text` is optional in the reply — and
+  # it has to be told apart from the two above it.
+  - name: a stage that returns variables and no text is not a failure
+    pipeline: vars-failure
+    input: read user dot name
+    expect: unchanged
+    expect_vars:
+      quiet.ok: true
+      quiet.changed: false
+      quiet.count: 5
+
+  # A skipped stage gets `ran: false` and nothing else. No `ok`, no `changed` —
+  # inventing them would let `first.ok` read true for a stage that never
+  # happened.
+  - name: a skipped stage reports that it did not run
+    pipeline: vars-skipped
+    app: Zed
+    input: read user dot name
+    expect: READ USER DOT NAME
+    expect_vars:
+      first.ran: false
+
+  # A command with no `returns:` speaks the old contract and knows nothing about
+  # any of this, and still gets the derived variables — so a script written
+  # before variables existed is still something a later stage can gate on.
+  - name: a plain stdin-to-stdout command still gets the derived variables
+    pipeline: vars-skipped
+    app: Zed
+    input: read user dot name
+    expect: READ USER DOT NAME
+    expect_vars:
+      quiet.ran: true
+      quiet.ok: true
+      quiet.changed: true
+
+# Pipelines that must not load at all.
+#
+# Scored separately because the property is different: these never reach a
+# transcript, and what is being checked is that `--check-config` says the useful
+# thing rather than that some stage did something. `expect_problem` is a
+# substring — the whole message is prose and would tie a case to its wording.
+refused:
+  - name: a condition reading a stage that runs later is refused
+    pipeline: reads-later-stage
+    expect_problem: runs *after* this stage
+
+  - name: a condition naming a stage nothing declares is refused
+    pipeline: reads-unknown-stage
+    expect_problem: nothing in this pipeline is called "cod_identifiers"
+
+  - name: the old bare-word condition is refused, and told what to write
+    pipeline: bare-word
+    expect_problem: 'write it as a pattern: /genre/'
+
+  - name: an expression that does not parse is refused at load
+    pipeline: bad-syntax
+    expect_problem: is not part of this language
+
+  - name: a transform named after the transcription metadata is refused
+    pipeline: reserved-name
+    expect_problem: would file its variables where asr already is
+
+  # The shipped script, speaking the protocol, with the stage below it gated on
+  # what it published. A sentence it takes:
+  - name: the shipped transform publishes what it converted
+    pipeline: vars-shipped
+    input: a python function called max retries
+    expect: a python function called max_retries
+    expect_vars:
+      code_identifiers.count: 1
+      code_identifiers.asked_model: false
+      dotted.ran: false
+
+  # And one it declines, which is what lets the stage below it have a turn.
+  - name: and stands aside for the next stage when it converted nothing
+    pipeline: vars-shipped
+    input: read user dot name
+    expect: read user.name
+    expect_vars:
+      code_identifiers.count: 0
+      dotted.ran: true
+      dotted.changed: true

--- a/tests/pipelines/refused/bad-syntax.yaml
+++ b/tests/pipelines/refused/bad-syntax.yaml
@@ -1,0 +1,7 @@
+# An expression that does not parse. Caught at load rather than on the first
+# dictation — `=~` is the operator people arrive expecting, so it is worth
+# failing on the line that has it rather than three stages into a transcript.
+languages: [en]
+pipeline:
+  - stage: numbers
+    when: text =~ "hello"

--- a/tests/pipelines/refused/bare-word.yaml
+++ b/tests/pipelines/refused/bare-word.yaml
@@ -1,0 +1,9 @@
+# The old form. `when: genre` used to mean "the word genre appears, on word
+# boundaries" and now parses as a variable nobody defined. Reading it as false
+# would be the silent failure this whole design removes, so it is refused — and
+# the message says what to write instead, because a breaking change that only
+# says "no" is a breaking change nobody can act on.
+languages: [en, fr]
+pipeline:
+  - stage: numbers
+    when: genre

--- a/tests/pipelines/refused/reads-later-stage.yaml
+++ b/tests/pipelines/refused/reads-later-stage.yaml
@@ -1,0 +1,18 @@
+# A condition reading a stage that runs *after* it.
+#
+# The failure this refuses is the one no runtime error can catch in time: at run
+# time "the stage below has not published anything yet" and "the stage published
+# nothing" are the same absence, and by then the transcript is already halfway
+# through. Only the pipeline as a whole knows the order, so only `validate` can
+# see the difference — the same argument that already refuses `fuzzy` before
+# `replacements`.
+languages: [en]
+transforms:
+  - name: later
+    description: publishes a count
+    command: counter.py --count 1
+    returns: json
+pipeline:
+  - stage: numbers
+    when: later.count == 0
+  - transform: later

--- a/tests/pipelines/refused/reads-unknown-stage.yaml
+++ b/tests/pipelines/refused/reads-unknown-stage.yaml
@@ -1,0 +1,7 @@
+# A condition naming a stage that is not in this pipeline at all. Distinct from
+# the ordering case above, and told apart in the message — one is "move it" and
+# the other is "you did not spell it right".
+languages: [en]
+pipeline:
+  - stage: numbers
+    when: cod_identifiers.count == 0

--- a/tests/pipelines/refused/reserved-name.yaml
+++ b/tests/pipelines/refused/reserved-name.yaml
@@ -1,0 +1,11 @@
+# A transform named after something already in the scope. `asr.confidence` comes
+# from transcription; a transform called `asr` would file its own variables in
+# the same place and leave no way to tell which writer a condition read.
+languages: [en]
+transforms:
+  - name: asr
+    description: collides with the transcription metadata
+    command: counter.py --count 1
+    returns: json
+pipeline:
+  - transform: asr

--- a/tests/pipelines/transforms/broken/counter.py
+++ b/tests/pipelines/transforms/broken/counter.py
@@ -1,0 +1,1 @@
+../counter/counter.py

--- a/tests/pipelines/transforms/counter/counter.py
+++ b/tests/pipelines/transforms/counter/counter.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""A `returns: json` transform that does nothing useful, on purpose.
+
+The variable machinery has to be scored on its own, separately from any stage
+whose job is interesting — otherwise a case that fails leaves you asking whether
+the carry-through broke or whether `code_identifiers` changed its mind about a
+word. So this contributes variables you choose from the fixture, and rewrites
+the text only when asked.
+
+    counter.py --count 3            -> vars {"count": 3}
+    counter.py --count 3 --upper    -> and the text upper-cased
+    counter.py --no-text            -> variables only; the sentence is untouched
+    counter.py --echo numbers.count -> vars {"saw": <that, from the context>}
+    counter.py --garbage            -> prints something that is not JSON
+    counter.py --fail               -> exits non-zero
+
+`--echo` is the one that matters most: it is the only way to show that what the
+pipeline carries actually reaches a script, rather than merely surviving inside
+Swift where a test can see it and a transform cannot.
+
+`--bump` and `--label-once` exist for one case: the same transform twice in one
+pipeline, which is the only way a namespace gets written over. A transform has
+one command, so two runs of it publish identical variables unless the script
+looks at what it published last time — and then the two runs differ:
+
+    counter.py --bump counter.count --label-once first-run
+
+    run 1   sees nothing          -> {"count": 1, "label": "first-run"}
+    run 2   sees counter.count=1  -> {"count": 2}
+
+which is both halves of the rule in one fixture. `count` is republished and must
+end at 2; `label` is *not* republished by the second run and must survive it.
+"""
+import argparse
+import json
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--count", type=int)
+    parser.add_argument("--label")
+    parser.add_argument("--echo")
+    parser.add_argument("--bump")
+    parser.add_argument("--label-once")
+    parser.add_argument("--upper", action="store_true")
+    parser.add_argument("--no-text", action="store_true")
+    parser.add_argument("--garbage", action="store_true")
+    parser.add_argument("--fail", action="store_true")
+    args = parser.parse_args()
+
+    if args.fail:
+        sys.stderr.write("asked to fail\n")
+        raise SystemExit(3)
+
+    if args.garbage:
+        # Declared `returns: json` and printed prose. The pipeline has to keep
+        # the transcript and record that this stage did not work — the one
+        # failure `--check-config` cannot catch, because it is in the script.
+        sys.stdout.write("this is not JSON")
+        return
+
+    envelope = json.loads(sys.stdin.read())
+    text = envelope["text"]
+    ctx = envelope.get("ctx", {})
+
+    def look(path):
+        namespace, _, name = path.partition(".")
+        return ctx.get("vars", {}).get(namespace, {}).get(name)
+
+    variables = {}
+    if args.count is not None:
+        variables["count"] = args.count
+    if args.label is not None:
+        variables["label"] = args.label
+    if args.echo is not None:
+        # A missing value is reported as -1 rather than omitted: "the script
+        # could not see it" and "the script did not look" are different
+        # failures, and a variable that is simply absent cannot tell them apart.
+        found = look(args.echo)
+        variables["saw"] = found if found is not None else -1
+    if args.bump is not None:
+        previous = look(args.bump)
+        variables["count"] = (previous if isinstance(previous, int) else 0) + 1
+        # Only on the run that found nothing, which is the first one. The second
+        # run must leave this key alone entirely — not republish it, not blank
+        # it — so that the pipeline is the only thing that could have carried it.
+        if args.label_once is not None and previous is None:
+            variables["label"] = args.label_once
+
+    reply = {"vars": variables}
+    if not args.no_text:
+        reply["text"] = text.upper() if args.upper else text
+
+    sys.stdout.write(json.dumps(reply))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/pipelines/transforms/counter/counter.py
+++ b/tests/pipelines/transforms/counter/counter.py
@@ -65,7 +65,13 @@ def main():
     ctx = envelope.get("ctx", {})
 
     def look(path):
-        namespace, _, name = path.partition(".")
+        # A dotted path is a stage's variable; a bare one is a seed sitting at
+        # the top of the context — `language`, `app`, `bundle_id`. Both are
+        # reachable because both are things a script legitimately branches on,
+        # and `language` in particular was once handed over wrong.
+        namespace, dot, name = path.partition(".")
+        if not dot:
+            return ctx.get(path)
         return ctx.get("vars", {}).get(namespace, {}).get(name)
 
     variables = {}

--- a/tests/pipelines/transforms/first/counter.py
+++ b/tests/pipelines/transforms/first/counter.py
@@ -1,0 +1,1 @@
+../counter/counter.py

--- a/tests/pipelines/transforms/quiet/counter.py
+++ b/tests/pipelines/transforms/quiet/counter.py
@@ -1,0 +1,1 @@
+../counter/counter.py

--- a/tests/pipelines/transforms/second/counter.py
+++ b/tests/pipelines/transforms/second/counter.py
@@ -1,0 +1,1 @@
+../counter/counter.py

--- a/tests/pipelines/transforms/third/counter.py
+++ b/tests/pipelines/transforms/third/counter.py
@@ -1,0 +1,1 @@
+../counter/counter.py

--- a/tests/pipelines/vars-conditions.yaml
+++ b/tests/pipelines/vars-conditions.yaml
@@ -1,0 +1,42 @@
+# A stage gated on what an earlier stage published, which is the whole reason
+# variables exist.
+#
+# `first` reports how many replacement rules fired. `second` runs only when that
+# is zero — the shape the real config wants for `dotted`, which should stand
+# down when `code_identifiers` has already taken the sentence. Scored on two
+# inputs: one the table rewrites and one it does not, so the same pipeline takes
+# both branches.
+#
+# `third` is the seed half: `app` and `language` are put in the scope before any
+# stage runs, so a condition can read them by name instead of only through the
+# `app:` key. Note that it is a real negation — `!app.contains(…)` — where the
+# `app:` key would have needed an anchored negative lookahead.
+languages: [en, fr]
+replacements:
+  Supabase: [super base]
+
+transforms:
+  - name: first
+    description: reports what the table did
+    command: counter.py --echo replacements.count
+    returns: json
+
+  - name: second
+    description: runs only when the table found nothing
+    command: counter.py --count 42
+    returns: json
+
+  - name: third
+    description: runs anywhere but a terminal
+    command: counter.py --count 7
+    returns: json
+
+pipeline:
+  - replacements
+  - transform: first
+  - stage: transform
+    transform: second
+    when: replacements.count == 0
+  - stage: transform
+    transform: third
+    when: '!app.contains("ghostty") && language == "en"'

--- a/tests/pipelines/vars-failure.yaml
+++ b/tests/pipelines/vars-failure.yaml
@@ -1,0 +1,36 @@
+# The ways a structured stage does not work, and what each leaves behind.
+#
+# All three must let the transcript through untouched — that is the rule this
+# whole file exists under — and all three must be *distinguishable afterwards*,
+# because "failed" and "ran and found nothing" want opposite responses from the
+# stage below and used to look identical.
+#
+#   broken   declared `returns: json` and printed prose      -> ok false
+#   crashed  exited non-zero                                  -> ok false
+#   quiet    returned variables and no `text` key             -> ok true, changed false
+#
+# The third is the one worth reading twice. Returning no `text` is not an error:
+# it is a stage saying it looked and left the sentence alone, which is different
+# from echoing the input back and is the reason `text` is optional in the reply.
+languages: [en]
+
+transforms:
+  - name: broken
+    description: declares json and prints prose
+    command: counter.py --garbage
+    returns: json
+
+  - name: second
+    description: exits non-zero
+    command: counter.py --fail
+    returns: json
+
+  - name: quiet
+    description: publishes a variable and touches no text
+    command: counter.py --count 5 --no-text
+    returns: json
+
+pipeline:
+  - transform: broken
+  - transform: second
+  - transform: quiet

--- a/tests/pipelines/vars-language.yaml
+++ b/tests/pipelines/vars-language.yaml
@@ -1,0 +1,20 @@
+# What language a structured command is told it is dealing with.
+#
+# `languages:` lists en first, and a French transcript detects as fr. The
+# context used to carry the *first configured* language rather than the
+# detected one — and to encode it over the correct value the scope already
+# held, under the same key, so the wrong one won. A script branching on
+# `ctx["language"]` therefore applied English rules to a French sentence.
+#
+# `first` reports back what it was given, so the case is scored from the far
+# side of the pipe rather than from what Swift believes it sent.
+languages: [en, fr]
+
+transforms:
+  - name: first
+    description: reports the language it was handed
+    command: counter.py --echo language
+    returns: json
+
+pipeline:
+  - transform: first

--- a/tests/pipelines/vars-override.yaml
+++ b/tests/pipelines/vars-override.yaml
@@ -1,0 +1,34 @@
+# The same transform twice, which is the only way a namespace gets written over.
+#
+# Allowed, deliberately. Refusing it would rule out running `replacements`
+# before and after a rewrite, which is a thing people do — so the rule is the one
+# a list executed top to bottom invites: the later run wins.
+#
+# `counter` bumps whatever it finds under its own name, and writes `label` only
+# on the run that found nothing. So the two runs publish different things, which
+# is what makes both halves of "carry through unless overridden" scoreable in one
+# pipeline:
+#
+#   counter.count   1 then 2   — republished, so the later value must win
+#   counter.label   set once   — never mentioned again, so it must survive
+#
+# `quiet` sits between them so that "the later run wins" is a claim about order
+# rather than about adjacency, and so that a third namespace is present to be
+# left alone by both.
+languages: [en]
+
+transforms:
+  - name: counter
+    description: bumps its own count, and labels itself the first time only
+    command: counter.py --bump counter.count --label-once first-run
+    returns: json
+
+  - name: quiet
+    description: publishes a count and touches no text
+    command: counter.py --count 9 --no-text
+    returns: json
+
+pipeline:
+  - transform: counter
+  - transform: quiet
+  - transform: counter

--- a/tests/pipelines/vars-shipped.yaml
+++ b/tests/pipelines/vars-shipped.yaml
@@ -1,0 +1,28 @@
+# The shipped `code_identifiers`, through the structured protocol, reached by
+# symlink so this scores the file people actually edit.
+#
+# Everything else in this section uses a script that publishes whatever its
+# flags say, which is right for testing the machinery and proves nothing about
+# whether a real transform can speak the protocol. This one does the opposite:
+# the transform is the one in examples/, the count is derived from the rewrite
+# it actually performed, and `dotted` below it is gated on that count — which is
+# the arrangement the default config wants, since the two overlap in every
+# terminal and only one of them should take a given sentence.
+languages: [en, fr]
+
+transforms:
+  - name: code_identifiers
+    description: spoken names as identifiers
+    command: code_identifiers.py
+    returns: json
+
+  - name: dotted
+    description: spoken dots as dots, when nothing else took the sentence
+    replace:
+      $1.$2: ["/(\\w+) dot (\\w+)/"]
+
+pipeline:
+  - transform: code_identifiers
+  - stage: transform
+    transform: dotted
+    when: code_identifiers.count == 0

--- a/tests/pipelines/vars-skipped.yaml
+++ b/tests/pipelines/vars-skipped.yaml
@@ -1,0 +1,30 @@
+# What a skipped stage leaves in the scope, and what a bare-text command does.
+#
+# `first` is gated on an app it will not match here, so it never runs. It gets
+# `ran: false` and nothing else — no `ok`, no `changed`. Inventing those would
+# let `first.ok` read true for a stage that never happened, which is exactly the
+# silent wrong answer the variables were added to remove. The way to ask is
+# `first.ran && first.ok`, and `&&` short-circuits so the second half is never
+# evaluated on a stage that has no `ok` to read.
+#
+# `quiet` is the back-compatibility half: no `returns:` at all, so it speaks the
+# old contract — text on stdin, text on stdout, no JSON anywhere. It still gets
+# the derived variables, so a script nobody has touched since before any of this
+# existed is still something a later stage can gate on.
+languages: [en]
+
+transforms:
+  - name: first
+    description: never runs here
+    command: counter.py --count 3
+    returns: json
+
+  - name: quiet
+    description: a plain stdin-to-stdout command, as they have always been
+    command: tr '[:lower:]' '[:upper:]'
+
+pipeline:
+  - stage: transform
+    transform: first
+    app: /ghostty/
+  - transform: quiet

--- a/tests/pipelines/vars.yaml
+++ b/tests/pipelines/vars.yaml
@@ -1,0 +1,33 @@
+# Variables carried from one stage to the next.
+#
+# Four stages, none of them interesting. `replacements` and `numbers` publish
+# what the pipeline derives plus one fact of their own; `first` and `second` are
+# the same script under two names, so they get two namespaces. What is scored is
+# that every namespace is still there at the end — a stage contributing nothing
+# erases nothing, and a stage contributing something erases nothing either.
+#
+# `first --echo replacements.count` is the half that cannot be faked in Swift:
+# it reports back what the *script* found in its context, so a case that passes
+# proves the scope reached the far side of a pipe rather than merely surviving
+# in memory. `second --echo first.count` then proves the same for a fact
+# published by another script rather than by a built-in stage.
+languages: [en, fr]
+replacements:
+  Supabase: [super base]
+
+transforms:
+  - name: first
+    description: publishes a count, and reports what replacements published
+    command: counter.py --count 2 --echo replacements.count
+    returns: json
+
+  - name: second
+    description: publishes its own count, and reports what first published
+    command: counter.py --count 7 --label kept --echo first.count
+    returns: json
+
+pipeline:
+  - replacements
+  - numbers
+  - transform: first
+  - transform: second


### PR DESCRIPTION
Every stage was `String -> String`, so the only thing one stage could tell the next was the sentence. A condition could ask "does the text still say *function*" and nothing else — which means a stage that had already done the work had no way to say so, and the stage below it re-derived the same judgement from the same words, or ran when it should not have.

`dotted` and `code_identifiers` are the pair that shows it: both fire in every terminal, both are about the same sentence, and neither can see the other. There was no way to write "only if nothing else took this".

Now there is:

```yaml
- transform: code_identifiers
- stage: transform
  transform: dotted
  when: code_identifiers.count == 0
```

## A stage returns what it contributed, not what it was given

A stage receives the whole scope and returns only its own part. That asymmetry is the design, not an economy: a stage has no way to spell "and everything else, unchanged", so it has no way to get that wrong. The pipeline is the only thing holding the accumulated scope and the only thing that could drop a namespace, and it never does.

Three rules follow, and each one closes a failure the obvious version invites:

**A stage writes under its own name.** The namespace comes from the pipeline, never from the stage. One stage reaching into another's facts is not guarded against — it is unspellable.

**Everything else carries through.** A stage contributing nothing erases nothing. Carrying is the loop's job rather than something each script has to remember, because a `sed` one-liner could never have echoed a namespace back, and a contract only some bodies can honour is not a contract.

**A name is a fact about the stage, not a claim about the text.** `code_identifiers.count` — how many names it converted — stays true after a later stage rewrites the sentence. A variable called `has_identifier` would quietly become a lie. Filing facts under the stage that produced them makes the first reading the natural one.

`ran`, `ok`, `changed` and `ms` are derived for every stage, whatever it is and whether or not it knows any of this exists. Derived, never claimed — a stage cannot forget to report `changed` and cannot report it about the wrong string. A skipped stage gets `ran` alone; inventing `ok` would let `grammar.ok` read true for a stage that never happened, so the way to ask is `grammar.ran && grammar.ok` and `&&` short-circuits for exactly that.

The built-ins publish real things too. `numbers.language` is the one worth naming: which grammar actually read the numbers, which is *not* the same answer as the pipeline's language, and which this app has computed and thrown away on the same line since numbers existed.

## Conditions that are not patterns are expressions

`/…/` still means a regular expression. Anything else is now an expression over the scope — a subset of [CEL](https://cel.dev), which is chosen for the specification rather than for any library. The evaluator is three hundred lines and any small grammar would have run; what a standard buys is that if this is ever rewritten in Python or Go, the configs people have already written keep meaning what they meant, because `cel-python` and `cel-go` implement the same operators.

```
paths          text, numbers.count, asr.confidence
literals       "a string", 12, 1.5, true, false
operators      &&  ||  !  ==  !=  <  <=  >  >=
methods        matches(re)  contains(s)  startsWith(s)  endsWith(s)
```

`!` is a real negation, which retires a footgun. Exclusion used to require an anchored negative lookahead, and `validate` had to refuse the unanchored form because `/(?!.*term)/` succeeds one character into "Terminal" and runs the stage everywhere it was written to stay out of. `!app.matches("term")` has no anchor to forget.

**An unknown name is an error, not false.** Silently false is how a condition stops working with nothing said, which is the failure this whole change exists to remove. Two of the three cases are caught at load, by `--check-config`, before a transcript reaches them:

- a name nothing defines — including `when: genre`, the old bare-word form
- a condition reading a stage declared **below** it, which no runtime error can catch in time: by then the transcript is already halfway through, and "has not run yet" and "reported nothing" are the same absence. Only the pipeline as a whole knows the order, which is the same argument that already refuses `fuzzy` before `replacements`.

### One thing is taken away

A bare word used to mean "this word appears, on word boundaries". It now parses as a variable. It was documented and used nowhere — not in the default config, not in an example, not in a fixture — and keeping it would have meant two condition languages in one key forever. `--check-config` refuses it by name and prints what to write instead:

```
numbers: when "genre" reads "genre", which is not a variable.
If you meant the word "genre" in the text, write it as a pattern: /genre/
```

## `returns: json`, declared and not sniffed

A `command:` gets the same channel by declaring it. In: `{text, ctx}`. Out: `{text?, vars?}` — both keys optional, because a stage that returns no `text` is saying it looked and left the sentence alone, which is different from echoing the input back and is not a failure.

Declared rather than detected, and the obvious alternative is why. "If stdout parses as an object with a `text` key, it is structured" breaks on exactly the transcript most likely to arrive in a folder that has a `code_identifiers` stage in it: one that *is* a JSON object. It would also make a script's protocol depend on its output, so a stage would change contract on one sentence in a thousand and nowhere else.

Off by default, and off is the whole of the old contract — stdout is the transcript, `sed` is still a transform, and nothing already written has to change. Scripts that never opt in still get the derived variables, so a script from before any of this is still something a later stage can gate on.

The app sets `PARROTFLOW_PROTOCOL=json` when — and only when — the transform declares it, so `returns:` stays the single declaration and a flag in the `command:` line cannot disagree with the key above it. It also keeps every script runnable by hand, which matters because every harness in `scripts/` pipes plain text.

## The default config is deliberately not switched over

`code_identifiers` still speaks the plain protocol on a new install.

A transform folder is written on first launch and **never overwritten**. Shipping `returns: json` in the default config would leave every existing install running the old `code_identifiers.py`, which knows nothing about the envelope, printing bare text into an app that would no longer read it — and that stage would silently stop doing anything. `config.example.yaml` shows the gating as a comment, and `authoring.md` names the hazard for anyone upgrading their own transform: edit the script first, then the config.

## Testing

`scripts/check-pipeline.sh` goes from 27 cases to **48**, all passing.

Twenty-one are on the variable machinery, scored against a script that publishes whatever its flags say rather than against a transform whose job is interesting — a failure is then about the carrying and never about whether some transform changed its mind about a word.

The override case is the one worth reading. A transform has one command, so two runs of it publish identical variables unless the script looks at what it published last time. So `counter` bumps its own count and labels itself only on the run that found nothing, and both halves of the rule fall out of one pipeline: `count` is republished and must end at 2, `label` is never mentioned again and must survive.

`--echo` is the half that cannot be faked in Swift — it reports back what the *script* found in its context, so a pass means the scope crossed a pipe rather than merely surviving in memory. `vars-shipped.yaml` does the same through the real `code_identifiers`, with `dotted` gated on what it published.

Five fixtures must not load at all, including the ordering case above.

**No regression on what this touched.** `code_identifiers` scores 38/43 change and 30/32 keep — identical before and after, measured by stashing the change and re-running. `check-numbers` 97/97, `check-dotted` 54/54, `check-replacements` 23/23, `check-eval` 25/25, `check-split`, `check-wake`, `check-transform-folders`, `check-seeded-transform`, `check-default-config` all unchanged.

`check-span` and `check-inplace` sit at 0/8 on this branch — and at 0/8 on a clean tree at `addf91b`, because they need the in-place substitution work that is not landed yet. Checked by stashing everything and re-running rather than assumed. `check-grammar` is 16/17 here and 16/17 at baseline.

## Also

`Replacements.exact` and `Numbers.read` are new overloads that report a count and the winning grammar; `applyExact` and `apply` are unchanged and still what every other caller uses. `Trace.recordStage` gained a `vars` column, so `trace.jsonl` answers "which transcripts did this actually fire on" with a `jq` query instead of a regex over English. The ASR numbers reach the pipeline from `Transcriber` rather than being read back off `Trace`, because the collector is only bound when someone asked for a trace and a condition must not work on the runs you are watching and stop on the runs you are not.

`--pipeline … --vars` prints the whole scope, and a skipped stage now names the values that decided it:

```
⊘ transform — skipped, when code_identifiers.count == 0 did not match (code_identifiers.count = 1)
```

## Not in this PR

The six transforms that funnel through `examples/transforms/_openai/openai_call.py` do not publish variables yet. That file is part of unlanded work in the working tree, and the `PARROTFLOW_PROTOCOL` branch it needs belongs with that change rather than with this one. Everything here stands without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JT3WG3JPW2i7bLE9fynG5u
