### PR TITLE
test: fifteen live collisions from one afternoon of dictation

### DIFF
--- a/docs/proposals/vocabulary-v2.md
+++ b/docs/proposals/vocabulary-v2.md
@@ -75,8 +75,8 @@ Rules for the agent doing a PR. Follow them exactly.
 | Built app | `.build/ParrotFlowDev.app/Contents/MacOS/ParrotFlow` |
 | Installed app | `/Applications/ParrotFlowDev.app/Contents/MacOS/ParrotFlow` |
 | Judge model | Ollama, `gemma4:e4b`, temperature 0. Do not benchmark with other models loaded; e4b is the stable reference. |
-| Menu cache | `tests/judge-menus.json` (66 menus, 53 reachable — re-harvested by PR #68 over the 130-clip set) |
-| Case set | `tests/menu-cases.yaml` (127 labelled clips, in two blocks) |
+| Menu cache | `tests/judge-menus.json` (66 menus, 53 reachable — re-harvested by PR #68 over the first 130 clips, so it has nothing for block 3 until the next `--harvest`) |
+| Case set | `tests/menu-cases.yaml` (145 clips, 141 labelled, in three blocks) |
 
 ### Environment preflight (run before any measurement)
 
@@ -138,7 +138,8 @@ PR #68, on the 127 labelled clips of `tests/menu-cases.yaml`, three runs per
 clip, against `0766c81`. Two clips changed outcome between runs (`17-39-19`
 and `11-10-43`, picked on 2 runs of 3); `before-after.py` had none. The old
 37-clip numbers (recall 30/37, picked 27/37, 16/10/2) do not compare with
-them.
+them. Block 3 was added after that run, so those baselines cover the first
+two blocks only. Re-record them at the next measurement.
 
 **Record two totals, not one.** A single `recall` and a single `picked` over
 127 clips can now hide a regression. 73 of the clips are controls that the
@@ -154,7 +155,9 @@ a change nobody asked for, and it needs an explanation before the PR lands.
 block a clip came from. Splitting the report belongs to whoever next touches
 PR 2's harness. Until then, split by hand: the `# picked up:` comment on
 every entry in block 2 says which class the clip is in, and every clip in
-block 1 is about a term.
+block 1 is about a term. Every clip in block 3 is about a term too. It holds
+no controls, so the control total stays at 73 and the term total grows by
+the 14 labelled clips block 3 adds.
 
 **Caveat that stands until PR 1:** the same clip scores ~12 nats apart
 between live dictation and replay. Every number above describes replays.

--- a/tests/menu-cases.yaml
+++ b/tests/menu-cases.yaml
@@ -1,5 +1,5 @@
 # Ground truth for scripts/menu-recall.py: what the speaker actually
-# said, written by hand. Two blocks, mined two different ways.
+# said, written by hand. Three blocks, gathered three different ways.
 #
 # `said` is pre-filled with what the app produced. Correct the lines
 # that are wrong, and blank the ones you cannot remember. A line left
@@ -569,3 +569,116 @@ cases:
   - wav: parrotflow-2026-08-07T07-36-58.wav
     # picked up: sampled at random, unfiltered. The app got Praisy right.
     said: "So let's say we have very low floor for Praisy, but with the judge. The judge would the the judge was n would know my terms and see that."
+
+# ---------------------------------------------------------------
+# Block 3 — one afternoon of live use, 2026-08-08 16:17 to 17:42,
+# in dictation order. Nathan re-dictated the standing regression
+# sentences and kept a design conversation going. Truth is known:
+# it is what he was saying at the time, and `trace.jsonl` holds the
+# decoder's own text from before the vocabulary pass ran.
+#
+# Almost every case here is an overwrite: the pass wrote a name
+# over an ordinary word the speaker meant. Blocks 1 and 2 reached
+# only 8 of those, and the class is what the pass gets wrong in
+# daily use. The three cases that are not overwrites are marked.
+#
+# Only the words the vocabulary pass got wrong are corrected here.
+# Plain decoder mistakes with no term involved are left as the app
+# wrote them, because `said` has to be what was spoken and a guess
+# at a word nobody remembers is worse than a known-wrong one.
+#
+# `# app:` records what the app delivered.
+# ---------------------------------------------------------------
+
+  - wav: parrotflow-2026-08-08T16-17-03.wav
+    # picked up: live use. Not an overwrite and not the spotter: the
+    # replacements stage wrote Vercel over Versailles. The second
+    # Vercel is right.
+    # app: We are deploying the we are visiting the Vercel castle while our app is being deployed on Vercel.
+    said: "We are deploying the we are visiting the Versailles castle while our app is being deployed on Vercel."
+
+  - wav: parrotflow-2026-08-08T16-18-00.wav
+    # picked up: live use. Two overwrites in one short sentence:
+    # Arexvy over "retry" and Redcrawl over "crawl".
+    # app: If the Arexvy fails, the Redcrawl will fail.
+    said: "If the retry fails, the crawl will fail."
+
+  - wav: parrotflow-2026-08-08T16-18-14.wav
+    # picked up: live use. The app wrote Supabase over "update".
+    # app: Explanations to Supabase.
+    said: "Explanations to update."
+
+  - wav: parrotflow-2026-08-08T16-18-23.wav
+    # picked up: live use. The app wrote Redcrawl over "crawl".
+    # app: You ask me to Redcrawl.
+    said: "You ask me to crawl."
+
+  - wav: parrotflow-2026-08-08T16-18-37.wav
+    # picked up: live use. The app wrote Matthieu over "matches".
+    # app: words that are near Matthieu.
+    said: "words that are near matches."
+
+  - wav: parrotflow-2026-08-08T16-18-45.wav
+    # picked up: live use. The app wrote Praisy over the first
+    # "praise". The decoder had heard that one as "spray"; the second
+    # "praise" it heard correctly, and the pass left it alone.
+    # app: They deserve Praisy. But never mind. They deserve praise for their shipping.
+    said: "They deserve praise. But never mind. They deserve praise for their shipping."
+
+  - wav: parrotflow-2026-08-08T16-19-02.wav
+    # picked up: live use. The app wrote Praisy's over "praise for" —
+    # one name over two ordinary words.
+    # app: They deserve Praisy's shipping.
+    said: "They deserve praise for shipping."
+
+  - wav: parrotflow-2026-08-08T16-19-18.wav
+    # picked up: live use. The app wrote Praisy over "proprietary".
+    # app: A Langsmith Praisy term.
+    said: "A Langsmith proprietary term."
+
+  - wav: parrotflow-2026-08-08T16-28-54.wav
+    # picked up: live use. A miss, not an overwrite: the pass never
+    # fired, so NLTagger stayed as the decoder wrote it. The set is
+    # dominated by overwrites, so this one is worth keeping.
+    # app: U if the anal tagger is not right, we can also use the available Gemma model, it should perform well too.
+    said: "U if the NLTagger is not right, we can also use the available Gemma model, it should perform well too."
+
+  - wav: parrotflow-2026-08-08T16-29-26.wav
+    # picked up: live use. The app wrote Claude over a verb. The
+    # decoder had heard "predicting"; the speaker said "generating"
+    # and re-dictated that one word in the next clip.
+    # app: Language models are better at Claude text than ranking proposals.
+    said: "Language models are better at generating text than ranking proposals."
+
+  - wav: parrotflow-2026-08-08T17-32-26.wav
+    # picked up: live use. Not an overwrite: two names were spoken and
+    # the pass wrote a third name over both.
+    # app: What argument can it make to choose Arexvy over Arexvy?
+    said: "What argument can it make to choose Praisy over Prissy?"
+
+  - wav: parrotflow-2026-08-08T17-37-39.wav
+    # picked up: live use, left unlabelled on purpose. The decoder
+    # wrote "How would it work? How would it work when there are
+    # multiple ambiguous terms?" and the spotter replaced "work when"
+    # with "Praisy" (spotter -4.93) — two ordinary words for one name.
+    # The speaker restarted the sentence and the wording of the
+    # restart is not known, so `said` is blank rather than guessed.
+    # app: How would it work? How would it Praisy there are multiple ambiguous terms?
+    said:
+
+  - wav: parrotflow-2026-08-08T17-39-32.wav
+    # picked up: live use. The app wrote Praisy over "train".
+    # app: As a side uh question, could we Praisy a very small classifier Very lightweight, that could answer the question is this phonetic segment this vocabulary term?
+    said: "As a side uh question, could we train a very small classifier Very lightweight, that could answer the question is this phonetic segment this vocabulary term?"
+
+  - wav: parrotflow-2026-08-08T17-40-19.wav
+    # picked up: live use. Two overwrites in one clip: Vercel over
+    # "level" and Arexvy over "heavy". "I ask another region" is a
+    # plain decoder mistake with no term in it, so it stays.
+    # app: I ask another region to make some research about this. Not too much high Vercel. So what I'm understanding is like could we train uh not an LLM of course it's too Arexvy, but something that can run very fast on CPU.
+    said: "I ask another region to make some research about this. Not too much high level. So what I'm understanding is like could we train uh not an LLM of course it's too heavy, but something that can run very fast on CPU."
+
+  - wav: parrotflow-2026-08-08T17-41-18.wav
+    # picked up: live use. The app wrote Praisy's over "train as".
+    # app: Something that would be fast and easy to Praisy's well, locally for users.
+    said: "Something that would be fast and easy to train as well, locally for users."


### PR DESCRIPTION
The eval set is thinnest exactly where the vocabulary pass fails in daily
use: a term written over an ordinary word the speaker meant. PR #68 found
only 8 reachable cases of it. On 2026-08-08 Nathan dictated to Claude all
afternoon and the pass did it repeatedly, so the truth is known.

This adds block 3 to `tests/menu-cases.yaml`: 15 clips from 16:17 to 17:42
that day. No code changes.

## The cases

| wav | app delivered | said | class |
|---|---|---|---|
| `16-17-03` | We are deploying the we are visiting the **Vercel** castle while our app is being deployed on Vercel. | … the **Versailles** castle … | replacements stage, not the spotter |
| `16-18-00` | If the **Arexvy** fails, the **Redcrawl** will fail. | If the **retry** fails, the **crawl** will fail. | overwrite ×2 |
| `16-18-14` | Explanations to **Supabase**. | Explanations to **update**. | overwrite |
| `16-18-23` | You ask me to **Redcrawl**. | You ask me to **crawl**. | overwrite |
| `16-18-37` | words that are near **Matthieu**. | words that are near **matches**. | overwrite |
| `16-18-45` | They deserve **Praisy**. But never mind. They deserve praise for their shipping. | They deserve **praise**. But never mind. … | overwrite |
| `16-19-02` | They deserve **Praisy's** shipping. | They deserve **praise for** shipping. | overwrite, one name over two words |
| `16-19-18` | A Langsmith **Praisy** term. | A Langsmith **proprietary** term. | overwrite |
| `16-28-54` | U if the **anal tagger** is not right, we can also use the available Gemma model, it should perform well too. | U if the **NLTagger** is not right … | **miss** |
| `16-29-26` | Language models are better at **Claude** text than ranking proposals. | … better at **generating** text … | overwrite |
| `17-32-26` | What argument can it make to choose **Arexvy** over **Arexvy**? | … choose **Praisy** over **Prissy**? | wrong term over two spoken names |
| `17-37-39` | How would it work? How would it **Praisy** there are multiple ambiguous terms? | *(blank)* | overwrite, **unlabelled** |
| `17-39-32` | As a side uh question, could we **Praisy** a very small classifier … | … could we **train** a very small classifier … | overwrite |
| `17-40-19` | … Not too much high **Vercel**. … it's too **Arexvy**, … | … high **level**. … it's too **heavy**, … | overwrite ×2 |
| `17-41-18` | Something that would be fast and easy to **Praisy's** well, locally for users. | … easy to **train as** well, … | overwrite |

12 overwrites, 1 miss, 1 replacements-stage substitution, 1 case of a third
name written over two spoken names.

## The blank one

`17-37-39` is left with `said:` empty on purpose. The log shows
`"work when" -> "Praisy" (spotter -4.93)`: the decoder wrote "work when"
and the spotter replaced two ordinary words with one name. But the speaker
restarted the sentence and the wording of the restart is not known.
`load_cases()` counts a blank label as unlabelled and skips it, which is the
right behaviour. A guessed label would silently teach the harness a wrong
answer, which is worse than no answer.

## How the labels were checked

`trace.jsonl` records the decoder's own text from before the vocabulary pass
ran, in the same entry as the delivered transcript. Every label was checked
against it. The first entry per wav was used, since the file is append-only.

Only the words the pass got wrong are corrected. Plain decoder mistakes with
no vocabulary term in them are left as the app wrote them — "I ask another
region" in `17-40-19` stays, and so do the disfluencies, because `said` has
to be what was spoken.

Clips whose only error was a plain ASR mistake were skipped: `17-31-40`
("In brand B" for "In branch B"), `17-34-14` ("we could just speak" for
"just pick"). `16-24-05` was also skipped — Redcrawl is in the right
position there, and whether "RXV" was spoken as Arexvy or as letters is not
knowable from the clip.

## Counts

|  | before | after |
|---|---|---|
| cases | 130 | 145 |
| labelled | 126 | 141 |
| unlabelled | 4 | 5 |

Verified with the harness's own parser:

```
python3 -c "from importlib.machinery import SourceFileLoader; r=SourceFileLoader('r','scripts/menu-recall.py').load_module(); c=r.load_cases(); print(len(c),'cases,',sum(1 for _,s in c if s),'labelled')"
145 cases, 141 labelled
```

Every wav exists in `~/Recordings/ParrotFlow Dev/`, and no wav is a duplicate
of the 130 already in the file.

## No measurement

Nothing was measured. Another agent held the app and Ollama at the time, so
the app was not built and no harness was run. The recall and picked
baselines in `docs/proposals/vocabulary-v2.md` were recorded by PR #68 over
blocks 1 and 2. They will move when someone next measures, because the set
grew. That is expected, not a regression. The doc now says so, and its case
set line is updated to 145 clips in three blocks.

The gate splits the totals by hand into clips that are about a term and
clips that are controls. Every clip in block 3 is about a term, so the
control total stays at 73 and the term total grows by 14. The doc says that
too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiQJipvz9Ps9tdDCRdisv
