### PR TITLE
test: the score block is worth three cases, the fitted scale is worth none

### DIFF
--- a/docs/proposals/vocabulary-v2.md
+++ b/docs/proposals/vocabulary-v2.md
@@ -75,7 +75,7 @@ Rules for the agent doing a PR. Follow them exactly.
 | Built app | `.build/ParrotFlowDev.app/Contents/MacOS/ParrotFlow` |
 | Installed app | `/Applications/ParrotFlowDev.app/Contents/MacOS/ParrotFlow` |
 | Judge model | Ollama, `gemma4:e4b`, temperature 0. Do not benchmark with other models loaded; e4b is the stable reference. |
-| Menu cache | `tests/judge-menus.json` (33 menus, 28 reachable) |
+| Menu cache | `tests/judge-menus.json` (66 menus, 53 reachable — re-harvested by PR #68 over the 130-clip set) |
 | Case set | `tests/menu-cases.yaml` (127 labelled clips, in two blocks) |
 
 ### Environment preflight (run before any measurement)
@@ -104,23 +104,40 @@ is the prototype; `(CTC-vs-CTC: …)` alone is v1.
 
 | Measurement | Command | Baseline |
 |---|---|---|
-| Menu recall | `python3 scripts/menu-recall.py` | recall 30/37, on the old 37-clip set — stale, see below |
-| Judge took it | same run | picked 27/37, same set — stale, see below |
-| Before/after | `python3 scripts/before-after.py` | 16 fixed / 10 broken / 2 regressed |
-| Judge on cache | `python3 scripts/tune-judge.py` | 24/28 with the sentinel bug; 26/28 with sentinel lines stripped |
-| Two-stage (fixed harness) | see PR 2 | 25/28, ceiling 28/28 |
+| Menu recall | `python3 scripts/menu-recall.py --runs 3` | recall 102/127, re-recorded on the 127-clip set by PR #68 |
+| Judge took it | same run | picked 90/127, same run |
+| Before/after | `python3 scripts/before-after.py --runs 3` | 20 fixed / 26 broken / 11 regressed / 70 already right |
+| Judge on cache | `python3 scripts/tune-judge.py` | 41/53 on the 66-menu cache (chance 17.4); 38/53 with `--no-scores` |
+| Two-stage (fixed harness) | see PR 2 | 25/28, ceiling 28/28 — on the old 28-menu cache |
+
+Split by class, from the same `--runs 3` run (the plan asks for two totals,
+and `menu-recall.py` still prints one):
+
+| | clips | recall | picked |
+|---|---|---|---|
+| about a term | 54 | 46 | 39 |
+| controls | 73 | 56 | 51 |
+
+The 11 regressed rows are the new baseline, not a regression introduced by
+PR #68 — they arrive with the 90 unfiltered clips. Nine of them are the
+vocabulary writing a term over an ordinary word that the judge then waved
+through: `crawl`→`Redcrawl` twice, `praise`→`Praisy`, `term`→`Praisy`,
+`matches`→`Matthieu`, `retry`→`Arexvy`, `Pretty`→`Arexvy`, `Versailles
+castle`→`Vercel castle`, `update`→`Supabase`. The other two (`12-46-08`,
+`00-57-25`) differ only by a hesitation the decoder wrote this time, and no
+vocabulary term is involved.
 
 Gates for every PR from PR 3 on: recall must not fall; `before-after.py`
 must show no new REGRESSED rows; judge `picked` must not fall below the
 baseline recorded for the same cache. A `--harvest` re-run changes the cache;
 re-record the baseline in the PR when you re-harvest, and say so.
 
-**The recall and picked baselines are stale.** They were recorded on a
-37-clip set. `tests/menu-cases.yaml` now holds 127 labelled clips: 90 more
-were merged from an unfiltered random sample (F11). The next run re-records
-both numbers. Expect them to drop in absolute terms, because 73 of the new
-clips are ordinary speech with no vocabulary term in them, and some of those
-carry decoder errors the vocabulary cannot fix.
+**The recall and picked baselines above were re-recorded on 2026-08-08** by
+PR #68, on the 127 labelled clips of `tests/menu-cases.yaml`, three runs per
+clip, against `0766c81`. Two clips changed outcome between runs (`17-39-19`
+and `11-10-43`, picked on 2 runs of 3); `before-after.py` had none. The old
+37-clip numbers (recall 30/37, picked 27/37, 16/10/2) do not compare with
+them.
 
 **Record two totals, not one.** A single `recall` and a single `picked` over
 127 clips can now hide a regression. 73 of the clips are controls that the
@@ -325,6 +342,19 @@ starts by checking the audio.
 → `Matthieu` (span 0.52) and → `Matthieu's` (span 0.56), and kept "Matthew
 at". That is the judge picking wrongly, and it is PR 7's territory. F15 is
 the case where the judge is never asked. → PR 9.
+
+**F16 — the judge prompt's numbers are worth less than the words around
+them (PR #68, 2026-08-08).** On a 53-case cache, five wordings of the same
+scale — the one that ships and four alternatives — score 38, 39, 40, 41 and
+42. The shipped wording is 41 and the λ-fitted number is 38 in that same
+sentence shape and 42 in another. No number wins in both shapes, so there is
+no effect to keep, and a one-case win from a reworded prompt is inside this
+spread. Two things
+follow. Do not re-tune this prompt by wording; measure the mechanism
+instead. And the scale's upper half is unreachable — 63% of the 73 score
+lines in the cache have a gap under 1 and the largest is 2.72, because
+`decide_above: 3.0` drops anything the audio argues against more strongly
+before it can reach a menu.
 
 ---
 
@@ -764,6 +794,65 @@ evidence problem, not a span one.
 ---
 
 ## PR 7 — evidence for the judge
+
+**Measured (PR #68, 2026-08-08). Nothing was changed.** The one item under
+`Do` — the difference precomputed, the block in the user message, the scale
+in the system message — was already built by PR 3
+(`VocabularyJudge.scoreBlock`, `Pipeline.swift`, `examples/prompts/verify_names.md`).
+Both follow-ups were A/B'd on a freshly harvested cache and neither beat the
+prompt that ships.
+
+The cache was re-harvested against `0766c81` over the 130 clips of
+`tests/menu-cases.yaml`: **66 menus, 53 of them reachable** (13 never held
+the true sentence), chance 17.4/53. `grep -c '" 0\.00'` is 0 and
+`--strip-sentinels` removes nothing, so F6 stays fixed at the source. Judge
+sampling at temperature 0 is exactly repeatable — the same 12 clips failed
+on two runs of the shipped prompt.
+
+**The score block is worth +3 of 53** on that cache: 41/53 with it, 38/53
+without. It wins `12-37-22`, `08-13-36`, `16-16-25` and `17-39-19` — all
+four are menus where the block says the *term* was heard slightly more
+clearly (0.0 to 2.2) and the ordinary word is what was said, so the small
+gap is what tells the model to read the sentence. It costs `15-36-12`
+("Pretty harsh review", gap 0.1), where the same evidence pushes it to
+`Arexvy`. The +2 the review measured on the old corrupted cache is now +3
+on clean evidence, and the case for the block is the mechanism rather than
+the size.
+
+**The pro-term prior stays.** Deleting the sentence scores 40/53 against
+41/53, and the case it costs is `07-36-58` — "very low floor for Prezi"
+against `Praisy`, a menu with no score block at all, which is exactly the
+class the sentence exists for. It does not cause F5's failure either: the
+`Redcrawl` sentence (`00-14-39`, "I mean in general in our data") is wrong
+with the prior and wrong without it, and the `Supabase` sentence
+(`01-02-23`) is right both ways even though the block says `Supabase` was
+heard 2.7 more clearly. One variant tried.
+
+**The prose scale beat the fitted λ.** F14's plateau (λ 0.1–0.75) says one
+unit of sentence evidence buys 1.3 to 10 nats, centre about 2.5. Four
+alternatives were tried. Three of them make a 2×2 with what ships, which is
+what separates the number from the sentence carrying it:
+
+| picked /53 | numbers "about 1 / about 4" | fitted 2.5 | plateau edges 1.3 / 10 |
+|---|---|---|---|
+| shipped sentence shape | **41** | 38 | 39 |
+| reshaped sentence | 40 | 42 | — |
+
+The same number scores 38 or 42 depending on the wording around it, and the
+same wording scores 38 to 41 depending on the number. There is no main
+effect to keep, which is F14's "wording is worth 8 points" arriving in the
+judge prompt. Nothing was changed.
+
+**Why the scale can barely fire.** Over the 73 score lines in the fresh
+cache, 63% of gaps are under 1 and the largest is 2.72. The prompt's "a gap
+over about 4 means the sound can decide" therefore never applies: PR 4's
+`decide_above: 3.0` drops a proposal the audio argues against by more than
+3 nats, so a reading that reaches the menu cannot carry a large gap. The
+upper half of the scale is dead text, and that — not its wording — is what
+would have to change for the sound to overrule a sentence.
+
+The live failure of 14:39:15 that F15 hands to PR 7 ("Matthew at" kept over
+`Matthieu's`) is now a case in `tests/judge-cases.yaml`.
 
 **Why.** F4, F6, F8. The judge is the weakest link; the one lever that
 measured is cleaner evidence. With the sentinel gone at the source (PR 3),

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -277,7 +277,8 @@ substitution. They are kept because they are what fixed the design: a per-word
 question cannot answer a sentence that says `Versailles` twice and means the
 palace once.
 
-Scored on `tests/judge-cases.yaml`, 58 proposals from real recordings:
+Scored on `tests/judge-cases.yaml` when it held 58 proposals from real
+recordings. The file holds 59 now; the case added in PR 7 was not scored here:
 
 | | approve | decline | overall | latency |
 | --- | --- | --- | --- | --- |

--- a/scripts/validate-judge.py
+++ b/scripts/validate-judge.py
@@ -12,8 +12,8 @@ text: a stage that can rewrite a transcript will, and this one runs on
 dictations nobody has read yet.
 
 Two numbers, because a single one hides the only failure that matters. The set
-is 33% approve and 67% decline, so a judge that answers DROP to everything
-scores 67% overall and is worthless. `approve` and `decline` are scored apart.
+is 29% approve and 71% decline, so a judge that answers DROP to everything
+scores 71% overall and is worthless. `approve` and `decline` are scored apart.
 
 Scoreboard
                             approve  decline  overall  latency

--- a/tests/judge-cases.yaml
+++ b/tests/judge-cases.yaml
@@ -316,3 +316,15 @@ cases:
     heard: "bedrock"
     term: "Redrock"
     expect: decline
+
+  # ---- observed live, 2026-08-08 14:39:15 ----
+  # The judge was offered two readings of the same span, "Matthieu"
+  # (span 0.52) and "Matthieu's" (span 0.56), and kept "Matthew at".
+  # The speaker said "Matthieu's". The possessive is the whole case:
+  # the span is two words, the term is one, and the reading that fits
+  # is the one that carries the 's.
+
+  - said: "Also tried those. I noticed that when the judge it's not invoked, uh the possessive is lost. So that is the case for that spray's Matthew at work."
+    heard: "Matthew at"
+    term: "Matthieu's"
+    expect: approve

--- a/tests/judge-menus.json
+++ b/tests/judge-menus.json
@@ -13,18 +13,21 @@
    "Oh I get it. So yes, instead we want to have a Arexvy. And then if the Arexvy fails, we want the Redcrawl to fail."
   ],
   "terms": "Arexvy, Arexvy., Redcrawl",
-  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"retry.\" -10.26   \"Arexvy.\" -9.80   — \"retry.\" heard 0.5 less clearly\n  \"retry\" -7.55   \"Arexvy\" -7.80   — \"Arexvy\" heard 0.3 less clearly\n  \"crawl\" -6.81   \"Redcrawl\" -8.24   — \"Redcrawl\" heard 1.4 less clearly"
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"retry.\" -10.26   \"Arexvy.\" -9.80   — \"retry.\" heard 0.5 less clearly\n  \"retry\" -9.20   \"Arexvy\" -8.31   — \"retry\" heard 0.9 less clearly\n  \"crawl\" -9.06   \"Redcrawl\" -9.58   — \"Redcrawl\" heard 0.5 less clearly"
  },
  {
   "wav": "parrotflow-2026-08-07T17-39-27.wav",
   "said": "Let's praise Matthieu's work.",
   "menu": [
-   "Let's praise Matthieu work.",
-   "Let's Praisy Matthieu work.",
-   "Let's Praisy's Matthieu work."
+   "Let's praise Mathieu's work.",
+   "Let's praise Matthieu's work.",
+   "Let's Praisy Mathieu's work.",
+   "Let's Praisy Matthieu's work.",
+   "Let's Praisy's Mathieu's work.",
+   "Let's Praisy's Matthieu's work."
   ],
-  "terms": "Praisy, Praisy's",
-  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -5.87   \"Praisy\" -6.80   — \"Praisy\" heard 0.9 less clearly"
+  "terms": "Matthieu, Praisy, Praisy's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -6.20   \"Praisy\" -6.59   — \"Praisy\" heard 0.4 less clearly\n  \"Mathieu's\" -6.97   \"Matthieu\" -7.00   — \"Matthieu\" heard 0.0 less clearly"
  },
  {
   "wav": "parrotflow-2026-08-07T17-39-19.wav",
@@ -52,7 +55,7 @@
    "Let's Praisy's Praisy's work."
   ],
   "terms": "Praisy, Praisy's",
-  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -5.49   \"Praisy\" -5.70   — \"Praisy\" heard 0.2 less clearly"
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -6.70   \"Praisy\" -7.05   — \"Praisy\" heard 0.4 less clearly"
  },
  {
   "wav": "parrotflow-2026-08-07T17-38-57.wav",
@@ -108,7 +111,7 @@
    "So let's Praisy's team's work."
   ],
   "terms": "Praisy, Praisy's",
-  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -6.83   \"Praisy\" -7.08   — \"Praisy\" heard 0.2 less clearly"
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -9.83   \"Praisy\" -9.91   — \"Praisy\" heard 0.1 less clearly"
  },
  {
   "wav": "parrotflow-2026-08-07T17-26-56.wav",
@@ -137,17 +140,11 @@
    "So the document was a really super base uh for discussion and the Supabase proposal for the database is great.",
    "So the document was a really super base uh for discussion and the Supabase proposal for the Supabase's great.",
    "So the document was a really super base uh for discussion and the Supabase proposal for the Supabase is great.",
-   "So the document was a really super base uh for discussion and the Supabase Praisy for the database is great.",
-   "So the document was a really super base uh for discussion and the Supabase Praisy for the Supabase's great.",
-   "So the document was a really super base uh for discussion and the Supabase Praisy for the Supabase is great.",
    "So the document was a really Supabase uh for discussion and the Supabase proposal for the database is great.",
    "So the document was a really Supabase uh for discussion and the Supabase proposal for the Supabase's great.",
-   "So the document was a really Supabase uh for discussion and the Supabase proposal for the Supabase is great.",
-   "So the document was a really Supabase uh for discussion and the Supabase Praisy for the database is great.",
-   "So the document was a really Supabase uh for discussion and the Supabase Praisy for the Supabase's great.",
-   "So the document was a really Supabase uh for discussion and the Supabase Praisy for the Supabase is great."
+   "So the document was a really Supabase uh for discussion and the Supabase proposal for the Supabase is great."
   ],
-  "terms": "Praisy, Supabase, Supabase's",
+  "terms": "Supabase, Supabase's",
   "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"super base\" -6.48   \"Supabase\" -8.00   — \"Supabase\" heard 1.5 less clearly\n  \"database\" -5.99   \"Supabase\" -3.82   — \"database\" heard 2.2 less clearly"
  },
  {
@@ -188,7 +185,13 @@
    "But my idea was to not substitute before the judge and only let the judge decide between what was heard by the decoder and what the decoder found similar. So in that case it would be both Praisy praise.",
    "But my idea was to not substitute before the judge and only let the judge decide between what was heard by the decoder and what the decoder found similar. So in that case it would be both Praisy Praisy.",
    "But my idea was to not substitute before the judge and only let the judge decide between what was heard by the decoder and what the decoder found similar. So in that case it would be both Praisy's praise.",
-   "But my idea was to not substitute before the judge and only let the judge decide between what was heard by the decoder and what the decoder found similar. So in that case it would be both Praisy's Praisy."
+   "But my idea was to not substitute before the judge and only let the judge decide between what was heard by the decoder and what the decoder found similar. So in that case it would be both Praisy's Praisy.",
+   "But my idea was to not substitute before the judge and only let the judge decide between what was Praisy the decoder and what the decoder found similar. So in that case it would be both praise and praise.",
+   "But my idea was to not substitute before the judge and only let the judge decide between what was Praisy the decoder and what the decoder found similar. So in that case it would be both praise and Praisy.",
+   "But my idea was to not substitute before the judge and only let the judge decide between what was Praisy the decoder and what the decoder found similar. So in that case it would be both Praisy praise.",
+   "But my idea was to not substitute before the judge and only let the judge decide between what was Praisy the decoder and what the decoder found similar. So in that case it would be both Praisy Praisy.",
+   "But my idea was to not substitute before the judge and only let the judge decide between what was Praisy the decoder and what the decoder found similar. So in that case it would be both Praisy's praise.",
+   "But my idea was to not substitute before the judge and only let the judge decide between what was Praisy the decoder and what the decoder found similar. So in that case it would be both Praisy's Praisy."
   ],
   "terms": "Praisy, Praisy's, Praisy.",
   "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -10.08   \"Praisy\" -9.58   — \"praise\" heard 0.5 less clearly\n  \"praise.\" -5.67   \"Praisy.\" -5.47   — \"praise.\" heard 0.2 less clearly"
@@ -198,7 +201,9 @@
   "said": "But replaced it with Praisy. So the judge couldn't see praise.",
   "menu": [
    "But replaced it with Prezi. So the judge couldn't see Braze.",
-   "But replaced it with Praisy. So the judge couldn't see Braze."
+   "But replaced it with Praisy. So the judge couldn't see Braze.",
+   "But Praisy Prezi. So the judge couldn't see Braze.",
+   "But Praisy Praisy. So the judge couldn't see Braze."
   ],
   "terms": "Praisy",
   "scores": ""
@@ -225,7 +230,7 @@
    "Let's Praisy's work Praisy has done."
   ],
   "terms": "Praisy, Praisy's",
-  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -9.20   \"Praisy\" -8.64   — \"praise\" heard 0.6 less clearly\n  \"Prissy\" -6.86   \"Praisy\" -6.15   — \"Prissy\" heard 0.7 less clearly"
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -9.17   \"Praisy\" -8.64   — \"praise\" heard 0.5 less clearly\n  \"Prissy\" -6.91   \"Praisy\" -6.19   — \"Prissy\" heard 0.7 less clearly"
  },
  {
   "wav": "parrotflow-2026-08-07T16-09-37.wav",
@@ -324,13 +329,10 @@
   "said": "So why? So I said Praisy, P-R-A-I-S-E. Why wasn't it considered as a term and why was it replaced by Pressy?",
   "menu": [
    "So why? So I said praise, P-R-A-I-S-E. Why wasn't it considered as a term and why was it replaced by Praisy?",
-   "So why? So I said praise, P-R-A-I-S-E. Why wasn't it considered as a term and why was it Praisy by Praisy?",
    "So why? So I said Praisy, P-R-A-I-S-E. Why wasn't it considered as a term and why was it replaced by Praisy?",
-   "So why? So I said Praisy, P-R-A-I-S-E. Why wasn't it considered as a term and why was it Praisy by Praisy?",
-   "So why? So I said Praisy's, P-R-A-I-S-E. Why wasn't it considered as a term and why was it replaced by Praisy?",
-   "So why? So I said Praisy's, P-R-A-I-S-E. Why wasn't it considered as a term and why was it Praisy by Praisy?"
+   "So why? So I said Praisy's, P-R-A-I-S-E. Why wasn't it considered as a term and why was it replaced by Praisy?"
   ],
-  "terms": "Praisy, Praisy's,, Praisy,",
+  "terms": "Praisy's,, Praisy,",
   "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise,\" -3.67   \"Praisy,\" -4.93   — \"Praisy,\" heard 1.3 less clearly"
  },
  {
@@ -398,5 +400,423 @@
   ],
   "terms": "Praisy",
   "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"Prissy\" -10.85   \"Praisy\" -9.58   — \"Prissy\" heard 1.3 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-04T10-28-14.wav",
+  "said": "Can you check if the quality gate is actually blocking the merge?",
+  "menu": [
+   "Can you check if the quality gate is actually blocking the merge?",
+   "Can you check if the quality gate is actually blocking the Vercel?"
+  ],
+  "terms": "Vercel?",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"merge?\" -8.85   \"Vercel?\" -8.80   — \"merge?\" heard 0.0 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-06T14-11-21.wav",
+  "said": "Supabase is where the crawl data lives and Vercel hosts the dashboard.",
+  "menu": [
+   "superbase is where the crawl data lives and Versal hosts the dashboard.",
+   "superbase is where the crawl data lives and Vercel hosts the dashboard.",
+   "superbase is where the Redcrawl data lives and Versal hosts the dashboard.",
+   "superbase is where the Redcrawl data lives and Vercel hosts the dashboard.",
+   "Supabase is where the crawl data lives and Versal hosts the dashboard.",
+   "Supabase is where the crawl data lives and Vercel hosts the dashboard.",
+   "Supabase is where the Redcrawl data lives and Versal hosts the dashboard.",
+   "Supabase is where the Redcrawl data lives and Vercel hosts the dashboard."
+  ],
+  "terms": "Redcrawl, Supabase, Vercel",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"Superbase\" -6.66   \"Supabase\" -6.78   — \"Supabase\" heard 0.1 less clearly\n  \"crawl\" -2.93   \"Redcrawl\" -4.95   — \"Redcrawl\" heard 2.0 less clearly\n  \"Versal\" -6.11   \"Vercel\" -6.32   — \"Vercel\" heard 0.2 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-06T09-10-32.wav",
+  "said": "Il faut geler le budget avant lundi, sinon Mira va râler.",
+  "menu": [
+   "Il faut geler le budget avant lundi, sinon Mira va râler.",
+   "Il faut geler le budget avant lundi, sinon Mirza râler.",
+   "Il faut geler le budget avant lundi, sinon Mirza's râler."
+  ],
+  "terms": "Mirza, Mirza's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"Mira\" -12.59   \"Mirza\" -12.25   — \"Mira\" heard 0.3 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-06T12-12-16.wav",
+  "said": "What do you mean by canonical? Currently we just you know whatever crawl file is canonical in the one that will be provided to the skill to work on to generate the eval set.",
+  "menu": [
+   "What do you mean by canonical? Currently we just you know whatever crawl file is canonical in the one that will be provided to the skill to work on to generate the eval set Yeah.",
+   "What do you mean by canonical? Currently we just you know whatever Redcrawl file is canonical in the one that will be provided to the skill to work on to generate the eval set Yeah.",
+   "What do you mean by canonical? Praisy we just you know whatever crawl file is canonical in the one that will be provided to the skill to work on to generate the eval set Yeah.",
+   "What do you mean by canonical? Praisy we just you know whatever Redcrawl file is canonical in the one that will be provided to the skill to work on to generate the eval set Yeah."
+  ],
+  "terms": "Praisy, Redcrawl",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"crawl\" -9.31   \"Redcrawl\" -10.62   — \"Redcrawl\" heard 1.3 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-06T11-37-13.wav",
+  "said": "I think one is worth implementing I'm more neutral about the second.",
+  "menu": [
+   "I think one is worth implementing a more neutral about the second.",
+   "I think one is worth implementing a more Redcrawl about the second."
+  ],
+  "terms": "Redcrawl",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"neutral\" -7.43   \"Redcrawl\" -8.75   — \"Redcrawl\" heard 1.3 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T14-47-26.wav",
+  "said": "Use a mermaid chart as well as a very detailed step-by-step simple explanation of how the data flows through the system in text and audio how shortlists or proposals are made and examples at each stage. Like real-world examples, including the judge prompt. Verbatim, not explanation, the text with substitutions.",
+  "menu": [
+   "Use a mermid chart as well as a very detailed step-by-step simple explanation of how the data flows through the system in text and audio how shortlists or proposals are made and examples at each stage. Like real-world examples, including the judge prompt. Verbatim, not explanation, the text with substitutions.",
+   "Use a mermid chart as well as a very detailed step-by-step simple explanation of how the data flows Praisy the system in text and audio how shortlists or proposals are made and examples at each stage. Like real-world examples, including the judge prompt. Verbatim, not explanation, the text with substitutions."
+  ],
+  "terms": "Praisy",
+  "scores": ""
+ },
+ {
+  "wav": "parrotflow-2026-08-07T09-46-57.wav",
+  "said": "The app is being deployed on Vercel.",
+  "menu": [
+   "The app is being deployed on Versal.",
+   "The app is being deployed on Vercel."
+  ],
+  "terms": "Vercel",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"Versal.\" -17.82   \"Vercel.\" -18.67   — \"Vercel.\" heard 0.8 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-06T22-51-48.wav",
+  "said": "So for the skill, try to reduce the number of sentences. Maybe you can try putting more words together in the sentence.",
+  "menu": [
+   "So for the scale, try to reduce the number of sentences. Maybe you can try putting more words together in the sentence.",
+   "So for the scale, try to reduce the Vercel sentences. Maybe you can try putting more words together in the sentence.",
+   "So for the scale, try to Redrock the number of sentences. Maybe you can try putting more words together in the sentence.",
+   "So for the scale, try to Redrock the Vercel sentences. Maybe you can try putting more words together in the sentence.",
+   "So for the scale, Claude to reduce the number of sentences. Maybe you can try putting more words together in the sentence.",
+   "So for the scale, Claude to reduce the Vercel sentences. Maybe you can try putting more words together in the sentence.",
+   "So for the scale, Claude to Redrock the number of sentences. Maybe you can try putting more words together in the sentence.",
+   "So for the scale, Claude to Redrock the Vercel sentences. Maybe you can try putting more words together in the sentence."
+  ],
+  "terms": "Claude, Redrock, Vercel",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"reduce\" -8.44   \"Redrock\" -9.39   — \"Redrock\" heard 0.9 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-06T14-11-36.wav",
+  "said": "Matthieu and Tasmeen are both on the Arexvy account.",
+  "menu": [
+   "Matthieu and Tasmine are both on the RXV account.",
+   "Matthieu and Tasmine are both on the Arexvy account.",
+   "Matthieu and Tasmeen are both on the RXV account.",
+   "Matthieu and Tasmeen are both on the Arexvy account."
+  ],
+  "terms": "Arexvy, Tasmeen",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"Tasmine\" -8.01   \"Tasmeen\" -8.75   — \"Tasmeen\" heard 0.7 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-08T01-02-23.wav",
+  "said": "You don't need to update the design.",
+  "menu": [
+   "You don't need to update the design.",
+   "You don't need to Supabase the design."
+  ],
+  "terms": "Supabase",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"update\" -11.03   \"Supabase\" -8.31   — \"update\" heard 2.7 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-04T11-19-17.wav",
+  "said": "Chain is a langsmith proprietary term.",
+  "menu": [
+   "Chain is a langsmith proprietary term.",
+   "Chain is a langsmith Praisy term."
+  ],
+  "terms": "Praisy",
+  "scores": ""
+ },
+ {
+  "wav": "parrotflow-2026-08-05T16-45-13.wav",
+  "said": "So it works on sound right so how does it match words heard with terms in the vocabulary.",
+  "menu": [
+   "So it works on sound right so how does it match words heard with terms in the vocabulary.",
+   "So it works on sound right so how does it Matthieu's heard with terms in the vocabulary.",
+   "So it works on sound right so how does it Matthieu words heard with terms in the vocabulary."
+  ],
+  "terms": "Matthieu, Matthieu's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"match\" -8.18   \"Matthieu\" -10.83   — \"Matthieu\" heard 2.7 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T09-35-01.wav",
+  "said": "So Mirza and Mira are going to the movies. The plot happens in the Versailles castle. In the meantime, they're checking if their apps deploys correctly on Vercel.",
+  "menu": [
+   "So Mirza and Mira are going to the movies. The plot happens in the Vercel castle. In the meantime, they're checking if their apps deploys correctly on Vercel.",
+   "So Mirza and Mirza going to the movies. The plot happens in the Vercel castle. In the meantime, they're checking if their apps deploys correctly on Vercel.",
+   "So Mirza and Mirza's going to the movies. The plot happens in the Vercel castle. In the meantime, they're checking if their apps deploys correctly on Vercel."
+  ],
+  "terms": "Mirza, Mirza's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"Mira\" -5.74   \"Mirza\" -6.67   — \"Mirza\" heard 0.9 less clearly\n  \"Versal.\" -8.70   \"Vercel.\" -8.82   — \"Vercel.\" heard 0.1 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-06T14-04-21.wav",
+  "said": "Hi Jess. I was able to use your your comments and explanations to update the skill I was working on so that the evaluation set it generates now is very faithful to yours. Only a couple of drifts. But I'll only know if it generalizes if you have a little bit Other full set of data queries crawl file and evaluation set.",
+  "menu": [
+   "Hi Jess. I was able to use your your comments and explanations to update the skill I was working on so that the evaluation set it generates now is very faithful to yours. Only a couple of drifts. But I'll only know if it generalizes if you have a little bit Other full set of data queries crawl file and evaluation set.",
+   "Hi Jess. I was able to use your your comments and explanations to update the skill I was working on so that the evaluation set it generates now is very faithful to yours. Only a couple of drifts. But I'll only know if it generalizes if you have a little bit Other full set of data queries Redcrawl file and evaluation set.",
+   "Hi Jess. I was able to use your your comments and explanations to Supabase the skill I was working on so that the evaluation set it generates now is very faithful to yours. Only a couple of drifts. But I'll only know if it generalizes if you have a little bit Other full set of data queries crawl file and evaluation set.",
+   "Hi Jess. I was able to use your your comments and explanations to Supabase the skill I was working on so that the evaluation set it generates now is very faithful to yours. Only a couple of drifts. But I'll only know if it generalizes if you have a little bit Other full set of data queries Redcrawl file and evaluation set.",
+   "Hi Jess. I was able to use your your comments and Praisy to update the skill I was working on so that the evaluation set it generates now is very faithful to yours. Only a couple of drifts. But I'll only know if it generalizes if you have a little bit Other full set of data queries crawl file and evaluation set.",
+   "Hi Jess. I was able to use your your comments and Praisy to update the skill I was working on so that the evaluation set it generates now is very faithful to yours. Only a couple of drifts. But I'll only know if it generalizes if you have a little bit Other full set of data queries Redcrawl file and evaluation set.",
+   "Hi Jess. I was able to use your your comments and Praisy to Supabase the skill I was working on so that the evaluation set it generates now is very faithful to yours. Only a couple of drifts. But I'll only know if it generalizes if you have a little bit Other full set of data queries crawl file and evaluation set.",
+   "Hi Jess. I was able to use your your comments and Praisy to Supabase the skill I was working on so that the evaluation set it generates now is very faithful to yours. Only a couple of drifts. But I'll only know if it generalizes if you have a little bit Other full set of data queries Redcrawl file and evaluation set."
+  ],
+  "terms": "Praisy, Redcrawl, Supabase",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"update\" -5.24   \"Supabase\" -5.65   — \"Supabase\" heard 0.4 less clearly\n  \"crawl\" -8.39   \"Redcrawl\" -10.45   — \"Redcrawl\" heard 2.1 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T13-09-30.wav",
+  "said": "Tell Praisy a Vercel deploy is done.",
+  "menu": [
+   "Tell preced a Vercel deploy is done.",
+   "Tell Praisy a Vercel deploy is done."
+  ],
+  "terms": "Praisy",
+  "scores": ""
+ },
+ {
+  "wav": "parrotflow-2026-08-07T17-50-00.wav",
+  "said": "Okay, so create a pending review on my behalf. Very short, concise, simple, standard technical English short sentences examples of the problems you have identified.",
+  "menu": [
+   "Okay, so create a pending review on my behalf. Very short, concise, simple, standard technical English short sentences examples of the problems you have identified.",
+   "Okay, so create a pending review on my behalf. Very short, concise, simple, standard technical English short Praisy examples of the problems you have identified."
+  ],
+  "terms": "Praisy",
+  "scores": ""
+ },
+ {
+  "wav": "parrotflow-2026-08-05T23-00-49.wav",
+  "said": "And then you have a list of possible alternatives for Versailles, such as Vercel.",
+  "menu": [
+   "And then you have a list of possible alternatives for Versailles, such as Versailles.",
+   "And then you have a list of possible alternatives for Versailles, such as Vercel.",
+   "And then you have a list of possible alternatives for Vercel, such as Versailles.",
+   "And then you have a list of possible alternatives for Vercel, such as Vercel.",
+   "And then you have a list of Tasmeen alternatives for Versailles, such as Versailles.",
+   "And then you have a list of Tasmeen alternatives for Versailles, such as Vercel.",
+   "And then you have a list of Tasmeen alternatives for Vercel, such as Versailles.",
+   "And then you have a list of Tasmeen alternatives for Vercel, such as Vercel."
+  ],
+  "terms": "Tasmeen, Vercel",
+  "scores": ""
+ },
+ {
+  "wav": "parrotflow-2026-08-06T12-37-22.wav",
+  "said": "so that as a feature we could later surface the choice, the decision to the user.",
+  "menu": [
+   "so that as a feature we could later surface the choice, the decision to the user.",
+   "so that as a feature we could later Supabase the choice, the decision to the user."
+  ],
+  "terms": "Supabase",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"surface\" -4.85   \"Supabase\" -4.17   — \"surface\" heard 0.7 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-08T00-14-39.wav",
+  "said": "I mean in general in our data.",
+  "menu": [
+   "I mean in general in our data.",
+   "I mean in Redcrawl in our data."
+  ],
+  "terms": "Redcrawl",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"general\" -9.88   \"Redcrawl\" -9.97   — \"Redcrawl\" heard 0.1 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-06T11-10-43.wav",
+  "said": "Dude, I'm asking for a verbatim example, not an explanation.",
+  "menu": [
+   "Dude, I'm asking for a verbatim example, not an explanation.",
+   "Dude, I'm asking for a verbatim example, not an Ollama."
+  ],
+  "terms": "Ollama",
+  "scores": ""
+ },
+ {
+  "wav": "parrotflow-2026-08-04T13-15-26.wav",
+  "said": "We could even have a a path option to the prompts and the rejects or the transforms. If they are complex we can just have them on a file and the config will resolve it so that it stay clean and easy to read.",
+  "menu": [
+   "We could even have a a path option to the prompts and the rejects or the transforms. If they are complex we can just have them on a file and the config will resolve it so that it stay clean and easy to read.",
+   "We could even have a a path option to the prompts and the rejects or the transforms. If they are complex we can just have them Tasmeen and the config will resolve it so that it stay clean and easy to read."
+  ],
+  "terms": "Tasmeen",
+  "scores": ""
+ },
+ {
+  "wav": "parrotflow-2026-08-07T08-13-36.wav",
+  "said": "I'm trying to understand how did he how he went from one PR fruit to another? How many commits are specifically For the purpose of that PR it seems like there was a lot of rebase and force pushed involved.",
+  "menu": [
+   "I'm trying to understand how did he how he went from one PR fruit to another? How many commits are specifically For the purpose of that PR it seems like there was a lot of rebase and force pushed involved.",
+   "I'm trying to understand how did he how he went from one PR fruit to another? How many commits are specifically For the purpose of that PR it seems like there was a lot of Supabase and force pushed involved.",
+   "I'm trying to understand how did he how he went from one PR fruit to another? How many commits are specifically For the purpose of that PR it seems like there Praisy of rebase and force pushed involved.",
+   "I'm trying to understand how did he how he went from one PR fruit to another? How many commits are specifically For the purpose of that PR it seems like there Praisy of Supabase and force pushed involved.",
+   "I'm trying to understand how did he how he went from one PR fruit to another? How many commits are Praisy For the purpose of that PR it seems like there was a lot of rebase and force pushed involved.",
+   "I'm trying to understand how did he how he went from one PR fruit to another? How many commits are Praisy For the purpose of that PR it seems like there was a lot of Supabase and force pushed involved.",
+   "I'm trying to understand how did he how he went from one PR fruit to another? How many commits are Praisy For the purpose of that PR it seems like there Praisy of rebase and force pushed involved.",
+   "I'm trying to understand how did he how he went from one PR fruit to another? How many commits are Praisy For the purpose of that PR it seems like there Praisy of Supabase and force pushed involved."
+  ],
+  "terms": "Praisy, Supabase",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"rebase\" -5.82   \"Supabase\" -3.59   — \"rebase\" heard 2.2 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-04T10-12-37.wav",
+  "said": "It's a community that Tasmeen asked me to crawl.",
+  "menu": [
+   "It's a community that Tasmin asked me to crawl.",
+   "It's a community that Tasmin asked me to Redcrawl.",
+   "It's a community that Tasmeen asked me to crawl.",
+   "It's a community that Tasmeen asked me to Redcrawl."
+  ],
+  "terms": "Redcrawl., Tasmeen",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"Tasmin\" -10.13   \"Tasmeen\" -10.68   — \"Tasmeen\" heard 0.5 less clearly\n  \"crawl.\" -10.06   \"Redcrawl.\" -11.83   — \"Redcrawl.\" heard 1.8 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-06T14-09-56.wav",
+  "said": "Let's recalibrate some of the words in the vocabulary. Make me dictate a few sentences containing words that are near matches to my vocabulary terms.",
+  "menu": [
+   "Let's recalibrate some of the words in the vocabulary. Make me dictate a few sentences containing words that are near matches to my vocabulary terms.",
+   "Let's recalibrate some of the words in the vocabulary. Make me dictate a few sentences containing words that are near matches to my Praisy terms.",
+   "Let's recalibrate some of the words in the vocabulary. Make me dictate a few sentences containing words that are near Matthieu to my vocabulary terms.",
+   "Let's recalibrate some of the words in the vocabulary. Make me dictate a few sentences containing words that are near Matthieu to my Praisy terms.",
+   "Let's recalibrate some of the words in the vocabulary. Make me dictate a few sentences containing words that are near Matthieu's to my vocabulary terms.",
+   "Let's recalibrate some of the words in the vocabulary. Make me dictate a few sentences containing words that are near Matthieu's to my Praisy terms."
+  ],
+  "terms": "Matthieu, Matthieu's, Praisy",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"matches\" -5.74   \"Matthieu\" -6.93   — \"Matthieu\" heard 1.2 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-06T14-12-30.wav",
+  "said": "She deserves praise for finishing that so fast.",
+  "menu": [
+   "She deserves praise for finishing that so fast.",
+   "She deserves Praisy finishing that so fast.",
+   "She deserves Praisy's finishing that so fast."
+  ],
+  "terms": "Praisy, Praisy's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -4.03   \"Praisy\" -4.99   — \"Praisy\" heard 1.0 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T13-19-22.wav",
+  "said": "Praisy is with us today.",
+  "menu": [
+   "Prissy is with us today.",
+   "Praisy is with us today."
+  ],
+  "terms": "Praisy",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"Prissy\" -11.79   \"Praisy\" -10.27   — \"Prissy\" heard 1.5 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-06T14-11-48.wav",
+  "said": "Praisy sent me the Ollama benchmarks yesterday afternoon.",
+  "menu": [
+   "Prissy sent me the Ollama benchmarks yesterday afternoon.",
+   "Praisy sent me the Ollama benchmarks yesterday afternoon."
+  ],
+  "terms": "Praisy",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"Prissy\" -10.86   \"Praisy\" -10.49   — \"Prissy\" heard 0.4 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-06T13-51-22.wav",
+  "said": "Hello, j'ai implémenté ce don on a discuté hier. Le heading sera toujours indexé et cherchable. J'ai aussi renforcé le schéma pour que le summary ne puisse pas être vide.",
+  "menu": [
+   "Hello, Jimplémenté so that on a discuté hier. Le heading sera toujours indexé et cherchable. J'ai aussi renforcé le schéma pour que le summary ne puisse pas être vide.",
+   "Hello, Jimplémenté so that on a discuté hier. Le heading sera toujours indexé et cherchable. J'ai aussi Redrock le schéma pour que le summary ne puisse pas être vide.",
+   "Hello, Jimplémenté so that on a discuté hier. Le heading sera toujours Praisy et cherchable. J'ai aussi renforcé le schéma pour que le summary ne puisse pas être vide.",
+   "Hello, Jimplémenté so that on a discuté hier. Le heading sera toujours Praisy et cherchable. J'ai aussi Redrock le schéma pour que le summary ne puisse pas être vide."
+  ],
+  "terms": "Praisy, Redrock",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"renforcé\" -8.31   \"Redrock\" -6.93   — \"renforcé\" heard 1.4 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T18-05-16.wav",
+  "said": "For example, after a dictation I press the button while the HUD tells me I can make a correction, it opens the correction dialogue and then I make changes.",
+  "menu": [
+   "For example, after a dictation I press the button while the HUD tells me I can make a correction, it opens the correction dialogue and then I make changes.",
+   "For example, after a dictation I Praisy the button while the HUD tells me I can make a correction, it opens the correction dialogue and then I make changes.",
+   "For example, after a dictation I Praisy's the button while the HUD tells me I can make a correction, it opens the correction dialogue and then I make changes."
+  ],
+  "terms": "Praisy, Praisy's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"press\" -8.37   \"Praisy\" -8.11   — \"press\" heard 0.3 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-04T12-54-09.wav",
+  "said": "Then I said the activation phrase plus not James but Patrick and the catch-all prompt returned. Nothing I can do with not James but Patrick.",
+  "menu": [
+   "Then I said the activation phrase plus not James but Patrick and the catch-old prompt returned. Nothing I can do with not James but Patrick.",
+   "Then I said the activation phrase plus not James but Praisy and the catch-old prompt returned. Nothing I can do with not James but Patrick.",
+   "Then I said the activation Praisy plus not James but Patrick and the catch-old prompt returned. Nothing I can do with not James but Patrick.",
+   "Then I said the activation Praisy plus not James but Praisy and the catch-old prompt returned. Nothing I can do with not James but Patrick.",
+   "Then I said the Matthieu phrase plus not James but Patrick and the catch-old prompt returned. Nothing I can do with not James but Patrick.",
+   "Then I said the Matthieu phrase plus not James but Praisy and the catch-old prompt returned. Nothing I can do with not James but Patrick.",
+   "Then I said the Matthieu Praisy plus not James but Patrick and the catch-old prompt returned. Nothing I can do with not James but Patrick.",
+   "Then I said the Matthieu Praisy plus not James but Praisy and the catch-old prompt returned. Nothing I can do with not James but Patrick."
+  ],
+  "terms": "Matthieu, Praisy",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"phrase\" -3.72   \"Praisy\" -5.07   — \"Praisy\" heard 1.3 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-06T15-47-25.wav",
+  "said": "And while you're doing that also support escaping. So if you press Esc during either recording or transcribing it stops even if the whole key is pressed.",
+  "menu": [
+   "And while you're doing that also support escaping. So if you press ASC during either recording or transcribing it stops even if the whole key is pressed.",
+   "And while you're doing that also support escaping. So if you press ASC during either recording Praisy it stops even if the whole key is pressed.",
+   "And while you're doing that also support escaping. So if you Praisy's during either recording or transcribing it stops even if the whole key is pressed.",
+   "And while you're doing that also support escaping. So if you Praisy's during either recording Praisy it stops even if the whole key is pressed.",
+   "And while you're doing that also support escaping. So if you Praisy ASC during either recording or transcribing it stops even if the whole key is pressed.",
+   "And while you're doing that also support escaping. So if you Praisy ASC during either recording Praisy it stops even if the whole key is pressed."
+  ],
+  "terms": "Praisy, Praisy's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"press\" -3.35   \"Praisy\" -5.97   — \"Praisy\" heard 2.6 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-06T15-36-12.wav",
+  "said": "Pretty harsh review.",
+  "menu": [
+   "Pretty harsh review.",
+   "Arexvy harsh review."
+  ],
+  "terms": "Arexvy",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"Pretty\" -13.40   \"Arexvy\" -13.52   — \"Arexvy\" heard 0.1 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T10-23-28.wav",
+  "said": "So I guess to close that loop, is there a way we can record the final transcription when the user press enters.",
+  "menu": [
+   "So I guess to close that loop, is there a way we can record the final transcription when the user press enters.",
+   "So I guess to close that loop, is there a way we can record the final transcription when the user Praisy enters.",
+   "So I guess to close that loop, is there a way we can record the final transcription when the user Praisy's enters.",
+   "So I guess to close that loop, is there a way we can record the final Praisy user press enters.",
+   "So I guess to close that loop, is there a way we can record the final Praisy user Praisy enters.",
+   "So I guess to close that loop, is there a way we can record the final Praisy user Praisy's enters.",
+   "So I guess to Claude that loop, is there a way we can record the final transcription when the user press enters.",
+   "So I guess to Claude that loop, is there a way we can record the final transcription when the user Praisy enters.",
+   "So I guess to Claude that loop, is there a way we can record the final transcription when the user Praisy's enters.",
+   "So I guess to Claude that loop, is there a way we can record the final Praisy user press enters.",
+   "So I guess to Claude that loop, is there a way we can record the final Praisy user Praisy enters.",
+   "So I guess to Claude that loop, is there a way we can record the final Praisy user Praisy's enters."
+  ],
+  "terms": "Claude, Praisy, Praisy's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"close\" -10.76   \"Claude\" -9.36   — \"close\" heard 1.4 less clearly\n  \"press\" -8.61   \"Praisy\" -8.63   — \"Praisy\" heard 0.0 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T13-09-46.wav",
+  "said": "The team deserves praise for shipping that fast.",
+  "menu": [
+   "The team deserves praise for shipping that fast.",
+   "The team deserves Praisy shipping that fast.",
+   "The team deserves Praisy's shipping that fast."
+  ],
+  "terms": "Praisy, Praisy's",
+  "scores": "\n\nHow clearly the recogniser heard each spelling over that stretch of\naudio. Closer to zero is clearer, and the vocabulary's own bonus has been\ntaken out, so the two are comparable.\n\n  \"praise\" -8.70   \"Praisy\" -10.49   — \"Praisy\" heard 1.8 less clearly"
+ },
+ {
+  "wav": "parrotflow-2026-08-07T07-36-58.wav",
+  "said": "So let's say we have very low floor for Praisy, but with the judge. The judge would the the judge was n would know my terms and see that.",
+  "menu": [
+   "So let's say we have very low floor for Prezi, but with the judge. The judge would the the judge was n would know my terms and see that.",
+   "So let's say we have very low floor for Praisy, but with the judge. The judge would the the judge was n would know my terms and see that."
+  ],
+  "terms": "Praisy",
+  "scores": ""
  }
 ]


### PR DESCRIPTION
PR 7 of the vocabulary v2 plan. It is a measurement. **No behaviour changed
and no prompt changed** — both A/Bs the plan asked for were run, and neither
beat what ships.

## What was already implemented

PR 7's one `Do` item was "the score block with the difference precomputed in
the user message; the scale in the system message". PR #63 built all of it:

| Item | Where |
|---|---|
| difference precomputed, one line per uncertain span | `VocabularyJudge.scoreBlock` |
| block in the **user** message, prompt in the system message | `Pipeline.swift:975` |
| a proposal with no scores contributes no line (F6) | `scoreBlock`, its `guard let` |
| the scale, in prose | `examples/prompts/verify_names.md` |
| `--no-scores`, `--strip-sentinels` | `scripts/tune-judge.py` |

So this PR is the two measured follow-ups, the live failure F15 hands to
PR 7, and the record.

## The fresh cache

Every number below comes from a cache harvested today against `0766c81`,
over the 130 clips of `tests/menu-cases.yaml` (127 labelled), through a
scratch `PARROTFLOW_CONFIG_DIR` built the way #63/#64/#65/#66 document: the
live `config.yaml` and `vocabulary.yaml`, the pipeline entry replaced by
`- vocabulary: verify_names.md  when: vocabulary.count > 0` with `context`
and `fuzzy` moved below it, the prompt copied in beside it, `llm.model` set
to `gemma4:e4b`, and an empty `voice/`. `~/.config/parrotflow-dev/` was not
touched and `make install` was not run. `gemma4:e4b-mlx` was unloaded with
`keep_alive: 0`; only `gemma4:e4b` was loaded for every run.

```
$ .build/ParrotFlowDev.app/Contents/MacOS/ParrotFlow --version
0766c81
$ git rev-parse --short HEAD
0766c81

$ PARROTFLOW_CONFIG_DIR=<scratch> python3 scripts/tune-judge.py --harvest
cached 66 menus to tests/judge-menus.json

$ grep -c '" 0\.00' tests/judge-menus.json
0
```

**66 menus, 53 reachable**, 13 never held the true sentence. Chance is
17.4/53. The old cache was 31 menus and 25 reachable, so nothing here
compares with a number recorded before it.

The judge at temperature 0 is exactly repeatable: two runs of the shipped
prompt failed on the same 12 clips. Each variant below is therefore one run,
and the two that decide anything were repeated and reproduced exactly.

## The score block is worth +3 of 53

```
$ PARROTFLOW_CONFIG_DIR=<scratch> python3 scripts/tune-judge.py
  verify_names.md      gemma4:e4b     sampled  scores full     picked 41/53   (13 menu(s) never held the answer)
  chance                                                       guess  17.4/53

$ PARROTFLOW_CONFIG_DIR=<scratch> python3 scripts/tune-judge.py --no-scores
  verify_names.md      gemma4:e4b     sampled  scores none     picked 38/53   (13 menu(s) never held the answer)

$ PARROTFLOW_CONFIG_DIR=<scratch> python3 scripts/tune-judge.py --strip-sentinels
  verify_names.md      gemma4:e4b     sampled  scores stripped picked 41/53   (13 menu(s) never held the answer)
  0 menu(s) had a 0.00 score line removed
```

Per case, not per total. The block wins four clips and loses one:

| clip | the line the model is shown | true reading |
|---|---|---|
| `12-37-22` | `"surface" -4.85  "Supabase" -4.17` (0.7) | surface |
| `08-13-36` | `"rebase" -5.82  "Supabase" -3.59` (2.2) | rebase |
| `16-16-25` | `"praise" -10.08  "Praisy" -9.58` (0.5) | praise |
| `17-39-19` | `"praise" -5.53  "Praisy" -5.51` (0.0) | praise |
| `15-36-12` | `"Pretty" -13.40  "Arexvy" -13.52` (0.1) | Pretty — **lost** |

In all five the term was heard about as clearly as the ordinary word, or
better. Four times the small gap is what stops the model trusting the sound;
once it pushes it the other way. All four wins are in the direction that
costs a user text — keeping the word the speaker said instead of writing a
name over it. The +2 the review measured on the corrupted cache is +3 on
clean evidence.

`--strip-sentinels` now removes nothing, which is F6 fixed at the source.

## The pro-term prior stays — one variant tried

Ablating "A spelling that looks like a garbled version of a vocabulary term
usually is one" scores **40/53 against 41/53**. Per case: it costs one clip
and fixes none.

- Costs `07-36-58`: "very low floor for **Prezi**" against `Praisy`, on a
  menu that carries **no score block at all**. That is the class the
  sentence exists for — a garbled spelling with no acoustic evidence beside
  it.
- It does not cause F5's failures, which is what the plan suspected:
  - `00-14-39` "I mean in general in our data" (`general` vs `Redcrawl`,
    gap 0.1) is **wrong with the prior and wrong without it**.
  - `01-02-23` "You don't need to update the design" (`update` vs
    `Supabase`, block says `Supabase` was heard **2.7 more clearly**) is
    **right both ways**.

Kept.

## The prose scale beat the fitted λ — four variants tried

F14's plateau (λ 0.1–0.75 all equal) says one unit of sentence evidence buys
1.3 to 10 nats, centre about 2.5. A single A/B cannot tell the number from
the words carrying it, so three of the four variants form a 2×2 with what
ships:

| picked /53 | "about 1 / about 4" (ships) | fitted 2.5 | plateau edges 1.3 / 10 |
|---|---|---|---|
| shipped sentence shape | **41** | 38 | 39 |
| reshaped sentence | 40 | 42 | not run |

Read it either way and there is nothing to keep. The fitted number against
the prose numbers is −3 in the shipped sentence shape (38 vs 41) and +2 in
the reshaped one (42 vs 40). The reshaped sentence against the shipped one
is −1 with the prose numbers (40 vs 41) and +4 with the fitted one (42 vs
38). The two swap sign on each other, which is an interaction and not an
effect.

Per case: the best variant (42) wins `15-36-12` and loses nothing — but the
reshaped sentence carrying the **prose** numbers wins that same clip too,
and loses `08-13-36` and `17-05-32`. So the flip belongs to the wording, not
to λ. Five wordings of one idea span 38–42, which is F14's "wording is worth
8 points" arriving in the judge prompt.

**Rejected. `examples/prompts/verify_names.md` is unchanged.** Recorded as
finding F16 so the next PR does not re-tune this prompt by wording.

I tuned and reported on the same 53 cases. There is no held-out set, which
is exactly why a one-case win is reported as noise rather than kept.

### Why the scale can hardly fire at all

Over the 73 score lines in the fresh cache:

| gap | share |
|---|---|
| under 1 | 63% |
| 1 to 2.5 | 33% |
| 2.5 to 4 | 4% |
| over 4 | 0% |

Median 0.74, largest 2.72. The prompt's "a gap over about 4 means the sound
can decide" therefore never applies. PR 4's `decide_above: 3.0` drops a
proposal the audio argues against by more than 3 nats, so a reading that
reaches a menu cannot carry a large gap. The upper half of the scale is dead
text. That is a mechanism to change, not a wording.

## The live failure, added to the case set

`tests/judge-cases.yaml` gains the 2026-08-08 14:39:15 dictation: the judge
was offered "Matthew at" → `Matthieu` (span 0.52) and → `Matthieu's` (span
0.56) and kept "Matthew at". The speaker said `Matthieu's`. Written in the
file's shape, `expect: approve`, under a dated comment like the other live
cases. The set is 59 cases now, so `validate-judge.py`'s "33% approve"
docstring (now 29%) and `docs/transcription.md`'s "58 proposals" were
corrected.

## Gates

Baseline measured by me today on this branch, whose only changes are text
files nothing reads at run time. There is no "after" configuration, because
nothing was kept — so no gate can fall, and these numbers are recorded as
the new baseline for the 127-clip set. The old 31/37 and 27/37 were on the
37-clip set and do not apply.

```
$ swift build -c release && scripts/build-app.sh
Build complete! (93.90s)
==> Done: .build/ParrotFlowDev.app

$ PARROTFLOW_CONFIG_DIR=<scratch> python3 scripts/menu-recall.py --runs 3
  recall  102/127   the true sentence was on the menu, majority of 3 runs
  picked  90/127   the judge chose it, majority of 3 runs
  2/127 clip(s) changed outcome between runs (F12a)
  (3 clip(s) unlabelled)

$ PARROTFLOW_CONFIG_DIR=<scratch> python3 scripts/before-after.py --runs 3
  fixed 20   broken 26   regressed 11   already right 70
  majority of 3 runs; 0 clip(s) changed outcome between runs (F12a)
```

**Flips.** `menu-recall.py` 2 of 127: `17-39-19` and `11-10-43`, both picked
on 2 runs of 3, both counted as picked by the majority rule.
`before-after.py` 0 of 127.

**Split by class**, because one pair of totals over 127 clips can hide a
regression and `menu-recall.py` does not know the blocks:

| | clips | recall | picked |
|---|---|---|---|
| about a term | 54 | 46 | 39 |
| controls | 73 | 56 | 51 |

Five controls sit at `~`: the menu held the true sentence and the judge took
another reading (`11-19-17`, `14-04-21`, `14-09-56`, `15-36-12`,
`13-09-46`). Those are the judge overwriting an ordinary word, and they are
the same clips the cache A/B fails on.

**The 11 regressed rows are the baseline, not something this PR did.** They
arrive with the 90 unfiltered clips (F11/F15), and `before` is what the app
delivered days ago under the old v1 pass. Nine are the vocabulary writing a
term over an ordinary word that the judge then waved through:

```
17-47-45  "have a retry ... if the retry fails ... the crawl to fail"
       -> "have a Arexvy ... if the Arexvy fails ... the Redcrawl to fail"
09-35-01  "the Versailles castle"       -> "the Vercel castle"
14-04-21  "explanations to update"      -> "Praisy to Supabase"
10-12-37  "asked me to crawl"           -> "asked me to Redcrawl"
14-09-56  "words that are near matches" -> "words that are near Matthieu"
13-09-46  "deserves praise for shipping"-> "deserves Praisy shipping"
11-19-17  "a langsmith proprietary term"-> "a langsmith Praisy term"
15-36-12  "Pretty harsh review"         -> "Arexvy harsh review"
14-11-21  "the crawl data lives"        -> "the Redcrawl data lives"
```

The other two (`12-46-08`, `00-57-25`) differ only by a hesitation the
decoder wrote this time; no vocabulary term is involved.

**Repository checks**, the ones that need no screen and no install:
`check-pipeline.sh` 57/57, `check-vocabulary-config.sh` 61/61,
`check-replacements.sh` 23/23, `check-transform-folders.sh` 12/12,
`check-no-voice.sh` 5/5, `check-default-config.sh` clean,
`check-seeded-transform.sh` clean, `check-numbers.sh` 97/97,
`check-dates.sh` 26/26, `check-wake.sh` 24/24, `check-split.sh` 14/14,
`check-dotted.sh` 54/54, `check-compose.sh` 21/21, `check-eval.sh` 25/25,
`check-pinned-certificate.sh` clean.

## Deviations

- Nothing was kept, so there is no A/B of the app itself. One gate run
  establishes the baseline instead of two comparing against it.
- The scale A/B needed a fourth variant the plan did not ask for — the
  fitted number in the shipped sentence shape — because without it the
  number and the wording cannot be told apart. Reported above; it is the
  cell that decides the answer.
- I did not touch the reranker (F14) or a larger judge (F8).
- `voice/` in the scratch config was empty, so no speaker audio is
  anywhere near this branch. `check-no-voice.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiQJipvz9Ps9tdDCRdisv
