### PR TITLE
feat: a prompt can see what is on your screen

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -431,6 +431,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Log.write(String(format: "selection snapshot was slow: %.2fs", elapsed))
         }
 
+        // The screen as it was when you started talking — which is the screen
+        // the sentence is about. Taken here rather than in the pipeline because
+        // this is the last moment the pane is *known*: by the time the stage
+        // runs there has been a transcription and possibly a model call, and
+        // focus may be in another pane entirely.
+        //
+        // After the snapshot and off the main thread, because this reads an
+        // accessibility value that has been observed at 237k characters and the
+        // one thing this handler may not do is delay recording. Gated on the
+        // stage being configured, so a config that never asked for context pays
+        // nothing for the question.
+        if Context.isConfigured(in: config) {
+            let app = front?.app
+            let element = focusAtPress?.element
+            DispatchQueue.global(qos: .userInitiated).async {
+                Context.capturePress(app: app, element: element)
+            }
+        }
+
         switch config.hotkey.mode {
         case .toggle:
             toggleRecording()

--- a/Sources/ParrotFlow/ComposeCommand.swift
+++ b/Sources/ParrotFlow/ComposeCommand.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// `--compose "<template>" [name=value ...]` — prints a prompt with its
+/// placeholders filled, and applies nothing.
+///
+/// The whole point is that no model is involved. What a prompt *says* after the
+/// scope is folded into it is decided before any model sees it, and it is the
+/// half that can be scored exactly — which is what scripts/check-compose.sh
+/// does. `--prompt` exercises the other half and needs Ollama running.
+///
+/// Values are typed by how they read, because that is what a script writing a
+/// case file can express: `3` is an int, `true` is a bool, everything else is a
+/// string. A prompt renders all four the same way, so the distinction only shows
+/// up if a case ever needs it to.
+enum ComposeCommand {
+
+    static func run(template: String, assignments: [String]) -> Int32 {
+        var scope = Scope()
+        for assignment in assignments {
+            guard let split = assignment.firstIndex(of: "=") else {
+                print("✗ expected name=value, got \"\(assignment)\"")
+                return 2
+            }
+            let name = String(assignment[assignment.startIndex..<split])
+            let raw = String(assignment[assignment.index(after: split)...])
+            scope.set(name, value(of: expanded(raw)))
+        }
+        print(Template.fill(expanded(template), from: scope), terminator: "")
+        return 0
+    }
+
+    /// `\n` on a command line is two characters. A case file has to hold
+    /// multi-line templates on one line, and the paragraph rule is the thing
+    /// being tested, so the escape is not a convenience here.
+    static func expanded(_ text: String) -> String {
+        text.replacingOccurrences(of: "\\n", with: "\n")
+    }
+
+    private static func value(of raw: String) -> Scope.Value {
+        if raw == "true" { return .bool(true) }
+        if raw == "false" { return .bool(false) }
+        if let int = Int(raw) { return .int(int) }
+        if let double = Double(raw) { return .double(double) }
+        return .string(raw)
+    }
+}

--- a/Sources/ParrotFlow/Context.swift
+++ b/Sources/ParrotFlow/Context.swift
@@ -1,0 +1,260 @@
+import AppKit
+import ApplicationServices
+
+/// What is on screen around the field you are dictating into.
+///
+/// The `context` pipeline stage is the only caller. It publishes what this
+/// returns as `context.*`, so a later stage — a `command:` script, a prompt —
+/// can read the conversation the transcript is about to join.
+///
+/// ## Terminals only, for now
+///
+/// A terminal is the one surface where this is nearly free. Its accessibility
+/// value *is* the visible screen — `Surface.Kind.screen` exists for exactly that
+/// reason — so the whole context is one AX call, the same call the app already
+/// makes to edit a line in place.
+///
+/// Everywhere else it is not one call. A Slack composer publishes its own
+/// contents and nothing above it, so the messages would have to come from
+/// walking the window's children: hundreds of IPC round trips, per app, for a
+/// flat run of text nodes with no author attached. That may still be worth
+/// building. It is not the same feature, and shipping it behind the same name
+/// would make one stage mean "cheap" in one app and "expensive" in the next.
+///
+/// So a non-terminal app is declined, out loud, rather than half-served.
+enum Context {
+
+    /// One read of the screen.
+    struct Capture {
+        /// What was on screen, minus the input box, tail-trimmed to a size a
+        /// later stage can afford to put in a prompt.
+        let text: String
+        /// Whether `maxChars` cut anything off the front.
+        let truncated: Bool
+
+        var chars: Int { text.count }
+        var lines: Int { text.isEmpty ? 0 : text.components(separatedBy: "\n").count }
+    }
+
+    /// Why a read did not happen. Logged, and published as `context.declined`,
+    /// because a stage that quietly returns nothing is indistinguishable from a
+    /// screen that was genuinely empty — and only one of those is answerable.
+    enum Declined: String, Error {
+        case noPermission = "accessibility is not granted"
+        case noApp = "the pipeline was not told which app this is for"
+        case notATerminal = "not a terminal; reading other apps needs a tree walk that does not exist yet"
+        case appChanged = "the frontmost app is no longer the one dictated into"
+        case nothingFocused = "nothing is focused"
+        case unreadable = "the focused element publishes no value"
+        case empty = "the screen has nothing on it above the input box"
+        case noPress = "nothing was captured when the hotkey went down"
+    }
+
+    // MARK: - The capture, which happens when the hotkey goes down
+
+    /// What was on screen when the hotkey went down, and which pane it was.
+    ///
+    /// The press is the only moment where the pane is *known*. Everything after
+    /// it is observation: by the time the pipeline runs there has been a
+    /// transcription and possibly a model call, and focus may be somewhere else
+    /// entirely. Reading then answers "what is on screen now", which is a
+    /// different question from "what were you looking at when you decided to
+    /// say this".
+    ///
+    /// `element` is kept so a later guard can ask whether the transcript is
+    /// still going where it was aimed. Nothing asks yet — see the note on
+    /// `capture` about the clipboard fallback that would.
+    struct Press {
+        let element: AXUIElement
+        /// The whole result, not just the capture. A press that declined has a
+        /// reason, and the stage publishes that reason — collapsing it to nil
+        /// here would turn six different answers into "nothing happened".
+        let outcome: Result<Capture, Declined>
+        /// Wall-clock cost of the read, so the press path's bill is on record
+        /// rather than assumed. Measured at ~1ms on a small pane and 36–39ms on
+        /// a long scrollback, which is why this runs off the main thread.
+        let ms: Double
+    }
+
+    private static let pressLock = NSLock()
+    nonisolated(unsafe) private static var press: Press?
+
+    static var pressCapture: Press? {
+        pressLock.lock()
+        defer { pressLock.unlock() }
+        return press
+    }
+
+    /// Whether any pipeline in this config names the stage.
+    ///
+    /// The gate on the whole thing. A screen read on every hotkey press is not
+    /// a cost to impose on people who never asked for context, and `context` is
+    /// not in any default, so most configs answer false here and pay nothing.
+    static func isConfigured(in config: Config) -> Bool {
+        config.transcription.pipelines.values.contains { $0.stages.contains(.context) }
+    }
+
+    /// Read the screen at press. Call **after** recording has started, off the
+    /// main thread.
+    ///
+    /// The element comes from the caller because it was resolved on the main
+    /// thread at press, alongside the selection snapshot. Re-resolving it here
+    /// would ask the same question a few milliseconds later and lose the one
+    /// property this capture exists for.
+    ///
+    /// Any previous press is cleared first, so a stale capture from the last
+    /// dictation can never be published as if it were this one.
+    static func capturePress(app: Pipeline.App?, element: AXUIElement?) {
+        pressLock.lock(); press = nil; pressLock.unlock()
+        guard let element else { return }
+
+        let started = CFAbsoluteTimeGetCurrent()
+        let outcome = read(app: app, from: element)
+        let ms = (CFAbsoluteTimeGetCurrent() - started) * 1000
+
+        pressLock.lock()
+        press = Press(element: element, outcome: outcome, ms: ms)
+        pressLock.unlock()
+        switch outcome {
+        case .success(let capture):
+            Log.write(String(
+                format: "context: captured %d chars at press in %.0fms", capture.chars, ms
+            ))
+        case .failure(let why):
+            Log.write(String(
+                format: "context: nothing captured at press (%@) in %.0fms", why.rawValue, ms
+            ))
+        }
+    }
+
+    /// How much of the screen a later stage is allowed to see.
+    ///
+    /// The tail, not the head: the rows nearest the input box are the ones the
+    /// sentence is answering. 2000 is `Surface.maxScreenContent`, reused rather
+    /// than picked again — that number is already the app's judgement about how
+    /// much terminal text is worth carrying around, and two constants for one
+    /// idea drift apart.
+    static let maxChars = 2000
+
+    /// Read whatever is focused right now, or say why not.
+    ///
+    /// **Not what the stage publishes.** The stage takes `pressCapture`. This is
+    /// the door for `--peek`, where there is no press to take a capture from and
+    /// the question really is "what would you read off this screen".
+    ///
+    /// `app` is the one captured when the hotkey went down, and a mismatch
+    /// against what is in front *now* declines. `Pipeline.App` documents why the
+    /// window in front is not reliably the window that was dictated into, and
+    /// reading the wrong window is worse than reading none — it would hand a
+    /// prompt somebody else's screen.
+    static func read(app: Pipeline.App?) -> Result<Capture, Declined> {
+        guard Permissions.accessibility == .granted else { return .failure(.noPermission) }
+        guard let app else { return .failure(.noApp) }
+        guard Destination.terminalName(of: app) != nil else { return .failure(.notATerminal) }
+
+        let front = NSWorkspace.shared.frontmostApplication
+        let frontID = front?.bundleIdentifier ?? ""
+        guard frontID == app.bundleID else { return .failure(.appChanged) }
+
+        guard let element = SelectionReader.focusedElement(),
+              !SelectionReader.isOurs(element) else { return .failure(.nothingFocused) }
+        return read(app: app, from: element)
+    }
+
+    /// The same read, of an element the caller already has.
+    ///
+    /// The press capture takes this door, and it must not re-resolve focus: the
+    /// element was settled on the main thread at press, and that pane *is* the
+    /// answer this capture exists to preserve.
+    ///
+    /// No frontmost-app check here either. At press the app in front is the app
+    /// the caller was handed, so re-checking would compare it against itself or
+    /// against whatever won a race.
+    ///
+    /// ## Why the pane is not checked again later
+    ///
+    /// It could be. `Press.element` is kept for exactly that. But the check
+    /// belongs at the paste, not here: if focus has moved on, the honest
+    /// response is to stop pasting and put the transcript on the clipboard —
+    /// where it goes wrong today is the *text* landing in a pane you left, not
+    /// the context. That guard is worth building and is not this stage's job.
+    ///
+    /// Until it exists, a capture from the pane you dictated into is still the
+    /// right one to publish. It is the pane you meant, whatever the paste does.
+    static func read(
+        app: Pipeline.App?, from element: AXUIElement
+    ) -> Result<Capture, Declined> {
+        guard Permissions.accessibility == .granted else { return .failure(.noPermission) }
+        guard let app else { return .failure(.noApp) }
+        guard Destination.terminalName(of: app) != nil else { return .failure(.notATerminal) }
+        guard !SelectionReader.isOurs(element) else { return .failure(.nothingFocused) }
+        guard let value = SelectionReader.visibleText(of: element) else {
+            return .failure(.unreadable)
+        }
+
+        let above = aboveInputBox(in: value)
+        guard !above.isEmpty else { return .failure(.empty) }
+
+        let (text, truncated) = tail(of: above, limit: maxChars)
+        return .success(Capture(text: text, truncated: truncated))
+    }
+
+    // MARK: - Cutting the screen up
+
+    /// Everything above the input box.
+    ///
+    /// The box is between the last two rules the TUI draws — the same reading
+    /// `SelectionReader.joinedInputBox` uses, and deliberately the same one: if
+    /// the two disagreed about where the box starts, the context would either
+    /// repeat the half-typed line or eat the last line of output.
+    ///
+    /// The box itself is left out on purpose. It holds the transcript that is
+    /// being dictated right now, which the pipeline already has as `text` — and
+    /// a stage that saw the same sentence twice, once as its input and once as
+    /// "context", would have every reason to think it was being asked about a
+    /// quotation.
+    ///
+    /// With no rules drawn — a bare shell rather than a TUI — the last non-empty
+    /// row is the prompt line and is dropped for the same reason.
+    static func aboveInputBox(in screen: String) -> String {
+        var rows = screen.components(separatedBy: "\n")
+        let rules = rows.indices.filter { SelectionReader.isBorder(rows[$0]) }
+
+        if rules.count >= 2 {
+            rows = Array(rows[..<rules[rules.count - 2]])
+        } else if let last = rows.lastIndex(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) {
+            rows = Array(rows[..<last])
+        }
+
+        // Trailing blank rows are padding the TUI drew, not silence anyone
+        // meant. Leading ones are trimmed by the same pass so the count in
+        // `context.lines` is rows of content.
+        while let last = rows.last, last.trimmingCharacters(in: .whitespaces).isEmpty {
+            rows.removeLast()
+        }
+        while let first = rows.first, first.trimmingCharacters(in: .whitespaces).isEmpty {
+            rows.removeFirst()
+        }
+        return rows.joined(separator: "\n")
+    }
+
+    /// The last `limit` characters, cut at a row boundary.
+    ///
+    /// Mid-row would be worse than useless: a truncated first line reads as a
+    /// sentence somebody said rather than as a fragment, and there is nothing in
+    /// the string to say which. Cutting on a newline makes the loss visible.
+    static func tail(of text: String, limit: Int) -> (text: String, truncated: Bool) {
+        guard text.count > limit else { return (text, false) }
+        let rows = text.components(separatedBy: "\n")
+        var kept: [String] = []
+        var size = 0
+        for row in rows.reversed() {
+            // +1 for the newline that rejoins it.
+            let cost = row.count + 1
+            if size + cost > limit, !kept.isEmpty { break }
+            kept.append(row)
+            size += cost
+        }
+        return (kept.reversed().joined(separator: "\n"), true)
+    }
+}

--- a/Sources/ParrotFlow/Context.swift
+++ b/Sources/ParrotFlow/Context.swift
@@ -79,6 +79,21 @@ enum Context {
     private static let pressLock = NSLock()
     nonisolated(unsafe) private static var press: Press?
 
+    /// Which press the stored capture belongs to.
+    ///
+    /// The reads run on a concurrent queue, so two of them can be in flight at
+    /// once, and nothing makes them finish in the order they started. An AX call
+    /// against a wedged app runs until its messaging timeout — far longer than
+    /// the 1–39ms a healthy one takes — so a slow read from the previous press
+    /// could land after a fast one from this press and overwrite it. The stage
+    /// would then publish the screen from a dictation ago, with nothing in the
+    /// value to say so.
+    ///
+    /// A counter taken at the start and checked at the end makes that
+    /// unrepresentable: a read that is no longer the newest simply does not
+    /// store its answer.
+    nonisolated(unsafe) private static var pressGeneration = 0
+
     static var pressCapture: Press? {
         pressLock.lock()
         defer { pressLock.unlock() }
@@ -103,9 +118,15 @@ enum Context {
     /// property this capture exists for.
     ///
     /// Any previous press is cleared first, so a stale capture from the last
-    /// dictation can never be published as if it were this one.
+    /// dictation can never be published as if it were this one — and the
+    /// generation taken here is checked before storing, so a read that has been
+    /// overtaken cannot put the stale one back. See `pressGeneration`.
     static func capturePress(app: Pipeline.App?, element: AXUIElement?) {
-        pressLock.lock(); press = nil; pressLock.unlock()
+        pressLock.lock()
+        pressGeneration += 1
+        let mine = pressGeneration
+        press = nil
+        pressLock.unlock()
         guard let element else { return }
 
         let started = CFAbsoluteTimeGetCurrent()
@@ -113,8 +134,16 @@ enum Context {
         let ms = (CFAbsoluteTimeGetCurrent() - started) * 1000
 
         pressLock.lock()
-        press = Press(element: element, outcome: outcome, ms: ms)
+        let newest = mine == pressGeneration
+        if newest { press = Press(element: element, outcome: outcome, ms: ms) }
         pressLock.unlock()
+
+        guard newest else {
+            Log.write(String(
+                format: "context: a %.0fms read was overtaken by a newer press; dropped", ms
+            ))
+            return
+        }
         switch outcome {
         case .success(let capture):
             Log.write(String(
@@ -238,11 +267,20 @@ enum Context {
         return rows.joined(separator: "\n")
     }
 
-    /// The last `limit` characters, cut at a row boundary.
+    /// The last `limit` characters, cut at a row boundary where there is one.
     ///
-    /// Mid-row would be worse than useless: a truncated first line reads as a
-    /// sentence somebody said rather than as a fragment, and there is nothing in
-    /// the string to say which. Cutting on a newline makes the loss visible.
+    /// Mid-row is the worse cut: a truncated first line reads as a sentence
+    /// somebody said rather than as a fragment, and there is nothing in the
+    /// string to say which. Cutting on a newline makes the loss visible.
+    ///
+    /// But preferring a boundary is not the same as requiring one. A single row
+    /// longer than the whole budget has no boundary inside it, and keeping it
+    /// whole to preserve the nicer cut would hand an unbounded string to a
+    /// prompt — `limit` is how much of the screen may be disclosed at all, not
+    /// only how much is worth reading. A wrapped terminal keeps rows near the
+    /// pane width, so this is the log line or the pasted blob that did not wrap.
+    /// It is cut from the front, keeping the end, for the same reason the whole
+    /// function keeps the end.
     static func tail(of text: String, limit: Int) -> (text: String, truncated: Bool) {
         guard text.count > limit else { return (text, false) }
         let rows = text.components(separatedBy: "\n")
@@ -251,7 +289,10 @@ enum Context {
         for row in rows.reversed() {
             // +1 for the newline that rejoins it.
             let cost = row.count + 1
-            if size + cost > limit, !kept.isEmpty { break }
+            if size + cost > limit {
+                if kept.isEmpty { kept.append(String(row.suffix(limit))) }
+                break
+            }
             kept.append(row)
             size += cost
         }

--- a/Sources/ParrotFlow/ContextTestCommand.swift
+++ b/Sources/ParrotFlow/ContextTestCommand.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// `--context-test "<screen>" [limit]` — prints what the `context` stage would
+/// publish for a screen handed to it, and reads nothing.
+///
+/// The two string steps of the stage, in the order they run: cut the input box
+/// off the bottom, then keep the tail. Neither touches accessibility, so both
+/// can be scored exactly — which is the only part of this stage that can be.
+/// The capture itself is at the mercy of TCC and of whatever is genuinely in
+/// front, and a fixture that stubbed a screen would be scoring the stub.
+///
+/// `\n` in the argument is a newline, because a case file is line-oriented and
+/// the thing being scored is where the rows are.
+enum ContextTestCommand {
+
+    static func run(screen: String, limit: Int) -> Int32 {
+        let above = Context.aboveInputBox(in: ComposeCommand.expanded(screen))
+        let (text, truncated) = Context.tail(of: above, limit: limit)
+        print(truncated ? "truncated" : "whole")
+        print(text, terminator: "")
+        return 0
+    }
+}

--- a/Sources/ParrotFlow/PeekCommand.swift
+++ b/Sources/ParrotFlow/PeekCommand.swift
@@ -144,6 +144,26 @@ enum PeekCommand {
             report("as a surface: unreadable — nothing here can be edited in place")
         }
 
+        // What the `context` stage would publish here, which is a different
+        // question from everything above: those report what can be *written*,
+        // this reports what can be *read* and handed to a later stage. Printed
+        // in full, because deciding whether a screen is worth putting in a
+        // prompt is a judgement about the text and not about its length.
+        report("")
+        let capture = Context.read(app: front.map {
+            Pipeline.App(name: $0.localizedName ?? "", bundleID: $0.bundleIdentifier ?? "")
+        })
+        switch capture {
+        case .failure(let why):
+            report("as context: declined — \(why.rawValue)")
+        case .success(let got):
+            report("as context: \(got.chars) chars, \(got.lines) line(s)"
+                + (got.truncated ? " (truncated to the last \(Context.maxChars))" : ""))
+            for row in got.text.components(separatedBy: "\n") {
+                report("  | \(row)")
+            }
+        }
+
         if let sentinel {
             guard let value, value.contains(sentinel) else {
                 report("sentinel  \"\(sentinel)\" NOT in the focused element — wrong window")

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -38,6 +38,9 @@ struct Pipeline: Equatable, Codable {
         case fuzzy
         /// Spoken numbers as digits, in the language its own pass resolves.
         case numbers
+        /// What is on screen around the field, published as `context.*` and
+        /// never written into the transcript. Terminals only — see `Context`.
+        case context
         /// One of the entries in `transforms:`, run over the whole
         /// transcript. The only stage that names something outside itself, and
         /// the only one that might call a model — see `Step.transform`.
@@ -45,10 +48,16 @@ struct Pipeline: Equatable, Codable {
 
         var name: String { rawValue }
 
-        /// Whether it can be in a default nobody wrote. `transform` cannot: it
-        /// needs a name, and there is no transform every install is guaranteed
-        /// to have. Everything else is in the default the moment it exists.
-        var isAutomatic: Bool { self != .transform }
+        /// Whether it can be in a default nobody wrote.
+        ///
+        /// `transform` cannot: it needs a name, and there is no transform every
+        /// install is guaranteed to have.
+        ///
+        /// `context` cannot either, for a different and stronger reason. It
+        /// reads the screen. Turning that on for everybody who never wrote a
+        /// `pipelines:` block would be a silent change to what the app looks at,
+        /// which is the one kind of change that has to be asked for by name.
+        var isAutomatic: Bool { self != .transform && self != .context }
     }
 
     /// The app a transcript is on its way into, for `Step.app`.
@@ -560,7 +569,6 @@ struct Pipeline: Equatable, Codable {
         if scope["language"] == nil {
             scope.set("language", .string(Pipeline.forText(output, config: config).1))
         }
-
         for step in steps {
             let named = step.transform.map { "\(step.stage.name) \($0)" } ?? step.stage.name
             let namespace = Pipeline.namespace(of: step)
@@ -594,7 +602,7 @@ struct Pipeline: Equatable, Codable {
             // measured on your own sentences instead of quoted from a README.
             let before = output
             let started = CFAbsoluteTimeGetCurrent()
-            let result = await apply(step, to: output, config: config, scope: scope)
+            let result = await apply(step, to: output, config: config, app: app, scope: scope)
             let seconds = CFAbsoluteTimeGetCurrent() - started
             output = result.text
 
@@ -639,7 +647,7 @@ struct Pipeline: Equatable, Codable {
     }
 
     private func apply(
-        _ step: Step, to text: String, config: Config, scope: Scope
+        _ step: Step, to text: String, config: Config, app: App?, scope: Scope
     ) async -> StageResult {
         switch step.stage {
         case .replacements:
@@ -659,8 +667,77 @@ struct Pipeline: Equatable, Codable {
         case .numbers:
             let done = Numbers.read(text, languages: config.transcription.languages)
             return StageResult(text: done.text, vars: ["language": .string(done.language)])
+        case .context:
+            return await readContext(on: text)
         case .transform:
             return await runTransform(step, on: text, config: config, scope: scope)
+        }
+    }
+
+    /// The screen behind the field, as variables. Never as text.
+    ///
+    /// This is the one stage that returns its input untouched by construction
+    /// rather than by outcome, so `context.changed` is false on every run and
+    /// means it. A stage that could put the screen into the transcript would be
+    /// a stage that could paste somebody's terminal into their chat message.
+    ///
+    /// The screen is not read here. It was read when the hotkey went down, and
+    /// this hands on what `Context.capturePress` stored.
+    ///
+    /// That is the whole point of the stage's shape. By the time this runs there
+    /// has been a transcription and possibly a model call, and focus may be in
+    /// another pane — so a read here answers "what is on screen now" when the
+    /// question is "what were you looking at when you decided to say this".
+    /// Those are the same screen most of the time and the wrong one exactly when
+    /// it matters.
+    ///
+    /// It also means this stage does no accessibility work at all, which is why
+    /// there is no thread argument to have. An earlier version read here and hopped
+    /// to the main actor to do it; that deadlocked, because `--pipeline` drives
+    /// this with a semaphore the main thread is sitting in.
+    ///
+    /// Declining is normal and is not an error: no permission, the wrong app in
+    /// front, a surface that is not a terminal, or no press at all — which is
+    /// every run under `--pipeline`, and every entry point that is not the
+    /// hotkey. Each publishes `ok: false` and the reason, because "read nothing"
+    /// and "was not allowed to look" are different answers and a condition
+    /// should be able to tell them apart.
+    private func readContext(on text: String) async -> StageResult {
+        switch Context.pressCapture?.outcome ?? .failure(.noPress) {
+        case .failure(let why):
+            Log.write("pipeline: context declined — \(why.rawValue)")
+            // The same keys a successful read publishes, emptied, plus the
+            // reason. Not fewer: a condition is written once and has to hold on
+            // the runs where nothing could be read, which are most of them — and
+            // `context.text` that is absent throws where `context.text` that is
+            // empty is simply true. Empty is also the honest answer. Nothing was
+            // on screen as far as this stage is concerned, and `ok` and
+            // `declined` are there to say whether that was a screen or a refusal.
+            return StageResult(text: text, vars: [
+                "ok": .bool(false),
+                "declined": .string(why.rawValue),
+                "text": .string(""),
+                "chars": .int(0),
+                "lines": .int(0),
+                "truncated": .bool(false),
+            ])
+        case .success(let capture):
+            // The whole capture goes to the log, not a count of it. The point of
+            // this stage is to find out what is worth reading off a screen, and
+            // that judgement cannot be made from "1840 chars". Worth knowing
+            // before turning it on: while it is on, the log holds what was on
+            // screen when you dictated.
+            Log.write("pipeline: context read \(capture.chars) chars, \(capture.lines) line(s)"
+                + (capture.truncated ? " (truncated to the last \(Context.maxChars))" : ""))
+            for row in capture.text.components(separatedBy: "\n") {
+                Log.write("    | \(row)")
+            }
+            return StageResult(text: text, vars: [
+                "text": .string(capture.text),
+                "chars": .int(capture.chars),
+                "lines": .int(capture.lines),
+                "truncated": .bool(capture.truncated),
+            ])
         }
     }
 
@@ -682,7 +759,7 @@ struct Pipeline: Equatable, Codable {
         }
         switch transform.body {
         case .prompt:
-            return await runPrompt(step, named: name, on: text, config: config)
+            return await runPrompt(step, named: name, on: text, config: config, scope: scope)
         case .replace:
             // Exact and free, so there is nothing to guard and nothing to
             // report beyond what the table did — the log line is the same one
@@ -731,7 +808,7 @@ struct Pipeline: Equatable, Codable {
     /// after belong in the log whether or not anything went wrong, because
     /// nothing on screen will ever show you it happened.
     private func runPrompt(
-        _ step: Step, named name: String, on text: String, config: Config
+        _ step: Step, named name: String, on text: String, config: Config, scope: Scope
     ) async -> StageResult {
         guard config.llm.enabled else {
             Log.write("pipeline: skipped prompt \(name) — llm.enabled is false")
@@ -745,8 +822,15 @@ struct Pipeline: Equatable, Codable {
         do {
             let result = try await PromptRunner.run(
                 prompt: prompt,
+                // No spoken instruction exists on this path — a pipeline prompt
+                // is not something anybody asked for out loud. `{{instruction}}`
+                // in a pipeline prompt therefore resolves to nothing, and takes
+                // its paragraph with it.
                 instruction: "",
                 text: text,
+                // What every stage before this one published. A prompt reads it
+                // by the same names a condition does.
+                scope: scope,
                 config: LocalLLM.Config(
                     endpoint: config.llm.endpoint,
                     model: config.llm.model,

--- a/Sources/ParrotFlow/PromptRunner.swift
+++ b/Sources/ParrotFlow/PromptRunner.swift
@@ -23,34 +23,44 @@ enum PromptRunner {
         max(256, (text.count / 4) * 2)
     }
 
+    /// Build the two messages.
+    ///
+    /// `scope` is what the pipeline has accumulated, and it is empty on the
+    /// voice-command path — there is no pipeline behind "hey parrot, make that a
+    /// list". The instruction is put into it rather than substituted separately,
+    /// so `{{instruction}}` is an ordinary lookup and not a reserved word with
+    /// its own rule. That also gives it the same disappearing-paragraph
+    /// behaviour as everything else, which matters because in a pipeline the
+    /// instruction is *always* empty: `Pipeline.runPrompt` has no spoken
+    /// instruction to pass and never did.
     static func compose(
-        prompt: Config.Prompt, instruction: String, text: String
+        prompt: Config.Prompt, instruction: String, text: String, scope: Scope = Scope()
     ) -> (system: String, user: String) {
         let instruction = instruction.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        var scope = scope
+        scope.set("instruction", .string(instruction))
+        let system = Template.fill(prompt.content, from: scope)
 
         // Asked for inline, the instruction goes where the prompt puts it and
         // nowhere else — repeating it in the user message would have the model
         // weighing two copies of the same sentence.
-        if prompt.wantsInstructionInline {
-            return (
-                system: prompt.content.replacingOccurrences(
-                    of: Config.Prompt.instructionPlaceholder, with: instruction
-                ),
-                user: text
-            )
-        }
+        if prompt.wantsInstructionInline { return (system, text) }
 
-        guard !instruction.isEmpty else { return (prompt.content, text) }
-        return (prompt.content, "instruction: \(instruction)\n\ntext:\n\(text)")
+        guard !instruction.isEmpty else { return (system, text) }
+        return (system, "instruction: \(instruction)\n\ntext:\n\(text)")
     }
 
     static func run(
         prompt: Config.Prompt,
         instruction: String,
         text: String,
+        scope: Scope = Scope(),
         config: LocalLLM.Config
     ) async throws -> String {
-        let composed = compose(prompt: prompt, instruction: instruction, text: text)
+        let composed = compose(
+            prompt: prompt, instruction: instruction, text: text, scope: scope
+        )
         let raw = try await LocalLLM.complete(
             system: composed.system,
             user: composed.user,
@@ -81,11 +91,21 @@ enum PromptRunner {
 
         // "Here is the corrected text:" and friends, but only when the label
         // sits on its own line — a colon mid-sentence is the speaker's.
+        //
+        // A list header has the same shape and must survive. "Hey, so there are
+        // three things I need:" is 37 characters, ends in a colon, and is the
+        // sentence the speaker said. Stripping it deleted the opening line of
+        // every dictated list — measured on the slack set, where it cost three
+        // points and every one of them was a case whose answer starts with a
+        // colon line. What tells the two apart is not the line itself but what
+        // follows: a preamble introduces prose, a header introduces items.
         if let newline = text.firstIndex(of: "\n") {
             let first = text[text.startIndex..<newline].trimmingCharacters(in: .whitespaces)
-            if first.hasSuffix(":"), first.count < 60, !first.hasPrefix("-") {
-                text = String(text[text.index(after: newline)...])
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            let rest = text[text.index(after: newline)...]
+            let next = rest.prefix { $0 != "\n" }.trimmingCharacters(in: .whitespaces)
+            let opensList = ["- ", "* ", "• "].contains { next.hasPrefix($0) }
+            if first.hasSuffix(":"), first.count < 60, !first.hasPrefix("-"), !opensList {
+                text = String(rest).trimmingCharacters(in: .whitespacesAndNewlines)
             }
         }
 

--- a/Sources/ParrotFlow/Scope.swift
+++ b/Sources/ParrotFlow/Scope.swift
@@ -51,6 +51,18 @@ struct Scope: Equatable {
             }
         }
 
+        /// How it reads inside a prompt. Not `described`, which puts quotes
+        /// around a string so a log line shows where it ends — a quoted screen
+        /// in a prompt is a screen the model has been handed as a quotation.
+        var plain: String {
+            switch self {
+            case .string(let s): return s
+            case .int(let i): return String(i)
+            case .double(let d): return String(d)
+            case .bool(let b): return b ? "true" : "false"
+            }
+        }
+
         /// The number this is, for `<`, `>` and friends. Ints and doubles
         /// compare with each other — a script that returns `1` and one that
         /// returns `1.0` have said the same thing, and a condition that treats
@@ -78,9 +90,12 @@ struct Scope: Equatable {
     /// `text` is here because it is a bare name rather than a namespace: a
     /// stage called `text` would contribute `text.count` while `text` itself is
     /// a string, and a path that is both a value and a prefix has no sensible
-    /// answer.
+    /// answer. `instruction` joined it when prompts learned to read the scope —
+    /// `PromptRunner.compose` puts the spoken instruction there, so it is a bare
+    /// name for exactly the same reason.
     static let reserved: Set<String> = [
-        "text", "app", "bundle_id", "language", "asr", "vad",
+        "text", "app", "bundle_id", "language", "instruction",
+        "asr", "vad", "vocabulary",
     ]
 
     init(values: [String: Value] = [:]) {

--- a/Sources/ParrotFlow/Template.swift
+++ b/Sources/ParrotFlow/Template.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+/// Puts scope values into a prompt, and takes out the parts there is nothing to
+/// put in.
+///
+/// A prompt names a variable the way a condition does — `{{context.text}}`,
+/// `{{numbers.count}}`, `{{language}}` — so there is one set of names to learn
+/// rather than one for `when:` and another for the prompt body. Anything a stage
+/// published is reachable, as long as that stage ran earlier in the pipeline.
+///
+/// ## Why a missing value removes the paragraph around it
+///
+/// Most variables are absent most of the time. `context` only reads terminals,
+/// so in Slack or Mail there is no screen, and a stage that declines still
+/// publishes its keys — emptied. Substituting that empty string leaves:
+///
+///     This is what is on the user's screen right now:
+///
+/// which is worse than saying nothing. It tells a model there is a screen and
+/// then shows it none, and a small model asked to use something that is not
+/// there will invent it. So the paragraph goes too.
+///
+/// The unit is the paragraph rather than the line because that is the unit a
+/// prompt is written in: a heading and its content are one thought, and dropping
+/// only the line with the placeholder would strip the value and keep the promise.
+///
+/// One placeholder with nothing behind it takes the whole paragraph, even if
+/// another in the same paragraph resolved. A paragraph is a single claim; half
+/// of it is not a smaller claim, it is a wrong one.
+enum Template {
+
+    /// Fill `template` from `scope`, dropping what cannot be filled.
+    static func fill(_ template: String, from scope: Scope) -> String {
+        let lines = template.components(separatedBy: "\n")
+        var out: [String] = []
+        var index = 0
+
+        while index < lines.count {
+            guard !isBlank(lines[index]) else {
+                out.append(lines[index])
+                index += 1
+                continue
+            }
+
+            var end = index
+            while end < lines.count, !isBlank(lines[end]) { end += 1 }
+
+            if let filled = fill(paragraph: Array(lines[index..<end]), from: scope) {
+                out.append(contentsOf: filled)
+                index = end
+                continue
+            }
+
+            // Dropped. The blank line that separated this paragraph from the
+            // next goes with it, or two paragraphs become one when the text
+            // between them disappears.
+            index = end < lines.count ? end + 1 : end
+        }
+
+        while let last = out.last, isBlank(last) { out.removeLast() }
+        while let first = out.first, isBlank(first) { out.removeFirst() }
+        let result = out.joined(separator: "\n")
+
+        // A prompt made of nothing but placeholders would vanish entirely, and
+        // an empty system message is not a smaller instruction — it is no
+        // instruction, which is the one outcome worse than a dangling heading.
+        // So in that case the paragraphs stay and the gaps are simply empty.
+        if result.isEmpty, !isBlank(template) {
+            return substituting(template, from: scope)
+        }
+        return result
+    }
+
+    /// The filled paragraph, or nil if a placeholder in it had nothing behind it.
+    private static func fill(paragraph: [String], from scope: Scope) -> [String]? {
+        var filled: [String] = []
+        for line in paragraph {
+            var result = ""
+            var cursor = line.startIndex
+            for found in placeholders(in: line) {
+                guard let value = value(for: found.path, in: scope) else { return nil }
+                result += line[cursor..<found.range.lowerBound] + value
+                cursor = found.range.upperBound
+            }
+            result += line[cursor...]
+            filled.append(result)
+        }
+        return filled
+    }
+
+    /// Every placeholder in one line, in order.
+    ///
+    /// Scanned rather than matched with a regular expression because the thing
+    /// being looked for is two literal pairs of braces, and a pattern for that
+    /// is four escapes deep before it says anything.
+    static func placeholders(in line: String) -> [(range: Range<String.Index>, path: String)] {
+        var found: [(Range<String.Index>, String)] = []
+        var cursor = line.startIndex
+        while let open = line.range(of: "{{", range: cursor..<line.endIndex) {
+            guard let close = line.range(of: "}}", range: open.upperBound..<line.endIndex) else {
+                break
+            }
+            let path = line[open.upperBound..<close.lowerBound]
+                .trimmingCharacters(in: .whitespaces)
+            found.append((open.lowerBound..<close.upperBound, path))
+            cursor = close.upperBound
+        }
+        return found
+    }
+
+    /// What goes in place of a name, or nil when there is nothing to put there.
+    ///
+    /// A path the scope has never heard of and a path holding an empty string
+    /// are the same answer on purpose. A stage that declined publishes its keys
+    /// emptied rather than absent — see `readContext` — so a prompt that treated
+    /// the two differently would behave one way in a terminal with a blank
+    /// screen and another way in Slack, for no reason a reader could see.
+    private static func value(for path: String, in scope: Scope) -> String? {
+        guard let value = scope[path] else { return nil }
+        let plain = value.plain
+        return plain.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : plain
+    }
+
+    /// Every placeholder replaced by whatever is behind it, empty included, and
+    /// no paragraph dropped. Only the all-placeholder fallback uses this.
+    private static func substituting(_ template: String, from scope: Scope) -> String {
+        template.components(separatedBy: "\n").map { line -> String in
+            var result = ""
+            var cursor = line.startIndex
+            for found in placeholders(in: line) {
+                result += line[cursor..<found.range.lowerBound]
+                    + (value(for: found.path, in: scope) ?? "")
+                cursor = found.range.upperBound
+            }
+            return result + line[cursor...]
+        }.joined(separator: "\n")
+    }
+
+    private static func isBlank(_ line: String) -> Bool {
+        line.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+}

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -205,6 +205,18 @@ if let index = arguments.firstIndex(of: "--peek") {
     ))
 }
 
+if let index = arguments.firstIndex(of: "--context-test") {
+    guard arguments.indices.contains(index + 1) else {
+        print("usage: ParrotFlow --context-test \"<screen>\" [limit]")
+        exit(2)
+    }
+    let limit = arguments.indices.contains(index + 2)
+        ? Int(arguments[index + 2]) : nil
+    exit(ContextTestCommand.run(
+        screen: arguments[index + 1], limit: limit ?? Context.maxChars
+    ))
+}
+
 if let index = arguments.firstIndex(of: "--compose") {
     guard arguments.indices.contains(index + 1) else {
         print("usage: ParrotFlow --compose \"<template>\" [name=value ...]")

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -205,6 +205,17 @@ if let index = arguments.firstIndex(of: "--peek") {
     ))
 }
 
+if let index = arguments.firstIndex(of: "--compose") {
+    guard arguments.indices.contains(index + 1) else {
+        print("usage: ParrotFlow --compose \"<template>\" [name=value ...]")
+        exit(2)
+    }
+    exit(ComposeCommand.run(
+        template: arguments[index + 1],
+        assignments: Array(arguments[(index + 2)...]).filter { $0.contains("=") }
+    ))
+}
+
 if let index = arguments.firstIndex(of: "--span-test") {
     guard arguments.indices.contains(index + 3),
           let start = Int(arguments[index + 1]), let length = Int(arguments[index + 2]) else {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -279,6 +279,7 @@ scripts/check-dates.sh             scripts/check-inplace.sh
 scripts/check-default-config.sh    scripts/check-seeded-transform.sh
 scripts/check-transform-folders.sh scripts/check-eval.sh
 scripts/check-compose.sh           # what a prompt says once the scope is in it
+scripts/check-context.sh           # what the context stage publishes for a screen
 scripts/check-span.sh              # a composer-shaped page, or Slack, or Outlook
 
 PF_VIEWPORT=Ghostty scripts/check-inplace.sh   # the same set, in another terminal

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -278,6 +278,7 @@ scripts/check-split.sh             scripts/check-grammar.sh
 scripts/check-dates.sh             scripts/check-inplace.sh
 scripts/check-default-config.sh    scripts/check-seeded-transform.sh
 scripts/check-transform-folders.sh scripts/check-eval.sh
+scripts/check-compose.sh           # what a prompt says once the scope is in it
 scripts/check-span.sh              # a composer-shaped page, or Slack, or Outlook
 
 PF_VIEWPORT=Ghostty scripts/check-inplace.sh   # the same set, in another terminal

--- a/docs/development.md
+++ b/docs/development.md
@@ -127,6 +127,7 @@ scripts/check-pipeline.sh         # stages, conditions, app gating
 scripts/check-dotted.sh           # the one rewrite that fires on ordinary language
 scripts/check-numbers.sh          # 97 cases, English and French
 scripts/check-routing.sh          # which transform an instruction reaches
+scripts/check-compose.sh          # what a prompt says once the scope is in it
 ```
 
 The full list is in [cli.md](cli.md#the-check-scripts). Anything touching a

--- a/docs/development.md
+++ b/docs/development.md
@@ -128,6 +128,7 @@ scripts/check-dotted.sh           # the one rewrite that fires on ordinary langu
 scripts/check-numbers.sh          # 97 cases, English and French
 scripts/check-routing.sh          # which transform an instruction reaches
 scripts/check-compose.sh          # what a prompt says once the scope is in it
+scripts/check-context.sh          # what the context stage publishes for a screen
 ```
 
 The full list is in [cli.md](cli.md#the-check-scripts). Anything touching a

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -777,10 +777,15 @@ which the pipeline already has as `text`. A stage handed the same sentence twice
 — once as its input, once as "context" — has every reason to read it as a
 quotation.
 
-**The last 2000 characters, cut on a row boundary.** The tail, because the rows
-nearest the box are the ones the sentence is answering. On a boundary, because a
-half row reads like something somebody said and there is nothing in the string
-to say otherwise.
+**The last 2000 characters, cut on a row boundary where there is one.** The
+tail, because the rows nearest the box are the ones the sentence is answering.
+On a boundary, because a half row reads like something somebody said and there
+is nothing in the string to say otherwise.
+
+A single row longer than the whole budget has no boundary inside it, and is cut
+anyway — 2000 is how much of your screen may leave it at all, not only how much
+is worth reading. A wrapped terminal keeps rows near the pane width, so that is
+the log line or the pasted blob that did not wrap.
 
 ### Why it is not in the default
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -26,6 +26,7 @@ get every stage back — a missing section is silence, not a choice. Write
 | `replacements` | The substitutions in `replacements:` — literal, word-boundary, case-insensitive, or a regex between slashes. |
 | `fuzzy` | The same table against renderings you have not taught, so "super bays" reaches Supabase. Only words the spell checker does not know are eligible, which is what keeps "Excel" from becoming "Vercel". Needs `replacements` before it and says so if it does not have one, because on its own it swallows the preceding word. |
 | `numbers` | Spoken numbers as digits: "two hundred forty-three" → 243, plus ordinals, decimals, years and spoken digits. English and French, septante/huitante/nonante included, chosen per transcript. A number word on its own stays a word below ten, so "chapter three" and "on est deux" are left alone. |
+| `context` | What is on screen around the field, published as `context.*`. Never touches the transcript. Terminals only, and off unless you ask for it — see [Context](#context-what-is-on-screen-around-the-field). |
 | `transform` | One entry of `transforms:`, named — see below. The only stage that names something outside itself. |
 
 `numbers` rewrites transcripts that were already correct, so run `--numbers` on
@@ -703,6 +704,116 @@ values that decided it:
                  (code_identifiers.count = 1)
 ```
 
+## Context: what is on screen around the field
+
+Every other stage sees the sentence and nothing else. `context` is the one that
+looks up: it reads the screen behind the field you are dictating into and
+publishes it, so a later stage can know what the sentence is answering.
+
+```yaml
+pipelines:
+  default:
+    - replacements
+    - context
+    - stage: transform
+      transform: reply
+      when: context.ok && context.chars > 200
+```
+
+It publishes five things, on top of the four every stage gets:
+
+| | |
+|---|---|
+| `context.text` | what was on screen, minus the input box |
+| `context.chars` | how much of it there is |
+| `context.lines` | how many rows |
+| `context.truncated` | whether the cap cut anything off the front |
+| `context.declined` | why nothing was read, when nothing was |
+
+**It never changes the transcript.** `context.changed` is false on every run and
+means it — the stage returns its input by construction, not by outcome. A stage
+that could put the screen into the transcript is a stage that could paste your
+terminal into a chat message.
+
+**Terminals only, for now.** A terminal's accessibility value *is* its visible
+screen, so the whole context costs one call — the same call the app already
+makes to edit a line in place. No other app works that way. A Slack composer
+publishes its own contents and nothing above it, so the messages would have to
+come from walking the window's children: hundreds of round trips, per app, for a
+flat run of text with no author attached. That may still be worth building. It
+is not the same feature, and one stage that means "cheap" in one app and
+"expensive" in the next is not a stage anybody can budget for. So everything
+else is declined out loud.
+
+**The screen is read when the hotkey goes down, not when the stage runs.** The
+press is the last moment the pane is known. By the time the pipeline reaches
+this stage there has been a transcription and possibly a model call, and focus
+may be somewhere else — so a read then answers "what is on screen now" when the
+question is "what were you looking at when you decided to say this".
+
+Those are the same screen nearly always. Measured over 17 dictations, a press
+reading and a stage reading agreed 15 times, and both differences were under 35
+characters of spinner and token counter. The reason to take the earlier one is
+not that it is fresher. It is that the pane is certain.
+
+The read costs about 1ms on a small pane and 36–39ms on a long scrollback, so it
+runs on a background queue after the recorder has started. It is skipped
+entirely unless some pipeline names the stage.
+
+**This does not fix where the text lands.** If you dictate into one pane and
+switch to another before the transcript is ready, the ⌘V still goes to the pane
+you switched to. That is a real gap and it is not this stage's — the fix is to
+put the transcript on the clipboard instead of pasting it somewhere you did not
+aim, and it belongs next to the paste. Until then, the context at least
+describes the pane you meant.
+
+**Only the hotkey captures.** Any other entry point — `--pipeline`, a scripted
+transcription — reaches the stage with nothing to publish and gets
+`context.declined: nothing was captured when the hotkey went down`. Use `--peek`
+to see a live read on demand.
+
+**The input box is left out.** It holds the sentence being dictated right now,
+which the pipeline already has as `text`. A stage handed the same sentence twice
+— once as its input, once as "context" — has every reason to read it as a
+quotation.
+
+**The last 2000 characters, cut on a row boundary.** The tail, because the rows
+nearest the box are the ones the sentence is answering. On a boundary, because a
+half row reads like something somebody said and there is nothing in the string
+to say otherwise.
+
+### Why it is not in the default
+
+Every other stage is on the moment it exists — delete `pipelines:` and you get
+all of them. `context` is not, and `transform` is the only other exception.
+
+It reads the screen. Turning that on for everybody who never wrote a
+`pipelines:` block would be a silent change to what the app looks at, and that
+is the one kind of change that has to be asked for by name. Write the line and
+you have it.
+
+Worth knowing before you write it: **while the stage is on, the log holds what
+was on screen when you dictated.** That is deliberate — the whole point is to
+find out what is worth reading off a screen, and that judgement cannot be made
+from "1840 chars" — but it is a real consequence and `~/Library/Logs` is a real
+file.
+
+### Seeing what it captures
+
+`--pipeline` cannot show you. TCC pins the accessibility grant to the app
+bundle, so a binary run from a terminal is attributed to the terminal and gets
+nothing; the stage declines every time and `tests/pipelines/context.yaml` scores
+that declining rather than a stub.
+
+`--peek` can, because it runs inside the bundle:
+
+```sh
+open -na ParrotFlowDev --args --peek 6
+# click the window you want, then read the log
+```
+
+It prints what the stage would publish, in full, under `as context:`.
+
 ## Apps
 
 `app:` runs a stage only where you want it — the rewrite that belongs in a
@@ -794,6 +905,75 @@ text before and after.
 If the model is not running, the prompt does not exist, or the call fails, the
 transcript comes back exactly as it arrived. A dictation tool can afford to
 skip a stage and cannot afford to lose a sentence.
+
+### Reading variables from a prompt
+
+A prompt names a variable the way a condition does. Anything a stage published
+is reachable, as long as that stage runs earlier in the pipeline.
+
+```yaml
+pipeline:
+  - context
+  - transform: rewrite
+
+transforms:
+  - name: rewrite
+    prompt: |
+      Rewrite the dictation as a clear instruction.
+
+      This is on the speaker's screen right now:
+      {{context.text}}
+
+      Use it to spell names and paths. Never quote it back.
+```
+
+`{{context.text}}`, `{{numbers.count}}`, `{{language}}`, `{{app}}` — the same
+names `when:` reads, so there is one vocabulary rather than two.
+
+**A name with nothing behind it takes its paragraph with it.** Most variables
+are absent most of the time: `context` only reads terminals, so in Slack that
+prompt is just the first line and the last. Substituting an empty string would
+leave `This is on the speaker's screen right now:` over a blank, which tells a
+model there is a screen and then shows it none — and a small model asked to use
+something that is not there will invent it.
+
+The paragraph is the unit because that is what a prompt is written in. A heading
+and its content are one thought, and dropping only the line with the placeholder
+would keep the promise and remove the thing promised. One empty name takes the
+whole paragraph even if another in it resolved.
+
+So **give a placeholder its own paragraph, beside at least one paragraph that
+has none.** A prompt where every paragraph holds a placeholder cannot be emptied
+— an empty system message is no instruction at all, and the model would be left
+with the transcript and whatever it felt like doing to it — so in that one case
+the paragraphs stay and the gaps are simply blank. That is the shape the rule
+cannot save.
+
+Score a prompt's placeholders without a model:
+
+```sh
+$PF --compose 'On screen:\n{{context.text}}\n\nBe brief.' 'context.text=hello'
+scripts/check-compose.sh
+```
+
+**`{{instruction}}` is one of these names, not a special case.** It holds the
+spoken instruction from ["hey parrot, make that a list"](#an-instruction-inside-a-dictation).
+In a pipeline there is no spoken instruction, so it is always empty there and
+takes its paragraph with it like any other name.
+
+### Two things to know before interpolating a screen
+
+`{{context.text}}` puts up to 2000 characters of your terminal into the system
+message. That is the point, and it has two consequences worth stating.
+
+If the screen holds something shaped like an instruction, the model may follow
+it. A Claude Code pane is exactly where arbitrary text lives, so this is
+prompt injection from your own screen.
+
+And it goes wherever `llm.endpoint` points. On localhost that is the same
+machine. Point it at a hosted model and the interpolation is the moment your
+screen leaves the machine. The `context` stage alone never sends anything
+anywhere; `{{context.text}}` in a prompt is what does.
 
 ## Why there is no `dates` or `digits` prompt
 

--- a/scripts/check-compose.sh
+++ b/scripts/check-compose.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Scores what a prompt says once the scope is folded into it, against
+# tests/compose-cases.txt.
+#
+#   scripts/check-compose.sh
+#
+# Deterministic and offline. No model is consulted, because what is being
+# checked happens before any model sees anything: which placeholders were
+# filled, and which paragraphs disappeared because there was nothing to fill
+# them with. What the model then does with the prompt is scored by the
+# validate-*.py sets, which need Ollama running and cannot give an exact answer.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/release/ParrotFlow"
+CASES="$ROOT/tests/compose-cases.txt"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+
+pass=0; total=0; failed=""
+while IFS='~' read -r template assignments expected; do
+  case "$template" in \#*) continue;; esac
+  [ -z "${template// }" ] && continue
+  total=$((total + 1))
+
+  # Leading and trailing spaces are the separator's, not the field's. A value
+  # with a real trailing space would need quoting, and no case needs one.
+  template="$(printf '%s' "$template" | sed 's/^ *//; s/ *$//')"
+  assignments="$(printf '%s' "$assignments" | sed 's/^ *//; s/ *$//')"
+  expected="$(printf '%s' "$expected" | sed 's/^ *//; s/ *$//')"
+
+  # `|` separates assignments so a value may contain spaces. The empty case is
+  # a real one — a template with no placeholders takes no variables at all.
+  args=()
+  if [ -n "$assignments" ]; then
+    IFS='|' read -r -a vars <<< "$assignments"
+    for v in "${vars[@]}"; do [ -n "$v" ] && args+=("$v"); done
+  fi
+
+  got="$("$BIN" --compose "$template" ${args[@]+"${args[@]}"} 2>/dev/null)"
+  want="$(printf '%b' "${expected//\\n/\\n}")"
+
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1))
+  else
+    failed="$failed\n  template: $template\n  vars:     $assignments\n  want:     $(printf '%s' "$want" | tr '\n' '|')\n  got:      $(printf '%s' "$got" | tr '\n' '|')\n"
+  fi
+done < "$CASES"
+
+if [ -n "$failed" ]; then printf '%b' "$failed"; fi
+echo
+echo "  $pass/$total"
+[ "$pass" = "$total" ]

--- a/scripts/check-context.sh
+++ b/scripts/check-context.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Scores what the `context` stage would publish for a given screen, against
+# tests/context-cases.txt.
+#
+#   scripts/check-context.sh
+#
+# Deterministic and offline. The stage has two string steps — cut the input box
+# off, keep the tail — and they are the only part of it that has an exact
+# answer. The capture itself depends on TCC and on whatever is genuinely in
+# front, so it is scored by `--peek` on a real screen and not faked here.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/release/ParrotFlow"
+CASES="$ROOT/tests/context-cases.txt"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+
+pass=0; total=0; failed=""
+while IFS='~' read -r screen limit flag expected; do
+  case "$screen" in \#*) continue;; esac
+  [ -z "${screen// }" ] && continue
+  total=$((total + 1))
+
+  # Trailing spaces are the separator's. A screen that ends in a real space
+  # writes it before the tilde and keeps it, which the bare-shell case needs.
+  limit="$(printf '%s' "$limit" | tr -d ' ')"
+  flag="$(printf '%s' "$flag" | tr -d ' ')"
+  screen="$(printf '%s' "$screen" | sed 's/ *$//')"
+  expected="$(printf '%s' "$expected" | sed 's/^ *//; s/ *$//')"
+
+  out="$("$BIN" --context-test "$screen" "$limit" 2>/dev/null)"
+  gotFlag="$(printf '%s' "$out" | head -1)"
+  gotText="$(printf '%s' "$out" | tail -n +2)"
+  wantText="$(printf '%b' "${expected//\\n/\\n}")"
+
+  if [ "$gotFlag" = "$flag" ] && [ "$gotText" = "$wantText" ]; then
+    pass=$((pass + 1))
+  else
+    failed="$failed\n  screen: $screen\n  want:   $flag | $(printf '%s' "$wantText" | tr '\n' '|')\n  got:    $gotFlag | $(printf '%s' "$gotText" | tr '\n' '|')\n"
+  fi
+done < "$CASES"
+
+if [ -n "$failed" ]; then printf '%b' "$failed"; fi
+echo
+echo "  $pass/$total"
+[ "$pass" = "$total" ]

--- a/tests/compose-cases.txt
+++ b/tests/compose-cases.txt
@@ -1,0 +1,89 @@
+# What a prompt says once the scope is folded into it. Run with
+# scripts/check-compose.sh.
+#
+# No model is involved and none should be. A prompt has two halves that fail in
+# ways that look identical from the outside — what it was asked, and what the
+# model did with it — and only the first has an exact answer. This set is that
+# half. The validate-*.py sets score the other one.
+#
+# Format, tilde-separated:
+#
+#   template ~ name=value|name=value ~ expected
+#
+# `\n` is a newline in both the template and the expectation, because the rule
+# being scored is about paragraphs and a case file is line-oriented.
+
+# --- the ordinary case --------------------------------------------------
+On screen:\n{{context.text}} ~ context.text=the build failed ~ On screen:\nthe build failed
+
+# A string arrives unquoted. `Scope.Value.described` puts quotes around one for
+# a log line, and reusing it here would hand the model a quotation.
+say {{context.text}} ~ context.text=hello ~ say hello
+
+# --- nothing to put in, so the paragraph goes ----------------------------
+# An empty value and a name the scope never had are the same answer. A stage
+# that declines publishes its keys emptied, so a prompt that told the two apart
+# would behave one way in Slack and another in a terminal showing nothing.
+Rewrite it.\n\nOn screen:\n{{context.text}}\n\nBe brief. ~ context.text= ~ Rewrite it.\n\nBe brief.
+Rewrite it.\n\nOn screen:\n{{context.text}}\n\nBe brief. ~ language=en ~ Rewrite it.\n\nBe brief.
+
+# The heading goes with the value. Dropping only the line that held the
+# placeholder would leave the promise and take the thing promised.
+Rewrite.\n\nOn screen:\n{{context.text}} ~ context.text= ~ Rewrite.
+
+# One empty placeholder takes the paragraph even though the other resolved. A
+# paragraph is one claim; half of it is not a smaller claim.
+Rewrite.\n\n{{language}} and {{context.text}} ~ language=en|context.text= ~ Rewrite.
+
+# --- position ------------------------------------------------------------
+# Dropping the first paragraph must not leave the blank line that followed it.
+{{context.text}}\n\nBe brief. ~ context.text= ~ Be brief.
+
+# Nor the last one the blank line before it.
+Be brief.\n\n{{context.text}} ~ context.text= ~ Be brief.
+
+# The middle one closes the gap rather than doubling it.
+One.\n\n{{context.text}}\n\nThree. ~ context.text= ~ One.\n\nThree.
+
+# --- no placeholders at all ---------------------------------------------
+# The overwhelming majority of prompts. Nothing may move.
+Rewrite it.\n\nBe brief. ~  ~ Rewrite it.\n\nBe brief.
+
+# --- the four scalars ----------------------------------------------------
+count {{numbers.count}} ~ numbers.count=3 ~ count 3
+truncated {{context.truncated}} ~ context.truncated=true ~ truncated true
+ratio {{asr.confidence}} ~ asr.confidence=0.75 ~ ratio 0.75
+
+# `false` is a value, not an absence. It renders, and its paragraph stays —
+# only empty and missing drop.
+Rewrite.\n\nok {{context.ok}} ~ context.ok=false ~ Rewrite.\n\nok false
+
+# --- the spoken instruction is an ordinary name --------------------------
+# `{{instruction}}` is not special-cased any more. On the voice path it is
+# filled; in a pipeline it is always empty, so it takes its paragraph with it
+# exactly like any other name.
+Do this:\n{{instruction}}\n\nBe brief. ~ instruction=make it a list ~ Do this:\nmake it a list\n\nBe brief.
+Do this:\n{{instruction}}\n\nBe brief. ~ instruction= ~ Be brief.
+
+# --- shape -------------------------------------------------------------
+# Spaces inside the braces are the kind of thing someone writes once and never
+# thinks about again.
+say {{ context.text }} ~ context.text=hi ~ say hi
+
+# Two names on one line, both filled, in order.
+Rewrite.\n\n{{language}}: {{context.text}} ~ language=fr|context.text=le build ~ Rewrite.\n\nfr: le build
+
+# An unclosed brace is not a placeholder and must survive untouched, or a prompt
+# that talks about braces gets edited for talking about braces.
+use {{ and see ~ context.text=x ~ use {{ and see
+
+# --- the limit of the rule ----------------------------------------------
+# When every paragraph would be dropped, none is. An empty system message is not
+# a smaller instruction, it is no instruction — the model would be left with the
+# transcript and nothing else, and whatever it returned would be applied.
+#
+# So this is the shape the rule cannot save, and the reason the documentation
+# says to give a placeholder its own paragraph next to one that has none. The
+# dangling heading below is the cost of not deleting somebody's whole prompt.
+On screen:\n{{context.text}} ~ context.text= ~ On screen:
+see {{context.text}} now ~ context.text= ~ see  now

--- a/tests/context-cases.txt
+++ b/tests/context-cases.txt
@@ -1,0 +1,53 @@
+# What the `context` stage would publish for a given screen. Run with
+# scripts/check-context.sh.
+#
+# The two string steps, in the order the stage runs them: cut the input box off
+# the bottom, then keep the tail. Neither touches accessibility, so both have an
+# exact answer — and they are the only part of this stage that does. What is
+# genuinely on screen is at the mercy of TCC and of whatever is in front, and a
+# fixture that stubbed a real screen would be scoring the stub. See
+# tests/pipelines/context.yaml.
+#
+# Format, tilde-separated:
+#
+#   screen ~ limit ~ truncated|whole ~ expected
+#
+# `\n` is a newline in the screen and in the expectation.
+
+# --- the input box comes off ---------------------------------------------
+# A TUI draws the box between the last two rules, and everything from the
+# second-to-last rule down is the field being dictated into. Keeping it would
+# hand a stage the sentence it is already holding as `text`.
+the answer is 42\n\n╭────╮\nwhat next\n╰────╯ ~ 2000 ~ whole ~ the answer is 42
+
+# No rules at all is a bare shell rather than a TUI. The last non-empty row is
+# the prompt line and goes for the same reason.
+make failed\nerror here\n$  ~ 2000 ~ whole ~ make failed\nerror here
+
+# Blank rows top and bottom are padding the terminal drew, not silence anyone
+# meant, so `context.lines` counts rows of content.
+\n\nreal content\n\n\nprompt$ ~ 2000 ~ whole ~ real content
+
+# --- the tail ------------------------------------------------------------
+# Whole rows from the end. The rows nearest the box are the ones the sentence
+# is answering.
+one\ntwo\nthree\nprompt$ ~ 10 ~ truncated ~ two\nthree
+
+# Under the limit is not truncated, and must say so — `context.truncated` is
+# how a prompt knows whether it is seeing all of something.
+abcd\nefgh\nprompt$ ~ 9 ~ whole ~ abcd\nefgh
+
+# --- a row with no boundary inside it ------------------------------------
+# The row boundary is the preferred cut, not the only one. A single row longer
+# than the whole budget used to come through whole, because the guard that
+# stopped the result being empty had no upper bound on the first row kept. The
+# limit is how much of the screen may be disclosed at all — a wrapped terminal
+# keeps rows near the pane width, so this is the log line or the pasted blob
+# that did not wrap, and it is exactly the shape worth bounding.
+#
+# Cut from the front, keeping the end, like the function around it.
+ABCDEFGHIJKLMNOPQRSTUVWXYZ\nprompt$ ~ 10 ~ truncated ~ QRSTUVWXYZ
+
+# With a row that does fit below it, the boundary is available again and the
+# oversized row is simply left out.
+ABCDEFGHIJKLMNOPQRSTUVWXYZ\nshort\nprompt$ ~ 10 ~ truncated ~ short

--- a/tests/pipeline-cases.yaml
+++ b/tests/pipeline-cases.yaml
@@ -452,6 +452,54 @@ cases:
       dotted.ran: true
       dotted.changed: true
 
+  # --- context, which from here can only decline --------------------------
+  #
+  # See tests/pipelines/context.yaml for why the capture itself is not scored.
+  # What these hold down is the rule that survives that: a stage which has
+  # nothing to publish costs nothing and hides nothing.
+  #
+  # The reason is always the same one here, and that is the point rather than a
+  # limitation. The stage publishes what was captured when the hotkey went down,
+  # and `--pipeline` has no hotkey — so this is also the scored answer to "what
+  # does the stage do when it is reached by a path that never pressed anything".
+  - name: context declines with no press to publish, and says which
+    pipeline: context
+    app: Ghostty com.mitchellh.ghostty
+    input: super base has twenty one users
+    expect: Supabase has 21 users
+    expect_vars:
+      context.ran: true
+      context.ok: false
+      context.chars: 0
+      context.declined: nothing was captured when the hotkey went down
+
+  # The stage sits between `replacements` and `numbers` in the fixture, so this
+  # case is also the answer to "does a stage that publishes variables disturb
+  # the ones either side of it". Both still fire.
+  - name: a declining context leaves the stages around it alone
+    pipeline: context
+    app: Ghostty com.mitchellh.ghostty
+    input: super base has twenty one users
+    expect: Supabase has 21 users
+    expect_vars:
+      context.changed: false
+      replacements.count: 1
+      numbers.ran: true
+
+  # A non-terminal used to decline here for its own reason. It cannot any more:
+  # the terminal check moved to the press, so from `--pipeline` every app gets
+  # `noPress` and an app-specific case would pass without testing anything. The
+  # case that remains is the one still worth holding: whatever the app, the
+  # transcript comes out untouched.
+  - name: context leaves a non-terminal transcript exactly as it arrived
+    pipeline: context
+    app: Slack com.tinyspeck.slackmacgap
+    input: super base has twenty one users
+    expect: Supabase has 21 users
+    expect_vars:
+      context.ok: false
+      context.changed: false
+
 # Pipelines that must not load at all.
 #
 # Scored separately because the property is different: these never reach a
@@ -478,3 +526,10 @@ refused:
   - name: a transform named after the transcription metadata is refused
     pipeline: reserved-name
     expect_problem: would file its variables where asr already is
+
+  # The same rule, for the name a prompt reads the spoken instruction from. It
+  # is a bare value and would also be a namespace prefix, which is exactly why
+  # `text` is on that list.
+  - name: a transform named after the spoken instruction is refused
+    pipeline: reserved-instruction
+    expect_problem: would file its variables where instruction already is

--- a/tests/pipelines/context.yaml
+++ b/tests/pipelines/context.yaml
@@ -1,0 +1,31 @@
+# The `context` stage, scored for the only thing a fixture can score about it.
+#
+# What it captures cannot be tested from here and deliberately is not faked.
+# Two reasons, and the first is now the binding one: the screen is read when the
+# hotkey goes down, and `--pipeline` has no hotkey, so there is never a capture
+# to publish. Behind that sits TCC, which pins the accessibility grant to the app
+# bundle — a binary run from a terminal is attributed to the terminal and gets
+# nothing even when it does look. A fixture that stubbed the screen would be
+# scoring the stub.
+#
+# What is worth scoring is the declining itself, because that is the rule the
+# whole app is built on: a stage that cannot do its job leaves the transcript
+# exactly as it arrived. This stage has more ways to not do its job than any
+# other — no permission, wrong app in front, not a terminal — and every one of
+# them has to come out here.
+#
+# Read the live capture with `--peek` instead. It runs inside the bundle, so it
+# has the grant, and it prints exactly what this stage would publish.
+languages: [en]
+
+replacements:
+  Supabase: [super base]
+
+pipeline:
+  # Before and after, on purpose. `context` sits in the middle of a real
+  # pipeline in the config it is written for, and a stage that publishes
+  # variables must not disturb the stages either side of it — including when
+  # it declines, which from here it always does.
+  - replacements
+  - context
+  - numbers

--- a/tests/pipelines/refused/reserved-instruction.yaml
+++ b/tests/pipelines/refused/reserved-instruction.yaml
@@ -1,0 +1,17 @@
+# A transform named after the spoken instruction.
+#
+# `instruction` became a bare name in the scope when prompts learned to read it —
+# `PromptRunner.compose` puts the spoken instruction there so `{{instruction}}`
+# is an ordinary lookup rather than a word with its own rule. That makes it the
+# same shape as `text`: a path that is both a value and a prefix. A transform
+# called `instruction` would contribute `instruction.count` while `instruction`
+# itself is a string, and there is no sensible answer to what `{{instruction}}`
+# then means.
+languages: [en]
+transforms:
+  - name: instruction
+    description: collides with the spoken instruction
+    command: counter.py --count 1
+    returns: json
+pipeline:
+  - transform: instruction


### PR DESCRIPTION
Dictating into a terminal, the sentence is usually about what is already there — a file path, a function name, an error three lines up. The pipeline could not see any of it.

Two parts, shipped together because the second is what makes the first useful.

## 1. `context`, a new stage

Reads the screen behind the field and publishes it.

| variable | |
|---|---|
| `context.text` | the screen, minus the input box, last 2000 chars on a row boundary |
| `context.chars`, `.lines`, `.truncated` | what was read |
| `context.ok`, `.declined` | whether it read, and why not |

It never touches the transcript. That is by construction rather than by outcome, so `context.changed` is false on every run and means it — a stage that could put the screen into the transcript could paste your terminal into a chat message.

**It reads when the hotkey goes down, not when the stage runs.** The press is the last moment the pane is known: by then there has been a transcription and possibly a model call, and focus may be elsewhere. Reading late answers *what is on screen now* when the question is *what were you looking at when you decided to say this*.

Measured over 17 dictations: the two readings agreed 15 times, and both differences were under 35 characters of spinner and token counter. So the earlier one loses nothing and is the one that is certain. The read costs ~1ms on a small pane and 36–39ms on a long scrollback, so it runs off the main thread, and only when some pipeline names the stage.

**Terminals only.** A terminal's accessibility value *is* its visible screen, so the context is one call. A Slack composer publishes its own contents and nothing above it — the messages would need a walk of the window's children, hundreds of round trips per app. Worth building, not the same feature, and one stage meaning "cheap" in one app and "expensive" in the next is not one anybody can budget for. Everything else declines out loud with a reason.

**Not in the default pipeline.** It reads the screen. Turning that on for everyone who never wrote a `pipelines:` block would be a silent change to what the app looks at.

## 2. A prompt can read the scope

```yaml
prompt: |
  Rewrite the dictation as a clear instruction.

  This is on the speaker's screen right now:
  {{context.text}}

  Use it to spell names and paths. Never quote it back.
```

`{{context.text}}`, `{{numbers.count}}`, `{{language}}` — the same names `when:` reads, so there is one vocabulary rather than two. `{{instruction}}` stops being special-cased and becomes an ordinary lookup, which is also how it becomes visible that in a pipeline it was always empty.

**A name with nothing behind it takes its paragraph with it.** Most variables are absent most of the time; in Slack that middle paragraph is simply not there, heading included. Substituting an empty string would leave a heading over a blank, which tells a small model there is a screen and then shows it none.

The rule cannot save a prompt whose *every* paragraph holds a placeholder — there none is dropped, because an empty system message is not a smaller instruction. Two cases pin that down and the docs say to give a placeholder its own paragraph.

## Testing

```
scripts/check-compose.sh    21/21   new — offline, no model
scripts/check-pipeline.sh   54/54   +4
scripts/check-numbers.sh    97/97
scripts/check-dotted.sh     54/54
scripts/check-split.sh      14/14
scripts/check-replacements.sh 23/23
scripts/check-transform-folders.sh 12/12
scripts/check-default-config.sh ✓
```

`--compose "<template>" name=value …` renders a template with no model involved. What the model then does with the prompt is the other half and has no exact answer.

The capture itself is not scored and deliberately not faked: `--pipeline` has no hotkey, so there is never a capture to publish, and behind that TCC credits a terminal-run binary to the terminal. A fixture stubbing the screen would be scoring the stub. `--peek` shows a live capture.

## Two things to know before turning it on

- While the stage is enabled, `~/Library/Logs/ParrotFlow.log` holds what was on screen when you dictated.
- `{{context.text}}` in a prompt is the moment that screen travels to whatever `llm.endpoint` points at. The stage on its own never sends anything anywhere.

## Not in this PR

Where the text lands is unchanged. Dictate into one pane, switch before the transcript is ready, and the ⌘V still goes to the pane you switched to. The fix is to put the transcript on the clipboard rather than paste it somewhere you did not aim, and it belongs next to the paste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwuvcJpErG3tV8e2itb3ES