### PR TITLE
feat: a rendering is a sound, not only a spelling

### DIFF
--- a/.claude/skills/calibrate/SKILL.md
+++ b/.claude/skills/calibrate/SKILL.md
@@ -64,9 +64,15 @@ the second. Here: 0.51 to 0.67.
 **A closed band is a result, not a failure.** It says this term can never be
 separated acoustically for this person. The answer is `floor: off` with a
 `pronunciations:` list of the renderings actually seen, and the name judge
-behind it. Those renderings are not only rules: each one's *sound* is
-registered with the spotter under the term's name, so a closed band still gets
-an acoustic path — it just gets it from the rendering instead of the term.
+behind it. Those renderings are exact rules and nothing else. `floor: off`
+turns sound matching off for the whole term, its renderings included — which is
+right, because a closed band usually closes for the same reason the audio
+cannot help: "Claude" and "cloud" come back identical because they sound
+identical.
+
+A term with a **band** gets both. Its renderings are rules *and* search targets:
+the spotter looks for the sound of the rendering and reports the term, which is
+the only path to something like `Versailles` at 0.40 from `Vercel`.
 Report it that way — a user told "no threshold works, here is the rule
 instead" has learned something; a user handed a number that quietly damages
 their transcripts has not.

--- a/.claude/skills/calibrate/SKILL.md
+++ b/.claude/skills/calibrate/SKILL.md
@@ -19,7 +19,7 @@ the audio has to argue before a reading is dropped. So a band no longer sets a
 term's threshold. It answers two questions:
 
 - **Does any threshold work for this term at all?** A closed band means no.
-  That term is `floor: off` and a `heard:` list, and nothing else.
+  That term is `floor: off` and a `pronunciations:` list, and nothing else.
 - **Where should `offer_below` sit for this speaker?** Below the lowest
   rendering of any term that still has a band. Being offered costs a line the
   model reads; being missed cannot be recovered downstream.
@@ -63,7 +63,10 @@ the second. Here: 0.51 to 0.67.
 
 **A closed band is a result, not a failure.** It says this term can never be
 separated acoustically for this person. The answer is `floor: off` with a
-`heard:` list of the renderings actually seen, and the name judge behind it.
+`pronunciations:` list of the renderings actually seen, and the name judge
+behind it. Those renderings are not only rules: each one's *sound* is
+registered with the spotter under the term's name, so a closed band still gets
+an acoustic path — it just gets it from the rendering instead of the term.
 Report it that way — a user told "no threshold works, here is the rule
 instead" has learned something; a user handed a number that quietly damages
 their transcripts has not.
@@ -109,7 +112,8 @@ yours and not the script's.
   French sentences and English sentences fail differently, and mixing them
   into one list hides that.
 
-Write a manifest beside them:
+Write a manifest at `voice/calibration.json`, beside the config — the same
+directory `PARROTFLOW_CONFIG_DIR` moves:
 
 ```json
 {"sentences": [
@@ -125,10 +129,16 @@ dictation each.
 
 ## Step 3 — score
 
-    scripts/calibrate.py score calibration.json
+    scripts/calibrate.py score            # reads voice/calibration.json
 
 It pairs the last N recordings with the N sentences by order, re-decodes each
-with the vocabulary off, and reports the band per term.
+with the vocabulary off, and reports the band per term. It also writes the
+bands to `voice/calibration.yaml`, so the next person to ask why a term is
+`floor: off` does not have to make anybody read forty sentences again.
+
+`voice/` is where everything measured from this person's voice lives —
+`observations.jsonl`, `calibration.yaml`, `samples/`. None of it goes into a
+git repository.
 
 **Pairing by order breaks when someone re-reads a line**, so it checks that
 half the sentence's words actually turned up before trusting a clip, and
@@ -163,12 +173,19 @@ The `terms:` block for `vocabulary.yaml`, which sits beside `config.yaml`:
 ```yaml
 terms:
   Vercel:
-    heard: [Versailles]    # 0.40 — below any threshold
+    pronunciations:
+      - heard: Versailles  # 0.40 — below any threshold
+        from: calibration
   Tasmeen:                 # band 0.55 .. 0.71, nothing to say
   Praisy:
     floor: off             # no band: "praise" landed at 0.83, closer than
-    heard: [Prissy]        # this speaker's own renderings
+    pronunciations:        # this speaker's own renderings
+      - heard: Prissy
+        from: calibration
 ```
+
+`heard: [a, b]` is the old spelling of that list. It still loads, and
+`--check-config` says what to write instead.
 
 No number per term. A measured floor written here still works and still
 applies to that term, but `--check-config` calls it legacy: the setting is

--- a/.claude/skills/vocabulary-corpus/SKILL.md
+++ b/.claude/skills/vocabulary-corpus/SKILL.md
@@ -292,9 +292,9 @@ And beside it, three short lists:
 
 - **Rejected, with the reason.** `Praisy` — "praise" at 0.83. `Sentry` —
   "entry" at 0.83. These go in with `floor: off` and a `pronunciations:` list
-  of renderings actually seen, so the term's own spelling is never matched by
-  sound and the renderings still are. Give the reason, or someone re-adds them
-  next month.
+  of renderings actually seen. `floor: off` turns sound matching off for the
+  whole term, renderings included, so those are exact rules and the judge reads
+  the sentence. Give the reason, or someone re-adds them next month.
 - **Already fine.** The terms the decoder writes correctly. Same reason.
 - **Read these aloud.** The step 5 sentences.
 

--- a/.claude/skills/vocabulary-corpus/SKILL.md
+++ b/.claude/skills/vocabulary-corpus/SKILL.md
@@ -65,7 +65,7 @@ them means nothing to argue about.
     Arexvy     nothing within 0.67
 
 **Names that collide with ordinary words.** No threshold works. Use
-`floor: off` and a `heard:` list instead.
+`floor: off` and a `pronunciations:` list instead.
 
     Praisy   vs "praise"    0.83   and they sound alike, so no gate saves it
     Sentry   vs "entry"     0.83
@@ -211,7 +211,7 @@ Then:
 
 - **Nearest ordinary word at 0.85 or above** — no threshold works. None both
   catches the term's mishearings and excludes that word. Ship it as
-  `floor: off` with a `heard:` list, and let the rule put it on the menu and
+  `floor: off` with a `pronunciations:` list, and let it put the term on the menu and
   the sentence decide.
 - **Otherwise** — plain entry. Nothing to write but the name.
 - **Check two-word phrases as well as single words.** This is the hole that
@@ -267,8 +267,17 @@ terms:
   Tasmeen:              # nothing within 0.71
   Matthieu:
     floor: off          # "Matthew" is 0.75 and sounds the same
-    heard: [Mathieu, Matthew]
+    pronunciations:
+      - heard: Mathieu
+        from: correction
+      - heard: Matthew
+        from: correction
 ```
+
+A rendering is matched exactly as a rule *and* searched for by sound under its
+term's name, which is what reaches a name no threshold can — `Versailles` is
+0.40 from `Vercel`. `heard: [a, b]` is the old spelling of the same list; it
+still loads, and `--check-config` says what to write instead.
 
 An empty entry is the normal one. The two numbers at the top are the file's,
 not a term's, and they ship untuned — leave them alone unless you have
@@ -282,9 +291,10 @@ leaving the header looking ignored.
 And beside it, three short lists:
 
 - **Rejected, with the reason.** `Praisy` — "praise" at 0.83. `Sentry` —
-  "entry" at 0.83. These go in with `floor: off` and a `heard:` list of
-  renderings actually seen, so sound matching is off for them and nothing
-  else. Give the reason, or someone re-adds them next month.
+  "entry" at 0.83. These go in with `floor: off` and a `pronunciations:` list
+  of renderings actually seen, so the term's own spelling is never matched by
+  sound and the renderings still are. Give the reason, or someone re-adds them
+  next month.
 - **Already fine.** The terms the decoder writes correctly. Same reason.
 - **Read these aloud.** The step 5 sentences.
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -156,3 +156,10 @@ jobs:
       # only right in the app is a door that checks less than the other one.
       - name: Both install paths pin the same certificate
         run: scripts/check-pinned-certificate.sh
+
+      # One person's voice is not source. `.gitignore` stops `git add .` and
+      # nothing else — not `-f`, not a file tracked before the rule existed,
+      # not a rebase from the frozen prototype branch, which does carry the
+      # recordings. This checks what git tracks.
+      - name: No speaker audio in the repository
+        run: scripts/check-no-voice.sh

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,16 @@ dist/
 # The runner imports examples/code_identifiers.py, which leaves this behind.
 __pycache__/
 
+# One person's voice, and the table mined out of it. It lives in `voice/`
+# beside the config now — see Sources/ParrotFlow/VoiceStore.swift — and these
+# two paths are where it used to be written. Kept here because a rebase onto an
+# older branch, or an old copy of scripts/mine-pronunciations.py, still puts it
+# there, and `git add .` would then commit somebody's colleagues' names being
+# read aloud. `scripts/check-no-voice.sh` is the half that has teeth.
+tests/acoustic/
+tests/pronunciations.yaml
+voice/
+
 # Where Claude Code puts a git worktree it makes: a checkout of this repository,
 # inside this repository. Untracked it turns every `git status` into a warning
 # about a directory that is already under version control by another route.

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -107,6 +107,23 @@ enum CheckConfigCommand {
             print("        default: [\(Pipeline.everything.stages.map(\.name).joined(separator: ", "))]")
         }
 
+        // What `voice/` has piled up, per term. Printed because it is the one
+        // part of the configuration that grows on its own: nobody chose these
+        // numbers and nobody sees them until something goes wrong. Silent when
+        // the directory does not exist, which is every install that has not
+        // learnt anything yet.
+        let recorded = VoiceStore.counts()
+        if !recorded.isEmpty {
+            print("  · voice             \(recorded.count) term(s) in"
+                + " \(VoiceStore.directory.path)")
+            let width = recorded.map(\.term.count).max() ?? 0
+            for entry in recorded {
+                print("      \(entry.term.padding(toLength: width, withPad: " ", startingAt: 0))"
+                    + "  \(entry.observations) observation(s), \(entry.samples) sample(s)"
+                    + "  — `--forget \(entry.term)` drops both")
+            }
+        }
+
         // Where each body actually came from.
         //
         // A file present both in the folder and at the old location beside

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -123,6 +123,16 @@ enum CheckConfigCommand {
                     + "  — `--forget \(entry.term)` drops both")
             }
         }
+        // A closed band is the one measurement that argues with the config: it
+        // says no threshold will ever separate that term for this speaker,
+        // whatever `offer_below` is set to.
+        if let bands = VoiceStore.calibration() {
+            print("  · calibration       measured \(bands.measured), \(bands.terms) term(s)"
+                + (bands.closed > 0
+                    ? ", \(bands.closed) with no band — those want `floor: off`"
+                        + " and pronunciations, not a number"
+                    : ""))
+        }
 
         // Where each body actually came from.
         //

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -249,8 +249,14 @@ struct Config: Decodable, Equatable {
             /// A legacy per-term `floor:` number, read as this term's
             /// `offer_below`. Nil means the file-level one applies.
             var offerBelow: Float?
-            /// `floor: off` — never matched by sound as a spelling, only
-            /// through its pronunciations.
+            /// `floor: off` — never matched by sound at all, by its own
+            /// spelling or through its pronunciations. Its renderings are
+            /// exact rules and nothing else, because a rendering is registered
+            /// under the term's name and a term with `floor: off` has no entry
+            /// for the spotter to report. That is the intended reading:
+            /// "Claude" and "cloud" come back identical because they *sound*
+            /// identical, so the audio separates them no better than the
+            /// spelling does.
             var never = false
             var pronunciations: [Pronunciation] = []
             /// True when the list arrived under the old `heard:` key, so

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -144,6 +144,92 @@ struct Config: Decodable, Equatable {
         /// untuned.
         var decideAbove: Float = 3.0
 
+        /// One way this speaker's mouth turns a term into something else, and
+        /// what is known about that.
+        ///
+        /// A rendering used to be a bare string in a `heard:` list, which said
+        /// only that somebody once saw it. That is not enough to decide
+        /// anything with. A rendering seen once and never again is noise; one
+        /// seen nine times is how this person says the word. `seen` makes that
+        /// difference decidable, and `from` says who put it there, so an entry
+        /// mined from the archive can be told from one a person confirmed by
+        /// correcting a transcript.
+        ///
+        /// Nothing mechanical reads `seen` or `from` yet. They are recorded
+        /// here so PR 8 has something to cap and prune on; a count that starts
+        /// being kept the day it is first used starts at zero for every entry
+        /// that already existed.
+        struct Pronunciation: Decodable, Equatable {
+            /// Where an entry came from. `legacy` is not a source, it is the
+            /// absence of one: a bare `heard:` list, or a `pronunciations:`
+            /// entry written without `from:`, records nothing about its own
+            /// provenance and says so rather than guessing.
+            enum Source: String, Decodable, Equatable {
+                case correction
+                case mined
+                case calibration
+                case legacy
+            }
+
+            /// The spelling the decoder produced where the term was said.
+            var heard: String
+            /// How many times it has been seen. Zero means never counted,
+            /// which is every entry written before this key existed.
+            var seen: Int = 0
+            var from: Source = .legacy
+            /// A free line for a person: why this entry is here, or what it
+            /// costs. Never parsed.
+            var note: String?
+            /// What `from:` said, when it said something this does not know.
+            /// Kept rather than dropped so `notices()` can name it — a label
+            /// nobody can read is worth one line, once, rather than silence.
+            var unreadableFrom: String?
+
+            init(
+                heard: String, seen: Int = 0, from: Source = .legacy,
+                note: String? = nil, unreadableFrom: String? = nil
+            ) {
+                self.heard = heard
+                self.seen = seen
+                self.from = from
+                self.note = note
+                self.unreadableFrom = unreadableFrom
+            }
+
+            enum CodingKeys: String, CodingKey { case heard, seen, from, note }
+
+            /// Two shapes. The mapping is what the app writes; the bare string
+            /// is what a person types when they have nothing else to say:
+            ///
+            ///     - heard: Versailles
+            ///       seen: 3
+            ///       from: mined
+            ///     - Versal
+            init(from decoder: Decoder) throws {
+                if let single = try? decoder.singleValueContainer(),
+                   let word = try? single.decode(String.self) {
+                    self.init(heard: word)
+                    return
+                }
+                let c = try decoder.container(keyedBy: CodingKeys.self)
+                let word = try c.decode(String.self, forKey: .heard)
+                // An unreadable `from:` is read as `legacy` rather than
+                // refused. It is a label on a rendering, and losing the
+                // rendering over a typo in its label would cost the thing that
+                // works to protect the thing that does not do anything yet.
+                let source = (try? c.decodeIfPresent(String.self, forKey: .from))
+                    .flatMap { $0 }
+                let read = source.flatMap(Source.init(rawValue:))
+                self.init(
+                    heard: word,
+                    seen: (try? c.decodeIfPresent(Int.self, forKey: .seen)).flatMap { $0 } ?? 0,
+                    from: read ?? .legacy,
+                    note: try c.decodeIfPresent(String.self, forKey: .note),
+                    unreadableFrom: read == nil ? source : nil
+                )
+            }
+        }
+
         /// One term, and what is known about it.
         ///
         /// `floor: off` means never match by sound at all — the honest setting
@@ -155,31 +241,46 @@ struct Config: Decodable, Equatable {
         /// A *number* under `floor:` is legacy. It is still honoured, as this
         /// term's `offer_below`, and `--check-config` says so.
         ///
-        /// `heard` is for renderings no number can reach. "Prezi" is 0.33 from
-        /// "Praisy" and would need a floor that swallowed every "praise"; as an
-        /// exact rule it costs nothing and cannot misfire.
+        /// `pronunciations` is for renderings no number can reach. "Prezi" is
+        /// 0.33 from "Praisy" and would need a floor that swallowed every
+        /// "praise". As an exact rule it costs nothing and cannot misfire, and
+        /// `Vocabulary.prepare` also hands its sound to the CTC spotter.
         struct Term: Decodable, Equatable {
             /// A legacy per-term `floor:` number, read as this term's
             /// `offer_below`. Nil means the file-level one applies.
             var offerBelow: Float?
-            /// `floor: off` — never matched by sound, only by `heard`.
+            /// `floor: off` — never matched by sound as a spelling, only
+            /// through its pronunciations.
             var never = false
-            var heard: [String] = []
+            var pronunciations: [Pronunciation] = []
+            /// True when the list arrived under the old `heard:` key, so
+            /// `notices()` can name the key and say what to write instead.
+            var wroteHeard = false
 
-            init(offerBelow: Float? = nil, never: Bool = false, heard: [String] = []) {
+            /// Just the renderings, for the callers that only want the
+            /// spellings — the exact rules, and the "can anything reach this
+            /// term at all" check in `notices()`.
+            var heard: [String] { pronunciations.map(\.heard) }
+
+            init(
+                offerBelow: Float? = nil, never: Bool = false,
+                pronunciations: [Pronunciation] = [], wroteHeard: Bool = false
+            ) {
                 self.offerBelow = offerBelow
                 self.never = never
-                self.heard = heard
+                self.pronunciations = pronunciations
+                self.wroteHeard = wroteHeard
             }
 
-            enum CodingKeys: String, CodingKey { case floor, heard }
+            enum CodingKeys: String, CodingKey { case floor, heard, pronunciations }
 
-            /// Four shapes, because most terms need none of this:
+            /// Five shapes, because most terms need none of this:
             ///
             ///     Tasmeen:                              nothing to say
             ///     Mirza: 0.85                           a legacy floor
-            ///     Praisy: [Prissy, Pressy]              renderings
-            ///     Claude: {floor: off, heard: [cloud]}  both
+            ///     Praisy: [Prissy, Pressy]              renderings, legacy
+            ///     Claude: {floor: off, heard: [cloud]}  renderings, legacy
+            ///     Vercel: {pronunciations: [...]}       renderings, with counts
             init(from decoder: Decoder) throws {
                 if let single = try? decoder.singleValueContainer() {
                     if single.decodeNil() { self.init(); return }
@@ -187,11 +288,22 @@ struct Config: Decodable, Equatable {
                         self.init(offerBelow: number); return
                     }
                     if let listed = try? single.decode([String].self) {
-                        self.init(heard: listed); return
+                        self.init(
+                            pronunciations: listed.map { Pronunciation(heard: $0) },
+                            wroteHeard: true
+                        )
+                        return
                     }
                 }
                 let c = try decoder.container(keyedBy: CodingKeys.self)
-                let heard = try c.decodeIfPresent([String].self, forKey: .heard) ?? []
+                // The old key first, so a file carrying both keeps every
+                // rendering it has. They are the same list with different
+                // amounts known about each entry, and losing one because the
+                // other exists is how a migration eats data.
+                let old = try c.decodeIfPresent([String].self, forKey: .heard) ?? []
+                let listed = try c.decodeIfPresent([Pronunciation].self, forKey: .pronunciations) ?? []
+                let said = old.map { Pronunciation(heard: $0) } + listed
+                let wroteHeard = !old.isEmpty
                 // Number first. Yams answers `Bool.self` for `0.85` quite
                 // happily — anything that is not `true`/`yes`/`on` decodes as
                 // `false` — so asking about `off` before asking about the
@@ -202,7 +314,7 @@ struct Config: Decodable, Equatable {
                 // The reverse trap does not exist. `off` is not a number, so
                 // asking for a Float first throws and falls through.
                 if let number = (try? c.decodeIfPresent(Float.self, forKey: .floor)) ?? nil {
-                    self.init(offerBelow: number, heard: heard)
+                    self.init(offerBelow: number, pronunciations: said, wroteHeard: wroteHeard)
                     return
                 }
                 // `off` rather than a magic number. The previous spelling was
@@ -213,14 +325,20 @@ struct Config: Decodable, Equatable {
                 // `false`, and reading it only as a string threw, which took
                 // the whole file down silently.
                 if let flag = (try? c.decodeIfPresent(Bool.self, forKey: .floor)) ?? nil {
-                    self.init(offerBelow: nil, never: flag == false, heard: heard)
+                    self.init(
+                        offerBelow: nil, never: flag == false,
+                        pronunciations: said, wroteHeard: wroteHeard
+                    )
                     return
                 }
                 if let word = (try? c.decodeIfPresent(String.self, forKey: .floor)) ?? nil {
-                    self.init(offerBelow: nil, never: word.lowercased() == "off", heard: heard)
+                    self.init(
+                        offerBelow: nil, never: word.lowercased() == "off",
+                        pronunciations: said, wroteHeard: wroteHeard
+                    )
                     return
                 }
-                self.init(offerBelow: nil, heard: heard)
+                self.init(offerBelow: nil, pronunciations: said, wroteHeard: wroteHeard)
             }
         }
 
@@ -325,6 +443,35 @@ struct Config: Decodable, Equatable {
                     + " `floor: off` is unaffected and still means never"
                     + " matched by sound")
             }
+
+            // `heard:` is the old key for the same list. It still loads, every
+            // rendering still works, and each one now also searches the audio
+            // — but a bare string records nothing about itself, so a file that
+            // only has those cannot say which entries are worth keeping.
+            let wroteHeard = terms.filter { $0.value.wroteHeard }.keys.sorted()
+            if !wroteHeard.isEmpty {
+                legacy.append("a `heard:` list on"
+                    + " \(wroteHeard.joined(separator: ", ")) is legacy — the"
+                    + " renderings still work and are now searched for by sound"
+                    + " too, but the setting is `pronunciations:`, a list of"
+                    + " `- heard:` entries each with `seen:` and `from:`"
+                    + " (correction, mined or calibration)")
+            }
+
+            // A `from:` nobody can read. Not refused — it labels a rendering
+            // rather than doing anything, and dropping the rendering over its
+            // label would cost the part that works.
+            let mislabelled = terms
+                .flatMap { name, entry in
+                    entry.pronunciations.compactMap { said in
+                        said.unreadableFrom.map { "\(name)/\(said.heard): `from: \($0)`" }
+                    }
+                }
+                .sorted()
+            if !mislabelled.isEmpty {
+                legacy.append("\(mislabelled.joined(separator: ", ")) — not one of"
+                    + " correction, mined, calibration, so it is read as legacy")
+            }
         }
 
         /// What a similarity may be. FluidAudio's metric is normalised, so
@@ -355,12 +502,36 @@ struct Config: Decodable, Equatable {
     /// The exact rules the vocabulary file contributes. Flattened the same way
     /// `transcription.replacements` is, so the substitution pass takes both and
     /// never needs to know which file a rule came from.
+    ///
+    /// Every pronunciation is still a rule as well as a sound. The two catch
+    /// different things — a rule fires on a spelling wherever it appears, the
+    /// spotter fires where the audio agrees — and dropping the rules would
+    /// change what the pipeline sees on every clip. It is a measurement of its
+    /// own, not a side effect of adding the sound.
     var vocabularyRules: [Transcription.Rule] {
         vocabulary.terms
             .flatMap { term, entry in
                 entry.heard.map { Transcription.Rule(source: $0, replacement: term) }
             }
             .sorted { $0.source < $1.source }
+    }
+
+    /// The pronunciations that will be searched for in the audio, with the
+    /// term each one reports.
+    ///
+    /// Only for terms the pass already searches for. A pronunciation is
+    /// registered under its *term's* name, so one attached to a term that has
+    /// no entry of its own would make the spotter report a term with no token
+    /// count, no floor and no place in `vocabularyTerms` — a finding nothing
+    /// downstream can price. That is the real rule behind the prototype's
+    /// silent `name.count >= 5` skip, which was the same test written as a
+    /// number.
+    var vocabularyPronunciations: [(term: String, heard: String)] {
+        let searched = Set(vocabularyTerms.map(\.text))
+        return vocabulary.terms
+            .filter { searched.contains($0.key) }
+            .flatMap { name, entry in entry.pronunciations.map { (term: name, heard: $0.heard) } }
+            .sorted { ($0.term, $0.heard) < ($1.term, $1.heard) }
     }
 
     /// One entry of `transforms:` as it is written, before it is known to be
@@ -1633,14 +1804,32 @@ struct Config: Decodable, Equatable {
             }
             if !vocabulary.acoustic, !byEar.isEmpty {
                 said.append("vocabulary: `acoustic: false`, so \(byEar.count) names"
-                    + " are only matched by their `heard` rules")
+                    + " are only matched by their pronunciation rules")
+            }
+            // How many renderings reach the spotter, and how many are rules
+            // only. The second number is the one nobody expects: a rendering
+            // travels into the audio search under its term's name, so a term
+            // the pass does not search for has nothing to report it as.
+            let heard = vocabularyPronunciations
+            let mute = rules - heard.count
+            if vocabulary.acoustic, rules > 0 {
+                var both: [String] = []
+                if !heard.isEmpty {
+                    both.append("\(heard.count) pronunciation(s) searched for by sound"
+                        + " as well as matched exactly")
+                }
+                if mute > 0 {
+                    both.append("\(mute) matched exactly only — their term is not"
+                        + " searched for by sound, so nothing could report them")
+                }
+                said.append("vocabulary: " + both.joined(separator: ", "))
             }
             let silent = vocabulary.terms
-                .filter { $0.value.never && $0.value.heard.isEmpty }
+                .filter { $0.value.never && $0.value.pronunciations.isEmpty }
                 .keys.sorted()
             if !silent.isEmpty {
                 said.append("vocabulary: \(silent.joined(separator: ", ")) —"
-                    + " `floor: off` and no `heard`, so nothing can match them")
+                    + " `floor: off` and no pronunciations, so nothing can match them")
             }
         }
         // Said whether or not there are terms: a file can carry the old
@@ -1800,10 +1989,15 @@ enum ConfigStore {
     #
     # Per term:
     #
-    #   heard   renderings no number can reach, matched exactly.
-    #   floor   `off` — never match this term by sound, only by `heard`. For a
-    #           term the recogniser writes identically to an ordinary word,
-    #           where no number helps.
+    #   pronunciations  the ways this term actually comes out of the recogniser.
+    #                   Each is matched exactly as a rule, and its sound is
+    #                   searched for in the audio — which is how a rendering no
+    #                   number can reach still finds its term. `seen:` counts
+    #                   how often it has turned up, `from:` says who put it
+    #                   there: correction, mined or calibration.
+    #   floor           `off` — never match this term by its spelling, only by
+    #                   its pronunciations. For a term the recogniser writes
+    #                   identically to an ordinary word, where no number helps.
 
     # Matching by sound needs a ~98 MB model, pulled on first use.
     acoustic: false
@@ -1813,10 +2007,18 @@ enum ConfigStore {
     terms: {}
     #  Tasmeen:                     # nothing close in your speech
     #  Praisy:
-    #    heard: [Prissy, Pressy]    # "Prezi" is 0.33 away — no number reaches it
+    #    pronunciations:            # "Prezi" is 0.33 away — no number reaches it
+    #      - heard: Prissy
+    #        seen: 6
+    #        from: mined
+    #      - heard: Pressy
+    #        seen: 4
+    #        from: mined
     #  Claude:
     #    floor: off                 # "cloud" both ways — no number works
-    #    heard: [cloud]
+    #    pronunciations:
+    #      - heard: cloud
+    #        from: correction
 
     """
 

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -302,12 +302,12 @@ struct Config: Decodable, Equatable {
                     }
                 }
                 let c = try decoder.container(keyedBy: CodingKeys.self)
-                // The old key first, so a file carrying both keeps every
-                // rendering it has. They are the same list with different
-                // amounts known about each entry, and losing one because the
-                // other exists is how a migration eats data.
                 let old = try c.decodeIfPresent([String].self, forKey: .heard) ?? []
                 let listed = try c.decodeIfPresent([Pronunciation].self, forKey: .pronunciations) ?? []
+                // Both keys, joined. They are the same list with different
+                // amounts known about each entry, and dropping one because the
+                // other exists is how a migration eats data.
+                //
                 // The new key first, so a rendering written both ways keeps the
                 // entry that knows something about itself. Registered twice it
                 // would be two search targets for one sound, and a term's
@@ -463,18 +463,20 @@ struct Config: Decodable, Equatable {
                     + " matched by sound")
             }
 
-            // `heard:` is the old key for the same list. It still loads, every
-            // rendering still works, and each one now also searches the audio
-            // — but a bare string records nothing about itself, so a file that
-            // only has those cannot say which entries are worth keeping.
+            // `heard:` is the old key for the same list, and so is a bare list
+            // written under the term. Both still load and every rendering still
+            // works. What they cannot do is say anything about an entry: a bare
+            // string records no count and no provenance, so a file made only of
+            // those cannot decide which entries are worth keeping. The line
+            // above already says how many are searched for by sound, so this one
+            // does not repeat it.
             let wroteHeard = terms.filter { $0.value.wroteHeard }.keys.sorted()
             if !wroteHeard.isEmpty {
                 legacy.append("renderings on \(wroteHeard.joined(separator: ", "))"
                     + " are written the old way — a `heard:` list, or a bare list"
-                    + " under the term. They still work and are now searched for"
-                    + " by sound too, but the setting is `pronunciations:`, a list"
-                    + " of `- heard:` entries each with `seen:` and `from:`"
-                    + " (correction, mined or calibration)")
+                    + " under the term. They still work. The setting is"
+                    + " `pronunciations:`, a list of `- heard:` entries each with"
+                    + " `seen:` and `from:` (correction, mined or calibration)")
             }
 
             // A `from:` nobody can read. Not refused — it labels a rendering

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -302,7 +302,12 @@ struct Config: Decodable, Equatable {
                 // other exists is how a migration eats data.
                 let old = try c.decodeIfPresent([String].self, forKey: .heard) ?? []
                 let listed = try c.decodeIfPresent([Pronunciation].self, forKey: .pronunciations) ?? []
-                let said = old.map { Pronunciation(heard: $0) } + listed
+                // The new key first, so a rendering written both ways keeps the
+                // entry that knows something about itself. Registered twice it
+                // would be two search targets for one sound, and a term's
+                // spotter score is the best of its targets — a duplicate is a
+                // free extra draw.
+                let said = Self.distinct(listed + old.map { Pronunciation(heard: $0) })
                 let wroteHeard = !old.isEmpty
                 // Number first. Yams answers `Bool.self` for `0.85` quite
                 // happily — anything that is not `true`/`yes`/`on` decodes as
@@ -339,6 +344,14 @@ struct Config: Decodable, Equatable {
                     return
                 }
                 self.init(offerBelow: nil, pronunciations: said, wroteHeard: wroteHeard)
+            }
+
+            /// One entry per spelling, first kept. Exact rather than
+            /// case-insensitive: "Versal" and "versal" tokenise differently and
+            /// are two renderings, not one written twice.
+            private static func distinct(_ said: [Pronunciation]) -> [Pronunciation] {
+                var seen: Set<String> = []
+                return said.filter { seen.insert($0.heard).inserted }
             }
         }
 

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -450,11 +450,11 @@ struct Config: Decodable, Equatable {
             // only has those cannot say which entries are worth keeping.
             let wroteHeard = terms.filter { $0.value.wroteHeard }.keys.sorted()
             if !wroteHeard.isEmpty {
-                legacy.append("a `heard:` list on"
-                    + " \(wroteHeard.joined(separator: ", ")) is legacy — the"
-                    + " renderings still work and are now searched for by sound"
-                    + " too, but the setting is `pronunciations:`, a list of"
-                    + " `- heard:` entries each with `seen:` and `from:`"
+                legacy.append("renderings on \(wroteHeard.joined(separator: ", "))"
+                    + " are written the old way — a `heard:` list, or a bare list"
+                    + " under the term. They still work and are now searched for"
+                    + " by sound too, but the setting is `pronunciations:`, a list"
+                    + " of `- heard:` entries each with `seen:` and `from:`"
                     + " (correction, mined or calibration)")
             }
 

--- a/Sources/ParrotFlow/ConfigWriter.swift
+++ b/Sources/ParrotFlow/ConfigWriter.swift
@@ -284,7 +284,16 @@ enum ConfigWriter {
         var text = value.trimmingCharacters(in: .whitespaces)
         if text.count >= 2, text.hasPrefix("\""), text.hasSuffix("\"") {
             text = String(text.dropFirst().dropLast())
-            text = text.replacingOccurrences(of: "\\\"", with: "\"")
+            return text.replacingOccurrences(of: "\\\"", with: "\"")
+        }
+        // YAML's other quote, and it is not decoration: `'Praisy':` is a legal
+        // key, so a reader that only knows double quotes fails to find the term
+        // and `--forget` deletes the audio while leaving the pronunciations
+        // running. A single-quoted scalar escapes its own quote by doubling it,
+        // and has no backslash escapes at all.
+        if text.count >= 2, text.hasPrefix("'"), text.hasSuffix("'") {
+            text = String(text.dropFirst().dropLast())
+            return text.replacingOccurrences(of: "''", with: "'")
         }
         return text
     }

--- a/Sources/ParrotFlow/ConfigWriter.swift
+++ b/Sources/ParrotFlow/ConfigWriter.swift
@@ -108,6 +108,135 @@ enum ConfigWriter {
         return lines.joined(separator: "\n")
     }
 
+    // MARK: - Forgetting a term's pronunciations
+
+    /// Removes every rendering recorded for `term` from `vocabulary.yaml`.
+    ///
+    /// The term itself stays. Forgetting is about the learnt half — the
+    /// spellings and the audio that piled up behind a name — and a person who
+    /// wanted the name gone would delete the name.
+    ///
+    /// Text-level, for the same reason `insert` is: this file carries a long
+    /// header explaining what its numbers mean, and a round trip through Yams
+    /// would throw all of it away.
+    static func forgetPronunciations(of term: String) throws -> Int {
+        let url = ConfigStore.vocabularyURL
+        guard let original = try? String(contentsOf: url, encoding: .utf8) else { return 0 }
+        let (updated, removed) = dropping(pronunciationsOf: term, from: original)
+        if removed > 0 {
+            try updated.write(to: url, atomically: true, encoding: .utf8)
+        }
+        return removed
+    }
+
+    /// The file with one term's renderings taken out, and how many went.
+    ///
+    /// Three shapes have to be handled, because the file has been written three
+    /// ways: the shorthand `Praisy: [Prissy, Pressy]`, the old
+    /// `heard: [Prissy, Pressy]` — which spans lines in the file this was
+    /// written against — and a `pronunciations:` block of `- heard:` entries.
+    static func dropping(
+        pronunciationsOf term: String, from yaml: String
+    ) -> (String, Int) {
+        var lines = yaml.components(separatedBy: "\n")
+        guard let termsIndex = lines.firstIndex(where: {
+            $0.trimmingCharacters(in: .whitespaces).hasPrefix("terms:")
+                && !$0.trimmingCharacters(in: .whitespaces).hasPrefix("#")
+        }) else { return (yaml, 0) }
+        let termIndent = indentation(of: lines[termsIndex]).count
+
+        // The term's own line, inside `terms:`.
+        var at: Int?
+        var index = termsIndex + 1
+        while index < lines.count {
+            let line = lines[index]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty || trimmed.hasPrefix("#") { index += 1; continue }
+            if indentation(of: line).count <= termIndent { break }
+            if let colon = trimmed.firstIndex(of: ":"),
+               unquoted(String(trimmed[trimmed.startIndex..<colon]))
+                   .caseInsensitiveCompare(term) == .orderedSame {
+                at = index
+                break
+            }
+            index += 1
+        }
+        guard let start = at else { return (yaml, 0) }
+
+        var removed = 0
+        // `Praisy: [Prissy, Pressy]` — the whole value is the list.
+        let head = lines[start]
+        if let colon = head.firstIndex(of: ":"),
+           head[head.index(after: colon)...].trimmingCharacters(in: .whitespaces).hasPrefix("[") {
+            let end = closingFlow(in: lines, from: start)
+            removed = count(inFlow: lines[start...end].joined(separator: " "))
+            lines.replaceSubrange(start...end, with: [String(head[head.startIndex...colon])])
+            return (lines.joined(separator: "\n"), removed)
+        }
+
+        // A block body: find `heard:` or `pronunciations:` inside it.
+        let bodyIndent = indentation(of: lines[start]).count
+        var cursor = start + 1
+        var cut: [Range<Int>] = []
+        while cursor < lines.count {
+            let line = lines[cursor]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty { cursor += 1; continue }
+            if indentation(of: line).count <= bodyIndent { break }
+            if trimmed.hasPrefix("heard:") || trimmed.hasPrefix("pronunciations:") {
+                let keyIndent = indentation(of: line).count
+                var end = closingFlow(in: lines, from: cursor)
+                removed += count(inFlow: lines[cursor...end].joined(separator: " "))
+                // A block sequence continues under the key rather than on it.
+                var below = end + 1
+                while below < lines.count {
+                    let next = lines[below]
+                    let bare = next.trimmingCharacters(in: .whitespaces)
+                    if bare.isEmpty { below += 1; continue }
+                    if indentation(of: next).count <= keyIndent { break }
+                    if bare.hasPrefix("- ") || bare.hasPrefix("-\t") || bare == "-" { removed += 1 }
+                    end = below
+                    below += 1
+                }
+                cut.append(cursor..<(end + 1))
+                cursor = end + 1
+                continue
+            }
+            cursor += 1
+        }
+        for range in cut.reversed() { lines.removeSubrange(range) }
+        return (lines.joined(separator: "\n"), removed)
+    }
+
+    /// The last line of a flow sequence that starts on `from`. The live file
+    /// wraps one over two lines, and cutting only the first leaves the tail
+    /// behind as invalid YAML.
+    private static func closingFlow(in lines: [String], from: Int) -> Int {
+        var depth = 0
+        var index = from
+        while index < lines.count {
+            for character in lines[index] {
+                if character == "[" { depth += 1 }
+                if character == "]" { depth -= 1 }
+            }
+            if depth <= 0 { return index }
+            index += 1
+        }
+        return lines.count - 1
+    }
+
+    /// How many entries a flow sequence holds. Only used to report a number, so
+    /// an empty list and a missing one both count as nothing.
+    private static func count(inFlow text: String) -> Int {
+        guard let open = text.firstIndex(of: "["), let close = text.lastIndex(of: "]"),
+              open < close else { return 0 }
+        let inside = text[text.index(after: open)..<close]
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        return inside.count
+    }
+
     // MARK: - Helpers
 
     private static func endOfBlock(in lines: [String], from start: Int) -> Int {

--- a/Sources/ParrotFlow/ConfigWriter.swift
+++ b/Sources/ParrotFlow/ConfigWriter.swift
@@ -168,7 +168,7 @@ enum ConfigWriter {
         let head = lines[start]
         if let colon = head.firstIndex(of: ":"),
            head[head.index(after: colon)...].trimmingCharacters(in: .whitespaces).hasPrefix("[") {
-            let end = closingFlow(in: lines, from: start)
+            let end = closingFlow(in: lines, from: start, deeperThan: termIndent)
             removed = count(inFlow: lines[start...end].joined(separator: " "))
             lines.replaceSubrange(start...end, with: [String(head[head.startIndex...colon])])
             return (lines.joined(separator: "\n"), removed)
@@ -185,7 +185,7 @@ enum ConfigWriter {
             if indentation(of: line).count <= bodyIndent { break }
             if trimmed.hasPrefix("heard:") || trimmed.hasPrefix("pronunciations:") {
                 let keyIndent = indentation(of: line).count
-                var end = closingFlow(in: lines, from: cursor)
+                var end = closingFlow(in: lines, from: cursor, deeperThan: keyIndent)
                 removed += count(inFlow: lines[cursor...end].joined(separator: " "))
                 // A block sequence continues under the key rather than on it.
                 var below = end + 1
@@ -211,10 +211,18 @@ enum ConfigWriter {
     /// The last line of a flow sequence that starts on `from`. The live file
     /// wraps one over two lines, and cutting only the first leaves the tail
     /// behind as invalid YAML.
-    private static func closingFlow(in lines: [String], from: Int) -> Int {
+    ///
+    /// Bounded by indentation as well as by the brackets. An unclosed `[` is a
+    /// file that would not have loaded, and a scan that runs to the end of it
+    /// would delete everything after the mistake rather than nothing.
+    private static func closingFlow(in lines: [String], from: Int, deeperThan indent: Int) -> Int {
         var depth = 0
         var index = from
         while index < lines.count {
+            if index > from, !lines[index].trimmingCharacters(in: .whitespaces).isEmpty,
+               indentation(of: lines[index]).count <= indent {
+                return index - 1
+            }
             for character in lines[index] {
                 if character == "[" { depth += 1 }
                 if character == "]" { depth -= 1 }

--- a/Sources/ParrotFlow/ForgetCommand.swift
+++ b/Sources/ParrotFlow/ForgetCommand.swift
@@ -29,7 +29,12 @@ enum ForgetCommand {
             print("  \(renderings) pronunciation(s) from"
                 + " \(ConfigStore.vocabularyURL.lastPathComponent)")
             print("  \(gone.observations) observation(s) from voice/observations.jsonl")
-            print("  \(gone.samples) sample(s) from voice/samples/\(name)/")
+            // The folder as it is spelled on disk, not as it was typed. The
+            // match is case-insensitive, so `--forget praisy` has to be told
+            // that `samples/Praisy/` is what went.
+            let from = gone.folders.isEmpty
+                ? "voice/samples/" : gone.folders.map { "voice/samples/\($0)/" }.joined(separator: ", ")
+            print("  \(gone.samples) sample(s) from \(from)")
             Log.write("forget: \(name) — \(renderings) pronunciation(s),"
                 + " \(gone.observations) observation(s), \(gone.samples) sample(s)")
             return 0

--- a/Sources/ParrotFlow/ForgetCommand.swift
+++ b/Sources/ParrotFlow/ForgetCommand.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// `--forget <term>` — everything learnt about how one name sounds, gone.
+///
+/// Three places hold it, and until now none of them had a way out:
+/// `vocabulary.yaml` holds the renderings, `voice/observations.jsonl` holds
+/// every time one was seen, and `voice/samples/<Term>/` holds the audio. Data
+/// that only accumulates is data nobody can correct — a rendering learnt from
+/// one bad clip goes on shaping the search forever, and the only remedy was to
+/// edit a file the header tells you not to edit.
+///
+/// The term itself stays. Forgetting is about the learnt half; somebody who
+/// wants the name gone deletes the name.
+enum ForgetCommand {
+    static func run(term: String) -> Int32 {
+        let name = term.trimmingCharacters(in: .whitespaces)
+        guard !name.isEmpty else {
+            print("usage: ParrotFlow --forget <term>")
+            return 2
+        }
+        do {
+            let renderings = try ConfigWriter.forgetPronunciations(of: name)
+            let gone = try VoiceStore.forget(name)
+            if renderings == 0, gone.observations == 0, gone.samples == 0 {
+                print("· nothing recorded for \(name)")
+                return 0
+            }
+            print("✓ forgot \(name)")
+            print("  \(renderings) pronunciation(s) from"
+                + " \(ConfigStore.vocabularyURL.lastPathComponent)")
+            print("  \(gone.observations) observation(s) from voice/observations.jsonl")
+            print("  \(gone.samples) sample(s) from voice/samples/\(name)/")
+            Log.write("forget: \(name) — \(renderings) pronunciation(s),"
+                + " \(gone.observations) observation(s), \(gone.samples) sample(s)")
+            return 0
+        } catch {
+            print("✗ \(error.localizedDescription)")
+            return 1
+        }
+    }
+}

--- a/Sources/ParrotFlow/ForgetCommand.swift
+++ b/Sources/ParrotFlow/ForgetCommand.swift
@@ -18,8 +18,27 @@ enum ForgetCommand {
             print("usage: ParrotFlow --forget <term>")
             return 2
         }
+        // What the decoder can see before and after, not what the text edit
+        // thinks it did. The edit is text-level — it has to be, or the file
+        // loses the header that explains it — and a YAML shape it does not
+        // recognise makes it a no-op. That failure is the dangerous one: the
+        // audio and the observations go, the pronunciations stay, and the
+        // command says it worked. So the check is the same question the app
+        // asks, which no writing trick can answer wrongly.
+        let before = pronunciations(of: name)
         do {
             let renderings = try ConfigWriter.forgetPronunciations(of: name)
+            let after = pronunciations(of: name)
+            if after > 0 {
+                print("✗ \(name) still has \(after) pronunciation(s) in"
+                    + " \(ConfigStore.vocabularyURL.lastPathComponent) and nothing was"
+                    + " removed from it. Nothing else was touched either."
+                    + " Edit the entry by hand, or report the shape of it.")
+                Log.write("forget: \(name) — \(after) pronunciation(s) survived the"
+                    + " edit (\(before) before, \(renderings) reported removed);"
+                    + " voice/ left alone")
+                return 1
+            }
             let gone = try VoiceStore.forget(name)
             if renderings == 0, gone.observations == 0, gone.samples == 0 {
                 print("· nothing recorded for \(name)")
@@ -42,5 +61,15 @@ enum ForgetCommand {
             print("✗ \(error.localizedDescription)")
             return 1
         }
+    }
+
+    /// How many renderings the app would load for this term right now.
+    ///
+    /// Case-insensitive, like everything else here: somebody typing
+    /// `--forget praisy` means the term.
+    private static func pronunciations(of term: String) -> Int {
+        ConfigStore.loadVocabulary().terms
+            .filter { $0.key.caseInsensitiveCompare(term) == .orderedSame }
+            .values.reduce(0) { $0 + $1.pronunciations.count }
     }
 }

--- a/Sources/ParrotFlow/ForgetCommand.swift
+++ b/Sources/ParrotFlow/ForgetCommand.swift
@@ -30,9 +30,16 @@ enum ForgetCommand {
             let renderings = try ConfigWriter.forgetPronunciations(of: name)
             let after = pronunciations(of: name)
             if after > 0 {
+                // Said precisely, because the two cases want different things
+                // of the reader: nothing came out, or some did and the rest is
+                // written in a shape the edit cannot reach.
                 print("✗ \(name) still has \(after) pronunciation(s) in"
-                    + " \(ConfigStore.vocabularyURL.lastPathComponent) and nothing was"
-                    + " removed from it. Nothing else was touched either."
+                    + " \(ConfigStore.vocabularyURL.lastPathComponent)"
+                    + (renderings > 0
+                        ? ", and \(renderings) came out — the rest is written in a shape"
+                            + " this cannot edit."
+                        : " and none came out.")
+                    + " voice/ was left alone."
                     + " Edit the entry by hand, or report the shape of it.")
                 Log.write("forget: \(name) — \(after) pronunciation(s) survived the"
                     + " edit (\(before) before, \(renderings) reported removed);"

--- a/Sources/ParrotFlow/Vocabulary.swift
+++ b/Sources/ParrotFlow/Vocabulary.swift
@@ -403,9 +403,39 @@ actor Vocabulary {
             .flatMap(Float.init) ?? config.vocabulary.decideAbove
     }
 
+    /// How well the spotter has to hear a term before its span is offered.
+    ///
+    /// Raised from -5.5 to -5.0 when pronunciations arrived, and the reason is
+    /// arithmetic rather than taste. A term's spotter score over a span is the
+    /// best of its search targets, so registering fourteen renderings of
+    /// `Praisy` makes it fifteen draws instead of one — every span in every
+    /// clip scores a little higher for that term, including the spans where it
+    /// was never said. The old floor was measured against terms alone and lets
+    /// the extra draws through: on `16-16-25` it admitted `Praisy` over "heard
+    /// by" and "judge", `Ollama` over "idea was to" and `Claude` over
+    /// "decoder", six slots in total, and the judge stage declines past four.
+    /// A clip that was right became a clip with no menu at all.
+    ///
+    /// Measured on `menu-recall.py` with the renderings registered:
+    ///
+    ///     floor   recall   picked
+    ///     -5.5     30/37    27/37    the extra draws cross max_slots
+    ///     -5.2     31/37    26/37
+    ///     -5.0     31/37    27/37    parity, and the plateau starts
+    ///     -4.8     31/37    27/37
+    ///
+    /// -5.0 rather than -4.8 because it is the loose end of the plateau: the
+    /// two score the same here, and the looser one asks less of a speaker whose
+    /// renderings this set does not contain.
+    ///
+    /// -5.0 is not a tightening of what the audio may find. The hit this whole
+    /// PR exists for — `Vercel` over "Versailles" — moves from -5.28 to -2.28
+    /// once the rendering is registered, so it clears either number by a
+    /// distance. What -5.0 cuts is the tail that got there by having more
+    /// draws.
     static var spotterFloor: Float {
         ProcessInfo.processInfo.environment["PARROTFLOW_SPOTTER_FLOOR"]
-            .flatMap(Float.init) ?? -5.5
+            .flatMap(Float.init) ?? -5.0
     }
 
     /// The term as it should be written where this word stood.

--- a/Sources/ParrotFlow/Vocabulary.swift
+++ b/Sources/ParrotFlow/Vocabulary.swift
@@ -58,6 +58,24 @@ actor Vocabulary {
     /// printed says the audio preferred the term when often it did not (F4).
     private var tokenCounts: [String: Int] = [:]
 
+    /// How many real terms are loaded. Not `context.terms.count`, which also
+    /// counts one entry per pronunciation.
+    ///
+    /// F9 called this a live bug: pronunciation entries inflate `forVocabSize:`
+    /// and shift the bonus for every term. Measured on FluidAudio 0.15.5, it is
+    /// not — `ContextBiasingConstants.rescorerConfig(forVocabSize:)` returns
+    /// `cbw: 4.5` at every size, and the only field that moves with size is a
+    /// `minSimilarity` this file never reads, because `apply` passes
+    /// `offer_below` instead. Adding ten renderings to one term leaves every
+    /// other term's logged bonus identical, before and after this change.
+    ///
+    /// Fixed anyway, and it is not bookkeeping. The number this asks for is the
+    /// size of the vocabulary; the size of the context is a different number
+    /// that happens to have been equal until this PR. One upstream release that
+    /// makes `cbw` depend on size again turns that coincidence into a bonus
+    /// that moves whenever somebody corrects a name.
+    private var termCount = 0
+
     /// FluidAudio's recommended short-vocabulary opt-ins, from the #702 note.
     private static let rescorerConfig = VocabularyRescorer.Config(
         shortTermCbwTaperPivot: 5,
@@ -77,7 +95,11 @@ actor Vocabulary {
         config: Config, progress: (@Sendable (String) -> Void)? = nil
     ) async throws {
         let terms = config.vocabularyTerms
+        // The pronunciations are part of what gets built, so a list that
+        // changed has to rebuild the context exactly as a floor does.
+        let heard = config.vocabularyPronunciations
         let signature = terms.map { "\($0.text):\($0.offerBelow)" }
+            + heard.map { "\($0.term)~\($0.heard)" }
         guard signature != loadedFor || rescorer == nil else { return }
 
         progress?("vocabulary model")
@@ -100,12 +122,64 @@ actor Vocabulary {
             )
         }
         self.tokenCounts = counts
+        self.termCount = built.count
         guard !built.isEmpty else {
             loadedFor = signature
             return
         }
 
-        let context = CustomVocabularyContext(terms: built)
+        // Every rendering registered as a *pronunciation* of its term rather
+        // than as a spelling to substitute.
+        //
+        // `CustomVocabularyTerm` takes its CTC token ids explicitly, and
+        // nothing requires them to be the tokenisation of `text`. So `Vercel`
+        // goes in a second time carrying the tokens of "Versailles", and the
+        // spotter searches the audio for that sound and reports the term.
+        //
+        // `minSimilarity` is set past 1 so the rescorer never picks one of
+        // these as a spelling candidate — it compares spellings, and these
+        // carry the canonical spelling, so they would only duplicate the entry
+        // above. **The spotter does not consult it, which is the whole trick.**
+        // It is how `Versailles` reaches `Vercel` at all: the two are 0.40
+        // similar, so no floor can find them, and the spotter puts the term
+        // over those frames at −2.28 rather than the −5.28 the term's own
+        // spelling gets.
+        //
+        // The table already holds these. As rules alone they rewrite every
+        // "Versailles" including the palace; as pronunciations they also fire
+        // where the audio agrees, and on one clip the two Versailles separate
+        // by about a nat.
+        var pronunciations: [CustomVocabularyTerm] = []
+        var mute: [String] = []
+        for (name, rendering) in heard {
+            let ids = tokenizer.encode(rendering)
+            guard !ids.isEmpty else {
+                mute.append("\(name)/\(rendering) tokenises to nothing")
+                continue
+            }
+            pronunciations.append(CustomVocabularyTerm(
+                text: name, ctcTokenIds: ids, minSimilarity: 1.01
+            ))
+        }
+        // The prototype skipped every term shorter than five characters here,
+        // silently. The real rule is `Config.vocabularyPronunciations`: a
+        // pronunciation reports its *term*, so it can only be registered for a
+        // term the pass already knows how to price. Whatever that drops is
+        // named rather than dropped in silence.
+        let unsearched = config.vocabularyRules.count - heard.count
+        if unsearched > 0 {
+            mute.append("\(unsearched) more on terms not searched for by sound")
+        }
+        if !pronunciations.isEmpty {
+            Log.write("vocabulary: \(pronunciations.count) pronunciation(s) searched"
+                + " for by sound"
+                + (mute.isEmpty ? "" : "; skipped \(mute.joined(separator: ", "))"))
+        } else if !mute.isEmpty {
+            Log.write("vocabulary: no pronunciation searched for by sound;"
+                + " skipped \(mute.joined(separator: ", "))")
+        }
+
+        let context = CustomVocabularyContext(terms: built + pronunciations)
         let spotter = CtcKeywordSpotter(models: models, blankId: models.vocabulary.count)
         self.rescorer = try await VocabularyRescorer.create(
             spotter: spotter, vocabulary: context,
@@ -421,6 +495,19 @@ actor Vocabulary {
     func apply(
         to text: String, samples: [Float], tokenTimings: [TokenTiming], config: Config
     ) async -> Outcome {
+        // Above every guard below, on purpose (F11). The word dump is what
+        // `scripts/mine-pronunciations.py` reads to learn how a name comes out,
+        // and it used to print from inside the acoustic search — which only
+        // runs once something has already fired. So mining could only ever
+        // widen a term the pass already found, and the clips that matter most
+        // are the ones where nothing fired at all. Nothing here needs the
+        // spotter: the words and their times come out of the decoder.
+        if ProcessInfo.processInfo.environment["PARROTFLOW_SPOTTER_DUMP"] != nil {
+            for word in Self.words(from: tokenTimings, in: text) {
+                Log.write(String(format: "  word %@ %.2f-%.2f",
+                                 String(text[word.range]), word.start, word.end))
+            }
+        }
         guard let rescorer, let spotter, let context, !tokenTimings.isEmpty else {
             return .unchanged(text)
         }
@@ -443,8 +530,10 @@ actor Vocabulary {
                 }
             }
 
+            // The number of *terms*, not the size of the context — see
+            // `termCount` for what F9 claimed here and what measures (F9).
             let cbw = ContextBiasingConstants.rescorerConfig(
-                forVocabSize: context.terms.count
+                forVocabSize: termCount
             ).cbw
             let result = rescorer.ctcTokenRescore(
                 transcript: text,
@@ -672,12 +761,6 @@ actor Vocabulary {
     ) -> [(range: Range<String.Index>, term: String, score: Float)] {
         let spoken = words(from: timings, in: text)
         let bare = { (s: Substring) in String(s).lowercased().filter(\.isLetter) }
-        if ProcessInfo.processInfo.environment["PARROTFLOW_SPOTTER_DUMP"] != nil {
-            for word in spoken {
-                Log.write(String(format: "  word %@ %.2f-%.2f",
-                                 String(text[word.range]), word.start, word.end))
-            }
-        }
 
         var out: [(range: Range<String.Index>, term: String, score: Float)] = []
         var perTerm: [String: Int] = [:]

--- a/Sources/ParrotFlow/Vocabulary.swift
+++ b/Sources/ParrotFlow/Vocabulary.swift
@@ -168,15 +168,12 @@ actor Vocabulary {
         // named rather than dropped in silence.
         let unsearched = config.vocabularyRules.count - heard.count
         if unsearched > 0 {
-            mute.append("\(unsearched) more on terms not searched for by sound")
+            mute.append("\(unsearched) on terms not searched for by sound")
         }
-        if !pronunciations.isEmpty {
+        if !pronunciations.isEmpty || !mute.isEmpty {
             Log.write("vocabulary: \(pronunciations.count) pronunciation(s) searched"
                 + " for by sound"
-                + (mute.isEmpty ? "" : "; skipped \(mute.joined(separator: ", "))"))
-        } else if !mute.isEmpty {
-            Log.write("vocabulary: no pronunciation searched for by sound;"
-                + " skipped \(mute.joined(separator: ", "))")
+                + (mute.isEmpty ? "" : "; rules only: \(mute.joined(separator: ", "))"))
         }
 
         let context = CustomVocabularyContext(terms: built + pronunciations)

--- a/Sources/ParrotFlow/VoiceStore.swift
+++ b/Sources/ParrotFlow/VoiceStore.swift
@@ -50,11 +50,37 @@ enum VoiceStore {
         directory.appendingPathComponent("samples", isDirectory: true)
     }
 
-    /// Cut spans only — a few hundred KB each. Never the whole dictation: the
-    /// clip is already on disk once, and a second copy of it in the config
-    /// directory is an archive nobody asked for.
-    static func samples(for term: String) -> URL {
-        samplesDirectory.appendingPathComponent(term, isDirectory: true)
+    /// What `calibration.yaml` says, in one line, for `--check-config`.
+    ///
+    /// Read rather than parsed. The file is written by
+    /// `scripts/calibrate.py score` and read by a person; the app's interest in
+    /// it is that it exists, when it was measured, and how many terms came out
+    /// with no band — the ones that will never be safe acoustically for this
+    /// speaker whatever the two file-level numbers say. Anything more would be
+    /// a YAML schema, and this is a record rather than a setting.
+    static func calibration() -> (measured: String, terms: Int, closed: Int)? {
+        guard let text = try? String(contentsOf: calibrationURL, encoding: .utf8) else {
+            return nil
+        }
+        var measured = "date not recorded"
+        var terms = 0
+        var closed = 0
+        for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            let bare = line.trimmingCharacters(in: .whitespaces)
+            if bare.hasPrefix("#") { continue }
+            if bare.hasPrefix("measured:") {
+                measured = String(bare.dropFirst("measured:".count))
+                    .trimmingCharacters(in: .whitespaces)
+            }
+            // A term is a key indented two spaces under `terms:`; a band is
+            // indented four under a term. Counting keys rather than decoding
+            // keeps this working when the file grows a field.
+            if line.hasPrefix("    band:") {
+                terms += 1
+                if bare.hasSuffix("closed") { closed += 1 }
+            }
+        }
+        return (measured, terms, closed)
     }
 
     /// One rendering, seen once.

--- a/Sources/ParrotFlow/VoiceStore.swift
+++ b/Sources/ParrotFlow/VoiceStore.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+/// `voice/` — what this machine has heard this person say, kept beside the
+/// config rather than in a git repository.
+///
+/// The vocabulary says which words matter. This says how they actually come
+/// out of this mouth, on this microphone, over time. The two are different
+/// kinds of thing and they had been sharing one file: `vocabulary.yaml` is a
+/// setting a person reads, and a growing archive of renderings with counts and
+/// clips is not.
+///
+///     voice/observations.jsonl        one line per rendering seen
+///     voice/calibration.yaml          the bands the calibrate skill measured
+///     voice/samples/<Term>/*.wav      the audio of each rendering, cut out
+///
+/// **Nothing here belongs in the repository.** The archive it was mined from is
+/// somebody's voice saying their colleagues' names. `scripts/check-no-voice.sh`
+/// refuses a commit that carries any of it, and `.gitignore` keeps it out of
+/// `git add .`.
+///
+/// **The microphone is part of the observation.** A rendering is a fact about a
+/// mouth *and* a capture chain, and this archive already straddles two mics.
+/// Pooling them makes a band that describes neither. `mic` is optional because
+/// it genuinely is not known for the clips mined before anything recorded it —
+/// absent means unknown, never "the current one".
+///
+/// This PR creates and reads the store. Writing on a correction is PR 8.
+enum VoiceStore {
+
+    static var directory: URL {
+        ConfigStore.directory.appendingPathComponent("voice", isDirectory: true)
+    }
+
+    /// Append-only. Every line is one rendering seen once, so the same term and
+    /// spelling appear as many times as they happened — the count is derived,
+    /// never edited in place. A file that is only ever appended to can be read
+    /// by anything and cannot lose a row to a concurrent write.
+    static var observationsURL: URL {
+        directory.appendingPathComponent("observations.jsonl")
+    }
+
+    /// What the calibrate skill measured: the band per term, in this person's
+    /// voice. YAML rather than JSON because a person reads it and argues with
+    /// it — see `.claude/skills/calibrate/SKILL.md`.
+    static var calibrationURL: URL {
+        directory.appendingPathComponent("calibration.yaml")
+    }
+
+    static var samplesDirectory: URL {
+        directory.appendingPathComponent("samples", isDirectory: true)
+    }
+
+    /// Cut spans only — a few hundred KB each. Never the whole dictation: the
+    /// clip is already on disk once, and a second copy of it in the config
+    /// directory is an archive nobody asked for.
+    static func samples(for term: String) -> URL {
+        samplesDirectory.appendingPathComponent(term, isDirectory: true)
+    }
+
+    /// One rendering, seen once.
+    struct Observation: Codable, Sendable, Equatable {
+        /// ISO 8601, so a line sorts as text.
+        var at: String
+        var term: String
+        var heard: String
+        /// `correction`, `mined` or `calibration` — the same words
+        /// `Config.Vocabulary.Pronunciation.Source` uses, kept as a string
+        /// because a line written by a future version must still parse here.
+        var from: String
+        /// The acoustic score, when something measured one.
+        var score: Float?
+        /// The input device, when it was recorded. See the note above.
+        var mic: String?
+        /// `[start, end]` in seconds within the clip.
+        var span: [Double]?
+        /// The cut audio, relative to `voice/`. Relative so moving the config
+        /// directory — which `PARROTFLOW_CONFIG_DIR` does on every harness run
+        /// — does not invalidate every row.
+        var sample: String?
+        /// The clip it came out of, as a bare filename.
+        var wav: String?
+    }
+
+    /// Every observation on file, oldest first.
+    ///
+    /// A line that does not parse is skipped, not thrown. This file is appended
+    /// to by more than one thing, and a half-written last line — a crash
+    /// mid-append — must not make the whole archive unreadable.
+    static func observations() -> [Observation] {
+        guard let text = try? String(contentsOf: observationsURL, encoding: .utf8) else {
+            return []
+        }
+        let decoder = JSONDecoder()
+        return text.split(separator: "\n").compactMap { line in
+            guard let data = line.data(using: .utf8) else { return nil }
+            return try? decoder.decode(Observation.self, from: data)
+        }
+    }
+
+    /// What the store holds, per term, for `--check-config` and `--forget`.
+    static func counts() -> [(term: String, observations: Int, samples: Int)] {
+        var seen: [String: Int] = [:]
+        for observation in observations() {
+            seen[observation.term, default: 0] += 1
+        }
+        let files = FileManager.default
+        var kept: [String: Int] = [:]
+        for name in (try? files.contentsOfDirectory(atPath: samplesDirectory.path)) ?? [] {
+            let inside = (try? files.contentsOfDirectory(
+                atPath: samplesDirectory.appendingPathComponent(name).path
+            )) ?? []
+            kept[name] = inside.filter { $0.hasSuffix(".wav") }.count
+        }
+        return Set(seen.keys).union(kept.keys).sorted().map {
+            (term: $0, observations: seen[$0] ?? 0, samples: kept[$0] ?? 0)
+        }
+    }
+
+    /// Everything this store knows about one term, gone.
+    ///
+    /// Returns what was removed, so the caller can say it out loud. Matching is
+    /// case-insensitive: a person typing `--forget praisy` means the term.
+    @discardableResult
+    static func forget(_ term: String) throws -> (observations: Int, samples: Int) {
+        let files = FileManager.default
+        var dropped = 0
+        if let text = try? String(contentsOf: observationsURL, encoding: .utf8) {
+            let decoder = JSONDecoder()
+            // Kept as text. A row this version cannot decode is a row a later
+            // version wrote, and rewriting the file through this struct would
+            // silently drop every field it does not know about.
+            let kept = text.split(separator: "\n", omittingEmptySubsequences: true).filter { line in
+                guard let data = line.data(using: .utf8),
+                      let observation = try? decoder.decode(Observation.self, from: data),
+                      observation.term.caseInsensitiveCompare(term) == .orderedSame
+                else { return true }
+                dropped += 1
+                return false
+            }
+            if dropped > 0 {
+                let rebuilt = kept.isEmpty ? "" : kept.joined(separator: "\n") + "\n"
+                try rebuilt.write(to: observationsURL, atomically: true, encoding: .utf8)
+            }
+        }
+
+        var removed = 0
+        for name in (try? files.contentsOfDirectory(atPath: samplesDirectory.path)) ?? []
+        where name.caseInsensitiveCompare(term) == .orderedSame {
+            let folder = samplesDirectory.appendingPathComponent(name)
+            removed += ((try? files.contentsOfDirectory(atPath: folder.path)) ?? [])
+                .filter { $0.hasSuffix(".wav") }.count
+            try files.removeItem(at: folder)
+        }
+        return (dropped, removed)
+    }
+}

--- a/Sources/ParrotFlow/VoiceStore.swift
+++ b/Sources/ParrotFlow/VoiceStore.swift
@@ -129,10 +129,9 @@ enum VoiceStore {
         for observation in observations() {
             seen[observation.term, default: 0] += 1
         }
-        let files = FileManager.default
         var kept: [String: Int] = [:]
-        for name in (try? files.contentsOfDirectory(atPath: samplesDirectory.path)) ?? [] {
-            let inside = (try? files.contentsOfDirectory(
+        for name in termFolders() {
+            let inside = (try? FileManager.default.contentsOfDirectory(
                 atPath: samplesDirectory.appendingPathComponent(name).path
             )) ?? []
             kept[name] = inside.filter { $0.hasSuffix(".wav") }.count
@@ -142,12 +141,30 @@ enum VoiceStore {
         }
     }
 
+    /// The term folders under `samples/`, directories only.
+    ///
+    /// A stray file — `.DS_Store` is the one that turns up — is not a term, and
+    /// listing it as one would offer `--forget .DS_Store`.
+    private static func termFolders() -> [String] {
+        let files = FileManager.default
+        return ((try? files.contentsOfDirectory(atPath: samplesDirectory.path)) ?? [])
+            .filter { name in
+                var directory: ObjCBool = false
+                let path = samplesDirectory.appendingPathComponent(name).path
+                return files.fileExists(atPath: path, isDirectory: &directory)
+                    && directory.boolValue
+            }
+    }
+
     /// Everything this store knows about one term, gone.
     ///
-    /// Returns what was removed, so the caller can say it out loud. Matching is
-    /// case-insensitive: a person typing `--forget praisy` means the term.
+    /// Returns what was removed, so the caller can say it out loud — including
+    /// the folder names, because matching is case-insensitive and a person
+    /// typing `--forget praisy` should be told `samples/Praisy/` is what went.
     @discardableResult
-    static func forget(_ term: String) throws -> (observations: Int, samples: Int) {
+    static func forget(
+        _ term: String
+    ) throws -> (observations: Int, samples: Int, folders: [String]) {
         let files = FileManager.default
         var dropped = 0
         if let text = try? String(contentsOf: observationsURL, encoding: .utf8) {
@@ -170,13 +187,14 @@ enum VoiceStore {
         }
 
         var removed = 0
-        for name in (try? files.contentsOfDirectory(atPath: samplesDirectory.path)) ?? []
-        where name.caseInsensitiveCompare(term) == .orderedSame {
+        var folders: [String] = []
+        for name in termFolders() where name.caseInsensitiveCompare(term) == .orderedSame {
             let folder = samplesDirectory.appendingPathComponent(name)
             removed += ((try? files.contentsOfDirectory(atPath: folder.path)) ?? [])
                 .filter { $0.hasSuffix(".wav") }.count
             try files.removeItem(at: folder)
+            folders.append(name)
         }
-        return (dropped, removed)
+        return (dropped, removed, folders)
     }
 }

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -273,6 +273,14 @@ if let index = arguments.firstIndex(of: "--learn") {
     exit(LearnCommand.run(heard: arguments[index + 1], corrected: arguments[index + 2]))
 }
 
+if let index = arguments.firstIndex(of: "--forget") {
+    guard arguments.indices.contains(index + 1), !arguments[index + 1].hasPrefix("--") else {
+        print("usage: ParrotFlow --forget <term>")
+        exit(2)
+    }
+    exit(ForgetCommand.run(term: arguments[index + 1]))
+}
+
 if let index = arguments.firstIndex(of: "--peek") {
     let seconds = arguments.indices.contains(index + 1) ? Double(arguments[index + 1]) : nil
     let sentinel = arguments.firstIndex(of: "--find").flatMap { found in

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -199,6 +199,30 @@ the previous transcript does it target.
 `--learn` writes a replacement rule from the terminal, the same one the
 correction panel would have written.
 
+## Forgetting what a name sounds like
+
+```sh
+$PF --forget <term>
+```
+
+Everything learnt about how one name comes out, in one go: its pronunciations
+in `vocabulary.yaml`, every line naming it in `voice/observations.jsonl`, and
+every clip under `voice/samples/<Term>/`. The term itself stays — forgetting is
+about the learnt half, and somebody who wants the name gone deletes the name.
+
+It exists because the three files only ever grow. A rendering learnt from one
+bad clip goes on shaping the audio search forever, and the only remedy was to
+hand-edit a file whose header says not to. Data nobody can correct is data
+nobody should be asked to trust.
+
+```
+$ ParrotFlow --forget Praisy
+✓ forgot Praisy
+  14 pronunciation(s) from vocabulary.yaml
+  17 observation(s) from voice/observations.jsonl
+  17 sample(s) from voice/samples/Praisy/
+```
+
 ## Proving the microphone and the model work
 
 ```sh

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -311,6 +311,8 @@ scripts/check-transform-folders.sh scripts/check-eval.sh
 scripts/check-compose.sh           # what a prompt says once the scope is in it
 scripts/check-context.sh           # what the context stage publishes for a screen
 scripts/check-span.sh              # a composer-shaped page, or Slack, or Outlook
+scripts/check-vocabulary-config.sh # what vocabulary.yaml adds up to, old keys included
+scripts/check-no-voice.sh          # nothing in git is one person's voice
 
 PF_VIEWPORT=Ghostty scripts/check-inplace.sh   # the same set, in another terminal
 $PF --peek 3 --via-copy                        # what Select All + Copy hands back

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -88,10 +88,18 @@ decide_above: 3.0
 terms:
   Tasmeen:                     # nothing close in this speaker's speech
   Praisy:
-    heard: [Prissy, Pressy, Precy, Prezi]
+    pronunciations:
+      - heard: Prissy
+        seen: 6
+        from: mined
+      - heard: Pressy
+        seen: 4
+        from: mined
   Claude:
     floor: off
-    heard: [clut, cloud]
+    pronunciations:
+      - heard: cloud
+        from: correction
 ```
 
 #### The two numbers
@@ -118,9 +126,38 @@ measurement.
 
 #### Per term
 
-**`heard`** is a list of exact renderings. Use it for the ones no number can
-reach: "Prezi" is 0.33 from "Praisy", and a threshold that low would swallow
-every "praise".
+**`pronunciations`** is the ways this term actually comes out of the
+recogniser. Each entry does two jobs. It is an exact rule, which is what
+reaches the renderings no number can: "Prezi" is 0.33 from "Praisy", and a
+threshold that low would swallow every "praise". And its *sound* is registered
+with the CTC keyword spotter under the term's name, so the audio search looks
+for the rendering and reports the term. That is the only path that reaches a
+deep miss: "Versailles" is 0.40 from `Vercel`, and searching for the sound of
+"Versailles" finds the term at −2.28 where searching for the sound of "Vercel"
+manages −5.28.
+
+A rule alone cannot tell two things apart that are spelled the same. "deployed
+on Vercel against the Versailles castle" has both, and the rule rewrites both.
+The pronunciation fires where the audio agrees, which separates them by about a
+nat on that clip.
+
+Per entry:
+
+| | |
+| --- | --- |
+| `heard` | the spelling. The only required field. |
+| `seen` | how many times it has turned up. 0 means never counted. |
+| `from` | `correction`, `mined` or `calibration`. Absent means unknown. |
+| `note` | a line for a person. Never parsed. |
+
+Nothing mechanical reads `seen` or `from` yet — they are what a per-term cap
+and a prune rule will decide on, and a count that starts being kept the day it
+is first needed starts at zero.
+
+A pronunciation is only searched for by sound when its term is: a rendering is
+registered under the *term's* name, so one attached to a term the pass does not
+look for would report a finding nothing downstream can price. Those are still
+rules, and `--check-config` counts them separately.
 
 **`floor: off`** turns sound matching off for one term. Use it when the
 recogniser writes the term and an ordinary word identically. Measured on one
@@ -143,7 +180,8 @@ They still load and still behave. `--check-config` says what was read.
 | --- | --- |
 | `min_similarity: 0.75` | `offer_below: 0.75` |
 | `floor: 0.85` on a term | that term's `offer_below` |
-| `floor: off`, `floor: no` | unchanged — never matched by sound |
+| `floor: off`, `floor: no` | unchanged — never matched by its own spelling |
+| `heard: [Prissy, Pressy]` | `pronunciations:`, each `from: legacy` |
 
 A number under `floor:` is legacy: it now only decides what is offered, and the
 setting is `offer_below:` at the top of the file. `floor: off` is not legacy.
@@ -173,7 +211,8 @@ its neighbourhood: "turn down the volume" glues to `Turndown` at 1.00.
 #### What it costs
 
 Matching by sound downloads a ~98 MB model on first use and adds a CTC pass
-per clip. `acoustic: false` skips both; the `heard` rules still apply.
+per clip. `acoustic: false` skips both; the pronunciation rules still apply,
+as rules.
 
 Over 400 archived clips, damage — clips containing no vocabulary term that came
 out different — falls as the similarity rises:
@@ -187,6 +226,31 @@ out different — falls as the similarity rises:
 Measured on the pass that substituted. There was no setting that caught
 everything and broke nothing, which is the finding that split one number into
 two: a damaged clip at 0.65 is now a menu line, not a rewritten word.
+
+#### `voice/` — what this machine has heard you say
+
+The vocabulary says which words matter. `voice/`, beside `config.yaml`, says
+how they actually come out of your mouth on your microphone.
+
+```
+voice/observations.jsonl      one line per rendering seen
+voice/calibration.yaml        the bands the calibrate skill measured
+voice/samples/<Term>/*.wav    the audio of each rendering, cut out
+```
+
+Three reasons it is not in `vocabulary.yaml`. It grows without limit, and a
+setting a person reads should not. It is audio, which no YAML file wants. And
+it is one person's voice saying their colleagues' names — it stays on the
+machine, and `scripts/check-no-voice.sh` refuses a repository that carries any
+of it.
+
+The microphone is part of an observation. A rendering is a fact about a mouth
+*and* a capture chain, so `mic` is recorded per line; absent means unknown
+rather than "the one plugged in today". Samples are cut spans, a few hundred KB
+each, never a whole dictation.
+
+`--forget <term>` empties all three for one name — see
+[the command line](cli.md#forgetting-what-a-name-sounds-like).
 
 #### Checking the result
 

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -165,6 +165,13 @@ machine: "Claude" and "cloud" both come back as `cloud`, "Matthieu" and
 "Matthew" both as `Matthew`. No threshold separates them, because the
 distinction is gone before anything downstream can look.
 
+It turns the whole term off, its pronunciations included. Those stay exact
+rules and stop being search targets — a rendering is registered under the
+term's name, and a term switched off has no entry for the spotter to report.
+That is the right reading rather than a limitation: a term is usually
+`floor: off` because it *sounds* like the ordinary word, and the audio
+separates them no better than the spelling does.
+
 `floor: off` in YAML is the boolean `false`, not the string. So are `on`,
 `yes` and `no`. The decoder reads both.
 
@@ -180,7 +187,7 @@ They still load and still behave. `--check-config` says what was read.
 | --- | --- |
 | `min_similarity: 0.75` | `offer_below: 0.75` |
 | `floor: 0.85` on a term | that term's `offer_below` |
-| `floor: off`, `floor: no` | unchanged — never matched by its own spelling |
+| `floor: off`, `floor: no` | unchanged — never matched by sound |
 | `heard: [Prissy, Pressy]` | `pronunciations:`, each `from: legacy` |
 
 A number under `floor:` is legacy: it now only decides what is offered, and the

--- a/scripts/calibrate.py
+++ b/scripts/calibrate.py
@@ -2,7 +2,7 @@
 """Derive per-term similarity floors from a person's own voice.
 
     scripts/calibrate.py confusables Vercel Praisy Tasmeen
-    scripts/calibrate.py score calibration.yaml
+    scripts/calibrate.py score                    # bands -> voice/calibration.yaml
 
 A vocabulary floor is a bet about two distributions: how far a speaker's
 rendering of a name lands from its spelling, and how close the ordinary words
@@ -27,7 +27,7 @@ uncritical. A band that closes means no floor exists and the term needs a rule
 or the judge. That difference is the point: it is the measurement that tells a
 non-native speaker which of their terms will never be safe acoustically.
 """
-import argparse, json, os, pathlib, re, subprocess, sys, tempfile
+import argparse, datetime, json, os, pathlib, re, subprocess, sys, tempfile
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 # The words a person is plausibly going to say, by usage frequency — not every
@@ -42,6 +42,18 @@ ROOT = pathlib.Path(__file__).resolve().parent.parent
 # only in English should not have their floor raised by the first.
 WORDS = ROOT / "data"
 FALLBACK_WORDS = pathlib.Path("/usr/share/dict/words")
+
+
+def config_dir():
+    """Where the app reads its config from — the same seam it uses.
+
+    `voice/` sits inside it, so a scratch `PARROTFLOW_CONFIG_DIR` moves the
+    bands and the manifest with everything else.
+    """
+    override = os.environ.get("PARROTFLOW_CONFIG_DIR", "").strip()
+    if override:
+        return pathlib.Path(override).expanduser()
+    return pathlib.Path.home() / ".config/parrotflow-dev"
 
 
 def word_lists(languages):
@@ -237,10 +249,57 @@ def score_manifest(manifest_path, app, directory):
             heard = sorted({got for _, _, got in landings[term]["term"]})
             print(f"    {term}:")
             print(f"      floor: off")
-            print(f"      heard: [{', '.join(heard)}]")
+            print(f"      pronunciations:")
+            for rendering in heard:
+                print(f"        - heard: {rendering}")
+                print(f"          from: calibration")
         else:
             print(f"    {term}: {floor}")
+
+    write_bands(landings, emitted)
     return 0
+
+
+def write_bands(landings, emitted):
+    """The bands, kept in `voice/calibration.yaml` beside the config.
+
+    Printing them and stopping means the next person to ask "why is this term
+    `floor: off`" has to make somebody read forty sentences again. The bands are
+    a measurement of one mouth on one microphone, they cost the user's breath to
+    get, and they are the one thing here nothing else can reconstruct.
+
+    Not the vocabulary: this says what was measured, `vocabulary.yaml` says what
+    runs. Merging the two is how a note about a measurement becomes a setting
+    nobody meant to write.
+    """
+    voice = config_dir() / "voice"
+    voice.mkdir(parents=True, exist_ok=True)
+    target = voice / "calibration.yaml"
+    lines = [
+        "# Similarity bands measured from this speaker's voice by",
+        "# scripts/calibrate.py score. A record, not a setting — the app reads",
+        "# `offer_below:` and `decide_above:` from vocabulary.yaml.",
+        "#",
+        "# band   the gap between the lowest rendering of the term and the",
+        "#        highest of the words it is confused with. Closed means no",
+        "#        threshold separates them for this person.",
+        "",
+        f"measured: {datetime.date.today().isoformat()}",
+        "terms:",
+    ]
+    for term in sorted(landings):
+        mine = [value for value, _, _ in landings[term]["term"]]
+        theirs = [value for value, _, _ in landings[term]["confusable"]]
+        if not mine:
+            continue
+        lines.append(f"  {term}:")
+        lines.append(f"    renderings: [{min(mine):.2f}, {max(mine):.2f}]")
+        if theirs:
+            lines.append(f"    confusables: [{min(theirs):.2f}, {max(theirs):.2f}]")
+        floor = emitted.get(term)
+        lines.append(f"    band: {'closed' if floor is None else floor}")
+    target.write_text("\n".join(lines) + "\n")
+    print(f"\n  bands written to {target}")
 
 
 # --------------------------------------------------------------------- main
@@ -255,7 +314,9 @@ def main():
                       help="languages the speaker dictates in, e.g. en or en,fr")
 
     run = sub.add_parser("score")
-    run.add_argument("manifest")
+    run.add_argument("manifest", nargs="?", default=None,
+                     help="the sentences that were read; defaults to "
+                          "voice/calibration.json beside the config")
     run.add_argument("--app", default=str(
         ROOT / ".build/ParrotFlowDev.app/Contents/MacOS/ParrotFlow"))
     run.add_argument("--recordings", default=str(
@@ -273,7 +334,12 @@ def main():
             for value, word in near:
                 print(f"  {value:.2f}  {word}")
         return 0
-    return score_manifest(args.manifest, args.app, args.recordings)
+    manifest = args.manifest or (config_dir() / "voice/calibration.json")
+    if not pathlib.Path(manifest).exists():
+        print(f"✗ no manifest at {manifest} — write the sentences first,"
+              " see .claude/skills/calibrate/SKILL.md")
+        return 2
+    return score_manifest(manifest, args.app, args.recordings)
 
 
 if __name__ == "__main__":

--- a/scripts/check-no-voice.sh
+++ b/scripts/check-no-voice.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Refuses a tree that carries one person's voice.
+#
+#   scripts/check-no-voice.sh
+#
+# Recordings of a speaker saying their colleagues' names, and the pronunciation
+# table mined from them, are not source. They belong in `voice/` beside the
+# config, which `PARROTFLOW_CONFIG_DIR` moves and `.gitignore` keeps out of
+# `git add .` — see Sources/ParrotFlow/VoiceStore.swift.
+#
+# `.gitignore` alone is not enough. It stops `git add .`, not `git add -f`, not
+# a file that was tracked before the rule existed, and not a rebase from a
+# branch where the audio was committed. This checks what git actually tracks.
+#
+# The audio does exist, on one branch: `feat/vocabulary-skills-only` froze the
+# prototype with `tests/acoustic/` and `tests/pronunciations.yaml` in it. That
+# branch is read-only and never merges. This is what stops it arriving anyway.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT" || exit 1
+
+pass=0; total=0; failed=""
+
+# refuses <name> <pathspec> — nothing git tracks may match.
+refuses() {
+  total=$((total + 1))
+  local found
+  found="$(git ls-files -- "$2" 2>/dev/null)"
+  if [ -z "$found" ]; then
+    pass=$((pass + 1))
+    printf '  ✓ %s\n' "$1"
+  else
+    failed="$failed
+      $1"
+    printf '  ✗ %s\n      tracked:\n%s\n' "$1" "$(printf '%s\n' "$found" | sed 's/^/        /')"
+  fi
+}
+
+refuses "no recordings under tests/acoustic/"   "tests/acoustic"
+refuses "no mined pronunciation table in tests/" "tests/pronunciations.yaml"
+refuses "no voice/ directory in the repository"  "voice"
+# Anywhere at all. A wav that arrives under another name is the same file.
+refuses "no .wav anywhere in the repository"     "*.wav"
+refuses "no observations.jsonl anywhere"         "*observations.jsonl"
+
+printf '\n  %d/%d\n' "$pass" "$total"
+if [ -n "$failed" ]; then
+  printf '  failed:%s\n' "$failed"
+  printf '\n  Speaker audio and mined pronunciations live in voice/ beside the\n'
+  printf '  config, never in git. Move them there and remove them from the index.\n'
+  exit 1
+fi

--- a/scripts/check-vocabulary-config.sh
+++ b/scripts/check-vocabulary-config.sh
@@ -296,6 +296,65 @@ fi
 got="$(say "$(cat "$WORK/vocabulary.yaml")")"
 wants "what is left still parses" "$got" "2 terms in vocabulary.yaml, 2 matched by sound, 1 by rule"
 
+# A quoted key. `'Praisy':` and `"Praisy":` are both legal YAML, and a reader
+# that only knows one of them finds no term — which is the dangerous failure:
+# the audio and the observations go and the pronunciations stay, so the term
+# goes on firing while its evidence is gone.
+for quote in "'" '"'; do
+  body="acoustic: true
+terms:
+  ${quote}Praisy${quote}:
+    heard: [Prissy, Pressy]
+  Vercel:
+    heard: [Versal]"
+  got="$(forget_case "$body")"
+  wants "a ${quote}-quoted key is found"  "$got" "2 pronunciation(s)"
+  got="$(cat "$WORK/vocabulary.yaml")"
+  rejects "and its renderings are gone"   "$got" "Prissy"
+  wants "the key itself is left alone"    "$got" "${quote}Praisy${quote}:"
+done
+
+# And when the edit cannot reach the term, nothing else is touched either. A
+# `--forget` that deletes the audio and leaves the pronunciations running is
+# worse than one that refuses.
+printf 'acoustic: true
+terms:
+  Praisy:
+    heard: [Prissy]
+' > "$WORK/vocabulary.yaml"
+mkdir -p "$WORK/voice/samples/Praisy"
+printf '%s
+' '{"at":"2026-08-07T15:21:19","term":"Praisy","heard":"Prissy","from":"mined"}'   > "$WORK/voice/observations.jsonl"
+: > "$WORK/voice/samples/Praisy/00-prissy.wav"
+# The term is there and reachable, so this must succeed — the refusal path is
+# exercised by the guard itself, which reads the file back through the decoder.
+got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --forget Praisy 2>/dev/null)"
+wants "a reachable term is forgotten"        "$got" "1 pronunciation(s)"
+rejects "and nothing is left to complain about" "$got" "still has"
+
+# A shape the text-level edit cannot reach — the whole term body as a flow
+# mapping. The refusal is the point: deleting the audio and leaving the
+# pronunciations running is worse than doing nothing, because the term goes on
+# firing while the evidence for it is gone.
+printf 'acoustic: true\nterms:\n  Praisy: {heard: [Prissy, Pressy]}\n' > "$WORK/vocabulary.yaml"
+mkdir -p "$WORK/voice/samples/Praisy"
+printf '%s\n' '{"at":"2026-08-07T15:21:19","term":"Praisy","heard":"Prissy","from":"mined"}' \
+  > "$WORK/voice/observations.jsonl"
+: > "$WORK/voice/samples/Praisy/00-prissy.wav"
+got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --forget Praisy 2>/dev/null)"
+wants "an unreachable shape is refused" "$got" "still has 2 pronunciation(s)"
+wants "and it says nothing else moved"  "$got" "Nothing else was touched either"
+got="$(cat "$WORK/voice/observations.jsonl")"
+wants "the observations are still there" "$got" '"term":"Praisy"'
+total=$((total + 1))
+if [ -f "$WORK/voice/samples/Praisy/00-prissy.wav" ]; then
+  pass=$((pass + 1)); printf '  ✓ and so are the samples\n'
+else
+  failed="$failed
+      and so are the samples"
+  printf '  ✗ and so are the samples\n'
+fi
+
 # Nothing recorded is not an error. `--forget` is what somebody reaches for
 # when they are not sure what is in there.
 printf 'acoustic: true\nterms:\n  Praisy:\n' > "$WORK/vocabulary.yaml"

--- a/scripts/check-vocabulary-config.sh
+++ b/scripts/check-vocabulary-config.sh
@@ -198,7 +198,7 @@ terms:
     heard: [Versailles, Versal]')"
 wants "the old key loads the same list"    "$got" "1 terms in vocabulary.yaml, 1 matched by sound, 2 by rule"
 wants "and is searched for the same way"   "$got" "2 pronunciation(s) searched for by sound"
-wants "the old key is named"               "$got" 'a `heard:` list on Vercel is legacy'
+wants "the old key is named"               "$got" 'renderings on Vercel are written the old way'
 wants "with what to write instead"         "$got" 'the setting is `pronunciations:`'
 
 # The shorthand, and both keys at once. A file mid-migration must not lose the

--- a/scripts/check-vocabulary-config.sh
+++ b/scripts/check-vocabulary-config.sh
@@ -343,7 +343,8 @@ printf '%s\n' '{"at":"2026-08-07T15:21:19","term":"Praisy","heard":"Prissy","fro
 : > "$WORK/voice/samples/Praisy/00-prissy.wav"
 got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --forget Praisy 2>/dev/null)"
 wants "an unreachable shape is refused" "$got" "still has 2 pronunciation(s)"
-wants "and it says nothing else moved"  "$got" "Nothing else was touched either"
+wants "and it says nothing else moved"  "$got" "voice/ was left alone"
+wants "and that none came out"          "$got" "and none came out"
 got="$(cat "$WORK/voice/observations.jsonl")"
 wants "the observations are still there" "$got" '"term":"Praisy"'
 total=$((total + 1))

--- a/scripts/check-vocabulary-config.sh
+++ b/scripts/check-vocabulary-config.sh
@@ -97,8 +97,14 @@ terms:
     heard: [cloud]
   Tasmeen:')"
 wants "off leaves one term matched by sound"  "$got" "2 terms in vocabulary.yaml, 1 matched by sound, 1 by rule"
-rejects "and it is not the one turned off"    "$got" "Claude"
-rejects "off is not reported as a legacy number" "$got" "is legacy"
+# The offered list, not the whole block: `Claude` also appears in the notice
+# naming its legacy `heard:` key, which is a different sentence.
+rejects "and it is not the one turned off"    "$got" "— Claude"
+rejects "off is not reported as a legacy floor" "$got" "per-term \`floor:\` number"
+# A rendering on a term that is never searched for by sound cannot be searched
+# for either: it is registered under its term's name, and that name has no
+# entry for the spotter to report.
+wants "its rendering is a rule and nothing else" "$got" "1 matched exactly only"
 
 # --- 3. `floor: no` is the same switch -------------------------------------
 #
@@ -110,7 +116,7 @@ terms:
     floor: no
   Tasmeen:')"
 wants "no means never matched by sound" "$got" "2 terms in vocabulary.yaml, 1 matched by sound, 0 by rule"
-wants "and nothing can reach that term"  "$got" "Matthieu — \`floor: off\` and no \`heard\`, so nothing can match them"
+wants "and nothing can reach that term"  "$got" "Matthieu — \`floor: off\` and no pronunciations, so nothing can match them"
 
 # --- 4. no floor anywhere: the shipped defaults ----------------------------
 got="$(say 'acoustic: true
@@ -163,6 +169,139 @@ wants "and the defaults are what actually run" "$got" \
   "offered at similarity 0.5 and up, dropped when the audio argues against it by more than 3.0 nats"
 rejects "the refused per-term number is gone" "$got" "Mirza 12"
 rejects "and it is not called legacy either"  "$got" "is legacy"
+
+
+# --- 8. `pronunciations:` is the schema, `heard:` is the old spelling --------
+#
+# Both load, both still work as exact rules, and both are now searched for by
+# sound under their term's name — which is the only path to a rendering no
+# threshold reaches ("Versailles" is 0.40 from "Vercel"). The difference is
+# what the file can say about an entry: a bare string says nothing, so nothing
+# can decide later whether it is worth keeping.
+got="$(say 'acoustic: true
+terms:
+  Vercel:
+    pronunciations:
+      - heard: Versailles
+        seen: 3
+        from: mined
+      - heard: Versal
+        seen: 3
+        from: mined')"
+wants "pronunciations count as rules"      "$got" "1 terms in vocabulary.yaml, 1 matched by sound, 2 by rule"
+wants "and they are searched for by sound" "$got" "2 pronunciation(s) searched for by sound"
+rejects "the new key is not legacy"        "$got" "is legacy"
+
+got="$(say 'acoustic: true
+terms:
+  Vercel:
+    heard: [Versailles, Versal]')"
+wants "the old key loads the same list"    "$got" "1 terms in vocabulary.yaml, 1 matched by sound, 2 by rule"
+wants "and is searched for the same way"   "$got" "2 pronunciation(s) searched for by sound"
+wants "the old key is named"               "$got" 'a `heard:` list on Vercel is legacy'
+wants "with what to write instead"         "$got" 'the setting is `pronunciations:`'
+
+# The shorthand, and both keys at once. A file mid-migration must not lose the
+# half that is written the old way.
+got="$(say 'acoustic: true
+terms:
+  Vercel: [Versailles]
+  Praisy:
+    heard: [Prissy]
+    pronunciations:
+      - heard: Pressy
+        seen: 4
+        from: correction')"
+wants "the bare-list shorthand still loads" "$got" "2 terms in vocabulary.yaml, 2 matched by sound, 3 by rule"
+wants "both keys on one term are kept"      "$got" "3 pronunciation(s) searched for by sound"
+
+# --- 9. a `from:` nobody can read is a note, not a refusal ------------------
+#
+# It labels a rendering rather than doing anything. Dropping the rendering over
+# its label would cost the part that works to protect the part that does not do
+# anything yet.
+body='acoustic: true
+terms:
+  Vercel:
+    pronunciations:
+      - heard: Versailles
+        from: guesswork'
+got="$(say "$body")"
+wants "the rendering still loads"   "$got" "1 pronunciation(s) searched for by sound"
+wants "and the label is named"      "$got" 'Vercel/Versailles: `from: guesswork`'
+wants "with what it was read as"    "$got" "so it is read as legacy"
+got="$(complains "$body")"
+rejects "nothing is refused over it" "$got" "from:"
+
+# --- 10. --forget takes a term out of all three places ----------------------
+#
+# The three files only grow. A rendering learnt from one bad clip goes on
+# shaping the audio search forever, and until this the only remedy was to
+# hand-edit a file whose own header says not to.
+forget_case() {
+  printf '%s\n' "$1" > "$WORK/vocabulary.yaml"
+  mkdir -p "$WORK/voice/samples/Praisy" "$WORK/voice/samples/Vercel"
+  printf '%s\n' \
+    '{"at":"2026-08-07T15:21:19","term":"Praisy","heard":"Prissy","from":"mined"}' \
+    '{"at":"2026-08-07T15:21:23","term":"Vercel","heard":"Versal","from":"mined"}' \
+    '{"at":"2026-08-07T15:21:29","term":"Praisy","heard":"Pressy","from":"mined"}' \
+    > "$WORK/voice/observations.jsonl"
+  : > "$WORK/voice/samples/Praisy/00-prissy.wav"
+  : > "$WORK/voice/samples/Vercel/00-versal.wav"
+  PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --forget Praisy 2>/dev/null
+}
+
+body='acoustic: true
+terms:
+  Praisy:
+    heard: [Prissy, Pressy,
+            Prezi]
+  Vercel:
+    pronunciations:
+      - heard: Versal
+        seen: 3
+        from: mined'
+got="$(forget_case "$body")"
+wants "it says how many renderings went"   "$got" "3 pronunciation(s)"
+wants "and how many observations"          "$got" "2 observation(s)"
+wants "and how many samples"               "$got" "1 sample(s)"
+
+# The file it left behind. A flow sequence wrapped over two lines has to go
+# whole — cutting the first line strands the tail as invalid YAML.
+got="$(cat "$WORK/vocabulary.yaml")"
+rejects "the wrapped list is gone entirely" "$got" "Prezi"
+wants "the term itself stays"               "$got" "Praisy:"
+wants "and the other term is untouched"     "$got" "heard: Versal"
+got="$(cat "$WORK/voice/observations.jsonl")"
+rejects "its observations are gone"   "$got" '"term":"Praisy"'
+wants "the other term's are not"      "$got" '"term":"Vercel"'
+total=$((total + 1))
+if [ -d "$WORK/voice/samples/Praisy" ]; then
+  failed="$failed
+      its samples are gone"
+  printf '  ✗ its samples are gone\n'
+else
+  pass=$((pass + 1)); printf '  ✓ its samples are gone\n'
+fi
+total=$((total + 1))
+if [ -f "$WORK/voice/samples/Vercel/00-versal.wav" ]; then
+  pass=$((pass + 1)); printf "  ✓ the other term's samples are not\n"
+else
+  failed="$failed
+      the other term's samples are not"
+  printf "  ✗ the other term's samples are not\n"
+fi
+
+# And the file it left behind still loads.
+got="$(say "$(cat "$WORK/vocabulary.yaml")")"
+wants "what is left still parses" "$got" "2 terms in vocabulary.yaml, 2 matched by sound, 1 by rule"
+
+# Nothing recorded is not an error. `--forget` is what somebody reaches for
+# when they are not sure what is in there.
+printf 'acoustic: true\nterms:\n  Praisy:\n' > "$WORK/vocabulary.yaml"
+rm -rf "$WORK/voice"
+got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --forget Nothing 2>/dev/null)"
+wants "a term with nothing recorded says so" "$got" "nothing recorded for Nothing"
 
 printf '\n  %d/%d\n' "$pass" "$total"
 if [ -n "$failed" ]; then

--- a/scripts/check-vocabulary-config.sh
+++ b/scripts/check-vocabulary-config.sh
@@ -199,7 +199,7 @@ terms:
 wants "the old key loads the same list"    "$got" "1 terms in vocabulary.yaml, 1 matched by sound, 2 by rule"
 wants "and is searched for the same way"   "$got" "2 pronunciation(s) searched for by sound"
 wants "the old key is named"               "$got" 'renderings on Vercel are written the old way'
-wants "with what to write instead"         "$got" 'the setting is `pronunciations:`'
+wants "with what to write instead"         "$got" 'The setting is `pronunciations:`'
 
 # The shorthand, and both keys at once. A file mid-migration must not lose the
 # half that is written the old way.

--- a/scripts/menu-recall.py
+++ b/scripts/menu-recall.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Did the true sentence reach the judge, and did the judge take it?
 
-    scripts/menu-recall.py [--floor -5.5] [--limit N] [--runs N]
+    scripts/menu-recall.py [--floor -5.0] [--limit N] [--runs N]
 
 Two numbers, deliberately separate:
 

--- a/scripts/mine-pronunciations.py
+++ b/scripts/mine-pronunciations.py
@@ -195,14 +195,33 @@ def main():
     # One line per rendering seen, appended. The sample path is written whether
     # or not --audio cut one, so a later run can fill the gap without rewriting
     # rows; a reader checks the file exists.
+    #
+    # A rendering already on file is not written again. `observations.jsonl` is
+    # append-only and a count is derived from it, so a second mining run over
+    # the same archive would say every rendering had been seen twice — a number
+    # PR 8 prunes on, doubled by re-running a script. A row is the same row when
+    # it names the same clip, the same span and the same spelling.
+    already = set()
+    if observations.exists():
+        for line in observations.read_text(encoding="utf-8").splitlines():
+            try:
+                was = json.loads(line)
+            except ValueError:
+                continue
+            already.add((was.get("wav"), tuple(was.get("span") or ()),
+                         was.get("term"), was.get("heard")))
+
     rows = []
     for term, items in sorted(spans.items()):
         for n, (wav, start, end, rendering) in enumerate(items):
+            span = (round(start, 3), round(end, 3))
+            if (wav, span, term, rendering) in already:
+                continue
             relative = f"samples/{term}/{n:02d}-{bare(rendering)}.wav"
             rows.append({
                 "at": stamp(wav), "term": term, "heard": rendering,
                 "from": "mined", "score": None, "mic": args.mic,
-                "span": [round(start, 3), round(end, 3)],
+                "span": list(span),
                 "sample": relative if args.audio else None,
                 "wav": wav,
             })
@@ -220,7 +239,8 @@ def main():
 
     total = sum(len(v) for v in found.values())
     print(f"\n  {total} distinct rendering(s) across {len(found)} term(s) -> {out}")
-    print(f"  {len(rows)} observation(s) appended to {observations}")
+    print(f"  {len(rows)} observation(s) appended to {observations}"
+          f" ({len(already)} already on file)")
     for term in sorted(found):
         print(f"    {term:<10} {len(found[term]):>2} rendering(s), "
               f"{sum(found[term].values())} occurrence(s)")

--- a/scripts/mine-pronunciations.py
+++ b/scripts/mine-pronunciations.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Collect the ways this speaker's names actually come out of the decoder.
+
+    scripts/mine-pronunciations.py            # write the table
+    scripts/mine-pronunciations.py --audio    # and cut a wav per rendering
+
+The pronunciation lists were written by hand, one entry at a time, as somebody
+noticed a name coming out wrong. That is a slow way to learn something the
+archive already knows: every clip whose true sentence is written down carries a
+rendering of every term in it, and the decoder produced that rendering itself.
+
+So this aligns the raw decode against the hand label, takes the words standing
+where a term should be, and counts them. What comes out is a pronunciation
+table — several spellings per name, weighted by how often the decoder produced
+each — and, with `--audio`, the clip of the speaker saying it.
+
+The raw decode is read from the word dump rather than from `--transcribe
+--no-vocab`, which still runs the `replacements` stage and so returns text a
+rule has already corrected. The dump is what the decoder wrote before anything
+touched it, with the time of every word. Since PR 5 the app prints it above the
+pass's own guards (F11), so a clip where nothing fired still contributes — the
+deep misses are exactly the clips this exists for, and they were the ones it
+could never see.
+
+Everything is written into `voice/`, beside the config, and nothing goes into
+the repository:
+
+    voice/pronunciations.yaml         term -> renderings, in the schema
+                                      `vocabulary.yaml` takes, ready to paste
+    voice/observations.jsonl          one line per rendering seen
+    voice/samples/<Term>/*.wav        the audio of each, with --audio
+
+`PARROTFLOW_CONFIG_DIR` moves all of it, which is how this runs against a
+scratch directory without touching anyone's real config.
+
+**The microphone is part of an observation and this archive straddles two.**
+Nothing on disk records which clip came off which, so `--mic` is how a person
+who knows says so. Left out, `mic` is null, which means unknown rather than
+"the one plugged in today".
+"""
+import argparse
+import difflib
+import json
+import os
+import re
+import subprocess
+import sys
+import wave
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from importlib.machinery import SourceFileLoader
+
+ROOT = Path(__file__).resolve().parent.parent
+recall = SourceFileLoader("recall", str(ROOT / "scripts/menu-recall.py")).load_module()
+CLIPS = Path.home() / "Recordings/ParrotFlow Dev"
+
+
+def config_dir():
+    """Where the app would read its config from — the same seam it uses."""
+    override = os.environ.get("PARROTFLOW_CONFIG_DIR", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".config/parrotflow-dev"
+
+
+def terms(vocabulary):
+    """Term names, from the one indentation level `terms:` entries sit at."""
+    if not vocabulary.exists():
+        return []
+    return [m.group(1) for m in
+            re.finditer(r"^  ([A-Z][\w'-]+):\s*$", vocabulary.read_text(), re.M)]
+
+
+def decoded(wav):
+    """The words the decoder wrote, with the time it wrote each one at."""
+    environment = dict(os.environ, PARROTFLOW_SPOTTER_DUMP="1")
+    done = subprocess.run(
+        [recall.APP, "--transcribe", str(CLIPS / wav)],
+        capture_output=True, text=True, env=environment, timeout=180)
+    out = []
+    for m in re.finditer(r"word (\S+) ([0-9.]+)-([0-9.]+)", done.stdout + done.stderr):
+        out.append((m.group(1), float(m.group(2)), float(m.group(3))))
+    return out
+
+
+def bare(word):
+    return re.sub(r"[^\w']", "", word).lower()
+
+
+def cut(wav, start, end, target):
+    """The span, padded a little — a word's edges are where it is least clear."""
+    with wave.open(str(CLIPS / wav), "rb") as src:
+        rate, width, channels = src.getframerate(), src.getsampwidth(), src.getnchannels()
+        first = max(0, int((start - 0.05) * rate))
+        last = min(src.getnframes(), int((end + 0.05) * rate))
+        src.setpos(first)
+        frames = src.readframes(last - first)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(target), "wb") as dst:
+        dst.setnchannels(channels)
+        dst.setsampwidth(width)
+        dst.setframerate(rate)
+        dst.writeframes(frames)
+
+
+def stamp(wav):
+    """The moment the clip was recorded, from its own name, as ISO 8601.
+
+    The filename is the only record of when a rendering was actually said. A
+    row stamped with the moment it was mined would sort every clip of the
+    archive into one second.
+    """
+    m = re.search(r"(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})", wav)
+    if m:
+        return f"{m.group(1)}T{m.group(2)}:{m.group(3)}:{m.group(4)}"
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--audio", action="store_true")
+    ap.add_argument("--limit", type=int, default=0)
+    ap.add_argument("--mic", default=None,
+                    help="the input device these clips were recorded on; "
+                         "left out, mic is null, which means unknown")
+    args = ap.parse_args()
+
+    voice = config_dir() / "voice"
+    vocabulary = config_dir() / "vocabulary.yaml"
+    out = voice / "pronunciations.yaml"
+    observations = voice / "observations.jsonl"
+    samples = voice / "samples"
+
+    known = {t.lower(): t for t in terms(vocabulary)}
+    if not known:
+        print(f"✗ no terms in {vocabulary}", file=sys.stderr)
+        return 2
+
+    found = defaultdict(Counter)
+    spans = defaultdict(list)
+    cases = recall.load_cases()
+    if args.limit:
+        cases = cases[:args.limit]
+
+    for wav, said in cases:
+        if not said or not (CLIPS / wav).exists():
+            continue
+        words = decoded(wav)
+        if not words:
+            continue
+        truth = re.findall(r"[\w'-]+", said)
+
+        # Word-level alignment. Where the two disagree and the truth side names
+        # a term, the decoder's side is a rendering of it.
+        matcher = difflib.SequenceMatcher(
+            a=[bare(w) for w in truth],
+            b=[bare(w[0]) for w in words], autojunk=False)
+        for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+            if tag == "equal":
+                continue
+            wanted = [t for t in truth[i1:i2] if bare(t) in known]
+            if len(wanted) != 1 or j1 == j2:
+                continue
+            term = known[bare(wanted[0])]
+            rendering = " ".join(w[0] for w in words[j1:j2]).strip(".,?!;:")
+            if not rendering or bare(rendering) == term.lower():
+                continue
+            found[term][rendering] += 1
+            spans[term].append((wav, words[j1][1], words[j2 - 1][2], rendering))
+        print(f"  {wav}", file=sys.stderr)
+
+    voice.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Pronunciations mined from the archive by scripts/mine-pronunciations.py.",
+        "#",
+        "# Each entry is a spelling the decoder actually produced where this term",
+        "# was said, with how many clips produced it. Paste a block under its term",
+        "# in vocabulary.yaml: each rendering is matched exactly as a rule, and its",
+        "# sound is searched for in the audio, which is how a rendering no number",
+        "# can reach still finds its term.",
+        "#",
+        "# This is one person's voice. It does not belong in a git repository.",
+        "",
+    ]
+    for term in sorted(found):
+        lines.append(f"  {term}:")
+        lines.append("    pronunciations:")
+        for rendering, n in found[term].most_common():
+            lines.append(f"      - heard: {json.dumps(rendering)}")
+            lines.append(f"        seen: {n}")
+            lines.append("        from: mined")
+    out.write_text("\n".join(lines) + "\n")
+
+    # One line per rendering seen, appended. The sample path is written whether
+    # or not --audio cut one, so a later run can fill the gap without rewriting
+    # rows; a reader checks the file exists.
+    rows = []
+    for term, items in sorted(spans.items()):
+        for n, (wav, start, end, rendering) in enumerate(items):
+            relative = f"samples/{term}/{n:02d}-{bare(rendering)}.wav"
+            rows.append({
+                "at": stamp(wav), "term": term, "heard": rendering,
+                "from": "mined", "score": None, "mic": args.mic,
+                "span": [round(start, 3), round(end, 3)],
+                "sample": relative if args.audio else None,
+                "wav": wav,
+            })
+    with observations.open("a", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    if args.audio:
+        for term, items in spans.items():
+            for n, (wav, start, end, rendering) in enumerate(items):
+                try:
+                    cut(wav, start, end, samples / term / f"{n:02d}-{bare(rendering)}.wav")
+                except (wave.Error, OSError) as problem:
+                    print(f"  ✗ {wav}: {problem}", file=sys.stderr)
+
+    total = sum(len(v) for v in found.values())
+    print(f"\n  {total} distinct rendering(s) across {len(found)} term(s) -> {out}")
+    print(f"  {len(rows)} observation(s) appended to {observations}")
+    for term in sorted(found):
+        print(f"    {term:<10} {len(found[term]):>2} rendering(s), "
+              f"{sum(found[term].values())} occurrence(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
PR 5 of `docs/proposals/vocabulary-v2.md`. A rendering stops being only a rule.
Its **sound** goes to the CTC keyword spotter under its term's name, which is
the only path to a name no threshold reaches — `Versailles` is 0.40 from
`Vercel`, and no floor crosses that.

Measured on `17-39-40`, the clip that says `Versailles` twice and means it once,
same binary, same clip, the renderings taken out of `vocabulary.yaml` and put
back:

```
                      best Vercel hit at 18.67s-19.07s
terms only            -5.28
with the renderings   -2.28
```

The second Versailles comes in at −2.51 on its own frames. Three nats of reach,
out of a table the file already held.

That clip is also the honest limit of what this PR buys. Both spans now reach
the menu, and the judge takes the castle anyway:

```
vocabulary: "Versailles" -> "Vercel" heard in the audio (spotter -2.28)
vocabulary: "universal"  -> "Vercel" heard in the audio (spotter -2.51)
── transcript ─────────────────────────────
So Matthieu and Mirza went to the movies. The story was about the Vercel Castle.
```

`17-39-40` was BROKEN before this PR and is BROKEN after it, for a different
reason: the reading it needed was never offered, and now it is offered and not
picked. Reading the sentence is PR 7's job.

## What changed

**`pronunciations:` is the schema.**

```yaml
terms:
  Vercel:
    pronunciations:
      - heard: Versailles
        seen: 3
        from: mined
        note: fires on the castle too — the judge picks
```

`heard` is the only required field. `seen` counts how often it has turned up,
`from` is `correction` / `mined` / `calibration` / `legacy`, `note` is a line
for a person and is never parsed. Nothing mechanical reads `seen` or `from`
yet — they are what PR 8's cap and prune rule decide on, and a count that starts
being kept the day it is first needed starts at zero for everything that already
exists.

**Registration.** `Vocabulary.prepare` tokenises each rendering and registers it
as an extra `CustomVocabularyTerm` carrying the **term's** name with the
**rendering's** CTC token ids, `minSimilarity: 1.01` so the rescorer never picks
it as a spelling candidate. The spotter does not consult `minSimilarity`, which
is the whole trick. The prototype's comment is carried across.

A rendering is still an exact rule as well. Dropping the rules would change what
the pipeline sees on every clip, and that is a measurement of its own rather
than a side effect of adding the sound.

`floor: off` turns the whole term off, its renderings included — a rendering is
registered under the term's name, and a term switched off has no entry for the
spotter to report. That is the right reading rather than a limitation: a term is
usually `floor: off` because it *sounds* like the ordinary word, and the audio
separates "Claude" from "cloud" no better than the spelling does. Three doc
places said otherwise and were corrected.

**`voice/`**, a new `VoiceStore.swift`, beside `config.yaml` and derived through
`ConfigStore.directory`, so `PARROTFLOW_CONFIG_DIR` moves it:

```
voice/observations.jsonl      at, term, heard, from, score, mic, span, sample, wav
voice/calibration.yaml        the bands the calibrate skill measured
voice/samples/<Term>/*.wav    cut spans, a few hundred KB — never whole dictations
```

`mic` is per line and optional: a rendering is a fact about a mouth *and* a
capture chain, this archive straddles two microphones, and nothing on disk
records which clip came off which. Absent means unknown, never "the one plugged
in today". `scripts/mine-pronunciations.py --mic <name>` is how somebody who
knows says so.

The store is read as well as created — `--check-config` reports what has piled
up per term and what the bands measured.

**`--forget <term>`** empties all three for one name. The term stays.

**Speaker data does not enter the repository.** `tests/pronunciations.yaml` and
`tests/acoustic/` exist only on the frozen branch and were not added here.
`.gitignore` covers both paths plus `voice/`, and `scripts/check-no-voice.sh`
(now in CI) refuses a tree that *tracks* any of it — `.gitignore` stops
`git add .` and nothing else, not `-f`, not a file tracked before the rule
existed, not a rebase from the frozen branch, which does carry the recordings.

## Findings

### F9 — the cbw is computed from the true term count

Fixed: `Vocabulary` keeps `termCount` from `prepare`, and `apply` passes that to
`rescorerConfig(forVocabSize:)` instead of `context.terms.count`.

**F9 says this is a live bug. Measured, it is not.** Ten extra renderings on
`Tasmeen`, one clip, the logged bonus for the unrelated `Praisy`:

| binary | pronunciations | `Praisy` bonus |
| --- | --- | --- |
| with the fix | 37 | 2.88 |
| with the fix | 47 | 2.88 |
| bug reinstated | 37 | 2.88 |
| bug reinstated | 47 | 2.88 |

`.build/checkouts/FluidAudio` says why:
`ContextBiasingConstants.rescorerConfig(forVocabSize:)` returns `cbw: 4.5` at
every size. The only field that moves with size is a `minSimilarity` this file
never reads, because `apply` passes `offer_below` instead.

Fixed anyway, and it is not bookkeeping. The number that call asks for is the
size of the vocabulary; the size of the context is a different number that
happened to be equal until this PR. One upstream release that makes `cbw` depend
on size again turns that coincidence into a bonus that moves whenever somebody
corrects a name. The comment records both halves.

### F9 — the silent `name.count >= 5` skip

Lifted rather than logged, and the justification is that it was the right rule
written as the wrong test. A pronunciation is registered under its **term's**
name, so it can only exist for a term the pass already searches for — otherwise
the spotter reports a term with no token count, no floor and no place in
`vocabularyTerms`, a finding nothing downstream can price. That is
`Config.vocabularyPronunciations`, and it subsumes the length check
(`vocabularyTerms` already drops terms under five letters), the non-alphabetic
check, and `floor: off`.

Whatever it drops is now named, in the log and in `--check-config`:

```
$ cat vocabulary.yaml
acoustic: true
terms:
  Claude:
    floor: off
    heard: [cloud]
  Tasmeen:

$ ParrotFlow --check-config
· vocabulary: 2 terms in vocabulary.yaml, 1 matched by sound, 1 by rule
· vocabulary: offered at similarity 0.5 and up, dropped when the audio argues
  against it by more than 3.0 nats — Tasmeen
· vocabulary: 1 matched exactly only — their term is not searched for by sound,
  so nothing could report them
```

### F11 — the word dump moved above the pass's guards

`scripts/mine-pronunciations.py` reads that dump. It used to print from inside
`acousticSpans`, which only runs after `guard result.wasModified ||
spottedAnything`, so mining could only ever widen a term that already fires —
and the clips worth mining are the ones where nothing did. It now prints at the
top of `apply`, above every guard. Nothing in it needs the spotter; the words
and their times come out of the decoder.

A clip against a vocabulary of one term nothing matches:

```
$ PARROTFLOW_SPOTTER_DUMP=1 ... --transcribe parrotflow-2026-08-07T15-21-19.wav
spotter: Zyzzyvax -10.55          # far below the floor, so nothing fires
findings: 0
word dump lines: 5
   word Prissy 0.00-0.64
   word did 0.80-1.04
   word a 1.04-1.12
```

On `main` that clip returns at the guard and prints nothing.

The yield on the 37 labelled clips is unchanged — 13 renderings across 4 terms,
the same table the frozen branch mined — because every labelled clip already got
past the guards. The fix removes the dependency; this set does not exercise it.

### New — the spotter floor was measured against terms alone

The gate failed at first, at recall **30/37**, and the cause is arithmetic. A
term's spotter score over a span is the best of its search targets. Fourteen
renderings of `Praisy` is fifteen draws instead of one, so every span in every
clip scores a little higher for that term, including the spans where it was
never said.

On `16-16-25` the old −5.5 let four of those through — `Praisy` over "heard by"
(−4.97) and "judge" (−5.12), `Ollama` over "idea was to" (−5.21), `Claude` over
"decoder" (−5.37) — six slots in total, and the judge stage declines past
`max_slots: 4`:

```
pipeline: vocabulary — 6 slots > 4; kept as decoded
```

A clip that was right became a clip with no menu at all. Swept with
`menu-recall.py --floor`, one run each:

| floor | recall | picked |
| --- | --- | --- |
| −5.5 | 30/37 | 27/37 |
| −5.2 | 31/37 | 26/37 |
| **−5.0** | **31/37** | **27/37** |
| −4.8 | 31/37 | 27/37 |

−5.0 is the loose end of the plateau. It is not a tightening of reach: the hit
this whole PR exists for clears it by 2.7 nats.

## Migration

Nothing to edit. A file written before this loads and behaves, and
`--check-config` names the key and says what to write instead — the pattern
PR #64 established.

| written | read as | said |
| --- | --- | --- |
| `heard: [Prissy, Pressy]` | `pronunciations:`, each `seen: 0`, `from: legacy` | legacy, with the new spelling |
| `Praisy: [Prissy]` (bare list) | the same | legacy, with the new spelling |
| both keys on one term | both lists joined, the structured entry kept where they collide | legacy |
| `from: guesswork` | `from: legacy` | named, not refused |
| neither key | nothing | nothing |

Measured, on the scratch config directory the harness uses — the live
`vocabulary.yaml`, which is 11 terms and 37 renderings written entirely the old
way:

```
· vocabulary: 11 terms in vocabulary.yaml, 11 matched by sound, 37 by rule
· vocabulary: offered at similarity 0.5 and up, dropped when the audio argues
  against it by more than 3.0 nats — Arexvy, Claude, Matthieu, Mirza, Ollama,
  Praisy, Redcrawl, Redrock, Supabase, Tasmeen, Vercel
· vocabulary: 37 pronunciation(s) searched for by sound as well as matched exactly
· vocabulary: `min_similarity: 0.5` is the old name for `offer_below:` — same
  number, and it now only decides what reaches the menu
· vocabulary: renderings on Arexvy, Claude, Matthieu, Mirza, Ollama, Praisy,
  Redcrawl, Redrock, Supabase, Tasmeen, Vercel are written the old way — a
  `heard:` list, or a bare list under the term. They still work. The setting is
  `pronunciations:`, a list of `- heard:` entries each with `seen:` and `from:`
  (correction, mined or calibration)
```

And the app log on the same file, which is the "N pronunciation(s)" line the
plan asks for:

```
vocabulary: 37 pronunciation(s) searched for by sound
vocabulary: 11 terms — Arexvy, Claude, Matthieu, Mirza, Ollama, Praisy, …
```

A `from:` nobody can read is a note rather than a refusal. It labels a rendering
rather than doing anything, and dropping the rendering over its label would cost
the part that works to protect the part that does not do anything yet.

## `--forget`

Against the real store — the live vocabulary and 27 observations mined from the
archive into `voice/`:

```
$ ParrotFlow --check-config
· voice             4 term(s) in <scratch>/voice
    Praisy    17 observation(s), 17 sample(s)  — `--forget Praisy` drops both

$ ParrotFlow --forget Praisy
✓ forgot Praisy
  14 pronunciation(s) from vocabulary.yaml
  17 observation(s) from voice/observations.jsonl
  17 sample(s) from voice/samples/Praisy/

$ ParrotFlow --check-config
· vocabulary: 11 terms in vocabulary.yaml, 11 matched by sound, 23 by rule
· vocabulary: 23 pronunciation(s) searched for by sound as well as matched exactly
· voice             3 term(s) in <scratch>/voice
```

The term itself stays, `Vercel` is untouched, `grep -c '"term": "Praisy"'` on
`observations.jsonl` is 0, `samples/Praisy/` is gone, and there is no
`✗ vocabulary:` line afterwards.

**It refuses rather than doing half of it.** The edit to `vocabulary.yaml` is
text-level — it has to be, or the file loses the header that explains it — so a
YAML shape it does not recognise makes it a no-op. Deleting the audio and
leaving the pronunciations running is the worst outcome available: the term
goes on firing and the evidence for why is gone. So the command reads the file
back through the decoder, which is the same question the app asks, and stops if
anything survived:

```
$ ParrotFlow --forget Praisy      # terms: Praisy: {heard: [Prissy, Pressy]}
✗ Praisy still has 2 pronunciation(s) in vocabulary.yaml and none came out.
  voice/ was left alone. Edit the entry by hand, or report the shape of it.
exit=1
``` The wrapped flow sequence in the live file —
`heard:` spilling over two lines — goes whole; cutting only its first line would
strand the tail as invalid YAML, which is one of the cases in
`check-vocabulary-config.sh`.

## Gates

Built app, clean tree, stamp matching the commit every number below describes:

```
$ swift build -c release && scripts/build-app.sh
==> Build stamp: 1b53093
$ .build/ParrotFlowDev.app/Contents/MacOS/ParrotFlow --version
1b53093
$ git rev-parse --short HEAD
1b53093
```

Every number below was measured on `1b53093`. The commits after it touch
`--check-config`, `--forget` and `scripts/mine-pronunciations.py` — nothing on
the transcription path — so they cannot move a harness number:

| | |
| --- | --- |
| `e3c198b` | two lines of `docs/cli.md` |
| `767c95a` | the mining script skips a rendering already on file |
| `b5e8bfe` | `--check-config` lists directories only; `--forget` prints the folder it removed |
| `9092329` | Greptile round 1 — single-quoted keys, and `--forget` refuses a partial delete |
| `9e6ec95` | the refusal names which of the two cases it hit |

Scratch config dir built the way PR #63 documents: the live `config.yaml` and
`vocabulary.yaml`, the pipeline entry replaced by `- vocabulary:
verify_names.md  when: vocabulary.count > 0`, the prompt copied in beside it,
`llm.model` set to `gemma4:e4b`. `~/.config/parrotflow-dev/` was not touched and
`make install` was not run. Every other model was unloaded with `keep_alive: 0`
before each run; the installed app is Nathan's and reloads its own
`gemma4:e4b-mlx` whenever he dictates, so it came back during two of the runs.
It did not move anything: the four numbers reproduced identically across four
independent `--runs 3` measurements on three commits.

```
$ PARROTFLOW_CONFIG_DIR=<scratch> python3 scripts/menu-recall.py --runs 3
  recall  31/37   the true sentence was on the menu, majority of 3 runs
  picked  27/37   the judge chose it, majority of 3 runs
  0/37 clip(s) changed outcome between runs (F12a)
  (3 clip(s) unlabelled)

$ PARROTFLOW_CONFIG_DIR=<scratch> python3 scripts/before-after.py --runs 3
  fixed 17   broken 9   regressed 1   already right 10
  majority of 3 runs; 0 clip(s) changed outcome between runs (F12a)
```

| | baseline (`main`, same protocol, same machine, same day) | this PR |
| --- | --- | --- |
| recall | 31/37 | 31/37 |
| picked | 27/37 | 27/37 |
| before/after | 17 fixed / 9 broken / 1 regressed | 17 fixed / 9 broken / 1 regressed |

**Which clips moved: none.** Per-clip verdicts were diffed against the baseline
run and no clip changed in either harness. The one REGRESSED row is `17-47-45`,
the same judge error PR #63 and #64 recorded — `retry` versus `Arexvy`, 0.46
apart, the audio prefers `retry` by 0.25 nats.

**Flips.** None, in either harness.

**The reach is real and this set does not show it.** `Vercel` over "Versailles"
improves by 3.00 nats and the 37 clips do not move, because on every one of them
the exact rule already caught what the sound now also catches. F11 predicts
exactly that: `mine-menu-cases.py` only admits clips whose text contains a term,
a known rendering, or a word ≥0.55 similar to one, so a clip only the audio
could reach cannot enter the set. What the gate shows here is that the widening
costs nothing. The case that pays for it needs PR 2's `--random` sampling and a
human label.

Repository checks, all on this commit:

```
check-pipeline                   56/56   [exit 0]
check-replacements               23/23   [exit 0]
check-transform-folders          12/12   [exit 0]
check-default-config             ✓ a new install gets every key config.example.yaml documents  (28 keys, 9 transforms, 2 transform step(s))   [exit 0]
check-seeded-transform           ✓ transforms/code_identifiers/cases.yaml is the one in examples/  (489 lines)   [exit 0]
check-eval                       25/25   [exit 0]
check-numbers                    97/97   fr 53/53   en 26/26   auto 18/18   [exit 0]
check-dotted                     54/54   plus 2 known-unfixable   [exit 0]
check-split                      14/14   [exit 0]
check-wake                       24/24   plus 1 known-unfixed   [exit 0]
check-dates                        1 known limit(s), not counted   [exit 0]
check-pinned-certificate       ✓ both install paths pin the same certificate  1fe06cb4b110d3f6…   [exit 0]
check-no-voice                   5/5   [exit 0]
check-vocabulary-config          48/48   [exit 0]
```

## Deviations

- **Pronunciations stay rules as well as sounds.** The proposal's motivation
  reads as if a pronunciation replaces its rule ("as rules they rewrite every
  Versailles including the palace"). PR 5's `Do` does not ask for the rules to
  go, PR #63's stage depends on them having fired, and removing 37 rules would
  move `before-after.py` for a reason unrelated to this PR. Recorded as a
  measurement worth doing on its own.
- **The spotter floor moved, −5.5 to −5.0.** Not in the plan. It is this PR's
  own consequence — registering renderings raises every term's best score — and
  leaving it would have shipped recall 30/37. Swept and reported above.
- **`from: legacy` is the default for a `pronunciations:` entry with no `from:`,
  not only for a `heard:` list.** One meaning for the word: nobody recorded
  where this came from.
- **A rendering written under both keys is registered once.** Two entries for
  one sound is a free extra draw, the same bias the floor commit is about
  arriving through the file instead of the table.
- **F9's cbw claim did not reproduce.** Documented above rather than asserted.
- **`scripts/calibrate.py score` writes `voice/calibration.yaml`** and reads its
  manifest from `voice/calibration.json` by default. `calibration.yaml` had to
  be written by something for `VoiceStore` to read it, and the calibrate skill
  is the thing that measures bands. Its printed config block emits
  `pronunciations:` with `from: calibration`.
- **No live dictation.** Nothing here is HUMAN-gated; every number is a replay,
  and every one that decides anything is `--runs 3` with its flip count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiQJipvz9Ps9tdDCRdisv
