### PR TITLE
feat: the surfaces are glass, and they throw light

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -34,11 +34,20 @@ concurrency:
 
 jobs:
   checks:
-    # macos-15, not 14: FluidAudio 0.15.5 declares swift-tools-version 6.0, and
-    # the macos-14 image ships Swift 5.10, so resolution fails before a line is
-    # compiled. Our own Package.swift still says 5.10 — that is the floor this
-    # package needs, not the toolchain a dependency needs to be read.
-    runs-on: macos-15
+    # macos-26, not 15: the glass on the floating surfaces is
+    # `NSGlassEffectView`, which exists in the macOS 26 SDK and no earlier one.
+    # `#available(macOS 26, *)` is a *runtime* check — it decides whether the
+    # branch runs, not whether the symbol has to be there to compile — so an
+    # older image fails with "cannot find NSGlassEffectView in scope" however
+    # the branch is guarded. The app still deploys to macOS 14; this is the SDK
+    # it is built against, which is a different number.
+    #
+    # Not 14 either, for the reason it never was: FluidAudio 0.15.5 declares
+    # swift-tools-version 6.0, and the macos-14 image ships Swift 5.10, so
+    # resolution fails before a line is compiled. Our own Package.swift still
+    # says 5.10 — that is the floor this package needs, not the toolchain a
+    # dependency needs to be read.
+    runs-on: macos-26
     timeout-minutes: 20
 
     steps:

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -68,11 +68,11 @@ enum PanelsCommand {
         // window is the exception and the reason this is a column at all: it is
         // an ordinary titled window, it follows the system, and it has to be
         // legible both ways. So it appears twice, once each.
-        let surfaces: [(NSView, NSSize, NSAppearance.Name)] = [
-            (NSHostingView(rootView: PillView().environmentObject(overlay)),
-             pillSize(overlay), .darkAqua),
-            (NSHostingView(rootView: PillView().environmentObject(overlayBlind)),
-             pillSize(overlayBlind), .darkAqua),
+        let surfaces: [(view: AnyView, size: NSSize, scheme: ColorScheme, drawn: Bool)] = [
+            (AnyView(PillView().environmentObject(overlay)),
+             pillSize(overlay), .dark, true),
+            (AnyView(PillView().environmentObject(overlayBlind)),
+             pillSize(overlayBlind), .dark, true),
             // The one real window the app has, and the first thing anyone sees.
             // On the sheet for the same reason as the rest: it is looked at,
             // not asserted on, and two screens that drift apart are obvious
@@ -81,36 +81,42 @@ enum PanelsCommand {
             // One of each context, because the second button is the difference
             // between them and it is the part worth being able to see: setting
             // up says "Cancel installation", revisiting says "Not now".
-            (NSHostingView(rootView: PermissionsView()
+            (AnyView(PermissionsView()
                 .environmentObject(PermissionsModel.showing(.microphone))),
-             NSSize(width: PermissionMetrics.width, height: PermissionMetrics.height), .aqua),
-            (NSHostingView(rootView: PermissionsView()
+             NSSize(width: PermissionMetrics.width, height: PermissionMetrics.height), .light, false),
+            (AnyView(PermissionsView()
                 .environmentObject(PermissionsModel.showing(
                     .accessibility, asked: true, context: .revisiting))),
-             NSSize(width: PermissionMetrics.width, height: PermissionMetrics.height), .darkAqua),
-            (NSHostingView(rootView: PillView().environmentObject(notice)),
-             pillSize(notice), .darkAqua),
-            (NSHostingView(rootView: PillView().environmentObject(thinking)),
-             pillSize(thinking), .darkAqua),
-            (NSHostingView(rootView: PillView().environmentObject(caution)),
-             pillSize(caution), .darkAqua),
+             NSSize(width: PermissionMetrics.width, height: PermissionMetrics.height), .dark, false),
+            (AnyView(PillView().environmentObject(notice)),
+             pillSize(notice), .dark, true),
+            (AnyView(PillView().environmentObject(thinking)),
+             pillSize(thinking), .dark, true),
+            (AnyView(PillView().environmentObject(caution)),
+             pillSize(caution), .dark, true),
             // The state the pill ends on, which is the only one that offers
             // rather than reports. Next to the notices because that is the
             // comparison that matters: it has to not look like one.
-            (NSHostingView(rootView: PillView().environmentObject(offer)),
-             pillSize(offer), .darkAqua),
-            (NSHostingView(rootView: CorrectionView().environmentObject(correction)),
-             NSSize(width: CorrectionMetrics.width, height: CorrectionMetrics.height(forRows: 2)), .darkAqua),
-            (NSHostingView(rootView: CorrectionView().environmentObject(rule)),
-             NSSize(width: CorrectionMetrics.width, height: CorrectionMetrics.height(forRows: 1)), .darkAqua),
-            (NSHostingView(rootView: PreviewView().environmentObject(preview)),
-             NSSize(width: PreviewMetrics.width, height: PreviewMetrics.height(forCharacters: 70)), .darkAqua),
+            (AnyView(PillView().environmentObject(offer)),
+             pillSize(offer), .dark, true),
+            (AnyView(CorrectionView().environmentObject(correction)),
+             NSSize(width: CorrectionMetrics.width, height: CorrectionMetrics.height(forRows: 2)), .dark, false),
+            (AnyView(CorrectionView().environmentObject(rule)),
+             NSSize(width: CorrectionMetrics.width, height: CorrectionMetrics.height(forRows: 1)), .dark, false),
+            // The dictation panel is deliberately not here. Its field is an
+            // `NSTextField` and its background is real Liquid Glass, and this
+            // sheet can draw neither — it came out as a white block inside an
+            // untinted rectangle, which is worse than an omission. Look at it
+            // with `--panels dictation`, on a screen, where both are real.
+            (AnyView(PreviewView().environmentObject(preview)),
+             NSSize(width: PreviewMetrics.sampleWidth + PreviewMetrics.bleed * 2,
+                    height: PreviewMetrics.height(for: preview.after, singleLine: false)), .dark, true),
         ]
 
         let margin: CGFloat = 36
         let gap: CGFloat = 24
-        let column = surfaces.map(\.1.width).max()! + margin * 2
-        let tall = surfaces.map(\.1.height).reduce(0, +) + gap * CGFloat(surfaces.count - 1) + margin * 2
+        let column = surfaces.map(\.size.width).max()! + margin * 2
+        let tall = surfaces.map(\.size.height).reduce(0, +) + gap * CGFloat(surfaces.count - 1) + margin * 2
         let size = NSSize(width: column * 2, height: tall)
 
         guard let canvas = NSBitmapImageRep(
@@ -132,18 +138,50 @@ enum PanelsCommand {
             NSRect(x: left, y: 0, width: column, height: size.height).fill()
 
             var top = size.height - margin
-            for (view, natural, appearance) in surfaces {
-                view.appearance = NSAppearance(named: appearance)
-                view.frame = NSRect(origin: .zero, size: natural)
-                view.layoutSubtreeIfNeeded()
-                guard let rep = view.bitmapImageRepForCachingDisplay(in: view.bounds) else { continue }
-                view.cacheDisplay(in: view.bounds, to: rep)
-                rep.draw(in: NSRect(
+            for (view, natural, scheme, drawn) in surfaces {
+                let box = NSRect(
                     x: left + (column - natural.width) / 2,
                     y: top - natural.height,
                     width: natural.width,
                     height: natural.height
-                ))
+                )
+
+                // Two ways to snapshot, and each is wrong for the other half.
+                //
+                // `ImageRenderer` draws the SwiftUI view itself, which is the
+                // only way to keep the pill's glow: the glow is a blur, a blur
+                // makes SwiftUI rasterize the layer, and `cacheDisplay` hands
+                // that back opaque — every pill came out in a black rectangle.
+                //
+                // But `ImageRenderer` cannot draw an AppKit-backed control, so
+                // the correction and preview panels come out with every text
+                // field empty. Those keep `cacheDisplay`, which has no blur to
+                // lose.
+                if drawn {
+                    // `assumeIsolated` because `ImageRenderer` is main-actor
+                    // bound and this is a plain synchronous function — called
+                    // from `main.swift` on the main thread and nowhere else.
+                    let rendered = MainActor.assumeIsolated { () -> NSImage? in
+                        let renderer = ImageRenderer(
+                            content: view
+                                .environment(\.colorScheme, scheme)
+                                .frame(width: natural.width, height: natural.height)
+                        )
+                        renderer.scale = 2
+                        renderer.isOpaque = false
+                        return renderer.nsImage
+                    }
+                    rendered?.draw(in: box)
+                } else {
+                    let hosting = NSHostingView(rootView: view)
+                    hosting.appearance = NSAppearance(named: scheme == .dark ? .darkAqua : .aqua)
+                    hosting.frame = NSRect(origin: .zero, size: natural)
+                    hosting.layoutSubtreeIfNeeded()
+                    if let rep = hosting.bitmapImageRepForCachingDisplay(in: hosting.bounds) {
+                        hosting.cacheDisplay(in: hosting.bounds, to: rep)
+                        rep.draw(in: box)
+                    }
+                }
                 top -= natural.height + gap
             }
         }
@@ -161,9 +199,10 @@ enum PanelsCommand {
         }
     }
 
+    /// The window's size, not the capsule's — the glow needs the bleed around
+    /// it or the sheet cuts the halo off square.
     private static func pillSize(_ model: PillModel) -> NSSize {
-        NSSize(width: PillMetrics.width(for: model.state, hasIcon: model.appIcon != nil),
-               height: PillMetrics.height)
+        PillMetrics.panelSize(for: model.state, hasIcon: model.appIcon != nil)
     }
 
     /// Something recognisable to sit in the pill's slot. Mail because that is
@@ -203,6 +242,12 @@ enum PanelsCommand {
         case "rule":
             correction.show(rules: [(heard: "Tasmin", corrected: "Tasmeen"),
                                     (heard: "Mick", corrected: "Mik")])
+        // The panel the pill's offer opens: one line, editable, over what was
+        // just dictated. A different shape from the transform preview below —
+        // short enough for a field rather than an area — and the one that is
+        // seen most, so it is worth being able to look at on its own.
+        case "dictation":
+            preview.show(transcript: "Let's ship the vocabulary harness on Tuesday.")
         case "preview":
             preview.show(
                 prompt: "Grammar",
@@ -224,10 +269,11 @@ enum PanelsCommand {
         // which is the only way to see whether the pill morphs or jumps.
         case "sequence":
             var phase = 0.0
-            ticker = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { _ in
+            let meter = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { _ in
                 phase += 0.05
                 pill.model.level = Float(0.5 + 0.45 * sin(phase * 2))
             }
+            ticker = meter
 
             let script: [(TimeInterval, () -> Void)] = [
                 (0.0, { pill.recording(icon: sampleIcon()) }),
@@ -247,7 +293,7 @@ enum PanelsCommand {
                 }
             }
         default:
-            print("usage: ParrotFlow --panels <notice|caution|failure|thinking|offer|vocabulary|rule|preview|pill|sequence> [seconds]")
+            print("usage: ParrotFlow --panels <notice|caution|failure|thinking|offer|vocabulary|rule|dictation|preview|pill|sequence> [seconds]")
             return 2
         }
 

--- a/Sources/ParrotFlow/ParrotStyle.swift
+++ b/Sources/ParrotFlow/ParrotStyle.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// The one place the floating surfaces agree on how they look.
@@ -53,14 +54,71 @@ extension View {
     /// `alive` is for work of unknown length. The rim turns and brightens, which
     /// is the only motion any of these surfaces make — it means the app is busy,
     /// so nothing else may borrow it for decoration.
-    func parrotSurface<S: InsettableShape>(_ shape: S, alive: Bool = false) -> some View {
+    ///
+    /// `glass` gives the surface a thickness: a lighter scrim, a sheen down the
+    /// face, and the rim's inner hairline weighted to the top so the edge reads
+    /// as lit. It is what tells you something is a lens over the desktop rather
+    /// than a card sitting on it. It needs an `NSVisualEffectView` behind the
+    /// window to have anything to be thick over — see `ParrotGlass`.
+    ///
+    /// `scrim` is how much of the desktop it keeps out, and only means anything
+    /// under glass. Default is thin, for the pill, which is glanced at. Pass
+    /// more for anything holding a sentence you have to read and select.
+    func parrotSurface<S: InsettableShape>(
+        _ shape: S, alive: Bool = false, glass: Bool = false, scrim: Double? = nil
+    ) -> some View {
         background {
-            shape.fill(.regularMaterial)
+            // No `.regularMaterial` under glass. That blurs what is inside the
+            // window, and on a panel with a clear background there is nothing
+            // inside it to blur — it comes out flat grey, and a scrim over flat
+            // grey is a black-to-grey gradient rather than glass. The material
+            // for those surfaces sits behind the whole window; see `ParrotGlass`.
+            if !glass {
+                shape.fill(.regularMaterial)
+            }
             // The material alone takes the shade of whatever is behind it, which
             // over a white page is a white panel. The scrim holds it dark.
-            shape.fill(Color.black.opacity(0.34))
+            //
+            // Much lighter under glass, because there the thing behind it is the
+            // desktop and the whole point is to see it. Not nothing: these carry
+            // white text over whatever happens to be there, and a bright page
+            // behind them would take the words with it.
+            //
+            // This is the transparency dial, and the only one — turning the
+            // backdrop's alpha down instead would let the desktop through
+            // unblurred. A surface you only glance at can afford to be thin; one
+            // you read a sentence off and select words in cannot, which is why
+            // the dialogs pass a heavier `scrim` than the pill's default.
+            //
+            // Nothing at all where the system has real Liquid Glass: it does
+            // its own tinting, through `tintColor` on the view behind, and a
+            // scrim painted on top of it is paint over glass.
+            if !glass {
+                shape.fill(Color.black.opacity(0.34))
+            } else if !ParrotGlass.isPlatform {
+                shape.fill(Color.black.opacity(scrim ?? 0.08))
+            }
+
+            if glass, !ParrotGlass.isPlatform {
+                // Light falling on the face, strongest at the top and gone by
+                // halfway down. Stops short of the bottom on purpose — a sheen
+                // that reaches both edges reads as a gradient fill rather than
+                // as a lit surface.
+                shape.fill(
+                    LinearGradient(
+                        stops: [
+                            .init(color: .white.opacity(0.14), location: 0),
+                            .init(color: .white.opacity(0.04), location: 0.42),
+                            .init(color: .clear, location: 0.72)
+                        ],
+                        startPoint: .top, endPoint: .bottom
+                    )
+                )
+            }
         }
-        .overlay { PlumageRim(shape: shape, alive: alive) }
+        // The lit edge is the rim's own inner hairline, weighted to the top —
+        // not a line of its own. See `PlumageRim`.
+        .overlay { PlumageRim(shape: shape, alive: alive, glass: glass) }
     }
 }
 
@@ -68,6 +126,9 @@ extension View {
 struct PlumageRim<S: InsettableShape>: View {
     let shape: S
     var alive: Bool = false
+    /// Weight the inner hairline toward the top, so it reads as light on the
+    /// edge. See the hairline below.
+    var glass: Bool = false
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var angle: Double = -90
@@ -81,12 +142,32 @@ struct PlumageRim<S: InsettableShape>: View {
             .opacity(alive ? 1 : 0.9)
             // A white hairline just inside keeps the edge glassy in light mode,
             // where saturated colour alone reads as a sticker.
+            //
+            // Under `glass` this same line is also the specular — bright along
+            // the top, gone by the sides. It is one line either way, and that
+            // is the point: a second hairline drawn a fraction inside this one
+            // does not read as light on a rounded edge, it reads as a second
+            // border with a dark gap between them, which is what it looks like.
             .overlay {
-                shape.inset(by: 1.4).strokeBorder(.white.opacity(0.12), lineWidth: 0.5)
+                shape.inset(by: 1.4).strokeBorder(hairline, lineWidth: glass ? 0.75 : 0.5)
             }
             .animation(.easeInOut(duration: 0.35), value: alive)
             .onChange(of: alive) { _, _ in spin() }
             .onAppear { spin() }
+    }
+
+    private var hairline: AnyShapeStyle {
+        guard glass else { return AnyShapeStyle(Color.white.opacity(0.12)) }
+        return AnyShapeStyle(
+            LinearGradient(
+                stops: [
+                    .init(color: .white.opacity(0.40), location: 0),
+                    .init(color: .white.opacity(0.10), location: 0.35),
+                    .init(color: .white.opacity(0.05), location: 1)
+                ],
+                startPoint: .top, endPoint: .bottom
+            )
+        )
     }
 
     private func spin() {
@@ -94,28 +175,340 @@ struct PlumageRim<S: InsettableShape>: View {
             withAnimation(.default) { angle = -90 }
             return
         }
-        withAnimation(.linear(duration: 3.2).repeatForever(autoreverses: false)) {
+        withAnimation(.linear(duration: 1.8).repeatForever(autoreverses: false)) {
             angle = 270
+        }
+    }
+}
+
+// MARK: - Fields
+
+/// A one-line field with the caret already at the end of the sentence.
+///
+/// SwiftUI's `TextField` selects everything when it takes focus. That is right
+/// for a field you are replacing and wrong for one you are correcting: the
+/// first key you press throws the sentence away, and the sentence is the thing
+/// you opened the panel to keep. There is no way to say otherwise from SwiftUI
+/// before macOS 15, and the field editor is an AppKit object either way.
+///
+/// So the field is an `NSTextField` and the selection is set by hand, once,
+/// when it becomes first responder — collapsed to the end, which is where you
+/// carry on typing from.
+struct EndCaretField: NSViewRepresentable {
+    typealias NSViewType = NSTextField
+    // Spelled out rather than as `Context`: this module has a `Context` of its
+    // own — the screen-capture stage — and it shadows the protocol's typealias,
+    // so the two methods below silently stop matching the requirement.
+    typealias Ctx = NSViewRepresentableContext<EndCaretField>
+
+    @Binding var text: String
+    var fontSize: CGFloat
+    var onSubmit: () -> Void
+
+    func makeNSView(context: Ctx) -> NSTextField {
+        let field = NSTextField(string: text)
+        field.delegate = context.coordinator
+        field.isBordered = false
+        field.drawsBackground = false
+        field.focusRingType = .none
+        field.font = .systemFont(ofSize: fontSize)
+        field.lineBreakMode = .byClipping
+        field.cell?.usesSingleLineMode = true
+        field.cell?.wraps = false
+        field.cell?.isScrollable = true
+        // Focus, then the caret. Both after the view is in a window: a field
+        // with no window has no field editor to put a selection in.
+        DispatchQueue.main.async {
+            field.window?.makeFirstResponder(field)
+            if let editor = field.currentEditor() {
+                editor.selectedRange = NSRange(location: field.stringValue.count, length: 0)
+            }
+        }
+        return field
+    }
+
+    func updateNSView(_ field: NSTextField, context: Ctx) {
+        if field.stringValue != text { field.stringValue = text }
+        if field.font?.pointSize != fontSize { field.font = .systemFont(ofSize: fontSize) }
+    }
+
+    func makeCoordinator() -> FieldCoordinator { FieldCoordinator(self) }
+
+    final class FieldCoordinator: NSObject, NSTextFieldDelegate {
+        private let parent: EndCaretField
+        init(_ parent: EndCaretField) { self.parent = parent }
+
+        func controlTextDidChange(_ notification: Notification) {
+            guard let field = notification.object as? NSTextField else { return }
+            parent.text = field.stringValue
+        }
+
+        func control(_ control: NSControl, textView: NSTextView,
+                     doCommandBy selector: Selector) -> Bool {
+            // Return commits. Escape is left alone so the panel's own
+            // `cancelOperation` still answers it.
+            guard selector == #selector(NSResponder.insertNewline(_:)) else { return false }
+            parent.onSubmit()
+            return true
+        }
+    }
+}
+
+// MARK: - Glass
+
+/// The backdrop that actually samples the desktop.
+///
+/// SwiftUI's `.regularMaterial` blurs what is inside its own *window*. These
+/// panels are borderless with a clear background, so there is nothing inside to
+/// blur and the material comes out flat grey — a scrim over flat grey is a
+/// black-to-grey gradient, which is what "glass" looked like before this.
+/// `NSVisualEffectView` with `.behindWindow` blending is the only thing on
+/// macOS that samples what is behind the window, and only AppKit has one.
+///
+/// It goes *under* the hosting view, masked to the same shape SwiftUI draws, so
+/// the frost stops where the surface does. Unmasked it fills the window, and on
+/// the pill that would frost the transparent margin the glow lives in.
+enum ParrotGlass {
+
+    /// Whether the system has real Liquid Glass, or we are drawing our own.
+    ///
+    /// Read by `parrotSurface` as well: with the platform material behind it,
+    /// the scrim and sheen it draws for the fallback would be paint over glass.
+    static var isPlatform: Bool {
+        if #available(macOS 26.0, *) { return true }
+        return false
+    }
+
+    /// Panel, backdrop and content, stacked in that order.
+    ///
+    /// `inset` is the transparent margin around the surface — the glow spills
+    /// into it. `tint` is how much of the desktop the surface keeps out; a
+    /// sentence you read word by word wants more of it than a pill you glance
+    /// at.
+    static func container(
+        _ content: NSView, radius: CGFloat, inset: CGFloat = 0, tint: NSColor? = nil
+    ) -> NSView {
+        let container = NSView(frame: content.frame)
+        container.autoresizesSubviews = true
+        container.addSubview(backdrop(
+            radius: radius, in: content.frame.size, inset: inset, tint: tint
+        ))
+        container.addSubview(content)
+        return container
+    }
+
+    /// The backdrop, behind the content rather than around it.
+    ///
+    /// `NSGlassEffectView` is documented as embedding a `contentView` in glass,
+    /// and that is the usual way to hold it. Not here: the SwiftUI view spans
+    /// the whole window because the glow has to spill into the margin, and a
+    /// content view inside the glass would be clipped to the glass's own
+    /// bounds. So it is used as a backdrop with an empty content view, and the
+    /// SwiftUI surface is drawn over it — the same shape, the same corner
+    /// radius, and the rim on top of both.
+    static func backdrop(
+        radius: CGFloat, in size: NSSize, inset: CGFloat = 0,
+        overlap: CGFloat = 2, tint: NSColor? = nil
+    ) -> NSView {
+        let edge = max(0, inset - overlap)
+        let frame = NSRect(
+            x: edge, y: edge,
+            width: size.width - edge * 2, height: size.height - edge * 2
+        )
+
+        if #available(macOS 26.0, *) {
+            let glass = NSGlassEffectView(frame: frame)
+            glass.cornerRadius = radius + overlap
+            glass.style = .regular
+            glass.tintColor = tint
+            // It wants one, and an empty view is the honest answer: the content
+            // is drawn over the glass, not inside it. See above.
+            glass.contentView = NSView(frame: glass.bounds)
+            glass.autoresizingMask = [.width, .height]
+            return glass
+        }
+
+        // Before macOS 26 there is no Liquid Glass, so it is assembled by hand:
+        // a blur that samples behind the window, and the scrim and sheen
+        // `parrotSurface` draws over it.
+        //
+        // The frost is drawn `overlap` points *outside* the surface rather than
+        // exactly under it. Two geometries have to agree — an AppKit mask image
+        // with circular corners, and a SwiftUI `.continuous` rounded rectangle
+        // — and where they disagree by a point the desktop shows through
+        // between the frost and the rim, which reads as the border floating off
+        // its own background.
+        let view = NSVisualEffectView(frame: frame)
+        view.material = .hudWindow
+        view.blendingMode = .behindWindow
+        view.state = .active
+        view.maskImage = mask(radius: radius + overlap)
+        // Full strength, always. Lowering `alphaValue` does not make the frost
+        // more transparent — it lets that fraction of the *raw* desktop through
+        // beside it, sharp and unblurred, which reads as a dirty window rather
+        // than a glass one.
+        view.alphaValue = 1
+        view.autoresizingMask = [.width, .height]
+        return view
+    }
+
+    /// A rounded rectangle to cut the frost to, stretchable along its middle.
+    ///
+    /// The cap insets are what let one small image stretch to any size without
+    /// the corners distorting, which is what makes this survive the pill's
+    /// width changing on every state. Only the pre-26 path needs it —
+    /// `NSGlassEffectView` has a `cornerRadius` of its own.
+    static func mask(radius: CGFloat) -> NSImage {
+        let size = NSSize(width: radius * 2 + 1, height: radius * 2 + 1)
+        let image = NSImage(size: size, flipped: false) { rect in
+            NSColor.black.setFill()
+            NSBezierPath(roundedRect: rect, xRadius: radius, yRadius: radius).fill()
+            return true
+        }
+        image.capInsets = NSEdgeInsets(top: radius, left: radius, bottom: radius, right: radius)
+        image.resizingMode = .stretch
+        return image
+    }
+}
+
+/// The light a surface throws onto whatever is behind it.
+///
+/// The rim is a 1.4pt hairline of the four feathers. This is the same hairline
+/// again, thick and blurred, drawn behind the glass so the colour spills past
+/// the edge instead of stopping at it — the surface lighting the desktop rather
+/// than sitting on it.
+///
+/// Whatever draws one has to leave a transparent margin around itself for the
+/// blur to land in, or the tail is cut off square at the window edge and the
+/// glow reads as a second border. See `PillMetrics.bleed`.
+///
+/// **While the app is busy the two turn opposite ways, at speeds that do not
+/// divide.** An even halo reads as a sticker with a drop shadow. At 2.6s and
+/// 4.1s the bright parts pass each other on a cycle far longer than either, so
+/// the bloom is brighter on one side, then another, and never repeats within
+/// the seconds anyone watches it. That irregularity is the whole effect; the
+/// spill on its own is just a glow.
+///
+/// It brightens while `alive`, which is the same signal the rim uses — the app
+/// is busy. Nothing else may borrow it.
+///
+/// Four layers. That is the budget: each is a full-size Gaussian blur, and this
+/// sits on screen for the whole of every dictation.
+struct PlumageBloom<S: InsettableShape>: View {
+    let shape: S
+    var alive: Bool = false
+    /// How much of it there is. The same absolute spill reads as far less
+    /// around a 900pt panel than around a 46pt pill — the glow is a proportion
+    /// of the edge it comes off, and the edge here is twenty times longer.
+    var intensity: Double = 1
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var outer: Double = -90
+    @State private var inner: Double = 90
+
+    var body: some View {
+        ZStack {
+            // One stroke, blurred three ways. Same width and same angle on all
+            // three, so their colours land on top of each other and sum into a
+            // single falloff — brightest at the edge, gone by the margin.
+            //
+            // Three *different* widths banded: a wide stroke and a narrow one
+            // put their colour at different distances from the edge, so scarlet
+            // sat inside teal in a visible stripe. Diffusion is one source
+            // spread further, not several sources.
+            //
+            // Chained `.shadow` was tried instead, to dodge the opaque backing
+            // a blur forces — see `build()`. It cannot diffuse. Each shadow
+            // casts the stroke *plus every shadow before it*, so a thin sharp
+            // source comes out as nested soft-edged copies of itself: four
+            // coloured borders drawn on top of each other, which is exactly
+            // what it looked like. A blur spreads one source; a shadow repeats
+            // it.
+            bloom(width: 9, blur: 24, opacity: (alive ? 0.22 : 0.13) * intensity, angle: outer)
+            bloom(width: 9, blur: 13, opacity: (alive ? 0.28 : 0.18) * intensity, angle: outer)
+            bloom(width: 9, blur: 5, opacity: (alive ? 0.42 : 0.28) * intensity, angle: outer)
+
+            // The unevenness, and the only layer that disagrees about where the
+            // colours are. Wide and heavily blurred so it has no edge of its
+            // own: it brightens one side of the halo and then another, which is
+            // what keeps the glow from reading as a decal.
+            bloom(width: 22, blur: 22, opacity: (alive ? 0.19 : 0.10) * intensity, angle: inner)
+        }
+        .animation(.easeInOut(duration: 0.4), value: alive)
+        .onChange(of: alive) { _, _ in spin() }
+        .onAppear { spin() }
+    }
+
+    private func bloom(width: CGFloat, blur: CGFloat, opacity: Double, angle: Double) -> some View {
+        shape
+            .strokeBorder(
+                AngularGradient(colors: Parrot.wheel, center: .center, angle: .degrees(angle)),
+                lineWidth: width
+            )
+            .blur(radius: blur)
+            .opacity(opacity)
+    }
+
+    /// The drift, and only while the app is busy.
+    ///
+    /// It turned all the time at first, which cost 40% of a core for as long as
+    /// the pill was on screen — four Gaussian blurs re-rendered every frame,
+    /// measured against 0% for the same pill standing still. A decoration that
+    /// expensive is not a decoration, it is a fan.
+    ///
+    /// Still, the reason to stop it is the rule that was already written on
+    /// `PlumageRim`: motion on these surfaces means the app is working, and
+    /// nothing may borrow it to look nice. A glow that drifts while nothing is
+    /// happening says something is happening. At rest the bloom is simply
+    /// there — lit, uneven, and still.
+    private func spin() {
+        guard alive, !reduceMotion else {
+            withAnimation(.easeInOut(duration: 0.4)) { outer = -90; inner = 90 }
+            return
+        }
+        // Opposite directions, and the two periods share no small factor, so
+        // the bright parts pass each other on a cycle far longer than either.
+        withAnimation(.linear(duration: 2.6).repeatForever(autoreverses: false)) {
+            outer = 270
+        }
+        withAnimation(.linear(duration: 4.1).repeatForever(autoreverses: false)) {
+            inner = -270
         }
     }
 }
 
 // MARK: - Chrome
 
-/// Four feathers, ascending. The app's mark at the size a label is set in.
+/// The bird, at the size a label is set in.
 ///
-/// The same four bars as the recording pill's meter with the sound taken out —
-/// which is what a dialog is: the pill, after it has heard you.
+/// The same parrot as the menu bar, built by `scripts/make-icons.py` from
+/// `Resources/parrot.svg`. It was four ascending feathers before — a mark
+/// derived from the pill's meter — which read as a signal-strength glyph next
+/// to a word in capitals rather than as this app. The bird is the thing people
+/// look for in the menu bar; the panels should be wearing it too.
+///
+/// Falls back to the feathers when the image is missing, which happens exactly
+/// once: running the binary outside its bundle.
 struct PlumageMark: View {
+    var size: CGFloat = 13
+
     var body: some View {
-        HStack(spacing: 1.5) {
-            ForEach(Array(Parrot.wheel.prefix(4).enumerated()), id: \.offset) { index, colour in
-                Capsule()
-                    .fill(colour)
-                    .frame(width: 2, height: 5 + CGFloat(index) * 2)
+        if let parrot = NSImage(named: "MenuBarParrotRecording") {
+            Image(nsImage: parrot)
+                .resizable()
+                .interpolation(.high)
+                .aspectRatio(contentMode: .fit)
+                .frame(width: size, height: size)
+        } else {
+            HStack(spacing: 1.5) {
+                ForEach(Array(Parrot.wheel.prefix(4).enumerated()), id: \.offset) { index, colour in
+                    Capsule()
+                        .fill(colour)
+                        .frame(width: 2, height: 5 + CGFloat(index) * 2)
+                }
             }
+            .frame(height: 11, alignment: .bottom)
         }
-        .frame(height: 11, alignment: .bottom)
     }
 }
 
@@ -174,30 +567,37 @@ struct PanelActions: View {
     let status: String
     let cancelTitle: String
     let confirmTitle: String
+    /// Sit closer to what is above. For a panel holding one line, the standing
+    /// 24pt of air over the buttons is most of a dead band across the bottom.
+    var compact: Bool = false
     let onCancel: () -> Void
     let onConfirm: () -> Void
 
     var body: some View {
         VStack(spacing: 0) {
-            Divider().opacity(0.5)
-
             HStack(spacing: 10) {
-                Text(status)
-                    .font(.system(size: 11))
-                    .foregroundStyle(.tertiary)
-                    .lineLimit(1)
+                // Empty when the panel says what it is somewhere better. The
+                // dictation panel puts its instruction above the field, at a
+                // size you can read, rather than in grey under the buttons.
+                if !status.isEmpty {
+                    Text(status)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                }
 
                 Spacer(minLength: 12)
 
-                ActionButton(title: cancelTitle, key: "esc", filled: false, action: onCancel)
+                ActionButton(title: cancelTitle, key: "esc", filled: false, quiet: true,
+                             action: onCancel)
                     .keyboardShortcut(.cancelAction)
 
                 ActionButton(title: confirmTitle, key: "⌘↩", filled: true, action: onConfirm)
                     .keyboardShortcut(.return, modifiers: .command)
             }
-            .padding(.top, 12)
+            .padding(.top, compact ? 4 : 12)
         }
-        .padding(.top, 12)
+        .padding(.top, compact ? 6 : 12)
     }
 }
 
@@ -207,6 +607,12 @@ struct ActionButton: View {
     let title: String
     let key: String
     let filled: Bool
+    /// No capsule, no border — the label and its key and nothing else.
+    ///
+    /// For the button you are not expected to press. Two bordered buttons side
+    /// by side make a choice out of what is really an action and a way out, and
+    /// on a panel this small that is a lot of furniture for "never mind".
+    var quiet: Bool = false
     let action: () -> Void
 
     @State private var hovering = false
@@ -219,10 +625,12 @@ struct ActionButton: View {
                     .foregroundStyle(filled ? AnyShapeStyle(.white) : AnyShapeStyle(.primary))
                 KeyCap(symbol: key, onFill: filled)
             }
-            .padding(.horizontal, 11)
+            .padding(.horizontal, quiet ? 4 : 11)
             .padding(.vertical, 6)
             .background {
-                if filled {
+                if quiet {
+                    Capsule().fill(Color.primary.opacity(hovering ? 0.08 : 0))
+                } else if filled {
                     Capsule().fill(
                         LinearGradient(
                             colors: [Parrot.action, Parrot.action.opacity(0.86)],
@@ -250,16 +658,41 @@ struct ActionButton: View {
 extension View {
 
     /// The one text field look: a quiet well that takes a sky ring when focused.
-    func parrotField(focused: Bool) -> some View {
-        padding(.horizontal, 9)
-            .padding(.vertical, 6)
+    /// A hairline under a field, instead of a box around it.
+    ///
+    /// Everything this panel needs to say about the field's bounds, said with
+    /// one line: where the text sits and how far it runs. A filled, bordered
+    /// box on top of glass is a rectangle inside a rectangle, and the glass is
+    /// already doing the job of separating the surface from the desktop.
+    func underlined() -> some View {
+        overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(
+                    LinearGradient(
+                        colors: [Parrot.action.opacity(0.55), Parrot.action.opacity(0.2)],
+                        startPoint: .leading, endPoint: .trailing
+                    )
+                )
+                .frame(height: 1)
+        }
+    }
+
+    /// `snug` trims the padding for a field whose text is already large. The
+    /// default was set around 13pt type; at 30 the same margins put a band of
+    /// empty either side of the sentence and make the box the subject.
+    func parrotField(focused: Bool, snug: Bool = false) -> some View {
+        padding(.horizontal, snug ? 12 : 9)
+            .padding(.vertical, snug ? 5 : 6)
             .background(
                 Color.primary.opacity(0.06),
                 in: RoundedRectangle(cornerRadius: Parrot.fieldRadius, style: .continuous)
             )
             .overlay {
+                // A hint that this is where the caret is, not a highlight. At
+                // 0.9 and 1.5pt the ring was the loudest thing on the panel and
+                // it framed the one thing you are supposed to be reading.
                 RoundedRectangle(cornerRadius: Parrot.fieldRadius, style: .continuous)
-                    .strokeBorder(Parrot.action.opacity(focused ? 0.9 : 0), lineWidth: 1.5)
+                    .strokeBorder(Parrot.action.opacity(focused ? 0.38 : 0), lineWidth: 1)
             }
             .animation(.easeOut(duration: 0.12), value: focused)
     }

--- a/Sources/ParrotFlow/ParrotStyle.swift
+++ b/Sources/ParrotFlow/ParrotStyle.swift
@@ -221,7 +221,13 @@ struct EndCaretField: NSViewRepresentable {
         DispatchQueue.main.async {
             field.window?.makeFirstResponder(field)
             if let editor = field.currentEditor() {
-                editor.selectedRange = NSRange(location: field.stringValue.count, length: 0)
+                // `NSString.length`, not `String.count`. AppKit selections are
+                // UTF-16 offsets and `count` is grapheme clusters, so one emoji
+                // or composed character in the sentence puts the caret short of
+                // the end — or inside a surrogate pair.
+                editor.selectedRange = NSRange(
+                    location: (field.stringValue as NSString).length, length: 0
+                )
             }
         }
         return field
@@ -245,8 +251,15 @@ struct EndCaretField: NSViewRepresentable {
 
         func control(_ control: NSControl, textView: NSTextView,
                      doCommandBy selector: Selector) -> Bool {
-            // Return commits. Escape is left alone so the panel's own
-            // `cancelOperation` still answers it.
+            // Return commits, and the panel says so: a one-line field shows ↩
+            // on its confirm button, not ⌘↩. There is no newline to insert in
+            // a field that holds one line, so Return meaning "done" is what
+            // every other one-line field on the system does — and advertising
+            // a modifier the field does not need is the part that was wrong.
+            // ⌘↩ still works, through the button's own shortcut.
+            //
+            // Escape is left alone so the panel's own `cancelOperation` still
+            // answers it.
             guard selector == #selector(NSResponder.insertNewline(_:)) else { return false }
             parent.onSubmit()
             return true
@@ -567,6 +580,9 @@ struct PanelActions: View {
     let status: String
     let cancelTitle: String
     let confirmTitle: String
+    /// What the confirm button advertises. ⌘↩ where Return would insert a
+    /// newline, ↩ where the field is one line and Return commits it.
+    var confirmKey: String = "⌘↩"
     /// Sit closer to what is above. For a panel holding one line, the standing
     /// 24pt of air over the buttons is most of a dead band across the bottom.
     var compact: Bool = false
@@ -592,7 +608,7 @@ struct PanelActions: View {
                              action: onCancel)
                     .keyboardShortcut(.cancelAction)
 
-                ActionButton(title: confirmTitle, key: "⌘↩", filled: true, action: onConfirm)
+                ActionButton(title: confirmTitle, key: confirmKey, filled: true, action: onConfirm)
                     .keyboardShortcut(.return, modifiers: .command)
             }
             .padding(.top, compact ? 4 : 12)

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -337,8 +337,8 @@ private struct Instrument: View {
                 // Sized explicitly: the pill fills whatever it is given, and
                 // the panel that owns it is what decides its width in the app.
                 PillView().environmentObject(Instrument.hearing)
-                    .frame(width: PillMetrics.recording(hasIcon: false),
-                           height: PillMetrics.height)
+                    .frame(width: PillMetrics.recording(hasIcon: false) + PillMetrics.bleed * 2,
+                           height: PillMetrics.height + PillMetrics.bleed * 2)
             case .accessibility:
                 Landing()
             }

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -146,10 +146,7 @@ final class PillHUD {
             model.state = state
         }
 
-        let size = NSSize(
-            width: PillMetrics.width(for: state, hasIcon: model.appIcon != nil),
-            height: PillMetrics.height
-        )
+        let size = PillMetrics.panelSize(for: state, hasIcon: model.appIcon != nil)
 
         if panel.isVisible {
             morph(to: size)
@@ -254,24 +251,54 @@ final class PillHUD {
 
     private func build() {
         let hosting = NSHostingView(rootView: PillView().environmentObject(model))
-        hosting.frame = NSRect(x: 0, y: 0, width: PillMetrics.recording(hasIcon: false),
-                               height: PillMetrics.height)
+        hosting.frame = NSRect(origin: .zero,
+                               size: PillMetrics.panelSize(for: .recording, hasIcon: false))
         // The panel is what resizes; the view follows it. Done this way round
         // because a SwiftUI frame inside a fixed panel centres a narrow pill in
         // a wide transparent box and takes the shadow with it.
         hosting.autoresizingMask = [.width, .height]
+        // Say the backing is transparent, out loud.
+        //
+        // The glow is a blur, and a blur makes SwiftUI rasterize the view into
+        // an offscreen layer — which it then composites opaque, painting the
+        // panel's whole rectangle behind the capsule. On a floating surface
+        // that is the one artefact you cannot have: it is a visible box around
+        // the pill, in the shape of the window nobody is supposed to know is
+        // there.
+        //
+        // The panel is already `isOpaque = false` with a clear background. That
+        // governs the window; this governs the layer the blur is drawn into,
+        // and they are two different claims.
+        hosting.wantsLayer = true
+        hosting.layer?.isOpaque = false
+        hosting.layer?.backgroundColor = NSColor.clear.cgColor
+
+        // Real glass under the capsule. See `ParrotGlass` for why AppKit has to
+        // do this and SwiftUI cannot — and why it is masked rather than left to
+        // fill the window, which here would frost the margin the glow lives in.
+        let container = ParrotGlass.container(
+            hosting, radius: PillMetrics.height / 2, inset: PillMetrics.bleed,
+            // Barely tinted. The pill is glanced at over whatever you are
+            // reading, and the less of that it takes away the better.
+            tint: NSColor.black.withAlphaComponent(0.10)
+        )
+
         let panel = NSPanel(
             contentRect: hosting.frame,
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )
-        panel.contentView = hosting
+        panel.contentView = container
         panel.isFloatingPanel = true
         panel.level = .statusBar
         panel.backgroundColor = .clear
         panel.isOpaque = false
-        panel.hasShadow = true
+        // Drawn in SwiftUI instead. The window shadow is traced from the
+        // window's alpha, so with a glow bleeding into the margin it would
+        // outline the blur rather than the capsule — a soft grey halo around a
+        // coloured one. A shadow under the capsule is the shape it should be.
+        panel.hasShadow = false
         panel.ignoresMouseEvents = true
         panel.hidesOnDeactivate = false
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
@@ -279,8 +306,13 @@ final class PillHUD {
         self.panel = panel
     }
 
-    /// Where a pill of this width sits: centred, 96pt off the bottom, on the
-    /// screen the pointer is on — which is the screen you are typing into.
+    /// Where a pill of this window width sits: the capsule centred, 96pt off
+    /// the bottom, on the screen the pointer is on — which is the screen you
+    /// are typing into.
+    ///
+    /// `width` is the window's, bleed included, so the margin is taken back off
+    /// both axes: what has to land at 96pt is the capsule you can see, not the
+    /// transparent border the glow spills into.
     ///
     /// Recomputed at every state rather than once at the first show, so a pill
     /// that grows stays centred and one that arrives after you have moved to
@@ -289,7 +321,8 @@ final class PillHUD {
         let mouse = NSEvent.mouseLocation
         let screen = NSScreen.screens.first { NSMouseInRect(mouse, $0.frame, false) } ?? NSScreen.main
         guard let visible = screen?.visibleFrame else { return panel?.frame.origin ?? .zero }
-        return NSPoint(x: visible.midX - width / 2, y: visible.minY + 96)
+        return NSPoint(x: visible.midX - width / 2,
+                       y: visible.minY + 96 - PillMetrics.bleed)
     }
 }
 
@@ -298,6 +331,17 @@ final class PillHUD {
 enum PillMetrics {
     static let height: CGFloat = 46
 
+    /// Transparent margin between the capsule and the edge of the window.
+    ///
+    /// The glow is drawn by blurring the rim, and a blur has to have somewhere
+    /// to go. The panel used to be exactly the size of the capsule, so anything
+    /// spilling outward was cut off square at the window edge — which is the
+    /// one artefact that gives a floating surface away as a window.
+    ///
+    /// It costs nothing: the margin is fully transparent and the panel ignores
+    /// the mouse, so a wider window is not a bigger target for anything.
+    /// `width(for:)` and `height` stay the size of the capsule you can see;
+    /// `panelSize` is what the window is set to.
     /// Wide enough for the widest blur's tail to reach zero before the window
     /// ends.
     ///
@@ -309,6 +353,13 @@ enum PillMetrics {
     /// is transparent but not invisible — a faint rectangle can still be made
     /// out where its bounds are, so the less of it there is beyond the glow, the
     /// less there is to see.
+    static let bleed: CGFloat = 52
+
+    static func panelSize(for state: PillState, hasIcon: Bool) -> NSSize {
+        NSSize(width: width(for: state, hasIcon: hasIcon) + bleed * 2,
+               height: height + bleed * 2)
+    }
+
     static let padding: CGFloat = 17
     static let gap: CGFloat = 11
     /// The gap on the meter's right, 2pt tighter than the one on its left.
@@ -417,7 +468,15 @@ struct PillView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .parrotSurface(Capsule(), alive: isWorking)
+        .parrotSurface(Capsule(), alive: isWorking, glass: true)
+        // Under the capsule, so it is the capsule's shape and not the glow's.
+        .shadow(color: .black.opacity(0.22), radius: 7, y: 2)
+        // Behind everything above it. `.background` applied last sits furthest
+        // back, which is where the bloom has to be — over the fill it would be
+        // a coloured film on the glass rather than light coming off the edge.
+        .background { PlumageBloom(shape: Capsule(), alive: isWorking) }
+        // The transparent margin the bloom spills into. See `PillMetrics.bleed`.
+        .padding(PillMetrics.bleed)
         // Bound to the state alone. The meter is fed about ten times a second
         // and must not drag a crossfade along behind it.
         .animation(.easeInOut(duration: PillHUD.motion), value: model.state)

--- a/Sources/ParrotFlow/PreviewPanel.swift
+++ b/Sources/ParrotFlow/PreviewPanel.swift
@@ -63,18 +63,34 @@ final class PreviewPanel {
 
     private func build() {
         let hosting = NSHostingView(rootView: PreviewView().environmentObject(model))
+        hosting.frame = NSRect(x: 0, y: 0, width: PreviewMetrics.minimumWidth, height: 260)
+        hosting.autoresizingMask = [.width, .height]
+
         let panel = PreviewKeyPanel(
-            contentRect: NSRect(x: 0, y: 0, width: PreviewMetrics.width, height: 260),
+            contentRect: hosting.frame,
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )
-        panel.contentView = hosting
+        // Same glass as the pill, and inset by the same kind of margin — the
+        // glow needs somewhere to land, and the frost must not fill it.
+        panel.contentView = ParrotGlass.container(
+            hosting, radius: Parrot.panelRadius, inset: PreviewMetrics.bleed,
+            // Heavier than the pill's: this holds a sentence you read word by
+            // word and select inside, and it has to stay legible over whatever
+            // happens to be behind it.
+            // Liquid Glass handles legibility itself, so this is a nudge rather
+            // than the scrim it replaced.
+            tint: NSColor.black.withAlphaComponent(0.20)
+        )
         panel.isFloatingPanel = true
         panel.level = .modalPanel
         panel.backgroundColor = .clear
         panel.isOpaque = false
-        panel.hasShadow = true
+        // Drawn in SwiftUI instead: the window shadow traces the window's
+        // alpha, so with a glow bleeding into the margin it would outline the
+        // blur rather than the panel.
+        panel.hasShadow = false
         panel.hidesOnDeactivate = false
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         panel.adoptParrotAppearance()
@@ -85,13 +101,11 @@ final class PreviewPanel {
     /// Grows with the longer of the two texts, up to a cap.
     private func resize() {
         guard let panel else { return }
+        let width = PreviewMetrics.width(for: model.after)
         let height = PreviewMetrics.height(
-            forCharacters: max(model.before.count, model.after.count)
+            for: model.after, singleLine: model.singleLine, transcript: model.isTranscript
         )
-        panel.setContentSize(NSSize(width: PreviewMetrics.width, height: height))
-        panel.contentView?.frame = NSRect(
-            x: 0, y: 0, width: PreviewMetrics.width, height: height
-        )
+        panel.setContentSize(NSSize(width: width, height: height))
     }
 
     private func reposition() {
@@ -109,16 +123,96 @@ final class PreviewPanel {
 }
 
 enum PreviewMetrics {
-    static let width: CGFloat = 560
-    private static let chrome: CGFloat = 146
-    private static let minimumBody: CGFloat = 92
-    private static let maximumBody: CGFloat = 320
+    /// The narrowest the panel gets.
+    ///
+    /// Small, because the panel is now sized by what you said and a short
+    /// correction is short. At 840 — the old fixed width — "Okay." arrived in a
+    /// panel built for a paragraph, and the emptiness read as a layout that had
+    /// not finished loading. Wide enough for the buttons and an eyebrow, and
+    /// nothing beyond that is reserved.
+    static let minimumWidth: CGFloat = 420
+    private static let maximumBody: CGFloat = 340
 
-    /// Roughly 74 characters to a line at this width and size.
-    static func height(forCharacters count: Int) -> CGFloat {
-        let lines = max(1, (count / 74) + 1)
-        let body = min(maximumBody, max(minimumBody, CGFloat(lines) * 19 + 24))
-        return chrome + body
+    /// Transparent margin for the glow to land in — same idea as the pill's.
+    /// See `PlumageBloom`.
+    static let bleed: CGFloat = 40
+
+    /// The size the sentence is set in — the whole point of the panel is to
+    /// read it back and put a caret in the middle of a word without aiming.
+    static let fontSize: CGFloat = 30
+
+    /// Everything either side of the text on one line. Just the panel's own
+    /// padding now that the field has no box, plus a little slack so the last
+    /// character is not against the edge.
+    private static let sideChrome: CGFloat = Parrot.panelPadding * 2 + 14
+
+    /// How wide the sentence actually is, measured rather than counted.
+    ///
+    /// Character counts were the first try and they cannot work here: "MMM" and
+    /// "iii" are the same count and nowhere near the same width, and the whole
+    /// decision below — one line or an area — turns on which side of the panel
+    /// edge the last word falls.
+    static func textWidth(_ text: String) -> CGFloat {
+        (text as NSString)
+            .size(withAttributes: [.font: NSFont.systemFont(ofSize: fontSize)])
+            .width
+    }
+
+    /// As wide as the sentence needs, between the minimum and what the screen
+    /// will take. The bleed is on top of both — it is window, not panel.
+    ///
+    /// It grows because the alternative is wrapping a sentence that would have
+    /// fitted, and a wrapped sentence is one you read twice. It stops because a
+    /// panel wider than the screen is not a panel.
+    static func width(for text: String) -> CGFloat {
+        min(max(minimumWidth, textWidth(text) + sideChrome), ceiling) + bleed * 2
+    }
+
+    /// The old fixed width, kept for the sheet: it draws one sample and the
+    /// sample should be a normal-looking panel rather than the narrowest one.
+    static let sampleWidth: CGFloat = 840
+
+    /// Nothing wider than the screen it appears on, less a margin so it still
+    /// reads as a panel floating over something.
+    static var ceiling: CGFloat {
+        let mouse = NSEvent.mouseLocation
+        let screen = NSScreen.screens.first { NSMouseInRect(mouse, $0.frame, false) } ?? NSScreen.main
+        guard let visible = screen?.visibleFrame else { return minimumWidth }
+        return max(minimumWidth, visible.width - 160 - bleed * 2)
+    }
+
+    /// One line means one field: a text area for a sentence that fits on a line
+    /// is a box with an acre of nothing under it, and a caret you have to aim
+    /// at. It fits when the panel is allowed to be wide enough to hold it.
+    static func singleLine(_ text: String) -> Bool {
+        !text.contains("\n") && textWidth(text) + sideChrome <= ceiling
+    }
+
+    /// Panel chrome, by which half of the panel it is.
+    ///
+    /// The dictation panel has no header and no status line — it has one title
+    /// above the field instead — so reserving room for a header it does not
+    /// draw is exactly the gap between the field and the buttons that made it
+    /// look unbalanced.
+    private static func chrome(transcript: Bool) -> CGFloat {
+        let padding = Parrot.panelPadding * 2
+        // The gap above the buttons, and the buttons.
+        let actions: CGFloat = transcript ? 10 + 28 : 24 + 28
+        // An eyebrow and its gap, or the struck-through original and its gap.
+        let title: CGFloat = transcript ? 13 + 10 : 21 + 10
+        return padding + actions + title
+    }
+
+    static func height(for text: String, singleLine: Bool, transcript: Bool = false) -> CGFloat {
+        let field = singleLine
+            ? fontSize + 6 + 1
+            : min(maximumBody, max(104, CGFloat(lines(text)) * (fontSize + 8) + 20))
+        return chrome(transcript: transcript) + field + bleed * 2
+    }
+
+    private static func lines(_ text: String) -> Int {
+        let perLine = max(1, minimumWidth - sideChrome)
+        return max(2, Int(ceil(textWidth(text) / perLine)))
     }
 }
 
@@ -142,6 +236,14 @@ final class PreviewModel: ObservableObject {
     /// Set when the panel is not proposing anything — see `loadTranscript`.
     @Published var note: String?
     @Published var status: String?
+    /// Whether this is a dictation being corrected rather than a rewrite being
+    /// proposed. The two want different things on screen — see the view.
+    @Published var isTranscript: Bool = false
+    /// Whether the text arrived short enough for a single-line field.
+    ///
+    /// Decided once, at load, and not recomputed as you type. A field that
+    /// turned into a text area mid-sentence would take the caret with it.
+    @Published var singleLine: Bool = false
 
     var onSubmit: (() -> Void)?
     var onCancel: (() -> Void)?
@@ -152,6 +254,8 @@ final class PreviewModel: ObservableObject {
         self.after = after
         self.note = nil
         self.status = nil
+        self.isTranscript = false
+        self.singleLine = PreviewMetrics.singleLine(after)
     }
 
     /// The whole sentence, as it was heard, ready to be edited.
@@ -172,7 +276,9 @@ final class PreviewModel: ObservableObject {
         self.before = text
         self.after = text
         self.note = "heard"
-        self.status = "Fix it here — it replaces what was written"
+        self.status = "Fix anything I got wrong — this replaces what I typed"
+        self.isTranscript = true
+        self.singleLine = PreviewMetrics.singleLine(text)
     }
 
     /// Nothing to apply — the prompt returned what it was given.
@@ -190,38 +296,117 @@ struct PreviewView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            header
+            // The transform preview keeps its header — you need to know which
+            // prompt wrote the thing you are being asked to accept. Correcting
+            // a dictation there is nothing to name: the sentence in the field
+            // is your own, and "DICTATION · HEARD" over it was a label for a
+            // thing that does not need labelling.
+            if !model.isTranscript {
+                header
+            }
 
-            ScrollView {
-                VStack(alignment: .leading, spacing: 10) {
+            // The instruction and the field are one group, and the group is
+            // what sits in the middle. Spacers either side rather than a fixed
+            // offset, so the same layout balances at any height the panel takes.
+            Spacer(minLength: 0)
+
+            VStack(alignment: .leading, spacing: 10) {
+                if model.isTranscript {
+                    // An eyebrow, in the slot the other panels put one in, and
+                    // quieter than the sentence under it. It was 19pt semibold
+                    // with the bird beside it, which made the signage the
+                    // loudest thing on a panel whose whole subject is the
+                    // sentence you are checking. A label labels.
+                    Text("Fix anything I got wrong".uppercased())
+                        .font(.system(size: 10, weight: .semibold, design: .rounded))
+                        .kerning(0.9)
+                        .foregroundStyle(.secondary)
+                        // A word of it came up highlighted, which is what a
+                        // selection looks like. Nothing draws a background
+                        // there, so whatever put it there, saying the label is
+                        // not selectable takes the possibility away.
+                        .textSelection(.disabled)
+                } else {
                     Text(model.before)
-                        .font(.system(size: 13))
+                        .font(.system(size: 16))
                         .foregroundStyle(.tertiary)
                         .strikethrough(!model.isUnchanged, color: .secondary.opacity(0.4))
                         .textSelection(.enabled)
                         .frame(maxWidth: .infinity, alignment: .leading)
-
-                    TextEditor(text: $model.after)
-                        .font(.system(size: 13))
-                        .scrollContentBackground(.hidden)
-                        .focused($editing)
-                        .frame(minHeight: 44)
-                        .parrotField(focused: editing)
                 }
+
+                field
             }
 
+            Spacer(minLength: 0)
+
             PanelActions(
-                status: model.status ?? "Edit it here before replacing",
+                status: model.isTranscript ? "" : (model.status ?? "Edit it here before replacing"),
                 cancelTitle: "Discard",
                 confirmTitle: "Replace",
+                compact: model.isTranscript,
                 onCancel: { model.onCancel?() },
                 onConfirm: { model.onSubmit?() }
             )
         }
         .padding(Parrot.panelPadding)
-        .frame(width: PreviewMetrics.width)
-        .parrotSurface(RoundedRectangle(cornerRadius: Parrot.panelRadius, style: .continuous))
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .parrotSurface(
+            RoundedRectangle(cornerRadius: Parrot.panelRadius, style: .continuous),
+            glass: true,
+            // Heavier than the pill's. This one holds a sentence you read word
+            // by word and select inside; the pill holds four words you glance
+            // at. Same glass, less of the desktop coming through it.
+            scrim: 0.30
+        )
+        .background {
+            PlumageBloom(
+                shape: RoundedRectangle(cornerRadius: Parrot.panelRadius, style: .continuous),
+                intensity: 1.7
+            )
+        }
+        .padding(PreviewMetrics.bleed)
         .onExitCommand { model.onCancel?() }
+    }
+
+    /// One line gets a field; anything longer gets an area. Neither gets a box.
+    ///
+    /// The box was a fourth rectangle inside three others — glass, rim, glow —
+    /// and it is what made a two-word correction look marooned in the middle of
+    /// it. The sentence sits on the glass with a hairline under it, so the text
+    /// is the surface rather than a thing parked on one.
+    ///
+    ///
+    /// A text area holding a sentence that fits on a line is a box with an acre
+    /// of empty under it and a caret you have to aim at. The panel grows
+    /// sideways instead — see `PreviewMetrics.width(for:)` — so a sentence gets
+    /// a line of its own for as long as the screen allows.
+    ///
+    /// 26pt in both. The old 13 was a caption, and this is the sentence about to
+    /// go into your document: the one thing on screen worth reading carefully,
+    /// and worth being able to put a caret in the middle of a word of without
+    /// aiming.
+    @ViewBuilder
+    private var field: some View {
+        if model.singleLine {
+            // `EndCaretField` rather than `TextField`: SwiftUI's selects the
+            // whole sentence when it takes focus, so the first key you press
+            // throws away the thing you opened the panel to keep.
+            EndCaretField(
+                text: $model.after,
+                fontSize: PreviewMetrics.fontSize,
+                onSubmit: { model.onSubmit?() }
+            )
+            .frame(height: PreviewMetrics.fontSize + 6)
+            .underlined()
+        } else {
+            TextEditor(text: $model.after)
+                .font(.system(size: PreviewMetrics.fontSize))
+                .scrollContentBackground(.hidden)
+                .focused($editing)
+                .frame(minHeight: 104)
+                .underlined()
+        }
     }
 
     private var header: some View {

--- a/Sources/ParrotFlow/PreviewPanel.swift
+++ b/Sources/ParrotFlow/PreviewPanel.swift
@@ -344,6 +344,9 @@ struct PreviewView: View {
                 status: model.isTranscript ? "" : (model.status ?? "Edit it here before replacing"),
                 cancelTitle: "Discard",
                 confirmTitle: "Replace",
+                // One line commits on Return; an area needs the modifier,
+                // because there Return is a newline.
+                confirmKey: model.singleLine ? "↩" : "⌘↩",
                 compact: model.isTranscript,
                 onCancel: { model.onCancel?() },
                 onConfirm: { model.onSubmit?() }

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -358,7 +358,7 @@ if let index = arguments.firstIndex(of: "--panel-sheet") {
 
 if let index = arguments.firstIndex(of: "--panels") {
     guard arguments.indices.contains(index + 1) else {
-        print("usage: ParrotFlow --panels <notice|caution|failure|thinking|offer|vocabulary|rule|preview|pill|sequence> [seconds]")
+        print("usage: ParrotFlow --panels <notice|caution|failure|thinking|offer|vocabulary|rule|dictation|preview|pill|sequence> [seconds]")
         exit(2)
     }
     let seconds = arguments.indices.contains(index + 2) ? Double(arguments[index + 2]) : nil

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -255,7 +255,7 @@ $PF --panel-sheet s.png   # draw every surface into one PNG, light beside dark
 ```
 
 `--panels` takes `pill`, `notice`, `caution`, `failure`, `thinking`, `offer`,
-`vocabulary`, `rule`, `preview` or `sequence`. `--panel-sheet` draws all of
+`vocabulary`, `rule`, `dictation`, `preview` or `sequence`. `--panel-sheet` draws all of
 them at once, which is where drift between them shows up.
 
 `sequence` is the one that cannot be checked from a still. The pill is a single


### PR DESCRIPTION
Appearance only. Stacked on #58, rebased onto it after the squash.

## The glass was never glass

SwiftUI's `.regularMaterial` blurs what is inside its own window. These panels
are borderless with a clear background, so there was nothing inside to blur —
the material fell back to flat grey, and the dark scrim over it read as a
black-to-grey gradient.

macOS 26 has real Liquid Glass. `ParrotGlass` puts an `NSGlassEffectView` behind
the window, which is the only thing on the platform that samples what is
actually behind it. Before 26 the hand-assembled version stays — an
`NSVisualEffectView` with `.behindWindow` blending, plus the scrim and sheen —
so the package still targets macOS 14.

`NSGlassEffectView` has its own `cornerRadius`, which removes a whole class of
problem: the fallback needs a stretched mask image with circular corners, and
where that disagreed with SwiftUI's `.continuous` rounded rectangle by a point,
the desktop showed through between the frost and the rim.

**Transparency is set by a tint on the material, never by its alpha.** Lowering
`alphaValue` does not thin the frost — it lets that fraction of the *raw*
desktop through beside it, sharp and unblurred, which reads as a dirty window
rather than a glass one.

## The light it throws

`PlumageBloom` is the rim's hairline again, thick and blurred, drawn behind the
glass so the colour spills past the edge instead of stopping at it.

Two things had to be got right:

- **One source spread, not several sources.** Three strokes of different widths
  banded — a wide stroke and a narrow one put their colour at different
  distances from the edge, so scarlet sat inside teal in a visible stripe. It is
  one stroke blurred three ways.
- **Blur, not shadow.** Chained `.shadow` was tried to dodge the offscreen
  rasterisation a blur forces. It cannot diffuse: each shadow casts the stroke
  *plus every shadow before it*, so a thin sharp source comes out as nested
  copies of itself — four coloured borders drawn on top of each other.

Both surfaces carry a transparent margin for the tail to land in. Cut off at the
window edge, the tail of a Gaussian is a hard rectangle, and a hard rectangle
around a floating panel is the window announcing itself.

### It only turns while the app is busy

Animating it always cost **40% of a core for as long as the pill was on screen**
— four Gaussian blurs re-rendered every frame — measured against **0%** for the
same pill standing still.

That is also the rule already written on `PlumageRim`: motion on these surfaces
means the app is working, and nothing may borrow it to look nice. A glow that
drifts while nothing is happening says something is happening.

| | before | after |
|---|---|---|
| idle | 0% | 0% |
| recording | 11.2% | 14.1% |
| thinking | 22.9% | 31.4% |

The 11.2% and 22.9% baselines are the existing meter and rim, not this change.

## The correction panel, rebuilt around its sentence

- As wide as the sentence needs and no wider, **measured** rather than counted —
  "MMM" and "iii" are the same character count and nowhere near the same width,
  and the one-line-or-not decision turns on exactly that. 420pt floor, screen
  ceiling.
- 30pt type, no box around the field, an eyebrow instead of a header, a quiet
  Discard.
- **The caret sits at the end, nothing selected.** SwiftUI's `TextField` selects
  everything on focus, so the first key you press throws away the sentence you
  opened the panel to keep. `EndCaretField` wraps `NSTextField` to say otherwise
  — there is no way to before macOS 15.
- No struck-through original when you are correcting your own dictation. The two
  lines start identical; showing a sentence twice so you can watch half of it get
  crossed out is a second thing to read for no answer.

The four-feather mark is the parrot from the menu bar. The feathers read as a
signal-strength glyph next to a word in capitals.

## Verification

`make app`, `--check-config`, all ten `--panels` modes and `--panel-sheet`, on a
tree with nothing else in it.

`--panels dictation` shows the correction panel on its own. It is deliberately
**not** on the sheet: its field is an `NSTextField` and its background is real
Liquid Glass, and the sheet can draw neither — it came out as a white block in
an untinted rectangle. A sheet that lies about a surface is worse than one that
omits it.

The `TextEditor` in the transform preview also renders as a placeholder bar on
the sheet now. Same class of artefact, real panel unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018n13uA5KXABqjXvUeE47Sf