### PR TITLE
test: the measurement harness, with the bugs the review found taken out

### DIFF
--- a/docs/proposals/vocabulary-v2.md
+++ b/docs/proposals/vocabulary-v2.md
@@ -377,6 +377,15 @@ every F13 fix they already contain. Then fix what the review found:
    pre-filled with the app's output and must be corrected by hand. (F11.)
 5. Fix the corrupted `approve` legend line in `tests/judge-cases.yaml` (F9).
 6. Report chance in every table that ranks (F13).
+7. `menu-recall.py` and `before-after.py`: add `--runs N`, default 1. It
+   replays each clip N times, keeps the per-clip majority, and reports how
+   many clips changed outcome between runs (F12a).
+
+**Measurement noise.** F12a: replaying the same clip gives scores up to ~5
+nats apart, so one replay is not a measurement. Any gate quoted from
+`menu-recall.py` or `before-after.py` must come with the flip count from
+`--runs 3` when the number is within 2 cases of the baseline it is compared
+with. A single-run number inside that band decides nothing.
 
 **HUMAN.** Labels for any newly mined cases.
 

--- a/examples/transforms/verify_names/menu.md
+++ b/examples/transforms/verify_names/menu.md
@@ -1,0 +1,24 @@
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: {terms} — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence, and every
+reading it might really have been. Exactly one is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading that makes sense as a sentence, unless the sound says
+otherwise by more than about 4. Answer with its letter only.

--- a/scripts/before-after.py
+++ b/scripts/before-after.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""What today's dictations produced then, and what they produce now.
+
+    scripts/before-after.py [--limit N] [--runs N]
+
+`before` is the transcript the app actually delivered when the clip was
+recorded, read from `trace.jsonl`. `after` is what the current build makes of
+the same audio. `said` is the hand label in `tests/menu-cases.yaml`.
+
+Four outcomes, and only two of them are interesting:
+
+    FIXED      wrong then, right now
+    BROKEN     wrong then, wrong still
+    REGRESSED  right then, wrong now
+    KEPT       right both times
+
+A clip that was already right is not evidence about this work in either
+direction, which is why they are counted and not listed.
+
+**`after` is a replay, and a replay is noisy (F12a).** The same clip decoded
+twice can score up to 5 nats apart, so a clip near a floor lands in FIXED on
+one run and BROKEN on the next. `--runs N` decodes each clip N times, keeps the
+majority verdict, and counts the clips that did not agree with themselves. The
+default is 1. Never call a REGRESSED row new on one run; re-run it with
+`--runs 3` and quote the flip count.
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+from importlib.machinery import SourceFileLoader
+
+ROOT = Path(__file__).resolve().parent.parent
+recall = SourceFileLoader("recall", str(ROOT / "scripts/menu-recall.py")).load_module()
+TRACE = Path.home() / "Recordings/ParrotFlow Dev/trace.jsonl"
+
+
+def originals():
+    """The transcript each clip delivered on the day it was recorded.
+
+    The *first* entry per clip, not the last. `trace.jsonl` is append-only and
+    every `--transcribe` re-run adds a fresh row, so taking the newest one made
+    `before` and `after` the same measurement wearing two labels — this file
+    reported eleven unchanged failures and zero of anything else.
+    """
+    out = {}
+    for line in TRACE.read_text().splitlines():
+        try:
+            entry = json.loads(line)
+        except ValueError:
+            continue
+        if entry.get("wav") and entry.get("final"):
+            out.setdefault(Path(entry["wav"]).name, entry["final"].strip())
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--limit", type=int, default=0)
+    ap.add_argument("--runs", type=int, default=1,
+                    help="decode each clip N times; keep the majority verdict "
+                         "and count the clips that flipped (F12a)")
+    args = ap.parse_args()
+    if args.runs < 1:
+        print("✗ --runs must be at least 1")
+        return 2
+
+    was = originals()
+    rows = {"FIXED": [], "BROKEN": [], "REGRESSED": [], "KEPT": []}
+    cases = recall.load_cases()
+    if args.limit:
+        cases = cases[:args.limit]
+
+    flipped = []
+    for wav, said in cases:
+        if not said or wav not in was:
+            continue
+        truth = recall.normalise(said)
+        seen, after = [], None
+        for _ in range(args.runs):
+            _, after = recall.run(wav, None)
+            seen.append(recall.normalise(after or "") == truth)
+        after_ok, moved = recall.majority(seen)
+        before_ok = recall.normalise(was[wav]) == truth
+        key = ("KEPT" if after_ok else "REGRESSED") if before_ok else \
+              ("FIXED" if after_ok else "BROKEN")
+        rows[key].append((wav, said, was[wav], after))
+        if moved:
+            flipped.append((wav, sum(seen), args.runs))
+        note = f"  (flipped: right on {sum(seen)}/{args.runs} runs)" if moved else ""
+        print(f"  {key:<10} {wav}{note}", file=sys.stderr)
+
+    for key in ("FIXED", "REGRESSED", "BROKEN"):
+        if not rows[key]:
+            continue
+        print(f"\n{'=' * 72}\n{key}  ({len(rows[key])})\n{'=' * 72}")
+        for wav, said, before, after in rows[key]:
+            print(f"\n{wav[22:-4]}")
+            print(f"  said:   {said}")
+            print(f"  before: {before}")
+            print(f"  after:  {after}")
+    print(f"\n  fixed {len(rows['FIXED'])}   broken {len(rows['BROKEN'])}"
+          f"   regressed {len(rows['REGRESSED'])}   already right {len(rows['KEPT'])}")
+    if args.runs == 1:
+        print("  one decode per clip — these verdicts carry replay noise"
+              " (F12a); confirm any REGRESSED row with --runs 3")
+    else:
+        print(f"  majority of {args.runs} runs;"
+              f" {len(flipped)} clip(s) changed outcome between runs (F12a)")
+        for wav, right, total in flipped:
+            print(f"    {wav}  right on {right}/{total}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/before-after.py
+++ b/scripts/before-after.py
@@ -76,14 +76,20 @@ def main():
         if not said or wav not in was:
             continue
         truth = recall.normalise(said)
-        seen, after = [], None
+        runs = []
         for _ in range(args.runs):
             _, after = recall.run(wav, None)
-            seen.append(recall.normalise(after or "") == truth)
+            runs.append((recall.normalise(after or "") == truth, after))
+        seen = [ok for ok, _ in runs]
         after_ok, moved = recall.majority(seen)
         before_ok = recall.normalise(was[wav]) == truth
         key = ("KEPT" if after_ok else "REGRESSED") if before_ok else \
               ("FIXED" if after_ok else "BROKEN")
+        # The `after:` line has to be evidence for the verdict above it, so it
+        # comes from a run that agreed with the majority. Printing the last
+        # run instead put a correct transcript under BROKEN whenever the clip
+        # flipped on its final replay.
+        after = next(text for ok, text in runs if ok == after_ok)
         rows[key].append((wav, said, was[wav], after))
         if moved:
             flipped.append((wav, sum(seen), args.runs))

--- a/scripts/menu-recall.py
+++ b/scripts/menu-recall.py
@@ -133,15 +133,16 @@ def main():
             print(f"  ·  {wav}  no `said` — skipped")
             continue
         truth = normalise(said)
-        seen_menu, seen_final = [], []
+        runs = []
         for _ in range(args.runs):
             menu, final = run(wav, args.floor)
             # No menu means no proposal was made anywhere. The decoder's own
             # text is then the only reading there was, and it counts as
             # recalled when the decoder was already right.
             offered = [normalise(o) for o in menu] or [normalise(final)]
-            seen_menu.append(truth in offered)
-            seen_final.append(normalise(final) == truth)
+            runs.append((truth in offered, normalise(final) == truth, menu, final))
+        seen_menu = [a for a, _, _, _ in runs]
+        seen_final = [b for _, b, _, _ in runs]
         in_menu, menu_moved = majority(seen_menu)
         took_it, final_moved = majority(seen_final)
 
@@ -149,6 +150,13 @@ def main():
         recalled += in_menu
         picked += took_it
         flipped += menu_moved or final_moved
+        # The menu and the transcript printed below have to be evidence for
+        # the mark beside them, so they come from a run that agreed with the
+        # majority on both counts. When no single run did, the one that agreed
+        # about the transcript wins: that is the line the reader acts on.
+        pick = ([r for r in runs if (r[0], r[1]) == (in_menu, took_it)]
+                or [r for r in runs if r[1] == took_it])[0]
+        menu, final = pick[2], pick[3]
         mark = "✓" if took_it else ("~" if in_menu else "✗")
         wobble = ""
         if menu_moved or final_moved:

--- a/scripts/menu-recall.py
+++ b/scripts/menu-recall.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Did the true sentence reach the judge, and did the judge take it?
+
+    scripts/menu-recall.py [--floor -5.5] [--limit N] [--runs N]
+
+Two numbers, deliberately separate:
+
+    recall   the menu held the sentence the speaker actually said
+    picked   the judge chose it
+
+A transcript shows neither. It shows the end of the chain, and a wrong end has
+two causes that want opposite fixes — propose more, or ask better. Tuning the
+proposal floor against transcript accuracy optimises the sum of the two and
+moves whichever happens to be cheaper.
+
+Ground truth comes from `tests/menu-cases.yaml`, written by hand. A case with
+no `said` is skipped and counted, rather than guessed at.
+
+Comparison ignores case, punctuation and runs of spaces. The judge picks whole
+sentences from a list this harness did not build, so an exact match on words is
+the question; a full stop is not.
+
+**A single run carries replay noise (F12a).** Replaying one clip twice can give
+different CTC scores — measured spread up to 5 nats on an 18-second clip — so
+the same audio can land on either side of a floor from one run to the next. One
+score is not a measurement. `--runs N` replays every clip N times and reports
+the per-clip majority, plus how many clips changed outcome between runs. The
+default is 1, which keeps the cost of a routine run where it was; use `--runs
+3` whenever a number is within about two cases of the one it is compared with.
+"""
+import argparse
+import os
+import re
+import subprocess
+import tempfile
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CASES = ROOT / "tests/menu-cases.yaml"
+# The freshly built app when there is one, the installed app otherwise. Every
+# measurement in this file is of code being changed, and `make app` writes here
+# while `make install` writes to /Applications — reading the wrong one scored a
+# stale binary and reported no change from work that had landed.
+_BUILT = ROOT / ".build/ParrotFlowDev.app/Contents/MacOS/ParrotFlow"
+APP = str(_BUILT) if _BUILT.exists() else "/Applications/ParrotFlowDev.app/Contents/MacOS/ParrotFlow"
+CLIPS = Path.home() / "Recordings/ParrotFlow Dev"
+
+
+def normalise(text):
+    return re.sub(r"\s+", " ", re.sub(r"[^\w\s']", "", text or "")).strip().lower()
+
+
+def load_cases():
+    """The two fields, without a YAML dependency this repo does not have."""
+    text = CASES.read_text()
+    cases, wav, said = [], None, None
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- wav:"):
+            if wav:
+                cases.append((wav, said))
+            wav, said = stripped.split(":", 1)[1].strip(), None
+        elif stripped.startswith("said:"):
+            body = stripped.split(":", 1)[1].split("#")[0].strip()
+            said = body.strip('"') or None
+        elif said is not None and stripped and not stripped.startswith("#"):
+            # A folded continuation line of `said:`.
+            said = said + " " + stripped.strip('"')
+    if wav:
+        cases.append((wav, said))
+    return cases
+
+
+def run(wav, floor):
+    """One clip through the app, with the menu captured off stderr."""
+    environment = dict(os.environ)
+    dump = Path(tempfile.mkdtemp()) / "menu.txt"
+    environment["PARROTFLOW_JUDGE_DUMP"] = str(dump)
+    if floor is not None:
+        environment["PARROTFLOW_SPOTTER_FLOOR"] = str(floor)
+    done = subprocess.run(
+        [APP, "--transcribe", str(CLIPS / wav)],
+        capture_output=True, text=True, env=environment, timeout=180,
+    )
+    blob = done.stdout + done.stderr
+    written = dump.read_text() if dump.exists() else ""
+    menu = [m.group(1) for m in re.finditer(r"^MENU [A-Z]\. (.*)$", written, re.M)]
+    final = None
+    lines = blob.splitlines()
+    for i, line in enumerate(lines):
+        if "transcript" in line and "─" in line and i + 1 < len(lines):
+            final = lines[i + 1].strip()
+    return menu, final
+
+
+def majority(outcomes):
+    """The outcome most runs agreed on, and whether they disagreed at all.
+
+    A tie goes to the worse outcome. An even number of runs that split down
+    the middle has not shown the clip working; it has shown the clip is noise
+    (F12a), and a gate should not be handed the flattering half.
+    """
+    yes = sum(1 for o in outcomes if o)
+    return yes * 2 > len(outcomes), 0 < yes < len(outcomes)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--floor", default=None,
+                    help="PARROTFLOW_SPOTTER_FLOOR for this run")
+    ap.add_argument("--limit", type=int, default=0)
+    ap.add_argument("--runs", type=int, default=1,
+                    help="replay each clip N times; report the majority and "
+                         "how many clips flipped between runs (F12a)")
+    args = ap.parse_args()
+    if args.runs < 1:
+        print("✗ --runs must be at least 1")
+        return 2
+
+    if not Path(APP).exists():
+        print(f"✗ {APP} not found — run `make install` first")
+        return 2
+
+    cases = load_cases()
+    if args.limit:
+        cases = cases[:args.limit]
+
+    scored = unlabelled = recalled = picked = flipped = 0
+    for wav, said in cases:
+        if not said:
+            unlabelled += 1
+            print(f"  ·  {wav}  no `said` — skipped")
+            continue
+        truth = normalise(said)
+        seen_menu, seen_final = [], []
+        for _ in range(args.runs):
+            menu, final = run(wav, args.floor)
+            # No menu means no proposal was made anywhere. The decoder's own
+            # text is then the only reading there was, and it counts as
+            # recalled when the decoder was already right.
+            offered = [normalise(o) for o in menu] or [normalise(final)]
+            seen_menu.append(truth in offered)
+            seen_final.append(normalise(final) == truth)
+        in_menu, menu_moved = majority(seen_menu)
+        took_it, final_moved = majority(seen_final)
+
+        scored += 1
+        recalled += in_menu
+        picked += took_it
+        flipped += menu_moved or final_moved
+        mark = "✓" if took_it else ("~" if in_menu else "✗")
+        wobble = ""
+        if menu_moved or final_moved:
+            wobble = (f"   flipped: recall {sum(seen_menu)}/{args.runs},"
+                      f" picked {sum(seen_final)}/{args.runs}")
+        print(f"  {mark}  {wav}  menu {len(menu) or 1}{wobble}")
+        if not took_it:
+            print(f"        said:  {said.strip()}")
+            print(f"        got:   {final}")
+            if not in_menu:
+                print("        the true reading was never offered")
+                for i, option in enumerate(menu):
+                    print(f"        offered {chr(65+i)}. {option}")
+
+    if not scored:
+        print("\nnothing scored — fill in `said` in tests/menu-cases.yaml")
+        return 1
+    how = "" if args.runs == 1 else f", majority of {args.runs} runs"
+    print(f"\n  recall  {recalled}/{scored}   the true sentence was on the menu{how}")
+    print(f"  picked  {picked}/{scored}   the judge chose it{how}")
+    if args.runs == 1:
+        print("  one run per clip — these numbers carry replay noise (F12a);"
+              " use --runs 3 before quoting them against a gate")
+    else:
+        print(f"  {flipped}/{scored} clip(s) changed outcome between runs (F12a)")
+    if unlabelled:
+        print(f"  ({unlabelled} clip(s) unlabelled)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/mine-menu-cases.py
+++ b/scripts/mine-menu-cases.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Build a labelling sheet for `menu-recall.py` out of the archive.
+
+    scripts/mine-menu-cases.py [--limit 60] > tests/menu-cases.yaml
+    scripts/mine-menu-cases.py --random 20 >> tests/menu-cases.yaml
+
+Every dictation that touched the vocabulary is already on disk twice: the clip
+in `~/Recordings`, and what the app made of it in `trace.jsonl`. What is
+missing is the one thing no machine has — what was actually said.
+
+So this writes the transcript into `said:` as a first draft. Labelling is then
+correcting the wrong ones rather than typing every sentence, and a clip the app
+got right needs no edit at all. That is the difference between a set somebody
+finishes and one they abandon.
+
+Clips are selected when the vocabulary was involved: a term in the finished
+text, a known mis-rendering from the `heard:` lists, or a name close enough to
+a term to have been a near miss. A dictation that never went near the
+vocabulary teaches this harness nothing.
+
+    - wav: parrotflow-….wav
+      # app: Let's praise the work Prissy has done.
+      said: "Let's praise the work Prissy has done."     <- fix this line
+
+Leave `said` blank to skip a clip. Delete the ones that are not about names.
+
+**That filter flatters recall (F11).** It admits a clip only when the app's own
+output already looks like a term, so a deep miss can never enter the set:
+"Versailles" is 0.40 from "Vercel", below the 0.55 gate, and a clip where the
+name vanished entirely has nothing to match on. Whatever the app misses hardest
+is exactly what this filter hides. `--random N` samples N clips with no filter
+at all — most will be about nothing, and the few that are not are the cases the
+filtered pass cannot reach.
+
+The other bias is `said:` itself. It is pre-filled with the app's own output,
+so a label left untouched agrees with the app by construction. Correcting the
+sheet by hand is not optional.
+"""
+import argparse
+import json
+import random
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CLIPS = Path.home() / "Recordings/ParrotFlow Dev"
+TRACE = CLIPS / "trace.jsonl"
+VOCAB = Path.home() / ".config/parrotflow-dev/vocabulary.yaml"
+
+
+def vocabulary():
+    """Terms and their known mis-renderings, without a YAML dependency."""
+    terms, heard, current = [], [], None
+    if not VOCAB.exists():
+        return terms, heard
+    for line in VOCAB.read_text().splitlines():
+        if line.startswith("#") or not line.strip():
+            continue
+        name = re.match(r"^  ([A-Za-z][\w'-]*):\s*$", line)
+        if name:
+            current = name.group(1)
+            terms.append(current)
+            continue
+        listed = re.search(r"heard:\s*\[(.*)", line)
+        if listed and current:
+            heard.extend(w.strip().strip("]") for w in listed.group(1).split(","))
+    return terms, [h for h in heard if h]
+
+
+def levenshtein(a, b):
+    previous = list(range(len(b) + 1))
+    for i, ca in enumerate(a, 1):
+        current = [i]
+        for j, cb in enumerate(b, 1):
+            current.append(min(current[-1] + 1, previous[j] + 1,
+                               previous[j - 1] + (ca != cb)))
+        previous = current
+    return previous[-1]
+
+
+def near(word, terms):
+    """Close enough to a term to have been a near miss, glued and lowercased."""
+    w = re.sub(r"[^a-z0-9]", "", word.lower())
+    if len(w) < 4:
+        return None
+    for term in terms:
+        t = term.lower()
+        if w == t:
+            return term
+        if 1 - levenshtein(w, t) / max(len(w), len(t)) >= 0.55:
+            return term
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--limit", type=int, default=60)
+    ap.add_argument("--random", type=int, default=0, metavar="N",
+                    help="sample N clips with no trigger filter (F11)")
+    ap.add_argument("--seed", type=int, default=0,
+                    help="seed for --random, so a sheet can be rebuilt")
+    args = ap.parse_args()
+
+    terms, heard = vocabulary()
+    if not terms and not args.random:
+        print(f"✗ no terms in {VOCAB}", file=sys.stderr)
+        return 2
+    lowered = {h.lower() for h in heard}
+
+    picked, seen = [], set()
+    for line in TRACE.read_text().splitlines():
+        try:
+            entry = json.loads(line)
+        except ValueError:
+            continue
+        wav, final = entry.get("wav"), (entry.get("final") or "").strip()
+        if not wav or not final:
+            continue
+        name = Path(wav).name
+        if name in seen or not (CLIPS / name).exists():
+            continue
+
+        if args.random:
+            # No filter at all. The point of this mode is the clips the
+            # filter below can never admit (F11), so nothing is asked of the
+            # text — not even that it mention a name.
+            seen.add(name)
+            picked.append((name, final, "sampled at random, unfiltered"))
+            continue
+
+        words = re.findall(r"[\w'-]+", final)
+        why = None
+        if any(w.lower() in lowered for w in words):
+            why = "a known mis-rendering"
+        elif any(near(w, terms) for w in words):
+            why = "a term or something near one"
+        if not why:
+            continue
+        seen.add(name)
+        picked.append((name, final, why))
+
+    if args.random:
+        pool = len(picked)
+        random.Random(args.seed).shuffle(picked)
+        picked = picked[:args.random]
+        order = "sampled at random"
+    else:
+        # Newest first: recent clips are the ones whose wording is still
+        # rememberable, and a label nobody can verify is worse than no label.
+        picked.reverse()
+        picked = picked[:args.limit]
+        pool = len(seen)
+        order = "newest first"
+
+    print(f"# Menu cases mined from {pool} candidate clips"
+          f" — {len(picked)} written, {order}.")
+    print("#")
+    print("# WARNING: `said` below is pre-filled with the app's OWN OUTPUT.")
+    print("# A line left as it is agrees with the app by construction, and a")
+    print("# set built that way measures nothing. Correct every line by hand")
+    print("# against the audio, blank the ones you cannot remember, and delete")
+    print("# any clip that is not about a name. See scripts/menu-recall.py.")
+    if args.random:
+        print("#")
+        print("# These clips were sampled with no trigger filter, so most will")
+        print("# be about nothing. That is the point: the filtered pass admits")
+        print("# a clip only when the app's output already looks like a term,")
+        print("# so it cannot show a name the app missed completely (F11).")
+    print()
+    print("cases:")
+    for name, final, why in picked:
+        print(f"  - wav: {name}")
+        print(f"    # picked up: {why}")
+        print(f'    said: "{final.replace(chr(34), chr(39))}"')
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/mine-menu-cases.py
+++ b/scripts/mine-menu-cases.py
@@ -97,7 +97,8 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--limit", type=int, default=60)
     ap.add_argument("--random", type=int, default=0, metavar="N",
-                    help="sample N clips with no trigger filter (F11)")
+                    help="sample N clips with no trigger filter; N replaces "
+                         "--limit and the newest-first order (F11)")
     ap.add_argument("--seed", type=int, default=0,
                     help="seed for --random, so a sheet can be rebuilt")
     args = ap.parse_args()

--- a/scripts/rerank-judge.py
+++ b/scripts/rerank-judge.py
@@ -221,7 +221,7 @@ def trim_scores(block, options):
     worse than no prose.
     """
     if not block:
-        return block
+        return ""
     kept = []
     for line in tune.strip_sentinels(block).splitlines():
         found = SCORE_LINE.search(line)
@@ -375,7 +375,7 @@ def main():
             ceiling += 1
             picked_chance += 1 / len(short)
             chosen = tune.ask(args.judge, prompt.replace("{terms}", case["terms"]),
-                              short, trim_scores(case.get("scores", ""), short))
+                              short, trim_scores(case.get("scores") or "", short))
             kept += chosen is not None and recall.normalise(chosen) == truth
         print(f"  two-stage, top-{n} then {args.judge}, shortlisted by "
               f"framing {chosen_framing!r}")

--- a/scripts/rerank-judge.py
+++ b/scripts/rerank-judge.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""Score every reading on its own, instead of asking for one letter.
+
+    scripts/rerank-judge.py                       # Qwen3-Reranker-0.6B
+    scripts/rerank-judge.py --model mixedbread-ai/mxbai-rerank-base-v2
+    scripts/rerank-judge.py --scores              # show it the acoustic numbers
+    scripts/rerank-judge.py --fuse                # sweep the CTC weight
+    scripts/rerank-judge.py --verbose             # list what it got wrong
+
+The judge today reads a lettered list of up to sixteen near-identical sentences
+and answers with one letter. That keeps the winner and throws away everything
+else — no margin, no runner-up, no way to say "too close, ask the user".
+
+A reranker is a cross-encoder: one question per candidate, answered `yes` or
+`no`, scored by the gap between those two logits. The candidates never see each
+other, so what comes back is a ranking with distances, not a vote.
+
+Runs off `tests/judge-menus.json`, so no decoding and no app build. Needs the
+MLX environment: `uv venv .venv-rerank && uv pip install mlx-lm`.
+
+Three numbers are reported, and the second matters as much as the first:
+
+    top-1   the true sentence ranked first
+    top-3   it reached the top three — what a two-stage design would get
+    margin  how far ahead the wrong answer was, when it was wrong
+
+Chance is printed beside every table. Half these menus hold two options, so a
+top-3 of 19/28 is worse than guessing (F13).
+
+`--stage2 N` shortlists to N and hands them to the judge. The shortlist goes
+in the app's menu order and its score block is trimmed to the lines that still
+separate two shortlisted options (F7). With `--framing all`, the shortlist is
+built from the framing with the best top-3, and the run says which.
+"""
+import argparse
+import json
+import re
+import string
+import sys
+from pathlib import Path
+from importlib.machinery import SourceFileLoader
+
+ROOT = Path(__file__).resolve().parent.parent
+CACHE = ROOT / "tests/judge-menus.json"
+recall = SourceFileLoader("recall", str(ROOT / "scripts/menu-recall.py")).load_module()
+# For `ask` and for F6's sentinel rule, which is defined once, there.
+tune = SourceFileLoader("tune", str(ROOT / "scripts/tune-judge.py")).load_module()
+
+DEFAULT_MODEL = "Qwen/Qwen3-Reranker-0.6B"
+
+# ── framings ─────────────────────────────────────────────────────────────────
+# A reranker scores how well a document answers a query. Our candidates are the
+# same sentence with one word changed, so they are all equally "about" any query
+# describing the topic — and what is left to separate them is term overlap. The
+# first framing here lists the vocabulary in the query and so scores a candidate
+# up for *containing* a vocabulary name, which is backwards: the whole question
+# is whether that name belongs there. The rest are attempts to give the model a
+# query the right answer actually matches better.
+#
+# `reverse` ranks ascending, for a framing that describes the wrong answer.
+
+FRAMINGS = {
+    "terms": dict(
+        instruct="The user is dictating. A speech recogniser mangles the names "
+                 "they use often, so several readings of the same audio are in "
+                 "play, differing only in those names. Judge whether this "
+                 "reading is what the user actually said.",
+        query="A dictated sentence. The user's vocabulary is: {terms} — "
+              "colleagues, products and tools they talk about every day. They "
+              "also talk about people and things that are not in that list.",
+    ),
+    "plain": dict(
+        instruct="Judge whether this is a correct transcription of dictated "
+                 "speech — every word being the word the speaker actually said.",
+        query="A sentence the user dictated.",
+    ),
+    "fluent": dict(
+        instruct="Judge whether the document is fluent, grammatical English "
+                 "that a person would actually say. A sentence is not fluent "
+                 "when a proper name stands where an ordinary verb or noun "
+                 "belongs, or where two words have been run into one name.",
+        query="A grammatical, natural English sentence where every word makes "
+              "sense in its place.",
+    ),
+    "misheard": dict(
+        instruct="Judge whether the document contains a speech-recognition "
+                 "error: a proper name or product name written where an "
+                 "ordinary English word was actually spoken, leaving a sentence "
+                 "that does not parse.",
+        query="A garbled transcription, where a proper name has replaced an "
+              "ordinary word and the sentence no longer makes sense.",
+        reverse=True,
+    ),
+    # Two rewordings of the same polarity. Picking the best of four framings on
+    # twenty-four cases is exactly how a fluke gets reported as a finding, so
+    # these are here to show whether the flip survives being said differently.
+    "misheard-short": dict(
+        instruct="Judge whether this sentence contains a transcription error.",
+        query="A sentence with a word transcribed wrongly.",
+        reverse=True,
+    ),
+    "misheard-long": dict(
+        instruct="This is dictated speech that a recogniser has transcribed. "
+                 "Judge whether one of the words is wrong — specifically a "
+                 "brand, product or person's name printed where the speaker "
+                 "actually said a common English word, or two common words run "
+                 "together into a single name. The result is a sentence that a "
+                 "native speaker would never produce.",
+        query="A transcript containing a misrecognised word, where a name "
+              "appears in a position no name could occupy.",
+        reverse=True,
+    ),
+}
+
+
+# ── prompt shapes ────────────────────────────────────────────────────────────
+# Each reranker was trained against one exact string, and a reranker fed a
+# string it was not trained on degrades quietly rather than failing. So these
+# are transcribed from the source, not paraphrased: Qwen's from the model
+# card's `format_instruction` / `prefix` / `suffix`, mixedbread's from
+# `mxbai_rerank/mxbai_rerank_v2.py`. The instruction is the only part meant to
+# be rewritten. The yes/no token ids come from each repo's `1_LogitScore`
+# rather than from re-encoding, which is where an off-by-one hides.
+
+def qwen3_prompt(instruct, query, document):
+    system = ('Judge whether the Document meets the requirements based on the '
+              'Query and the Instruct provided. Note that the answer can only '
+              'be "yes" or "no".')
+    body = f"<Instruct>: {instruct}\n<Query>: {query}\n<Document>: {document}"
+    return (f"<|im_start|>system\n{system}<|im_end|>\n"
+            f"<|im_start|>user\n{body}<|im_end|>\n"
+            f"<|im_start|>assistant\n<think>\n\n</think>\n\n")
+
+
+def mxbai_prompt(instruct, query, document):
+    task = ("You are a search relevance expert who evaluates how well documents "
+            "match search queries. For each query-document pair, carefully "
+            "analyze the semantic relationship between them, then provide your "
+            "binary relevance judgment (0 for not relevant, 1 for relevant).\n"
+            "Relevance:")
+    return ("<|im_start|>system\nYou are Qwen, created by Alibaba Cloud. You are "
+            "a helpful assistant.<|im_end|>\n<|im_start|>user\n"
+            f"instruction: {instruct}\nquery: {query}\n"
+            f"document: {document}\n{task}<|im_end|>\n<|im_start|>assistant\n")
+
+
+SHAPES = {                        # builder, true id, false id
+    "qwen3": (qwen3_prompt, 9693, 2152),
+    "mxbai": (mxbai_prompt, 16, 15),
+}
+
+
+def shape_for(name):
+    return "mxbai" if "mxbai" in name.lower() else "qwen3"
+
+
+# ── the model ────────────────────────────────────────────────────────────────
+
+class Reranker:
+    """One forward pass per candidate; the score is the yes/no logit gap.
+
+    The gap is kept rather than the probability. Probabilities saturate — two
+    candidates at 0.999 and 0.9999 look identical and are four nats apart — and
+    the whole reason for using a reranker here is to get a usable distance.
+    """
+
+    def __init__(self, name):
+        import mlx.core as mx
+        from mlx_lm import load
+        self.mx = mx
+        self.model, self.tok = load(name)
+        self.build, self.yes, self.no = SHAPES[shape_for(name)]
+
+    def score(self, instruct, query, document):
+        text = self.build(instruct, query, document)
+        ids = self.mx.array([self.tok.encode(text, add_special_tokens=False)])
+        logits = self.model(ids)[0, -1]
+        return float(logits[self.yes] - logits[self.no])
+
+
+# ── the acoustic evidence ────────────────────────────────────────────────────
+
+SCORE_LINE = re.compile(r'"([^"]+)"\s+(-?\d+\.\d+)\s+"([^"]+)"\s+(-?\d+\.\d+)')
+
+
+def slots(block):
+    """The score block back into pairs: (reading, nats, reading, nats)."""
+    return [(a, float(x), b, float(y))
+            for a, x, b, y in SCORE_LINE.findall(block or "")]
+
+
+def commits(option, spelling):
+    """Does this reading commit to that spelling? Same test as `ctc_total`."""
+    return spelling.strip(".,?!;:") in option
+
+
+def trim_scores(block, options):
+    """The score block cut down to what still separates these options (F7).
+
+    A line keeps its place only if it passes both tests.
+
+    It has to be a measurement. A 0.00 heard score is the sentinel, not a
+    number (F6), so the rule is `tune-judge.strip_sentinels` — defined once,
+    there.
+
+    And the shortlisted options have to still disagree about it. Two of them
+    must stand in different relations to the pair of spellings; a line every
+    survivor answers the same way describes a choice that is no longer on the
+    menu, and the judge then reads a number about an option it cannot pick.
+    "Contains" is the crude test `ctc_total` already uses, and crude is right
+    here: a sentence can hold both spellings at once ("Let's praise Praisy's
+    work"), and that is a third relation, not a tie.
+
+    Measured on the cached menus, top-3 shortlists, gemma4:e4b: order fix
+    alone 23→24, this trim alone 23, both 25/28. The trim on its own is worse
+    than nothing because it can strand a sentinel line as the only survivor,
+    which is exactly the lying evidence F6 describes.
+
+    The preamble is kept, but only while some score line survives. If none
+    does, the whole block goes: prose promising numbers that are absent is
+    worse than no prose.
+    """
+    if not block:
+        return block
+    kept = []
+    for line in tune.strip_sentinels(block).splitlines():
+        found = SCORE_LINE.search(line)
+        if not found:
+            kept.append(line)
+            continue
+        a, _, b, _ = found.groups()
+        stances = {(commits(o, a), commits(o, b)) for o in options}
+        if len(stances) > 1:
+            kept.append(line)
+    if not any(SCORE_LINE.search(line) for line in kept):
+        return ""
+    return "\n".join(kept)
+
+
+def ctc_total(option, pairs):
+    """This option's acoustic score, summed over the slots it commits to.
+
+    Each line of the score block is one uncertain stretch of audio with two
+    spellings for it. An option picks one spelling per stretch, so summing the
+    score of whichever spelling it contains gives that whole reading a number.
+    A slot that matches neither spelling is skipped rather than guessed at.
+    """
+    total = 0.0
+    for a, x, b, y in pairs:
+        left, right = a.strip(".,?!;:") in option, b.strip(".,?!;:") in option
+        if left and not right:
+            total += x
+        elif right and not left:
+            total += y
+    return total
+
+
+# ── the run ──────────────────────────────────────────────────────────────────
+
+def evaluate(cases, rank, fuse=None):
+    """rank(case) -> [(score, option)] best first. Returns the tallies."""
+    top1 = top3 = 0
+    misses = []
+    for case in cases:
+        truth = recall.normalise(case["said"])
+        ranked = rank(case)
+        if fuse is not None:
+            pairs = slots(case.get("scores"))
+            ranked = sorted(((s + fuse * ctc_total(o, pairs), o)
+                             for s, o in ranked), reverse=True)
+        order = [recall.normalise(o) for _, o in ranked]
+        place = order.index(truth) if truth in order else 99
+        top1 += place == 0
+        top3 += place < 3
+        if place != 0:
+            gap = ranked[0][0] - (ranked[place][0] if place < len(ranked) else 0)
+            misses.append((case, ranked, place, gap))
+    return top1, top3, misses
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", default=DEFAULT_MODEL)
+    ap.add_argument("--scores", action="store_true",
+                    help="append the acoustic evidence to each candidate")
+    ap.add_argument("--fuse", action="store_true",
+                    help="sweep the weight on the CTC score")
+    ap.add_argument("--framing", default="terms", choices=sorted(FRAMINGS) + ["all"])
+    ap.add_argument("--stage2", type=int, nargs="?", const=3, default=0,
+                    metavar="N", help="shortlist to N, then let the judge pick")
+    ap.add_argument("--judge", default="gemma4:e4b")
+    ap.add_argument("--limit", type=int, default=0)
+    ap.add_argument("--verbose", action="store_true")
+    args = ap.parse_args()
+
+    if not CACHE.exists():
+        print("✗ no cache — run scripts/tune-judge.py --harvest first")
+        return 2
+
+    cases = [c for c in json.loads(CACHE.read_text())
+             if recall.normalise(c["said"]) in [recall.normalise(o) for o in c["menu"]]]
+    unreachable = len(json.loads(CACHE.read_text())) - len(cases)
+    if args.limit:
+        cases = cases[:args.limit]
+
+    # What ranking at random would score, given these menu sizes. Half of them
+    # hold two options, so a top-3 near 19 means nothing at all — this line is
+    # here because the first run of this script was read as a good result.
+    sizes = [len(c["menu"]) for c in cases]
+    chance1 = sum(1 / n for n in sizes)
+    chance3 = sum(min(3, n) / n for n in sizes)
+
+    model = Reranker(args.model)
+    name = args.model.split("/")[-1]
+    print(f"\n  {name}   {len(cases)} menus, sizes {min(sizes)}–{max(sizes)}"
+          f"   ({unreachable} never held the answer)")
+    print(f"  chance                     top-1 {chance1:.1f}/{len(cases)}"
+          f"   top-3 {chance3:.1f}/{len(cases)}\n")
+
+    best = None
+    for key in (sorted(FRAMINGS) if args.framing == "all" else [args.framing]):
+        frame = FRAMINGS[key]
+        cached = {}
+
+        def rank(case, frame=frame, cached=cached):
+            if id(case) in cached:
+                return cached[id(case)]
+            query = frame["query"].format(terms=case["terms"] or "none listed")
+            tail = ("\n\nHow clearly the recogniser heard each spelling, closer "
+                    "to zero being clearer:" + case["scores"].split("comparable.")[-1]
+                    ) if args.scores and case.get("scores") else ""
+            # A reversed framing describes the *wrong* answer, so its score is
+            # negated here rather than sorted the other way. Everything
+            # downstream — the fusion with the acoustic score, the margins in
+            # the miss list — can then assume higher is better.
+            sign = -1 if frame.get("reverse") else 1
+            out = sorted(((sign * model.score(frame["instruct"], query, o + tail), o)
+                          for o in case["menu"]), reverse=True)
+            cached[id(case)] = out
+            return out
+
+        top1, top3, misses = evaluate(cases, rank)
+        flag = "  ← below chance" if top1 < chance1 else ""
+        print(f"  {key:<26} top-1 {top1:>2}/{len(cases)}   top-3 {top3:>2}/{len(cases)}{flag}")
+        # The shortlist is only as good as the framing that built it, and the
+        # second stage measures what the shortlist left reachable. Keeping the
+        # last framing in the loop shortlisted with "terms" — alphabetically
+        # last, and the one that scores below chance (F7).
+        if best is None or (top3, top1) > (best[2], best[3]):
+            best = (key, rank, top3, top1, misses)
+    chosen_framing, rank, _, _, misses = best
+    print()
+
+    if args.stage2:
+        # The reranker cannot pick, but it can rule out. The judge cannot rule
+        # out sixteen options reliably, but it can pick from three. Neither
+        # number below is worth anything on its own — `ceiling` is what the
+        # shortlist left reachable, and `picked` is what the judge did with it.
+        prompt = (ROOT / "examples/transforms/verify_names/menu.md").read_text().strip()
+        n = args.stage2
+        ceiling = kept = 0
+        ceiling_chance = picked_chance = 0.0
+        for case in cases:
+            truth = recall.normalise(case["said"])
+            top = [o for _, o in rank(case)[:n]]
+            # Back into the app's own order, decoder's reading first. The
+            # reranker chooses *which* readings survive, not the order they
+            # are read in: position in the list is worth about eight points
+            # to the judge, and letting the reranker set it cost a case (F7).
+            place = {o: i for i, o in enumerate(case["menu"])}
+            short = sorted(top, key=lambda o: place.get(o, len(place)))
+            ceiling_chance += min(n, len(case["menu"])) / len(case["menu"])
+            if truth not in [recall.normalise(o) for o in short]:
+                continue
+            ceiling += 1
+            picked_chance += 1 / len(short)
+            chosen = tune.ask(args.judge, prompt.replace("{terms}", case["terms"]),
+                              short, trim_scores(case.get("scores", ""), short))
+            kept += chosen is not None and recall.normalise(chosen) == truth
+        print(f"  two-stage, top-{n} then {args.judge}, shortlisted by "
+              f"framing {chosen_framing!r}")
+        print(f"    shortlist ceiling        {ceiling}/{len(cases)}"
+              f"   (chance {ceiling_chance:.1f})")
+        print(f"    picked                   {kept}/{len(cases)}"
+              f"   (chance {picked_chance:.1f})\n")
+
+    if args.fuse:
+        print("\n  fused with the acoustic score — total = logit gap + λ · nats")
+        print(f"    {'chance':<7} top-1 {chance1:>4.1f}/{len(cases)}"
+              f"  top-3 {chance3:>4.1f}")
+        for lam in (0.0, 0.05, 0.1, 0.2, 0.3, 0.5, 0.75, 1.0, 1.5, 2.0):
+            a, b, _ = evaluate(cases, rank, fuse=lam)
+            bar = "█" * a
+            print(f"    λ {lam:<5} top-1 {a:>4}/{len(cases)}  top-3 {b:>4}  {bar}")
+
+    if args.verbose and misses:
+        print(f"\n{'=' * 72}\nranked wrong ({len(misses)})\n{'=' * 72}")
+        for case, ranked, place, gap in misses:
+            where = f"place {place + 1}" if place < 90 else "not ranked"
+            print(f"\n{case['wav'][22:-4]}   true reading at {where}, {gap:.2f} behind")
+            print(f"  said:  {case['said'][:150]}")
+            for score, option in ranked[:3]:
+                mark = "✓" if recall.normalise(option) == recall.normalise(case["said"]) else " "
+                print(f"  {mark} {score:>7.2f}  {option[:150]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tune-judge.py
+++ b/scripts/tune-judge.py
@@ -104,7 +104,7 @@ def strip_sentinels(block):
     not there, so the whole block goes with them.
     """
     if not block:
-        return block
+        return ""
     kept = [line for line in block.splitlines() if not SENTINEL_LINE.match(line)]
     if not any(SCORE_LINE.search(line) for line in kept):
         return ""
@@ -204,7 +204,7 @@ def main():
             continue
         scored += 1
         chance += 1 / len(case["menu"])
-        block = "" if args.no_scores else case.get("scores", "")
+        block = "" if args.no_scores else (case.get("scores") or "")
         if args.strip_sentinels and block:
             trimmed = strip_sentinels(block)
             stripped += trimmed != block

--- a/scripts/tune-judge.py
+++ b/scripts/tune-judge.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Score a judge prompt against menus already harvested from the archive.
+
+    scripts/tune-judge.py --harvest              # run the app once, cache the menus
+    scripts/tune-judge.py                        # score the shipped menu.md
+    scripts/tune-judge.py --prompt v6.md         # score a candidate
+    scripts/tune-judge.py --prompt v6.md --model gemma4:12b
+    scripts/tune-judge.py --strip-sentinels      # drop the fake 0.00 score lines
+
+Harvesting is the slow part — every clip is decoded, and that is a second or
+two each. It does not depend on the prompt, so it is done once and cached.
+After that a variant costs one model call per case, which is what makes trying
+six of them reasonable.
+
+The number reported is **picked**: of the menus that held the true sentence,
+how many the model chose. Menus that never held it are counted separately and
+excluded — a prompt cannot be blamed for an option that was not on the list,
+and leaving them in hides the difference between prompts behind a constant.
+
+`chance` is printed beside it — what guessing one letter would score on these
+menu sizes. Half the cached menus hold two options, so guessing gets 8.1/28,
+not the 2 that a menu of sixteen would suggest. A total with no chance beside
+it says nothing (F13).
+"""
+import argparse
+import json
+import os
+import re
+import string
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CACHE = ROOT / "tests/judge-menus.json"
+PROMPT = ROOT / "examples/transforms/verify_names/menu.md"
+CLIPS = Path.home() / "Recordings/ParrotFlow Dev"
+ENDPOINT = os.environ.get("PARROTFLOW_LLM_ENDPOINT", "http://localhost:11434") + "/api/chat"
+
+sys.path.insert(0, str(ROOT / "scripts"))
+from importlib.machinery import SourceFileLoader
+
+recall = SourceFileLoader("recall", str(ROOT / "scripts/menu-recall.py")).load_module()
+# The freshly built app, resolved the same way `menu-recall.py` resolves it.
+# This file used to name /Applications outright, so a harvest ran the installed
+# binary while every other measurement ran the built one — and it cached six
+# menus where there were thirty-two.
+APP = recall.APP
+
+
+def harvest():
+    cases = []
+    for wav, said in recall.load_cases():
+        if not said:
+            continue
+        dump = Path(tempfile.mkdtemp()) / "menu.txt"
+        environment = dict(os.environ, PARROTFLOW_JUDGE_DUMP=str(dump))
+        subprocess.run([APP, "--transcribe", str(CLIPS / wav)],
+                       capture_output=True, text=True, env=environment, timeout=180)
+        if not dump.exists():
+            continue
+        text = dump.read_text()
+        system = re.search(r"^SYSTEM (.*)$", text, re.M)
+        menu = [m.group(1) for m in re.finditer(r"^MENU [A-Z]\. (.*)$", text, re.M)]
+        block = re.search(r"^SCORES (.*)$", text, re.M)
+        if len(menu) < 2:
+            continue
+        cases.append({
+            "wav": wav, "said": said, "menu": menu,
+            "terms": re.search(r"includes: (.*?) —", system.group(1)).group(1)
+            if system and "includes: " in system.group(1) else "",
+            "scores": block.group(1).replace("\\n", "\n") if block else "",
+        })
+        print(f"  {wav}  {len(menu)} options", file=sys.stderr)
+    CACHE.write_text(json.dumps(cases, indent=1, ensure_ascii=False))
+    print(f"\ncached {len(cases)} menus to {CACHE.relative_to(ROOT)}", file=sys.stderr)
+
+
+STRAY = []   # replies whose first character was not the answer
+
+# One line of the score block: two spellings for one stretch of audio, each
+# with its score in nats. The first number is the *heard* score — what the
+# decoder actually wrote.
+SCORE_LINE = re.compile(r'"([^"]*)"\s+(-?\d+\.\d+)\s+"([^"]*)"\s+(-?\d+\.\d+)')
+SENTINEL_LINE = re.compile(r'^\s*"[^"]*"\s+0\.00\s')
+
+
+def strip_sentinels(block):
+    """Drop score lines whose heard score is the 0.00 sentinel (F6).
+
+    A spotter-only proposal has no heard score. The prototype writes zero for
+    it, and the block then reads as a measurement: `"his" 0.00 "Praisy" -3.88
+    — "Praisy" heard 3.9 less clearly` claims the recogniser heard "his"
+    perfectly, which nothing measured. 10 of the 33 cached menus carry one.
+
+    Zero is also a legal best score in nats, so a real zero cannot be told
+    from the sentinel here. That is why this is a flag on the harness and not
+    a fix: PR 3 removes the sentinel at the source, and then this flag has
+    nothing to do.
+
+    If every score line goes, the preamble is left promising numbers that are
+    not there, so the whole block goes with them.
+    """
+    if not block:
+        return block
+    kept = [line for line in block.splitlines() if not SENTINEL_LINE.match(line)]
+    if not any(SCORE_LINE.search(line) for line in kept):
+        return ""
+    return "\n".join(kept)
+
+
+def ask(model, system, options, scores="", logprobs=False):
+    """The judge's choice, either sampled or read off the letter distribution.
+
+    Sampling keeps only the winner. `logprobs` asks Ollama (0.32+) for the
+    distribution over the first token instead, which costs the same call and
+    returns a ranking with margins — and is immune to the failure below.
+
+    The sampled path takes the first letter *anywhere* in the reply, so a model
+    that answers "The answer is C" is recorded as having said A. Replies that
+    did not begin with a bare letter are collected in STRAY so the size of that
+    effect is visible rather than assumed.
+    """
+    body = "\n".join(f"{string.ascii_uppercase[i]}. {o}" for i, o in enumerate(options))
+    payload = {
+        "model": model, "stream": False, "think": False,
+        "options": {"temperature": 0, "num_predict": 8},
+        "messages": [{"role": "system", "content": system},
+                     {"role": "user", "content": body + scores + "\n\nWhich letter?"}],
+    }
+    if logprobs:
+        payload |= {"logprobs": True, "top_logprobs": 20}
+    request = urllib.request.Request(
+        ENDPOINT, data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(request, timeout=60) as response:
+        answer = json.loads(response.read())
+    reply = answer["message"]["content"].strip()
+
+    if logprobs and answer.get("logprobs"):
+        ranked = ranking(answer["logprobs"][0].get("top_logprobs", []), options)
+        return ranked[0][1] if ranked else None
+
+    if not reply[:1].isalpha():
+        STRAY.append(reply)
+    letter = re.search(r"[A-Za-z]", reply)
+    if not letter:
+        return None
+    index = string.ascii_uppercase.index(letter.group().upper())
+    return options[index] if index < len(options) else None
+
+
+def ranking(top, options):
+    """The letters in the first-token distribution, best first, as options.
+
+    Ollama returns whatever the model might have said — words, punctuation,
+    whitespace. Only entries that are a single letter naming an option on this
+    menu mean anything, and the rest are dropped rather than ranked.
+    """
+    out = []
+    for entry in top:
+        token = entry["token"].strip()
+        # `isalpha` is true of "é" and of Cyrillic, which are not menu letters
+        # and are not in `ascii_uppercase` — asking for their index raises.
+        if len(token) != 1 or token.upper() not in string.ascii_uppercase:
+            continue
+        index = string.ascii_uppercase.index(token.upper())
+        if index < len(options):
+            out.append((entry["logprob"], options[index]))
+    return sorted(out, reverse=True)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--harvest", action="store_true")
+    ap.add_argument("--prompt", default=str(PROMPT))
+    ap.add_argument("--model", default=os.environ.get("PARROTFLOW_JUDGE_MODEL", "gemma4:e4b"))
+    ap.add_argument("--verbose", action="store_true")
+    ap.add_argument("--no-scores", action="store_true",
+                    help="withhold the acoustic block, to measure what it is worth")
+    ap.add_argument("--strip-sentinels", action="store_true",
+                    help="drop score lines whose heard score is 0.00 (F6)")
+    ap.add_argument("--logprobs", action="store_true",
+                    help="read the letter distribution instead of sampling one")
+    args = ap.parse_args()
+
+    if args.harvest:
+        harvest()
+        return 0
+    if not CACHE.exists():
+        print("✗ no cache — run with --harvest first")
+        return 2
+
+    prompt = Path(args.prompt).read_text().strip()
+    cases = json.loads(CACHE.read_text())
+    scored = picked = unreachable = stripped = 0
+    chance = 0.0
+    for case in cases:
+        truth = recall.normalise(case["said"])
+        if truth not in [recall.normalise(o) for o in case["menu"]]:
+            unreachable += 1
+            continue
+        scored += 1
+        chance += 1 / len(case["menu"])
+        block = "" if args.no_scores else case.get("scores", "")
+        if args.strip_sentinels and block:
+            trimmed = strip_sentinels(block)
+            stripped += trimmed != block
+            block = trimmed
+        chosen = ask(args.model, prompt.replace("{terms}", case["terms"]), case["menu"],
+                     block, logprobs=args.logprobs)
+        right = chosen is not None and recall.normalise(chosen) == truth
+        picked += right
+        if args.verbose and not right:
+            print(f"  ✗ {case['wav']}  {len(case['menu'])} options")
+            print(f"      said:  {case['said']}")
+            print(f"      chose: {chosen}")
+
+    name = Path(args.prompt).name
+    how = "logprob" if args.logprobs else "sampled"
+    shown = "none" if args.no_scores else ("stripped" if args.strip_sentinels else "full")
+    lead = f"  {name:<20} {args.model:<14} {how:<8} scores {shown:<9}"
+    print(f"\n{lead}picked {picked}/{scored}"
+          f"   ({unreachable} menu(s) never held the answer)")
+    # What guessing one letter would score on these menu sizes. Half of them
+    # hold two options, so it is not 1/16 per case. A total printed without
+    # this line is unreadable (F13).
+    print(f"{'  chance':<{len(lead)}}guess  {chance:.1f}/{scored}")
+    if args.strip_sentinels:
+        print(f"  {stripped} menu(s) had a 0.00 score line removed")
+    if STRAY:
+        print(f"  {len(STRAY)} reply(s) did not start with a letter, so the first"
+              f" letter of a word was read as the answer: {STRAY[:3]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/judge-cases.yaml
+++ b/tests/judge-cases.yaml
@@ -7,6 +7,16 @@
 # expect: approve — the name was misheard and this puts it right
 # expect: decline — an ordinary word is about to be overwritten
 #
+# One category is easy to label backwards. A spelling correction —
+# "urza spells mirza", "Versal spells V E R C E L" — teaches a mapping.
+# The word before "spells" is the source, and rewriting it destroys the
+# correction the user is making: "Mirza spells mirza" teaches nothing.
+# These are declines however wrong the word looks. Four were labelled
+# approve until 2026-08-07.
+#
+# The activation phrase is not a reliable marker for them. It is itself
+# mangled — "Hey Barrot", "by the way pirate" — so `spells` is the tell.
+#
 # Fill in `expect` by hand. Half of these should be declines: the
 # stage runs on every transcript, so a confident wrong approval
 # costs more than a missed name.
@@ -25,12 +35,12 @@ cases:
   - said: "Uh, by the way, Irza spells Mirza mirza."
     heard: "Irza"
     term: "Mirza"
-    expect: approve
+    expect: decline
 
   - said: "Uh by the way pirate urza spells mirza"
     heard: "urza"
     term: "Mirza"
-    expect: approve
+    expect: decline
 
   - said: "It's a community that Tasmin asked me to crawl."
     heard: "Tasmin"
@@ -130,7 +140,7 @@ cases:
   - said: "Hey Barrot Versal Spells V E R C E L"
     heard: "Versal"
     term: "Vercel"
-    expect: approve
+    expect: decline
 
   - said: "It's possible that Prissy added a strict ten megabytes limits."
     heard: "Prissy"
@@ -140,7 +150,7 @@ cases:
   - said: "Hey Parrot, Pressy spells Pr. A I S Y"
     heard: "Pressy"
     term: "Praisy"
-    expect: approve
+    expect: decline
 
   - said: "When you're ready, I have something for you."
     heard: "ready,"

--- a/tests/judge-menus.json
+++ b/tests/judge-menus.json
@@ -1,0 +1,442 @@
+[
+ {
+  "wav": "parrotflow-2026-08-07T18-06-26.wav",
+  "said": "Uh would that improve the recognition of the terms with time?",
+  "menu": [
+   "Uh would that improve the recognition of the terms with time?",
+   "Uh would that improve the recognition of the Praisy time?"
+  ],
+  "terms": "Praisy",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"terms with\" 0.00   \"Praisy\" -5.49   — \"Praisy\" heard 5.5 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T17-47-45.wav",
+  "said": "Oh I get it. So yes, instead we want to have a retry. And then if the retry fails, we want the crawl to fail.",
+  "menu": [
+   "Oh I get it. So yes, instead we want to have a retry. And then if the retry fails, we want the crawl to fail.",
+   "Oh I get it. So yes, instead we want to have a retry. And then if the retry fails, we want the Redcrawl to fail.",
+   "Oh I get it. So yes, instead we want to have a retry. And then if the Arexvy fails, we want the crawl to fail.",
+   "Oh I get it. So yes, instead we want to have a retry. And then if the Arexvy fails, we want the Redcrawl to fail.",
+   "Oh I get it. So yes, instead we want to have a Arexvy And then if the retry fails, we want the crawl to fail.",
+   "Oh I get it. So yes, instead we want to have a Arexvy And then if the retry fails, we want the Redcrawl to fail.",
+   "Oh I get it. So yes, instead we want to have a Arexvy And then if the Arexvy fails, we want the crawl to fail.",
+   "Oh I get it. So yes, instead we want to have a Arexvy And then if the Arexvy fails, we want the Redcrawl to fail."
+  ],
+  "terms": "Arexvy, Redcrawl",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"retry.\" -10.26   \"Arexvy\" -9.80   — \"retry.\" heard 0.5 less clearly\n  \"retry\" -7.55   \"Arexvy\" -7.80   — \"Arexvy\" heard 0.2 less clearly\n  \"crawl\" -6.81   \"Redcrawl\" -8.24   — \"Redcrawl\" heard 1.4 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T17-39-27.wav",
+  "said": "Let's praise Matthieu's work.",
+  "menu": [
+   "Let's praise Mathieu's work.",
+   "Let's praise Matthieu's work.",
+   "Let's Praisy Mathieu's work.",
+   "Let's Praisy Matthieu's work.",
+   "Let's Praisy's Mathieu's work.",
+   "Let's Praisy's Matthieu's work."
+  ],
+  "terms": "Matthieu, Praisy, Praisy's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -6.20   \"Praisy\" -6.59   — \"Praisy\" heard 0.4 less clearly\n  \"Mathieu's\" -6.97   \"Matthieu\" -7.00   — \"Matthieu\" heard 0.0 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T17-39-19.wav",
+  "said": "Let's praise Mirza's work.",
+  "menu": [
+   "Let's praise Mirza's work.",
+   "Let's Praisy Mirza's work.",
+   "Let's Praisy's Mirza's work."
+  ],
+  "terms": "Praisy, Praisy's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -7.07   \"Praisy\" -6.80   — \"praise\" heard 0.3 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T17-39-03.wav",
+  "said": "Let's praise Praisy's work.",
+  "menu": [
+   "Let's praise praise his work.",
+   "Let's praise Praisy work.",
+   "Let's praise Praisy's work.",
+   "Let's Praisy praise his work.",
+   "Let's Praisy Praisy work.",
+   "Let's Praisy Praisy's work.",
+   "Let's Praisy's praise his work.",
+   "Let's Praisy's Praisy work.",
+   "Let's Praisy's Praisy's work."
+  ],
+  "terms": "Praisy, Praisy's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -5.75   \"Praisy\" -5.75   — \"praise\" heard 0.0 less clearly\n  \"his\" 0.00   \"Praisy\" -3.88   — \"Praisy\" heard 3.9 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T17-38-57.wav",
+  "said": "Let's praise Praisy's work.",
+  "menu": [
+   "Let's praise Precise Work.",
+   "Let's praise Praisy Work.",
+   "Let's Praisy Precise Work.",
+   "Let's Praisy Praisy Work.",
+   "Let's Praisy's Precise Work.",
+   "Let's Praisy's Praisy Work."
+  ],
+  "terms": "Praisy, Praisy's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -6.32   \"Praisy\" -6.48   — \"Praisy\" heard 0.2 less clearly\n  \"Precise\" -7.45   \"Praisy\" -5.91   — \"Precise\" heard 1.5 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T17-38-44.wav",
+  "said": "So let's praise the work that Praisy has done.",
+  "menu": [
+   "So let's praise the work that Pressy has done.",
+   "So let's praise the work that Praisy has done.",
+   "So let's Praisy work that Pressy has done.",
+   "So let's Praisy work that Praisy has done.",
+   "So let's Praisy's work that Pressy has done.",
+   "So let's Praisy's work that Praisy has done."
+  ],
+  "terms": "Praisy, Praisy's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -5.88   \"Praisy\" -6.68   — \"Praisy\" heard 0.8 less clearly\n  \"Pressy\" -5.60   \"Praisy\" -5.78   — \"Praisy\" heard 0.2 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T17-27-35.wav",
+  "said": "Let's praise the amazing work Praisy did.",
+  "menu": [
+   "Let's praise the amazing work praise he did.",
+   "Let's praise the amazing work Praisy did.",
+   "Let's praise the amazing work Praisy's did.",
+   "Let's Praisy amazing work praise he did.",
+   "Let's Praisy amazing work Praisy did.",
+   "Let's Praisy amazing work Praisy's did.",
+   "Let's Praisy's amazing work praise he did.",
+   "Let's Praisy's amazing work Praisy did.",
+   "Let's Praisy's amazing work Praisy's did."
+  ],
+  "terms": "Praisy, Praisy's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -9.46   \"Praisy\" -9.66   — \"Praisy\" heard 0.2 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T17-27-23.wav",
+  "said": "So let's praise the team's work.",
+  "menu": [
+   "So let's praise the team's work.",
+   "So let's Praisy team's work.",
+   "So let's Praisy's team's work."
+  ],
+  "terms": "Praisy, Praisy's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -6.83   \"Praisy\" -7.08   — \"Praisy\" heard 0.2 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T17-26-56.wav",
+  "said": "I changed settings in Vercel",
+  "menu": [
+   "I changed settings in Versal.",
+   "I changed settings in Vercel."
+  ],
+  "terms": "Vercel",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"Versal.\" -8.24   \"Vercel\" -9.72   — \"Vercel\" heard 1.5 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T17-26-30.wav",
+  "said": "I changed some settings in Vercel",
+  "menu": [
+   "I changed some settings in Vercel.",
+   "I changed some Praisy Vercel."
+  ],
+  "terms": "Praisy",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"settings in\" 0.00   \"Praisy\" -5.48   — \"Praisy\" heard 5.5 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T17-19-57.wav",
+  "said": "My ask that was that for those sentences you give me the menu that was offered in the prompts. Also for the recent transcript where Universal was mixed up with Vercel.",
+  "menu": [
+   "My ask that was that for those sentences you give me the menu that was offered in the prompts. Also for the recent transcript where Universal was mixed up with Versailles.",
+   "My ask that was that for those sentences you give me the menu that was offered in the prompts. Also for the recent transcript where Universal was mixed up with Vercel.",
+   "My ask that was that for those sentences you give me the menu that was offered in the prompts. Also for the recent Praisy where Universal was mixed up with Versailles.",
+   "My ask that was that for those sentences you give me the menu that was offered in the prompts. Also for the recent Praisy where Universal was mixed up with Vercel."
+  ],
+  "terms": "Praisy, Vercel",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"transcript\" 0.00   \"Praisy\" -5.42   — \"Praisy\" heard 5.4 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T17-17-10.wav",
+  "said": "You and me for sure. Mirza should be too. But he's not on all project, so Let me add that to my to the list.",
+  "menu": [
+   "You and me for sure. Mirza should be too. But he's not on all project, so Let me add that to my to the list.",
+   "You and me for sure. Mirza should be too. But he's not on all project, so Let me Claude my to the list."
+  ],
+  "terms": "Claude",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"add that to\" 0.00   \"Claude\" -5.25   — \"Claude\" heard 5.2 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T17-05-42.wav",
+  "said": "So the document was a really super base uh for discussion and the Supabase proposal for the database is great.",
+  "menu": [
+   "So the document was a really super base uh for discussion and the super base proposal for the database is great.",
+   "So the document was a really super base uh for discussion and the super base proposal for the Supabase's great.",
+   "So the document was a really super base uh for discussion and the super base Praisy for the database is great.",
+   "So the document was a really super base uh for discussion and the super base Praisy for the Supabase's great.",
+   "So the document was a really super base uh for discussion and the Supabase proposal for the database is great.",
+   "So the document was a really super base uh for discussion and the Supabase proposal for the Supabase's great.",
+   "So the document was a really super base uh for discussion and the Supabase Praisy for the database is great.",
+   "So the document was a really super base uh for discussion and the Supabase Praisy for the Supabase's great.",
+   "So the document was a really Supabase uh for discussion and the super base proposal for the database is great.",
+   "So the document was a really Supabase uh for discussion and the super base proposal for the Supabase's great.",
+   "So the document was a really Supabase uh for discussion and the super base Praisy for the database is great.",
+   "So the document was a really Supabase uh for discussion and the super base Praisy for the Supabase's great.",
+   "So the document was a really Supabase uh for discussion and the Supabase proposal for the database is great.",
+   "So the document was a really Supabase uh for discussion and the Supabase proposal for the Supabase's great.",
+   "So the document was a really Supabase uh for discussion and the Supabase Praisy for the database is great.",
+   "So the document was a really Supabase uh for discussion and the Supabase Praisy for the Supabase's great."
+  ],
+  "terms": "Praisy, Supabase, Supabase's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"super base\" -6.48   \"Supabase\" -8.00   — \"Supabase\" heard 1.5 less clearly\n  \"database\" -5.99   \"Supabase\" -3.82   — \"database\" heard 2.2 less clearly\n  \"proposal\" 0.00   \"Praisy\" -5.02   — \"Praisy\" heard 5.0 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T17-05-32.wav",
+  "said": "Praisy and Mirza worked on the new Vercel deployment.",
+  "menu": [
+   "Prizzi and Mirza worked on the new Versal deployment.",
+   "Prizzi and Mirza worked on the new Vercel deployment.",
+   "Praisy and Mirza worked on the new Versal deployment.",
+   "Praisy and Mirza worked on the new Vercel deployment."
+  ],
+  "terms": "Praisy, Vercel",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"versal\" -10.80   \"Vercel\" -11.21   — \"Vercel\" heard 0.4 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T17-05-12.wav",
+  "said": "Let's praise Praisy's work.",
+  "menu": [
+   "Let's praise praise work.",
+   "Let's praise Praisy work.",
+   "Let's praise Praisy's work.",
+   "Let's Praisy praise work.",
+   "Let's Praisy Praisy work.",
+   "Let's Praisy Praisy's work.",
+   "Let's Praisy's praise work.",
+   "Let's Praisy's Praisy work.",
+   "Let's Praisy's Praisy's work."
+  ],
+  "terms": "Praisy, Praisy's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -13.46   \"Praisy\" -12.51   — \"praise\" heard 1.0 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T16-12-33.wav",
+  "said": "But replaced it with Praisy. So the judge couldn't see praise.",
+  "menu": [
+   "But replaced it with Prezi. So the judge couldn't see Braze.",
+   "But replaced it with Praisy. So the judge couldn't see Braze.",
+   "But Praisy Prezi. So the judge couldn't see Braze.",
+   "But Praisy Praisy. So the judge couldn't see Braze."
+  ],
+  "terms": "Praisy",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"Prezi\" 0.00   \"Praisy\" -3.43   — \"Praisy\" heard 3.4 less clearly\n  \"replaced it with\" 0.00   \"Praisy\" -4.02   — \"Praisy\" heard 4.0 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T16-12-20.wav",
+  "said": "So the acoustic pass found praise.",
+  "menu": [
+   "So the acoustic pass found praise.",
+   "So the acoustic pass found Praisy",
+   "So the acoustic pass found Praisy's",
+   "So the Claude pass found praise.",
+   "So the Claude pass found Praisy",
+   "So the Claude pass found Praisy's"
+  ],
+  "terms": "Claude, Praisy, Praisy's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise.\" -4.61   \"Praisy\" -3.47   — \"praise.\" heard 1.1 less clearly\n  \"acoustic\" 0.00   \"Claude\" -5.17   — \"Claude\" heard 5.2 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T16-09-50.wav",
+  "said": "Let's praise the work Praisy has done.",
+  "menu": [
+   "Let's praise the work Prissy has done.",
+   "Let's praise the work Praisy has done.",
+   "Let's Praisy work Prissy has done.",
+   "Let's Praisy work Praisy has done.",
+   "Let's Praisy's work Prissy has done.",
+   "Let's Praisy's work Praisy has done."
+  ],
+  "terms": "Praisy, Praisy's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -9.09   \"Praisy\" -8.56   — \"praise\" heard 0.5 less clearly\n  \"Prissy\" -6.90   \"Praisy\" -6.13   — \"Prissy\" heard 0.8 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T16-09-37.wav",
+  "said": "Let's praise the work Praisy has done.",
+  "menu": [
+   "Let's praise the work Prissy has done.",
+   "Let's praise the work Praisy has done.",
+   "Let's Praisy work Prissy has done.",
+   "Let's Praisy work Praisy has done.",
+   "Let's Praisy's work Prissy has done.",
+   "Let's Praisy's work Praisy has done."
+  ],
+  "terms": "Praisy, Praisy's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -8.29   \"Praisy\" -8.75   — \"Praisy\" heard 0.5 less clearly\n  \"Prissy\" -9.32   \"Praisy\" -8.27   — \"Prissy\" heard 1.1 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T16-09-15.wav",
+  "said": "Let's praise the work Praisy has done",
+  "menu": [
+   "Let's praise the work Priss.y has done",
+   "Let's praise the work Praisy's done",
+   "Let's praise the work Praisy has done",
+   "Let's Praisy work Priss.y has done",
+   "Let's Praisy work Praisy's done",
+   "Let's Praisy work Praisy has done",
+   "Let's Praisy's work Priss.y has done",
+   "Let's Praisy's work Praisy's done",
+   "Let's Praisy's work Praisy has done"
+  ],
+  "terms": "Praisy, Praisy's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -7.23   \"Praisy\" -7.11   — \"praise\" heard 0.1 less clearly\n  \"Priss.y\" -8.23   \"Praisy\" -7.57   — \"Priss.y\" heard 0.7 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T16-09-06.wav",
+  "said": "Praisy did an amazing job.",
+  "menu": [
+   "Prissy d did an amazing job.",
+   "Praisy d did an amazing job."
+  ],
+  "terms": "Praisy",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"Prissy\" -13.08   \"Praisy\" -11.84   — \"Prissy\" heard 1.2 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T16-09-00.wav",
+  "said": "Is Praisy here today?",
+  "menu": [
+   "Is Prissy here today?",
+   "Is Praisy here today?"
+  ],
+  "terms": "Praisy",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"Prissy\" -11.93   \"Praisy\" -10.97   — \"Prissy\" heard 1.0 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T16-05-04.wav",
+  "said": "While they were watching the movie, their app was being deployed on Vercel.",
+  "menu": [
+   "While they were watching the movie, their app was being deployed on Vercel.",
+   "While they were Matthieu the movie, their app was being deployed on Vercel."
+  ],
+  "terms": "Matthieu",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"watching\" -9.26   \"Matthieu\" -9.58   — \"Matthieu\" heard 0.3 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T16-04-42.wav",
+  "said": "Mira and Mirza went to the movie. The movie was about the Versailles Castle. While they were watching the movie, their app was being deployed on Vercel.",
+  "menu": [
+   "Mirza and Mira went to the movie. The movie was about the Versailles Castle. While they were watching the movie, their app was being the plot on Versailles.",
+   "Mirza and Mira went to the movie. The movie was about the Versailles Castle. While they were watching the movie, their app was being the plot on Vercel.",
+   "Mirza and Mira went to the movie. The movie was about the Vercel Castle. While they were watching the movie, their app was being the plot on Versailles.",
+   "Mirza and Mira went to the movie. The movie was about the Vercel Castle. While they were watching the movie, their app was being the plot on Vercel.",
+   "Mirza and Mirza went to the movie. The movie was about the Versailles Castle. While they were watching the movie, their app was being the plot on Versailles.",
+   "Mirza and Mirza went to the movie. The movie was about the Versailles Castle. While they were watching the movie, their app was being the plot on Vercel.",
+   "Mirza and Mirza went to the movie. The movie was about the Vercel Castle. While they were watching the movie, their app was being the plot on Versailles.",
+   "Mirza and Mirza went to the movie. The movie was about the Vercel Castle. While they were watching the movie, their app was being the plot on Vercel.",
+   "Mirza and Mirza's went to the movie. The movie was about the Versailles Castle. While they were watching the movie, their app was being the plot on Versailles.",
+   "Mirza and Mirza's went to the movie. The movie was about the Versailles Castle. While they were watching the movie, their app was being the plot on Vercel.",
+   "Mirza and Mirza's went to the movie. The movie was about the Vercel Castle. While they were watching the movie, their app was being the plot on Versailles.",
+   "Mirza and Mirza's went to the movie. The movie was about the Vercel Castle. While they were watching the movie, their app was being the plot on Vercel."
+  ],
+  "terms": "Mirza, Mirza's, Vercel",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"Mira\" -6.75   \"Mirza\" -8.17   — \"Mirza\" heard 1.4 less clearly\n  \"Versailles\" 0.00   \"Vercel\" -4.83   — \"Vercel\" heard 4.8 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T16-04-28.wav",
+  "said": "So let's praise Praisy's work.",
+  "menu": [
+   "So let's praise Pracy's work.",
+   "So let's praise Praisy's work.",
+   "So let's Praisy Pracy's work.",
+   "So let's Praisy Praisy's work.",
+   "So let's Praisy's Pracy's work.",
+   "So let's Praisy's Praisy's work."
+  ],
+  "terms": "Praisy, Praisy's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -11.65   \"Praisy\" -11.72   — \"Praisy\" heard 0.1 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T15-37-38.wav",
+  "said": "So why? So I said Praisy, P-R-A-I-S-E. Why wasn't it considered as a term and why was it replaced by Pressy?",
+  "menu": [
+   "So why? So I said praise, P-R-A-I-S-E. Why wasn't it considered as a term and why was it replaced by Praisy?",
+   "So why? So I said praise, P-R-A-I-S-E. Why wasn't it considered as a term and why was it Praisy by Praisy?",
+   "So why? So I said praise, P-R-A-I-S-E. Tasmeen wasn't it considered as a term and why was it replaced by Praisy?",
+   "So why? So I said praise, P-R-A-I-S-E. Tasmeen wasn't it considered as a term and why was it Praisy by Praisy?",
+   "So why? So I said Praisy P-R-A-I-S-E. Why wasn't it considered as a term and why was it replaced by Praisy?",
+   "So why? So I said Praisy P-R-A-I-S-E. Why wasn't it considered as a term and why was it Praisy by Praisy?",
+   "So why? So I said Praisy P-R-A-I-S-E. Tasmeen wasn't it considered as a term and why was it replaced by Praisy?",
+   "So why? So I said Praisy P-R-A-I-S-E. Tasmeen wasn't it considered as a term and why was it Praisy by Praisy?",
+   "So why? So I said Praisy's P-R-A-I-S-E. Why wasn't it considered as a term and why was it replaced by Praisy?",
+   "So why? So I said Praisy's P-R-A-I-S-E. Why wasn't it considered as a term and why was it Praisy by Praisy?",
+   "So why? So I said Praisy's P-R-A-I-S-E. Tasmeen wasn't it considered as a term and why was it replaced by Praisy?",
+   "So why? So I said Praisy's P-R-A-I-S-E. Tasmeen wasn't it considered as a term and why was it Praisy by Praisy?"
+  ],
+  "terms": "Praisy, Praisy's, Tasmeen",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise,\" -3.81   \"Praisy\" -5.19   — \"Praisy\" heard 1.4 less clearly\n  \"Why\" 0.00   \"Tasmeen\" -4.79   — \"Tasmeen\" heard 4.8 less clearly\n  \"replaced\" 0.00   \"Praisy\" -5.15   — \"Praisy\" heard 5.2 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T15-37-32.wav",
+  "said": "Let's praise Praisy.",
+  "menu": [
+   "Let's praise Praisy.",
+   "Let's Praisy Praisy.",
+   "Let's Praisy's Praisy."
+  ],
+  "terms": "Praisy, Praisy's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -13.25   \"Praisy\" -12.13   — \"praise\" heard 1.1 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T15-37-24.wav",
+  "said": "Let's praise Praisy.",
+  "menu": [
+   "Let's praise Praisy.",
+   "Let's Praisy Praisy.",
+   "Let's Praisy's Praisy."
+  ],
+  "terms": "Praisy, Praisy's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -9.57   \"Praisy\" -9.53   — \"praise\" heard 0.0 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T15-36-50.wav",
+  "said": "Let's praise the work that Praisy has done.",
+  "menu": [
+   "Let's praise the work that Prissy has done.",
+   "Let's praise the work that Praisy has done.",
+   "Let's Praisy work that Prissy has done.",
+   "Let's Praisy work that Praisy has done.",
+   "Let's Praisy's work that Prissy has done.",
+   "Let's Praisy's work that Praisy has done."
+  ],
+  "terms": "Praisy, Praisy's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -8.92   \"Praisy\" -8.93   — \"Praisy\" heard 0.0 less clearly\n  \"Prissy\" -8.50   \"Praisy\" -8.43   — \"Prissy\" heard 0.1 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T15-36-40.wav",
+  "said": "Praisy is here.",
+  "menu": [
+   "Prissy is here.",
+   "Praisy is here."
+  ],
+  "terms": "Praisy",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"Prissy\" -13.52   \"Praisy\" -12.27   — \"Prissy\" heard 1.2 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T15-21-29.wav",
+  "said": "Matthieu published a pull request.",
+  "menu": [
+   "Mathieu published a pull request.",
+   "Matthieu published a pull request."
+  ],
+  "terms": "Matthieu",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"Mathieu\" -6.23   \"Matthieu\" -5.82   — \"Mathieu\" heard 0.4 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T15-21-19.wav",
+  "said": "Praisy did a great job.",
+  "menu": [
+   "Prissy did a great job.",
+   "Praisy did a great job."
+  ],
+  "terms": "Praisy",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"Prissy\" -10.85   \"Praisy\" -9.58   — \"Prissy\" heard 1.3 less clearly"
+ }
+]

--- a/tests/menu-cases.yaml
+++ b/tests/menu-cases.yaml
@@ -1,0 +1,167 @@
+# Menu cases mined from 300 candidate clips — 40 written, newest first.
+#
+# `said` is pre-filled with what the app produced. Correct the lines
+# that are wrong, blank the ones you cannot remember, and delete any
+# clip that is not about a name. See scripts/menu-recall.py.
+
+cases:
+  - wav: parrotflow-2026-08-07T18-06-26.wav
+    # picked up: a term or something near one
+    said: "Uh would that improve the recognition of the terms with time?"
+
+  - wav: parrotflow-2026-08-07T17-47-45.wav
+    # picked up: a term or something near one
+    said: "Oh I get it. So yes, instead we want to have a retry. And then if the retry fails, we want the crawl to fail."
+
+  - wav: parrotflow-2026-08-07T17-39-40.wav
+    # picked up: a known mis-rendering
+    said: "So Matthieu and Mirza went to the movies. The story was about the Versailles Castle. It's a universal story. But at the same time they were watching their app being deployed on Vercel."
+
+  - wav: parrotflow-2026-08-07T17-39-27.wav
+    # picked up: a term or something near one
+    said: "Let's praise Matthieu's work."
+
+  - wav: parrotflow-2026-08-07T17-39-19.wav
+    # picked up: a term or something near one
+    said: "Let's praise Mirza's work."
+
+  - wav: parrotflow-2026-08-07T17-39-03.wav
+    # picked up: a term or something near one
+    said: "Let's praise Praisy's work."
+
+  - wav: parrotflow-2026-08-07T17-38-57.wav
+    # picked up: a term or something near one
+    said: "Let's praise Praisy's work."
+
+  - wav: parrotflow-2026-08-07T17-38-44.wav
+    # picked up: a term or something near one
+    said: "So let's praise the work that Praisy has done."
+
+  - wav: parrotflow-2026-08-07T17-27-35.wav
+    # picked up: a term or something near one
+    said: "Let's praise the amazing work Praisy did."
+
+  - wav: parrotflow-2026-08-07T17-27-23.wav
+    # picked up: a term or something near one
+    said: "So let's praise the team's work."
+
+  - wav: parrotflow-2026-08-07T17-26-56.wav
+    # picked up: a term or something near one
+    said: "I changed settings in Vercel"
+
+  - wav: parrotflow-2026-08-07T17-26-30.wav
+    # picked up: a term or something near one
+    said: "I changed some settings in Vercel"
+
+  - wav: parrotflow-2026-08-07T17-19-57.wav
+    # picked up: a known mis-rendering
+    said: "My ask that was that for those sentences you give me the menu that was offered in the prompts. Also for the recent transcript where Universal was mixed up with Vercel."
+
+  - wav: parrotflow-2026-08-07T17-17-10.wav
+    # picked up: a term or something near one
+    said: "You and me for sure. Mirza should be too. But he's not on all project, so Let me add that to my to the list."
+
+  - wav: parrotflow-2026-08-07T17-05-42.wav
+    # picked up: a term or something near one
+    said: "So the document was a really super base uh for discussion and the Supabase proposal for the database is great."
+
+  - wav: parrotflow-2026-08-07T17-05-32.wav
+    # picked up: a term or something near one
+    said: "Praisy and Mirza worked on the new Vercel deployment."
+
+  - wav: parrotflow-2026-08-07T17-05-12.wav
+    # picked up: a term or something near one
+    said: "Let's praise Praisy's work."
+
+  - wav: parrotflow-2026-08-07T16-16-25.wav
+    # picked up: a term or something near one
+    said: "But my idea was to not substitute before the judge and only let the judge decide between what was heard by the decoder and what the decoder found similar. So in that case it would be both praise and Praisy."
+
+  - wav: parrotflow-2026-08-07T16-12-33.wav
+    # picked up: a known mis-rendering
+    said: "But replaced it with Praisy. So the judge couldn't see praise."
+
+  - wav: parrotflow-2026-08-07T16-12-20.wav
+    # picked up: a term or something near one
+    said: "So the acoustic pass found praise."
+
+  - wav: parrotflow-2026-08-07T16-09-50.wav
+    # picked up: a known mis-rendering
+    said: "Let's praise the work Praisy has done."
+
+  - wav: parrotflow-2026-08-07T16-09-37.wav
+    # picked up: a known mis-rendering
+    said: "Let's praise the work Praisy has done."
+
+  - wav: parrotflow-2026-08-07T16-09-15.wav
+    # picked up: a term or something near one
+    said: "Let's praise the work Praisy has done"
+
+  - wav: parrotflow-2026-08-07T16-09-06.wav
+    # picked up: a term or something near one
+    said: "Praisy did an amazing job."
+
+  - wav: parrotflow-2026-08-07T16-09-00.wav
+    # picked up: a term or something near one
+    said: "Is Praisy here today?"
+
+  - wav: parrotflow-2026-08-07T16-05-04.wav
+    # picked up: a term or something near one
+    said: "While they were watching the movie, their app was being deployed on Vercel."
+
+  - wav: parrotflow-2026-08-07T16-04-42.wav
+    # picked up: a known mis-rendering
+    said: "Mira and Mirza went to the movie. The movie was about the Versailles Castle. While they were watching the movie, their app was being deployed on Vercel."
+
+  - wav: parrotflow-2026-08-07T16-04-28.wav
+    # picked up: a term or something near one
+    said: "So let's praise Praisy's work."
+
+  - wav: parrotflow-2026-08-07T15-37-38.wav
+    # picked up: a term or something near one
+    said: "So why? So I said Praisy, P-R-A-I-S-E. Why wasn't it considered as a term and why was it replaced by Pressy?"
+
+  - wav: parrotflow-2026-08-07T15-37-32.wav
+    # picked up: a known mis-rendering
+    said: "Let's praise Praisy."
+
+  - wav: parrotflow-2026-08-07T15-37-24.wav
+    # picked up: a known mis-rendering
+    said: "Let's praise Praisy."
+
+  - wav: parrotflow-2026-08-07T15-37-01.wav
+    # picked up: a term or something near one
+    said:
+
+  - wav: parrotflow-2026-08-07T15-36-50.wav
+    # picked up: a known mis-rendering
+    said: "Let's praise the work that Praisy has done."
+
+  - wav: parrotflow-2026-08-07T15-36-40.wav
+    # picked up: a term or something near one
+    said: "Praisy is here."
+
+  - wav: parrotflow-2026-08-07T15-31-32.wav
+    # picked up: a term or something near one
+    said:
+
+  - wav: parrotflow-2026-08-07T15-28-16.wav
+    # picked up: a term or something near one
+    said:
+
+  - wav: parrotflow-2026-08-07T15-25-41.wav
+    # picked up: a term or something near one
+    said: "But if we disabled the vocabulary, the floors shouldn't matter anymore."
+
+  - wav: parrotflow-2026-08-07T15-21-29.wav
+    # picked up: a known mis-rendering
+    said: "Matthieu published a pull request."
+
+  - wav: parrotflow-2026-08-07T15-21-23.wav
+    # picked up: a known mis-rendering
+    said: "Praisy did a great job."
+
+  - wav: parrotflow-2026-08-07T15-21-19.wav
+    # picked up: a known mis-rendering
+    said: "Praisy did a great job."
+


### PR DESCRIPTION
PR 2 of `docs/proposals/vocabulary-v2.md`. Test-only: nothing under `Sources/`
changes.

## What was ported

From the frozen `feat/vocabulary-skills-only`, read with `git show`, never
committed to:

| File | |
|---|---|
| `scripts/menu-recall.py` | did the true sentence reach the judge, did the judge take it |
| `scripts/mine-menu-cases.py` | builds the labelling sheet out of the archive |
| `scripts/tune-judge.py` | scores a judge prompt against the cached menus |
| `scripts/before-after.py` | what a clip produced then, what it produces now |
| `scripts/rerank-judge.py` | the reranker spike and the two-stage harness |
| `tests/menu-cases.yaml` | 40 clips, 37 labelled |
| `tests/judge-menus.json` | 33 cached menus, 28 reachable |
| `tests/judge-cases.yaml` | the 2026-08-07 relabels (the four "spells" cases are declines) |

One file the plan does not list came with them:
`examples/transforms/verify_names/menu.md`. It is the judge prompt that
`tune-judge.py` and `rerank-judge.py --stage2` score. Without it neither
harness runs. PR 3 renames it to `verify_names.md` and installs it; nothing
installs `examples/` today.

Every F13 fix already in these scripts is kept: the built app before the
installed one, the first `trace.jsonl` entry per clip, the non-ASCII guard in
`ranking()`.

## The fixes

**F7 — `--stage2` shortlist order.** The shortlist is now presented in the
app's own menu order, decoder's reading first. The reranker chooses *which*
readings survive, not the order they are read in.

**F7 — `--stage2` score block.** The block is trimmed to lines that are still
about this shortlist. A line survives two tests: it has to be a real
measurement (not the 0.00 sentinel, F6), and the shortlisted options have to
still disagree about it.

Ablated on the cached menus, mxbai-rerank-base-v2, framing `misheard`, top-3,
judged by `gemma4:e4b`:

| | picked |
|---|---|
| neither fix | 23/28 |
| order only | 24/28 |
| discriminating trim only | 23/28 |
| both, sentinel lines kept | 23/28 |
| **both, sentinel lines dropped** | **25/28** |

This differs from the ledger, which recorded the trim as worth +1 on its own.
It is not. The trim on its own can strand a sentinel line as the only survivor
— on `2026-08-07T17-05-42` it dropped the two real Supabase lines and kept
`"proposal" 0.00 "Praisy" -5.02` — and that costs a case. The +2 is real; the
attribution in F7 was not. So `trim_scores` applies F6's rule too, and reuses
`tune-judge.strip_sentinels` rather than restating it.

**F7 — `--framing all` with `--stage2`.** It now shortlists with the framing
that scored the best top-3, and prints which. It used to take the last framing
in the loop, which is `terms` alphabetically — the one that scores below
chance.

**F6 — `tune-judge.py --strip-sentinels`.** Drops score lines whose heard score
is 0.00. 10 of the 33 cached menus carry one, 7 of them among the 28 reachable.

**F11 — `mine-menu-cases.py --random N`.** Samples clips with no trigger
filter, with `--seed` so a sheet can be rebuilt. The generated header now
starts `WARNING: said below is pre-filled with the app's OWN OUTPUT`, and the
random mode explains why an unfiltered sample is the point.

**F9 — `tests/judge-cases.yaml`.** The legend read
`# expect: decline — the name was misheard and this puts it right`. It says
`approve`.

**F13 — chance.** `tune-judge.py` prints it. `rerank-judge.py` prints it for
the shortlist ceiling, for the two-stage pick, and above the fusion sweep.

## F12a — replay noise

New since the plan was written. Decoder scores are not stable across replays of
identical samples: spread up to ~5 nats on a long clip. A single replayed score
is not a measurement.

`menu-recall.py` and `before-after.py` take `--runs N`, default 1 so a routine
run costs what it did. It replays each clip N times, reports the per-clip
majority (a tie goes to the worse outcome) and how many clips changed outcome
between runs. Both docstrings say single-run numbers carry replay noise. With
`--runs 1` the summary says so on stdout as well.

`docs/proposals/vocabulary-v2.md` gains a "Measurement noise" note in PR 2: a
gate quoted from either script must carry the flip count from `--runs 3` when
the number is within 2 cases of the baseline it is compared with.

## Measured

Ollama `gemma4:e4b`, temperature 0, nothing else loaded (`gemma4:e4b-mlx` was
idle in memory and was unloaded first).

```
$ python3 scripts/tune-judge.py

  menu.md              gemma4:e4b     sampled  scores full     picked 24/28   (5 menu(s) never held the answer)
  chance                                                       guess  8.1/28
```

```
$ python3 scripts/tune-judge.py --strip-sentinels

  menu.md              gemma4:e4b     sampled  scores stripped picked 26/28   (5 menu(s) never held the answer)
  chance                                                       guess  8.1/28
  7 menu(s) had a 0.00 score line removed
```

```
$ .venv-rerank/bin/python scripts/rerank-judge.py \
    --model mixedbread-ai/mxbai-rerank-base-v2 --framing misheard --stage2 3

  mxbai-rerank-base-v2   28 menus, sizes 2–16   (5 never held the answer)
  chance                     top-1 8.1/28   top-3 19.9/28

  misheard                   top-1 19/28   top-3 28/28

  two-stage, top-3 then gemma4:e4b, shortlisted by framing 'misheard'
    shortlist ceiling        28/28   (chance 19.9)
    picked                   25/28   (chance 10.8)
```

```
$ .venv-rerank/bin/python scripts/rerank-judge.py --framing all --stage2 3

  Qwen3-Reranker-0.6B   28 menus, sizes 2–16   (5 never held the answer)
  chance                     top-1 8.1/28   top-3 19.9/28

  fluent                     top-1  8/28   top-3 19/28  ← below chance
  misheard                   top-1 10/28   top-3 26/28
  misheard-long              top-1 16/28   top-3 23/28
  misheard-short             top-1 11/28   top-3 21/28
  plain                      top-1  8/28   top-3 23/28  ← below chance
  terms                      top-1  6/28   top-3 17/28  ← below chance

  two-stage, top-3 then gemma4:e4b, shortlisted by framing 'misheard'
    shortlist ceiling        26/28   (chance 19.9)
    picked                   23/28   (chance 10.2)
```

It states its choice rather than refusing. Note what it picked: `misheard`,
top-3 26/28. The old code would have shortlisted with `terms`, top-3 17/28 —
below chance.

### The plumbing, not a baseline

`scripts/build-app.sh` first; the stamp is `fbc4069-dirty` (dirty because of
these test files).

```
$ python3 scripts/menu-recall.py --limit 3

  ✓  parrotflow-2026-08-07T18-06-26.wav  menu 1
  ✗  parrotflow-2026-08-07T17-47-45.wav  menu 1
  ✗  parrotflow-2026-08-07T17-39-40.wav  menu 4

  recall  1/3   the true sentence was on the menu
  picked  1/3   the judge chose it
  one run per clip — these numbers carry replay noise (F12a); use --runs 3 before quoting them against a gate
```

```
$ python3 scripts/menu-recall.py --limit 3 --runs 3

  recall  1/3   the true sentence was on the menu, majority of 3 runs
  picked  1/3   the judge chose it, majority of 3 runs
  0/3 clip(s) changed outcome between runs (F12a)
```

```
$ python3 scripts/before-after.py --limit 3 --runs 3

  fixed 1   broken 1   regressed 1   already right 0
  majority of 3 runs; 0 clip(s) changed outcome between runs (F12a)
```

**These are not the baseline.** The 30/37 recall and 27/37 picked in the plan
were measured against the prototype build. Main still runs v1 vocabulary logic
until PR 3, so 1/3 here is what v1 does on three clips, and `--limit 3` was run
only to prove the harness executes end to end against a freshly built app. The
`before-after.py` REGRESSED row is v1 versus the archive, not a regression from
this PR — this PR changes no app code.

`make install` was not run. `~/.config/parrotflow-dev/` was not modified.

## Review

**Round 1** found one thing, and it was right. With `--runs` above 1 the
verdict is the majority over the runs, but the printed transcript was the last
run's — so a clip that flipped on its final replay showed a correct sentence
under BROKEN. Both scripts now print a run that agreed with the majority. In
`menu-recall.py`, a run that agreed on both recall and picked; when no single
run did, the one that agreed about the transcript, because that is the line the
reader acts on. Two smaller things went in with it: `strip_sentinels` and
`trim_scores` return `""` rather than passing `None` into the prompt, and
`--random` says in its help that N replaces `--limit`.

**Round 2**: no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiQJipvz9Ps9tdDCRdisv
