### PR TITLE
feat: a vocabulary that is learnt rather than written

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -5,6 +5,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private var config = Config()
     private var configWatcher: FileWatcher?
+    private var vocabularyWatcher: FileWatcher?
 
     private let hotKeys = HotKeyManager()
     private let recorder = Recorder()
@@ -419,6 +420,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func watchConfig() {
         try? ConfigStore.createIfMissing()
         configWatcher = FileWatcher(url: ConfigStore.fileURL) { [weak self] in
+            self?.loadConfig(announceErrors: true)
+        }
+        // The vocabulary is a second file and needs its own watch. It is the
+        // one the app writes to itself — a term learnt from a correction, a
+        // floor measured from a recording — so "takes effect on the next
+        // restart" is the wrong behaviour for the file most likely to change
+        // while the app is running.
+        vocabularyWatcher = FileWatcher(url: ConfigStore.vocabularyURL) { [weak self] in
             self?.loadConfig(announceErrors: true)
         }
     }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -6,6 +6,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var config = Config()
     private var configWatcher: FileWatcher?
     private var vocabularyWatcher: FileWatcher?
+    private var transformWatchers: [FileWatcher] = []
 
     private let hotKeys = HotKeyManager()
     private let recorder = Recorder()
@@ -218,6 +219,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
         applyConfig()
+        // After the load, not with the other watchers: a transform can be
+        // renamed, removed or pointed at a different file, so which files are
+        // worth watching is only known once the config has been read.
+        watchTransformFiles()
     }
 
     /// Says a config problem once, at the moment it appears.
@@ -429,6 +434,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // while the app is running.
         vocabularyWatcher = FileWatcher(url: ConfigStore.vocabularyURL) { [weak self] in
             self?.loadConfig(announceErrors: true)
+        }
+    }
+
+    /// Every file a transform reads its body from — `prompt: { path: slack.md }`
+    /// and `replace: { path: … }`.
+    ///
+    /// Those are read once, when the config is decoded, so without this a
+    /// prompt edit does nothing until `config.yaml` happens to be saved. That
+    /// is the wrong way round: a prompt is the file somebody iterates on,
+    /// twenty times in a row, and `config.yaml` is the one they touch monthly.
+    ///
+    /// Rebuilt on every load rather than added to, because a transform can be
+    /// renamed, removed, or pointed at a different file, and a watcher left
+    /// behind would reload on a file nothing reads.
+    private func watchTransformFiles() {
+        transformWatchers = config.transforms.compactMap { transform in
+            guard let source = transform.source else { return nil }
+            return FileWatcher(url: source.url) { [weak self] in
+                self?.loadConfig(announceErrors: true)
+            }
         }
     }
 

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -61,9 +61,153 @@ struct Config: Decodable, Equatable {
     /// 18/19 — and `confirm` is what makes the residue survivable.
     var freeForm: Bool = true
 
+    /// Read from `vocabulary.yaml` beside the config, not from `config.yaml`.
+    /// It is maintained by the app rather than by hand — see `Vocabulary`.
+    var vocabulary: Vocabulary = Vocabulary()
+
     enum CodingKeys: String, CodingKey {
         case hotkey, audio, feedback, transcription, llm, transforms, prompts, updates
         case freeForm = "free_form"
+    }
+
+    /// The words you dictate that the recogniser gets wrong, and what the app
+    /// has learnt about each one.
+    ///
+    /// Not only names. A colleague's surname, a drug brand, an internal
+    /// project, a library, an acronym, or any word a non-native speaker says in
+    /// a way the model was not trained on — the common property is that it
+    /// sounds like something else, not that it is a proper noun.
+    ///
+    /// Its own file because the two halves have different owners. `config.yaml`
+    /// is written by a person and read by the app; `vocabulary.yaml` is written
+    /// by the app — the correction panel, `--learn`, the calibrate skill — and
+    /// only read by a person. Mixing them means a hand edit and a learnt entry
+    /// land in the same file, and one of them eventually loses.
+    struct Vocabulary: Decodable, Equatable {
+
+        /// Whether names are matched by sound at all. Off costs nothing; on
+        /// pulls a ~98 MB model on first use.
+        var acoustic: Bool = false
+
+        /// How close a decoded word must sound to a name before it is replaced,
+        /// unless the name says otherwise.
+        ///
+        /// 0.75 is the measured default on this machine. Below it, ordinary
+        /// words start being overwritten: "vessel" lands 0.67 from "Vercel"
+        /// and "Alama" 0.67 from "Ollama".
+        var minSimilarity: Float = 0.75
+
+        /// One term, and what is known about it.
+        ///
+        /// `floor` is the similarity this term needs, overriding the default.
+        /// `off` means never match by sound at all — the honest setting when
+        /// the decoder writes the term and an ordinary word identically.
+        /// Measured here: "Claude" and "cloud" both come back as "cloud", so
+        /// no threshold can separate them.
+        ///
+        /// `heard` is for renderings no floor can reach. "Prezi" is 0.33 from
+        /// "Praisy" and would need a floor that swallowed every "praise"; as an
+        /// exact rule it costs nothing and cannot misfire.
+        struct Term: Decodable, Equatable {
+            var floor: Float?
+            /// `floor: off` — never matched by sound, only by `heard`.
+            var never = false
+            var heard: [String] = []
+
+            init(floor: Float? = nil, never: Bool = false, heard: [String] = []) {
+                self.floor = floor
+                self.never = never
+                self.heard = heard
+            }
+
+            enum CodingKeys: String, CodingKey { case floor, heard }
+
+            /// Four shapes, because most terms need none of this:
+            ///
+            ///     Tasmeen:                              nothing to say
+            ///     Mirza: 0.85                           a floor
+            ///     Praisy: [Prissy, Pressy]              renderings
+            ///     Claude: {floor: off, heard: [cloud]}  both
+            init(from decoder: Decoder) throws {
+                if let single = try? decoder.singleValueContainer() {
+                    if single.decodeNil() { self.init(); return }
+                    if let number = try? single.decode(Float.self) {
+                        self.init(floor: number); return
+                    }
+                    if let listed = try? single.decode([String].self) {
+                        self.init(heard: listed); return
+                    }
+                }
+                let c = try decoder.container(keyedBy: CodingKeys.self)
+                let heard = try c.decodeIfPresent([String].self, forKey: .heard) ?? []
+                // `off` rather than a magic number. The previous spelling was
+                // `1.0`, which reads as maximum strictness and meant the
+                // opposite — never fire at all.
+                // `off` is a YAML 1.1 boolean, not a string — as are `on`,
+                // `yes` and `no`. Written as `floor: off` it arrives here as
+                // `false`, and reading it only as a string threw, which took
+                // the whole file down silently.
+                if let flag = (try? c.decodeIfPresent(Bool.self, forKey: .floor)) ?? nil {
+                    self.init(floor: nil, never: flag == false, heard: heard)
+                    return
+                }
+                if let word = (try? c.decodeIfPresent(String.self, forKey: .floor)) ?? nil {
+                    self.init(floor: nil, never: word.lowercased() == "off", heard: heard)
+                    return
+                }
+                self.init(
+                    floor: try c.decodeIfPresent(Float.self, forKey: .floor),
+                    heard: heard
+                )
+            }
+        }
+
+        var terms: [String: Term] = [:]
+
+        enum CodingKeys: String, CodingKey {
+            case acoustic, terms
+            case minSimilarity = "min_similarity"
+        }
+
+        init() {}
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            self.init()
+            if let on = try c.decodeIfPresent(Bool.self, forKey: .acoustic) {
+                acoustic = on
+            }
+            if let floor = try c.decodeIfPresent(Float.self, forKey: .minSimilarity) {
+                minSimilarity = floor
+            }
+            terms = try c.decodeIfPresent([String: Term].self, forKey: .terms) ?? [:]
+        }
+    }
+
+    /// The terms given to the decoder as acoustic context, each with its floor.
+    ///
+    /// Short and non-alphabetic terms are dropped. A four-character term
+    /// free-start aligns to almost any run of frames, which is what makes short
+    /// terms the over-firing ones, and a name carrying a dot or a digit is not
+    /// something the decoder could have produced.
+    var vocabularyTerms: [(text: String, minSimilarity: Float)] {
+        vocabulary.terms
+            .filter { term, entry in
+                !entry.never && term.count >= 5 && term.allSatisfy(\.isLetter)
+            }
+            .map { ($0.key, $0.value.floor ?? vocabulary.minSimilarity) }
+            .sorted { $0.0 < $1.0 }
+    }
+
+    /// The exact rules the vocabulary file contributes. Flattened the same way
+    /// `transcription.replacements` is, so the substitution pass takes both and
+    /// never needs to know which file a rule came from.
+    var vocabularyRules: [Transcription.Rule] {
+        vocabulary.terms
+            .flatMap { term, entry in
+                entry.heard.map { Transcription.Rule(source: $0, replacement: term) }
+            }
+            .sorted { $0.source < $1.source }
     }
 
     /// One entry of `transforms:` as it is written, before it is known to be
@@ -1231,9 +1375,36 @@ struct Config: Decodable, Equatable {
     /// wasn't. Announcing is not complaining, and the two cannot share a list
     /// that one end of the app treats as failure.
     func notices() -> [String] {
-        let said: [String] = transforms.compactMap { transform in
+        var said: [String] = transforms.compactMap { transform in
             guard case .command(let command) = transform.body else { return nil }
             return "transforms: \"\(transform.name)\" runs a program — \(command)"
+        }
+
+        // The vocabulary is learnt rather than written, so it is the part of
+        // the configuration nobody remembers the contents of. Printed in full.
+        let rules = vocabularyRules.count
+        if !vocabulary.terms.isEmpty {
+            let byEar = vocabularyTerms
+            said.append("vocabulary: \(vocabulary.terms.count) terms in"
+                + " \(ConfigStore.vocabularyURL.lastPathComponent),"
+                + " \(byEar.count) matched by sound, \(rules) by rule")
+            if vocabulary.acoustic, !byEar.isEmpty {
+                said.append("vocabulary: by sound at floor \(vocabulary.minSimilarity) — "
+                    + byEar.map { $0.minSimilarity == vocabulary.minSimilarity
+                        ? $0.text : "\($0.text) \($0.minSimilarity)" }
+                        .joined(separator: ", "))
+            }
+            if !vocabulary.acoustic, !byEar.isEmpty {
+                said.append("vocabulary: `acoustic: false`, so \(byEar.count) names"
+                    + " are only matched by their `heard` rules")
+            }
+            let silent = vocabulary.terms
+                .filter { $0.value.never && $0.value.heard.isEmpty }
+                .keys.sorted()
+            if !silent.isEmpty {
+                said.append("vocabulary: \(silent.joined(separator: ", ")) —"
+                    + " `floor: off` and no `heard`, so nothing can match them")
+            }
         }
         return said
     }
@@ -1281,6 +1452,12 @@ enum ConfigStore {
 
     static var fileURL: URL {
         directory.appendingPathComponent("config.yaml")
+    }
+
+    /// The learnt half. Missing is normal and means an empty vocabulary — it
+    /// is written the first time something is learnt, not at install.
+    static var vocabularyURL: URL {
+        directory.appendingPathComponent("vocabulary.yaml")
     }
 
     /// Where every transform's folder sits — `TransformFolder` resolves the
@@ -1333,10 +1510,69 @@ enum ConfigStore {
             try defaultCodeIdentifiersCases.write(to: cases, atomically: true, encoding: .utf8)
             Log.write("config: wrote transforms/code_identifiers/cases.yaml")
         }
+        // The vocabulary, empty but explained. Written so the file exists to
+        // be found and read — a person who never dictates a mangled word
+        // should still be able to see what the app would learn about them, and
+        // an empty file with a header does that better than a missing one.
+        if !fm.fileExists(atPath: vocabularyURL.path) {
+            try fm.createDirectory(at: directory, withIntermediateDirectories: true)
+            try defaultVocabularyYAML.write(
+                to: vocabularyURL, atomically: true, encoding: .utf8
+            )
+            Log.write("config: wrote vocabulary.yaml")
+        }
+
         guard !fm.fileExists(atPath: fileURL.path) else { return }
         try fm.createDirectory(at: directory, withIntermediateDirectories: true)
         try defaultYAML.write(to: fileURL, atomically: true, encoding: .utf8)
     }
+
+    /// What `vocabulary.yaml` says before anything has been learnt.
+    ///
+    /// Every term is commented out. A vocabulary that arrives with entries in
+    /// it is a vocabulary tuned for somebody else's voice, and the floors are
+    /// the part that cannot be guessed — "Vercel" needs 0.75 on one person and
+    /// would overwrite "vessel" on another.
+    static let defaultVocabularyYAML = """
+    # ParrotFlow vocabulary — words you say that the recogniser gets wrong.
+    #
+    # Not only names. A colleague's surname, a drug brand, an internal project,
+    # a library, an acronym, or any word you pronounce in a way the model was
+    # not trained on. What they have in common is that they sound like
+    # something else.
+    #
+    # DO NOT EDIT UNLESS YOU REALLY KNOW WHAT YOU ARE DOING.
+    #
+    # This file is learnt while you use the app. Entries arrive when you correct
+    # a term, and the floors are measured from your own voice — not chosen. A
+    # wrong number here does not fail loudly: it silently rewrites words you
+    # meant, in every dictation, until you notice.
+    #
+    # If you want to change something, the safe move is to let the app measure
+    # again rather than to pick a number.
+    #
+    #   floor   how close a word must sound to the term before it is replaced,
+    #           from 0 to 1. Left out, the default below applies. `off` means
+    #           never match by sound — the setting for a term the recogniser
+    #           writes identically to an ordinary word, where no number helps.
+    #   heard   renderings no floor can reach, matched exactly.
+
+    # Matching by sound needs a ~98 MB model, pulled on first use.
+    acoustic: false
+    min_similarity: 0.75
+
+    terms: {}
+    #  Tasmeen:                     # nothing close in your speech
+    #  Mirza:
+    #    floor: 0.85                # "Mira" lands at 0.80
+    #  Praisy:
+    #    floor: 0.90                # "praise" lands at 0.83
+    #    heard: [Prissy, Pressy]
+    #  Claude:
+    #    floor: off                 # "cloud" both ways — no floor works
+    #    heard: [cloud]
+
+    """
 
     /// The shipped copy of examples/transforms/code_identifiers/cases.yaml.
     ///
@@ -2180,9 +2416,27 @@ if __name__ == "__main__":
         // A relative `command:` is relative to the file that declared it, so a
         // config carries its scripts beside it and a `--pipeline` fixture
         // carries its own.
-        return try YAMLDecoder().decode(
+        var config = try YAMLDecoder().decode(
             Config.self, from: text, userInfo: [.configDirectory: directory]
         )
+        config.vocabulary = loadVocabulary()
+        return config
+    }
+
+    /// `vocabulary.yaml`, or an empty one. A vocabulary that will not parse is
+    /// reported and skipped rather than thrown: it is learnt state, and losing
+    /// dictation entirely because one line of it is malformed would be the
+    /// wrong trade.
+    static func loadVocabulary() -> Config.Vocabulary {
+        guard let text = try? String(contentsOf: vocabularyURL, encoding: .utf8),
+              !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return Config.Vocabulary() }
+        do {
+            return try YAMLDecoder().decode(Config.Vocabulary.self, from: text)
+        } catch {
+            Log.write("vocabulary.yaml could not be read (\(error)); ignoring it")
+            return Config.Vocabulary()
+        }
     }
 
     /// Computed rather than a constant because the dev build seeds a different

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -2410,8 +2410,14 @@ if __name__ == "__main__":
     static func load() throws -> Config {
         try createIfMissing()
         let text = try String(contentsOf: fileURL, encoding: .utf8)
+        // An empty config.yaml is a supported state — it means "defaults for
+        // everything" — and it must not take the vocabulary down with it. The
+        // two files are independent, and one of them being blank says nothing
+        // about the other.
         if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return Config()
+            var bare = Config()
+            bare.vocabulary = loadVocabulary()
+            return bare
         }
         // A relative `command:` is relative to the file that declared it, so a
         // config carries its scripts beside it and a `--pipeline` fixture

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -380,7 +380,11 @@ struct Pipeline: Equatable, Codable {
             }
             // `text.matches(…)` and friends: `text` is a seed and a namespace
             // prefix is not, so a path under a stage is only ever a variable.
-            if Scope.reserved.contains(namespace), namespace != "asr", namespace != "vad" {
+            // `asr`, `vad` and `vocabulary` are seeded as groups by the
+            // transcriber; the rest of the reserved names are bare strings, so
+            // a dotted path under one of those is a mistake.
+            if Scope.reserved.contains(namespace),
+               !["asr", "vad", "vocabulary"].contains(namespace) {
                 problems.append(
                     "\(named): \(label) \"\(condition)\" reads \"\(path)\", but \"\(namespace)\""
                         + " is text rather than a group of variables"
@@ -569,6 +573,16 @@ struct Pipeline: Equatable, Codable {
         if scope["language"] == nil {
             scope.set("language", .string(Pipeline.forText(output, config: config).1))
         }
+        // Same reason, for the acoustic pass. It runs inside transcription and
+        // seeds these itself; every other way in — `--replace`, `--pipeline`,
+        // a case set — has no audio and so seeds nothing, and a condition
+        // reading `vocabulary.count` then fails the *whole* expression rather
+        // than resolving to zero. `a || b` is not a rescue when `a` throws.
+        if scope["vocabulary.count"] == nil {
+            scope.set("vocabulary.count", .int(0))
+            scope.set("vocabulary.changes", .string(""))
+        }
+
         for step in steps {
             let named = step.transform.map { "\(step.stage.name) \($0)" } ?? step.stage.name
             let namespace = Pipeline.namespace(of: step)
@@ -605,6 +619,33 @@ struct Pipeline: Equatable, Codable {
             let result = await apply(step, to: output, config: config, app: app, scope: scope)
             let seconds = CFAbsoluteTimeGetCurrent() - started
             output = result.text
+
+            // `vocabulary.count` answers one question: was a vocabulary term
+            // written into this transcript? Not "by which mechanism" — sound
+            // and exact rules are both ways of getting the same term in, and a
+            // caller asking whether to check the result does not care which
+            // fired. The acoustic pass seeds its own count before the pipeline
+            // starts; a rule whose target is a vocabulary term adds to it here.
+            if step.stage == .replacements, case .string(let wrote)? = result.vars["changes"] {
+                let known = Set(config.vocabulary.terms.keys)
+                let hits = wrote.split(separator: ";").filter { pair in
+                    guard let arrow = pair.range(of: "->") else { return false }
+                    return known.contains(
+                        pair[arrow.upperBound...].trimmingCharacters(in: .whitespaces)
+                    )
+                }.count
+                if hits > 0 {
+                    let before: Int
+                    if case .int(let had)? = scope["vocabulary.count"] { before = had }
+                    else { before = 0 }
+                    scope.set("vocabulary.count", .int(before + hits))
+                    if case .string(let had)? = scope["vocabulary.changes"], !had.isEmpty {
+                        scope.set("vocabulary.changes", .string(had + "; " + wrote))
+                    } else {
+                        scope.set("vocabulary.changes", .string(wrote))
+                    }
+                }
+            }
 
             // Derived, never claimed. `changed` is the comparison this loop just
             // made, and a stage cannot get it wrong by forgetting to report it
@@ -651,8 +692,20 @@ struct Pipeline: Equatable, Codable {
     ) async -> StageResult {
         switch step.stage {
         case .replacements:
-            let done = Replacements.exact(to: text, rules: config.transcription.rules)
-            return StageResult(text: done.text, vars: ["count": .int(done.count)])
+            // Both tables. `config.yaml` holds the patterns and deletions a
+            // person wrote; `vocabulary.yaml` holds the names the app learnt.
+            // One pass, so a rule behaves the same whichever file it came from.
+            let done = Replacements.exact(
+                to: text, rules: config.transcription.rules + config.vocabularyRules
+            )
+            // `changes` as well as `count`, so a later stage can judge what
+            // this one did. A stage handed only the finished sentence cannot
+            // tell which words were rewritten, and guessing is how a judge
+            // starts reverting things nobody changed.
+            return StageResult(text: done.text, vars: [
+                "count": .int(done.count),
+                "changes": .string(done.changes),
+            ])
         case .fuzzy:
             // From the rules, not from the table's keys. Fuzzy matching
             // compares spellings, so a target is only a candidate if it is one

--- a/Sources/ParrotFlow/Replacements.swift
+++ b/Sources/ParrotFlow/Replacements.swift
@@ -72,12 +72,17 @@ enum Replacements {
     /// Counted per *rule*, not per substitution: "two rules fired" is the
     /// question a condition is asking, and a rule that replaced the same word
     /// four times did one thing, not four.
+    /// - Returns: the rewritten text, how many rules fired, and what each one
+    ///   wrote — `heard -> written`, joined by `; `. The third is for a stage
+    ///   that has to judge the substitutions rather than make them: a judge
+    ///   handed only the finished sentence cannot see what changed in it.
     static func exact(
         to text: String, rules: [Config.Transcription.Rule]
-    ) -> (text: String, count: Int) {
+    ) -> (text: String, count: Int, changes: String) {
         var output = text
         var deleted = false
         var fired = 0
+        var changes: [String] = []
 
         for rule in rules {
             guard let pattern = try? NSRegularExpression(
@@ -95,10 +100,14 @@ enum Replacements {
             if output != before {
                 fired += 1
                 if rule.isDeletion { deleted = true }
+                if !rule.isDeletion { changes.append("\(rule.source) -> \(rule.replacement)") }
             }
         }
 
-        return (deleted ? tidy(output) : output, fired)
+        return (
+            deleted ? tidy(output) : output, fired,
+            changes.joined(separator: "; ")
+        )
     }
 
     /// Closes the gaps a deletion leaves — doubled spaces, a space before a

--- a/Sources/ParrotFlow/TranscribeCommand.swift
+++ b/Sources/ParrotFlow/TranscribeCommand.swift
@@ -6,7 +6,11 @@ import Foundation
 /// change the YAML, re-run, see whether the name came out right.
 enum TranscribeCommand {
 
-    static func run(path: String) -> Int32 {
+    /// - Parameter withVocabulary: false for `--no-vocab`, which decodes the
+    ///   clip as the recogniser heard it. Calibration needs that: measuring how
+    ///   far a speaker's rendering lands from a term is meaningless if the term
+    ///   has already been written over it.
+    static func run(path: String, withVocabulary: Bool = true) -> Int32 {
         guard #available(macOS 14, *) else {
             print("✗ transcription needs macOS 14 or later")
             return 1
@@ -18,9 +22,10 @@ enum TranscribeCommand {
             return 1
         }
 
-        let config: Config
+        var config: Config
         do {
             config = try ConfigStore.load()
+            if !withVocabulary { config.vocabulary.acoustic = false }
         } catch {
             print("✗ config: \(CheckConfigCommand.describe(error))")
             return 1

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -161,6 +161,33 @@ actor Transcriber {
         }
         Trace.current?.recordASR(result, model: Repo.parakeetV3.rawValue)
 
+        // Before the pipeline, because this is the last point where the words
+        // still line up with the audio they came from. Every text stage after
+        // it — numbers especially — rewrites words the token timings index.
+        var text = result.text
+        var vocabularyCount = 0
+        var vocabularyChanges = ""
+        if Vocabulary.wanted(config) {
+            do {
+                try await Vocabulary.shared.prepare(config: config) { [weak self] label in
+                    Task { await self?.setStatus(.downloading(label)) }
+                }
+                if let samples = gated?.decodable == true
+                    ? gated?.samples : Self.samples(at: url) {
+                    let outcome = await Vocabulary.shared.apply(
+                        to: text, samples: samples,
+                        tokenTimings: result.tokenTimings ?? [], config: config
+                    )
+                    text = outcome.text
+                    vocabularyCount = outcome.count
+                    vocabularyChanges = outcome.changes
+                }
+            } catch {
+                Log.write("vocabulary: \(error.localizedDescription); left as decoded")
+            }
+            setStatus(.ready)
+        }
+
         // The same numbers the trace records, handed to the pipeline as well.
         //
         // Not read back off `Trace`, deliberately. The collector is bound only
@@ -169,13 +196,19 @@ actor Transcriber {
         // the runs you are watching and quietly stop on the runs you are not.
         // So the trace consumes these; it does not own them.
         return await Self.applyReplacements(
-            to: result.text, config: config, app: app,
+            to: text, config: config, app: app,
             seed: Scope(values: [
                 "asr.model": .string(Repo.parakeetV3.rawValue),
                 "asr.confidence": .double(Double(result.confidence)),
                 "asr.duration": .double(result.duration),
                 "asr.processing": .double(result.processingTime),
                 "asr.words": .int(result.tokenTimings?.count ?? 0),
+                // What the vocabulary pass wrote, for a stage that judges the
+                // substitutions rather than making them. Seeded even when it
+                // did nothing, so `vocabulary.count > 0` is a condition a
+                // pipeline can read rather than an error about a missing path.
+                "vocabulary.count": .int(vocabularyCount),
+                "vocabulary.changes": .string(vocabularyChanges),
             ]),
             progress: progress
         )
@@ -252,6 +285,23 @@ actor Transcriber {
             segments: segments.map { ($0.startTime, $0.endTime) },
             decodable: decodable
         )
+    }
+
+    /// The clip as 16 kHz mono samples, for the vocabulary pass when the
+    /// speech gate is off and has not already read them. Nil rather than
+    /// throwing: a name left misheard is worth less than a lost dictation.
+    static func samples(at url: URL) -> [Float]? {
+        guard let file = try? AVAudioFile(forReading: url),
+              file.processingFormat.sampleRate == sampleRate,
+              file.processingFormat.channelCount == 1,
+              let buffer = AVAudioPCMBuffer(
+                  pcmFormat: file.processingFormat,
+                  frameCapacity: AVAudioFrameCount(file.length)
+              ),
+              (try? file.read(into: buffer)) != nil,
+              let channel = buffer.floatChannelData?[0]
+        else { return nil }
+        return Array(UnsafeBufferPointer(start: channel, count: Int(buffer.frameLength)))
     }
 
     // MARK: - Closing long pauses

--- a/Sources/ParrotFlow/Vocabulary.swift
+++ b/Sources/ParrotFlow/Vocabulary.swift
@@ -1,0 +1,196 @@
+import FluidAudio
+import Foundation
+
+/// Writes the names in `vocabulary:` into a transcript that got them wrong,
+/// by matching sound rather than spelling.
+///
+/// This runs inside transcription, not in the pipeline. It needs the audio and
+/// the token timings the decoder produced, and a pipeline stage only ever sees
+/// text — once `numbers` has turned "nineteen" into "19" the timings no longer
+/// line up with the words.
+///
+/// ## The settings, and why they are not the defaults
+///
+/// FluidAudio proposes a replacement two ways. The first matches the decoded
+/// words against the vocabulary by edit distance, gated by `minSimilarity`.
+/// The second — the spotter-anchored rescue — replaces a span because the CTC
+/// keyword spotter heard the term there, and it ignores similarity entirely.
+///
+/// On stock settings the rescue is on and its own floors are disabled, which
+/// is why an earlier attempt at this was removed: 370 of 386 clips containing
+/// none of the vocabulary came out altered, and sweeping `minSimilarity` to
+/// 0.90 did nothing because it was gating the wrong path. FluidAudio's #702
+/// and #724 notes say the same thing — the rescue is the dominant source of
+/// short-keyword over-firing, and it only runs at all for vocabularies of ten
+/// terms or fewer, which is every vocabulary written here.
+///
+/// So the rescue is off and the short-term boost is tapered. Measured over the
+/// same 386 clips: 10 altered at `minSimilarity` 0.65, 4 at 0.75, 0 at 0.85.
+/// The two wrong fires at 0.65 are names that sound like real words, which is
+/// what the per-term floor in `vocabulary.terms` is for.
+@available(macOS 14, *)
+actor Vocabulary {
+
+    static let shared = Vocabulary()
+
+    /// Loading the models is a ~98 MB download and several seconds, so the
+    /// whole apparatus is kept and only rebuilt when the terms change.
+    private var loadedFor: [String] = []
+    private var spotter: CtcKeywordSpotter?
+    private var rescorer: VocabularyRescorer?
+    private var context: CustomVocabularyContext?
+
+    /// FluidAudio's recommended short-vocabulary opt-ins, from the #702 note.
+    private static let rescorerConfig = VocabularyRescorer.Config(
+        shortTermCbwTaperPivot: 5,
+        shortTermCbwTaperExponent: 2.0,
+        spotterRescueEnabled: false
+    )
+
+    /// True when there is something to do, so the caller can skip the work of
+    /// gathering audio for a config that asked for none of this.
+    static func wanted(_ config: Config) -> Bool {
+        config.vocabulary.acoustic && !config.vocabularyTerms.isEmpty
+    }
+
+    /// Downloads and builds what is needed, or reuses it. Reports progress so
+    /// the first run does not look like a hang.
+    func prepare(
+        config: Config, progress: (@Sendable (String) -> Void)? = nil
+    ) async throws {
+        let terms = config.vocabularyTerms
+        let signature = terms.map { "\($0.text):\($0.minSimilarity)" }
+        guard signature != loadedFor || rescorer == nil else { return }
+
+        progress?("vocabulary model")
+        let models = try await CtcModels.downloadAndLoad()
+        let directory = CtcModels.defaultCacheDirectory(for: .ctc110m)
+        let tokenizer = try await CtcTokenizer.load(from: directory)
+
+        // Pre-tokenising is what makes the spotter fire at all. A term built
+        // from text alone carries no CTC token ids and is skipped in silence.
+        let built = terms.compactMap { term -> CustomVocabularyTerm? in
+            let ids = tokenizer.encode(term.text)
+            guard !ids.isEmpty else {
+                Log.write("vocabulary: \"\(term.text)\" tokenises to nothing; skipped")
+                return nil
+            }
+            return CustomVocabularyTerm(
+                text: term.text, ctcTokenIds: ids, minSimilarity: term.minSimilarity
+            )
+        }
+        guard !built.isEmpty else {
+            loadedFor = signature
+            return
+        }
+
+        let context = CustomVocabularyContext(terms: built)
+        let spotter = CtcKeywordSpotter(models: models, blankId: models.vocabulary.count)
+        self.rescorer = try await VocabularyRescorer.create(
+            spotter: spotter, vocabulary: context,
+            config: Self.rescorerConfig, ctcModelDirectory: directory
+        )
+        self.spotter = spotter
+        self.context = context
+        self.loadedFor = signature
+        Log.write("vocabulary: \(built.count) terms — \(built.map(\.text).joined(separator: ", "))")
+    }
+
+    /// What one pass did, for the pipeline to read. `changes` is
+    /// `heard -> written`, joined by `; ` — the same shape `replacements`
+    /// publishes, so a judge stage can read either without knowing which
+    /// proposed the substitution.
+    struct Outcome: Sendable {
+        let text: String
+        let count: Int
+        let changes: String
+
+        static func unchanged(_ text: String) -> Outcome {
+            Outcome(text: text, count: 0, changes: "")
+        }
+    }
+
+    /// The transcript with any vocabulary term the decoder missed written in.
+    ///
+    /// Returns the text unchanged on every failure. A name that stays misheard
+    /// is a worse transcript; a dictation that does not arrive is no transcript.
+    func apply(
+        to text: String, samples: [Float], tokenTimings: [TokenTiming], config: Config
+    ) async -> Outcome {
+        guard let rescorer, let spotter, let context, !tokenTimings.isEmpty else {
+            return .unchanged(text)
+        }
+
+        do {
+            let spotted = try await spotter.spotKeywordsWithLogProbs(
+                audioSamples: samples, customVocabulary: context, minScore: nil
+            )
+            guard !spotted.logProbs.isEmpty else { return .unchanged(text) }
+
+            let result = rescorer.ctcTokenRescore(
+                transcript: text,
+                tokenTimings: tokenTimings,
+                logProbs: spotted.logProbs,
+                frameDuration: spotted.frameDuration,
+                cbw: ContextBiasingConstants.rescorerConfig(forVocabSize: context.terms.count).cbw,
+                marginSeconds: ContextBiasingConstants.defaultMarginSeconds,
+                minSimilarity: config.vocabulary.minSimilarity
+            )
+            guard result.wasModified else { return .unchanged(text) }
+
+            // Every replacement, named. This is the stage most likely to be
+            // blamed for a sentence nobody recognises, and the log is where
+            // that gets settled.
+            var made: [String] = []
+            for change in result.replacements where change.shouldReplace {
+                Log.write(
+                    "vocabulary: \"\(change.originalWord)\" -> "
+                        + "\"\(change.replacementWord ?? "")\" (\(change.reason))"
+                )
+                // The acoustic scores travel with the pair. They are the one
+                // piece of evidence a judge reading the sentence cannot get
+                // for itself, and they are independent of it: how confidently
+                // the decoder heard each spelling, rather than which one fits.
+                made.append(String(
+                    format: "%@ -> %@ @ %.2f/%.2f",
+                    change.originalWord, change.replacementWord ?? "",
+                    change.originalScore, change.replacementScore ?? 0
+                ))
+            }
+            return Outcome(
+                text: Self.restorePunctuation(from: text, to: result.text),
+                count: made.count,
+                changes: made.joined(separator: "; ")
+            )
+        } catch {
+            Log.write("vocabulary: \(error.localizedDescription); left as decoded")
+            return .unchanged(text)
+        }
+    }
+
+    /// Puts back the trailing punctuation a replacement drops.
+    ///
+    /// The rescorer replaces the word and not what followed it, so "on Olama?"
+    /// comes back as "on Ollama" and the question mark is gone. Measured on the
+    /// archive: it happened to 4 of the 8 substitutions at the shipped setting.
+    /// Only trailing marks on words that changed are restored, and only when
+    /// the two texts still have the same number of words — anything else is a
+    /// rewrite this should not be second-guessing.
+    static func restorePunctuation(from original: String, to rescored: String) -> String {
+        let before = original.split(separator: " ", omittingEmptySubsequences: false)
+        let after = rescored.split(separator: " ", omittingEmptySubsequences: false)
+        guard before.count == after.count else { return rescored }
+
+        let marks = CharacterSet(charactersIn: ".,?!:;")
+        return zip(before, after).map { was, now -> String in
+            guard was != now, !now.isEmpty else { return String(now) }
+            let tail = String(was.reversed().prefix {
+                $0.unicodeScalars.allSatisfy(marks.contains)
+            }.reversed())
+            guard !tail.isEmpty,
+                  !now.unicodeScalars.contains(where: marks.contains)
+            else { return String(now) }
+            return now + tail
+        }.joined(separator: " ")
+    }
+}

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -61,11 +61,17 @@ if let index = arguments.firstIndex(of: "--record") {
 
 if let index = arguments.firstIndex(of: "--transcribe") {
     guard arguments.indices.contains(index + 1) else {
-        print("usage: ParrotFlow --transcribe <file.wav>")
+        print("usage: ParrotFlow --transcribe <file.wav> [--no-vocab]")
         exit(2)
     }
-    exit(TranscribeCommand.run(path: arguments[index + 1]))
+    exit(TranscribeCommand.run(
+        path: arguments[index + 1],
+        withVocabulary: !arguments.contains("--no-vocab")
+    ))
 }
+
+
+
 
 if let index = arguments.firstIndex(of: "--replace") {
     guard arguments.indices.contains(index + 1) else {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -72,6 +72,12 @@ transcription:
   # The spelling you want, and the ways it comes out wrong. Whole words,
   # case-insensitive. A /slashed/ source is a regex and the target is then a
   # template ($1 writes back a capture); an empty target deletes instead.
+  #
+  # Words the recogniser mangles — a colleague's surname, a product, an
+  # acronym — go in vocabulary.yaml beside this file instead. That one is
+  # learnt while you use the app rather than written by hand, which is why it
+  # is kept apart. Patterns, deletions and anything that is not a word you say
+  # belong here.
   replacements:
     "": ['/[,]?\s*\b(?:mm[-‑]?hmm|uh[-‑]?huh|mhm|u+m+|u+h+|erm+|hmm+|mm+)\b[,]?/']
     Tasmeen: [Tasmid, Tasmin, Tasmine]

--- a/scripts/check-transform-folders.sh
+++ b/scripts/check-transform-folders.sh
@@ -162,7 +162,7 @@ seeded="$(PARROTFLOW_CONFIG_DIR="$FRESH" "$BIN" --seed-config 2>/dev/null)"
 
 check "a first launch writes the transform as a folder" \
   "$(cd "$FRESH" && find . -type f | sed 's|^\./||' | sort | tr '\n' ' ')" \
-  "config.yaml transforms/code_identifiers/cases.yaml transforms/code_identifiers/code_identifiers.py "
+  "config.yaml transforms/code_identifiers/cases.yaml transforms/code_identifiers/code_identifiers.py vocabulary.yaml "
 
 check "the seeded script is executable" \
   "$([ -x "$FRESH/transforms/code_identifiers/code_identifiers.py" ] && echo yes || echo no)" \


### PR DESCRIPTION
Words the recogniser gets wrong — a colleague's surname, a drug brand, an
internal project, an acronym, anything a non-native speaker says in a way the
model was not trained on. They are matched by sound, so one entry covers
renderings nobody has written down.

**Off by default.** It pulls a ~98 MB model on first use, and a term that
sounds like an ordinary word will overwrite that word until its floor is
measured.

## Why this is back

Acoustic biasing was tried in July and removed: 370 of 386 clips containing
none of the vocabulary came out altered. Right removal, wrong reason.
FluidAudio proposes replacements two ways, and the sweep moved the gate on one
while the other stayed open — the spotter rescue "is acoustic-evidence driven
and otherwise ignores similarity", and no config was passed, so it ran on
defaults. With the rescue off and the short-term boost tapered, over the same
400 archived clips:

| setting | clips damaged | terms recovered |
| --- | --- | --- |
| July default | 370/386 | 8/8 |
| rescue off | 52/386 | 8/8 |
| + floor 0.65 | 10/386 | 5/8 |
| + floor 0.75 | 4/386 | 3/8 |
| + floor 0.85 | 0/386 | 2/8 |

## A separate file

`vocabulary.yaml` sits beside `config.yaml`, not inside it. The two have
different owners: one is written by a person and read by the app, the other is
written by the app and read by a person. Mixed together, a hand edit and a
learnt entry land in the same file and one of them eventually loses.

It seeds empty with every example commented out. The floors cannot be
guessed — shipping someone else's is how `Vercel` starts overwriting `vessel`.

```yaml
acoustic: true
min_similarity: 0.75

terms:
  Tasmeen:                     # nothing close in this speaker's speech
  Mirza:
    floor: 0.85                # "Mira" lands at 0.80
  Praisy:
    floor: 0.90                # "praise" lands at 0.83
    heard: [Prissy, Pressy, Precy, Prezi]
  Claude:
    floor: off                 # "cloud" both ways — no floor works
    heard: [clut, cloud]
```

`floor: off` is the honest setting when the recogniser writes the term and an
ordinary word identically. Measured here: `Claude`/`cloud`, `Matthieu`/`Matthew`
and `Supabase`/`super base` each come back as one string, and no threshold
separates a distinction that was gone before anything downstream could look.

Both mechanisms report through `vocabulary.count` — how many terms were
written into this transcript, by sound or by rule. A caller deciding whether
to check the result does not care which fired.

## Worth a reviewer's attention

- `Config.Vocabulary.Term` decodes four shapes (null, number, list, mapping).
- `floor: off` is a **YAML 1.1 boolean**, not a string. Reading it only as a
  string threw and took the whole file down silently.
- Terms under five letters, or with a digit or dot, are dropped: a short term
  free-start aligns to almost any run of frames, and a term the decoder could
  not have produced is not a term.
- `Vocabulary.restorePunctuation` puts back the trailing mark the rescorer
  drops — `Olama?` came back as `Ollama`.

## Not in this PR

The measurement harnesses that produced every number above, the
`verify_names` stage that reads the sentence, the docs rewrite, and two
skills. Each will follow as its own PR once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgCqXv7PvYk5jH4BxXG9P5