### PR TITLE
fix: the judge harness says what it needs instead of raising

### DIFF
--- a/scripts/validate-judge.py
+++ b/scripts/validate-judge.py
@@ -233,9 +233,18 @@ def ask(model, system, said, heard, term, tokens, speaker_framed=False):
 # --------------------------------------------------------------------- main
 
 def load_shipped():
-    """The judge as it ships, imported rather than reimplemented."""
+    """The judge as it ships, imported rather than reimplemented.
+
+    Optional: the transform is a separate thing from this harness, and a
+    checkout without it should say so rather than raise from inside importlib.
+    """
     import importlib.util
     path = ROOT / "examples/transforms/verify_names/verify_names.py"
+    if not path.exists():
+        print(f"✗ --script needs {path.relative_to(ROOT)}, which is not in this"
+              " checkout.\n  Score the no-model control instead:"
+              " validate-judge.py none --code-only")
+        raise SystemExit(2)
     spec = importlib.util.spec_from_file_location("verify_names", path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)


### PR DESCRIPTION
`scripts/validate-judge.py --script` imports the `verify_names` transform,
which is not in the repository yet — it arrives with the stage itself in a
later PR. On a checkout without it the harness died inside `importlib`:

```
FileNotFoundError: examples/transforms/verify_names/verify_names.py
```

which reads like a bug in the harness rather than a missing optional
dependency. It now says which file it wants, and points at the mode that
works without one:

```
✗ --script needs examples/transforms/verify_names/verify_names.py, which is
  not in this checkout.
  Score the no-model control instead: validate-judge.py none --code-only
```

My own miss from #53 — a harness whose dependency points forward instead of
back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgCqXv7PvYk5jH4BxXG9P5