### PR TITLE
fix: silence 19 of 20 Swift 6 concurrency warnings

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -43,7 +43,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var announcedUpdate: String?
 
     private lazy var transcriber = Transcriber { [weak self] status in
-        DispatchQueue.main.async { self?.handleTranscriberStatus(status) }
+        DispatchQueue.main.async { [weak self] in self?.handleTranscriberStatus(status) }
     }
     private var transcriptionLabel: String?
     /// Bumped by every transcription, so a stage label arriving late from one
@@ -670,22 +670,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     app: app.map { Trace.App(name: $0.name, bundleID: $0.bundleID) },
                     beside: recording.url.deletingLastPathComponent()
                 ) {
+                    // One immutable copy, taken before the closure rather
+                    // than read from inside it. `self` here is the enclosing
+                    // Task's weak capture, which is a *var* — and reading a var
+                    // from concurrently-executing code is an error under the
+                    // Swift 6 language mode. This still holds it weakly, so a
+                    // delegate that goes away still stops the progress updates.
+                    let delegate = self
                     let text = try await self?.transcriber.transcribe(
                         url: recording.url, config: config, app: app,
                         progress: { label in
-                            Task { @MainActor [weak self] in
+                            Task { @MainActor in
                                 // Still this dictation, and still one that has
                                 // something on screen to replace.
-                                guard let self, self.transcriptionRun == run,
-                                      self.transcriptionLabel != nil else { return }
-                                self.beginProgress(label)
+                                guard let delegate, delegate.transcriptionRun == run,
+                                      delegate.transcriptionLabel != nil else { return }
+                                delegate.beginProgress(label)
                             }
                         }
                     ) ?? ""
                     Trace.current?.recordFinal(text)
                     return text
                 }
-                await MainActor.run {
+                await MainActor.run { [weak self] in
                     guard let self else { return }
                     // Only if the screen is still ours. Push-to-talk does not
                     // wait, so a second press while this one was in flight has
@@ -700,7 +707,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     )
                 }
             } catch {
-                await MainActor.run {
+                await MainActor.run { [weak self] in
                     guard let self else { return }
                     if self.transcriptionRun == run { self.endProgress() }
                     Log.write("transcription failed: \(error.localizedDescription)")
@@ -790,7 +797,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         keepWarmInFlight = true
         Task.detached(priority: .background) { [weak self] in
             await LocalLLM.keepWarm(system: system, config: llm)
-            await MainActor.run { self?.keepWarmInFlight = false }
+            await MainActor.run { [weak self] in self?.keepWarmInFlight = false }
         }
     }
 
@@ -839,7 +846,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     freeForm: freeForm,
                     config: llmConfig
                 )
-                await MainActor.run {
+                await MainActor.run { [weak self] in
                     guard let self else { return }
                     switch decision {
                     case .matched(let capability):
@@ -870,7 +877,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     }
                 }
             } catch {
-                await MainActor.run {
+                await MainActor.run { [weak self] in
                     Log.write("routing failed: \(error.localizedDescription)")
                     self?.endProgress()
                     self?.flash(error.localizedDescription, tone: .failure)
@@ -974,9 +981,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     command: command, lastTranscript: context,
                     language: language, config: llmConfig
                 )
-                await MainActor.run { self?.apply(result, command: command) }
+                await MainActor.run { [weak self] in self?.apply(result, command: command) }
             } catch {
-                await MainActor.run {
+                await MainActor.run { [weak self] in
                     Log.write("command interpretation failed: \(error.localizedDescription)")
                     self?.endProgress()
                     self?.flash(error.localizedDescription, tone: .failure)
@@ -1029,14 +1036,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 guard let result = try await self?.perform(
                     transform, instruction: instruction, on: target
                 ) else { return }
-                await MainActor.run {
+                await MainActor.run { [weak self] in
                     self?.finishTransform(
                         transform: transform, selection: selection,
                         before: target, after: result
                     )
                 }
             } catch {
-                await MainActor.run {
+                await MainActor.run { [weak self] in
                     Log.write("transform failed: \(error.localizedDescription)")
                     self?.endProgress()
                     self?.flash(error.localizedDescription, tone: .failure)
@@ -1616,7 +1623,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let catalogue = Catalogue(transforms: config.transforms)
 
         /// Write what was said, and say why it is not what was asked for.
-        func giveUp(_ why: String, tone: NoticeTone = .caution) {
+        @Sendable func giveUp(_ why: String, tone: NoticeTone = .caution) {
             endProgress()
             Log.write("inline: \(why); wrote the text as dictated")
             insertDictation(text, to: destination)
@@ -1624,14 +1631,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             setLabel(why, clearAfter: 7)
         }
 
-        func run(_ transform: Config.Transform) {
+        @Sendable func run(_ transform: Config.Transform) {
             beginProgress(transform.progressLabel)
             Task { [weak self] in
                 do {
                     guard let result = try await self?.perform(
                         transform, instruction: instruction, on: text
                     ) else { return }
-                    await MainActor.run {
+                    await MainActor.run { [weak self] in
                         guard let self else { return }
                         self.endProgress()
                         let cleaned = result.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1682,7 +1689,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     instruction: instruction, catalogue: catalogue,
                     freeForm: freeForm, config: llm
                 )
-                await MainActor.run {
+                await MainActor.run { [weak self] in
                     guard let self else { return }
                     switch decision {
                     case .matched(.transform(let transform)):
@@ -1758,7 +1765,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         command: instruction, lastTranscript: text,
                         language: language, config: llm
                     )
-                    await MainActor.run {
+                    await MainActor.run { [weak self] in
                         guard let self else { return }
                         self.endProgress()
                         switch result {
@@ -1789,7 +1796,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         }
                     }
                 } catch {
-                    await MainActor.run {
+                    await MainActor.run { [weak self] in
                         guard let self else { return }
                         self.endProgress()
                         self.giveUpInline(


### PR DESCRIPTION
The build printed 20 warnings. All are in `AppDelegate.swift`. All are the same family: reading `self` from concurrently-executing code.

They are warnings today and errors under the Swift 6 language mode. So this is a deadline, not a defect. Nothing here is broken at runtime.

This PR removes 19 of them. No behaviour changes.

## The cause

Almost all of them have one cause.

`Task { [weak self] in` captures `self` as a mutable optional. A closure nested inside then reads that variable. Reading a var from another concurrent context is what the compiler objects to.

The fix is a capture list on the nested closure. That makes a fresh capture instead of reading the outer one.

```swift
// before
await MainActor.run {
    guard let self else { return }
    ...
}

// after
await MainActor.run { [weak self] in
    guard let self else { return }
    ...
}
```

Thirteen closures got this. It is the shape line 294 already used, so it is not a new pattern in this file. Most of them already began with `guard let self else { return }`, so their behaviour is unchanged.

## Three that needed a different shape

**The progress closure in `startTranscription`.** It is `@Sendable`, and the `Task` inside it read the outer weak var through its own capture list. It now takes one immutable copy of the weak reference before the closure, so the nested `Task` has something stable to capture. It is still weak — a delegate that goes away still stops the updates.

**`giveUp` and `run` in `runInline`.** Local functions called from inside a `Task`. Now `@Sendable`.

**The transcriber status callback.** Hops to main with its own capture list.

## The one left

Line 46 still warns. It wants `AppDelegate` to be Sendable, which for an AppKit delegate means marking the class `@MainActor`.

I tried that. It removes this warning and produces twelve new ones plus one error, because every Timer callback in the file then needs annotating too. That is its own piece of work, so I stopped.

## Testing

`swift build -c release` is clean apart from that one warning, and one from the FluidAudio package that is not ours.

Check scripts pass: pipeline 27/27, replacements 23/23, numbers 97/97, dotted 54/54, eval 25/25, split 14/14, wake 24/24.

**But none of them reach `AppDelegate`.** They are all CLI paths. This file is the recording, transcription and insertion flow, and nothing automated covers it. It wants a few real dictations before it is trusted — press the hotkey, check the progress label still updates, check a transform that calls the model still finishes.

## Not related to #48

That PR does not touch this file. This one branches off `main` and can merge on its own, in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JT3WG3JPW2i7bLE9fynG5u
