### PR TITLE
feat: two thresholds, so offering and writing stop sharing a number

### DIFF
--- a/.claude/skills/calibrate/SKILL.md
+++ b/.claude/skills/calibrate/SKILL.md
@@ -1,16 +1,31 @@
 ---
 name: calibrate
-description: Derive per-term similarity floors for ParrotFlow from the user's own voice — write sentences containing each vocabulary term and the words it can be confused with, have the user read them aloud into the app, and compute the safe band per term. Use after gathering a vocabulary, when a name keeps being mis-transcribed, or when a term is overwriting an ordinary word.
+description: Measure a ParrotFlow vocabulary against the user's own voice — write sentences containing each vocabulary term and the words it can be confused with, have the user read them aloud into the app, and compute the safe band per term. Use after gathering a vocabulary, when a name keeps being mis-transcribed, or when a term is overwriting an ordinary word.
 ---
 
 # Calibrating a vocabulary against one person's voice
 
-A similarity floor is a bet about two things: how far this speaker's rendering
+A similarity band is a fact about two things: how far this speaker's rendering
 of a name lands from its spelling, and how close the ordinary words that sound
 like it land. Both are properties of a mouth. Neither can be read off a
 dictionary, and the gap between them differs enormously between speakers.
 
-This skill measures both, per term, and derives the floor from the gap.
+This skill measures both, per term.
+
+**What the bands decide now.** The app no longer takes a number per term. It
+takes two numbers for the whole file — `offer_below`, how far a spelling may
+sit from a term and still reach the judge's menu, and `decide_above`, how hard
+the audio has to argue before a reading is dropped. So a band no longer sets a
+term's threshold. It answers two questions:
+
+- **Does any threshold work for this term at all?** A closed band means no.
+  That term is `floor: off` and a `heard:` list, and nothing else.
+- **Where should `offer_below` sit for this speaker?** Below the lowest
+  rendering of any term that still has a band. Being offered costs a line the
+  model reads; being missed cannot be recovered downstream.
+
+Do not tune `offer_below` from one term. It is one number for the file, and a
+band that argues for moving it is a report, not an edit.
 
 **Everything stays on the machine.** The recordings are already on disk, the
 decoding runs locally, and nothing leaves. Say so before asking anyone to read
@@ -35,23 +50,23 @@ scored against the term:
     said "Versailles"    heard "Versailles"   0.40
     said "verify"        heard "verify"       0.50
 
-The floor goes in the gap between the lowest of the first group and the
-highest of the second. Here: anywhere from 0.51 to 0.67, so 0.58.
+The band is the gap between the lowest of the first group and the highest of
+the second. Here: 0.51 to 0.67.
 
-## The band is the answer, not just the floor
+## The band is the answer
 
     wide band     0.50 .. 0.67   the speaker separates them clearly.
                                  Pick the middle and stop thinking about it.
     narrow band   0.62 .. 0.67   works, but one bad day of diction breaks it.
     no band       0.71 .. 0.67   the confusables land CLOSER than the speaker's
-                                 own renderings. No floor exists.
+                                 own renderings. No threshold exists.
 
 **A closed band is a result, not a failure.** It says this term can never be
-safe acoustically for this person. The answer is `floor: off` with a `heard:`
-list of the renderings actually seen, and the `verify_names` judge behind it.
-Report it that way — a user told "no floor works,
-here is the rule instead" has learned something; a user handed a floor that
-quietly damages their transcripts has not.
+separated acoustically for this person. The answer is `floor: off` with a
+`heard:` list of the renderings actually seen, and the name judge behind it.
+Report it that way — a user told "no threshold works, here is the rule
+instead" has learned something; a user handed a number that quietly damages
+their transcripts has not.
 
 Band widths across a whole vocabulary are also the honest way to talk about
 accent. A speaker whose bands are all wide needs almost no tuning. A speaker
@@ -69,8 +84,8 @@ the compound matcher glues the pair.
 
 **Pass only the languages this person dictates in.** The default is `en,fr`,
 and each language adds neighbours the other does not have. "Praisy" is 0.83
-from the English "praise" and 0.67 from the French "vrais", so a floor derived
-with both languages is set for a speaker who uses both. Wrong for someone who
+from the English "praise" and 0.67 from the French "vrais", so a band measured
+with both languages describes a speaker who uses both. Wrong for someone who
 only dictates in English, and it costs them a term.
 
 Take the top three or four per term. Below about 0.55 nothing will ever be
@@ -89,7 +104,7 @@ yours and not the script's.
   tickets, whatever the codebase and Slack gathering turned up. A sentence
   someone would never say is read in a voice they never use.
 - **Three per term, three per confusable.** Fewer and one odd reading moves
-  the floor; more and nobody finishes.
+  the band; more and nobody finishes.
 - **Write them in the language they would be said in.** A French speaker's
   French sentences and English sentences fail differently, and mixing them
   into one list hides that.
@@ -113,7 +128,7 @@ dictation each.
     scripts/calibrate.py score calibration.json
 
 It pairs the last N recordings with the N sentences by order, re-decodes each
-with the vocabulary off, and reports the band and floor per term.
+with the vocabulary off, and reports the band per term.
 
 **Pairing by order breaks when someone re-reads a line**, so it checks that
 half the sentence's words actually turned up before trusting a clip, and
@@ -124,22 +139,22 @@ refuses the ones that do not match:
         heard:    And then for the code base, I think you can already uh
 
 Have those read again rather than working around them. A mispaired clip does
-not fail loudly — it produces a confident floor from two unrelated sentences.
+not fail loudly — it produces a confident band from two unrelated sentences.
 
 ## Step 4 — check it against real speech
 
 **Read speech is not dictated speech.** People enunciate when reading from a
 screen, and an enunciated `Versailles` separates from `Vercel` in a way
 ordinary muttered dictation does not. That biases every band wider than
-reality and sets floors slightly too low.
+reality.
 
-So before shipping the floors, run them against recordings the person made
+So before reporting anything, run the terms against recordings the person made
 without thinking about it:
 
     ParrotFlow --boost-eval --terms Vercel,Tasmeen,Praisy --limit 400
 
-Any term whose new floor causes damage there had its band measured from
-reading rather than speaking. Raise it, and say why.
+A term that causes damage there had its band measured from reading rather than
+speaking. Say so — it is a candidate for `floor: off`, not for a number.
 
 ## What to hand back
 
@@ -148,13 +163,16 @@ The `terms:` block for `vocabulary.yaml`, which sits beside `config.yaml`:
 ```yaml
 terms:
   Vercel:
-    floor: 0.58            # band 0.50 .. 0.67, measured
-    heard: [Versailles]    # 0.40 — below any floor
-  Tasmeen: 0.62            # band 0.55 .. 0.71
+    heard: [Versailles]    # 0.40 — below any threshold
+  Tasmeen:                 # band 0.55 .. 0.71, nothing to say
   Praisy:
     floor: off             # no band: "praise" landed at 0.83, closer than
     heard: [Prissy]        # this speaker's own renderings
 ```
+
+No number per term. A measured floor written here still works and still
+applies to that term, but `--check-config` calls it legacy: the setting is
+`offer_below:` at the top of the file.
 
 `floor: off` is the YAML boolean `false`, not the string. So are `on`, `yes`
 and `no`. The decoder reads both, but write it the way the file already does.
@@ -164,9 +182,12 @@ because it is normally written by the app. This skill is one of the things
 that writes it, so editing it here is the intended path — say so, rather than
 letting the header look like it was ignored.
 
-And a one-line summary per term saying what was measured, because the number
-on its own is unarguable-with in six months:
+And a one-line summary per term saying what was measured, because a `heard:`
+list on its own is unarguable-with in six months:
 
-    Vercel     band 0.50 .. 0.67   wide, floor uncritical
+    Vercel     band 0.50 .. 0.67   wide
     Tasmeen    band 0.55 .. 0.71   wide
     Praisy     no band             "praise" at 0.83 — rule instead
+
+Then one line for the file: the lowest rendering across every term that still
+has a band, and whether `offer_below` currently sits below it.

--- a/.claude/skills/vocabulary-corpus/SKILL.md
+++ b/.claude/skills/vocabulary-corpus/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vocabulary-corpus
-description: Gather the first vocabulary for ParrotFlow — the names, jargon and acronyms a person actually says — from their codebase and their Slack, and turn it into a `vocabulary.yaml` with a per-term floor. Use when setting ParrotFlow up on a new machine or a new project, when dictation keeps mangling the same words, or when someone asks what terms they should add.
+description: Gather the first vocabulary for ParrotFlow — the names, jargon and acronyms a person actually says — from their codebase and their Slack, and turn it into a `vocabulary.yaml`. Use when setting ParrotFlow up on a new machine or a new project, when dictation keeps mangling the same words, or when someone asks what terms they should add.
 ---
 
 # Building someone's first vocabulary
@@ -58,13 +58,14 @@ kinds, and only two are worth adding.
 Glued back together they match exactly, so no threshold can reach anything
 else, and they cannot damage a transcript. Take all of these.
 
-**Distinctive names with nothing near them.** Take these too, at a low floor.
+**Distinctive names with nothing near them.** Take these too. Nothing near
+them means nothing to argue about.
 
     Tasmeen    nothing within 0.71 in 234k dictionary words
     Arexvy     nothing within 0.67
 
-**Names that collide with ordinary words.** No floor works. Use `floor: off`
-and a `heard:` list instead.
+**Names that collide with ordinary words.** No threshold works. Use
+`floor: off` and a `heard:` list instead.
 
     Praisy   vs "praise"    0.83   and they sound alike, so no gate saves it
     Sentry   vs "entry"     0.83
@@ -165,10 +166,17 @@ Two things to tell the user when you hand it over:
   `slack_mentions` roster as well as the vocabulary, so one gathering serves
   both. The roster lives in `slack_mentions.py` beside the config.
 
-## Step 3 — reject the collisions, and set the floors
+## Step 3 — reject the collisions
 
-For each surviving candidate, find its nearest ordinary word. The floor goes
-just above that, so nothing else can reach the term.
+For each surviving candidate, find its nearest ordinary word. That distance
+decides one thing: whether the term can be matched by sound at all.
+
+There is no number to pick per term. The app takes two numbers for the whole
+file — `offer_below`, how far a spelling may sit from a term and still reach
+the judge's menu, and `decide_above`, how hard the audio has to argue before a
+reading is dropped. Leave both at their defaults. A near neighbour is no longer
+a word that gets overwritten; it is a second line on a menu, and the sentence
+picks.
 
 Use `NSSpellChecker` for "is this a word", because that is what
 `Replacements.isRealWord` uses. Check only the languages this person dictates
@@ -201,10 +209,11 @@ FluidAudio's gate computes:
 
 Then:
 
-- **Nearest ordinary word at 0.85 or above** — no floor works. No threshold
-  both catches the term's mishearings and excludes that word. Ship it as
-  `floor: off` with a `heard:` list instead.
-- **Otherwise** — floor = nearest + 0.05, capped at 0.90.
+- **Nearest ordinary word at 0.85 or above** — no threshold works. None both
+  catches the term's mishearings and excludes that word. Ship it as
+  `floor: off` with a `heard:` list, and let the rule put it on the menu and
+  the sentence decide.
+- **Otherwise** — plain entry. Nothing to write but the name.
 - **Check two-word phrases as well as single words.** This is the hole that
   bites: `Turndown` has no dictionary collision and scores a clean 1.00, but
   "turn down the volume" glues to `turndown` and gets rewritten. Any term
@@ -249,16 +258,21 @@ The contents of `vocabulary.yaml`, which sits beside `config.yaml`:
 
 ```yaml
 acoustic: true
-min_similarity: 0.75
+offer_below: 0.50
+decide_above: 3.0
 
 terms:
-  RedCrawl: 0.95        # "red crawl", glues to 1.00
-  LangSmith: 0.95
-  Tasmeen:              # nothing within 0.71 — the default is enough
-  Matthieu: 0.80        # "Matthew" is 0.75
+  RedCrawl:             # "red crawl", glues to 1.00
+  LangSmith:
+  Tasmeen:              # nothing within 0.71
+  Matthieu:
+    floor: off          # "Matthew" is 0.75 and sounds the same
+    heard: [Mathieu, Matthew]
 ```
 
-A bare number is the floor. An empty entry takes `min_similarity`.
+An empty entry is the normal one. The two numbers at the top are the file's,
+not a term's, and they ship untuned — leave them alone unless you have
+measured the whole set.
 
 That file carries a "do not edit unless you know what you are doing" header
 because it is normally written by the app — from corrections and from
@@ -270,7 +284,7 @@ And beside it, three short lists:
 - **Rejected, with the reason.** `Praisy` — "praise" at 0.83. `Sentry` —
   "entry" at 0.83. These go in with `floor: off` and a `heard:` list of
   renderings actually seen, so sound matching is off for them and nothing
-  else. Give the reason, or someone re-adds them with a floor next month.
+  else. Give the reason, or someone re-adds them next month.
 - **Already fine.** The terms the decoder writes correctly. Same reason.
 - **Read these aloud.** The step 5 sentences.
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -138,6 +138,13 @@ jobs:
       - name: The config a new install gets
         run: scripts/check-default-config.sh
 
+      # The other learnt file. Nobody rereads vocabulary.yaml, so a key that
+      # quietly stops meaning what it meant is invisible — and one already did:
+      # Yams answers `Bool.self` for `0.85`, so a decoder that asks about
+      # `floor: off` first reads every measured floor as "never match this".
+      - name: What vocabulary.yaml adds up to
+        run: scripts/check-vocabulary-config.sh
+
       # The same trap, one directory over: the transform folder a first launch
       # is seeded with against the copy in examples/ that people read and
       # score. It has always been able to drift and has never been checked

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1468,6 +1468,22 @@ struct Config: Decodable, Equatable {
             found.append("pipelines: \"\(name)\" is not a configured language, so that pipeline never runs"
                 + " — configured: \(transcription.languages.joined(separator: ", "))")
         }
+        // A similarity is 0 to 1 and nothing else can be one. Above 1 no
+        // reading ever reaches the menu and the whole vocabulary goes quiet;
+        // below 0 every span reaches it. Both are a number typed in the wrong
+        // units, and both look like the feature being broken.
+        if vocabulary.offerBelow < 0 || vocabulary.offerBelow > 1 {
+            found.append("vocabulary: `offer_below: \(vocabulary.offerBelow)` is outside 0 to 1"
+                + " — it is a similarity, where 1.0 is the term spelled exactly")
+        }
+        // Nats, and the audio arguing against a reading by a negative amount
+        // is the audio agreeing with it. At or below 0 every proposal the
+        // decoder does not already prefer is dropped before anyone sees it.
+        if vocabulary.decideAbove <= 0 {
+            found.append("vocabulary: `decide_above: \(vocabulary.decideAbove)` drops every"
+                + " reading the audio does not already prefer — it is a margin in nats,"
+                + " and it has to be above 0")
+        }
         found += replacementProblems()
         // A `path:` that named nothing readable. The entry is gone rather than
         // idle — the pipeline step that names it will say so too — and a
@@ -1564,9 +1580,13 @@ struct Config: Decodable, Equatable {
             said.append("vocabulary: \(vocabulary.terms.count) terms in"
                 + " \(ConfigStore.vocabularyURL.lastPathComponent),"
                 + " \(byEar.count) matched by sound, \(rules) by rule")
+            // Spelled out rather than printed as `offer_below 0.5`. The key
+            // names the job; only a sentence says which way the number points.
             if vocabulary.acoustic, !byEar.isEmpty {
-                said.append("vocabulary: offered below \(vocabulary.offerBelow),"
-                    + " written without asking above \(vocabulary.decideAbove) nats — "
+                said.append("vocabulary: offered at similarity"
+                    + " \(vocabulary.offerBelow) and up, dropped when the audio"
+                    + " argues against it by more than \(vocabulary.decideAbove)"
+                    + " nats — "
                     + byEar.map { $0.offerBelow == vocabulary.offerBelow
                         ? $0.text : "\($0.text) \($0.offerBelow)" }
                         .joined(separator: ", "))
@@ -1725,16 +1745,18 @@ enum ConfigStore {
     # a term. If you want to change something, the safe move is to let the app
     # measure again rather than to pick a number.
     #
-    # Two numbers, and they do different jobs. Offering a reading and writing
-    # one are different risks, and one threshold could not do both: strict
-    # enough to be safe it caught 2 of 20 misheard names, loose enough to catch
-    # them "in general" became "in Redcrawl".
+    # Two numbers, and they do different jobs. What a spelling makes worth
+    # looking at and what the audio can veto are different questions, and one
+    # threshold answering both was safe or useful and never both: strict enough
+    # to be safe it caught 2 of 20 misheard names, loose enough to catch them
+    # "in general" became "in Redcrawl".
     #
     #   offer_below    how far a word's spelling may sit from the term and
-    #                  still reach the menu, from 0 to 1. Being offered costs a
-    #                  line the model reads; being missed cannot be undone.
+    #                  still reach the menu, from 0 to 1, where 1.0 is the term
+    #                  spelled exactly. Being offered costs a line the model
+    #                  reads; being missed cannot be undone.
     #   decide_above   how hard the audio has to argue against a reading, in
-    #                  nats, before it is dropped rather than offered.
+    #                  nats, before it is dropped instead of offered.
     #
     # Per term:
     #

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -234,6 +234,16 @@ struct Config: Decodable, Equatable {
         /// should not fail to load because a key was renamed.
         var legacy: [String] = []
 
+        /// Numbers the file asked for and did not get, in words, for
+        /// `problems()`.
+        ///
+        /// Refused here rather than reported and used. Nothing downstream
+        /// re-checks them, so a similarity of 85 would silence the whole
+        /// vocabulary on every dictation until somebody happened to run
+        /// `--check-config`. The default is kept instead, and the complaint
+        /// says which number is actually running.
+        var refused: [String] = []
+
         enum CodingKeys: String, CodingKey {
             case acoustic, terms
             case minSimilarity = "min_similarity"
@@ -252,8 +262,9 @@ struct Config: Decodable, Equatable {
             // `min_similarity` was the file-level floor that did both jobs. It
             // now does one, so it is read as `offer_below` — the number is
             // kept, the meaning narrows.
+            var asked: (key: String, value: Float)?
             if let old = try c.decodeIfPresent(Float.self, forKey: .minSimilarity) {
-                offerBelow = old
+                asked = ("min_similarity", old)
                 legacy.append("`min_similarity: \(old)` is the old name for"
                     + " `offer_below:` — same number, and it now only decides"
                     + " what reaches the menu")
@@ -261,12 +272,49 @@ struct Config: Decodable, Equatable {
             // Written explicitly it wins, whatever the old key said. A file
             // carrying both is mid-migration and the new key is the intent.
             if let offered = try c.decodeIfPresent(Float.self, forKey: .offerBelow) {
-                offerBelow = offered
+                asked = ("offer_below", offered)
             }
+            // A similarity is 0 to 1 and nothing else can be one. Above 1 no
+            // reading ever reaches the menu; below 0 every span does. Both are
+            // a number in the wrong units, and both look like the vocabulary
+            // being broken rather than like a setting.
+            if let asked {
+                if Self.similarities.contains(asked.value) {
+                    offerBelow = asked.value
+                } else {
+                    refused.append("`\(asked.key): \(asked.value)` is outside 0 to 1 —"
+                        + " it is a similarity, where 1.0 is the term spelled exactly."
+                        + " Running at \(offerBelow)")
+                }
+            }
+            // Nats, and the audio arguing against a reading by a negative
+            // amount is the audio agreeing with it. At or below 0 every
+            // proposal the decoder does not already prefer is dropped before
+            // anyone sees it.
             if let decided = try c.decodeIfPresent(Float.self, forKey: .decideAbove) {
-                decideAbove = decided
+                if decided > 0 {
+                    decideAbove = decided
+                } else {
+                    refused.append("`decide_above: \(decided)` would drop every reading"
+                        + " the audio does not already prefer — it is a margin in nats,"
+                        + " and it has to be above 0. Running at \(decideAbove)")
+                }
             }
             terms = try c.decodeIfPresent([String: Term].self, forKey: .terms) ?? [:]
+
+            // The same range, one level down. A legacy per-term floor is still
+            // a similarity, and one in the wrong units takes only its own term
+            // out of reach — which is worse than the file-level case, because
+            // the rest of the vocabulary goes on working and hides it.
+            let wrong = terms
+                .filter { _, entry in entry.offerBelow.map { !Self.similarities.contains($0) } ?? false }
+                .keys.sorted()
+            for name in wrong { terms[name]?.offerBelow = nil }
+            if !wrong.isEmpty {
+                refused.append("`floor:` on \(wrong.joined(separator: ", ")) is outside"
+                    + " 0 to 1 — it is a similarity, where 1.0 is the term spelled"
+                    + " exactly. Running those at \(offerBelow)")
+            }
 
             let floored = terms.filter { $0.value.offerBelow != nil }.keys.sorted()
             if !floored.isEmpty {
@@ -278,6 +326,10 @@ struct Config: Decodable, Equatable {
                     + " matched by sound")
             }
         }
+
+        /// What a similarity may be. FluidAudio's metric is normalised, so
+        /// anything outside this is a number in the wrong units.
+        private static let similarities: ClosedRange<Float> = 0...1
     }
 
     /// The terms given to the decoder as acoustic context, each with the
@@ -1468,22 +1520,10 @@ struct Config: Decodable, Equatable {
             found.append("pipelines: \"\(name)\" is not a configured language, so that pipeline never runs"
                 + " — configured: \(transcription.languages.joined(separator: ", "))")
         }
-        // A similarity is 0 to 1 and nothing else can be one. Above 1 no
-        // reading ever reaches the menu and the whole vocabulary goes quiet;
-        // below 0 every span reaches it. Both are a number typed in the wrong
-        // units, and both look like the feature being broken.
-        if vocabulary.offerBelow < 0 || vocabulary.offerBelow > 1 {
-            found.append("vocabulary: `offer_below: \(vocabulary.offerBelow)` is outside 0 to 1"
-                + " — it is a similarity, where 1.0 is the term spelled exactly")
-        }
-        // Nats, and the audio arguing against a reading by a negative amount
-        // is the audio agreeing with it. At or below 0 every proposal the
-        // decoder does not already prefer is dropped before anyone sees it.
-        if vocabulary.decideAbove <= 0 {
-            found.append("vocabulary: `decide_above: \(vocabulary.decideAbove)` drops every"
-                + " reading the audio does not already prefer — it is a margin in nats,"
-                + " and it has to be above 0")
-        }
+        // Numbers `vocabulary.yaml` asked for and did not get. Refused where
+        // they were read, so what runs is the default; said here, because a
+        // setting that does nothing is exactly what this list is for.
+        found += vocabulary.refused.map { "vocabulary: \($0)" }
         found += replacementProblems()
         // A `path:` that named nothing readable. The entry is gone rather than
         // idle — the pipeline step that names it will say so too — and a

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -116,33 +116,58 @@ struct Config: Decodable, Equatable {
         /// pulls a ~98 MB model on first use.
         var acoustic: Bool = false
 
-        /// How close a decoded word must sound to a name before it is replaced,
-        /// unless the name says otherwise.
+        /// How far a decoded word's spelling may sit from a term and still be
+        /// worth a line on the judge's menu. FluidAudio's similarity, where
+        /// 1.0 is the term written out exactly.
         ///
-        /// 0.75 is the measured default on this machine. Below it, ordinary
-        /// words start being overwritten: "vessel" lands 0.67 from "Vercel"
-        /// and "Alama" 0.67 from "Ollama".
-        var minSimilarity: Float = 0.75
+        /// One of the two numbers that replaced the single floor (F1). That
+        /// floor decided both what to look at and what to write, and no value
+        /// did both jobs: at 0.75 only 2 of 20 misheard names were caught, and
+        /// low enough to catch them "in general" became "in Redcrawl". This
+        /// one only decides what to look at. Being offered costs a menu line;
+        /// being missed cannot be recovered downstream at any price.
+        ///
+        /// Shipped untuned. F5's sentences suggest 0.50 is still permissive
+        /// even for a proposal, and measuring that is PR 7's job.
+        var offerBelow: Float = 0.50
+
+        /// How far the audio may argue against a proposal, in nats of raw CTC
+        /// score, before the proposal is dropped instead of offered.
+        ///
+        /// The other of the two numbers. Raw on purpose: the rescorer's own
+        /// margin carries the vocabulary bonus, and deciding on the boosted
+        /// number is how "praise" became `Praisy` (F4). Read by
+        /// `Vocabulary.proposalMargin`.
+        ///
+        /// Generous. `versal` -> `Vercel` is 0.82 against and correct, so the
+        /// gate has to sit well clear of an ordinary near-tie. Also shipped
+        /// untuned.
+        var decideAbove: Float = 3.0
 
         /// One term, and what is known about it.
         ///
-        /// `floor` is the similarity this term needs, overriding the default.
-        /// `off` means never match by sound at all — the honest setting when
-        /// the decoder writes the term and an ordinary word identically.
+        /// `floor: off` means never match by sound at all — the honest setting
+        /// when the decoder writes the term and an ordinary word identically.
         /// Measured here: "Claude" and "cloud" both come back as "cloud", so
-        /// no threshold can separate them.
+        /// no threshold can separate them. That is a switch, not a threshold,
+        /// so the two file-level numbers do not replace it.
         ///
-        /// `heard` is for renderings no floor can reach. "Prezi" is 0.33 from
+        /// A *number* under `floor:` is legacy. It is still honoured, as this
+        /// term's `offer_below`, and `--check-config` says so.
+        ///
+        /// `heard` is for renderings no number can reach. "Prezi" is 0.33 from
         /// "Praisy" and would need a floor that swallowed every "praise"; as an
         /// exact rule it costs nothing and cannot misfire.
         struct Term: Decodable, Equatable {
-            var floor: Float?
+            /// A legacy per-term `floor:` number, read as this term's
+            /// `offer_below`. Nil means the file-level one applies.
+            var offerBelow: Float?
             /// `floor: off` — never matched by sound, only by `heard`.
             var never = false
             var heard: [String] = []
 
-            init(floor: Float? = nil, never: Bool = false, heard: [String] = []) {
-                self.floor = floor
+            init(offerBelow: Float? = nil, never: Bool = false, heard: [String] = []) {
+                self.offerBelow = offerBelow
                 self.never = never
                 self.heard = heard
             }
@@ -152,14 +177,14 @@ struct Config: Decodable, Equatable {
             /// Four shapes, because most terms need none of this:
             ///
             ///     Tasmeen:                              nothing to say
-            ///     Mirza: 0.85                           a floor
+            ///     Mirza: 0.85                           a legacy floor
             ///     Praisy: [Prissy, Pressy]              renderings
             ///     Claude: {floor: off, heard: [cloud]}  both
             init(from decoder: Decoder) throws {
                 if let single = try? decoder.singleValueContainer() {
                     if single.decodeNil() { self.init(); return }
                     if let number = try? single.decode(Float.self) {
-                        self.init(floor: number); return
+                        self.init(offerBelow: number); return
                     }
                     if let listed = try? single.decode([String].self) {
                         self.init(heard: listed); return
@@ -167,6 +192,19 @@ struct Config: Decodable, Equatable {
                 }
                 let c = try decoder.container(keyedBy: CodingKeys.self)
                 let heard = try c.decodeIfPresent([String].self, forKey: .heard) ?? []
+                // Number first. Yams answers `Bool.self` for `0.85` quite
+                // happily — anything that is not `true`/`yes`/`on` decodes as
+                // `false` — so asking about `off` before asking about the
+                // number read every measured floor as `floor: off` and dropped
+                // the term from sound matching entirely. Silently: a term that
+                // is merely never matched still loads.
+                //
+                // The reverse trap does not exist. `off` is not a number, so
+                // asking for a Float first throws and falls through.
+                if let number = (try? c.decodeIfPresent(Float.self, forKey: .floor)) ?? nil {
+                    self.init(offerBelow: number, heard: heard)
+                    return
+                }
                 // `off` rather than a magic number. The previous spelling was
                 // `1.0`, which reads as maximum strictness and meant the
                 // opposite — never fire at all.
@@ -175,25 +213,32 @@ struct Config: Decodable, Equatable {
                 // `false`, and reading it only as a string threw, which took
                 // the whole file down silently.
                 if let flag = (try? c.decodeIfPresent(Bool.self, forKey: .floor)) ?? nil {
-                    self.init(floor: nil, never: flag == false, heard: heard)
+                    self.init(offerBelow: nil, never: flag == false, heard: heard)
                     return
                 }
                 if let word = (try? c.decodeIfPresent(String.self, forKey: .floor)) ?? nil {
-                    self.init(floor: nil, never: word.lowercased() == "off", heard: heard)
+                    self.init(offerBelow: nil, never: word.lowercased() == "off", heard: heard)
                     return
                 }
-                self.init(
-                    floor: try c.decodeIfPresent(Float.self, forKey: .floor),
-                    heard: heard
-                )
+                self.init(offerBelow: nil, heard: heard)
             }
         }
 
         var terms: [String: Term] = [:]
 
+        /// Legacy keys this file was read with, in words, for `notices()`.
+        ///
+        /// Migration is done here rather than reported here: the file loads
+        /// and behaves, and the sentence explaining what to write instead is
+        /// printed by whoever prints notices. A file nobody edits by hand
+        /// should not fail to load because a key was renamed.
+        var legacy: [String] = []
+
         enum CodingKeys: String, CodingKey {
             case acoustic, terms
             case minSimilarity = "min_similarity"
+            case offerBelow = "offer_below"
+            case decideAbove = "decide_above"
         }
 
         init() {}
@@ -204,25 +249,54 @@ struct Config: Decodable, Equatable {
             if let on = try c.decodeIfPresent(Bool.self, forKey: .acoustic) {
                 acoustic = on
             }
-            if let floor = try c.decodeIfPresent(Float.self, forKey: .minSimilarity) {
-                minSimilarity = floor
+            // `min_similarity` was the file-level floor that did both jobs. It
+            // now does one, so it is read as `offer_below` — the number is
+            // kept, the meaning narrows.
+            if let old = try c.decodeIfPresent(Float.self, forKey: .minSimilarity) {
+                offerBelow = old
+                legacy.append("`min_similarity: \(old)` is the old name for"
+                    + " `offer_below:` — same number, and it now only decides"
+                    + " what reaches the menu")
+            }
+            // Written explicitly it wins, whatever the old key said. A file
+            // carrying both is mid-migration and the new key is the intent.
+            if let offered = try c.decodeIfPresent(Float.self, forKey: .offerBelow) {
+                offerBelow = offered
+            }
+            if let decided = try c.decodeIfPresent(Float.self, forKey: .decideAbove) {
+                decideAbove = decided
             }
             terms = try c.decodeIfPresent([String: Term].self, forKey: .terms) ?? [:]
+
+            let floored = terms.filter { $0.value.offerBelow != nil }.keys.sorted()
+            if !floored.isEmpty {
+                legacy.append("a per-term `floor:` number on"
+                    + " \(floored.joined(separator: ", ")) is legacy — it still"
+                    + " sets what is offered for that term, but the setting is"
+                    + " `offer_below:` at the top of the file."
+                    + " `floor: off` is unaffected and still means never"
+                    + " matched by sound")
+            }
         }
     }
 
-    /// The terms given to the decoder as acoustic context, each with its floor.
+    /// The terms given to the decoder as acoustic context, each with the
+    /// spelling distance at which it is worth offering.
+    ///
+    /// The file-level `offer_below` unless the term carries a legacy `floor:`
+    /// number of its own, which FluidAudio already treats as an override of the
+    /// value passed alongside it.
     ///
     /// Short and non-alphabetic terms are dropped. A four-character term
     /// free-start aligns to almost any run of frames, which is what makes short
     /// terms the over-firing ones, and a name carrying a dot or a digit is not
     /// something the decoder could have produced.
-    var vocabularyTerms: [(text: String, minSimilarity: Float)] {
+    var vocabularyTerms: [(text: String, offerBelow: Float)] {
         vocabulary.terms
             .filter { term, entry in
                 !entry.never && term.count >= 5 && term.allSatisfy(\.isLetter)
             }
-            .map { ($0.key, $0.value.floor ?? vocabulary.minSimilarity) }
+            .map { ($0.key, $0.value.offerBelow ?? vocabulary.offerBelow) }
             .sorted { $0.0 < $1.0 }
     }
 
@@ -1491,9 +1565,10 @@ struct Config: Decodable, Equatable {
                 + " \(ConfigStore.vocabularyURL.lastPathComponent),"
                 + " \(byEar.count) matched by sound, \(rules) by rule")
             if vocabulary.acoustic, !byEar.isEmpty {
-                said.append("vocabulary: by sound at floor \(vocabulary.minSimilarity) — "
-                    + byEar.map { $0.minSimilarity == vocabulary.minSimilarity
-                        ? $0.text : "\($0.text) \($0.minSimilarity)" }
+                said.append("vocabulary: offered below \(vocabulary.offerBelow),"
+                    + " written without asking above \(vocabulary.decideAbove) nats — "
+                    + byEar.map { $0.offerBelow == vocabulary.offerBelow
+                        ? $0.text : "\($0.text) \($0.offerBelow)" }
                         .joined(separator: ", "))
             }
             if !vocabulary.acoustic, !byEar.isEmpty {
@@ -1508,6 +1583,9 @@ struct Config: Decodable, Equatable {
                     + " `floor: off` and no `heard`, so nothing can match them")
             }
         }
+        // Said whether or not there are terms: a file can carry the old
+        // file-level key and nothing else.
+        said += vocabulary.legacy.map { "vocabulary: \($0)" }
         return said
     }
 
@@ -1632,9 +1710,7 @@ enum ConfigStore {
     /// What `vocabulary.yaml` says before anything has been learnt.
     ///
     /// Every term is commented out. A vocabulary that arrives with entries in
-    /// it is a vocabulary tuned for somebody else's voice, and the floors are
-    /// the part that cannot be guessed — "Vercel" needs 0.75 on one person and
-    /// would overwrite "vessel" on another.
+    /// it is a vocabulary tuned for somebody else's voice.
     static let defaultVocabularyYAML = """
     # ParrotFlow vocabulary — words you say that the recogniser gets wrong.
     #
@@ -1646,32 +1722,38 @@ enum ConfigStore {
     # DO NOT EDIT UNLESS YOU REALLY KNOW WHAT YOU ARE DOING.
     #
     # This file is learnt while you use the app. Entries arrive when you correct
-    # a term, and the floors are measured from your own voice — not chosen. A
-    # wrong number here does not fail loudly: it silently rewrites words you
-    # meant, in every dictation, until you notice.
+    # a term. If you want to change something, the safe move is to let the app
+    # measure again rather than to pick a number.
     #
-    # If you want to change something, the safe move is to let the app measure
-    # again rather than to pick a number.
+    # Two numbers, and they do different jobs. Offering a reading and writing
+    # one are different risks, and one threshold could not do both: strict
+    # enough to be safe it caught 2 of 20 misheard names, loose enough to catch
+    # them "in general" became "in Redcrawl".
     #
-    #   floor   how close a word must sound to the term before it is replaced,
-    #           from 0 to 1. Left out, the default below applies. `off` means
-    #           never match by sound — the setting for a term the recogniser
-    #           writes identically to an ordinary word, where no number helps.
-    #   heard   renderings no floor can reach, matched exactly.
+    #   offer_below    how far a word's spelling may sit from the term and
+    #                  still reach the menu, from 0 to 1. Being offered costs a
+    #                  line the model reads; being missed cannot be undone.
+    #   decide_above   how hard the audio has to argue against a reading, in
+    #                  nats, before it is dropped rather than offered.
+    #
+    # Per term:
+    #
+    #   heard   renderings no number can reach, matched exactly.
+    #   floor   `off` — never match this term by sound, only by `heard`. For a
+    #           term the recogniser writes identically to an ordinary word,
+    #           where no number helps.
 
     # Matching by sound needs a ~98 MB model, pulled on first use.
     acoustic: false
-    min_similarity: 0.75
+    offer_below: 0.50
+    decide_above: 3.0
 
     terms: {}
     #  Tasmeen:                     # nothing close in your speech
-    #  Mirza:
-    #    floor: 0.85                # "Mira" lands at 0.80
     #  Praisy:
-    #    floor: 0.90                # "praise" lands at 0.83
-    #    heard: [Prissy, Pressy]
+    #    heard: [Prissy, Pressy]    # "Prezi" is 0.33 away — no number reaches it
     #  Claude:
-    #    floor: off                 # "cloud" both ways — no floor works
+    #    floor: off                 # "cloud" both ways — no number works
     #    heard: [cloud]
 
     """

--- a/Sources/ParrotFlow/Vocabulary.swift
+++ b/Sources/ParrotFlow/Vocabulary.swift
@@ -37,8 +37,9 @@ import Foundation
 ///
 /// So the rescue is off and the short-term boost is tapered. Measured over the
 /// same 386 clips: 10 altered at `minSimilarity` 0.65, 4 at 0.75, 0 at 0.85.
-/// The two wrong fires at 0.65 are names that sound like real words, which is
-/// what the per-term floor in `vocabulary.terms` is for.
+/// Those numbers describe a pass that substituted. This one proposes, so the
+/// similarity it is given is `offer_below:` and a wrong fire costs a menu line
+/// rather than a rewritten word — see `Config.Vocabulary.offerBelow`.
 @available(macOS 14, *)
 actor Vocabulary {
 
@@ -76,7 +77,7 @@ actor Vocabulary {
         config: Config, progress: (@Sendable (String) -> Void)? = nil
     ) async throws {
         let terms = config.vocabularyTerms
-        let signature = terms.map { "\($0.text):\($0.minSimilarity)" }
+        let signature = terms.map { "\($0.text):\($0.offerBelow)" }
         guard signature != loadedFor || rescorer == nil else { return }
 
         progress?("vocabulary model")
@@ -95,7 +96,7 @@ actor Vocabulary {
             }
             counts[term.text] = ids.count
             return CustomVocabularyTerm(
-                text: term.text, ctcTokenIds: ids, minSimilarity: term.minSimilarity
+                text: term.text, ctcTokenIds: ids, minSimilarity: term.offerBelow
             )
         }
         self.tokenCounts = counts
@@ -319,11 +320,13 @@ actor Vocabulary {
     /// argues against by this much is not a reading, and offering it spends a
     /// menu line on noise.
     ///
-    /// Generous on purpose. `versal` -> `Vercel` is 0.82 against and correct,
-    /// so the gate has to sit well clear of an ordinary near-tie.
-    static var proposalMargin: Float {
+    /// `decide_above:` in `vocabulary.yaml` is the setting. The env override
+    /// stays because the harness sweeps this number, and a harness that has to
+    /// rewrite the user's file to measure one point is a harness that
+    /// eventually leaves it rewritten.
+    static func proposalMargin(_ config: Config) -> Float {
         ProcessInfo.processInfo.environment["PARROTFLOW_PROPOSAL_MARGIN"]
-            .flatMap(Float.init) ?? 3.0
+            .flatMap(Float.init) ?? config.vocabulary.decideAbove
     }
 
     static var spotterFloor: Float {
@@ -450,7 +453,7 @@ actor Vocabulary {
                 frameDuration: spotted.frameDuration,
                 cbw: cbw,
                 marginSeconds: ContextBiasingConstants.defaultMarginSeconds,
-                minSimilarity: config.vocabulary.minSimilarity
+                minSimilarity: config.vocabulary.offerBelow
             )
             // Not `guard result.wasModified` any more. The acoustic search
             // below runs whether or not the spelling gate proposed anything,
@@ -476,6 +479,7 @@ actor Vocabulary {
             // silently dropped every replacement before this was written that
             // way.
             var decided: [(raw: Float, bonus: Float, applied: Bool, dropped: Bool)] = []
+            let margin = Self.proposalMargin(config)
             var rebuilt = ""
             var cursor = text.startIndex
             // Where a position in `text` lands in `rebuilt`, as a running
@@ -508,7 +512,7 @@ actor Vocabulary {
                 // Dropped when the audio argues hard against it — neither
                 // applied nor offered. Kept in the list so the index still
                 // lines up with `found`.
-                let dropped = !applies && change.originalScore - raw > Self.proposalMargin
+                let dropped = !applies && change.originalScore - raw > margin
                 decided.append((raw, bonus, applies, dropped))
             }
             rebuilt += text[cursor...]

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -82,26 +82,43 @@ corrections, from `--learn`, from the calibrate skill.
 
 ```yaml
 acoustic: true
-min_similarity: 0.75
+offer_below: 0.50
+decide_above: 3.0
 
 terms:
   Tasmeen:                     # nothing close in this speaker's speech
-  Mirza:
-    floor: 0.85                # "Mira" lands at 0.80
   Praisy:
-    floor: 0.90                # "praise" lands at 0.83
     heard: [Prissy, Pressy, Precy, Prezi]
   Claude:
     floor: off
     heard: [clut, cloud]
 ```
 
-A term has two ways in, and most need one.
+#### The two numbers
 
-**`floor`** is how close a decoded word must sound before it is replaced, from
-0 to 1. Omitted, `min_similarity` applies.
+Offering a reading and writing one are different risks, so they have different
+settings. One threshold used to do both jobs and no value did them both: strict
+enough to be safe it caught 2 of 20 misheard names, and loose enough to catch
+them "in general" became "in Redcrawl".
 
-**`heard`** is a list of exact renderings. Use it for the ones no floor can
+**`offer_below`** is how far a decoded word's spelling may sit from a term and
+still reach the judge's menu, from 0 to 1, where 1.0 is the term written out
+exactly. It decides what is looked at, not what is written. Being offered costs
+a line the model reads; being missed cannot be recovered downstream at any
+price, so it is set low.
+
+**`decide_above`** is how hard the audio has to argue against a reading, in
+nats, before the reading is dropped rather than offered. Raw scores: the
+rescorer's own margin carries the vocabulary bonus, and a term can win a span
+its sound lost badly — `Redcrawl` beat "general" by 0.57 boosted and lost by
+5.28 raw.
+
+Both ship untuned at the values above. They are the mechanism, not a
+measurement.
+
+#### Per term
+
+**`heard`** is a list of exact renderings. Use it for the ones no number can
 reach: "Prezi" is 0.33 from "Praisy", and a threshold that low would swallow
 every "praise".
 
@@ -111,47 +128,65 @@ machine: "Claude" and "cloud" both come back as `cloud`, "Matthieu" and
 "Matthew" both as `Matthew`. No threshold separates them, because the
 distinction is gone before anything downstream can look.
 
+`floor: off` in YAML is the boolean `false`, not the string. So are `on`,
+`yes` and `no`. The decoder reads both.
+
 Terms shorter than five letters are dropped, as are terms with a digit or a
 dot. A short term aligns to almost any run of frames. A term the decoder could
 not have produced is not a term.
 
-#### Choosing a floor
+#### Files written before the two numbers
 
-Set it just above the closest ordinary word. `scripts/calibrate.py confusables
-<term> --lang en,fr` lists what is in reach:
+They still load and still behave. `--check-config` says what was read.
 
-    Praisy   praise 0.83   raise 0.67   pray 0.67     -> floor 0.90
-    Redrock  bedrock 0.86  redock 0.86                -> floor 0.90
-    Vercel   vessel 0.67   vertex 0.67                -> floor 0.75
+| written | read as |
+| --- | --- |
+| `min_similarity: 0.75` | `offer_below: 0.75` |
+| `floor: 0.85` on a term | that term's `offer_below` |
+| `floor: off`, `floor: no` | unchanged — never matched by sound |
+
+A number under `floor:` is legacy: it now only decides what is offered, and the
+setting is `offer_below:` at the top of the file. `floor: off` is not legacy.
+It is a switch rather than a threshold, and the two file-level numbers do not
+replace it.
+
+#### What is in reach of a term
+
+`scripts/calibrate.py confusables <term> --lang en,fr` lists the ordinary words
+a term can be confused with:
+
+    Praisy   praise 0.83   raise 0.67   pray 0.67
+    Redrock  bedrock 0.86  redock 0.86
+    Vercel   vessel 0.67   vertex 0.67
 
 Pass only the languages you dictate in. "Praisy" is 0.83 from the English
-"praise" and 0.67 from the French "vrais", so the floor differs by 0.16
-depending on who is speaking.
+"praise" and 0.67 from the French "vrais", so the neighbourhood differs by 0.16
+depending on who is speaking. Under `offer_below` a close neighbour is no
+longer a word that gets overwritten — it is a second line on the menu, and the
+sentence picks.
 
 Two things to check that a word list does not tell you. `NSSpellChecker`
 accepts any all-caps run as a word, so `XQZPT` looks known — ask about the
 lowercase form. And a term shaped like a verb-particle pair is unsafe whatever
 its neighbourhood: "turn down the volume" glues to `Turndown` at 1.00.
 
-`floor: off` in YAML is the boolean `false`, not the string. So are `on`,
-`yes` and `no`. The decoder reads both.
-
 #### What it costs
 
 Matching by sound downloads a ~98 MB model on first use and adds a CTC pass
 per clip. `acoustic: false` skips both; the `heard` rules still apply.
 
-Over 400 archived clips, with the shipped settings, damage — clips containing
-no vocabulary term that came out different — falls with the floor:
+Over 400 archived clips, damage — clips containing no vocabulary term that came
+out different — falls as the similarity rises:
 
-| floor | clips damaged | terms recovered |
+| similarity | clips damaged | terms recovered |
 | --- | --- | --- |
 | 0.65 | 10/386 | 5/8 |
 | 0.75 | 4/386 | 3/8 |
 | 0.85 | 0/386 | 2/8 |
 
-Higher floors are safer and catch less. There is no setting that catches
-everything and breaks nothing.
+Measured on the pass that substituted. There was no setting that caught
+everything and broke nothing, which is the finding that split one number into
+two: a damaged clip at 0.65 is now a menu line, not a rewritten word.
 
 #### Checking the result
 

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -96,10 +96,10 @@ terms:
 
 #### The two numbers
 
-Offering a reading and writing one are different risks, so they have different
-settings. One threshold used to do both jobs and no value did them both: strict
-enough to be safe it caught 2 of 20 misheard names, and loose enough to catch
-them "in general" became "in Redcrawl".
+What a spelling makes worth looking at and what the audio can veto are
+different questions. One threshold used to answer both and no value answered
+them both: strict enough to be safe it caught 2 of 20 misheard names, and loose
+enough to catch them "in general" became "in Redcrawl".
 
 **`offer_below`** is how far a decoded word's spelling may sit from a term and
 still reach the judge's menu, from 0 to 1, where 1.0 is the term written out

--- a/scripts/check-vocabulary-config.sh
+++ b/scripts/check-vocabulary-config.sh
@@ -6,10 +6,11 @@
 # The file is learnt, not written, so nobody rereads it and a key that quietly
 # stops meaning what it meant is invisible. Two things are scored here.
 #
-#   the two numbers    `offer_below` decides what reaches the menu,
-#                      `decide_above` decides what is written without asking.
-#                      They are separate because one threshold could not do
-#                      both jobs (F1).
+#   the two numbers    `offer_below` is the spelling distance at which a
+#                      reading still reaches the menu; `decide_above` is how
+#                      hard the audio has to argue before it is dropped
+#                      instead. They are separate because one threshold could
+#                      not do both jobs (F1).
 #   the old spellings  a file written before them still loads and still
 #                      behaves: `min_similarity:` is read as `offer_below:`, a
 #                      per-term `floor:` number still sets that term's, and
@@ -41,6 +42,14 @@ say() {
   printf '%s\n' "$1" > "$WORK/vocabulary.yaml"
   PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --check-config 2>/dev/null \
     | sed -n 's/^  · vocabulary: //p'
+}
+
+# complains <vocabulary.yaml body> — the same for the ✗ list, which is what
+# `--check-config` exits 1 on.
+complains() {
+  printf '%s\n' "$1" > "$WORK/vocabulary.yaml"
+  PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --check-config 2>/dev/null \
+    | sed -n 's/^  ✗ vocabulary: //p'
 }
 
 # wants <name> <text> <substring> — the substring has to be in the text.
@@ -76,7 +85,7 @@ terms:
     floor: 0.85
   Tasmeen:')"
 wants "a legacy floor still sets what that term offers" "$got" "Mirza 0.85"
-wants "the other term is on the file default"          "$got" "0.5"
+wants "the other term is on the file default"          "$got" "similarity 0.5 and up"
 wants "and the key is called legacy"                   "$got" "is legacy"
 wants "with what to write instead"                     "$got" '`offer_below:` at the top of the file'
 
@@ -107,8 +116,8 @@ wants "and nothing can reach that term"  "$got" "Matthieu — \`floor: off\` and
 got="$(say 'acoustic: true
 terms:
   Tasmeen:')"
-wants "the default offer floor"    "$got" "offered below 0.5,"
-wants "the default decide margin"  "$got" "above 3.0 nats"
+wants "the default offer floor"    "$got" "offered at similarity 0.5 and up"
+wants "the default decide margin"  "$got" "by more than 3.0 nats"
 rejects "and nothing is legacy"    "$got" "is legacy"
 
 # --- 5. the old file-level key ---------------------------------------------
@@ -116,7 +125,7 @@ got="$(say 'acoustic: true
 min_similarity: 0.75
 terms:
   Tasmeen:')"
-wants "min_similarity is read as offer_below" "$got" "offered below 0.75,"
+wants "min_similarity is read as offer_below" "$got" "offered at similarity 0.75 and up"
 wants "and named as the old spelling"         "$got" '`min_similarity: 0.75` is the old name for `offer_below:`'
 
 # --- 6. both file-level keys: the new one is the intent --------------------
@@ -126,8 +135,21 @@ offer_below: 0.40
 decide_above: 5.5
 terms:
   Tasmeen:')"
-wants "offer_below wins over min_similarity" "$got" "offered below 0.4,"
-wants "decide_above is read"                 "$got" "above 5.5 nats"
+wants "offer_below wins over min_similarity" "$got" "offered at similarity 0.4 and up"
+wants "decide_above is read"                 "$got" "by more than 5.5 nats"
+
+# --- 7. a number in the wrong units is a fault, not a notice --------------
+#
+# Both look exactly like the vocabulary being broken: above 1 nothing ever
+# reaches the menu, at or below 0 nats every reading the decoder does not
+# already prefer is dropped before anyone sees it.
+got="$(complains 'acoustic: true
+offer_below: 85
+decide_above: 0
+terms:
+  Tasmeen:')"
+wants "a similarity outside 0 to 1 is refused" "$got" '`offer_below: 85.0` is outside 0 to 1'
+wants "a margin at 0 nats is refused"          "$got" '`decide_above: 0.0` drops every'
 
 printf '\n  %d/%d\n' "$pass" "$total"
 if [ -n "$failed" ]; then

--- a/scripts/check-vocabulary-config.sh
+++ b/scripts/check-vocabulary-config.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Checks what `vocabulary.yaml` adds up to, old spellings included.
+#
+#   scripts/check-vocabulary-config.sh
+#
+# The file is learnt, not written, so nobody rereads it and a key that quietly
+# stops meaning what it meant is invisible. Two things are scored here.
+#
+#   the two numbers    `offer_below` decides what reaches the menu,
+#                      `decide_above` decides what is written without asking.
+#                      They are separate because one threshold could not do
+#                      both jobs (F1).
+#   the old spellings  a file written before them still loads and still
+#                      behaves: `min_similarity:` is read as `offer_below:`, a
+#                      per-term `floor:` number still sets that term's, and
+#                      `floor: off` still means never matched by sound.
+#
+# The last one has teeth. Yams answers `Bool.self` for `0.85` — anything that
+# is not `true`/`yes`/`on` decodes as `false` — so a decoder that asks about
+# `off` before asking about the number reads every measured floor as
+# `floor: off` and drops the term from sound matching. That is silent: the file
+# loads, the term is simply never found again. Cases 1 and 4 are that bug.
+#
+# Every case is a whole config directory in /tmp read through
+# PARROTFLOW_CONFIG_DIR, so this says nothing about the config on the machine
+# and scores the same anywhere.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/release/ParrotFlow"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+
+WORK="$(mktemp -d -t parrotflow-vocabulary)"
+trap 'rm -rf "$WORK"' EXIT
+printf 'transcription:\n  languages: [en]\n' > "$WORK/config.yaml"
+
+pass=0; total=0; failed=""
+
+# say <vocabulary.yaml body> — the `vocabulary:` notices of `--check-config`,
+# one per line, with the leading marker stripped.
+say() {
+  printf '%s\n' "$1" > "$WORK/vocabulary.yaml"
+  PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --check-config 2>/dev/null \
+    | sed -n 's/^  · vocabulary: //p'
+}
+
+# wants <name> <text> <substring> — the substring has to be in the text.
+wants() {
+  total=$((total + 1))
+  if printf '%s' "$2" | grep -qF -- "$3"; then
+    pass=$((pass + 1))
+    printf '  ✓ %s\n' "$1"
+  else
+    failed="$failed
+      $1"
+    printf '  ✗ %s\n      want  %s\n      got   %s\n' "$1" "$3" "$2"
+  fi
+}
+
+# rejects <name> <text> <substring> — and the substring has to be absent.
+rejects() {
+  total=$((total + 1))
+  if printf '%s' "$2" | grep -qF -- "$3"; then
+    failed="$failed
+      $1"
+    printf '  ✗ %s\n      unwanted  %s\n      got       %s\n' "$1" "$3" "$2"
+  else
+    pass=$((pass + 1))
+    printf '  ✓ %s\n' "$1"
+  fi
+}
+
+# --- 1. a per-term floor, the shape every learnt file has ------------------
+got="$(say 'acoustic: true
+terms:
+  Mirza:
+    floor: 0.85
+  Tasmeen:')"
+wants "a legacy floor still sets what that term offers" "$got" "Mirza 0.85"
+wants "the other term is on the file default"          "$got" "0.5"
+wants "and the key is called legacy"                   "$got" "is legacy"
+wants "with what to write instead"                     "$got" '`offer_below:` at the top of the file'
+
+# --- 2. `floor: off` still means never matched by sound --------------------
+got="$(say 'acoustic: true
+terms:
+  Claude:
+    floor: off
+    heard: [cloud]
+  Tasmeen:')"
+wants "off leaves one term matched by sound"  "$got" "2 terms in vocabulary.yaml, 1 matched by sound, 1 by rule"
+rejects "and it is not the one turned off"    "$got" "Claude"
+rejects "off is not reported as a legacy number" "$got" "is legacy"
+
+# --- 3. `floor: no` is the same switch -------------------------------------
+#
+# `no` is a YAML 1.1 boolean like `off`, and a term with no `heard` and no
+# sound matching can be reached by nothing at all — which is worth saying.
+got="$(say 'acoustic: true
+terms:
+  Matthieu:
+    floor: no
+  Tasmeen:')"
+wants "no means never matched by sound" "$got" "2 terms in vocabulary.yaml, 1 matched by sound, 0 by rule"
+wants "and nothing can reach that term"  "$got" "Matthieu — \`floor: off\` and no \`heard\`, so nothing can match them"
+
+# --- 4. no floor anywhere: the shipped defaults ----------------------------
+got="$(say 'acoustic: true
+terms:
+  Tasmeen:')"
+wants "the default offer floor"    "$got" "offered below 0.5,"
+wants "the default decide margin"  "$got" "above 3.0 nats"
+rejects "and nothing is legacy"    "$got" "is legacy"
+
+# --- 5. the old file-level key ---------------------------------------------
+got="$(say 'acoustic: true
+min_similarity: 0.75
+terms:
+  Tasmeen:')"
+wants "min_similarity is read as offer_below" "$got" "offered below 0.75,"
+wants "and named as the old spelling"         "$got" '`min_similarity: 0.75` is the old name for `offer_below:`'
+
+# --- 6. both file-level keys: the new one is the intent --------------------
+got="$(say 'acoustic: true
+min_similarity: 0.75
+offer_below: 0.40
+decide_above: 5.5
+terms:
+  Tasmeen:')"
+wants "offer_below wins over min_similarity" "$got" "offered below 0.4,"
+wants "decide_above is read"                 "$got" "above 5.5 nats"
+
+printf '\n  %d/%d\n' "$pass" "$total"
+if [ -n "$failed" ]; then
+  printf '  failed:%s\n' "$failed"
+  exit 1
+fi

--- a/scripts/check-vocabulary-config.sh
+++ b/scripts/check-vocabulary-config.sh
@@ -138,18 +138,31 @@ terms:
 wants "offer_below wins over min_similarity" "$got" "offered at similarity 0.4 and up"
 wants "decide_above is read"                 "$got" "by more than 5.5 nats"
 
-# --- 7. a number in the wrong units is a fault, not a notice --------------
+# --- 7. a number in the wrong units is refused, not just reported ----------
 #
 # Both look exactly like the vocabulary being broken: above 1 nothing ever
 # reaches the menu, at or below 0 nats every reading the decoder does not
-# already prefer is dropped before anyone sees it.
-got="$(complains 'acoustic: true
+# already prefer is dropped before anyone sees it. Nothing downstream
+# re-checks them, so the value has to be refused where it is read — reporting
+# it and running it anyway means every dictation is quietly wrong until
+# somebody happens to run this command.
+body='acoustic: true
 offer_below: 85
 decide_above: 0
 terms:
-  Tasmeen:')"
+  Mirza:
+    floor: 12
+  Tasmeen:'
+got="$(complains "$body")"
 wants "a similarity outside 0 to 1 is refused" "$got" '`offer_below: 85.0` is outside 0 to 1'
-wants "a margin at 0 nats is refused"          "$got" '`decide_above: 0.0` drops every'
+wants "a margin at 0 nats is refused"          "$got" '`decide_above: 0.0` would drop every'
+wants "a per-term floor outside 0 to 1 too"    "$got" '`floor:` on Mirza is outside 0 to 1'
+
+got="$(say "$body")"
+wants "and the defaults are what actually run" "$got" \
+  "offered at similarity 0.5 and up, dropped when the audio argues against it by more than 3.0 nats"
+rejects "the refused per-term number is gone" "$got" "Mirza 12"
+rejects "and it is not called legacy either"  "$got" "is legacy"
 
 printf '\n  %d/%d\n' "$pass" "$total"
 if [ -n "$failed" ]; then


### PR DESCRIPTION
PR 4 of `docs/proposals/vocabulary-v2.md`. One number decided both what to look
at and what to write. Now two numbers do one job each.

## What changed

**`vocabulary.yaml` takes two file-level numbers.**

```yaml
acoustic: true
offer_below: 0.50   # spelling: how far a word may sit from a term and still
                    # reach the judge's menu, 1.0 being the term spelled exactly
decide_above: 3.0   # audio: how hard it has to argue against a reading, in
                    # nats of raw score, before the reading is dropped instead
```

`offer_below` is what `Vocabulary.apply` hands the rescorer as `minSimilarity`,
and what a term's own entry can still override. `decide_above` is what
`Vocabulary.proposalMargin` reads — the constant PR 3 landed, now a config key.
`PARROTFLOW_PROPOSAL_MARGIN` still overrides it, because the harness sweeps
this number and a harness that rewrites the user's file to measure one point is
a harness that eventually leaves it rewritten.

**Both ship untuned.** F5's sentences suggest 0.50 is permissive even for a
proposal. That measurement is PR 7's, and this PR is the mechanism it needs.

**`--check-config` says which way the numbers point.**

```
· vocabulary: 11 terms in vocabulary.yaml, 11 matched by sound, 37 by rule
· vocabulary: offered at similarity 0.5 and up, dropped when the audio argues
  against it by more than 3.0 nats — Arexvy, Claude, Matthieu, Mirza, Ollama,
  Praisy, Redcrawl, Redrock, Supabase, Tasmeen, Vercel
```

`offered below 0.5` was the first wording and it reads as the opposite of what
it does. The key name says the job; only a sentence says the direction.

**A number in the wrong units is refused, not run.** Both look exactly like the
vocabulary being broken: `offer_below` outside 0 to 1 means nothing ever
reaches the menu, and `decide_above` at or below 0 nats drops every reading the
decoder does not already prefer. The default is kept and the complaint says
which number is running. A per-term `floor:` gets the same treatment.

```
✗ vocabulary: `offer_below: 85.0` is outside 0 to 1 — it is a similarity, where
  1.0 is the term spelled exactly. Running at 0.5
```

## Migration

Nothing to edit. A file written before these keys loads and behaves, and
`--check-config` names what it read.

| written | read as | said |
| --- | --- | --- |
| `min_similarity: 0.75` | `offer_below: 0.75` | legacy, with the new spelling |
| `floor: 0.85` on a term | that term's `offer_below` | legacy, per term |
| `floor: off`, `floor: no` | unchanged — never matched by sound | nothing |
| neither | `offer_below: 0.50`, `decide_above: 3.0` | nothing |

`floor: off` is not legacy. It is a switch rather than a threshold — "Claude"
and "cloud" both come back as `cloud`, so no number separates them — and the
two file-level numbers do not replace it.

Measured, on a scratch config directory:

```
$ cat vocabulary.yaml
acoustic: true
terms:
  Mirza:
    floor: 0.85
  Tasmeen:

$ ParrotFlow --check-config
· vocabulary: offered at similarity 0.5 and up, dropped when the audio argues
  against it by more than 3.0 nats — Mirza 0.85, Tasmeen
· vocabulary: a per-term `floor:` number on Mirza is legacy — it still sets
  what is offered for that term, but the setting is `offer_below:` at the top
  of the file. `floor: off` is unaffected and still means never matched by sound
```

**The Yams fix from the prototype is kept, and it is the reason for a check of
its own.** Yams answers `Bool.self` for `0.85` — anything that is not
`true`/`yes`/`on` decodes as `false` — so asking about `floor: off` before
asking about the number read every measured floor as "never match this term"
and dropped it from sound matching. Silently: the file loads, the term is
simply never found again. The number is decoded first. The reverse trap does
not exist, because `off` is not a number and the Float decode throws.

## Findings

| | |
|---|---|
| **F1** | The per-term floor decided both what to look at and what to write. It now only decides what to look at, and the audio's veto is a separate number. |
| **F5** | 0.50 is shipped, not endorsed. The doc comment on `offerBelow` and `docs/transcription.md` both say it is the mechanism rather than a measurement, and name PR 7. |
| **F9** | Nothing here touches spans or positions. |
| **F12a** | Every harness number below is `--runs 3` with the flip count quoted. |

## Gates

Built app, clean tree, stamp matching HEAD:

```
$ swift build -c release && scripts/build-app.sh
Build complete!
==> Done: .build/ParrotFlowDev.app
$ .build/ParrotFlowDev.app/Contents/MacOS/ParrotFlow --version
84d4b24
$ git rev-parse --short HEAD
84d4b24
```

The live config still names the old transform, so every harness run went
through a scratch config dir under `PARROTFLOW_CONFIG_DIR`, built the way PR
#63 documents: the live `config.yaml` and `vocabulary.yaml`, the pipeline entry
replaced by `- vocabulary: verify_names.md  when: vocabulary.count > 0`, the
prompt copied in beside it, and `llm.model` set to `gemma4:e4b`.
`~/.config/parrotflow-dev/` was not touched and `make install` was not run.
Ollama had nothing else loaded.

The live `vocabulary.yaml` carries `min_similarity: 0.50` and no per-term
floors, so it migrates to `offer_below: 0.50` — the same number the PR 3
baselines were measured at. `decide_above` defaults to the 3.0 that was the
constant. The gates should therefore be flat, and they are.

```
$ PARROTFLOW_CONFIG_DIR=<scratch> python3 scripts/menu-recall.py --runs 3
  recall  31/37   the true sentence was on the menu, majority of 3 runs
  picked  27/37   the judge chose it, majority of 3 runs
  0/37 clip(s) changed outcome between runs (F12a)
  (3 clip(s) unlabelled)

$ PARROTFLOW_CONFIG_DIR=<scratch> python3 scripts/before-after.py --runs 3
  fixed 17   broken 9   regressed 1   already right 10
  majority of 3 runs; 0 clip(s) changed outcome between runs (F12a)
```

Against PR 3's baselines: recall 31 → **31/37**, picked 27 → **27/37**,
before/after 17 fixed / 9 broken / 1 regressed → **17 / 9 / 1**. Nothing moved.

**Flips.** None, in either harness, on the run above. Measured twice: the same
protocol against 2d57ccf gave the same four numbers with one flip in
`before-after` — `17-39-27`, right on 2 of 3 runs, counted FIXED by majority.
That clip is one of the two PR #63 named as replay-noisy (F12a). Every other
clip agreed with itself across six replays.

The one REGRESSED row is `17-47-45`, the same one PR #63 recorded: `retry` and
`Arexvy` are 0.46 apart and the audio prefers `retry` by 0.25 nats, so at a
0.50 offer floor the reading is correctly offered and only the sentence can
refuse it. It is a judge error, and the judge's prompt is PR 7's.

Repository checks:

```
check-vocabulary-config    22/22   (new)
check-pipeline             56/56
check-replacements         23/23
check-transform-folders    12/12
check-eval                 25/25
check-numbers              97/97
check-wake                 24/24
check-split                14/14
check-dotted               54/54
check-dates                26/26
check-default-config       clean
check-seeded-transform     clean
check-pinned-certificate   clean
```

## Deviations

- **`decide_above` is the drop margin, not an auto-apply margin.** The plan
  describes it as "nats of RAW margin needed to write without asking". What the
  router actually uses that number for is the other end: a proposal the audio
  argues against by more than this is dropped rather than offered. Wiring the
  key to the constant PR 3 landed is what the PR was asked to do; wiring it to
  `autoApplies` instead would change what gets written on every clip, which is
  a tuning change and not this PR's. Every doc comment, the seeded template and
  `--check-config` describe what it does, not what the plan's one-liner said.
- **A per-term `floor:` number still works.** The plan says the two file-level
  numbers replace it. Deleting it would change every existing file's behaviour
  on the day it was read, and the plan also says the migration must keep
  working. So it is honoured as that term's `offer_below`, called legacy, and
  FluidAudio already treats a term's own `minSimilarity` as an override of the
  value passed alongside it — this is that same override, renamed.
- **`min_similarity:` migrates too.** The plan names only the per-term key. The
  file-level one is the same threshold doing the same two jobs, and leaving it
  as a live key next to `offer_below` would be two names for one number.
- **`vocabularyRules` did not change shape.** It reads only `heard:`, which
  neither threshold touches. `vocabularyTerms` changed: its tuple label is
  `offerBelow`.
- **The seeded `vocabulary.yaml` ships `offer_below: 0.50`, where it used to
  ship `min_similarity: 0.75`.** A new install has `acoustic: false`, so
  nothing changes until someone turns sound matching on — and when they do,
  0.75 is the floor of a pass that substituted.
- **The two vocabulary skills were updated.** They wrote `min_similarity:` and
  a number per term, which this PR makes legacy the moment it lands. Their
  measurement methods are unchanged; what they write, and what a band is for,
  are not.

## Coverage

`scripts/check-vocabulary-config.sh`, 22 cases, in CI beside
`check-default-config.sh`. Whole config directories in /tmp read through
`PARROTFLOW_CONFIG_DIR`, so it says nothing about the config on the machine.
It covers both spellings of every key, both YAML booleans, the defaults, the
precedence when a file carries old and new, and the three range faults —
including that the default is what runs afterwards. Cases 1 and 4 are the Yams
bug: with the boolean asked about first, case 1 loses `Mirza 0.85` and case 4
is unaffected, which is exactly how that bug hides.

## Review

| Round | Finding | Fix |
|---|---|---|
| 1 | P1: a threshold in the wrong units is reported by `problems()` and then used, because nothing downstream re-reads it | Refused where it is read (84d4b24). The default runs, the complaint says which number that is, and a per-term `floor:` is treated the same. |
| 2 | none | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiQJipvz9Ps9tdDCRdisv
