### PR TITLE
test: four ways to ask the judge, measured

### DIFF
--- a/docs/proposals/judge-framings.md
+++ b/docs/proposals/judge-framings.md
@@ -1,0 +1,270 @@
+# Four ways to ask the judge — what each one is worth
+
+**Nothing won. Do not change the prompt.**
+
+The shipped prompt scores 41/53 on the cached menus, against a chance of
+17.4/53. Ten framings were measured. The best scored 42/53 and the worst 35.
+A win of one case is noise: F16 measured five wordings of a single sentence
+spanning 38 to 42. The same 53 cases were tuned on and reported on. There is
+no held-out set.
+
+One number did move. On the nine clips where an ordinary English word was
+overwritten by a vocabulary term, **the shipped prompt gets 0 of 8**
+(the ninth was never on its menu). Adding one paragraph about where a name can
+stand takes 2 of the 8 and costs nothing overall. Deleting the term list takes
+4 of the 8 and costs 3 cases overall.
+
+That trade is the finding. The term list is what tells the judge that `Praisy`
+is a spelling at all. Remove it and the judge writes `Prissy`. Keep it and the
+judge writes `Praisy` where the speaker said "praise". **One sentence cannot
+serve both, so this is a mechanism to change, not a prompt to reword.**
+
+Measured with `scripts/judge-framings.py` against `tests/judge-menus.json`,
+`gemma4:e4b`, temperature 0, nothing else loaded. No build, no install.
+
+---
+
+## The four questions, in full
+
+### 1. Baseline — the shipped prompt
+
+```
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: {terms} — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence, and every
+reading it might really have been. Exactly one is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading that makes sense as a sentence, unless the sound says
+otherwise by more than about 4. Answer with its letter only.
+```
+
+`{terms}` is filled in per case, e.g. `Praisy, Praisy's` or `Redcrawl., Tasmeen`.
+
+**41/53. 0/8 of the collision class.**
+
+### 2. No term list — two wordings
+
+Only the first paragraph changes. Everything else is the baseline.
+
+```diff
+ The user dictates text. The speech recogniser mangles names they use often.
+-Their vocabulary includes: {terms} — colleagues, products and tools they talk
+-about every day.
++Their vocabulary includes colleagues, products and tools they talk about
++every day. The names in it are not listed here.
+```
+
+**36/53. 3/8.** And the sentence deleted outright, with the pointer to it
+repaired:
+
+```diff
+ The user dictates text. The speech recogniser mangles names they use often.
+-Their vocabulary includes: {terms} — colleagues, products and tools they talk
+-about every day.
+
+-That list is not everyone they know. They also talk about other people,
++Their vocabulary is not everyone they know. They also talk about other people,
+```
+
+**38/53. 4/8.**
+
+### 3. Inverted polarity — three wordings
+
+Only the last paragraph changes. Ported from `rerank-judge.py`'s `misheard`
+family, which F14 measured as the polarity that works for a reranker.
+
+```diff
+-Pick the reading that makes sense as a sentence, unless the sound says
+-otherwise by more than about 4. Answer with its letter only.
++Every reading but one contains a speech-recognition error: a proper name or
++product name written where an ordinary English word was actually spoken,
++leaving a sentence that does not parse. Rule those readings out. Answer with
++the letter of the one that is left, unless the sound says otherwise by more
++than about 4.
+```
+
+**35/53. 1/8.** Short:
+
+```
+All but one of these readings contain a transcription error. Rule them out.
+Answer with the letter of the one that does not, unless the sound says
+otherwise by more than about 4.
+```
+
+**35/53. 0/8.** Long:
+
+```
+In all but one of these readings, a brand, product or person's name is
+printed where the speaker actually said a common English word, or two common
+words have been run together into a single name — leaving a sentence a native
+speaker would never produce. Find those readings and rule them out. Answer
+with the letter of the reading that is left, unless the sound says otherwise
+by more than about 4.
+```
+
+**38/53. 1/8.**
+
+### 4. Typed terms, and a rule about position
+
+The list carries a kind, from `tests/term-kinds.yaml`:
+
+```diff
+-Their vocabulary includes: Praisy, Praisy's — colleagues, products and tools
+-they talk about every day.
++Their vocabulary includes: Praisy (a person), Praisy's (a person) —
++colleagues, products and tools they talk about every day.
+```
+
+**40/53. 0/8** on its own. With one paragraph added before the final one:
+
+```
+Each name above is labelled with what kind of thing it is. A name can only
+stand where a name of that kind can stand. A product, a brand or a drug is
+not a verb, so it cannot follow "to" as an infinitive, and it does not
+modify a noun the way an adjective does. A person is not an adjective
+either. A reading that puts a name in a position no name of its kind can
+occupy is not what the user said.
+```
+
+**42/53. 2/8.** The same paragraph with the kinds taken out, on the ordinary
+bare list:
+
+```
+A name can only stand where a name can stand. A name is not a verb, so it
+cannot follow "to" as an infinitive, and it does not modify a noun the way
+an adjective does. A reading that puts a name in a position no name can
+occupy is not what the user said.
+```
+
+**41/53. 2/8.** So the labels are worth nothing and the question is worth 2 of
+the 8.
+
+---
+
+## Three real cases
+
+Verbatim from `tests/judge-menus.json`. The score block is what the judge was
+shown, in the user message.
+
+### Fixed by the position rule — `13-09-46`
+
+```
+said: The team deserves praise for shipping that fast.
+terms: Praisy, Praisy's
+
+  A. The team deserves praise for shipping that fast.
+  B. The team deserves Praisy shipping that fast.
+  C. The team deserves Praisy's shipping that fast.
+
+  "praise" -8.70   "Praisy" -10.49   — "Praisy" heard 1.8 less clearly
+```
+
+| arm | chose |
+|---|---|
+| baseline | **B** — "deserves Praisy shipping" |
+| inverted, all three | B or C |
+| typed, no rule | B |
+| position rule (typed or bare) | **A** ✓ |
+| no term list | **A** ✓ |
+
+The sound already says "praise" by 1.8 nats. The shipped prompt overrides it
+anyway. "deserves Praisy shipping" is not English, and only the arms that ask
+about position or hide the list notice.
+
+### Wrong in every arm — `10-12-37`
+
+```
+said: It's a community that Tasmeen asked me to crawl.
+terms: Redcrawl., Tasmeen
+
+  A. It's a community that Tasmin asked me to crawl.
+  B. It's a community that Tasmin asked me to Redcrawl.
+  C. It's a community that Tasmeen asked me to crawl.
+  D. It's a community that Tasmeen asked me to Redcrawl.
+
+  "Tasmin" -10.13   "Tasmeen" -10.68   — "Tasmeen" heard 0.5 less clearly
+  "crawl." -10.06   "Redcrawl." -11.83   — "Redcrawl." heard 1.8 less clearly
+```
+
+Every arm takes **D**, except the two that hide the list, which take **A** and
+lose `Tasmeen` instead. The sentence has two slots. One name is right and one
+is wrong, and no framing tried can say different things about them, because
+every option carries both. This is the case that argues for a per-slot
+question.
+
+### Broken by a new arm — `07-36-58`
+
+```
+said: So let's say we have very low floor for Praisy, but with the judge. ...
+terms: Praisy
+(no score block — the router proposed this from spelling alone)
+
+  A. So let's say we have very low floor for Prezi, but with the judge. ...
+  B. So let's say we have very low floor for Praisy, but with the judge. ...
+```
+
+Baseline, all three inverted arms and typed-without-a-rule take **B** ✓. The
+position rule takes **A**, and so does every arm without the term list. The
+speaker is talking *about* their vocabulary term, so the name really is in a
+noun slot, and with no acoustic evidence the list is all there is. PR #68 lost
+this same clip when it ablated the pro-term sentence.
+
+---
+
+## The ordinary-word collision class
+
+The nine clips PR #68 recorded as regressed. Five are also the controls at `~`
+in `menu-recall.py` (`11-19-17`, `14-04-21`, `14-09-56`, `15-36-12`,
+`13-09-46`).
+
+| clip | said → written | ships | no list | inverted | typed | + rule |
+|---|---|---|---|---|---|---|
+| `17-47-45` | retry/crawl → Arexvy/Redcrawl | ✗ | ✗ | ✗ | ✗ | ✗ |
+| `09-35-01` | Versailles → Vercel castle | never reached a menu ||||| |
+| `14-04-21` | to update → to Supabase | ✗ | ✗ | ✗ | ✗ | ✗ |
+| `10-12-37` | to crawl → to Redcrawl | ✗ | ✗ | ✗ | ✗ | ✗ |
+| `14-09-56` | near matches → near Matthieu | ✗ | ✗ | ✗ | ✗ | ✗ |
+| `13-09-46` | praise for → Praisy | ✗ | ✓ | ✗ | ✗ | ✓ |
+| `11-19-17` | proprietary → Praisy | ✗ | ✓ | ✗ | ✗ | ✓ |
+| `15-36-12` | Pretty → Arexvy | ✗ | ✓ | ✓ | ✗ | ✗ |
+| `14-11-21` | the crawl → the Redcrawl | ✗ | ✓ | ✗ | ✗ | ✗ |
+| | **total** | **0/8** | **4/8** | **1/8** | **0/8** | **2/8** |
+
+"no list" is the deletion wording, "inverted" the ported wording, "+ rule" the
+typed list with the position rule. The kind-free version of the rule also
+takes 2 of 8, but a different two — `13-09-46` and `15-36-12`. Four of the
+eight resist every framing, and three of those four hold more than one
+uncertain slot.
+
+---
+
+## Recommendation
+
+Ship nothing. No arm clears the noise floor, and the two that move the
+collision class each break a case the list exists to protect.
+
+Measure the per-slot question next. Show the sentence once with a blank per
+uncertain span, and under each blank only that span's candidates. That is the
+only shape that can show the name where it is a candidate and hide it where it
+is not — which is exactly what `10-12-37` needs and what a menu of whole
+sentences cannot express. It also makes the cost linear in slots instead of
+the product PR 6 had to cap at two.
+
+Recorded as F17 in [vocabulary-v2.md](vocabulary-v2.md).

--- a/docs/proposals/judge-framings.md
+++ b/docs/proposals/judge-framings.md
@@ -125,11 +125,12 @@ by more than about 4.
 
 The list carries a kind, from `tests/term-kinds.yaml`:
 
+Only `{terms}` changes. The sentence around it is the shipped one.
+
 ```diff
--Their vocabulary includes: Praisy, Praisy's — colleagues, products and tools
--they talk about every day.
-+Their vocabulary includes: Praisy (a person), Praisy's (a person) —
-+colleagues, products and tools they talk about every day.
+-Their vocabulary includes: Praisy, Praisy's — colleagues, products and tools they talk
++Their vocabulary includes: Praisy (a person), Praisy's (a person) — colleagues, products and tools they talk
+ about every day.
 ```
 
 **40/53. 0/8** on its own. With one paragraph added before the final one:

--- a/docs/proposals/vocabulary-v2.md
+++ b/docs/proposals/vocabulary-v2.md
@@ -108,6 +108,7 @@ is the prototype; `(CTC-vs-CTC: …)` alone is v1.
 | Judge took it | same run | picked 90/127, same run |
 | Before/after | `python3 scripts/before-after.py --runs 3` | 20 fixed / 26 broken / 11 regressed / 70 already right |
 | Judge on cache | `python3 scripts/tune-judge.py` | 41/53 on the 66-menu cache (chance 17.4); 38/53 with `--no-scores` |
+| Judge framings | `python3 scripts/judge-framings.py` | baseline 41/53, and 0/8 of the ordinary-word collision class (F17) |
 | Two-stage (fixed harness) | see PR 2 | 25/28, ceiling 28/28 — on the old 28-menu cache |
 
 Split by class, from the same `--runs 3` run (the plan asks for two totals,
@@ -355,6 +356,91 @@ instead. And the scale's upper half is unreachable — 63% of the 73 score
 lines in the cache have a gap under 1 and the largest is 2.72, because
 `decide_above: 3.0` drops anything the audio argues against more strongly
 before it can reach a menu.
+
+**F17 — the term list is the prior, and the prior is load-bearing (spike,
+2026-08-08).** Ten framings of the judge's question, all prompt-only, all
+scored by `scripts/judge-framings.py` against the same 53 cached menus.
+Chance is 17.4/53 on every row. **The set tuned on and the set reported on
+are the same 53 cases; there is no held-out set**, so anything inside F16's
+wording spread of ±2 has not moved.
+
+The class this spike was run for is the nine clips PR #68 recorded as
+regressed — an ordinary English word overwritten by a term, waved through by
+the judge. Eight are reachable; `09-35-01` ("the Versailles castle") never
+held the true sentence on its menu. **The shipped prompt gets 0 of those 8.**
+
+| framing | wordings | picked /53 | collision class /8 |
+|---|---|---|---|
+| baseline, the shipped prompt | — | **41** | **0** |
+| no term list | 2 | 36, 38 | 3, 4 |
+| inverted polarity | 3 | 35, 35, 38 | 1, 0, 1 |
+| typed terms, `Redcrawl (a product)` | 1 | 40 | 0 |
+| typed terms + a position rule | 1 | 42 | 2 |
+| the position rule alone, bare list | 1 | 41 | 2 |
+| no term list + the position rule | 1 | 36 | 4 |
+
+*H1 is true and rejected.* Cutting the enumeration wins 5 clips and loses 8,
+for 38/53. It wins exactly what the hypothesis predicts — `14-11-21` "the
+crawl data", `00-14-39` "in general in our data", `15-36-12` "Pretty harsh",
+`11-19-17` "proprietary term", `13-09-46` "praise for shipping" — and every
+one of the 8 it loses is a term that was right, now spelled as something the
+judge can read: `Praisy` → `Prissy` four times, `Prizzi` once and `Prezi`
+once, and `Arexvy` → `RXV`. The eighth (`10-23-28`, a 12-option menu) goes
+the other way and takes a reading that writes `Claude` and `Praisy` into "to
+close that loop … when the user press enters". The list is the only thing
+that tells the judge `Praisy` is a spelling at all.
+
+So the two classes want opposite things from one sentence, and that is the
+finding. No wording of the term list can serve both: it has to be present for
+a name to be spellable and absent for a name to be doubted. This is a
+mechanism to change, not a prompt to reword.
+
+*H2 by polarity is rejected.* Three wordings ported from `rerank-judge.py`'s
+`misheard` family score 35, 35 and 38 against 41, and 1, 0 and 1 of the
+collision class. F14's inversion does not transfer. A reranker scores one
+candidate at a time, so its polarity can be flipped by reading the score
+backwards; a judge that must name one letter has to perform the inversion
+itself, and it is worse at that than at picking.
+
+*H2 by syntax is the only thing that moved the class without paying for it.*
+Adding one paragraph — a name cannot be an infinitive after "to" and does not
+modify a noun like an adjective — scores 41/53 with the bare list and 42/53
+with typed names, and both take 2 of the 8. Typing the names on its own,
+with no position rule, scores 40/53 and 0 of 8, so the labels do nothing and
+the question does the work. The +1 is inside F16's spread and is not a
+result; the 0→2 on the collision class at zero total cost is the only
+signal in this spike.
+
+*The combination adds nothing.* `no-terms` and `typed` cannot be combined at
+all — one deletes the list the other annotates. Cutting the list and adding
+the position rule scores 36/53 and 4 of 8, no better on the class than
+cutting the list alone and 2 worse overall.
+
+*Repeatable.* `baseline`, `typed-slot` and `no-terms-cut` were each run
+twice in separate processes and reproduced exactly — same total, same
+per-case diff. Temperature 0 holds, as PR #68 found.
+
+*Not measured here, and why.* Cloze menus (one blank per uncertain slot,
+typed candidates under each, letters answered per blank) and cloze scored by
+logprob are not prompt changes: `VocabularyJudge` composes whole sentences
+today, so a blank means rewriting how the question is built. Fusion has
+nothing to fuse until a framing produces margins. An `NLTagger` part-of-speech
+signal needs its own accuracy study on lightly punctuated dictation before it
+can be judged as a signal at all. All three are deferred, not rejected.
+
+**Recommendation: ship no prompt change.** Nothing here clears the noise
+floor on 53 tuned cases. The one arm worth carrying forward is the position
+rule, and it should be carried as evidence rather than as a patch — 2 of 8
+is not a fix for a class the judge fails completely.
+
+What the next PR should measure instead is the per-slot question, because the
+conflict this spike measured is per-slot. The term list has to be visible
+where the name is a candidate and invisible where it is not, and a menu of
+whole sentences cannot express that — every option carries every name. A
+cloze menu can: the sentence once, a blank per uncertain span, and under each
+blank only the candidates for that span, typed. That also makes the cost
+linear in slots instead of the product PR 6 had to cap at two. Measure it
+against these same 53 menus before any of it reaches the app.
 
 ---
 

--- a/docs/proposals/vocabulary-v2.md
+++ b/docs/proposals/vocabulary-v2.md
@@ -359,7 +359,9 @@ before it can reach a menu.
 
 **F17 — the term list is the prior, and the prior is load-bearing (spike,
 2026-08-08).** Ten framings of the judge's question, all prompt-only, all
-scored by `scripts/judge-framings.py` against the same 53 cached menus.
+scored by `scripts/judge-framings.py` against the same 53 cached menus. The
+prompts themselves, and the cases they turn on, are in
+[judge-framings.md](judge-framings.md).
 Chance is 17.4/53 on every row. **The set tuned on and the set reported on
 are the same 53 cases; there is no held-out set**, so anything inside F16's
 wording spread of ±2 has not moved.

--- a/scripts/judge-framings.py
+++ b/scripts/judge-framings.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""Score named ways of *asking* the judge, against the menus already cached.
+
+    scripts/judge-framings.py --classify          # label the vocabulary terms once
+    scripts/judge-framings.py                     # every framing, one table
+    scripts/judge-framings.py --framing baseline,invert-ported
+    scripts/judge-framings.py --json out.json     # per-case results, for a diff later
+
+`tune-judge.py` answers "is this prompt file better". This answers a narrower
+question: the judge's errors nearly all belong to one class — an ordinary
+English word colliding with a vocabulary term, and the term winning — so what
+happens if the *question* changes rather than its wording?
+
+Each framing is an edit list applied to the shipped `verify_names.md`, plus a
+way of rendering the term list. Nothing here writes a prompt file, and nothing
+here changes the app. The edits are exact substrings of the shipped prompt and
+the run fails loudly if one stops matching, so a framing can never quietly
+become "the shipped prompt again".
+
+Three things are printed and all three are needed:
+
+    picked   of the menus that held the true sentence, how many were chosen
+    chance   what guessing one letter scores on these menu sizes (F13)
+    diff     which clips each framing wins and loses against the baseline
+
+**The tuning set and the reporting set are the same 53 cases.** There is no
+held-out set. A one- or two-case difference is inside the wording noise F16
+measured (five wordings of one sentence spanned 38 to 41), so a framing that
+moves by less than that has not moved.
+
+Deferred, deliberately not implemented here: cloze menus (one blank per
+uncertain slot, letters answered per blank), cloze scored by logprob, fusion
+with the acoustic margin, and an NLTagger part-of-speech signal. The first two
+are not prompt changes — the stage composes whole sentences today, so a blank
+means rewriting how `VocabularyJudge` builds its question. `FRAMINGS` is a
+plain registry so they can be added beside these without moving anything.
+"""
+import argparse
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+from importlib.machinery import SourceFileLoader
+
+ROOT = Path(__file__).resolve().parent.parent
+CACHE = ROOT / "tests/judge-menus.json"
+PROMPT = ROOT / "examples/prompts/verify_names.md"
+KINDS = ROOT / "tests/term-kinds.yaml"
+ENDPOINT = os.environ.get("PARROTFLOW_LLM_ENDPOINT", "http://localhost:11434") + "/api/chat"
+
+recall = SourceFileLoader("recall", str(ROOT / "scripts/menu-recall.py")).load_module()
+# `ask` (one call, the app's own letter rule) and `chosen` live there and are
+# not restated here — a harness that reads a reply differently from the app is
+# scoring a choice nobody ships.
+tune = SourceFileLoader("tune", str(ROOT / "scripts/tune-judge.py")).load_module()
+
+
+# ── the class this file exists for ───────────────────────────────────────────
+# The nine rows PR #68 recorded as regressed by the vocabulary pass: an
+# ordinary English word overwritten by a term, waved through by the judge.
+# Five of them are also the controls that sit at `~` in `menu-recall.py`
+# (marked below). A total over 53 cases can improve while these get worse,
+# which is the whole reason they are tallied on their own.
+
+COLLISIONS = {
+    "17-47-45": "retry/crawl        -> Arexvy/Redcrawl",
+    "09-35-01": "Versailles castle  -> Vercel castle",
+    "14-04-21": "explanations to update -> Praisy to Supabase",   # control at ~
+    "10-12-37": "asked me to crawl  -> to Redcrawl",
+    "14-09-56": "near matches       -> near Matthieu",            # control at ~
+    "13-09-46": "praise for shipping -> Praisy shipping",         # control at ~
+    "11-19-17": "proprietary term   -> Praisy term",              # control at ~
+    "15-36-12": "Pretty harsh       -> Arexvy harsh",             # control at ~
+    "14-11-21": "the crawl data     -> the Redcrawl data",
+}
+
+
+# ── pieces of the shipped prompt, quoted exactly ─────────────────────────────
+# Line breaks included. These are the seams every framing cuts on.
+
+ENUMERATION = ("Their vocabulary includes: {terms} — colleagues, products and tools they talk\n"
+               "about every day.")
+
+THAT_LIST = "That list is not everyone they know."
+
+PICK = ("Pick the reading that makes sense as a sentence, unless the sound says\n"
+        "otherwise by more than about 4. Answer with its letter only.")
+
+# The clause that ties the answer to the acoustic block. Every framing keeps
+# it, so the only thing changing between them is the question itself.
+TAIL = "unless the sound says otherwise by more than about 4"
+
+
+# ── framings ─────────────────────────────────────────────────────────────────
+# `edits`  exact (old, new) substitutions on the shipped prompt, applied in order
+# `terms`  "bare" (the shipped comma list) or "typed" (each name with its kind)
+#
+# The three `invert-*` framings are one hypothesis in three wordings. F16
+# measured wording at up to 4 cases inside one idea, so a single wording is not
+# a measurement of the idea.
+
+INVERT_PORTED = (
+    "Every reading but one contains a speech-recognition error: a proper name or\n"
+    "product name written where an ordinary English word was actually spoken,\n"
+    "leaving a sentence that does not parse. Rule those readings out. Answer with\n"
+    "the letter of the one that is left, " + TAIL + ".")
+
+INVERT_SHORT = (
+    "All but one of these readings contain a transcription error. Rule them out.\n"
+    "Answer with the letter of the one that does not, " + TAIL + ".")
+
+INVERT_LONG = (
+    "In all but one of these readings, a brand, product or person's name is\n"
+    "printed where the speaker actually said a common English word, or two common\n"
+    "words have been run together into a single name — leaving a sentence a native\n"
+    "speaker would never produce. Find those readings and rule them out. Answer\n"
+    "with the letter of the reading that is left, " + TAIL + ".")
+
+# Typing the names is only half of H2. This sentence is the other half: it asks
+# a question about position, which is the thing a plausibility prior cannot
+# answer. It goes in as its own paragraph, before the instruction to pick.
+SLOT_RULE = (
+    "Each name above is labelled with what kind of thing it is. A name can only\n"
+    "stand where a name of that kind can stand. A product, a brand or a drug is\n"
+    "not a verb, so it cannot follow \"to\" as an infinitive, and it does not\n"
+    "modify a noun the way an adjective does. A person is not an adjective\n"
+    "either. A reading that puts a name in a position no name of its kind can\n"
+    "occupy is not what the user said.\n\n")
+
+# The same rule with the kinds taken out. `typed-slot` changes two things at
+# once — the labels and the question — and this is the half that needs no
+# labels, so it says which half did the work. It is also the only form of the
+# rule that can be combined with cutting the term list, because a name cannot
+# be labelled and withheld at the same time.
+SLOT_RULE_PLAIN = (
+    "A name can only stand where a name can stand. A name is not a verb, so it\n"
+    "cannot follow \"to\" as an infinitive, and it does not modify a noun the way\n"
+    "an adjective does. A reading that puts a name in a position no name can\n"
+    "occupy is not what the user said.\n\n")
+
+# Deleting the enumeration outright, and repairing the sentence that pointed
+# at it. Two framings share this, so it is written once.
+CUT_EDITS = [
+    ("The user dictates text. The speech recogniser mangles names they use often.\n"
+     + ENUMERATION,
+     "The user dictates text. The speech recogniser mangles names they use often."),
+    (THAT_LIST, "Their vocabulary is not everyone they know."),
+]
+
+FRAMINGS = {
+    "baseline": dict(
+        doc="the shipped prompt, unchanged — the control",
+        edits=[], terms="bare"),
+
+    # H1: the list is the prior. F14 measured the same shape in a reranker
+    # query, where listing the vocabulary scored below chance.
+    "no-terms": dict(
+        doc="the same prompt with the names not enumerated",
+        edits=[(ENUMERATION,
+                "Their vocabulary includes colleagues, products and tools they talk about\n"
+                "every day. The names in it are not listed here.")],
+        terms="bare"),
+    "no-terms-cut": dict(
+        doc="the enumeration sentence deleted outright",
+        edits=CUT_EDITS, terms="bare"),
+
+    # H2 via polarity: ask which reading is wrong, keep the other. Ported from
+    # `rerank-judge.py`'s `misheard`, `misheard-short` and `misheard-long`.
+    "invert-ported": dict(
+        doc="which readings contain a misrecognition; take the one left",
+        edits=[(PICK, INVERT_PORTED)], terms="bare"),
+    "invert-short": dict(
+        doc="the same, said in two sentences",
+        edits=[(PICK, INVERT_SHORT)], terms="bare"),
+    "invert-long": dict(
+        doc="the same, spelled out",
+        edits=[(PICK, INVERT_LONG)], terms="bare"),
+
+    # H2 via syntax: the names carry a kind, and the question is whether a name
+    # of that kind fits the slot.
+    "typed": dict(
+        doc="the same prompt, names labelled with their kind",
+        edits=[], terms="typed"),
+    "typed-slot": dict(
+        doc="typed names, plus the rule that a kind has positions",
+        edits=[(PICK, SLOT_RULE + PICK)], terms="typed"),
+
+    # Run only after the arms above, and only because two of them moved the
+    # collision class. `slot-only` splits `typed-slot` in half; `no-terms-slot`
+    # is the one combination the two winners allow.
+    "slot-only": dict(
+        doc="the bare list, plus the position rule with no kinds",
+        edits=[(PICK, SLOT_RULE_PLAIN + PICK)], terms="bare"),
+    "no-terms-slot": dict(
+        doc="no enumeration, plus the position rule with no kinds",
+        edits=CUT_EDITS + [(PICK, SLOT_RULE_PLAIN + PICK)],
+        terms="bare"),
+}
+
+
+def build(framing):
+    """The shipped prompt with this framing's edits applied.
+
+    Every edit must match exactly once. A silently missing edit turns a
+    framing into the baseline and reports it as a finding, which is the one
+    failure this harness cannot be allowed to have.
+    """
+    text = PROMPT.read_text().strip()
+    for old, new in FRAMINGS[framing]["edits"]:
+        if text.count(old) != 1:
+            raise SystemExit(
+                f"✗ framing {framing!r}: its edit no longer matches "
+                f"{PROMPT.name} exactly once ({text.count(old)} times).\n"
+                f"   looked for: {old[:60]!r}...")
+        text = text.replace(old, new)
+    return text
+
+
+# ── the term kinds ───────────────────────────────────────────────────────────
+
+ARTICLE = {"a": "an", "e": "an", "i": "an", "o": "an", "u": "an"}
+CLASSES = ["person", "product", "brand", "drug", "tool", "company"]
+
+
+def base_term(form):
+    """`Praisy's` and `Arexvy.` and `Vercel?` are all one term.
+
+    The cached `terms` string is what the app put in the system message, and
+    that carries the inflected surface forms the router proposed.
+    """
+    word = form.strip().rstrip(".?!,;:")
+    for suffix in ("'s", "’s"):
+        if word.endswith(suffix):
+            word = word[: -len(suffix)]
+    return word
+
+
+def load_kinds():
+    """term -> kind, from the YAML `--classify` writes.
+
+    Parsed by hand. The repo has no YAML dependency and this file is two
+    columns; `menu-recall.load_cases` makes the same choice for the same
+    reason.
+    """
+    if not KINDS.exists():
+        raise SystemExit(f"✗ no {KINDS.relative_to(ROOT)} — run with --classify first")
+    kinds = {}
+    for line in KINDS.read_text().splitlines():
+        line = line.split("#")[0].strip()
+        if not line or ":" not in line:
+            continue
+        term, kind = line.split(":", 1)
+        if kind.strip():
+            kinds[term.strip()] = kind.strip()
+    return kinds
+
+
+def render_terms(raw, style, kinds):
+    """The term list as the system message will carry it."""
+    if style == "bare" or not raw:
+        return raw
+    out = []
+    for form in raw.split(","):
+        form = form.strip()
+        if not form:
+            continue
+        kind = kinds.get(base_term(form))
+        if kind is None:
+            out.append(form)          # unlabelled rather than guessed at
+            continue
+        out.append(f"{form} ({ARTICLE.get(kind[0], 'a')} {kind})")
+    return ", ".join(out)
+
+
+def classify(model):
+    """Label each term in the cache once, and write the YAML.
+
+    Eleven terms. The model is asked with no context at all, which is the
+    honest version of what the app could do offline — and it is small enough
+    to check by hand, so a wrong label is the author's, not the model's.
+    """
+    cases = json.loads(CACHE.read_text())
+    terms = sorted({base_term(f) for c in cases for f in c["terms"].split(",") if f.strip()})
+    system = ("You label a word with what kind of thing it names. Answer with exactly "
+              "one of these words and nothing else: " + ", ".join(CLASSES) + ".")
+    lines = []
+    for term in terms:
+        payload = {
+            "model": model, "stream": False, "think": False,
+            "options": {"temperature": 0, "num_predict": 8},
+            "messages": [{"role": "system", "content": system},
+                         {"role": "user", "content": f"{term}\n\nWhat kind of thing is it?"}],
+        }
+        request = urllib.request.Request(
+            ENDPOINT, data=json.dumps(payload).encode(),
+            headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(request, timeout=60) as response:
+            reply = json.loads(response.read())["message"]["content"].strip().lower()
+        kind = next((c for c in CLASSES if c in reply), "")
+        print(f"  {term:<12} {model}: {reply!r:<14} -> {kind or 'UNPARSED'}")
+        lines.append(f"  {term}: {kind}")
+    print(f"\n{len(terms)} terms. Check every one by hand before using it.")
+    return lines
+
+
+# ── the run ──────────────────────────────────────────────────────────────────
+
+def reachable(cases):
+    """The menus that held the true sentence, and what the rest cost.
+
+    A prompt cannot be blamed for an option that was never on the list, and
+    counting those in hides every difference behind a constant.
+    """
+    keep = [c for c in cases
+            if recall.normalise(c["said"]) in [recall.normalise(o) for o in c["menu"]]]
+    return keep, len(cases) - len(keep)
+
+
+def run(cases, framing, model, kinds):
+    """One framing over every reachable menu. Returns wav -> (right, chosen)."""
+    system = build(framing)
+    style = FRAMINGS[framing]["terms"]
+    out = {}
+    for case in cases:
+        terms = render_terms(case["terms"], style, kinds)
+        chosen = tune.ask(model, system.replace("{terms}", terms), case["menu"],
+                          case.get("scores") or "")
+        right = chosen is not None and recall.normalise(chosen) == recall.normalise(case["said"])
+        out[case["wav"]] = (right, chosen)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--framing", default="all",
+                    help="comma-separated framing names, or 'all'")
+    ap.add_argument("--model", default=os.environ.get("PARROTFLOW_JUDGE_MODEL", "gemma4:e4b"))
+    ap.add_argument("--classify", action="store_true",
+                    help="label the vocabulary terms with gemma4:e4b and stop")
+    ap.add_argument("--json", metavar="PATH", help="write per-case results here")
+    ap.add_argument("--list", action="store_true", help="print the framings and stop")
+    args = ap.parse_args()
+
+    if args.list:
+        for name, frame in FRAMINGS.items():
+            print(f"  {name:<16} {frame['doc']}")
+        return 0
+    if not CACHE.exists():
+        print("✗ no cache — run scripts/tune-judge.py --harvest first")
+        return 2
+    if args.classify:
+        for line in classify(args.model):
+            print(line)
+        return 0
+
+    names = list(FRAMINGS) if args.framing == "all" else args.framing.split(",")
+    for name in names:
+        if name not in FRAMINGS:
+            print(f"✗ no framing {name!r}; --list shows them all")
+            return 2
+    kinds = load_kinds() if any(FRAMINGS[n]["terms"] == "typed" for n in names) else {}
+
+    cases, unreachable = reachable(json.loads(CACHE.read_text()))
+    chance = sum(1 / len(c["menu"]) for c in cases)
+    print(f"\n  {len(cases)} reachable menus, {unreachable} never held the answer."
+          f"  Judge {args.model}, temperature 0.")
+    print(f"  Chance is {chance:.1f}/{len(cases)} — half these menus hold two options (F13).")
+    print("  The same 53 cases are tuned on and reported on. There is no held-out set.\n")
+
+    results = {}
+    for name in names:
+        before = len(tune.STRAY)
+        results[name] = run(cases, name, args.model, kinds)
+        picked = sum(right for right, _ in results[name].values())
+        stray = len(tune.STRAY) - before
+        note = f"   {stray} reply(s) had no bare letter" if stray else ""
+        print(f"  {name:<16} picked {picked:>2}/{len(cases)}"
+              f"   (chance {chance:.1f}){note}")
+
+    control = names[0]
+    if len(names) > 1:
+        print(f"\n  per case, against {control!r} — + won, - lost\n")
+        for name in names[1:]:
+            won = [c["wav"][22:-4] for c in cases
+                   if results[name][c["wav"]][0] and not results[control][c["wav"]][0]]
+            lost = [c["wav"][22:-4] for c in cases
+                    if results[control][c["wav"]][0] and not results[name][c["wav"]][0]]
+            print(f"  {name:<16} +{len(won)} {' '.join(won) or '-'}")
+            print(f"  {'':<16} -{len(lost)} {' '.join(lost) or '-'}")
+
+    print(f"\n  the ordinary-word collision class — {len(COLLISIONS)} clips PR #68 recorded\n")
+    header = "  " + f"{'clip':<10}{'what collided':<40}"
+    print(header + "".join(f"{n[:9]:<10}" for n in names))
+    present = {c["wav"][22:-4] for c in cases}
+    for stamp, what in COLLISIONS.items():
+        if stamp not in present:
+            print(f"  {stamp:<10}{what:<40}" + "unreachable — never on the menu")
+            continue
+        wav = next(c["wav"] for c in cases if c["wav"][22:-4] == stamp)
+        marks = "".join(f"{'   ✓':<10}" if results[n][wav][0] else f"{'   ✗':<10}"
+                        for n in names)
+        print(f"  {stamp:<10}{what:<40}{marks}")
+    scored = [s for s in COLLISIONS if s in present]
+    print()
+    for name in names:
+        got = sum(results[name][next(c['wav'] for c in cases if c['wav'][22:-4] == s)][0]
+                  for s in scored)
+        print(f"  {name:<16} {got}/{len(scored)} of the collision class")
+
+    if args.json:
+        Path(args.json).write_text(json.dumps(
+            {n: {w: {"right": r, "chose": c} for w, (r, c) in res.items()}
+             for n, res in results.items()}, indent=1, ensure_ascii=False))
+        print(f"\n  per-case results written to {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/judge-framings.py
+++ b/scripts/judge-framings.py
@@ -354,7 +354,8 @@ def main():
             print(line)
         return 0
 
-    names = list(FRAMINGS) if args.framing == "all" else args.framing.split(",")
+    names = (list(FRAMINGS) if args.framing == "all"
+             else [n.strip() for n in args.framing.split(",") if n.strip()])
     for name in names:
         if name not in FRAMINGS:
             print(f"✗ no framing {name!r}; --list shows them all")
@@ -366,7 +367,8 @@ def main():
     print(f"\n  {len(cases)} reachable menus, {unreachable} never held the answer."
           f"  Judge {args.model}, temperature 0.")
     print(f"  Chance is {chance:.1f}/{len(cases)} — half these menus hold two options (F13).")
-    print("  The same 53 cases are tuned on and reported on. There is no held-out set.\n")
+    print(f"  The same {len(cases)} cases are tuned on and reported on."
+          " There is no held-out set.\n")
 
     results = {}
     for name in names:
@@ -390,22 +392,21 @@ def main():
             print(f"  {'':<16} -{len(lost)} {' '.join(lost) or '-'}")
 
     print(f"\n  the ordinary-word collision class — {len(COLLISIONS)} clips PR #68 recorded\n")
-    header = "  " + f"{'clip':<10}{'what collided':<40}"
-    print(header + "".join(f"{n[:9]:<10}" for n in names))
-    present = {c["wav"][22:-4] for c in cases}
+    print("  " + f"{'clip':<10}{'what collided':<44}"
+          + "".join(f"{n[:9]:<10}" for n in names))
+    # The stamp is the clip's time, which is what every finding cites. A clip
+    # that never held its true sentence is not in `cases` at all, and saying so
+    # is the point: it cannot be scored by any framing.
+    at_stamp = {c["wav"][22:-4]: c["wav"] for c in cases}
     for stamp, what in COLLISIONS.items():
-        if stamp not in present:
-            print(f"  {stamp:<10}{what:<40}" + "unreachable — never on the menu")
-            continue
-        wav = next(c["wav"] for c in cases if c["wav"][22:-4] == stamp)
-        marks = "".join(f"{'   ✓':<10}" if results[n][wav][0] else f"{'   ✗':<10}"
-                        for n in names)
-        print(f"  {stamp:<10}{what:<40}{marks}")
-    scored = [s for s in COLLISIONS if s in present]
+        wav = at_stamp.get(stamp)
+        marks = ("unreachable — never on the menu" if wav is None else
+                 "".join(f"{'   ✓' if results[n][wav][0] else '   ✗':<10}" for n in names))
+        print(f"  {stamp:<10}{what:<44}{marks}")
+    scored = [at_stamp[s] for s in COLLISIONS if s in at_stamp]
     print()
     for name in names:
-        got = sum(results[name][next(c['wav'] for c in cases if c['wav'][22:-4] == s)][0]
-                  for s in scored)
+        got = sum(results[name][wav][0] for wav in scored)
         print(f"  {name:<16} {got}/{len(scored)} of the collision class")
 
     if args.json:

--- a/tests/term-kinds.yaml
+++ b/tests/term-kinds.yaml
@@ -1,0 +1,34 @@
+# What kind of thing each vocabulary term names.
+#
+# Spike data for `scripts/judge-framings.py`, not a config file. Nothing at run
+# time reads this, and `vocabulary.yaml`'s schema is unchanged. If a typed term
+# list turns out to be worth shipping, that is the PR that adds a `kind:` to
+# the vocabulary — not this file.
+#
+# The 11 terms are the ones in `tests/judge-menus.json`. Every label was
+# proposed once by `gemma4:e4b` with no context (`--classify`) and then checked
+# by hand. Three were changed:
+#
+#   Claude    brand -> product   the assistant is the thing being talked about
+#   Redcrawl  brand -> product   ~/Documents/redcrawl, a monorepo
+#   Redrock   brand -> product   ~/Documents/redrock, a Q&A assistant
+#
+# Eight were kept. `Praisy` was the one the model could not know, and it read
+# it right: the archive has "Is Praisy here today?" and "Praisy did an amazing
+# job", so `person` is correct.
+#
+# Inflected forms are not listed. `Praisy's`, `Arexvy.` and `Vercel?` all
+# reduce to their term in `judge-framings.base_term`.
+
+terms:
+  Arexvy: drug
+  Claude: product
+  Matthieu: person
+  Mirza: person
+  Ollama: tool
+  Praisy: person
+  Redcrawl: product
+  Redrock: product
+  Supabase: product
+  Tasmeen: person
+  Vercel: company


### PR DESCRIPTION
A measurement spike. **No prompt, no app and no schema changed.**
`examples/prompts/verify_names.md` and `vocabulary.yaml` are untouched.

The judge scores 41/53 on the cached menus. Its errors concentrate in one
class: an ordinary English word collides with a vocabulary term and the term
wins. PR #68 recorded nine such clips. **On those, the shipped prompt scores
0 of 8** (the ninth, `09-35-01` "the Versailles castle", never held the true
sentence on its menu, so it cannot be scored).

This PR asks whether the *question* is wrong, not its wording.

**Read [`docs/proposals/judge-framings.md`](docs/proposals/judge-framings.md)
first.** It is the short version: the verdict, the actual text of every arm as
a diff on the shipped prompt, and three real menus from the cache. The tables
below are the full record.

## How it was measured

`scripts/judge-framings.py`, offline against `tests/judge-menus.json` — 66
menus, 53 reachable, chance **17.4/53**. Judge `gemma4:e4b` at temperature 0,
Ollama; `gemma4:e4b-mlx` and `gemma4:12b` unloaded with `keep_alive: 0`, so
only `gemma4:e4b` was resident (F8, and "isolate models when benchmarking").
No build, no install, `~/.config/parrotflow-dev/` untouched.

Every framing is an exact edit list applied to the shipped prompt, and `build`
raises if an edit stops matching it exactly once. A framing cannot quietly
become the baseline.

**I tuned and reported on the same 53 cases. There is no held-out set.**
F16 measured five wordings of one sentence spanning 38–42, so anything inside
±2 has not moved.

**Repeatable.** `baseline`, `typed-slot` and `no-terms-cut` each ran twice in
separate processes and reproduced exactly — same total, same per-case diff.
Baseline reproduced 41/53, as PR #68 recorded.

## Every framing, against chance 17.4/53

| # | framing | wordings | picked /53 | collision class /8 |
|---|---|---|---|---|
| 1 | baseline, the shipped prompt | — | **41** | **0** |
| 2 | no term list, enumeration neutralised | 1 | 36 | 3 |
| 2 | no term list, enumeration deleted | 1 | 38 | 4 |
| 3 | inverted polarity, ported from `misheard` | 1 | 35 | 1 |
| 3 | inverted polarity, short | 1 | 35 | 0 |
| 3 | inverted polarity, long | 1 | 38 | 1 |
| 4 | typed terms, `Redcrawl (a product)` | 1 | 40 | 0 |
| 4 | typed terms + a position rule | 1 | 42 | 2 |
| 5 | the position rule alone, bare list | 1 | 41 | 2 |
| 5 | no term list + the position rule | 1 | 36 | 4 |

Chance is 17.4/53 on every row. Ten runs, one call per case each.

## The collision class, clip by clip

The nine rows PR #68 recorded. Five of them are also the controls sitting at
`~` in `menu-recall.py` (`11-19-17`, `14-04-21`, `14-09-56`, `15-36-12`,
`13-09-46`).

| clip | what collided | baseline | no-terms-cut | invert-ported | typed | typed-slot | slot-only |
|---|---|---|---|---|---|---|---|
| `17-47-45` | retry/crawl → Arexvy/Redcrawl | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
| `09-35-01` | Versailles castle → Vercel castle | — unreachable, never on the menu — |||||
| `14-04-21` | explanations to update → Praisy to Supabase | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
| `10-12-37` | asked me to crawl → to Redcrawl | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
| `14-09-56` | near matches → near Matthieu | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
| `13-09-46` | praise for shipping → Praisy shipping | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ |
| `11-19-17` | proprietary term → Praisy term | ✗ | ✓ | ✗ | ✗ | ✓ | ✗ |
| `15-36-12` | Pretty harsh → Arexvy harsh | ✗ | ✓ | ✓ | ✗ | ✗ | ✓ |
| `14-11-21` | the crawl data → the Redcrawl data | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ |
| | **total** | **0/8** | **4/8** | **1/8** | **0/8** | **2/8** | **2/8** |

Four of the eight are untouched by every framing tried. `17-47-45` and
`14-04-21` carry three and two collisions in one sentence.

## H1 — the term list is the prior, and the prior is load-bearing

Two wordings. Neutralising the enumeration scores 36/53, deleting it scores
38/53. Against 41/53.

It wins **exactly** what the hypothesis predicts. +5: `14-11-21` "the crawl
data", `00-14-39` "in general in our data", `15-36-12` "Pretty harsh",
`11-19-17` "proprietary term", `13-09-46` "praise for shipping".

And every one of the 8 it loses is a term that **was** right, now spelled as
something the judge can read:

| clip | said | chosen without the list |
|---|---|---|
| `16-09-50`, `16-09-37`, `15-36-50`, `14-11-48` | `Praisy` | `Prissy` |
| `17-05-32` | `Praisy` | `Prizzi` |
| `07-36-58` | `Praisy` | `Prezi` |
| `14-11-36` | `Arexvy` | `RXV` |
| `10-23-28` | "to close that loop … the user press enters" | "to **Claude** that loop … the user **Praisy** enters" |

So H1 is **true and rejected**. The list is the only thing that tells the
judge `Praisy` is a spelling at all. The two classes want opposite things
from one sentence: it has to be present for a name to be spellable, and
absent for a name to be doubted. That is a mechanism to change, not a prompt
to reword.

## H2 by polarity — rejected, three wordings

35, 35 and 38 against 41; 1, 0 and 1 of the collision class. All three are
ports of `rerank-judge.py`'s `misheard`, `misheard-short` and `misheard-long`.

F14's inversion does not transfer. A reranker scores one candidate at a time,
so its polarity flips by reading the score backwards. A judge that must name
one letter has to perform the inversion itself, and it is worse at that than
at picking.

## H2 by syntax — the only thing that moved the class without paying

One extra paragraph: a name is not a verb, so it cannot follow "to" as an
infinitive, and it does not modify a noun the way an adjective does.

| | picked /53 | class /8 |
|---|---|---|
| baseline | 41 | 0 |
| typed names only | 40 | 0 |
| position rule, bare list | 41 | 2 |
| position rule + typed names | 42 | 2 |

Typing the names on its own does nothing — 40/53 and 0/8. The position rule
does the work. The +1 for typing is inside F16's spread and is not a result;
0→2 on the collision class at zero total cost is the only signal in this
spike.

## The 11 typed terms

Each proposed once by `gemma4:e4b` with no context
(`judge-framings.py --classify`), then checked by hand. Stored in
`tests/term-kinds.yaml`, which nothing at run time reads.

| term | model said | kept | why |
|---|---|---|---|
| Arexvy | drug | drug | GSK's RSV vaccine |
| Claude | brand | **product** | the assistant is the thing being talked about |
| Matthieu | person | person | |
| Mirza | person | person | "Mirza and Mira are going to the movies" |
| Ollama | tool | tool | |
| Praisy | person | person | the archive has "Is Praisy here today?" |
| Redcrawl | brand | **product** | `~/Documents/redcrawl`, a monorepo |
| Redrock | brand | **product** | `~/Documents/redrock`, a Q&A assistant |
| Supabase | product | product | |
| Tasmeen | person | person | |
| Vercel | company | company | "Vercel hosts the dashboard" |

8 of 11 kept, 3 corrected. The one the model could not know — `Praisy` — it
read right.

## Combinations

`no-terms` and `typed` cannot be combined at all: one deletes the list the
other annotates. That is itself a result about H1 and H2.

Cutting the list plus the kind-free position rule scores 36/53 and 4/8 — no
better on the class than cutting the list alone, and 2 worse overall.

## What was dropped from the spike, and why

- **Cloze structured picks** and **cloze by logprob** — highest ceiling, but a
  win there is not a prompt change: `VocabularyJudge` composes whole sentences
  today, so a blank means rewriting how the question is built. Deferred to a
  round 2, not rejected.
- **Fusion with the acoustic margin** — nothing to fuse until a framing
  produces margins, which only the logprob arm would.
- **NLTagger** — needs its own accuracy study on lightly punctuated dictation
  before it can be judged as a signal. A separate question, not a judge
  framing.

`FRAMINGS` is a plain registry, so the deferred arms can be added beside these
without restructuring the script.

## Recommendation

**Ship no prompt change.** Nothing here clears the noise floor on 53 tuned
cases. The position rule is the only arm worth carrying forward, and it should
be carried as evidence — 2 of 8 is not a fix for a class the judge fails
completely.

**Reject** cutting the term list (net −3, and the losses are the class the
list exists for), inverted polarity (worse in all three wordings), and typed
names on their own (0/8).

**What the next PR should measure** is the per-slot question, because the
conflict measured here is per-slot. The term list has to be visible where the
name is a candidate and invisible where it is not, and a menu of whole
sentences cannot express that — every option carries every name. A cloze menu
can: the sentence once, a blank per uncertain span, and under each blank only
that span's candidates, typed. That also makes the cost linear in slots
instead of the product PR 6 had to cap at two. Measure it against these same
53 menus first.

Recorded as **F17** in `docs/proposals/vocabulary-v2.md`.

## Deviations

- The scope was narrowed mid-spike, on request: cloze, fusion and NLTagger
  were dropped, with the reasons above.
- Two framings were added that the brief did not ask for, both after the fact
  and both needed to read the result: `slot-only` splits `typed-slot` in half
  and shows the labels do nothing, and `no-terms-slot` is the one combination
  the two winning arms allow.
- Inverted polarity is inverted **in the instruction**, not in the scoring
  direction. The judge answers with one letter, so there is no score to read
  backwards; the model is asked to rule the wrong readings out and name what
  is left. This is not identical to a reranker's `reverse=True`.
- The repository check scripts were not run. They need the built binary, and
  the spike is forbidden from building the app. Nothing here is Swift, config
  or a prompt file.
- `tests/term-kinds.yaml` is spike data under `tests/`. It is not read at run
  time and `vocabulary.yaml`'s schema is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiQJipvz9Ps9tdDCRdisv
