### PR TITLE
fix: F12 was measurement noise — one audio path, and a checksum at the seam

### DIFF
--- a/Sources/ParrotFlow/Trace.swift
+++ b/Sources/ParrotFlow/Trace.swift
@@ -83,7 +83,9 @@ enum Trace {
         private let lock = NSLock()
 
         private let wav: String
-        private let source: Source
+        /// Readable from outside: the seam log names the run it describes, and
+        /// "live or replay" is exactly what this field already knows.
+        let source: Source
         private var asr: ASR?
         private var vad: VAD?
         private var stages: [Stage] = []

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -172,8 +172,13 @@ actor Transcriber {
                 try await Vocabulary.shared.prepare(config: config) { [weak self] label in
                     Task { await self?.setStatus(.downloading(label)) }
                 }
-                if let samples = gated?.decodable == true
-                    ? gated?.samples : Self.samples(at: url) {
+                // The gate has already read the clip, so re-reading it would
+                // be a second decode of the same file for the same array.
+                let gateSamples = gated?.decodable == true ? gated?.samples : nil
+                if let samples = gateSamples ?? Self.samples(at: url) {
+                    Self.logVocabularySamples(
+                        samples, from: gateSamples == nil ? .file : .gate
+                    )
                     let outcome = await Vocabulary.shared.apply(
                         to: text, samples: samples,
                         tokenTimings: result.tokenTimings ?? [], config: config
@@ -181,6 +186,13 @@ actor Transcriber {
                     text = outcome.text
                     vocabularyCount = outcome.count
                     vocabularyChanges = outcome.changes
+                } else {
+                    // The pass is configured and did nothing, which used to
+                    // look exactly like the pass finding no names. Say which.
+                    Log.write(
+                        "vocabulary samples: none — no 16 kHz mono samples for"
+                            + " \(url.lastPathComponent); left as decoded"
+                    )
                 }
             } catch {
                 Log.write("vocabulary: \(error.localizedDescription); left as decoded")
@@ -248,21 +260,17 @@ actor Transcriber {
     ///
     /// Fails open: if the detector is unavailable the clip is transcribed.
     /// Losing real speech is far worse than an occasional stray "Yeah."
+    ///
+    /// A clip it cannot read fails open too. Reading it used to throw here and
+    /// lose the dictation; the decoder is handed the same URL a line later and
+    /// reports the real failure itself, so there is nothing for this to add.
     private func runSpeechGate(url: URL) async throws -> SpeechGate? {
         guard let vad else { return nil }
 
-        let file = try AVAudioFile(forReading: url)
-        let format = file.processingFormat
-        guard let buffer = AVAudioPCMBuffer(
-            pcmFormat: format,
-            frameCapacity: AVAudioFrameCount(file.length)
-        ) else { return nil }
-        try file.read(into: buffer)
-        guard let channel = buffer.floatChannelData?[0] else { return nil }
-        let samples = Array(UnsafeBufferPointer(start: channel, count: Int(buffer.frameLength)))
-        let decodable = format.sampleRate == Self.sampleRate && format.channelCount == 1
+        guard let clip = Self.read(url) else { return nil }
+        let samples = clip.samples
         guard !samples.isEmpty else {
-            return SpeechGate(samples: samples, segments: [], decodable: decodable)
+            return SpeechGate(samples: samples, segments: [], decodable: clip.is16kMono)
         }
 
         let segments = try await vad.segmentSpeech(samples)
@@ -283,25 +291,99 @@ actor Transcriber {
         return SpeechGate(
             samples: samples,
             segments: segments.map { ($0.startTime, $0.endTime) },
-            decodable: decodable
+            decodable: clip.is16kMono
+        )
+    }
+
+    // MARK: - The seam the vocabulary pass sits on
+
+    /// Which of the two readers produced the samples handed to `Vocabulary`.
+    ///
+    /// There is one call site and two branches, and for a clip the recorder
+    /// wrote they must produce the same array: both read the same file at its
+    /// own `processingFormat`. Naming the branch in the log is what makes that
+    /// checkable instead of assumed.
+    enum SampleSource: String {
+        /// Already read by `runSpeechGate`.
+        case gate
+        /// Read here, because the gate is off or could not use what it read.
+        case file
+    }
+
+    /// One line saying exactly what the vocabulary pass was given.
+    ///
+    /// A dictation and a replay of its archived wav scored the same term ~12
+    /// nats apart (finding F12), and nothing on disk could say whether the two
+    /// runs even saw the same audio. This line answers that with a grep. One
+    /// helper for both branches on purpose: two format strings would drift and
+    /// the comparison would stop being mechanical.
+    ///
+    /// The run's own origin comes from the trace, which already records `live`
+    /// or `cli` per dictation. `unknown` means no collector was bound — a
+    /// command that does not trace, not a third audio path.
+    nonisolated static func logVocabularySamples(_ samples: [Float], from source: SampleSource) {
+        let seconds = Double(samples.count) / sampleRate
+        let head = String(
+            format: "vocabulary samples: %d samples, %.2fs, checksum %08x",
+            samples.count, seconds, checksum(samples)
+        )
+        Log.write("\(head) (\(Trace.current?.source.rawValue ?? "unknown"), \(source.rawValue))")
+    }
+
+    /// FNV-1a over the raw bits of every sample.
+    ///
+    /// Not a digest anyone should trust for anything else. It has one job: to
+    /// change when a single sample changes, so two runs can be compared by
+    /// eye. Hashing the bit pattern rather than the value keeps `-0.0` and
+    /// `0.0` distinct, which is what "the same array" has to mean here.
+    nonisolated static func checksum(_ samples: [Float]) -> UInt32 {
+        var hash: UInt32 = 2_166_136_261
+        for sample in samples {
+            var bits = sample.bitPattern
+            for _ in 0..<4 {
+                hash = (hash ^ (bits & 0xFF)) &* 16_777_619
+                bits >>= 8
+            }
+        }
+        return hash
+    }
+
+    /// The one reader. Everything that needs the clip as numbers goes through
+    /// here — the speech gate, and the vocabulary pass when the gate is off.
+    ///
+    /// It used to be two readers with the same body written twice, and they
+    /// only agreed by luck. A live dictation and a replay of its archived wav
+    /// scored the same term far apart (finding F12), and the first thing that
+    /// had to be ruled out was whether the two runs were even looking at the
+    /// same samples. Two copies of a file read cannot be ruled out; one can.
+    ///
+    /// Nil rather than throwing: a name left misheard is worth less than a
+    /// lost dictation.
+    static func read(_ url: URL) -> (samples: [Float], is16kMono: Bool)? {
+        guard let file = try? AVAudioFile(forReading: url) else { return nil }
+        let format = file.processingFormat
+        guard let buffer = AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: AVAudioFrameCount(file.length)
+        ),
+            (try? file.read(into: buffer)) != nil,
+            let channel = buffer.floatChannelData?[0]
+        else { return nil }
+        return (
+            Array(UnsafeBufferPointer(start: channel, count: Int(buffer.frameLength))),
+            format.sampleRate == sampleRate && format.channelCount == 1
         )
     }
 
     /// The clip as 16 kHz mono samples, for the vocabulary pass when the
-    /// speech gate is off and has not already read them. Nil rather than
-    /// throwing: a name left misheard is worth less than a lost dictation.
+    /// speech gate is off and has not already read them.
+    ///
+    /// Nil for anything else: the decoder reaches those clips through the URL,
+    /// which resamples, and this does not. Handing the pass a differently
+    /// sampled array would be the second audio path all over again.
     static func samples(at url: URL) -> [Float]? {
-        guard let file = try? AVAudioFile(forReading: url),
-              file.processingFormat.sampleRate == sampleRate,
-              file.processingFormat.channelCount == 1,
-              let buffer = AVAudioPCMBuffer(
-                  pcmFormat: file.processingFormat,
-                  frameCapacity: AVAudioFrameCount(file.length)
-              ),
-              (try? file.read(into: buffer)) != nil,
-              let channel = buffer.floatChannelData?[0]
-        else { return nil }
-        return Array(UnsafeBufferPointer(start: channel, count: Int(buffer.frameLength)))
+        guard let clip = read(url), clip.is16kMono else { return nil }
+        return clip.samples
     }
 
     // MARK: - Closing long pauses

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -359,9 +359,17 @@ actor Transcriber {
     ///
     /// Nil rather than throwing: a name left misheard is worth less than a
     /// lost dictation.
-    static func read(_ url: URL) -> (samples: [Float], is16kMono: Bool)? {
+    ///
+    /// - Parameter require16kMono: nil for any other format, decided from the
+    ///   header before a buffer is allocated. A caller that cannot use the
+    ///   samples should not pay to read an hour of audio to find that out.
+    static func read(
+        _ url: URL, require16kMono: Bool = false
+    ) -> (samples: [Float], is16kMono: Bool)? {
         guard let file = try? AVAudioFile(forReading: url) else { return nil }
         let format = file.processingFormat
+        let is16kMono = format.sampleRate == sampleRate && format.channelCount == 1
+        guard is16kMono || !require16kMono else { return nil }
         guard let buffer = AVAudioPCMBuffer(
             pcmFormat: format,
             frameCapacity: AVAudioFrameCount(file.length)
@@ -371,7 +379,7 @@ actor Transcriber {
         else { return nil }
         return (
             Array(UnsafeBufferPointer(start: channel, count: Int(buffer.frameLength))),
-            format.sampleRate == sampleRate && format.channelCount == 1
+            is16kMono
         )
     }
 
@@ -382,8 +390,7 @@ actor Transcriber {
     /// which resamples, and this does not. Handing the pass a differently
     /// sampled array would be the second audio path all over again.
     static func samples(at url: URL) -> [Float]? {
-        guard let clip = read(url), clip.is16kMono else { return nil }
-        return clip.samples
+        read(url, require16kMono: true)?.samples
     }
 
     // MARK: - Closing long pauses

--- a/docs/proposals/vocabulary-v2.md
+++ b/docs/proposals/vocabulary-v2.md
@@ -213,18 +213,35 @@ widen what already fires. → PR 2 (counter-measures), PR 6 (dump moved).
 clip; replay-to-replay is stable). Until reconciled, every measurement
 describes replays. → PR 1, blocking for any live claim.
 
-**F12a — the audio was never the difference (PR 1, 2026-08-08).** There is
-one audio path, not two. `Transcriber.transcribe` reads the clip from the
+**F12a — F12 was measurement noise, not two audio paths (PR 1,
+2026-08-08).** Two things were wrong with F12.
+
+*There is one audio path.* `Transcriber.transcribe` reads the clip from the
 same URL whether it was just dictated or replayed off disk, and the branch
 at the seam is gate-versus-no-gate, not live-versus-replay. Measured on the
-six clips of 2026-08-08 01:01–01:19 that have both a live and a replay
+six clips of 2026-08-08 01:01–01:19 that carry both a live and a replay
 `trace.jsonl` entry: VAD total, VAD segments, ASR confidence and every token
-timing are identical to the last digit. Same audio, same timings. What still
-differs is downstream of the samples — the live binary that night was
-unstamped and of unverified build (F5). The seam now logs a checksum of the
-samples on both paths, so the next live dictation settles it with one grep.
-Replay noise floor: 1 run in 8 moved 0.22 nats, on the first run after the
-CoreML cache went cold; the other 7 were bit-identical.
+timing are identical to the last digit. Same audio, same timings.
+
+*Replay-to-replay is not stable.* The CTC scores move between processes on
+byte-identical input. Ten replays of one clip, same seam checksum every time:
+
+| Clip | Term score, 10 runs | Spread |
+|---|---|---|
+| 01-03-24 (4.05s) | -4.49 ×7, -4.91 ×2, **-5.35 ×1** | 0.86 nats |
+| 01-19-35 (18.63s) | -1.96 ×6, -2.07 ×1, -1.81 ×1, -6.84 ×2 | 5.03 nats |
+
+The bolded -5.35 is the *live* number F12 was built on for that clip
+(`'Supabase'=-5.35 > 'update'=-10.13`, 01:03:29). A replay reproduces it,
+exactly, one run in ten. So the live-versus-replay gap is the same
+distribution sampled twice.
+
+**Consequences.** Do not read a single score as a measurement — the noise
+reaches 5 nats on a long clip, which is larger than most margins this plan
+argues about. Anything that ranks on score needs repeated runs, or it needs
+to rank on the decision rather than the number. The seam checksum is now
+logged on both paths, so audio can be ruled out in one grep before anyone
+chases a score again.
 
 **F13 — harness traps already hit once.** Kept verbatim so they are not
 reintroduced: a hardcoded `/Applications` path scored a stale binary; the

--- a/docs/proposals/vocabulary-v2.md
+++ b/docs/proposals/vocabulary-v2.md
@@ -213,6 +213,19 @@ widen what already fires. → PR 2 (counter-measures), PR 6 (dump moved).
 clip; replay-to-replay is stable). Until reconciled, every measurement
 describes replays. → PR 1, blocking for any live claim.
 
+**F12a — the audio was never the difference (PR 1, 2026-08-08).** There is
+one audio path, not two. `Transcriber.transcribe` reads the clip from the
+same URL whether it was just dictated or replayed off disk, and the branch
+at the seam is gate-versus-no-gate, not live-versus-replay. Measured on the
+six clips of 2026-08-08 01:01–01:19 that have both a live and a replay
+`trace.jsonl` entry: VAD total, VAD segments, ASR confidence and every token
+timing are identical to the last digit. Same audio, same timings. What still
+differs is downstream of the samples — the live binary that night was
+unstamped and of unverified build (F5). The seam now logs a checksum of the
+samples on both paths, so the next live dictation settles it with one grep.
+Replay noise floor: 1 run in 8 moved 0.22 nats, on the first run after the
+CoreML cache went cold; the other 7 were bit-identical.
+
 **F13 — harness traps already hit once.** Kept verbatim so they are not
 reintroduced: a hardcoded `/Applications` path scored a stale binary; the
 newest `trace.jsonl` entry is the current run, take the first per clip;


### PR DESCRIPTION
## The problem (F12)

F12 says a live dictation and a replay of its archived wav score the same term
~12 nats apart, that replay-to-replay is stable, and that until they agree
every measurement describes replays. This PR instruments the seam, then
measures.

**Result: F12 was measurement noise.** There is one audio path, and
replay-to-replay is not stable. Details below, with numbers.

## What moved, and why

**The seam is logged.** At the point `Vocabulary.apply` receives samples, one
line now says what it was handed:

```
vocabulary samples: 64776 samples, 4.05s, checksum 8b1377a5 (cli, gate)
```

Sample count, duration, an FNV-1a checksum of the raw sample bits, the run's
origin (`live` or `cli`, read off the trace), and which branch produced the
samples (`gate` or `file`). One helper writes both branches so the two lines
cannot drift in format. `Trace.Collector.source` stopped being private so the
line can name the run.

**The clip is read in one place.** `runSpeechGate` and `Transcriber.samples(at:)`
each carried their own copy of the same AVAudioFile read, with slightly
different acceptance rules. They agreed only by luck. Both now go through
`Transcriber.read`, which decides from the file header whether it can hand back
16 kHz mono before it allocates a buffer.

**A silent skip now says so.** With the vocabulary pass configured but no 16 kHz
mono samples available, the pass used to do nothing and log nothing, which
looked exactly like the pass finding no names.

**No vocabulary logic changed.**

## Finding 1 — there is one audio path

The plan's model was that the live path feeds `gated?.samples` and the replay
path feeds `Self.samples(at:)`. That is not what the code does. Live and replay
both enter `Transcriber.transcribe(url:config:)` with the same URL and run the
same code; the branch at the seam is gate-versus-no-gate, not
live-versus-replay. Every replay below logs `(cli, gate)`, and a live dictation
with the speech gate on takes the same `gate` branch.

`closeLongPauses` was suspect number one. Ruled out: the closed clip goes to the
decoder only, never to the vocabulary pass, and `restoreTimings` puts the
timings back on the recording's own clock. Both paths get the original samples
with original-clock timings, always.

Six clips from 2026-08-08 01:01–01:19 have both a live and a replay entry in
`~/Recordings/ParrotFlow Dev/trace.jsonl` (first entry per clip, per F13).
On all six, live and replay hold **identical** VAD totals, identical VAD
segments, identical ASR confidence and identical token timings — to the last
digit. Same audio in, same spans out.

## Finding 2 — replay-to-replay is not stable

The CTC scores move between processes on byte-identical input. Ten replays of
each clip, same seam checksum on every run:

| Clip | seam checksum | Term score, 10 runs | Spread |
|---|---|---|---|
| 01-03-24 (4.05s) | `8b1377a5` | -4.49 ×7, -4.91 ×2, **-5.35 ×1** | 0.86 nats |
| 01-19-35 (18.63s) | `2c310467` | -1.96 ×6, -2.07 ×1, -1.81 ×1, -6.84 ×2 | 5.03 nats |

The bolded **-5.35** is the *live* line F12 was built on for that clip:

```
01:03:29  vocabulary: "update" -> "Supabase" (CTC-vs-CTC: 'Supabase'=-5.35 > 'update'=-10.13)
```

A replay reproduces it exactly — score and decoded-word score both — one run in
ten. The live-versus-replay gap is the same distribution sampled twice.

Two other causes were tested and ruled out on the way:

- **Vocabulary size.** The bonus is computed from `context.terms.count`. Scored
  01-03-24 with the live 11-term vocabulary and with a 1-term vocabulary via
  `PARROTFLOW_CONFIG_DIR`: identical checksum, identical scores both ways.
- **The prototype's extra logic.** The prototype build replayed the same six
  clips at 01:44; its `(CTC-vs-CTC: …)` numbers match this PR's on four of six.

## What this costs the plan

A single score is not a measurement. The noise reaches 5 nats on a long clip,
which is larger than most margins this plan argues about (F4's 5.3, F6's 3.9).
Anything that ranks on score needs repeated runs, or needs to rank on the
decision instead of the number. Recorded as **F12a** in
`docs/proposals/vocabulary-v2.md`.

## Measured: what the six clips give

`swift build -c release && scripts/build-app.sh`, stamp `7cdb760` (clean tree,
no `-dirty`). Each clip replayed twice through
`.build/ParrotFlowDev.app/Contents/MacOS/ParrotFlow --transcribe`:

| Clip | checksum | samples | seconds | scores |
|---|---|---|---|---|
| 01-01-56 | `3f24b2ac` | 47241 | 2.95 | `'Supabase'=-7.46 > 'update'=-13.52` |
| 01-02-23 | `26a318ef` | 40521 | 2.53 | `'Supabase'=-5.43 > 'update'=-11.03` |
| 01-03-24 | `8b1377a5` | 64776 | 4.05 | `'Supabase'=-4.49 > 'update'=-8.55` |
| 01-03-56 | `658e9bba` | 105200 | 6.58 | `'Redcrawl'=-2.28 > 'general.'=-8.07` |
| 01-04-20 | `e5fd9d40` | 75591 | 4.72 | `'Redrock'=-7.82 > 'bedrock'=-8.99` |
| 01-19-35 | `2c310467` | 298086 | 18.63 | `'Supabase'=-1.96 > 'update'=-8.17` |

The checksum is stable on every run of every clip. The scores are the modal
value; see Finding 2 for the spread.

## Before/after the fix

The scores do not move, and that is the result rather than a gap in the
testing. The fix removes a duplicated file read; both copies were already
returning the same array for a clip the recorder wrote, which the checksums now
prove. Same six clips, before and after the one-reader change, at the modal
score:

| Clip | before | after |
|---|---|---|
| 01-01-56 | `-7.46 / -13.52`, `3f24b2ac` | `-7.46 / -13.52`, `3f24b2ac` |
| 01-02-23 | `-5.43 / -11.03`, `26a318ef` | `-5.43 / -11.03`, `26a318ef` |
| 01-03-24 | `-4.49 / -8.55`, `8b1377a5` | `-4.49 / -8.55`, `8b1377a5` |
| 01-03-56 | `-2.28 / -8.07`, `658e9bba` | `-2.28 / -8.07`, `658e9bba` |
| 01-04-20 | `-7.82 / -8.99`, `e5fd9d40` | `-7.82 / -8.99`, `e5fd9d40` |
| 01-19-35 | `-1.96 / -8.17`, `2c310467` | `-1.96 / -8.17`, `2c310467` |

## Caveat

The live binary of 2026-08-08 was unstamped and of unverified provenance (F5),
so any comparison against that night's live lines is indicative, not proof.
That caveat is why Finding 2 matters more than Finding 1: it explains the gap
without needing to know which binary ran.

Also: `~/Library/Logs/ParrotFlow-Dev.log` had rotated past 01:19 before this PR
started — `Log.write` truncates at 1 MB — so the 01:02–01:19 live lines are
gone. The one live line quoted above comes from the plan itself. The live
side of the six-clip comparison comes from `trace.jsonl`, which is append-only
and survived.

## Open, needs a human

- [ ] **One fresh live dictation on an installed, stamped build**, then a replay
      of the same wav, comparing the two `vocabulary samples:` lines. Equal
      checksum closes the audio question directly instead of by inference.
      Expect the *scores* to differ anyway — that is Finding 2, not a
      regression. This cannot be done from the archive: every live line on disk
      was written by an unstamped binary, and installing one is Nathan's call
      (`make install` is out of scope here).

## Verification run

```
swift build -c release && scripts/build-app.sh          # Build complete!, stamp 7cdb760
.build/ParrotFlowDev.app/Contents/MacOS/ParrotFlow --transcribe <clip.wav>   # x2 per clip
grep "vocabulary samples:" ~/Library/Logs/ParrotFlow-Dev.log | tail -4
```

```
2026-08-08 03:35:45  vocabulary samples: 64776 samples, 4.05s, checksum 8b1377a5 (cli, gate)
2026-08-08 03:35:47  vocabulary samples: 64776 samples, 4.05s, checksum 8b1377a5 (cli, gate)
2026-08-08 03:35:49  vocabulary samples: 64776 samples, 4.05s, checksum 8b1377a5 (cli, gate)
2026-08-08 03:35:51  vocabulary samples: 64776 samples, 4.05s, checksum 8b1377a5 (cli, gate)
```

No app instance was left running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiQJipvz9Ps9tdDCRdisv
