### PR TITLE
Two skills: gathering a vocabulary, and calibrating it

### DIFF
--- a/.claude/skills/calibrate/SKILL.md
+++ b/.claude/skills/calibrate/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: calibrate
+description: Derive per-term similarity floors for ParrotFlow from the user's own voice — write sentences containing each vocabulary term and the words it can be confused with, have the user read them aloud into the app, and compute the safe band per term. Use after gathering a vocabulary, when a name keeps being mis-transcribed, or when a term is overwriting an ordinary word.
+---
+
+# Calibrating a vocabulary against one person's voice
+
+A similarity floor is a bet about two things: how far this speaker's rendering
+of a name lands from its spelling, and how close the ordinary words that sound
+like it land. Both are properties of a mouth. Neither can be read off a
+dictionary, and the gap between them differs enormously between speakers.
+
+This skill measures both, per term, and derives the floor from the gap.
+
+**Everything stays on the machine.** The recordings are already on disk, the
+decoding runs locally, and nothing leaves. Say so before asking anyone to read
+their colleagues' names aloud.
+
+## What the measurement is
+
+For each term, two sets of sentences:
+
+    Vercel        "I deployed my app on Vercel this morning."
+                  "We should move staging to Vercel before Friday."
+
+    confusables   "We visited the gardens at Versailles last summer."
+                  "Please verify the build before you merge."
+
+The user reads all of them. Every clip is re-decoded with the vocabulary
+**off**, which is what `--transcribe --no-vocab` does, and each rendering is
+scored against the term:
+
+    said "Vercel"        heard "Versal"       0.67
+    said "Vercel"        heard "Vercel"       1.00
+    said "Versailles"    heard "Versailles"   0.40
+    said "verify"        heard "verify"       0.50
+
+The floor goes in the gap between the lowest of the first group and the
+highest of the second. Here: anywhere from 0.51 to 0.67, so 0.58.
+
+## The band is the answer, not just the floor
+
+    wide band     0.50 .. 0.67   the speaker separates them clearly.
+                                 Pick the middle and stop thinking about it.
+    narrow band   0.62 .. 0.67   works, but one bad day of diction breaks it.
+    no band       0.71 .. 0.67   the confusables land CLOSER than the speaker's
+                                 own renderings. No floor exists.
+
+**A closed band is a result, not a failure.** It says this term can never be
+safe acoustically for this person. The answer is `floor: off` with a `heard:`
+list of the renderings actually seen, and the `verify_names` judge behind it.
+Report it that way — a user told "no floor works,
+here is the rule instead" has learned something; a user handed a floor that
+quietly damages their transcripts has not.
+
+Band widths across a whole vocabulary are also the honest way to talk about
+accent. A speaker whose bands are all wide needs almost no tuning. A speaker
+with three closed bands has three terms that need rules, and that is a fact
+about their speech rather than a judgement about it.
+
+## Step 1 — find the confusables
+
+    scripts/calibrate.py confusables Vercel Praisy Tasmeen --lang en
+
+Dictionary neighbours within 0.55, plus the glued two-word phrases — `turn
+down`, `back end`, `set up`. That second list matters: `Turndown` has no
+single-word collision at all and still eats "turn down the volume", because
+the compound matcher glues the pair.
+
+**Pass only the languages this person dictates in.** The default is `en,fr`,
+and each language adds neighbours the other does not have. "Praisy" is 0.83
+from the English "praise" and 0.67 from the French "vrais", so a floor derived
+with both languages is set for a speaker who uses both. Wrong for someone who
+only dictates in English, and it costs them a term.
+
+Take the top three or four per term. Below about 0.55 nothing will ever be
+proposed anyway, so testing them wastes the user's breath.
+
+## Step 2 — write the sentences
+
+This is the part that is a judgement rather than a lookup, which is why it is
+yours and not the script's.
+
+- **Bury the term mid-clause.** A word read on its own decodes differently
+  from one surrounded by speech, and the surrounded case is the real one.
+- **Vary what surrounds it.** Different neighbours, different sentence
+  positions, never twice at the end.
+- **Make them sound like this person.** Use their domain — deploys, crawls,
+  tickets, whatever the codebase and Slack gathering turned up. A sentence
+  someone would never say is read in a voice they never use.
+- **Three per term, three per confusable.** Fewer and one odd reading moves
+  the floor; more and nobody finishes.
+- **Write them in the language they would be said in.** A French speaker's
+  French sentences and English sentences fail differently, and mixing them
+  into one list hides that.
+
+Write a manifest beside them:
+
+```json
+{"sentences": [
+  {"n": 1, "text": "I deployed my app on Vercel this morning.",
+   "contains": "Vercel", "kind": "term", "against": "Vercel"},
+  {"n": 2, "text": "We visited the gardens at Versailles last summer.",
+   "contains": "Versailles", "kind": "confusable", "against": "Vercel"}
+]}
+```
+
+Then print the numbered sentences for the user to read **in order**, one
+dictation each.
+
+## Step 3 — score
+
+    scripts/calibrate.py score calibration.json
+
+It pairs the last N recordings with the N sentences by order, re-decodes each
+with the vocabulary off, and reports the band and floor per term.
+
+**Pairing by order breaks when someone re-reads a line**, so it checks that
+half the sentence's words actually turned up before trusting a clip, and
+refuses the ones that do not match:
+
+    ✗ 2 recording(s) do not match their sentence
+        expected: I deployed my app on Vercel this morning.
+        heard:    And then for the code base, I think you can already uh
+
+Have those read again rather than working around them. A mispaired clip does
+not fail loudly — it produces a confident floor from two unrelated sentences.
+
+## Step 4 — check it against real speech
+
+**Read speech is not dictated speech.** People enunciate when reading from a
+screen, and an enunciated `Versailles` separates from `Vercel` in a way
+ordinary muttered dictation does not. That biases every band wider than
+reality and sets floors slightly too low.
+
+So before shipping the floors, run them against recordings the person made
+without thinking about it:
+
+    ParrotFlow --boost-eval --terms Vercel,Tasmeen,Praisy --limit 400
+
+Any term whose new floor causes damage there had its band measured from
+reading rather than speaking. Raise it, and say why.
+
+## What to hand back
+
+The `terms:` block for `vocabulary.yaml`, which sits beside `config.yaml`:
+
+```yaml
+terms:
+  Vercel:
+    floor: 0.58            # band 0.50 .. 0.67, measured
+    heard: [Versailles]    # 0.40 — below any floor
+  Tasmeen: 0.62            # band 0.55 .. 0.71
+  Praisy:
+    floor: off             # no band: "praise" landed at 0.83, closer than
+    heard: [Prissy]        # this speaker's own renderings
+```
+
+`floor: off` is the YAML boolean `false`, not the string. So are `on`, `yes`
+and `no`. The decoder reads both, but write it the way the file already does.
+
+That file carries a "do not edit unless you know what you are doing" header
+because it is normally written by the app. This skill is one of the things
+that writes it, so editing it here is the intended path — say so, rather than
+letting the header look like it was ignored.
+
+And a one-line summary per term saying what was measured, because the number
+on its own is unarguable-with in six months:
+
+    Vercel     band 0.50 .. 0.67   wide, floor uncritical
+    Tasmeen    band 0.55 .. 0.71   wide
+    Praisy     no band             "praise" at 0.83 — rule instead

--- a/.claude/skills/vocabulary-corpus/SKILL.md
+++ b/.claude/skills/vocabulary-corpus/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: vocabulary-corpus
+description: Gather the first vocabulary for ParrotFlow — the names, jargon and acronyms a person actually says — from their codebase and their Slack, and turn it into a `vocabulary.yaml` with a per-term floor. Use when setting ParrotFlow up on a new machine or a new project, when dictation keeps mangling the same words, or when someone asks what terms they should add.
+---
+
+# Building someone's first vocabulary
+
+The vocabulary is a flat list of words you want written correctly. One entry
+covers every way the recogniser mangles a name, including renderings nobody has
+seen yet — which is what a `replacements` rule cannot do, because a rule needs
+the mistake to have happened first.
+
+The hard part is not finding candidate terms. It is throwing away the ones that
+will do damage. Most of this skill is rejection criteria, and they are all
+earned from measurements: see the scoreboard in `docs/transcription.md`.
+
+**What you are producing:** a `vocabulary:` block for the user's config, and a
+short list of terms that need checking by ear because a machine cannot settle
+them.
+
+## Say this before you ask for anything
+
+The user is about to hand over their colleagues' names and their company's
+internal vocabulary. Tell them where it goes, in plain words, before they do:
+
+> Everything here stays on your Mac. ParrotFlow transcribes locally with a
+> model on your machine, the config file is a text file in your home
+> directory, and nothing you paste is sent anywhere. The only network call the
+> app makes on its own is a daily check for a new release.
+
+Then keep it true:
+
+- **Do not put names into any tool that leaves the machine.** No web search on
+  a colleague's name to check its spelling, no asking a hosted model to tidy
+  the list. Work from what the user pastes.
+- **Write only to the user's config.** Names belong in
+  `~/.config/parrotflow/config.yaml`, not in a scratch file somewhere, and not
+  in a commit.
+- **Do not repeat the whole roster back in chat** beyond what is needed to
+  confirm a decision. A list of everyone someone works with is not something
+  to restate for the sake of a tidy summary.
+
+If the user is on a project with `transforms:` that call a hosted API — the
+OpenAI scripts in this repo are an example — say so plainly, because that is a
+real exception to "nothing leaves the machine" and it is theirs to weigh.
+
+## The shape of a good term
+
+Measured over 505 transcripts and 15 screened candidates, terms sort into four
+kinds, and only two are worth adding.
+
+**Compounds the decoder splits.** The best case by a distance.
+
+    RedCrawl   -> "red crawl"     glued: redcrawl   1.00
+    LangSmith  -> "Lang Smith"    glued: langsmith  1.00
+    Firecrawl  -> "fire crawl"    glued: firecrawl  1.00
+
+Glued back together they match exactly, so no threshold can reach anything
+else, and they cannot damage a transcript. Take all of these.
+
+**Distinctive names with nothing near them.** Take these too, at a low floor.
+
+    Tasmeen    nothing within 0.71 in 234k dictionary words
+    Arexvy     nothing within 0.67
+
+**Names that collide with ordinary words.** No floor works. Use `floor: off`
+and a `heard:` list instead.
+
+    Praisy   vs "praise"    0.83   and they sound alike, so no gate saves it
+    Sentry   vs "entry"     0.83
+    Postgres heard as "posters"   0.75
+
+**Words the decoder already writes correctly.** Reject — pure risk, no gain.
+
+    Supabase, Playwright, Drizzle, Tailwind, GitHub, OpenAI, TypeScript
+
+## Step 1 — mine the codebase
+
+Read a **subset**, not the tree. What you want is words the person says out
+loud in conversation about this project, which is a much smaller set than the
+words in the code.
+
+Look at, in this order:
+
+- `package.json`, `Package.swift`, `pyproject.toml`, `go.mod`, `Cargo.toml` —
+  dependency and workspace names.
+- `README.md` and the top of `docs/` — product names, service names, the
+  domain nouns.
+- Directory names one level under `src/`, `packages/`, `apps/`.
+- `.env.example` keys, and service names in `docker-compose.yml`.
+
+Record the languages in use as you go — from the manifests and file
+extensions. You will need them for the spell-check gate in step 3 and for the
+sentences in step 5, and a French speaker's vocabulary must be checked against
+French too.
+
+Then apply these, in order:
+
+1. **Drop anything under 5 letters or containing non-letters.** `db`, `ci`,
+   `gpt-4o`, `CLAUDE.md`. The vocabulary only accepts 5+ letters.
+2. **Drop ordinary words.** `build`, `config`, `content`, `parser`, `types`,
+   `scripts`, `format`. These get written correctly and boosting them creates
+   chances to overwrite the same word used normally.
+3. **Drop what you type but never say.** `ipaddr`, `esbuild`, `postcss`,
+   `undici`, `octokit`, `picomatch`, `autoprefixer`. This is the biggest cut
+   and the easiest to forget — a lockfile is not a conversation.
+4. **Convert slugs to spellings.** This is the trap. The vocabulary writes the
+   term verbatim, so the entry has to be the output you want:
+
+       package.json says   you would say         the term should be
+       langchain           "LangChain"           LangChain
+       tailwindcss         "Tailwind CSS"        Tailwind CSS
+       nextjs              "Next JS"             Next.js  (rejected: has a dot)
+
+## Step 2 — the Slack prompt
+
+People's names are the highest-value terms in the whole exercise, and they are
+not in any repository. Hand the user this to paste into their Slack assistant. It is deliberately
+self-contained — no channel names to fill in, no options to pick. A setup step
+that asks the user to configure it is a setup step they abandon.
+
+```
+Look at every Slack channel and DM I have posted in or been mentioned in
+over the last 30 days. Do not ask me which ones — work it out from my
+activity, and cover all of them.
+
+Return four lists as plain text. No commentary, no summary, no preamble.
+
+1. PEOPLE
+   Everyone who posted in those conversations or who I addressed by name.
+   One per line, as:  Display Name | @handle
+   Use the spelling of their name as they write it themselves, accents and
+   all. Include people I only mentioned by first name.
+
+2. PRODUCTS AND BRANDS
+   Names of tools, vendors, services, internal systems and repositories that
+   come up in conversation. One per line. Give the exact capitalisation the
+   team uses: "LangChain" not "langchain", "RedCrawl" not "redcrawl".
+
+3. ACRONYMS AND JARGON
+   Short forms and in-house terms an outsider would not understand.
+   One per line, as:  TERM | what it means
+
+4. RECURRING WORDS
+   Any other word that appears often in these conversations and is not
+   ordinary English or French — project names, codenames, place names,
+   anything I say a lot.
+
+Rules for all four lists:
+- Only words people say out loud in meetings and messages. Skip anything
+  that appears only inside code blocks, file paths, URLs or log output.
+- Skip ordinary words. I want what a dictation tool would get wrong.
+- Spelling is the whole point. A name spelled wrong here becomes a name
+  spelled wrong in everything I dictate from now on.
+```
+
+Two things to tell the user when you hand it over:
+
+- **Names are the point.** A colleague's name is dictated constantly, is
+  usually foreign to the recogniser, and has no other fix.
+- **Spelling matters more than completeness.** A name spelled the way they
+  write it is a term; a name spelled the way Slack's assistant guessed is a
+  term that will write the wrong thing forever.
+- **The handles are worth keeping.** `Display Name | @handle` feeds the
+  `slack_mentions` roster as well as the vocabulary, so one gathering serves
+  both. The roster lives in `slack_mentions.py` beside the config.
+
+## Step 3 — reject the collisions, and set the floors
+
+For each surviving candidate, find its nearest ordinary word. The floor goes
+just above that, so nothing else can reach the term.
+
+Use `NSSpellChecker` for "is this a word", because that is what
+`Replacements.isRealWord` uses. Check only the languages this person dictates
+in — a French word list rejects English terms that are perfectly safe for an
+English-only speaker:
+
+```swift
+// swift spell.swift word1 word2 ...
+import AppKit
+let checker = NSSpellChecker.shared
+for word in CommandLine.arguments.dropFirst() {
+    let known = ["en", "fr"].contains { language in
+        checker.checkSpelling(
+            of: word, startingAt: 0, language: language,
+            wrap: false, inSpellDocumentWithTag: 0, wordCount: nil
+        ).location == NSNotFound
+    }
+    print("\(word)\t\(known)")
+}
+```
+
+**All-caps is a trap.** `NSSpellChecker` accepts any all-caps run as an
+acronym — `XQZPT` comes back known. Ask about the lowercase form for anything
+capitalised.
+
+For the distance, use plain Levenshtein over the longer length, which is what
+FluidAudio's gate computes:
+
+    similarity = 1 - editDistance / max(len(a), len(b))
+
+Then:
+
+- **Nearest ordinary word at 0.85 or above** — no floor works. No threshold
+  both catches the term's mishearings and excludes that word. Ship it as
+  `floor: off` with a `heard:` list instead.
+- **Otherwise** — floor = nearest + 0.05, capped at 0.90.
+- **Check two-word phrases as well as single words.** This is the hole that
+  bites: `Turndown` has no dictionary collision and scores a clean 1.00, but
+  "turn down the volume" glues to `turndown` and gets rewritten. Any term
+  shaped like a verb-particle pair — `turn down`, `back end`, `set up`,
+  `check out`, `log in`, `time out` — is unsafe by construction.
+
+## Step 4 — screen with TTS, but do not trust it
+
+Synthesising each term in a carrying sentence and transcribing it tells you
+whether the decoder mangles the word at all. It is fast and it needs no
+dictation from the user.
+
+Use **Kokoro**, not macOS `say`. `say` has no pronunciation control — its
+`[[inpt PHON]]` escape is read aloud as words — and it mispronounces invented
+names. Measured: `Neuroplexorin` failed 6/6 under `say` and passed 12/12 under
+Kokoro, because `say` was saying it wrong. Screening with `say` would have
+added a term that needs nothing.
+
+Three or four voices, three carrying sentences each. A bare word decodes
+differently from one buried in speech, and the buried case is the real one.
+
+**The loop cannot tell you which end failed.** A wrong transcript means either
+the recogniser misheard or the voice mispronounced, and those call for
+opposite conclusions. Have the user listen before trusting any verdict.
+
+## Step 5 — the only measurement that counts
+
+TTS answers whether the *model* knows a word. It says nothing about whether the
+word survives *this speaker*, and accent is most of the problem — the whole
+reason a non-native speaker needs this.
+
+So: write three or four sentences per surviving term, hand them to the user,
+and have them **read the sentences aloud into ParrotFlow**. Then compare what
+came back against what they read.
+
+That settles pronunciation and accent at once, and nothing else does. For a
+dozen terms it is a few minutes of reading.
+
+## What to hand back
+
+The contents of `vocabulary.yaml`, which sits beside `config.yaml`:
+
+```yaml
+acoustic: true
+min_similarity: 0.75
+
+terms:
+  RedCrawl: 0.95        # "red crawl", glues to 1.00
+  LangSmith: 0.95
+  Tasmeen:              # nothing within 0.71 — the default is enough
+  Matthieu: 0.80        # "Matthew" is 0.75
+```
+
+A bare number is the floor. An empty entry takes `min_similarity`.
+
+That file carries a "do not edit unless you know what you are doing" header
+because it is normally written by the app — from corrections and from
+`--learn`. This skill is the other thing that writes it. Say that, rather than
+leaving the header looking ignored.
+
+And beside it, three short lists:
+
+- **Rejected, with the reason.** `Praisy` — "praise" at 0.83. `Sentry` —
+  "entry" at 0.83. These go in with `floor: off` and a `heard:` list of
+  renderings actually seen, so sound matching is off for them and nothing
+  else. Give the reason, or someone re-adds them with a floor next month.
+- **Already fine.** The terms the decoder writes correctly. Same reason.
+- **Read these aloud.** The step 5 sentences.
+
+## Two things worth saying out loud to the user
+
+**A vocabulary does not replace the replacement table.** Measured over 505
+transcripts: the vocabulary caught 3 renderings no rule covered, and every one
+it missed was already covered by a rule. It reduces how often you write a rule;
+it does not remove the need. Mishearings that land far from the spelling —
+`Tasmine` at 0.57, `RXV` at 0.50 — are out of reach of any safe threshold.
+
+**Terms are not free.** Each one is another chance to overwrite a correct word,
+and the risk is dominated by *which* terms rather than how many. Nine terms
+where three collide with ordinary words is worse than thirty that do not.


### PR DESCRIPTION
The last piece of the vocabulary work. Two skills, no code.

**`vocabulary-corpus`** builds the first vocabulary. It reads package
manifests and a Slack export for the names a person actually says, screens
each against a word list, and sets a floor just above the nearest ordinary
word. Terms that collide too closely do not get a floor at all — they ship as
`floor: off` with a `heard:` list.

**`calibrate`** measures the floor instead of deriving it. It writes sentences
containing each term and sentences containing its confusables, has the user
read them aloud, re-decodes every clip with the vocabulary off, and reports
the band between the two groups. A closed band — confusables landing nearer
than the speaker's own renderings — is a result, and the skill says so rather
than returning a floor that quietly damages transcripts.

## What changed since they were written

Both predate the schema decision, so both handed back a
`transcription: replacements:` block that does not exist. They now write
`vocabulary.yaml`, with `acoustic:`, `min_similarity:` and `terms:` as
shipped, and the bare-number shorthand for a floor.

The `--lang` guidance is folded in here too, which is where it belongs:
`calibrate.py confusables` defaults to `en,fr`, and each language adds
neighbours the other has not got. Verified against the script:

    --lang en     Praisy   0.83 praise   0.67 raise   0.67 pray   0.67 daisy
    --lang en,fr  Praisy   0.83 praise   0.67 vrais

So a floor derived with both is set for a bilingual speaker. For someone who
only dictates in English it is set too high, and it costs them the term.

## Checked, not assumed

`--no-vocab`, `--boost-eval --terms`, `--learn`, `calibrate.py confusables`
and `calibrate.py score` all exist as the skills invoke them.
`Replacements.isRealWord` is still the spell check they point at.

Both skills say that `vocabulary.yaml` carries a "do not edit unless you know
what you are doing" header because the app normally writes it, and that these
skills are the other thing that writes it. Otherwise the header reads as
something they ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgCqXv7PvYk5jH4BxXG9P5