### PR TITLE
feat: a name may claim two places in a sentence, not six

### DIFF
--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1256,6 +1256,7 @@ struct Config: Decodable, Equatable {
                 case maxSlots = "max_slots"
                 case maxReadings = "max_readings"
                 case maxPerSlot = "max_per_slot"
+                case maxPerTerm = "max_per_term"
             }
 
             init(from decoder: Decoder) throws {
@@ -1273,7 +1274,7 @@ struct Config: Decodable, Equatable {
                     prompt = judged
                     var caps = VocabularyJudge.Caps.standard
                     // Each optional and each on its own: a person raising the
-                    // menu ceiling should not have to restate the other two.
+                    // menu ceiling should not have to restate the rest.
                     if let slots = try c.decodeIfPresent(Int.self, forKey: .maxSlots) {
                         caps.slots = slots
                     }
@@ -1282,6 +1283,9 @@ struct Config: Decodable, Equatable {
                     }
                     if let perSlot = try c.decodeIfPresent(Int.self, forKey: .maxPerSlot) {
                         caps.perSlot = perSlot
+                    }
+                    if let perTerm = try c.decodeIfPresent(Int.self, forKey: .maxPerTerm) {
+                        caps.perTerm = perTerm
                     }
                     self.caps = caps
                     namesBoth = stage != nil || named != nil

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -920,15 +920,24 @@ struct Pipeline: Equatable, Codable {
         ) + VocabularyJudge.ruleParts(rules, in: text, before: findings?.text)
 
         let slots = VocabularyJudge.slots(in: text, from: parts, caps: caps)
-        // Logged on every run, not only when the count is fatal. `max_slots` is
-        // the cliff this stage falls off — one slot over and the whole menu is
-        // declined — so the distance to it has to be measurable before a change
-        // that widens what fires, not inferred afterwards from the clips that
-        // broke.
-        Log.write("vocabulary judge: \(slots.count) slot(s) from \(parts.count) proposal(s)"
-            + (slots.isEmpty ? "" : " — " + slots.map {
+        // Two numbers on every run, not only when the count is fatal.
+        // `max_slots` is the cliff this stage falls off — one slot over and the
+        // whole menu is declined — so the distance to it has to be measurable
+        // before a change that widens what fires, not inferred afterwards from
+        // the clips that broke.
+        //
+        // Counts only. **Which words** is behind `PARROTFLOW_JUDGE_DUMP`, the
+        // switch that already means "write this dictation's menu down for a
+        // harness to read". The log is a plain file under `Library/Logs` and it
+        // outlives the dictation, so a diagnostic that is on for everybody
+        // spells names into it on runs where nothing was even offered.
+        var census = "vocabulary judge: \(slots.count) slot(s) from \(parts.count) proposal(s)"
+        if !slots.isEmpty, ProcessInfo.processInfo.environment["PARROTFLOW_JUDGE_DUMP"] != nil {
+            census += " — " + slots.map {
                 "\"\(text[$0.range])\" (\($0.terms.joined(separator: "/")))"
-            }.joined(separator: ", ")))
+            }.joined(separator: ", ")
+        }
+        Log.write(census)
         guard !slots.isEmpty else {
             return StageResult(text: text, vars: ["asked": .int(0), "slots": .int(0)])
         }

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -925,7 +925,10 @@ struct Pipeline: Equatable, Codable {
         // declined — so the distance to it has to be measurable before a change
         // that widens what fires, not inferred afterwards from the clips that
         // broke.
-        Log.write("vocabulary judge: \(slots.count) slot(s) from \(parts.count) proposal(s)")
+        Log.write("vocabulary judge: \(slots.count) slot(s) from \(parts.count) proposal(s)"
+            + (slots.isEmpty ? "" : " — " + slots.map {
+                "\"\(text[$0.range])\" (\($0.terms.joined(separator: "/")))"
+            }.joined(separator: ", ")))
         guard !slots.isEmpty else {
             return StageResult(text: text, vars: ["asked": .int(0), "slots": .int(0)])
         }

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -920,6 +920,12 @@ struct Pipeline: Equatable, Codable {
         ) + VocabularyJudge.ruleParts(rules, in: text, before: findings?.text)
 
         let slots = VocabularyJudge.slots(in: text, from: parts, caps: caps)
+        // Logged on every run, not only when the count is fatal. `max_slots` is
+        // the cliff this stage falls off — one slot over and the whole menu is
+        // declined — so the distance to it has to be measurable before a change
+        // that widens what fires, not inferred afterwards from the clips that
+        // broke.
+        Log.write("vocabulary judge: \(slots.count) slot(s) from \(parts.count) proposal(s)")
         guard !slots.isEmpty else {
             return StageResult(text: text, vars: ["asked": .int(0), "slots": .int(0)])
         }

--- a/Sources/ParrotFlow/Vocabulary.swift
+++ b/Sources/ParrotFlow/Vocabulary.swift
@@ -375,9 +375,17 @@ actor Vocabulary {
         "will", "would", "can", "could", "should", "my", "your", "our", "their",
     ]
 
-    /// How many readings one term may contribute to a menu. The cap is the
-    /// point: recall wants every plausible span offered, and a person reading
-    /// a lettered list wants a list they can read.
+    /// How many **spotter** spans one term may contribute. Not the menu.
+    ///
+    /// It read "how many readings one term may contribute to a menu", which is
+    /// not what it does and not where it is used. It gates `acousticSpans`
+    /// only, so it never saw the rescorer's own proposals, the wider spans, or
+    /// a `replacements` rule — and a term reaches a menu from all four. The
+    /// menu-level cap is `VocabularyJudge.Caps.perTerm`, which is applied where
+    /// the four meet.
+    ///
+    /// Kept where it is because it is cheaper here: a detection refused now
+    /// never becomes a proposal, and a 19-second clip yields ninety of them.
     static var spansPerTerm: Int {
         ProcessInfo.processInfo.environment["PARROTFLOW_SPANS_PER_TERM"]
             .flatMap(Int.init) ?? 2

--- a/Sources/ParrotFlow/VocabularyJudge.swift
+++ b/Sources/ParrotFlow/VocabularyJudge.swift
@@ -352,7 +352,7 @@ enum VocabularyJudge {
     /// also wrote the term. Guessing there is how a correct word gets a wrong
     /// spelling put first on the menu.
     static func rewritten(
-        _ heard: String, _ term: String, in before: String, became standing: Int
+        _ heard: String, _ term: String, in before: String, became stands: Int
     ) -> [Int]? {
         var marks: [(at: String.Index, rule: Bool)] =
             Vocabulary.spans(of: heard, in: before, ignoringCase: true)
@@ -360,7 +360,7 @@ enum VocabularyJudge {
             + Vocabulary.spans(of: term, in: before, ignoringCase: true)
                 .map { ($0.lowerBound, false) }
         marks.sort { $0.at < $1.at }
-        guard marks.count == standing else { return nil }
+        guard marks.count == stands else { return nil }
         return marks.indices.filter { marks[$0].rule }
     }
 

--- a/Sources/ParrotFlow/VocabularyJudge.swift
+++ b/Sources/ParrotFlow/VocabularyJudge.swift
@@ -41,14 +41,41 @@ enum VocabularyJudge {
         /// words. Past this many the stage keeps what the decoder wrote and
         /// says so — a menu nobody can read decides nothing.
         var slots = 4
-        /// The menu, not the slot count, is what the model is bad at. Three
-        /// binary slots is eight readings and was the most that measured
-        /// useful, so sixteen is the ceiling — a slot offering three readings
-        /// costs another slot its second one.
+        /// The menu, not the slot count, is what the model is bad at. Four
+        /// binary slots is sixteen readings, so `slots` at 4 and this at 16
+        /// are the same statement twice — and a slot that offers three
+        /// readings costs another slot its second one.
+        ///
+        /// Not measured. It was set to match `slots`, and nothing since has
+        /// looked for the length a menu stops being read at. Say so rather
+        /// than borrow a number from F7, which was the harness.
         var readings = 16
         /// Readings per slot, the decoder's own included. Two alternatives is
         /// what a lettered list stays readable at.
+        ///
+        /// Readability is the whole of the reason, deliberately. The number
+        /// that was going to justify it — a three-option shortlist scoring the
+        /// same as the full menu — is F7's, and F7 was the harness reordering
+        /// the shortlist. PR #62 re-ablated it and the effect belonged to the
+        /// ordering. Nothing measured says three is the right size, so nothing
+        /// measured should be quoted for it.
         var perSlot = 3
+        /// Places in one sentence that may be about the same term.
+        ///
+        /// `perSlot` bounds one place. Nothing bounded a term across places,
+        /// and a term reaches a menu from four directions at once — a
+        /// `replacements` rule that already rewrote the text, the rescorer's
+        /// own proposal, the wider spans built around it, and the CTC spotter
+        /// hearing it somewhere else entirely. On `17-39-40` that is six
+        /// slots for three terms, which is past `slots` and declines the whole
+        /// menu.
+        ///
+        /// So the menu grows with the size of the vocabulary rather than with
+        /// how noisily one term fires. Two, because a name said twice in one
+        /// sentence is ordinary and a name said three times is rare enough
+        /// that the third mention is more often the spotter than the speaker.
+        /// See `slots(in:from:caps:)` for which two survive.
+        var perTerm = 2
 
         static let standard = Caps()
 
@@ -62,7 +89,8 @@ enum VocabularyJudge {
         var problems: [String] {
             var found: [String] = []
             for (name, value) in [
-                ("max_slots", slots), ("max_readings", readings), ("max_per_slot", perSlot),
+                ("max_slots", slots), ("max_readings", readings),
+                ("max_per_slot", perSlot), ("max_per_term", perTerm),
             ] where value < 1 {
                 found.append("vocabulary: \(name) is \(value) — it has to be at least 1")
             }
@@ -72,6 +100,31 @@ enum VocabularyJudge {
             }
             return found
         }
+    }
+
+    /// How well evidenced a reading is, best first.
+    ///
+    /// Only `perTerm` reads this, and only to decide which places survive when
+    /// one term claims too many. It is a rank rather than a score because
+    /// there is no number the four sources share: a rule has none at all, a
+    /// wider span was never measured acoustically, and the spotter scores the
+    /// term without scoring the word the decoder wrote.
+    enum Standing: Int, Comparable {
+        /// A `replacements` rule already rewrote the text here. Strongest, not
+        /// because the rule is right but because it has already been acted on
+        /// — dropping this slot is the one case where the speaker is left with
+        /// a substitution and no way to refuse it.
+        case rule = 0
+        /// The rescorer proposed it and both spellings were scored.
+        case scored = 1
+        /// A wider span built around one of the above. Nothing scored it.
+        case wide = 2
+        /// The spotter heard the term over these frames. Nothing scored the
+        /// word the decoder wrote there, so there is no comparison — this is
+        /// the source that fires on "went to the" and "deployed on".
+        case spotted = 3
+
+        static func < (a: Standing, b: Standing) -> Bool { a.rawValue < b.rawValue }
     }
 
     /// One place in the sentence still in question, and the readings of it.
@@ -89,6 +142,8 @@ enum VocabularyJudge {
         var options: [String]
         /// The vocabulary terms this slot is about, for `{terms}`.
         let terms: [String]
+        /// The best-evidenced of the readings in it, for `Caps.perTerm`.
+        let standing: Standing
     }
 
     /// One proposal reduced to what the menu needs: a span, what stands there
@@ -106,6 +161,8 @@ enum VocabularyJudge {
         let other: String
         /// The vocabulary term at stake, for `{terms}`.
         let term: String
+        /// Where this reading came from, for `Caps.perTerm`.
+        let standing: Standing
     }
 
     // MARK: - Gathering
@@ -133,6 +190,15 @@ enum VocabularyJudge {
         let wanted = proposals
             .filter { !$0.applied && !$0.heard.isEmpty && $0.heard != $0.term }
             .sorted { $0.range.lowerBound < $1.range.lowerBound }
+        // Which of the three acoustic sources made a proposal, read off its
+        // scores rather than carried as a flag. `Vocabulary.apply` already
+        // says the same thing there: the rescorer scores both spellings, a
+        // wider span is scored by neither, and a spotter hit scores only the
+        // term (F6 — absent means absent, so absence is readable).
+        func standing(_ proposal: Vocabulary.Proposal) -> Standing {
+            if proposal.heardScore != nil, proposal.termScore != nil { return .scored }
+            return proposal.termScore == nil ? .wide : .spotted
+        }
         for proposal in wanted {
             // Offsets rather than the index itself. A `String.Index` belongs to
             // the string it was made from, and `text` is a different string
@@ -142,7 +208,8 @@ enum VocabularyJudge {
             if let already = resolved[span] {
                 parts.append(Part(
                     range: already, decoded: proposal.heard,
-                    other: proposal.term, term: proposal.term
+                    other: proposal.term, term: proposal.term,
+                    standing: standing(proposal)
                 ))
                 continue
             }
@@ -175,7 +242,8 @@ enum VocabularyJudge {
             resolved[span] = found
             parts.append(Part(
                 range: found, decoded: proposal.heard,
-                other: proposal.term, term: proposal.term
+                other: proposal.term, term: proposal.term,
+                standing: standing(proposal)
             ))
         }
         return parts
@@ -235,7 +303,7 @@ enum VocabularyJudge {
             guard !heard.isEmpty, !term.isEmpty, heard != term,
                   !heard.hasPrefix("/"), !term.contains("$")
             else { continue }
-            let standing = Vocabulary.spans(of: term, in: text, ignoringCase: true)
+            let stands = Vocabulary.spans(of: term, in: text, ignoringCase: true)
             guard let before else {
                 // No acoustic pass ran, so there is no earlier text to compare
                 // against — `--pipeline`, `--replace`, any path with no audio.
@@ -243,26 +311,28 @@ enum VocabularyJudge {
                 // `changes`, so it fired at least once, and a pre-existing term
                 // would be a second occurrence. More than one and nothing here
                 // can say which, so none are offered.
-                if standing.count == 1 {
+                if stands.count == 1 {
                     parts.append(Part(
-                        range: standing[0], decoded: heard, other: heard, term: term
+                        range: stands[0], decoded: heard, other: heard, term: term,
+                        standing: .rule
                     ))
-                } else if standing.count > 1 {
-                    Log.write("vocabulary judge: \"\(term)\" stands \(standing.count) time(s)"
+                } else if stands.count > 1 {
+                    Log.write("vocabulary judge: \"\(term)\" stands \(stands.count) time(s)"
                         + " and no acoustic pass ran, so which one \"\(heard)\" became"
                         + " cannot be told; that reading is not offered")
                 }
                 continue
             }
-            guard let mine = rewritten(heard, term, in: before, became: standing.count) else {
-                Log.write("vocabulary judge: \"\(term)\" stands \(standing.count) time(s) and"
+            guard let mine = rewritten(heard, term, in: before, became: stands.count) else {
+                Log.write("vocabulary judge: \"\(term)\" stands \(stands.count) time(s) and"
                     + " the transcript before the rules cannot account for that many;"
                     + " \"\(heard)\" is not offered back")
                 continue
             }
             for index in mine {
                 parts.append(Part(
-                    range: standing[index], decoded: heard, other: heard, term: term
+                    range: stands[index], decoded: heard, other: heard, term: term,
+                    standing: .rule
                 ))
             }
         }
@@ -296,6 +366,52 @@ enum VocabularyJudge {
 
     // MARK: - Slots and readings
 
+    /// The places one term may claim, cut to `limit`, best evidenced first.
+    ///
+    /// The order the survivors are chosen in is the point. A term arrives from
+    /// four sources at once and they are not equally worth a menu line, so the
+    /// cut is by `Standing` first and by position second — earliest wins a tie,
+    /// because a reader meets the leftmost place first and because the spotter's
+    /// spans, which are the ones this mostly cuts, arrive sorted by score and
+    /// not by where they sit.
+    ///
+    /// Measured on `17-39-40`, six slots for three terms: `Vercel` claims the
+    /// two places a rule rewrote plus "universal", and "universal" is the one
+    /// that goes. What survives is returned in the order it arrived in, so the
+    /// menu still reads left to right.
+    ///
+    /// A slot naming several terms is charged to all of them and kept while
+    /// **any** of them has room. Refusing it because one term is full would drop
+    /// a place that is still a live question about another.
+    ///
+    /// Applied to finished slots, not to the groups they are built from. A group
+    /// whose readings all collapse to the decoder's own is not a question and is
+    /// dropped anyway — letting it spend a term's budget on the way out would
+    /// cost a real place for nothing.
+    private static func capped(_ slots: [Slot], in text: String, to limit: Int) -> [Slot] {
+        guard limit >= 1, !slots.isEmpty else { return slots }
+        let ranked = slots.indices.sorted { left, right in
+            if slots[left].standing != slots[right].standing {
+                return slots[left].standing < slots[right].standing
+            }
+            return slots[left].range.lowerBound < slots[right].range.lowerBound
+        }
+        var used: [String: Int] = [:]
+        var keep = Set<Int>()
+        for index in ranked {
+            let slot = slots[index]
+            guard slot.terms.contains(where: { used[$0, default: 0] < limit }) else {
+                Log.write("vocabulary judge: \"\(text[slot.range])\" is a"
+                    + " \(slot.terms.joined(separator: "/")) reading past max_per_term"
+                    + " \(limit); not offered")
+                continue
+            }
+            for term in slot.terms { used[term, default: 0] += 1 }
+            keep.insert(index)
+        }
+        return slots.indices.filter(keep.contains).map { slots[$0] }
+    }
+
     /// Every position still in question, left to right, as one slot each.
     ///
     /// Overlapping spans used to be dropped, earliest wins. That was right when
@@ -305,6 +421,11 @@ enum VocabularyJudge {
     /// word. So they are grouped, and the slot covers the widest of them.
     ///
     /// A slot with one reading is not a question, so it is left out.
+    ///
+    /// `caps.perTerm` is applied to the slots rather than to the parts. Two
+    /// readings of one span — `Praisy` and `Praisy's` over "praise" — are one
+    /// place, not two, and counting them separately would spend the budget on
+    /// the case this stage exists for.
     static func slots(in text: String, from parts: [Part], caps: Caps) -> [Slot] {
         let sorted = parts.sorted { left, right in
             left.range.lowerBound == right.range.lowerBound
@@ -381,10 +502,11 @@ enum VocabularyJudge {
             guard kept.count > 1 else { continue }
             built.append(Slot(
                 range: span, options: kept,
-                terms: Array(Set(group.parts.map(\.term))).sorted()
+                terms: Array(Set(group.parts.map(\.term))).sorted(),
+                standing: group.parts.map(\.standing).min() ?? .spotted
             ))
         }
-        return built
+        return capped(built, in: text, to: caps.perTerm)
     }
 
     /// Every sentence the slots allow, the untouched one first.
@@ -394,9 +516,11 @@ enum VocabularyJudge {
     /// burying it costs declines.
     ///
     /// A slot can offer more than two readings, so the menu is trimmed rather
-    /// than the slot count capped. Speculative readings — the wider spans,
-    /// which sort last — go first, because a menu longer than eight measured
-    /// worse than a menu missing its least likely entry.
+    /// than the slot count capped. The trim takes a slot's **last** reading,
+    /// which after `slots` has ranked them is the narrowest span — and, among
+    /// spans of one width, the possessive. So the readings that go are the
+    /// ones that change least of the sentence, and a menu never loses the
+    /// decoder's own reading, which is always first.
     static func readings(
         in text: String, from slots: [Slot], caps: Caps
     ) -> (sentences: [String], choices: [[Int]], slots: [Slot], truncated: Bool) {

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -46,6 +46,7 @@ measured during transcription and cannot survive being written to a file.
   max_slots: 4        # optional; past this many, keep what the decoder wrote
   max_readings: 16    # optional; trim the menu to this
   max_per_slot: 3     # optional; readings per place, the decoder's included
+  max_per_term: 2     # optional; places in one sentence about the same name
 ```
 
 The filename is a prompt beside `config.yaml` — the only part you own. It must
@@ -60,6 +61,15 @@ word you meant literally can be undone. The app works out which occurrences the
 rule wrote by comparing the transcript before and after it. When two rules
 write the same term into one sentence that comparison cannot say which is
 which, and then neither is offered — the log says so.
+
+**`max_per_term` is the one to move if menus stop being built.** One name
+reaches a menu from four directions — a rule that already rewrote the text, the
+sound-matching pass, the wider spans it builds around a split name, and the
+keyword spotter hearing the name somewhere else in the clip. Nothing else caps
+the total, so a noisy name can spend every slot on its own and push the count
+past `max_slots`, at which point the whole menu is declined. The cap keeps the
+two best-evidenced places and says in the log which it dropped. Raise it when a
+name really does appear three times in one sentence.
 
 `when: vocabulary.count > 0` is not optional in practice. Without it the stage
 costs a model call on every dictation, including the ones where nothing was

--- a/docs/proposals/vocabulary-v2.md
+++ b/docs/proposals/vocabulary-v2.md
@@ -26,7 +26,7 @@ Do not relitigate these; they were argued and settled on 2026-08-08.
 | Stage name | `vocabulary`. The pipeline entry is `- vocabulary: verify_names.md`. |
 | `menu.py` | Retired entirely. The only user-facing artifact is the prompt file. `menu.py` survives on the frozen prototype branch as reference. |
 | Rule slots | Path of least resistance: rule substitutions are still found by term search, limitation documented. `replacements` does not learn to publish ranges. |
-| Knobs | Optional stage params with defaults (`max_slots: 4`, `max_readings: 16`, `max_per_slot: 3`), not env vars. The vocabulary-pass envs the harness already uses (`PARROTFLOW_SPOTTER_FLOOR`, `PARROTFLOW_JUDGE_DUMP`) stay. |
+| Knobs | Optional stage params with defaults (`max_slots: 4`, `max_readings: 16`, `max_per_slot: 3`, `max_per_term: 2`), not env vars. The vocabulary-pass envs the harness already uses (`PARROTFLOW_SPOTTER_FLOOR`, `PARROTFLOW_JUDGE_DUMP`) stay. |
 | Freeze | One `wip:` commit on `feat/vocabulary-skills-only`, then the branch is read-only forever. |
 | Execution | One PR at a time, in a worktree, by an agent. No stacking. A PR merges only when its gates pass and its Greptile review rounds are fully addressed; the next PR starts only after the merge. |
 
@@ -668,6 +668,49 @@ re-measure, but do not resize the menu on the old number.
 `menu-recall.py` output: the "praise he / praise his" clips must offer the
 wide reading; "Mirza's" must keep its possessive; "Versailles." must keep
 its full stop.
+
+**Landed (PR #66, 2026-08-08) — mostly by PR 3, which this plan told it to
+do.** PR 3's own `Do` list says "the acoustic search, the wider-span
+variants, and the possessive carry: port from the prototype's `apply`" and
+"widest-first ranking, per-slot cap". So four of the five items here were
+already on `main` before PR 6 started, and the three named clips already
+behaved. Where each lives:
+
+| Item | Where | Note |
+|---|---|---|
+| span, span+1, span+2 × term, term+`'s`, tested independently | `Vocabulary.widerSpans` | Same as the prototype, plus PR 3's guard that refuses a possessive at a sentence end |
+| possessive carried through a substitution | `Vocabulary.inflected` | `Mirza's` stays `Mirza's` |
+| trailing punctuation trimmed before replacing | `Vocabulary.trailingMarks`, and the trim at the end of `acousticSpans` | `Versailles.` keeps its full stop |
+| widest first, possessive as tiebreak | `VocabularyJudge.slots` | Identical ranking to `menu.py` line 237 |
+| cap readings per term | `Caps.perSlot` bounds one **place**; nothing bounded a **term** | The gap PR #66 filled |
+
+So PR 6 shipped the missing cap, `max_per_term`, applied in
+`VocabularyJudge.slots` where the four sources of a reading meet — a rule,
+the rescorer, a wider span and the spotter. Justified by readability, not by
+F7: `perSlot`'s doc comment now says so out loud, and `readings` admits it
+was never measured.
+
+Swept on `menu-recall.py`, one run each, everything else at the shipped
+settings:
+
+| `max_per_term` | recall | picked |
+|---|---|---|
+| 1 | 28/37 | 24/37 |
+| **2** | **31/37** | **27/37** |
+| 3 | 31/37 | 27/37 |
+| 99 (off) | 31/37 | 27/37 |
+
+2 is the tight end of the plateau, which is the end to take for a cap whose
+job is headroom. The spotter floor was **not** moved.
+
+Also here: the judge logs its slot count on every run, so the distance to
+`max_slots` can be measured rather than reconstructed from the clips that
+broke. On the 40 clips: 0 slots ×5, 1 ×17, 2 ×14, 3 ×3, 6 ×1. The one over
+the cap is `17-39-40`, which `max_per_term: 2` takes from 6 slots to 5 —
+still declined, and the anatomy is in PR #66. Its three surviving spotter
+slots are "went to the" → `Matthieu`, "universal" → `Vercel` and "deployed
+on" → `Claude`, none of which is a name anybody said. That is PR 7's
+evidence problem, not a span one.
 
 ---
 

--- a/tests/pipeline-cases.yaml
+++ b/tests/pipeline-cases.yaml
@@ -543,3 +543,9 @@ refused:
   - name: a name judge with no prompt file is refused
     pipeline: vocabulary-no-prompt
     expect_problem: names no prompt file
+
+  # A cap below 1 silences the stage on every transcript. Refused by name, so
+  # the reader learns which of the four numbers they typed.
+  - name: a menu cap of zero is refused and named
+    pipeline: vocabulary-cap-zero
+    expect_problem: max_per_term is 0

--- a/tests/pipelines/refused/vocabulary-cap-zero.yaml
+++ b/tests/pipelines/refused/vocabulary-cap-zero.yaml
@@ -1,0 +1,15 @@
+# A menu cap set to zero.
+#
+# Every one of the four caps silences the stage when it is below 1, and each
+# does it in a way that reads as the judge being broken rather than as a number
+# being wrong: `max_per_term: 0` means no place in any sentence is ever about a
+# vocabulary term, so no menu is ever built and nothing says why.
+#
+# Refused at load instead, by name, so the person who typed it learns which
+# number they typed. `max_per_term` is the one here because it is the newest;
+# the same check covers `max_slots`, `max_readings` and `max_per_slot`.
+languages: [en]
+pipeline:
+  - replacements
+  - vocabulary: verify_names.md
+    max_per_term: 0


### PR DESCRIPTION
PR 6 of `docs/proposals/vocabulary-v2.md`. Names arrive split ("praise he"),
possessed ("Mirza's") and punctuated ("Versailles."), and every reading built
from the shorter span strands a word.

**Four of PR 6's five items were already on `main`.** PR 3's own `Do` list told
it to port "the acoustic search, the wider-span variants, and the possessive
carry" and "widest-first ranking, per-slot cap". It did. The three clips this
PR is supposed to fix already behaved before it started, and the numbers below
say so: recall and before/after do not move.

The fifth item did not land. Nothing capped what **one term** contributes to a
menu, and that is the cap the plan reserved as this PR's headroom knob.

## What was already there, and where

| Item | Where | Evidence |
| --- | --- | --- |
| span, span+1, span+2 × `term`, `term + 's`, each pair tested independently | `Vocabulary.widerSpans` | `"praise his" -> "Praisy" (span 0.45)` and `"praise his" -> "Praisy's" (span 0.59)` both offered on `17-39-03` |
| a trailing possessive carried through a substitution | `Vocabulary.inflected` | `"Mirza's" -> "Mirza" applied` and the transcript still reads `Mirza's` |
| trailing punctuation trimmed before replacing | `Vocabulary.trailingMarks`, plus the trim at the end of `acousticSpans` | `"Pressy." -> "Praisy" applied` → `Let's praise Praisy.` |
| widest span first, possessive as tiebreak | `VocabularyJudge.slots` | Identical to `menu.py` line 237 on the frozen branch |

Same as the prototype in every case, with one deliberate narrowing PR 3
recorded: a possessive is not offered at a sentence end.

## What this PR adds

**`max_per_term: 2`.** A name reaches a menu from four directions at once — a
`replacements` rule that already rewrote the text, the rescorer's own proposal,
the wider spans built around it, and the CTC spotter hearing it somewhere else
in the clip. `max_per_slot` bounds one place. Nothing bounded the total, so a
noisy name spends slots that belong to other names.

```yaml
- vocabulary: verify_names.md
  when: vocabulary.count > 0
  max_per_term: 2     # optional; places in one sentence about the same name
```

**Which two survive is a rank, not a score,** because the four sources share no
number: a rule has none at all, a wider span was never measured acoustically,
and the spotter scores the term without scoring the word the decoder wrote. So
`VocabularyJudge.Standing` — rule, then scored, then wide, then spotted — with
the earliest place breaking a tie. The cap is applied to finished slots, so a
group whose readings all collapse to the decoder's own cannot spend a term's
budget on its way to being dropped.

**The judge logs its slot count on every run.** `max_slots: 4` is a cliff: one
over and the whole menu is declined, which in a transcript looks exactly like a
clip nobody proposed anything for. It was logged only when it was already
fatal.

```
vocabulary judge: 6 slot(s) from 6 proposal(s) — "Matthieu" (Matthieu), "went to the" (Matthieu), "Vercel" (Vercel), "universal" (Vercel), "deployed on" (Claude), "Vercel" (Vercel)
```

**Two comments corrected.** `Vocabulary.spansPerTerm` said it capped "readings
one term may contribute to a menu"; it gates the spotter only, and never saw
the other three sources. `readings()` said the trim takes the wider spans
first; since the widest-first ranking landed it takes the narrowest.

## The cap's justification, and what it is not

Menu readability, and nothing else. `max_per_slot`'s doc comment now says so
out loud and names what it is *not* leaning on: the three-option shortlist that
scored the same as the full menu is F7's, F7 was the harness reordering the
shortlist, and PR #62's ablation gave the effect back to the ordering. The
menu was not resized on that number. `max_readings` now admits it was never
measured either — it was set to match `max_slots`.

`max_per_term: 2` says a name said twice in one sentence is ordinary and a
third mention is more often the spotter than the speaker. Swept rather than
chosen, one run each, everything else at the shipped settings:

| `max_per_term` | recall | picked |
| --- | --- | --- |
| 1 | 28/37 | 24/37 |
| **2** | **31/37** | **27/37** |
| 3 | 31/37 | 27/37 |
| 99 (off) | 31/37 | 27/37 |

2 is the tight end of the plateau, which is the end to take for a cap whose job
is headroom. **The spotter floor was not moved** — it is still −5.0, where
PR #65 left it.

## Slot counts, before and after

The risk this PR was handed: widening pushes slot counts past `max_slots`, the
judge declines everything, and recall drops. Measured on the 40 clips of
`tests/menu-cases.yaml`, per-clip majority of 3 runs:

| slots | before | after |
| --- | --- | --- |
| 0 | 5 | 5 |
| 1 | 17 | 17 |
| 2 | 14 | 14 |
| 3 | 3 | 3 |
| 4 | 0 | 0 |
| 5 | 0 | **1** |
| 6 | **1** | 0 |
| **over `max_slots: 4`** | **1** | **1** |

Nothing widened, so nothing moved except the one clip the cap acts on.

**`17-39-40` is that clip, and it is worth reading.** Six slots for three
terms:

```
"Matthieu"     (Matthieu)   rule — offers "Mathieu" back
"went to the"  (Matthieu)   spotter -4.98
"Vercel"       (Vercel)     rule — offers "Versailles" back   ← the answer is here
"universal"    (Vercel)     spotter -2.51
"deployed on"  (Claude)     spotter -4.65
"Vercel"       (Vercel)     rule
```

`max_per_term: 2` drops `"universal"`, which is the right one to drop and the
one the rank picks:

```
vocabulary judge: "universal" is a Vercel reading past max_per_term 2; not offered
vocabulary judge: 5 slot(s) from 6 proposal(s) — …
pipeline: vocabulary — 5 slots > 4; kept as decoded
```

Five is still over four, so the clip is still BROKEN — but it now comes out
right on 1 run in 3 instead of 0, which is the flip counted below. Its two
remaining spotter slots, `"went to the" → Matthieu` and `"deployed on" →
Claude`, are not names anybody said. That is an evidence problem, which is
PR 7's, not a span one.

## Gates

Built app, clean tree, stamp matching HEAD:

```
$ swift build -c release && scripts/build-app.sh
==> Build stamp: f7e7d1e
$ .build/ParrotFlowDev.app/Contents/MacOS/ParrotFlow --version
f7e7d1e
$ git rev-parse --short HEAD
f7e7d1e
```

Measured first on `6af93d6` and re-measured, whole, on `f7e7d1e` after
Greptile round 1. Both give the same four numbers and the same per-clip
verdicts. The two commits between them are `2ce6077` (renames an `Int`
parameter of `rewritten`) and `f7e7d1e` (puts the census words behind
`PARROTFLOW_JUDGE_DUMP`, and adds a refused fixture) — neither is on the
transcription path.

Scratch config dir built the way PR #63/#64/#65 document: the live
`config.yaml` and `vocabulary.yaml`, the pipeline entry replaced by
`- vocabulary: verify_names.md  when: vocabulary.count > 0` with `context` and
`fuzzy` moved below it, the prompt copied in beside it, `llm.model` set to
`gemma4:e4b`, and an empty scratch `voice/`. `~/.config/parrotflow-dev/` was
not touched and `make install` was not run. Other models were unloaded with
`keep_alive: 0`; Nathan's installed app reloaded its own `gemma4:e4b-mlx`
during the runs, as it did in PR #65, and the per-clip verdicts are identical
across baseline and after, so it moved nothing.

```
$ PARROTFLOW_CONFIG_DIR=<scratch> python3 scripts/menu-recall.py --runs 3
  recall  31/37   the true sentence was on the menu, majority of 3 runs
  picked  27/37   the judge chose it, majority of 3 runs
  0/37 clip(s) changed outcome between runs (F12a)
  (3 clip(s) unlabelled)

$ PARROTFLOW_CONFIG_DIR=<scratch> python3 scripts/before-after.py --runs 3
  fixed 17   broken 9   regressed 1   already right 10
  majority of 3 runs; 1 clip(s) changed outcome between runs (F12a)
    parrotflow-2026-08-07T17-39-40.wav  right on 1/3
```

Baseline measured by me on this machine today, on `824d402` — `main` plus the
slot-count log line, which cannot move a transcript:

| | baseline | this PR | gate |
| --- | --- | --- | --- |
| recall | 31/37 | 31/37 | ≥ 31/37 ✓ |
| picked | 27/37 | 27/37 | ≥ 27/37 ✓ |
| before/after | 17 / 9 / 1 | 17 / 9 / 1 | no worse ✓ |

**Per-clip diff: no clip changed verdict in either harness.**

```
menu-recall:   40 clips base, 40 clips after, 0 moved
before-after:  37 clips base, 37 clips after, 0 moved
```

**Flips.** `menu-recall.py` 0 in both. `before-after.py` 0 in the baseline, 1
here: `17-39-40`, right on 1 of 3 runs, verdict unchanged at BROKEN. That clip
sits on the `max_slots` boundary and the cap moved it from 6 slots to 5, so
replay noise now occasionally takes it under four. It is the only clip in the
set anywhere near the cliff.

The one REGRESSED row is `17-47-45`, unchanged since PR #63: `retry` versus
`Arexvy`, 0.46 apart, the audio prefers `retry` by 0.25 nats. A judge error,
not a mechanism one.

## The three named clips

**"praise he / praise his" — the wide reading is on the menu** (`17-39-03`):

```
vocabulary: "praise his" -> "Praisy"   also offered (span 0.45)
vocabulary: "praise his" -> "Praisy's" also offered (span 0.59)
vocabulary judge: 2 slot(s) from 9 proposal(s) — "praise" (Praisy/Praisy's), "praise his" (Praisy/Praisy's)
MENU C. Let's praise Praisy's work.
── transcript ─────────────────────────────
Let's praise Praisy's work.
```

Both readings of the wide span are offered, and each cleared the floor on its
own — 0.45 and 0.59 are on opposite sides of anything that would have tested
the possessive only where the plain term already passed.

**"Mirza's" — the possessive survives** (`17-39-19`):

```
vocabulary: "Mirza's" -> "Mirza" applied (raw -5.56 vs -6.39, bonus 2.88)
MENU A. Let's praise Mirza's work.
```

The rescorer replaces the whole token; `inflected` puts the `'s` back, so an
auto-applied substitution keeps the grammar the decoder had right.

**"Versailles." — the full stop survives.** Two clips, because the archive
holds the sentence-final case and the mid-sentence one separately.

`15-37-32`, a rendering with a full stop replaced by its term:

```
vocabulary: "Pressy." -> "Praisy" applied (raw -10.55 vs -11.71, bonus 2.88)
── transcript ─────────────────────────────
Let's praise Praisy.
```

`17-47-45`, the same thing reaching a menu rather than being written:

```
vocabulary judge: 3 slot(s) from 6 proposal(s) — "retry." (Arexvy.), "retry" (Arexvy), "crawl" (Redcrawl)
MENU E. Oh I get it. So yes, instead we want to have a Arexvy. And then if the retry fails, we want the crawl to fail.
```

The reading on the menu is `Arexvy.` and not `Arexvy`, so no option on the list
is a sentence nobody could have said.

And `16-04-42`, where `Versailles` is offered back on both sides of one
sentence:

```
MENU B. Mirza and Mira went to the movie. The movie was about the Versailles Castle. … being the plot on Vercel.
```

## Repository checks

All on `f7e7d1e`:

```
check-pipeline                  57/57   [exit 0]   (a refused fixture for max_per_term: 0)
check-replacements              23/23   [exit 0]
check-transform-folders         12/12   [exit 0]
check-default-config           ✓ a new install gets every key config.example.yaml documents  (28 keys, 9 transforms, 2 transform step(s))   [exit 0]
check-seeded-transform         ✓ transforms/code_identifiers/cases.yaml is the one in examples/  (489 lines)   [exit 0]
check-eval                      25/25   [exit 0]
check-numbers                   97/97   fr 53/53   en 26/26   auto 18/18   [exit 0]
check-dotted                    54/54   plus 2 known-unfixable   [exit 0]
check-split                     14/14   [exit 0]
check-wake                      24/24   plus 1 known-unfixed   [exit 0]
check-dates                     26/26 in 2s   1 known limit(s), not counted   [exit 0]
check-pinned-certificate       ✓ both install paths pin the same certificate  1fe06cb4b110d3f6…   [exit 0]
check-no-voice                  5/5   [exit 0]
check-vocabulary-config         61/61   [exit 0]
```

`check-span.sh`, `check-inplace.sh`, `check-grammar.sh`, `check-routing.sh` and
`check-spelling.sh` were not run: the first two need `make install`, a real
screen and Accessibility, and none of the five touches anything on this branch.

A bad cap is refused rather than run, in the shape `--check-config` already
uses for the other three:

```
$ ParrotFlow --check-config       # max_per_term: 0
✗ pipeline en: vocabulary: max_per_term is 0 — it has to be at least 1
```

## Review

Two rounds with `greptile-apps[bot]`.

| Round | Finding | Outcome |
| --- | --- | --- |
| 1 (P1, security) | The slot census wrote each slot's dictated substring and its terms to the persistent log on every run that produced a slot, including declined ones | Fixed in `f7e7d1e`: counts stay unconditional, words moved behind `PARROTFLOW_JUDGE_DUMP` |
| 1 (P2) | The cap's survivor ranking has no deterministic test | Half fixed: a refused fixture covers the validation contract, `check-pipeline.sh` 57/57. The ranking half is argued — there is no Swift test target, `--pipeline` and `--replace` have no audio so every part is `.rule` and `Standing` never has two values to order, and the input that would exercise it is a wav of the speaker's voice that `check-no-voice.sh` keeps out of the repository |
| 2 | 8 files reviewed, 0 comments added | — |

## Deviations

- **Four of five items were verification, not implementation.** Reported above
  rather than re-ported. Re-porting `widerSpans` from the frozen branch would
  have reverted PR 3's sentence-end guard, which is worth a case.
- **The cap counts places, not readings.** The plan says "cap readings per
  term at 2–3". Read literally that is `max_per_slot`, which already ships at
  3, and applying a reading cap of 2–3 *across* slots breaks the `Praisy`
  clips, where one term legitimately fills two places with three readings
  each. Two readings of one span — `Praisy` and `Praisy's` over "praise" — are
  one question, not two, and counting them separately spends the budget on the
  case the stage exists for.
- **A new stage param, not an env var,** which is what the plan's decisions
  table settles. The sweep above was run by editing `max_per_term:` in the
  scratch config, not by adding an override the harness would then own.
- **No new script.** The slot-count table came from a throwaway reader of the
  log line this PR adds. The log line is the durable part.
- **No live dictation.** Every number is a replay, `--runs 3`, with its flip
  count. Nothing here is HUMAN-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiQJipvz9Ps9tdDCRdisv
