### PR TITLE
test: 90 unfiltered clips, and F15 in the plan

### DIFF
--- a/docs/proposals/vocabulary-v2.md
+++ b/docs/proposals/vocabulary-v2.md
@@ -76,7 +76,7 @@ Rules for the agent doing a PR. Follow them exactly.
 | Installed app | `/Applications/ParrotFlowDev.app/Contents/MacOS/ParrotFlow` |
 | Judge model | Ollama, `gemma4:e4b`, temperature 0. Do not benchmark with other models loaded; e4b is the stable reference. |
 | Menu cache | `tests/judge-menus.json` (33 menus, 28 reachable) |
-| Case set | `tests/menu-cases.yaml` (37 labelled clips) |
+| Case set | `tests/menu-cases.yaml` (127 labelled clips, in two blocks) |
 
 ### Environment preflight (run before any measurement)
 
@@ -104,8 +104,8 @@ is the prototype; `(CTC-vs-CTC: …)` alone is v1.
 
 | Measurement | Command | Baseline |
 |---|---|---|
-| Menu recall | `python3 scripts/menu-recall.py` | recall 30/37 |
-| Judge took it | same run | picked 27/37 |
+| Menu recall | `python3 scripts/menu-recall.py` | recall 30/37, on the old 37-clip set — stale, see below |
+| Judge took it | same run | picked 27/37, same set — stale, see below |
 | Before/after | `python3 scripts/before-after.py` | 16 fixed / 10 broken / 2 regressed |
 | Judge on cache | `python3 scripts/tune-judge.py` | 24/28 with the sentinel bug; 26/28 with sentinel lines stripped |
 | Two-stage (fixed harness) | see PR 2 | 25/28, ceiling 28/28 |
@@ -114,6 +114,14 @@ Gates for every PR from PR 3 on: recall must not fall; `before-after.py`
 must show no new REGRESSED rows; judge `picked` must not fall below the
 baseline recorded for the same cache. A `--harvest` re-run changes the cache;
 re-record the baseline in the PR when you re-harvest, and say so.
+
+**The recall and picked baselines are stale.** They were recorded on a
+37-clip set. `tests/menu-cases.yaml` now holds 127 labelled clips: 90 more
+were merged from an unfiltered random sample (F11). The next run re-records
+both numbers. Expect them to drop in absolute terms, because 73 of the new
+clips are ordinary speech with no vocabulary term in them, and some of those
+carry decoder errors the vocabulary cannot fix. The gate is still "must not
+fall" against a baseline measured on the same set.
 
 **Caveat that stands until PR 1:** the same clip scores ~12 nats apart
 between live dictation and replay. Every number above describes replays.
@@ -281,6 +289,21 @@ between models. The 1.5B model is worse than the 0.5B. Fusion
 (0.1–0.75). Acoustic numbers pasted into the document: 20→16 — a
 cross-encoder does not read them.
 
+**F15 — a correctly-decoded term gets no slot, so a dropped possessive is
+unrecoverable.** Measured live on 2026-08-08 at 14:37:21 and 14:37:41.
+"Let's praise Matthieu's work" was decoded as "Let's praise Matthieu work",
+and the run produced **no vocabulary log lines at all**. The decoder spelled
+the term right, so nothing was proposed. With no proposal there is no slot,
+the judge never runs, and the `'s` the decoder dropped cannot be put back.
+The possessive variants added in PR 6 only exist where a substitution is
+proposed. Contrast 14:38:21: "Let's praise Praisy's work" did produce a
+proposal, and the judge chose the possessive reading correctly.
+
+*This is not judge quality.* At 14:39:15 the judge was offered "Matthew at"
+→ `Matthieu` (span 0.52) and → `Matthieu's` (span 0.56), and kept "Matthew
+at". That is the judge picking wrongly, and it is PR 7's territory. F15 is
+the case where the judge is never asked. → PR 9.
+
 ---
 
 ## Build order
@@ -299,9 +322,11 @@ an agent working alone verifies by running gates, not by being read.
 | PR 6 | PR 6 | Span variants |
 | PR 7 | PR 7 | Evidence for the judge |
 | PR 8 | PR 8 | Learn from corrections |
+| PR 9 | — | A term the decoder got right, missing its possessive |
 
 PR 0 → PR 1 → PR 2 are strictly ordered. PR 3 depends on PR 2. PRs 4–8
-depend on PR 3 and land in order.
+depend on PR 3 and land in order. PR 9 is unscoped and does not block
+anything.
 
 ---
 
@@ -571,7 +596,9 @@ export PARROTFLOW_CONFIG_DIR=/tmp/pf-scratch
 python3 scripts/tune-judge.py --harvest    # re-harvest against this binary
 grep -c '" 0\.00' tests/judge-menus.json   # 0 — the sentinel is gone at the source (F6)
 python3 scripts/tune-judge.py              # record; the cache changed, so record rather than compare
-python3 scripts/menu-recall.py --runs 3    # gate: recall ≥ 30/37, picked ≥ 27/37, report flips
+python3 scripts/menu-recall.py --runs 3    # gate: recall and picked must not fall below the baseline
+                                           # re-recorded on the 127-clip set; 30/37 and 27/37 were
+                                           # measured on the old 37-clip set and do not apply
 python3 scripts/before-after.py --runs 3   # gate: no new REGRESSED rows
 ```
 
@@ -721,6 +748,30 @@ the one dropped; `--forget` still removes everything.
 
 ---
 
+## PR 9 — a term the decoder got right, missing its possessive
+
+**Why.** F15. The vocabulary only acts where it proposes something. When the
+decoder spells a term correctly, nothing is proposed, no slot is opened, and
+the judge is never asked. "Let's praise Matthieu's work" comes out as "Let's
+praise Matthieu work" and no vocabulary line is logged. PR 6's possessive
+variants cannot help, because they are readings of a substitution that was
+never offered.
+
+**Options, neither chosen.** (a) Open a possessive slot inside the
+vocabulary pass: a vocabulary term already in the transcript, followed by a
+bare noun, with an `'s` in the audio. That keeps the fix where the term
+knowledge is, and costs a slot on sentences that are already correct. (b)
+Treat it as ordinary dictation grammar, outside the vocabulary pass, because
+the same `'s` goes missing after names that are not terms. That is a larger
+stage and it needs its own eval set.
+
+This PR is **unscoped and unmeasured**. Nothing here has a number attached.
+How often the decoder drops a possessive after a term is not known, and no
+one has checked whether the `'s` is in the audio at all in these clips.
+Measure that first, then pick (a) or (b).
+
+---
+
 ## Standing regression sentences
 
 Dictate end-to-end after any PR that touches the router, the judge, or the
@@ -733,9 +784,13 @@ three. HUMAN — these need a voice.
 4. "Let's praise Praisy's work"
 5. "deployed on Vercel against the Versailles Castle", one sentence
 6. "Matthieu's work"
+7. "Let's praise Matthieu's work" — the `'s` must survive (F15)
+8. "Let's praise Antonio's work" — the control. Antonio is not a
+   vocabulary term, so this shows whether a fix for 7 over-fires on
+   ordinary names.
 
-These six belong in `tests/menu-cases.yaml` with their clips as soon as the
-clips exist (PR 3's HUMAN step records them).
+These eight belong in `tests/menu-cases.yaml` with their clips as soon as
+the clips exist (PR 3's HUMAN step records them).
 
 ## Open questions, deliberately not settled here
 

--- a/docs/proposals/vocabulary-v2.md
+++ b/docs/proposals/vocabulary-v2.md
@@ -120,8 +120,23 @@ re-record the baseline in the PR when you re-harvest, and say so.
 were merged from an unfiltered random sample (F11). The next run re-records
 both numbers. Expect them to drop in absolute terms, because 73 of the new
 clips are ordinary speech with no vocabulary term in them, and some of those
-carry decoder errors the vocabulary cannot fix. The gate is still "must not
-fall" against a baseline measured on the same set.
+carry decoder errors the vocabulary cannot fix.
+
+**Record two totals, not one.** A single `recall` and a single `picked` over
+127 clips can now hide a regression. 73 of the clips are controls that the
+vocabulary should not touch at all; if one of them flips the right way while
+a clip that is about a term flips the wrong way, the total does not move and
+the gate passes on a real loss. So the gate is: **no clip that is about a
+vocabulary term may go to a worse mark**, and the 73 controls are reported
+beside it as a separate total. The controls should not move at all in either
+direction. The vocabulary does not touch them, so a control that changes is
+a change nobody asked for, and it needs an explanation before the PR lands.
+
+`menu-recall.py` prints one pair of totals today and does not know which
+block a clip came from. Splitting the report belongs to whoever next touches
+PR 2's harness. Until then, split by hand: the `# picked up:` comment on
+every entry in block 2 says which class the clip is in, and every clip in
+block 1 is about a term.
 
 **Caveat that stands until PR 1:** the same clip scores ~12 nats apart
 between live dictation and replay. Every number above describes replays.
@@ -289,15 +304,22 @@ between models. The 1.5B model is worse than the 0.5B. Fusion
 (0.1–0.75). Acoustic numbers pasted into the document: 20→16 — a
 cross-encoder does not read them.
 
-**F15 — a correctly-decoded term gets no slot, so a dropped possessive is
-unrecoverable.** Measured live on 2026-08-08 at 14:37:21 and 14:37:41.
-"Let's praise Matthieu's work" was decoded as "Let's praise Matthieu work",
-and the run produced **no vocabulary log lines at all**. The decoder spelled
-the term right, so nothing was proposed. With no proposal there is no slot,
-the judge never runs, and the `'s` the decoder dropped cannot be put back.
-The possessive variants added in PR 6 only exist where a substitution is
-proposed. Contrast 14:38:21: "Let's praise Praisy's work" did produce a
-proposal, and the judge chose the possessive reading correctly.
+**F15 — a correctly-decoded term gets no slot, so a missing possessive is
+unrecoverable.** Measured live on 2026-08-08 at 14:37:21 and 14:37:41. The
+sentence "Let's praise Matthieu's work" came out as "Let's praise Matthieu
+work", and the run produced **no vocabulary log lines at all**. The decoder
+spelled the term right, so nothing was proposed. With no proposal there is
+no slot, the judge never runs, and the missing `'s` cannot be put back at
+any later stage. The possessive variants added in PR 6 only exist where a
+substitution is proposed. Contrast 14:38:21: "Let's praise Praisy's work"
+did produce a proposal, and the judge chose the possessive reading
+correctly.
+
+What is measured here is the **transcript and the empty log**, nothing more.
+The intended sentence is Nathan's own, so the possessive was meant. Whether
+the `'s` is audible in the recording is not known, and nobody has looked. So
+"the decoder dropped it" is the likely reading, not a measured one. PR 9
+starts by checking the audio.
 
 *This is not judge quality.* At 14:39:15 the judge was offered "Matthew at"
 → `Matthieu` (span 0.52) and → `Matthieu's` (span 0.56), and kept "Matthew
@@ -766,9 +788,12 @@ the same `'s` goes missing after names that are not terms. That is a larger
 stage and it needs its own eval set.
 
 This PR is **unscoped and unmeasured**. Nothing here has a number attached.
-How often the decoder drops a possessive after a term is not known, and no
-one has checked whether the `'s` is in the audio at all in these clips.
-Measure that first, then pick (a) or (b).
+F15 measured one transcript and one empty log. How often a possessive goes
+missing after a term is not known, and nobody has checked whether the `'s`
+is audible in the clip at all. Option (a) only works if it is: a slot that
+asks the audio a question the audio cannot answer is a coin toss. So the
+first step is to listen to the 14:37 clips and to count the cases across the
+archive. Then pick (a) or (b).
 
 ---
 

--- a/tests/menu-cases.yaml
+++ b/tests/menu-cases.yaml
@@ -1,8 +1,12 @@
-# Menu cases mined from 300 candidate clips — 40 written, newest first.
+# Ground truth for scripts/menu-recall.py: what the speaker actually
+# said, written by hand. Two blocks, mined two different ways.
 #
 # `said` is pre-filled with what the app produced. Correct the lines
-# that are wrong, blank the ones you cannot remember, and delete any
-# clip that is not about a name. See scripts/menu-recall.py.
+# that are wrong, and blank the ones you cannot remember. A line left
+# as it is agrees with the app by construction.
+#
+# Block 1 — mined from 300 candidate clips by trigger, 40 written,
+# newest first.
 
 cases:
   - wav: parrotflow-2026-08-07T18-06-26.wav
@@ -165,3 +169,403 @@ cases:
     # picked up: a known mis-rendering
     said: "Praisy did a great job."
 
+# ---------------------------------------------------------------
+# Block 2 — sampled at random from 1579 candidate clips with no
+# trigger filter (`mine-menu-cases.py --random`), then corrected by
+# hand. 93 sampled, 90 kept here.
+#
+# Block 1 was mined by trigger, so it only holds clips whose text
+# already looked like a term. A name the app missed completely can
+# never enter that way (F11). This block can hold one, and it does:
+# 2026-08-05T23-31-30 is `Vercel` written as "Brazil", which is too
+# far from the term for any filter or floor to reach.
+#
+# The trigger filter would have admitted 23 of these 90 clips. The
+# other 67 it never sees. Most of them are about nothing, and they
+# are kept on purpose. They are the control that shows the pass
+# leaving ordinary speech alone. Keeping only the clips that mention
+# a term would rebuild the bias F11 names.
+#
+# `# app:` records what the app produced. It is written only where
+# the hand label disagrees with it.
+# ---------------------------------------------------------------
+
+  - wav: parrotflow-2026-08-04T10-28-14.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Can you check if the quality gate is actually blocking the merge?"
+
+  - wav: parrotflow-2026-08-05T17-56-55.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "What could find the answer?"
+
+  - wav: parrotflow-2026-08-07T12-41-44.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "or a good sentence to explain them they can make corrections."
+
+  - wav: parrotflow-2026-08-07T18-04-42.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "So can we add okay?"
+
+  - wav: parrotflow-2026-08-06T12-09-03.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Can we have one prompt for all words?"
+
+  - wav: parrotflow-2026-08-05T22-07-51.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    # app: I don't know how urgent is it to tackle this as a little bit.
+    said: "I don't know how urgent is it to tackle this as"
+
+  - wav: parrotflow-2026-08-07T14-19-36.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "So when you have three pronunciations."
+
+  - wav: parrotflow-2026-08-06T14-11-21.wav
+    # picked up: sampled at random, unfiltered. The app got Supabase, Vercel right.
+    said: "Supabase is where the crawl data lives and Vercel hosts the dashboard."
+
+  - wav: parrotflow-2026-08-07T07-10-36.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "That was working before."
+
+  - wav: parrotflow-2026-08-06T09-10-32.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Il faut geler le budget avant lundi, sinon Mira va râler."
+
+  - wav: parrotflow-2026-08-04T10-55-04.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "What are our enforced coverage rules?"
+
+  - wav: parrotflow-2026-08-06T12-12-16.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    # app: What do you mean by canonical? Currently we just you know whatever crawl file is canonical in the one that will be provided to the skill to work on to generate the eval set Yeah.
+    said: "What do you mean by canonical? Currently we just you know whatever crawl file is canonical in the one that will be provided to the skill to work on to generate the eval set."
+
+  - wav: parrotflow-2026-08-05T12-46-08.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "So are you training are you testing against the same prompt that does sort of everything for 5.6 Luna?"
+
+  - wav: parrotflow-2026-08-07T12-17-01.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Liquid glass, I mean."
+
+  - wav: parrotflow-2026-08-06T11-37-13.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    # app: I think one is worth implementing a more neutral about the second.
+    said: "I think one is worth implementing I'm more neutral about the second."
+
+  - wav: parrotflow-2026-08-06T14-27-51.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Switch the following branch."
+
+  - wav: parrotflow-2026-08-07T14-47-26.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    # app: Use a mermid chart as well as a very detailed step-by-step simple explanation of how the data flows through the system in text and audio how shortlists or proposals are made and examples at each stage. Like real-world examples, including the judge prompt. Verbatim, not explanation, the text with substitutions.
+    said: "Use a mermaid chart as well as a very detailed step-by-step simple explanation of how the data flows through the system in text and audio how shortlists or proposals are made and examples at each stage. Like real-world examples, including the judge prompt. Verbatim, not explanation, the text with substitutions."
+
+  - wav: parrotflow-2026-08-05T00-57-25.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Actually, let's make a little change. we're gonna re temporarily replace all our prompts with those scripts with open AI. So for every prompts we have email with bullets to restore that. Spelling Grammar In fact we we we're just using OpenAI for all our prompt but instead of changing our app we're using scripts."
+
+  - wav: parrotflow-2026-08-06T12-02-30.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "About the term is found in two places. Don't we have the information of where it is to reconcile that with the original transcription?"
+
+  - wav: parrotflow-2026-08-04T16-17-18.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "What do you mean you and wh why do we need anything over SSH?"
+
+  - wav: parrotflow-2026-08-07T09-46-57.wav
+    # picked up: sampled at random, unfiltered. The app got Vercel right.
+    said: "The app is being deployed on Vercel."
+
+  - wav: parrotflow-2026-08-05T00-58-27.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "So put the OpenAI wiring in a script and import that script in three different prompts."
+
+  - wav: parrotflow-2026-08-06T22-51-48.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    # app: So for the scale, try to reduce the number of sentences. Maybe you can try putting more words together in the sentence.
+    said: "So for the skill, try to reduce the number of sentences. Maybe you can try putting more words together in the sentence."
+
+  - wav: parrotflow-2026-08-06T14-11-36.wav
+    # picked up: sampled at random, unfiltered. The app got Arexvy, Matthieu, Tasmeen right.
+    said: "Matthieu and Tasmeen are both on the Arexvy account."
+
+  - wav: parrotflow-2026-08-06T16-49-32.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    # app: Not with my linear call but with the fact that the information to answer is missing from Mm.
+    said: "Not with my lenient call but with the fact that the information to answer is missing from Mm."
+
+  - wav: parrotflow-2026-08-06T10-45-24.wav
+    # picked up: sampled at random, unfiltered. The app got Mirza right.
+    said: "Mirza is my friend."
+
+  - wav: parrotflow-2026-08-04T11-20-21.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Good morning Peter, I added a few more comments."
+
+  - wav: parrotflow-2026-08-05T09-56-45.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Also onboarding process."
+
+  - wav: parrotflow-2026-08-06T09-46-01.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "How could we make that context?"
+
+  - wav: parrotflow-2026-08-04T12-52-59.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Hey Parrot, I meant with Patrick."
+
+  - wav: parrotflow-2026-08-04T23-30-34.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "I think I get the message, we can stop here."
+
+  - wav: parrotflow-2026-08-06T12-07-30.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "No, there is no cap."
+
+  - wav: parrotflow-2026-08-08T01-02-23.wav
+    # picked up: sampled at random, unfiltered. The app wrote Supabase over an ordinary word.
+    # app: You don't need to Supabase the design.
+    said: "You don't need to update the design."
+
+  - wav: parrotflow-2026-08-08T00-06-27.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "I mean the colors in the liquid glass background."
+
+  - wav: parrotflow-2026-08-07T07-40-08.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "And how could you rank them?"
+
+  - wav: parrotflow-2026-08-07T13-21-16.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Here is the stand up digest."
+
+  - wav: parrotflow-2026-08-05T23-31-30.wav
+    # picked up: sampled at random, unfiltered. The app missed Vercel.
+    # app: I just deployed to Brazil.
+    said: "I just deployed to Vercel."
+
+  - wav: parrotflow-2026-08-06T15-11-24.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    # app: And each commit would be one PR. So I want to have multiple PRs because small PRs get better AI reviews from grapile on GitHub.
+    said: "And each commit would be one PR. So I want to have multiple PRs because small PRs get better AI reviews from Greptile on GitHub."
+
+  - wav: parrotflow-2026-08-04T11-19-17.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Chain is a langsmith proprietary term."
+
+  - wav: parrotflow-2026-08-05T16-45-13.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "So it works on sound right so how does it match words heard with terms in the vocabulary."
+
+  - wav: parrotflow-2026-08-07T09-35-01.wav
+    # picked up: sampled at random, unfiltered. The app got Mirza, Vercel right.
+    said: "So Mirza and Mira are going to the movies. The plot happens in the Versailles castle. In the meantime, they're checking if their apps deploys correctly on Vercel."
+
+  - wav: parrotflow-2026-08-06T15-30-59.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "But those comments are a problem too."
+
+  - wav: parrotflow-2026-08-06T14-04-21.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Hi Jess. I was able to use your your comments and explanations to update the skill I was working on so that the evaluation set it generates now is very faithful to yours. Only a couple of drifts. But I'll only know if it generalizes if you have a little bit Other full set of data queries crawl file and evaluation set."
+
+  - wav: parrotflow-2026-08-04T11-38-10.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Okay, I would like to refactor the Slack mentions prompt based on that brief."
+
+  - wav: parrotflow-2026-08-07T09-37-06.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "So is it in the pipeline?"
+
+  - wav: parrotflow-2026-08-07T13-09-30.wav
+    # picked up: sampled at random, unfiltered. The app missed Praisy.
+    # app: Tell preced a Vercel deploy is done.
+    said: "Tell Praisy a Vercel deploy is done."
+
+  - wav: parrotflow-2026-08-05T12-21-15.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    # app: The convention we're trying to follow is to define schemas using Z and generate Variance from it. In that case, we'd generate interfaces from Z source of truth.
+    said: "The convention we're trying to follow is to define schemas using Zod and generate Variance from it. In that case, we'd generate interfaces from Zod source of truth."
+
+  - wav: parrotflow-2026-08-07T17-50-00.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Okay, so create a pending review on my behalf. Very short, concise, simple, standard technical English short sentences examples of the problems you have identified."
+
+  - wav: parrotflow-2026-08-05T23-00-49.wav
+    # picked up: sampled at random, unfiltered. The app missed Vercel.
+    # app: And then you have a list of possible alternatives for Versailles, such as Versailles.
+    said: "And then you have a list of possible alternatives for Versailles, such as Vercel."
+
+  - wav: parrotflow-2026-08-06T12-37-22.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "so that as a feature we could later surface the choice, the decision to the user."
+
+  - wav: parrotflow-2026-08-08T00-14-39.wav
+    # picked up: sampled at random, unfiltered. The app wrote Redcrawl over an ordinary word.
+    # app: I mean in Redcrawl in our data.
+    said: "I mean in general in our data."
+
+  - wav: parrotflow-2026-08-06T11-10-43.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Dude, I'm asking for a verbatim example, not an explanation."
+
+  - wav: parrotflow-2026-08-08T01-01-40.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    # app: Any other ID then heard it?
+    said: "Any other idea than \"heard it\"?"
+
+  - wav: parrotflow-2026-08-07T23-50-26.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "It's a fair it's a fair call."
+
+  - wav: parrotflow-2026-08-05T01-27-50.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Okay, so let's not remove anything for now."
+
+  - wav: parrotflow-2026-08-04T13-15-26.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "We could even have a a path option to the prompts and the rejects or the transforms. If they are complex we can just have them on a file and the config will resolve it so that it stay clean and easy to read."
+
+  - wav: parrotflow-2026-08-07T08-13-36.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "I'm trying to understand how did he how he went from one PR fruit to another? How many commits are specifically For the purpose of that PR it seems like there was a lot of rebase and force pushed involved."
+
+  - wav: parrotflow-2026-08-08T00-30-03.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    # app: and the plan must be in scratch more.
+    said: "and the plan must be in scratchtml."
+
+  - wav: parrotflow-2026-08-04T12-58-21.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Is it the same bug as this?"
+
+  - wav: parrotflow-2026-08-05T14-49-53.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    # app: Where is the latency game coming from?
+    said: "Where is the latency gain coming from?"
+
+  - wav: parrotflow-2026-08-06T21-08-32.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Tu viens même pas voir tes parents ?"
+
+  - wav: parrotflow-2026-08-04T10-23-52.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Address Pr comments."
+
+  - wav: parrotflow-2026-08-06T13-19-40.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Because they depend on each other. There is codependence."
+
+  - wav: parrotflow-2026-08-06T21-08-07.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    # app: Entrain dans le Gers ?
+    said: "En train dans le Gers ?"
+
+  - wav: parrotflow-2026-08-04T18-13-26.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Good luck with your project."
+
+  - wav: parrotflow-2026-08-05T14-10-46.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "But the idea okay."
+
+  - wav: parrotflow-2026-08-04T18-32-36.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Voilà le rapport envoyé par la compagnie d'assurance. Lis-le et mets-le en contexte de la discussion de la synthèse qu'on vient de faire et aussi tant qu'on y est met le dossier dans le dossier principal du projet."
+
+  - wav: parrotflow-2026-08-05T01-02-22.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Yeah but"
+
+  - wav: parrotflow-2026-08-04T10-12-37.wav
+    # picked up: sampled at random, unfiltered. The app got Tasmeen right.
+    said: "It's a community that Tasmeen asked me to crawl."
+
+  - wav: parrotflow-2026-08-06T14-09-56.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Let's recalibrate some of the words in the vocabulary. Make me dictate a few sentences containing words that are near matches to my vocabulary terms."
+
+  - wav: parrotflow-2026-08-04T17-22-31.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Can you give examples of such query-independent facts?"
+
+  - wav: parrotflow-2026-08-06T14-12-30.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "She deserves praise for finishing that so fast."
+
+  - wav: parrotflow-2026-08-07T14-35-52.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Tu vois, de pouvoir dire on aime."
+
+  - wav: parrotflow-2026-08-07T13-19-22.wav
+    # picked up: sampled at random, unfiltered. The app got Praisy right.
+    said: "Praisy is with us today."
+
+  - wav: parrotflow-2026-08-07T12-35-15.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "No, I want the text to be also bigger. So it's more easy it's easier to select and read."
+
+  - wav: parrotflow-2026-08-07T13-10-53.wav
+    # picked up: sampled at random, unfiltered. The app got Vercel right.
+    said: "Vercel and databricks are both in the diagram."
+
+  - wav: parrotflow-2026-08-06T14-11-48.wav
+    # picked up: sampled at random, unfiltered. The app got Ollama, Praisy right.
+    said: "Praisy sent me the Ollama benchmarks yesterday afternoon."
+
+  - wav: parrotflow-2026-08-06T13-20-20.wav
+    # picked up: sampled at random, unfiltered. The app got Vercel right.
+    said: "And the last thing we could do is add a very short definition to each vocabulary terms. For people it could be a person or a teammate, Vercel, an application deployment platform, etc."
+
+  - wav: parrotflow-2026-08-06T13-51-22.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    # app: Hello, Jimplémenté so that on a discuté hier. Le heading sera toujours indexé et cherchable. J'ai aussi renforcé le schéma pour que le summary ne puisse pas être vide.
+    said: "Hello, j'ai implémenté ce don on a discuté hier. Le heading sera toujours indexé et cherchable. J'ai aussi renforcé le schéma pour que le summary ne puisse pas être vide."
+
+  - wav: parrotflow-2026-08-07T18-05-16.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "For example, after a dictation I press the button while the HUD tells me I can make a correction, it opens the correction dialogue and then I make changes."
+
+  - wav: parrotflow-2026-08-04T12-54-09.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    # app: Then I said the activation phrase plus not James but Patrick and the catch-old prompt returned. Nothing I can do with not James but Patrick.
+    said: "Then I said the activation phrase plus not James but Patrick and the catch-all prompt returned. Nothing I can do with not James but Patrick."
+
+  - wav: parrotflow-2026-08-06T21-31-24.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Works f works for me."
+
+  - wav: parrotflow-2026-08-06T12-54-00.wav
+    # picked up: sampled at random, unfiltered. The app got Mirza right.
+    said: "I'm not sure how to interpret this. For example, what is the link between Mirza and Movies, the movie plot?"
+
+  - wav: parrotflow-2026-08-06T15-47-25.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    # app: And while you're doing that also support escaping. So if you press ASC during either recording or transcribing it stops even if the whole key is pressed.
+    said: "And while you're doing that also support escaping. So if you press Esc during either recording or transcribing it stops even if the whole key is pressed."
+
+  - wav: parrotflow-2026-08-06T15-36-12.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Pretty harsh review."
+
+  - wav: parrotflow-2026-08-04T18-29-00.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Okay, go ahead and create the GitHub issues."
+
+  - wav: parrotflow-2026-08-07T10-23-28.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "So I guess to close that loop, is there a way we can record the final transcription when the user press enters."
+
+  - wav: parrotflow-2026-08-07T13-09-46.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "The team deserves praise for shipping that fast."
+
+  - wav: parrotflow-2026-08-05T16-56-24.wav
+    # picked up: sampled at random, unfiltered. No vocabulary term, a control
+    said: "Can the per word score be adjusted with?"
+
+  - wav: parrotflow-2026-08-07T07-36-58.wav
+    # picked up: sampled at random, unfiltered. The app got Praisy right.
+    said: "So let's say we have very low floor for Praisy, but with the judge. The judge would the the judge was n would know my terms and see that."


### PR DESCRIPTION
Two jobs, both text only. No code, no script, no Swift file changed.

## Job 1 — the hand-labelled random sample

`mine-menu-cases.py` selects a clip only when the app's own text already
holds a term, a known mis-rendering, or a word 0.55 similar to a term. A name
the app missed completely cannot enter that way, so the case set is
structurally blind to the misses that matter most (F11). PR #65 showed it:
the `Versailles` → `Vercel` acoustic reach moved from -5.28 to -2.28 and not
one case-set clip changed.

`mine-menu-cases.py --random` sampled 93 clips out of 1579 with no filter at
all. Nathan corrected the labels by hand against the audio. This merges them.

### Counts

| | |
|---|---|
| entries in the sheet | 93 |
| `said:` blank | 0 |
| hand-corrected (`said` differs from the app's own text) | 22 |
| mention a vocabulary term, exactly | 17 |
| already in `tests/menu-cases.yaml`, skipped | 2 |
| dropped | 1 |
| **merged** | **90** |

The sheet did not use the `# picked up:` comment to carry the app's text. It
used a `was:` key instead, one per entry, all 93 present. `was:` is the app's
own output and `said:` is the hand label. The merge turns `was:` into a
`# app:` comment, and writes it only where it disagrees with `said:`. That
matches the file's comment style and keeps it out of the loader's way.

What the 90 merged clips are:

| Class | Count |
|---|---|
| the app missed a term | 3 |
| the app wrote a term over an ordinary word | 2 |
| the app got a term right | 12 |
| no vocabulary term at all, a control | 73 |

The trigger filter would have admitted 23 of the 90. The other 67 it never
sees. One of those 67 is about a term and no filter or floor could ever reach
it: `2026-08-05T23-31-30`, where `Vercel` came out as **"Brazil"**. That clip
is the reason this sample exists.

Two of the merged clips reproduce F5's sentences from the archive:

- `2026-08-08T01-02-23` — app "You don't need to **Supabase** the design",
  said "you don't need to update the design"
- `2026-08-08T00-14-39` — app "I mean in **Redcrawl** in our data", said
  "I mean in general in our data"

### What was dropped, and why

**1 dropped.** `parrotflow-2026-08-06T16-47-02.wav`. The label reads "Okay,
just go back to PR 1 PR one and install." It renders the same spoken words
two ways in one sentence, so it cannot be ground truth for an exact match.

**2 skipped as duplicates.** `parrotflow-2026-08-07T15-36-40.wav` and
`parrotflow-2026-08-07T16-09-50.wav` were already in the file. Their labels
in the random sheet are identical to the ones already there, so nothing was
lost. Dedupe is by wav filename.

**Nothing else was dropped**, and that is deliberate. The 73 clips with no
vocabulary term are the control that shows the pass leaving ordinary speech
alone. Some of them carry decoder errors the vocabulary cannot fix at all
("mermid" for "mermaid", "Z" for "Zod", "grapile" for "Greptile"). Dropping
those would keep only the clips the app can get right or the vocabulary can
fix, which is exactly the selection bias F11 names.

### Verification

No measurement was run. Another agent held the app and Ollama, so this PR
does not build, run, or replay anything.

Mechanical check only: `load_cases()` imported from `scripts/menu-recall.py`
with `SourceFileLoader` and called on the merged file.

```
total cases   : 130
labelled      : 127
unlabelled    : 3
unique wavs   : 130
duplicate wavs: []
comment leaks : []
clips missing : 0
```

Every entry parses. No wav appears twice. Every clip named exists in
`~/Recordings/ParrotFlow Dev`. The 3 unlabelled clips are the pre-existing
blank ones in block 1.

**The recall baseline will move.** `recall 30/37` and `picked 27/37` were
measured on the 37-clip set. The set is now 127 labelled clips. Both numbers
should be expected to fall in absolute terms, because 73 of the new clips are
ordinary speech and some of them the vocabulary can never fix. That is the
set growing, not a regression. Whoever measures next re-records the baseline.
The doc is updated to say so and the PR 3 gate now points at "must not fall
against a baseline measured on the same set" instead of at fixed numbers.

## Job 2 — F15 in the plan

Added to the findings ledger:

> **F15 — a correctly-decoded term gets no slot, so a dropped possessive is
> unrecoverable.** Measured live on 2026-08-08 at 14:37:21 and 14:37:41.
> "Let's praise Matthieu's work" was decoded as "Let's praise Matthieu work",
> and the run produced **no vocabulary log lines at all**. The decoder
> spelled the term right, so nothing was proposed. With no proposal there is
> no slot, the judge never runs, and the `'s` the decoder dropped cannot be
> put back. The possessive variants added in PR 6 only exist where a
> substitution is proposed. Contrast 14:38:21: "Let's praise Praisy's work"
> did produce a proposal, and the judge chose the possessive reading
> correctly.
>
> *This is not judge quality.* At 14:39:15 the judge was offered "Matthew at"
> → `Matthieu` (span 0.52) and → `Matthieu's` (span 0.56), and kept "Matthew
> at". That is the judge picking wrongly, and it is PR 7's territory. F15 is
> the case where the judge is never asked. → PR 9.

F15 goes to a new **PR 9 — a term the decoder got right, missing its
possessive**, added to the build order table and written as a section after
PR 8. Two options are sketched and neither is chosen: (a) open a possessive
slot when a term already in the transcript is followed by a bare noun and the
audio shows an `'s`, or (b) treat it as dictation grammar outside the
vocabulary pass. The section says plainly that PR 9 is unscoped and
unmeasured, and that it blocks nothing.

Two standing regression sentences added:

7. "Let's praise Matthieu's work" — the `'s` must survive (F15)
8. "Let's praise Antonio's work" — the control. Antonio is not a vocabulary
   term, so it shows whether a fix for 7 over-fires on ordinary names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiQJipvz9Ps9tdDCRdisv
