### PR TITLE
test: the blank form moves the failure instead of fixing it

### DIFF
--- a/docs/proposals/judge-framings.md
+++ b/docs/proposals/judge-framings.md
@@ -579,3 +579,382 @@ patch.
    should be shipped. That is a gap for `menu-cases.yaml` to fill.
 
 Recorded as F18 in [vocabulary-v2.md](vocabulary-v2.md).
+
+---
+
+# Round 3 — the same question, in blanks
+
+**The blanks lose. Do not change the shape.**
+
+Round 2 credited the blank form with 3 cases on the collision class, but it
+changed the wording and the shape at once. Round 3 changes only the shape. The
+shipped prompt, the shipped vocabulary list and the shipped score block go into
+both arms. One states the sentence once per reading. The other states it once,
+with a numbered blank per uncertain span and the candidates under each number.
+
+| arm | total /53 | multi-slot /18 | single-slot /35 | collision /8 |
+|---|---|---|---|---|
+| sentence — what ships today | **41** | **12** | **29** | 0 |
+| blank | 37 | 9 | 28 | **3** |
+| chance | 17.4 | 2.8 | 14.6 | 2.1 |
+
+The blank form wins the collision class and loses the total. **It wins 4 cases
+and loses 8.** Round 2's 6/8 does not survive: with the shipped question the
+blanks reach 3/8, and 2 of the 3 are single-slot clips, where the two arms ask
+nearly the same question. **So the shape is worth about half of what round 2
+credited it with. The other half was the wording.**
+
+And the collision class is a fixed list of 8 clips, which hides the real
+result. Counted over all 77 uncertain spans, **the blank form does not fix the
+failure. It moves it.**
+
+| | collision clips, 16 spans | every other clip, 61 spans |
+|---|---|---|
+| sentence | 4 right, **12 overwrites** | 57 right, **3 overwrites**, 1 name lost |
+| blank | 10 right, **6 overwrites** | 49 right, **8 overwrites**, 4 names lost |
+
+An *overwrite* is the error the whole spike is about: the speaker said an
+ordinary word and the arm wrote a name over it. On the 8 clips PR #68 named,
+the blanks halve them. On the other 45 clips they more than double them. Over
+all 77 spans the overwrite count barely moves — 15 against 14 — and the blanks
+lose 4 names where the sentence loses 1.
+
+And 37/53 is not a score the blank form owns. A blank must letter its own
+candidates, and that choice carries no information. Sorting them instead of
+keeping the app's order takes the arm to **31/53** and the overwrites to 20.
+**Letter order moves it 6 cases; the shape moves it 4.**
+
+Measured with `scripts/judge-blanks.py` against `tests/judge-menus.json`,
+`gemma4:e4b`, temperature 0, nothing else loaded. The control re-measured at
+41/53, reproducing rounds 1 and 2 exactly. Three full runs gave identical
+totals and identical per-case diffs. No reply was unreadable. No build, no
+install.
+
+**The same 53 cases are tuned on and reported on.** There is no held-out set.
+
+## The one variable
+
+Three sentences of `verify_names.md` describe the shape of the question and of
+the answer. Those three change and nothing else does. They are quoted in
+`BLANK_EDITS` and the run fails loudly if one stops matching the prompt file.
+
+```diff
+-A name matcher was unsure about some words. Below is the sentence, and every
+-reading it might really have been. Exactly one is what the user said.
++A name matcher was unsure about some words. Below is the sentence with each of
++them blanked and numbered, and every reading each blank might really have been.
++Exactly one reading of each blank is what the user said.
+```
+```diff
+-Pick the reading that makes sense as a sentence, unless the sound says
+-otherwise by more than about 4. Answer with its letter only.
++Pick the reading of each blank that makes sense as a sentence, unless the sound
++says otherwise by more than about 4. Answer with one letter per blank and
++nothing else, like "1=A 2=B".
+```
+
+The user message ends `Which letter for each blank?` instead of the app's
+`Which letter?`. One string for every case, so a one-blank case and a
+three-blank case are asked in the same words.
+
+Everything else is identical: the vocabulary list, the paragraph about
+"spells", the paragraph about the acoustic gap, the "makes sense as a sentence"
+test, and the score block, which goes in unchanged because it names spellings
+and not slots. Chance is the same number for both arms, because the slot
+readings multiply back out to the menu — the harness refuses to run a case
+where they do not.
+
+Only 14 of the 53 replies used `1=A 2=B`. 29 were a single letter for a single
+blank, read by the app's own rule. 10 were bare letters in order — `A B` for
+two blanks. **Nothing was unreadable**, so the losses below are answers, not
+formatting.
+
+## What a blank question looks like — `10-12-37`
+
+The clip round 1 named as the one that argues for a per-slot question. The
+score block is the same text in both arms.
+
+```
+It's a community that ___1___ asked me to ___2___
+
+1. A. Tasmin
+   B. Tasmeen
+
+2. A. crawl.
+   B. Redcrawl.
+
+  "Tasmin" -10.13   "Tasmeen" -10.68   — "Tasmeen" heard 0.5 less clearly
+  "crawl." -10.06   "Redcrawl." -11.83   — "Redcrawl." heard 1.8 less clearly
+
+Which letter for each blank?
+```
+
+The blank arm gets it. The sentence arm takes `Tasmeen … Redcrawl`, and has in
+every framing of every round. One name is right and one is wrong, and a menu of
+whole sentences carries both in every option.
+
+## The collision class
+
+| clip | spans | said → written | sentence | blank |
+|---|---:|---|---|---|
+| `17-47-45` | 3 | retry/crawl → Arexvy/Redcrawl | ✗ | ✗ |
+| `09-35-01` | | Versailles → Vercel castle | never reached a menu ||
+| `14-04-21` | 3 | explanations to update → Praisy to Supabase | ✗ | ✗ |
+| `10-12-37` | 2 | asked me to crawl → to Redcrawl | ✗ | **✓** |
+| `14-09-56` | 2 | near matches → near Matthieu | ✗ | ✗ |
+| `13-09-46` | 1 | praise for shipping → Praisy shipping | ✗ | ✗ |
+| `11-19-17` | 1 | proprietary term → Praisy term | ✗ | **✓** |
+| `15-36-12` | 1 | Pretty harsh → Arexvy harsh | ✗ | **✓** |
+| `14-11-21` | 3 | the crawl data → the Redcrawl data | ✗ | ✗ |
+| | | **total** | **0/8** | **3/8** |
+
+The shipped prompt is 0/8 for the fourth round running. The blanks take 3.
+Only one of the 3 is the multi-slot case the shape was designed for. The other
+two are one-span clips — `Chain is a langsmith ___ term.` and `___ harsh
+review.` — where the two arms differ only in that the blank arm prints the
+sentence once instead of twice.
+
+## The trade, per span
+
+A case counts only when every one of its spans is right, so a three-span case
+scores zero whether it missed one span or three. `17-47-45` is the example: the
+sentence arm gets none of its three spans, the blank arm gets two, and both
+score ✗. Per span is where the trade is legible.
+
+77 spans over the 53 cases. Two ways to be wrong, and they are not the same
+mistake.
+
+| arm | right | wrote a name over an ordinary word | kept what was decoded, losing the name |
+|---|---|---|---|
+| sentence | **61/77** | 15 | **1** |
+| blank | 59/77 | **14** | 4 |
+
+Split by whether the clip is in PR #68's list:
+
+| | collision clips, 16 spans | every other clip, 61 spans |
+|---|---|---|
+| sentence | 4 right, 12 overwrites, 0 names lost | 57 right, 3 overwrites, 1 name lost |
+| blank | **10 right**, **6 overwrites**, 0 names lost | 49 right, **8 overwrites**, 4 names lost |
+
+The five overwrites the blank form adds outside the list are all the same
+mistake it fixes inside it:
+
+```
+17-27-23   "praise the"             -> "Praisy's"
+09-10-32   "Mira va"                -> "Mirza"
+23-00-49   "Versailles,"            -> "Vercel,"
+10-23-28   "transcription when the" -> "Praisy"
+10-23-28   "press"                  -> "Praisy's"
+```
+
+`23-00-49` is the one to read twice. It is `alternatives for Versailles, such
+as Vercel` — the speaker named both, and the blank arm wrote the vocabulary
+term over the place name. That is `09-35-01` again, the clip round 1 could
+never score.
+
+One caveat on the classification. A span that `slots` merged can hold two
+decisions at once, and then it lands in whichever column the whole span falls
+in. `17-39-27` is such a span: true `praise Matthieu's`, blank arm
+`Praisy's Matthieu's`. It is counted as a name lost, and it is also an
+overwrite of "praise". One of the four.
+
+## The blanks are not stable under letter order
+
+A blank has to letter its own candidates, and the order is a free choice. The
+arm above uses the order the app's own menu introduces them in. Sorting them
+instead changes no word of the question. `--order sorted`:
+
+| blank arm, letters in | total /53 | multi-slot /18 | collision /8 | spans right | overwrites | names lost |
+|---|---|---|---|---|---|---|
+| menu order | 37 | 9 | 3 | 59/77 | 14 | 4 |
+| sorted | **31** | **5** | **5** | **47/77** | **20** | **10** |
+| sentence arm, unaffected | 41 | 12 | 0 | 61/77 | 15 | 1 |
+
+**Letter order moves the blank arm by 6 cases. The shape itself moves it by 4.**
+It also changes *which* clips of the collision class it gets: `11-19-17` is won
+in menu order and lost in sorted, and `14-09-56`, `13-09-46` and `14-11-21` go
+the other way. The sentence arm keeps the app's menu untouched and scores 41
+and 61/77 in both runs, which is the check that the harness is varying only
+what it says it varies.
+
+So 37/53 is not the blank form's score. It is one point in a range the form
+reaches by an accident of alphabet. **A shape whose answer turns on which
+candidate got the letter A is not a shape to ship**, whichever end of the range
+is quoted.
+
+Two replies were unreadable under sorted order — `2=B 3=A`, which names two of
+three blanks, and `A=A B=B`. Both are counted wrong. In menu order there were
+none.
+
+## The multi-slot subset
+
+18 of the 53 cases hold more than one uncertain span, 42 spans between them.
+35 hold one span. **77 spans over 53 cases.**
+
+The shape can only differ where a case holds more than one span. It does differ
+there, and it differs the wrong way: **12/18 as sentences, 9/18 as blanks.** On
+the 35 single-span cases the two arms score 29 and 28, which is one case and is
+noise.
+
+So the subset where the shape is a real question prefers the sentence.
+
+## Per case
+
+```
+all          +4  17-19-57  11-19-17  10-12-37  15-36-12
+             -8  17-39-27  17-27-23  17-05-32  09-10-32
+                 14-11-36  23-00-49  10-23-28  07-36-58
+
+multi-slot   +1  10-12-37
+             -4  17-05-32  14-11-36  23-00-49  10-23-28
+
+single-slot  +3  17-19-57  11-19-17  15-36-12
+             -4  17-39-27  17-27-23  09-10-32  07-36-58
+```
+
+### What the losses have in common — a span wider than a word
+
+Four of the eight losses hold a span that is more than one word — `17-39-27`,
+`17-27-23`, `09-10-32`, `10-23-28`. `slots` merges spans that overlap, so a
+span can be `praise the` or `transcription when the`. In the sentence form
+those words stay in a sentence. In the blank form the frame around the blank is
+what is left, and what is left is not English.
+
+```
+So let's ___1___ team's work.        <- 17-27-23, the true reading is "praise the"
+
+1. A. praise the
+   B. Praisy
+   C. Praisy's
+```
+
+```
+So I guess to ___1___ that loop, is there a way we can record the
+final ___2___ user ___3___ enters.   <- 10-23-28, 12 options, 3 spans
+
+2. A. transcription when the
+   B. Praisy
+```
+
+The sentence arm reads `record the final transcription when the user press
+enters` and takes it. The blank arm chooses between `transcription when the`
+and `Praisy` inside `record the final ___ user`, which is a frame no reading
+completes.
+
+That cost is structural. A blank helps when the span is a word and hurts when
+the span is a phrase. **23 of the 77 spans in this cache hold a reading of more
+than one word.**
+
+### `07-36-58` — the clip that keeps breaking
+
+```
+So let's say we have very low floor for ___1___ but with the judge. ...
+
+1. A. Prezi,
+   B. Praisy,
+```
+
+The true reading is `Praisy,`. The sentence arm takes it, the blank arm takes
+`Prezi,`. PR #68 lost this clip when it cut the pro-term sentence, and round
+1's position rule lost it too. The term list is still in this prompt. The blank
+removes what made the list usable: the speaker is talking *about* the term, and
+the blank hides the sentence that says so.
+
+## Every number in rounds 1–3 excludes the live collisions
+
+`tests/judge-menus.json` was harvested before PR #70. Its newest clip is
+`2026-08-08T01-02-23`. The 15 clips PR #70 added were dictated the same
+afternoon, 16:17 to 17:42, and **none of them are in the cache.** Re-harvesting
+runs the app, so this round could not add them.
+
+Every judge number in rounds 1, 2 and 3 — 41/53, 0/8, 37/53, 3/8, and every
+number in F16, F17 and F18 — is measured on 53 menus that hold none of them.
+
+The 15 are almost all the ordinary-word collision class, which is the class the
+shipped prompt scores 0 on. This is what a harvest would add, read off the
+`# app:` lines in `tests/menu-cases.yaml`:
+
+| clip | what the pass did | would it enter the cache? |
+|---|---|---|
+| `16-17-03` | Vercel over "Versailles" — the replacements stage, not the spotter | no menu |
+| `16-18-00` | Arexvy over "retry", Redcrawl over "crawl" | yes, 2 spans |
+| `16-18-14` | Supabase over "update" | yes |
+| `16-18-23` | Redcrawl over "crawl" | yes |
+| `16-18-37` | Matthieu over "matches" | yes |
+| `16-18-45` | Praisy over "spray"; the speaker said "praise" | yes, unreachable |
+| `16-19-02` | Praisy's over "praise for" | yes |
+| `16-19-18` | Praisy over "proprietary" | yes |
+| `16-28-54` | nothing fired; NLTagger stayed as decoded | no menu |
+| `16-29-26` | Claude over "predicting"; the speaker said "generating" | yes, unreachable |
+| `17-32-26` | Arexvy over both Praisy and Prissy | yes, reachability unknown |
+| `17-37-39` | Praisy over "work when"; `said` deliberately blank | skipped by the harvest |
+| `17-39-32` | Praisy over "train" | yes |
+| `17-40-19` | Vercel over "level", Arexvy over "heavy" | yes, 2 spans |
+| `17-41-18` | Praisy's over "train as" | yes |
+
+**12 of the 15 would enter the cache, and 9 of those would be scorable.** Two
+are unreachable because the word the speaker said was never decoded, so no
+menu can hold it. One cannot be called without running it.
+
+That column is a prediction, not a measurement. It rests on one fact in the
+code: `Vocabulary.autoApplies` writes a term in only when the decoded word is
+**not** a real word, or is the same word with a space in it.
+`Replacements.applyFuzzy` is gated on the same test. Every clip above replaced
+an ordinary English word — "retry", "crawl", "update", "matches", "praise",
+"proprietary", "train", "level", "heavy" — so neither could have fired, and the
+judge must have been asked, which means a menu existed. Only a harvest settles
+it.
+
+Adding 9 scorable collision clips would roughly double a class the shipped
+prompt is 0 of 8 on. **That is the number to want next, and it matters more
+than the 4 cases this round moved.**
+
+## The data gap, still open
+
+Round 2 recorded it and round 3 cannot close it. On all 8 not-a-word spans in
+this cache the speaker meant the vocabulary term. There is no clip where the
+decoder wrote a non-word and the non-word was right, so **no rule about that
+class can be falsified.** The `--sweep` result that reaches 8/8 at about 1.5
+nats is unfalsifiable rather than good.
+
+What would fill it: a clip where the speaker says a proper name that is *not*
+in the vocabulary, whose spelling is in no dictionary, and which sounds like a
+term that is. A colleague called `Tasmin` beside the vocabulary's `Tasmeen`. A
+product called `Prezi` beside `Praisy`. `Arexvi` beside `Arexvy`. The right
+answer on that span is "keep what the decoder wrote", and one such clip breaks
+the 8/8 unanimity that currently makes every offset look safe.
+
+## Recommendation
+
+**Ship nothing, again.** There is no trade to weigh here, because the blank
+form does not buy the thing it was meant to buy.
+
+The trade looks like one case metric against another — 3/8 of the collision
+class against 4 cases of the total. Per span it is not a trade at all. The
+overwrite is the error that matters, and the blank form commits 14 of them
+against the sentence form's 15. It halves them on the 8 clips PR #68 happened
+to write down and it more than doubles them on the other 45, including
+`23-00-49`, where it writes `Vercel` over the place the speaker named. **The
+class did not shrink. It moved off the list we were watching.** On top of that
+the blanks lose 4 names where the sentence loses 1.
+
+If the numbers had come out the other way — collision class up, total down —
+the decision would be Nathan's. They did not. Both metrics say the same thing
+once they are counted per span.
+
+There is also nothing stable to ship. Sorting the candidates inside a blank
+changes no word of the question and moves the arm 6 cases, from 37 to 31, and
+the overwrite count from 14 to 20. The shape moves the total by 4. The choice
+of which candidate gets the letter A moves it by more.
+
+One thing is still worth keeping, and it is what the shape is for. `10-12-37`
+is the only multi-slot collision clip any arm in three rounds has got, and both
+blank arms get it. A blank is right for a span that is one word and wrong for a
+span that is a phrase. If the blanks are tried again, change the slot recovery
+and not the prompt: a merged span of four words should not be a blank at all,
+and 23 of the 77 spans here hold a reading of more than one word.
+
+Do the harvest first. Nine more collision clips against a prompt that scores 0
+of 8 on that class will say more than a fourth wording.
+
+Recorded as F19 in [vocabulary-v2.md](vocabulary-v2.md).

--- a/docs/proposals/judge-framings.md
+++ b/docs/proposals/judge-framings.md
@@ -632,6 +632,14 @@ install.
 
 **The same 53 cases are tuned on and reported on.** There is no held-out set.
 
+Every failure of both arms is in
+[tests/judge-failures.txt](../../tests/judge-failures.txt), verbatim — the
+system message, the user message, the raw reply and the error type for each of
+the 12 sentence-arm and 16 blank-arm failures, 8 of which both arms fail.
+Regenerate it with `scripts/judge-blanks.py --dump-failures
+tests/judge-failures.txt`, which reruns both arms, so it cannot drift from the
+numbers above.
+
 ## The one variable
 
 Three sentences of `verify_names.md` describe the shape of the question and of

--- a/docs/proposals/vocabulary-v2.md
+++ b/docs/proposals/vocabulary-v2.md
@@ -594,7 +594,14 @@ vocabulary, whose spelling is in no dictionary, and which sounds like a term
 that is — a colleague `Tasmin` beside `Tasmeen`, a product `Prezi` beside
 `Praisy`. → `menu-cases.yaml`.
 
+Every failure of both arms is in `tests/judge-failures.txt`, verbatim, with the
+prompt each one was given. `scripts/judge-blanks.py --dump-failures` rewrites
+it from a fresh run.
+
 **Recommendation: ship no shape, and re-harvest before the next round.**
+Changing the shape of the question is not the lever. Rounds 1, 2 and 3 have now
+measured ten wordings, two routers and two shapes against one prompt that has
+not moved off 41/53 or off 0/8.
 
 ---
 

--- a/docs/proposals/vocabulary-v2.md
+++ b/docs/proposals/vocabulary-v2.md
@@ -512,6 +512,90 @@ blank form carrying the *shipped* question, so form is separated from content
 — this spike changed both at once and cannot say what the blanks would be
 worth on their own.
 
+**F19 — the blank form moves the failure, it does not fix it (spike,
+2026-08-08).** F18 left one thing unresolved: it changed the judge's wording
+and the shape of its question at the same time, so the blanks' 6/8 on the
+collision class could have been either. This measures the shape alone. Both
+arms carry the shipped `verify_names.md`, the shipped vocabulary list and the
+shipped score block. Only three sentences differ, and all three describe the
+shape of the question and of the answer. One arm states the sentence once per
+reading. The other states it once, with a numbered blank per uncertain span and
+the candidates under each number, answered `1=A 2=B`. Measured by
+`scripts/judge-blanks.py` on the same 53 cached menus, `gemma4:e4b`,
+temperature 0. Prompts and cases in [judge-framings.md](judge-framings.md).
+**Same set tuned on and reported on, no held-out set.** Three full runs gave
+identical totals and identical per-case diffs, and no reply was unreadable.
+
+| arm | total /53 | multi-slot /18 | single-slot /35 | collision /8 |
+|---|---|---|---|---|
+| sentence — what ships | **41** | **12** | **29** | 0 |
+| blank | 37 | 9 | 28 | **3** |
+| chance | 17.4 | 2.8 | 14.6 | 2.1 |
+
+*Half of round 2's win was the wording.* With the shipped question the blanks
+score 3/8 on the collision class, not 6/8, and 2 of the 3 are single-span
+clips where the two arms ask nearly the same question. The shape moves the
+class by about half what F18 credited it with.
+
+*The collision class is a fixed list of 8 clips, and that hides the result.*
+Counted over all 77 uncertain spans, with an *overwrite* being the error the
+spike exists for — the speaker said an ordinary word, the arm wrote a name:
+
+| | collision clips, 16 spans | every other clip, 61 spans |
+|---|---|---|
+| sentence | 4 right, **12 overwrites**, 0 names lost | 57 right, **3 overwrites**, 1 name lost |
+| blank | 10 right, **6 overwrites**, 0 names lost | 49 right, **8 overwrites**, 4 names lost |
+
+Over all 77 spans the overwrite count barely moves — 15 against 14. The blanks
+halve it on the 8 clips PR #68 wrote down and more than double it on the other
+45, including `23-00-49`, where the speaker named Versailles *and* Vercel and
+the blank arm wrote the term over the place. **The class did not shrink, it
+moved off the list being watched.** The blanks also lose 4 names to the
+sentence form's 1.
+
+*The blank arm is not stable.* A blank has to letter its own candidates, and
+the order is a free choice that changes no word of the question. Sorting them
+instead of keeping the app's menu order moves the arm from 37/53 to **31/53**,
+multi-slot from 9/18 to 5/18, overwrites from 14 to 20, names lost from 4 to
+10 — and the collision class *up*, from 3/8 to 5/8, on a different set of
+clips. **Letter order moves it 6 cases; the shape moves it 4.** The sentence
+arm keeps the app's menu and scores 41 and 61/77 in both runs, which is the
+check that only the stated variable moved.
+
+*The shape breaks on a span wider than a word.* `slots` merges overlapping
+spans, so a span can be `praise the` or `transcription when the`. Blanking it
+leaves a frame no reading completes — `So let's ___ team's work.` 4 of the 8
+losses hold such a span, and 23 of the 77 spans in the cache hold a reading of
+more than one word.
+
+*The multi-slot subset — the only place the shape can differ — prefers the
+sentence*, 12/18 against 9/18. On the 35 single-span cases the arms score 29
+and 28, which is noise.
+
+**Every judge number in F16, F17, F18 and F19 excludes the live collisions.**
+`tests/judge-menus.json` was harvested before PR #70; its newest clip is
+`2026-08-08T01-02-23`, and the 15 clips PR #70 added were dictated that
+afternoon. **12 of the 15 would enter the cache and 9 would be scorable** —
+2 are unreachable because the word the speaker said was never decoded, and 1
+cannot be called without running it. Of the 3 that stay out, 2 produce no menu
+(`16-17-03` was the replacements stage, `16-28-54` never fired) and `17-37-39`
+has no label, so the harvest skips it. That prediction rests
+on `Vocabulary.autoApplies` and `Replacements.applyFuzzy` both refusing to
+rewrite a real dictionary word, so every clip that overwrote "retry", "crawl",
+"update", "matches", "praise", "proprietary", "train", "level" or "heavy" must
+have gone through the judge. The 15 are almost all the collision class, so a
+harvest would roughly double a class the shipped prompt is 0 of 8 on.
+**That number is worth more than anything this round moved.**
+
+*The F18 data gap is still open.* On all 8 not-a-word spans in this cache the
+speaker meant the term, so no rule about that class can be falsified. What
+fills it: one clip where the speaker says a proper name that is not in the
+vocabulary, whose spelling is in no dictionary, and which sounds like a term
+that is — a colleague `Tasmin` beside `Tasmeen`, a product `Prezi` beside
+`Praisy`. → `menu-cases.yaml`.
+
+**Recommendation: ship no shape, and re-harvest before the next round.**
+
 ---
 
 ## Build order

--- a/scripts/judge-blanks.py
+++ b/scripts/judge-blanks.py
@@ -6,6 +6,7 @@
     scripts/judge-blanks.py --repeat 3         # run both arms three times over
     scripts/judge-blanks.py --order sorted     # letter the blanks' candidates differently
     scripts/judge-blanks.py --json out.json    # per-case results
+    scripts/judge-blanks.py --dump-failures tests/judge-failures.txt
 
 Round 1 (`judge-framings.py`) changed the judge's question and found that no
 wording wins (F17). Round 2 (`judge-routing.py`) tried to route each case away
@@ -243,17 +244,20 @@ def ask_blanks(model, system, item, order):
     those tokens on anything, since it answers one letter.
     """
     per_slot = options_for(item, order)
+    user = question(item, order)
     payload = {
         "model": model, "stream": False, "think": False,
         "options": {"temperature": 0, "num_predict": max(8, 6 * len(per_slot))},
         "messages": [{"role": "system", "content": system},
-                     {"role": "user", "content": question(item, order)}],
+                     {"role": "user", "content": user}],
     }
     request = urllib.request.Request(
         ENDPOINT, data=json.dumps(payload).encode(),
         headers={"Content-Type": "application/json"})
     with urllib.request.urlopen(request, timeout=120) as response:
         reply = json.loads(response.read())["message"]["content"].strip()
+    tune.LAST.clear()
+    tune.LAST.update(system=system, user=user, reply=reply)
     picked, item["how"] = read_answer(reply, per_slot)
     return picked
 
@@ -283,6 +287,8 @@ def run(items, arm, model, order):
             got = ask_blanks(model, system.replace("{terms}", case["terms"]), item, order)
         item[arm] = got == item["truth"]
         item[arm + " chose"] = got
+        # Kept so `--dump-failures` can print the call rather than rebuild it.
+        item[arm + " call"] = dict(tune.LAST)
 
 
 def trade(items, arm):
@@ -315,6 +321,89 @@ def trade(items, arm):
     return right, overwrite, lost, spans
 
 
+RULE = "=" * 78
+BAR = "-" * 78
+
+
+def errors(item, arm):
+    """[(kind, what)] — one entry per span this arm got wrong.
+
+    The same rule `trade` counts by. A reply the harness could not read at all
+    is its own kind: the arm answered, but not about these blanks.
+    """
+    chose = item[arm + " chose"]
+    if chose is None:
+        return [("unreadable", "the reply named no set of blanks")]
+    out = []
+    for index, truth in enumerate(item["truth"]):
+        if chose[index] != truth:
+            kind = "overwrite" if truth == item["heard"][index] else "name lost"
+            out.append((kind, f"{truth!r} -> {chose[index]!r}"))
+    return out or [("other", "every span is right but the case is not")]
+
+
+def dump_failures(items, path, model, order, chance):
+    """Every failing case in both arms, exactly as the model was given it.
+
+    The messages are the strings that went over the wire, kept by `tune.LAST`
+    rather than rebuilt here. A dump that reassembles the prompt is a dump that
+    can disagree with the run it claims to explain.
+    """
+    failed = {arm: [i for i in items if not i[arm]] for arm in ARMS}
+    both = {routing.stamp(i["case"]) for i in failed["sentence"]} \
+        & {routing.stamp(i["case"]) for i in failed["blank"]}
+
+    out = ["Every judge failure, verbatim — round 3 of the judge spike.", "",
+           "What the model was sent and what it said back, for every case each arm",
+           "got wrong. Nothing here is tidied, shortened or paraphrased. The system",
+           "and user messages are the strings that went over the wire.", "",
+           "Regenerate — it must never drift from the numbers in the report:", "",
+           f"    scripts/judge-blanks.py --dump-failures {path}", "",
+           "The report is docs/proposals/judge-framings.md, round 3.", "",
+           f"Judge {model}, temperature 0, letters inside a blank in {order} order.",
+           f"{len(items)} reachable cached menus, chance {chance:.1f}.",
+           f"sentence {sum(i['sentence'] for i in items)}/{len(items)},"
+           f" blank {sum(i['blank'] for i in items)}/{len(items)}.", "",
+           "Two errors are named. `overwrite` is a name written where the speaker",
+           "said an ordinary word — the failure this whole spike is about. `name",
+           "lost` is a real name left as the decoder mangled it. A span that `slots`",
+           "merged can hold both, and then it is named by whichever the whole span",
+           "matches.", "", RULE, "INDEX", RULE, ""]
+
+    for arm in ARMS:
+        out += [f"{arm} arm — {len(failed[arm])} failures", ""]
+        for item in failed[arm]:
+            stamp = routing.stamp(item["case"])
+            kinds = ", ".join(sorted({kind for kind, _ in errors(item, arm)}))
+            mark = "both arms fail" if stamp in both else ""
+            out.append(f"  {stamp:<10} {len(item['spans'])} span(s)  "
+                       f"{kinds:<24} {mark}")
+        out.append("")
+
+    for arm in ARMS:
+        out += [RULE, f"{arm.upper()} ARM — {len(failed[arm])} FAILURES", RULE, ""]
+        for item in failed[arm]:
+            stamp = routing.stamp(item["case"])
+            call = item[arm + " call"]
+            out += [BAR,
+                    f"clip      {stamp}",
+                    f"arm       {arm}",
+                    f"both      {'yes — the other arm fails this clip too' if stamp in both else 'no — the other arm gets this clip'}",
+                    f"spans     {len(item['spans'])}",
+                    f"said:     {item['case']['said']}",
+                    f"true:     {item['truth']}"]
+            out += [f"error:    {kind:<11} {what}" for kind, what in errors(item, arm)]
+            out += ["", "--- system message ---", call["system"],
+                    "--- user message ---", call["user"],
+                    "--- reply ---", call["reply"],
+                    "--- resolved to ---", repr(item[arm + " chose"]), ""]
+        out.append(BAR)
+        out.append("")
+
+    Path(path).write_text("\n".join(out))
+    return failed, both
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--model", default=os.environ.get("PARROTFLOW_JUDGE_MODEL", "gemma4:e4b"))
@@ -325,6 +414,8 @@ def main():
     ap.add_argument("--show", metavar="STAMP",
                     help="print both prompts for one clip, verbatim, and stop")
     ap.add_argument("--json", metavar="PATH", help="write per-case results here")
+    ap.add_argument("--dump-failures", metavar="PATH",
+                    help="write every failing case of both arms, verbatim, here")
     args = ap.parse_args()
 
     if not CACHE.exists():
@@ -452,6 +543,14 @@ def main():
         print(f"  {clip:<10}{len(item['spans']):<7}{what:<44}{marks}")
     print("  " + f"{'total':<10}{'':<7}{'':<44}"
           + "".join(f"{f'{sum(i[a] for i in scored)}/{len(scored)}':<10}" for a in ARMS))
+
+    if args.dump_failures:
+        failed, both = dump_failures(items, args.dump_failures, args.model,
+                                     args.order, chance)
+        print(f"\n  {len(failed['sentence'])} sentence-arm failures,"
+              f" {len(failed['blank'])} blank-arm failures,"
+              f" {len(both)} clips both arms fail")
+        print(f"  written verbatim to {args.dump_failures}")
 
     if args.json:
         Path(args.json).write_text(json.dumps(

--- a/scripts/judge-blanks.py
+++ b/scripts/judge-blanks.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+"""Score the *shipped* judge question in two shapes, against the cached menus.
+
+    scripts/judge-blanks.py                    # both arms, one table
+    scripts/judge-blanks.py --show 10-12-37    # the two prompts for one clip, verbatim
+    scripts/judge-blanks.py --repeat 3         # run both arms three times over
+    scripts/judge-blanks.py --order sorted     # letter the blanks' candidates differently
+    scripts/judge-blanks.py --json out.json    # per-case results
+
+Round 1 (`judge-framings.py`) changed the judge's question and found that no
+wording wins (F17). Round 2 (`judge-routing.py`) tried to route each case away
+from the judge, found the router inverted, and found one thing that did move:
+the same question asked per blank instead of per sentence takes the
+ordinary-word collision class from 3/8 to 6/8. But round 2 changed the wording
+*and* the shape at once, so it cannot say which one did it.
+
+This file changes one thing. Both arms carry the shipped `verify_names.md`, the
+same vocabulary list and the same score block. Only the shape differs:
+
+    sentence   every reading of the whole sentence, lettered — what ships today
+    blank      the sentence once with each uncertain span blanked and numbered,
+               the candidates listed under each number, answered `1=A 2=B`
+
+Three sentences of the shipped prompt have to change, because they describe the
+shape of the answer. They are quoted in `BLANK_EDITS` and the run fails loudly
+if one stops matching the prompt file. Nothing else moves.
+
+Two numbers are printed for each arm and both are needed. The **case** total is
+what every earlier round reported, and it is all-or-nothing: a three-span case
+scores zero whether it missed one span or three. The **span** tally splits the
+errors into the two that are not the same mistake — a name written over an
+ordinary word, and a name lost — because the decision between these shapes is a
+decision about which of those to prefer.
+
+`--order` is the control on the one free choice a blank forces: which candidate
+gets the letter A. It changes no word of the question, and it moves the blank
+arm more than the shape does. The sentence arm ignores it, which is the check
+that only the stated variable moves.
+
+**The same 53 cases are tuned on and reported on.** There is no held-out set,
+and every number here excludes the 15 live collisions PR #70 added to
+`tests/menu-cases.yaml` — the menu cache predates them and re-harvesting needs
+the app built.
+"""
+import argparse
+import json
+import os
+import re
+import string
+import sys
+import urllib.request
+from math import prod
+from pathlib import Path
+from importlib.machinery import SourceFileLoader
+
+ROOT = Path(__file__).resolve().parent.parent
+CACHE = ROOT / "tests/judge-menus.json"
+PROMPT = ROOT / "examples/prompts/verify_names.md"
+ENDPOINT = os.environ.get("PARROTFLOW_LLM_ENDPOINT", "http://localhost:11434") + "/api/chat"
+
+recall = SourceFileLoader("recall", str(ROOT / "scripts/menu-recall.py")).load_module()
+tune = SourceFileLoader("tune", str(ROOT / "scripts/tune-judge.py")).load_module()
+framings = SourceFileLoader("framings", str(ROOT / "scripts/judge-framings.py")).load_module()
+# The slot recovery — `slots`, `check`, `analyse` — is round 2's and is not
+# rebuilt here. It diffs the menu options against each other to find the spans
+# the spotter was unsure about, and refuses to run on a case whose slots do not
+# rebuild the menu exactly.
+routing = SourceFileLoader("routing", str(ROOT / "scripts/judge-routing.py")).load_module()
+
+COLLISIONS = framings.COLLISIONS
+
+
+# ── the one difference between the arms ──────────────────────────────────────
+# Exact substrings of the shipped prompt, replaced in order. Only sentences
+# that describe the *shape* of the question and of the answer are touched. The
+# vocabulary list, the paragraph about "spells", the paragraph about the
+# acoustic gap and the "makes sense as a sentence" test are all left as they
+# ship — those are the content, and round 2 already showed content moves more
+# than shape does.
+
+BLANK_EDITS = [
+    ("A name matcher was unsure about some words. Below is the sentence, and every\n"
+     "reading it might really have been. Exactly one is what the user said.",
+     "A name matcher was unsure about some words. Below is the sentence with each of\n"
+     "them blanked and numbered, and every reading each blank might really have been.\n"
+     "Exactly one reading of each blank is what the user said."),
+
+    ("Pick the reading that makes sense as a sentence, unless the sound says\n"
+     "otherwise by more than about 4. Answer with its letter only.",
+     "Pick the reading of each blank that makes sense as a sentence, unless the sound\n"
+     "says otherwise by more than about 4. Answer with one letter per blank and\n"
+     'nothing else, like "1=A 2=B".'),
+]
+
+# The user message ends with this in the blank arm. The sentence arm ends with
+# the app's own "Which letter?", which `tune.ask` appends. One string is used
+# whatever the slot count, so a single-blank case and a three-blank case are
+# asked in exactly the same words — otherwise the multi-slot split below would
+# be comparing two different prompts.
+BLANK_TAIL = "\n\nWhich letter for each blank?"
+
+
+def blank_prompt():
+    """The shipped prompt with the three shape sentences replaced.
+
+    Every edit must match exactly once. A silently missing edit would turn this
+    arm back into the control and report it as a finding, which is the one
+    failure this harness cannot be allowed to have. `framings.build` guards its
+    own edits the same way and for the same reason.
+    """
+    text = PROMPT.read_text().strip()
+    for old, new in BLANK_EDITS:
+        if text.count(old) != 1:
+            raise SystemExit(
+                f"✗ the blank arm's edit no longer matches {PROMPT.name} exactly once "
+                f"({text.count(old)} times).\n   looked for: {old[:60]!r}...")
+        text = text.replace(old, new)
+    return text
+
+
+# ── the blank form ───────────────────────────────────────────────────────────
+
+def numbered(ref, spans):
+    """The sentence with every uncertain span replaced by `___1___`, `___2___`.
+
+    `routing.blank` blanks one span and leaves the others as the decoder wrote
+    them, because round 2 asked one question per span. Here one question covers
+    every span, so every span is a hole. That is the whole of the shape change:
+    the sentence is stated once, not once per reading.
+    """
+    out, cursor = [], 0
+    for index, (a, b) in enumerate(spans):
+        out += ref[cursor:a]
+        out.append(f"___{index + 1}___")
+        cursor = b
+    out += ref[cursor:]
+    return " ".join(out)
+
+
+def slot_options(item, index):
+    """A slot's readings, in the order the menu introduces them.
+
+    `routing.analyse` sorts them, which is fine when each slot is its own call.
+    Here the letters sit inside the one question the control also answers, and
+    letter order is a real effect on a small model — so the order is taken from
+    the menu the app itself built. Then the only thing that differs between the
+    two arms is the shape. `--order sorted` measures what that choice is worth.
+    """
+    seen = []
+    for fillers in item["fillers"]:
+        if fillers[index] not in seen:
+            seen.append(fillers[index])
+    return seen
+
+
+def options_for(item, order):
+    per_slot = [slot_options(item, i) for i in range(len(item["spans"]))]
+    if order == "sorted":
+        per_slot = [sorted(o) for o in per_slot]
+    # The cartesian product of the slot readings has to be the menu, or the two
+    # arms are not answering the same question and chance is not the same
+    # number. `routing.check` already proved the two *sets* are equal; this
+    # proves no menu option is a duplicate of another, which is what makes the
+    # sizes agree too.
+    if prod(len(o) for o in per_slot) != len(item["case"]["menu"]):
+        raise SystemExit(
+            f'✗ {routing.stamp(item["case"])}: {len(item["case"]["menu"])} options but '
+            f'{prod(len(o) for o in per_slot)} combinations of slot readings')
+    return per_slot
+
+
+def question(item, order):
+    """The user message of the blank arm, score block and all."""
+    lines = [numbered(item["ref"], item["spans"]), ""]
+    for index, options in enumerate(options_for(item, order)):
+        for letter, option in enumerate(options):
+            head = f"{index + 1}." if letter == 0 else "  "
+            lines.append(f"{head} {string.ascii_uppercase[letter]}. {option}")
+        lines.append("")
+    # The score block goes in exactly as the app wrote it and exactly as the
+    # control receives it. It names spellings, not slots, so it needs no
+    # rewriting for the blanks — and rewriting it would be a second variable.
+    return "\n".join(lines).rstrip() + (item["case"].get("scores") or "") + BLANK_TAIL
+
+
+ANSWER = re.compile(r"(\d+)\s*[=:.\)]?\s*([A-Za-z])\b")
+STRAY = []        # replies this harness could not map onto the blanks at all
+
+
+def read_answer(reply, per_slot):
+    """(the reading each blank was given, how the reply was read).
+
+    `1=A 2=B` is what the prompt asks for and it is not what most replies give.
+    Two fallbacks are allowed, and which one was used is recorded per case
+    rather than assumed, because a shape whose answers cannot be read is a
+    worse shape and hiding that would flatter the arm.
+
+    * `numbered`   — the asked-for form.
+    * `letters`    — one bare letter per blank, in order. `A B` for two blanks.
+    * `app rule`   — a single blank answered with a single letter, read by
+                     `tune.chosen`, which is the app's own rule and is exactly
+                     what the control does with the same reply.
+    * `unreadable` — nothing this harness can map onto the blanks. Counted as
+                     wrong, and collected in STRAY.
+    """
+    picked = {}
+    for number, letter in ANSWER.findall(reply):
+        index = int(number) - 1
+        letter = string.ascii_uppercase.index(letter.upper())
+        if 0 <= index < len(per_slot) and letter < len(per_slot[index]):
+            picked.setdefault(index, per_slot[index][letter])
+    if len(picked) == len(per_slot):
+        return [picked[i] for i in range(len(per_slot))], "numbered"
+
+    if len(per_slot) == 1:
+        index = tune.chosen(reply, len(per_slot[0]))
+        if index is None:
+            STRAY.append(reply)
+            return None, "unreadable"
+        return [per_slot[0][index]], "app rule"
+
+    bare = [w for w in re.split(r"[^A-Za-z]+", reply.upper())
+            if len(w) == 1 and w in string.ascii_uppercase]
+    if len(bare) == len(per_slot):
+        out = []
+        for options, letter in zip(per_slot, bare):
+            index = string.ascii_uppercase.index(letter)
+            if index >= len(options):
+                STRAY.append(reply)
+                return None, "unreadable"
+            out.append(options[index])
+        return out, "letters"
+    STRAY.append(reply)
+    return None, "unreadable"
+
+
+def ask_blanks(model, system, item, order):
+    """One call per case, like the control. The answer names every blank.
+
+    `num_predict` is the app's 8 for a single blank and grows with the blanks,
+    because `1=A 2=B 3=C` is simply a longer answer than `B`. That is a
+    consequence of the shape, not a second variable — the control cannot spend
+    those tokens on anything, since it answers one letter.
+    """
+    per_slot = options_for(item, order)
+    payload = {
+        "model": model, "stream": False, "think": False,
+        "options": {"temperature": 0, "num_predict": max(8, 6 * len(per_slot))},
+        "messages": [{"role": "system", "content": system},
+                     {"role": "user", "content": question(item, order)}],
+    }
+    request = urllib.request.Request(
+        ENDPOINT, data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(request, timeout=120) as response:
+        reply = json.loads(response.read())["message"]["content"].strip()
+    picked, item["how"] = read_answer(reply, per_slot)
+    return picked
+
+
+def ask_sentence(model, system, item):
+    """The control — the app's own call, on the app's own whole-sentence menu."""
+    case = item["case"]
+    chosen = tune.ask(model, system, case["menu"], case.get("scores") or "")
+    if chosen is None:
+        return None
+    return item["fillers"][case["menu"].index(chosen)]
+
+
+ARMS = {
+    "sentence": "the shipped prompt, whole-sentence menu — what ships today",
+    "blank": "the shipped prompt, one numbered blank per uncertain span",
+}
+
+
+def run(items, arm, model, order):
+    system = (framings.build("baseline") if arm == "sentence" else blank_prompt())
+    for item in items:
+        case = item["case"]
+        if arm == "sentence":
+            got = ask_sentence(model, system.replace("{terms}", case["terms"]), item)
+        else:
+            got = ask_blanks(model, system.replace("{terms}", case["terms"]), item, order)
+        item[arm] = got == item["truth"]
+        item[arm + " chose"] = got
+
+
+def trade(items, arm):
+    """Per span, the two ways an arm can be wrong. Counting cases hides this.
+
+    A case is right only when every span is, so a three-span case scores zero
+    whether it missed one span or three. The two errors are not the same error
+    and the decision between the arms is a decision about which one to prefer:
+
+        overwrite   the speaker said the ordinary word, the arm wrote the name.
+                    This is the class the whole spike exists for (F17).
+        name lost   the speaker said the name, the arm kept what was decoded.
+
+    The decoded reading of a span is `routing.decoded_filler` — the one reading
+    carrying no vocabulary term, which is exact because the proposals are the
+    only thing that put those spellings on the menu.
+    """
+    right = overwrite = lost = spans = 0
+    for item in items:
+        chose = item.get(arm + " chose")
+        for index, truth in enumerate(item["truth"]):
+            spans += 1
+            got = chose[index] if chose else None
+            if got == truth:
+                right += 1
+            elif truth == item["heard"][index]:
+                overwrite += 1
+            else:
+                lost += 1
+    return right, overwrite, lost, spans
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", default=os.environ.get("PARROTFLOW_JUDGE_MODEL", "gemma4:e4b"))
+    ap.add_argument("--order", default="menu", choices=["menu", "sorted"],
+                    help="letter order inside a blank (default: the menu's own)")
+    ap.add_argument("--repeat", type=int, default=1,
+                    help="run both arms this many times, to show the totals are stable")
+    ap.add_argument("--show", metavar="STAMP",
+                    help="print both prompts for one clip, verbatim, and stop")
+    ap.add_argument("--json", metavar="PATH", help="write per-case results here")
+    args = ap.parse_args()
+
+    if not CACHE.exists():
+        print("✗ no cache — run scripts/tune-judge.py --harvest first")
+        return 2
+    cases, unreachable = routing.reachable(json.loads(CACHE.read_text()))
+    items = routing.analyse(cases)
+
+    if args.show:
+        item = next((i for i in items if routing.stamp(i["case"]) == args.show), None)
+        if item is None:
+            print(f"✗ no reachable case {args.show!r}")
+            return 2
+        case = item["case"]
+        print(f'\n  said   {case["said"]}\n  terms  {case["terms"]}')
+        print("\n─── arm 1, sentence — SYSTEM ───\n")
+        print(framings.build("baseline").replace("{terms}", case["terms"]))
+        print("\n─── arm 1, sentence — USER ───\n")
+        # Mirrors the message `tune.ask` builds. It is printed rather than
+        # returned by that function, so this is the one place the two can
+        # drift; the report quotes it, so check it against `tune.ask` if the
+        # app's message changes.
+        print("\n".join(f"{string.ascii_uppercase[i]}. {o}"
+                        for i, o in enumerate(case["menu"]))
+              + (case.get("scores") or "") + "\n\nWhich letter?")
+        print("\n─── arm 2, blank — SYSTEM ───\n")
+        print(blank_prompt().replace("{terms}", case["terms"]))
+        print("\n─── arm 2, blank — USER ───\n")
+        print(question(item, args.order))
+        return 0
+
+    # Chance is the same number for both arms, and that is not a coincidence:
+    # the slot readings multiply out to the menu, so guessing a letter per
+    # blank and guessing a letter on the menu are the same lottery.
+    chance = sum(1 / len(c["menu"]) for c in cases)
+    multi = [i for i in items if len(i["spans"]) > 1]
+    single = [i for i in items if len(i["spans"]) == 1]
+    slots = sum(len(i["spans"]) for i in items)
+
+    print(f"\n  {len(cases)} reachable menus, {unreachable} never held the answer."
+          f"  Judge {args.model}, temperature 0.")
+    print(f"  Chance is {chance:.1f}/{len(cases)}, the same for both arms (F13).")
+    print(f"  {len(multi)} cases hold more than one uncertain span "
+          f"({sum(len(i['spans']) for i in multi)} spans), "
+          f"{len(single)} hold one. {slots} spans over the {len(cases)} cases.")
+    print(f"  Letters inside a blank are in {args.order} order.")
+    print(f"  The same {len(cases)} cases are tuned on and reported on."
+          " There is no held-out set.")
+    print("  The cache predates PR #70, so none of the 15 live collisions"
+          " of 2026-08-08 are in it.\n")
+
+    for pass_number in range(args.repeat):
+        before = len(STRAY) + len(tune.STRAY)
+        for arm in ARMS:
+            run(items, arm, args.model, args.order)
+        if args.repeat > 1:
+            print(f"  run {pass_number + 1}   "
+                  + "   ".join(f"{a} {sum(i[a] for i in items)}/{len(cases)}"
+                               for a in ARMS)
+                  + f"   ({len(STRAY) + len(tune.STRAY) - before} unreadable replies)")
+    if args.repeat > 1:
+        print()
+
+    # How the blank arm's replies came back, over the last run only. The asked
+    # -for `1=A 2=B` is the minority; the rest is bare letters, which the app's
+    # own rule reads. None of it is a reason a case was scored wrong.
+    last = {how: sum(i.get("how") == how for i in items)
+            for how in ("numbered", "letters", "app rule", "unreadable")}
+    print("  blank-arm replies — "
+          + ", ".join(f"{count} {how}" for how, count in last.items() if count))
+
+    print(f"  {'arm':<10}{'total':<12}{'multi-slot':<14}{'single-slot':<14}"
+          f"{'collision':<12}")
+    at = {routing.stamp(i["case"]): i for i in items}
+    scored = [at[c] for c in COLLISIONS if c in at]
+    for arm, doc in ARMS.items():
+        print(f"  {arm:<10}"
+              f"{f'{sum(i[arm] for i in items)}/{len(cases)}':<12}"
+              f"{f'{sum(i[arm] for i in multi)}/{len(multi)}':<14}"
+              f"{f'{sum(i[arm] for i in single)}/{len(single)}':<14}"
+              f"{f'{sum(i[arm] for i in scored)}/{len(scored)}':<12}{doc}")
+    print(f"  {'chance':<10}{chance:<12.1f}"
+          f"{sum(1 / len(i['case']['menu']) for i in multi):<14.1f}"
+          f"{sum(1 / len(i['case']['menu']) for i in single):<14.1f}"
+          f"{sum(1 / len(i['case']['menu']) for i in scored):<12.1f}")
+
+    print(f"\n  by span, not by case — {slots} spans, and the two ways to be wrong\n")
+    print(f"  {'arm':<10}{'right':<12}{'wrote the name over an':<26}"
+          f"{'kept what was decoded,':<26}")
+    print(f"  {'':<10}{'':<12}{'ordinary word':<26}{'losing the name':<26}")
+    for arm in ARMS:
+        right, overwrite, lost, spans_seen = trade(items, arm)
+        print(f"  {arm:<10}{f'{right}/{spans_seen}':<12}{overwrite:<26}{lost:<26}")
+    print("\n  A case counts only when every one of its spans is right, so the totals"
+          "\n  above hide this. The two columns are the trade between the arms.")
+
+    print(f"\n  the collision class, by span — {sum(len(at[c]['spans']) for c in COLLISIONS if c in at)}"
+          " spans over the 8 reachable clips\n")
+    for arm in ARMS:
+        right, overwrite, lost, spans_seen = trade(scored, arm)
+        print(f"  {arm:<10}{f'{right}/{spans_seen}':<12}{overwrite:<26}{lost:<26}")
+
+    if STRAY or tune.STRAY:
+        print(f"\n  {len(tune.STRAY)} sentence-arm replies had no bare letter;"
+              f" {len(STRAY)} blank-arm replies could not be read at all.")
+        for reply in (STRAY + tune.STRAY)[:4]:
+            print(f"    {reply!r}")
+
+    print("\n  per case — + the blank arm won, - it lost\n")
+    for name, subset in (("all", items), ("multi-slot", multi), ("single-slot", single)):
+        won = [routing.stamp(i["case"]) for i in subset if i["blank"] and not i["sentence"]]
+        lost = [routing.stamp(i["case"]) for i in subset if i["sentence"] and not i["blank"]]
+        print(f"  {name:<12} +{len(won)} {' '.join(won) or '-'}")
+        print(f"  {'':<12} -{len(lost)} {' '.join(lost) or '-'}")
+
+    print(f"\n  the ordinary-word collision class — {len(COLLISIONS)} clips, PR #68\n")
+    print("  " + f"{'clip':<10}{'slots':<7}{'what collided':<44}"
+          + "".join(f"{a:<10}" for a in ARMS))
+    for clip, what in COLLISIONS.items():
+        item = at.get(clip)
+        if item is None:
+            print(f"  {clip:<10}{'':<7}{what:<44}unreachable — never on the menu")
+            continue
+        marks = "".join(f"{'✓' if item[a] else '✗':<10}" for a in ARMS)
+        print(f"  {clip:<10}{len(item['spans']):<7}{what:<44}{marks}")
+    print("  " + f"{'total':<10}{'':<7}{'':<44}"
+          + "".join(f"{f'{sum(i[a] for i in scored)}/{len(scored)}':<10}" for a in ARMS))
+
+    if args.json:
+        Path(args.json).write_text(json.dumps(
+            [{"wav": i["case"]["wav"], "said": i["case"]["said"],
+              "slots": len(i["spans"]), "options": options_for(i, args.order),
+              "decoded": i["heard"], "true": i["truth"], "read as": i.get("how"),
+              **{a: i[a] for a in ARMS},
+              **{f"{a} chose": i[f"{a} chose"] for a in ARMS}} for i in items],
+            indent=1, ensure_ascii=False))
+        print(f"\n  per-case results written to {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tune-judge.py
+++ b/scripts/tune-judge.py
@@ -80,6 +80,13 @@ def harvest():
 
 STRAY = []   # replies whose first character was not the answer
 
+# The most recent call, verbatim: `system`, `user`, `reply`. `judge-blanks.py
+# --dump-failures` prints exactly what a failing case was sent and what came
+# back, and rebuilding the user message in the harness is how such a dump
+# drifts from what actually went over the wire. Overwritten on every call, so
+# read it immediately after `ask` returns.
+LAST = {}
+
 # One line of the score block: two spellings for one stretch of audio, each
 # with its score in nats. The first number is the *heard* score — what the
 # decoder actually wrote.
@@ -128,11 +135,12 @@ def ask(model, system, options, scores="", logprobs=False, lead=""):
     reply read by the same rule as every other arm.
     """
     body = "\n".join(f"{string.ascii_uppercase[i]}. {o}" for i, o in enumerate(options))
+    user = lead + body + scores + "\n\nWhich letter?"
     payload = {
         "model": model, "stream": False, "think": False,
         "options": {"temperature": 0, "num_predict": 8},
         "messages": [{"role": "system", "content": system},
-                     {"role": "user", "content": lead + body + scores + "\n\nWhich letter?"}],
+                     {"role": "user", "content": user}],
     }
     if logprobs:
         payload |= {"logprobs": True, "top_logprobs": 20}
@@ -142,6 +150,8 @@ def ask(model, system, options, scores="", logprobs=False, lead=""):
     with urllib.request.urlopen(request, timeout=60) as response:
         answer = json.loads(response.read())
     reply = answer["message"]["content"].strip()
+    LAST.clear()
+    LAST.update(system=system, user=user, reply=reply)
 
     if logprobs and answer.get("logprobs"):
         ranked = ranking(answer["logprobs"][0].get("top_logprobs", []), options)

--- a/tests/judge-failures.txt
+++ b/tests/judge-failures.txt
@@ -1,0 +1,1612 @@
+Every judge failure, verbatim — round 3 of the judge spike.
+
+What the model was sent and what it said back, for every case each arm
+got wrong. Nothing here is tidied, shortened or paraphrased. The system
+and user messages are the strings that went over the wire.
+
+Regenerate — it must never drift from the numbers in the report:
+
+    scripts/judge-blanks.py --dump-failures tests/judge-failures.txt
+
+The report is docs/proposals/judge-framings.md, round 3.
+
+Judge gemma4:e4b, temperature 0, letters inside a blank in menu order.
+53 reachable cached menus, chance 17.4.
+sentence 41/53, blank 37/53.
+
+Two errors are named. `overwrite` is a name written where the speaker
+said an ordinary word — the failure this whole spike is about. `name
+lost` is a real name left as the decoder mangled it. A span that `slots`
+merged can hold both, and then it is named by whichever the whole span
+matches.
+
+==============================================================================
+INDEX
+==============================================================================
+
+sentence arm — 12 failures
+
+  17-47-45   3 span(s)  overwrite                both arms fail
+  17-19-57   1 span(s)  name lost                
+  17-05-42   2 span(s)  overwrite                both arms fail
+  16-12-20   1 span(s)  overwrite                both arms fail
+  14-11-21   3 span(s)  overwrite                both arms fail
+  11-19-17   1 span(s)  overwrite                
+  14-04-21   3 span(s)  overwrite                both arms fail
+  00-14-39   1 span(s)  overwrite                both arms fail
+  10-12-37   2 span(s)  overwrite                
+  14-09-56   2 span(s)  overwrite                both arms fail
+  15-36-12   1 span(s)  overwrite                
+  13-09-46   1 span(s)  overwrite                both arms fail
+
+blank arm — 16 failures
+
+  17-47-45   3 span(s)  overwrite                both arms fail
+  17-39-27   1 span(s)  name lost                
+  17-27-23   1 span(s)  overwrite                
+  17-05-42   2 span(s)  overwrite                both arms fail
+  17-05-32   2 span(s)  name lost                
+  16-12-20   1 span(s)  overwrite                both arms fail
+  14-11-21   3 span(s)  overwrite                both arms fail
+  09-10-32   1 span(s)  overwrite                
+  14-11-36   2 span(s)  name lost                
+  14-04-21   3 span(s)  overwrite                both arms fail
+  23-00-49   3 span(s)  overwrite                
+  00-14-39   1 span(s)  overwrite                both arms fail
+  14-09-56   2 span(s)  overwrite                both arms fail
+  10-23-28   3 span(s)  overwrite                
+  13-09-46   1 span(s)  overwrite                both arms fail
+  07-36-58   1 span(s)  name lost                
+
+==============================================================================
+SENTENCE ARM — 12 FAILURES
+==============================================================================
+
+------------------------------------------------------------------------------
+clip      17-47-45
+arm       sentence
+both      yes — the other arm fails this clip too
+spans     3
+said:     Oh I get it. So yes, instead we want to have a retry. And then if the retry fails, we want the crawl to fail.
+true:     ['retry.', 'retry', 'crawl']
+error:    overwrite   'retry.' -> 'Arexvy.'
+error:    overwrite   'retry' -> 'Arexvy'
+error:    overwrite   'crawl' -> 'Redcrawl'
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Arexvy, Arexvy., Redcrawl — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence, and every
+reading it might really have been. Exactly one is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading that makes sense as a sentence, unless the sound says
+otherwise by more than about 4. Answer with its letter only.
+--- user message ---
+A. Oh I get it. So yes, instead we want to have a retry. And then if the retry fails, we want the crawl to fail.
+B. Oh I get it. So yes, instead we want to have a retry. And then if the retry fails, we want the Redcrawl to fail.
+C. Oh I get it. So yes, instead we want to have a retry. And then if the Arexvy fails, we want the crawl to fail.
+D. Oh I get it. So yes, instead we want to have a retry. And then if the Arexvy fails, we want the Redcrawl to fail.
+E. Oh I get it. So yes, instead we want to have a Arexvy. And then if the retry fails, we want the crawl to fail.
+F. Oh I get it. So yes, instead we want to have a Arexvy. And then if the retry fails, we want the Redcrawl to fail.
+G. Oh I get it. So yes, instead we want to have a Arexvy. And then if the Arexvy fails, we want the crawl to fail.
+H. Oh I get it. So yes, instead we want to have a Arexvy. And then if the Arexvy fails, we want the Redcrawl to fail.
+
+How clearly the recogniser heard each spelling over that stretch of
+audio. Closer to zero is clearer, and the vocabulary's own bonus has been
+taken out, so the two are comparable.
+
+  "retry." -10.26   "Arexvy." -9.80   — "retry." heard 0.5 less clearly
+  "retry" -9.20   "Arexvy" -8.31   — "retry" heard 0.9 less clearly
+  "crawl" -9.06   "Redcrawl" -9.58   — "Redcrawl" heard 0.5 less clearly
+
+Which letter?
+--- reply ---
+H
+--- resolved to ---
+['Arexvy.', 'Arexvy', 'Redcrawl']
+
+------------------------------------------------------------------------------
+clip      17-19-57
+arm       sentence
+both      no — the other arm gets this clip
+spans     1
+said:     My ask that was that for those sentences you give me the menu that was offered in the prompts. Also for the recent transcript where Universal was mixed up with Vercel.
+true:     ['Vercel.']
+error:    name lost   'Vercel.' -> 'Versailles.'
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Vercel — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence, and every
+reading it might really have been. Exactly one is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading that makes sense as a sentence, unless the sound says
+otherwise by more than about 4. Answer with its letter only.
+--- user message ---
+A. My ask that was that for those sentences you give me the menu that was offered in the prompts. Also for the recent transcript where Universal was mixed up with Versailles.
+B. My ask that was that for those sentences you give me the menu that was offered in the prompts. Also for the recent transcript where Universal was mixed up with Vercel.
+
+Which letter?
+--- reply ---
+A
+--- resolved to ---
+['Versailles.']
+
+------------------------------------------------------------------------------
+clip      17-05-42
+arm       sentence
+both      yes — the other arm fails this clip too
+spans     2
+said:     So the document was a really super base uh for discussion and the Supabase proposal for the database is great.
+true:     ['super base', 'database is']
+error:    overwrite   'database is' -> 'Supabase is'
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Supabase, Supabase's — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence, and every
+reading it might really have been. Exactly one is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading that makes sense as a sentence, unless the sound says
+otherwise by more than about 4. Answer with its letter only.
+--- user message ---
+A. So the document was a really super base uh for discussion and the Supabase proposal for the database is great.
+B. So the document was a really super base uh for discussion and the Supabase proposal for the Supabase's great.
+C. So the document was a really super base uh for discussion and the Supabase proposal for the Supabase is great.
+D. So the document was a really Supabase uh for discussion and the Supabase proposal for the database is great.
+E. So the document was a really Supabase uh for discussion and the Supabase proposal for the Supabase's great.
+F. So the document was a really Supabase uh for discussion and the Supabase proposal for the Supabase is great.
+
+How clearly the recogniser heard each spelling over that stretch of
+audio. Closer to zero is clearer, and the vocabulary's own bonus has been
+taken out, so the two are comparable.
+
+  "super base" -6.48   "Supabase" -8.00   — "Supabase" heard 1.5 less clearly
+  "database" -5.99   "Supabase" -3.82   — "database" heard 2.2 less clearly
+
+Which letter?
+--- reply ---
+C
+--- resolved to ---
+['super base', 'Supabase is']
+
+------------------------------------------------------------------------------
+clip      16-12-20
+arm       sentence
+both      yes — the other arm fails this clip too
+spans     1
+said:     So the acoustic pass found praise.
+true:     ['praise.']
+error:    overwrite   'praise.' -> 'Praisy.'
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Praisy. — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence, and every
+reading it might really have been. Exactly one is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading that makes sense as a sentence, unless the sound says
+otherwise by more than about 4. Answer with its letter only.
+--- user message ---
+A. So the acoustic pass found praise.
+B. So the acoustic pass found Praisy.
+
+How clearly the recogniser heard each spelling over that stretch of
+audio. Closer to zero is clearer, and the vocabulary's own bonus has been
+taken out, so the two are comparable.
+
+  "praise." -4.61   "Praisy." -3.47   — "praise." heard 1.1 less clearly
+
+Which letter?
+--- reply ---
+B
+--- resolved to ---
+['Praisy.']
+
+------------------------------------------------------------------------------
+clip      14-11-21
+arm       sentence
+both      yes — the other arm fails this clip too
+spans     3
+said:     Supabase is where the crawl data lives and Vercel hosts the dashboard.
+true:     ['Supabase', 'crawl', 'Vercel']
+error:    overwrite   'crawl' -> 'Redcrawl'
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Redcrawl, Supabase, Vercel — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence, and every
+reading it might really have been. Exactly one is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading that makes sense as a sentence, unless the sound says
+otherwise by more than about 4. Answer with its letter only.
+--- user message ---
+A. superbase is where the crawl data lives and Versal hosts the dashboard.
+B. superbase is where the crawl data lives and Vercel hosts the dashboard.
+C. superbase is where the Redcrawl data lives and Versal hosts the dashboard.
+D. superbase is where the Redcrawl data lives and Vercel hosts the dashboard.
+E. Supabase is where the crawl data lives and Versal hosts the dashboard.
+F. Supabase is where the crawl data lives and Vercel hosts the dashboard.
+G. Supabase is where the Redcrawl data lives and Versal hosts the dashboard.
+H. Supabase is where the Redcrawl data lives and Vercel hosts the dashboard.
+
+How clearly the recogniser heard each spelling over that stretch of
+audio. Closer to zero is clearer, and the vocabulary's own bonus has been
+taken out, so the two are comparable.
+
+  "Superbase" -6.66   "Supabase" -6.78   — "Supabase" heard 0.1 less clearly
+  "crawl" -2.93   "Redcrawl" -4.95   — "Redcrawl" heard 2.0 less clearly
+  "Versal" -6.11   "Vercel" -6.32   — "Vercel" heard 0.2 less clearly
+
+Which letter?
+--- reply ---
+H
+--- resolved to ---
+['Supabase', 'Redcrawl', 'Vercel']
+
+------------------------------------------------------------------------------
+clip      11-19-17
+arm       sentence
+both      no — the other arm gets this clip
+spans     1
+said:     Chain is a langsmith proprietary term.
+true:     ['proprietary']
+error:    overwrite   'proprietary' -> 'Praisy'
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Praisy — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence, and every
+reading it might really have been. Exactly one is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading that makes sense as a sentence, unless the sound says
+otherwise by more than about 4. Answer with its letter only.
+--- user message ---
+A. Chain is a langsmith proprietary term.
+B. Chain is a langsmith Praisy term.
+
+Which letter?
+--- reply ---
+B
+--- resolved to ---
+['Praisy']
+
+------------------------------------------------------------------------------
+clip      14-04-21
+arm       sentence
+both      yes — the other arm fails this clip too
+spans     3
+said:     Hi Jess. I was able to use your your comments and explanations to update the skill I was working on so that the evaluation set it generates now is very faithful to yours. Only a couple of drifts. But I'll only know if it generalizes if you have a little bit Other full set of data queries crawl file and evaluation set.
+true:     ['explanations', 'update', 'crawl']
+error:    overwrite   'explanations' -> 'Praisy'
+error:    overwrite   'update' -> 'Supabase'
+error:    overwrite   'crawl' -> 'Redcrawl'
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Praisy, Redcrawl, Supabase — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence, and every
+reading it might really have been. Exactly one is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading that makes sense as a sentence, unless the sound says
+otherwise by more than about 4. Answer with its letter only.
+--- user message ---
+A. Hi Jess. I was able to use your your comments and explanations to update the skill I was working on so that the evaluation set it generates now is very faithful to yours. Only a couple of drifts. But I'll only know if it generalizes if you have a little bit Other full set of data queries crawl file and evaluation set.
+B. Hi Jess. I was able to use your your comments and explanations to update the skill I was working on so that the evaluation set it generates now is very faithful to yours. Only a couple of drifts. But I'll only know if it generalizes if you have a little bit Other full set of data queries Redcrawl file and evaluation set.
+C. Hi Jess. I was able to use your your comments and explanations to Supabase the skill I was working on so that the evaluation set it generates now is very faithful to yours. Only a couple of drifts. But I'll only know if it generalizes if you have a little bit Other full set of data queries crawl file and evaluation set.
+D. Hi Jess. I was able to use your your comments and explanations to Supabase the skill I was working on so that the evaluation set it generates now is very faithful to yours. Only a couple of drifts. But I'll only know if it generalizes if you have a little bit Other full set of data queries Redcrawl file and evaluation set.
+E. Hi Jess. I was able to use your your comments and Praisy to update the skill I was working on so that the evaluation set it generates now is very faithful to yours. Only a couple of drifts. But I'll only know if it generalizes if you have a little bit Other full set of data queries crawl file and evaluation set.
+F. Hi Jess. I was able to use your your comments and Praisy to update the skill I was working on so that the evaluation set it generates now is very faithful to yours. Only a couple of drifts. But I'll only know if it generalizes if you have a little bit Other full set of data queries Redcrawl file and evaluation set.
+G. Hi Jess. I was able to use your your comments and Praisy to Supabase the skill I was working on so that the evaluation set it generates now is very faithful to yours. Only a couple of drifts. But I'll only know if it generalizes if you have a little bit Other full set of data queries crawl file and evaluation set.
+H. Hi Jess. I was able to use your your comments and Praisy to Supabase the skill I was working on so that the evaluation set it generates now is very faithful to yours. Only a couple of drifts. But I'll only know if it generalizes if you have a little bit Other full set of data queries Redcrawl file and evaluation set.
+
+How clearly the recogniser heard each spelling over that stretch of
+audio. Closer to zero is clearer, and the vocabulary's own bonus has been
+taken out, so the two are comparable.
+
+  "update" -5.24   "Supabase" -5.65   — "Supabase" heard 0.4 less clearly
+  "crawl" -8.39   "Redcrawl" -10.45   — "Redcrawl" heard 2.1 less clearly
+
+Which letter?
+--- reply ---
+H
+--- resolved to ---
+['Praisy', 'Supabase', 'Redcrawl']
+
+------------------------------------------------------------------------------
+clip      00-14-39
+arm       sentence
+both      yes — the other arm fails this clip too
+spans     1
+said:     I mean in general in our data.
+true:     ['general']
+error:    overwrite   'general' -> 'Redcrawl'
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Redcrawl — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence, and every
+reading it might really have been. Exactly one is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading that makes sense as a sentence, unless the sound says
+otherwise by more than about 4. Answer with its letter only.
+--- user message ---
+A. I mean in general in our data.
+B. I mean in Redcrawl in our data.
+
+How clearly the recogniser heard each spelling over that stretch of
+audio. Closer to zero is clearer, and the vocabulary's own bonus has been
+taken out, so the two are comparable.
+
+  "general" -9.88   "Redcrawl" -9.97   — "Redcrawl" heard 0.1 less clearly
+
+Which letter?
+--- reply ---
+B
+--- resolved to ---
+['Redcrawl']
+
+------------------------------------------------------------------------------
+clip      10-12-37
+arm       sentence
+both      no — the other arm gets this clip
+spans     2
+said:     It's a community that Tasmeen asked me to crawl.
+true:     ['Tasmeen', 'crawl.']
+error:    overwrite   'crawl.' -> 'Redcrawl.'
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Redcrawl., Tasmeen — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence, and every
+reading it might really have been. Exactly one is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading that makes sense as a sentence, unless the sound says
+otherwise by more than about 4. Answer with its letter only.
+--- user message ---
+A. It's a community that Tasmin asked me to crawl.
+B. It's a community that Tasmin asked me to Redcrawl.
+C. It's a community that Tasmeen asked me to crawl.
+D. It's a community that Tasmeen asked me to Redcrawl.
+
+How clearly the recogniser heard each spelling over that stretch of
+audio. Closer to zero is clearer, and the vocabulary's own bonus has been
+taken out, so the two are comparable.
+
+  "Tasmin" -10.13   "Tasmeen" -10.68   — "Tasmeen" heard 0.5 less clearly
+  "crawl." -10.06   "Redcrawl." -11.83   — "Redcrawl." heard 1.8 less clearly
+
+Which letter?
+--- reply ---
+D
+--- resolved to ---
+['Tasmeen', 'Redcrawl.']
+
+------------------------------------------------------------------------------
+clip      14-09-56
+arm       sentence
+both      yes — the other arm fails this clip too
+spans     2
+said:     Let's recalibrate some of the words in the vocabulary. Make me dictate a few sentences containing words that are near matches to my vocabulary terms.
+true:     ['matches', 'vocabulary']
+error:    overwrite   'matches' -> 'Matthieu'
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Matthieu, Matthieu's, Praisy — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence, and every
+reading it might really have been. Exactly one is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading that makes sense as a sentence, unless the sound says
+otherwise by more than about 4. Answer with its letter only.
+--- user message ---
+A. Let's recalibrate some of the words in the vocabulary. Make me dictate a few sentences containing words that are near matches to my vocabulary terms.
+B. Let's recalibrate some of the words in the vocabulary. Make me dictate a few sentences containing words that are near matches to my Praisy terms.
+C. Let's recalibrate some of the words in the vocabulary. Make me dictate a few sentences containing words that are near Matthieu to my vocabulary terms.
+D. Let's recalibrate some of the words in the vocabulary. Make me dictate a few sentences containing words that are near Matthieu to my Praisy terms.
+E. Let's recalibrate some of the words in the vocabulary. Make me dictate a few sentences containing words that are near Matthieu's to my vocabulary terms.
+F. Let's recalibrate some of the words in the vocabulary. Make me dictate a few sentences containing words that are near Matthieu's to my Praisy terms.
+
+How clearly the recogniser heard each spelling over that stretch of
+audio. Closer to zero is clearer, and the vocabulary's own bonus has been
+taken out, so the two are comparable.
+
+  "matches" -5.74   "Matthieu" -6.93   — "Matthieu" heard 1.2 less clearly
+
+Which letter?
+--- reply ---
+C
+--- resolved to ---
+['Matthieu', 'vocabulary']
+
+------------------------------------------------------------------------------
+clip      15-36-12
+arm       sentence
+both      no — the other arm gets this clip
+spans     1
+said:     Pretty harsh review.
+true:     ['Pretty']
+error:    overwrite   'Pretty' -> 'Arexvy'
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Arexvy — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence, and every
+reading it might really have been. Exactly one is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading that makes sense as a sentence, unless the sound says
+otherwise by more than about 4. Answer with its letter only.
+--- user message ---
+A. Pretty harsh review.
+B. Arexvy harsh review.
+
+How clearly the recogniser heard each spelling over that stretch of
+audio. Closer to zero is clearer, and the vocabulary's own bonus has been
+taken out, so the two are comparable.
+
+  "Pretty" -13.40   "Arexvy" -13.52   — "Arexvy" heard 0.1 less clearly
+
+Which letter?
+--- reply ---
+B
+--- resolved to ---
+['Arexvy']
+
+------------------------------------------------------------------------------
+clip      13-09-46
+arm       sentence
+both      yes — the other arm fails this clip too
+spans     1
+said:     The team deserves praise for shipping that fast.
+true:     ['praise for']
+error:    overwrite   'praise for' -> 'Praisy'
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Praisy, Praisy's — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence, and every
+reading it might really have been. Exactly one is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading that makes sense as a sentence, unless the sound says
+otherwise by more than about 4. Answer with its letter only.
+--- user message ---
+A. The team deserves praise for shipping that fast.
+B. The team deserves Praisy shipping that fast.
+C. The team deserves Praisy's shipping that fast.
+
+How clearly the recogniser heard each spelling over that stretch of
+audio. Closer to zero is clearer, and the vocabulary's own bonus has been
+taken out, so the two are comparable.
+
+  "praise" -8.70   "Praisy" -10.49   — "Praisy" heard 1.8 less clearly
+
+Which letter?
+--- reply ---
+B
+--- resolved to ---
+['Praisy']
+
+------------------------------------------------------------------------------
+
+==============================================================================
+BLANK ARM — 16 FAILURES
+==============================================================================
+
+------------------------------------------------------------------------------
+clip      17-47-45
+arm       blank
+both      yes — the other arm fails this clip too
+spans     3
+said:     Oh I get it. So yes, instead we want to have a retry. And then if the retry fails, we want the crawl to fail.
+true:     ['retry.', 'retry', 'crawl']
+error:    overwrite   'retry' -> 'Arexvy'
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Arexvy, Arexvy., Redcrawl — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence with each of
+them blanked and numbered, and every reading each blank might really have been.
+Exactly one reading of each blank is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading of each blank that makes sense as a sentence, unless the sound
+says otherwise by more than about 4. Answer with one letter per blank and
+nothing else, like "1=A 2=B".
+--- user message ---
+Oh I get it. So yes, instead we want to have a ___1___ And then if the ___2___ fails, we want the ___3___ to fail.
+
+1. A. retry.
+   B. Arexvy.
+
+2. A. retry
+   B. Arexvy
+
+3. A. crawl
+   B. Redcrawl
+
+How clearly the recogniser heard each spelling over that stretch of
+audio. Closer to zero is clearer, and the vocabulary's own bonus has been
+taken out, so the two are comparable.
+
+  "retry." -10.26   "Arexvy." -9.80   — "retry." heard 0.5 less clearly
+  "retry" -9.20   "Arexvy" -8.31   — "retry" heard 0.9 less clearly
+  "crawl" -9.06   "Redcrawl" -9.58   — "Redcrawl" heard 0.5 less clearly
+
+Which letter for each blank?
+--- reply ---
+1=A 2=B 3=A
+--- resolved to ---
+['retry.', 'Arexvy', 'crawl']
+
+------------------------------------------------------------------------------
+clip      17-39-27
+arm       blank
+both      no — the other arm gets this clip
+spans     1
+said:     Let's praise Matthieu's work.
+true:     ["praise Matthieu's"]
+error:    name lost   "praise Matthieu's" -> "Praisy's Matthieu's"
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Matthieu, Praisy, Praisy's — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence with each of
+them blanked and numbered, and every reading each blank might really have been.
+Exactly one reading of each blank is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading of each blank that makes sense as a sentence, unless the sound
+says otherwise by more than about 4. Answer with one letter per blank and
+nothing else, like "1=A 2=B".
+--- user message ---
+Let's ___1___ work.
+
+1. A. praise Mathieu's
+   B. praise Matthieu's
+   C. Praisy Mathieu's
+   D. Praisy Matthieu's
+   E. Praisy's Mathieu's
+   F. Praisy's Matthieu's
+
+How clearly the recogniser heard each spelling over that stretch of
+audio. Closer to zero is clearer, and the vocabulary's own bonus has been
+taken out, so the two are comparable.
+
+  "praise" -6.20   "Praisy" -6.59   — "Praisy" heard 0.4 less clearly
+  "Mathieu's" -6.97   "Matthieu" -7.00   — "Matthieu" heard 0.0 less clearly
+
+Which letter for each blank?
+--- reply ---
+F
+--- resolved to ---
+["Praisy's Matthieu's"]
+
+------------------------------------------------------------------------------
+clip      17-27-23
+arm       blank
+both      no — the other arm gets this clip
+spans     1
+said:     So let's praise the team's work.
+true:     ['praise the']
+error:    overwrite   'praise the' -> "Praisy's"
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Praisy, Praisy's — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence with each of
+them blanked and numbered, and every reading each blank might really have been.
+Exactly one reading of each blank is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading of each blank that makes sense as a sentence, unless the sound
+says otherwise by more than about 4. Answer with one letter per blank and
+nothing else, like "1=A 2=B".
+--- user message ---
+So let's ___1___ team's work.
+
+1. A. praise the
+   B. Praisy
+   C. Praisy's
+
+How clearly the recogniser heard each spelling over that stretch of
+audio. Closer to zero is clearer, and the vocabulary's own bonus has been
+taken out, so the two are comparable.
+
+  "praise" -9.83   "Praisy" -9.91   — "Praisy" heard 0.1 less clearly
+
+Which letter for each blank?
+--- reply ---
+C
+--- resolved to ---
+["Praisy's"]
+
+------------------------------------------------------------------------------
+clip      17-05-42
+arm       blank
+both      yes — the other arm fails this clip too
+spans     2
+said:     So the document was a really super base uh for discussion and the Supabase proposal for the database is great.
+true:     ['super base', 'database is']
+error:    overwrite   'database is' -> "Supabase's"
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Supabase, Supabase's — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence with each of
+them blanked and numbered, and every reading each blank might really have been.
+Exactly one reading of each blank is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading of each blank that makes sense as a sentence, unless the sound
+says otherwise by more than about 4. Answer with one letter per blank and
+nothing else, like "1=A 2=B".
+--- user message ---
+So the document was a really ___1___ uh for discussion and the Supabase proposal for the ___2___ great.
+
+1. A. super base
+   B. Supabase
+
+2. A. database is
+   B. Supabase's
+   C. Supabase is
+
+How clearly the recogniser heard each spelling over that stretch of
+audio. Closer to zero is clearer, and the vocabulary's own bonus has been
+taken out, so the two are comparable.
+
+  "super base" -6.48   "Supabase" -8.00   — "Supabase" heard 1.5 less clearly
+  "database" -5.99   "Supabase" -3.82   — "database" heard 2.2 less clearly
+
+Which letter for each blank?
+--- reply ---
+A B
+--- resolved to ---
+['super base', "Supabase's"]
+
+------------------------------------------------------------------------------
+clip      17-05-32
+arm       blank
+both      no — the other arm gets this clip
+spans     2
+said:     Praisy and Mirza worked on the new Vercel deployment.
+true:     ['Praisy', 'Vercel']
+error:    name lost   'Vercel' -> 'Versal'
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Praisy, Vercel — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence with each of
+them blanked and numbered, and every reading each blank might really have been.
+Exactly one reading of each blank is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading of each blank that makes sense as a sentence, unless the sound
+says otherwise by more than about 4. Answer with one letter per blank and
+nothing else, like "1=A 2=B".
+--- user message ---
+___1___ and Mirza worked on the new ___2___ deployment.
+
+1. A. Prizzi
+   B. Praisy
+
+2. A. Versal
+   B. Vercel
+
+How clearly the recogniser heard each spelling over that stretch of
+audio. Closer to zero is clearer, and the vocabulary's own bonus has been
+taken out, so the two are comparable.
+
+  "versal" -6.88   "Vercel" -7.70   — "Vercel" heard 0.8 less clearly
+
+Which letter for each blank?
+--- reply ---
+B A
+--- resolved to ---
+['Praisy', 'Versal']
+
+------------------------------------------------------------------------------
+clip      16-12-20
+arm       blank
+both      yes — the other arm fails this clip too
+spans     1
+said:     So the acoustic pass found praise.
+true:     ['praise.']
+error:    overwrite   'praise.' -> 'Praisy.'
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Praisy. — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence with each of
+them blanked and numbered, and every reading each blank might really have been.
+Exactly one reading of each blank is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading of each blank that makes sense as a sentence, unless the sound
+says otherwise by more than about 4. Answer with one letter per blank and
+nothing else, like "1=A 2=B".
+--- user message ---
+So the acoustic pass found ___1___
+
+1. A. praise.
+   B. Praisy.
+
+How clearly the recogniser heard each spelling over that stretch of
+audio. Closer to zero is clearer, and the vocabulary's own bonus has been
+taken out, so the two are comparable.
+
+  "praise." -4.61   "Praisy." -3.47   — "praise." heard 1.1 less clearly
+
+Which letter for each blank?
+--- reply ---
+B
+--- resolved to ---
+['Praisy.']
+
+------------------------------------------------------------------------------
+clip      14-11-21
+arm       blank
+both      yes — the other arm fails this clip too
+spans     3
+said:     Supabase is where the crawl data lives and Vercel hosts the dashboard.
+true:     ['Supabase', 'crawl', 'Vercel']
+error:    overwrite   'crawl' -> 'Redcrawl'
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Redcrawl, Supabase, Vercel — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence with each of
+them blanked and numbered, and every reading each blank might really have been.
+Exactly one reading of each blank is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading of each blank that makes sense as a sentence, unless the sound
+says otherwise by more than about 4. Answer with one letter per blank and
+nothing else, like "1=A 2=B".
+--- user message ---
+___1___ is where the ___2___ data lives and ___3___ hosts the dashboard.
+
+1. A. superbase
+   B. Supabase
+
+2. A. crawl
+   B. Redcrawl
+
+3. A. Versal
+   B. Vercel
+
+How clearly the recogniser heard each spelling over that stretch of
+audio. Closer to zero is clearer, and the vocabulary's own bonus has been
+taken out, so the two are comparable.
+
+  "Superbase" -6.66   "Supabase" -6.78   — "Supabase" heard 0.1 less clearly
+  "crawl" -2.93   "Redcrawl" -4.95   — "Redcrawl" heard 2.0 less clearly
+  "Versal" -6.11   "Vercel" -6.32   — "Vercel" heard 0.2 less clearly
+
+Which letter for each blank?
+--- reply ---
+B B B
+--- resolved to ---
+['Supabase', 'Redcrawl', 'Vercel']
+
+------------------------------------------------------------------------------
+clip      09-10-32
+arm       blank
+both      no — the other arm gets this clip
+spans     1
+said:     Il faut geler le budget avant lundi, sinon Mira va râler.
+true:     ['Mira va']
+error:    overwrite   'Mira va' -> 'Mirza'
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Mirza, Mirza's — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence with each of
+them blanked and numbered, and every reading each blank might really have been.
+Exactly one reading of each blank is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading of each blank that makes sense as a sentence, unless the sound
+says otherwise by more than about 4. Answer with one letter per blank and
+nothing else, like "1=A 2=B".
+--- user message ---
+Il faut geler le budget avant lundi, sinon ___1___ râler.
+
+1. A. Mira va
+   B. Mirza
+   C. Mirza's
+
+How clearly the recogniser heard each spelling over that stretch of
+audio. Closer to zero is clearer, and the vocabulary's own bonus has been
+taken out, so the two are comparable.
+
+  "Mira" -12.59   "Mirza" -12.25   — "Mira" heard 0.3 less clearly
+
+Which letter for each blank?
+--- reply ---
+B
+--- resolved to ---
+['Mirza']
+
+------------------------------------------------------------------------------
+clip      14-11-36
+arm       blank
+both      no — the other arm gets this clip
+spans     2
+said:     Matthieu and Tasmeen are both on the Arexvy account.
+true:     ['Tasmeen', 'Arexvy']
+error:    name lost   'Arexvy' -> 'RXV'
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Arexvy, Tasmeen — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence with each of
+them blanked and numbered, and every reading each blank might really have been.
+Exactly one reading of each blank is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading of each blank that makes sense as a sentence, unless the sound
+says otherwise by more than about 4. Answer with one letter per blank and
+nothing else, like "1=A 2=B".
+--- user message ---
+Matthieu and ___1___ are both on the ___2___ account.
+
+1. A. Tasmine
+   B. Tasmeen
+
+2. A. RXV
+   B. Arexvy
+
+How clearly the recogniser heard each spelling over that stretch of
+audio. Closer to zero is clearer, and the vocabulary's own bonus has been
+taken out, so the two are comparable.
+
+  "Tasmine" -8.01   "Tasmeen" -8.75   — "Tasmeen" heard 0.7 less clearly
+
+Which letter for each blank?
+--- reply ---
+B A
+--- resolved to ---
+['Tasmeen', 'RXV']
+
+------------------------------------------------------------------------------
+clip      14-04-21
+arm       blank
+both      yes — the other arm fails this clip too
+spans     3
+said:     Hi Jess. I was able to use your your comments and explanations to update the skill I was working on so that the evaluation set it generates now is very faithful to yours. Only a couple of drifts. But I'll only know if it generalizes if you have a little bit Other full set of data queries crawl file and evaluation set.
+true:     ['explanations', 'update', 'crawl']
+error:    overwrite   'update' -> 'Supabase'
+error:    overwrite   'crawl' -> 'Redcrawl'
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Praisy, Redcrawl, Supabase — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence with each of
+them blanked and numbered, and every reading each blank might really have been.
+Exactly one reading of each blank is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading of each blank that makes sense as a sentence, unless the sound
+says otherwise by more than about 4. Answer with one letter per blank and
+nothing else, like "1=A 2=B".
+--- user message ---
+Hi Jess. I was able to use your your comments and ___1___ to ___2___ the skill I was working on so that the evaluation set it generates now is very faithful to yours. Only a couple of drifts. But I'll only know if it generalizes if you have a little bit Other full set of data queries ___3___ file and evaluation set.
+
+1. A. explanations
+   B. Praisy
+
+2. A. update
+   B. Supabase
+
+3. A. crawl
+   B. Redcrawl
+
+How clearly the recogniser heard each spelling over that stretch of
+audio. Closer to zero is clearer, and the vocabulary's own bonus has been
+taken out, so the two are comparable.
+
+  "update" -5.24   "Supabase" -5.65   — "Supabase" heard 0.4 less clearly
+  "crawl" -8.39   "Redcrawl" -10.45   — "Redcrawl" heard 2.1 less clearly
+
+Which letter for each blank?
+--- reply ---
+1=A 2=B 3=B
+--- resolved to ---
+['explanations', 'Supabase', 'Redcrawl']
+
+------------------------------------------------------------------------------
+clip      23-00-49
+arm       blank
+both      no — the other arm gets this clip
+spans     3
+said:     And then you have a list of possible alternatives for Versailles, such as Vercel.
+true:     ['possible', 'Versailles,', 'Vercel.']
+error:    overwrite   'Versailles,' -> 'Vercel,'
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Tasmeen, Vercel — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence with each of
+them blanked and numbered, and every reading each blank might really have been.
+Exactly one reading of each blank is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading of each blank that makes sense as a sentence, unless the sound
+says otherwise by more than about 4. Answer with one letter per blank and
+nothing else, like "1=A 2=B".
+--- user message ---
+And then you have a list of ___1___ alternatives for ___2___ such as ___3___
+
+1. A. possible
+   B. Tasmeen
+
+2. A. Versailles,
+   B. Vercel,
+
+3. A. Versailles.
+   B. Vercel.
+
+Which letter for each blank?
+--- reply ---
+1=A 2=B 3=B
+--- resolved to ---
+['possible', 'Vercel,', 'Vercel.']
+
+------------------------------------------------------------------------------
+clip      00-14-39
+arm       blank
+both      yes — the other arm fails this clip too
+spans     1
+said:     I mean in general in our data.
+true:     ['general']
+error:    overwrite   'general' -> 'Redcrawl'
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Redcrawl — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence with each of
+them blanked and numbered, and every reading each blank might really have been.
+Exactly one reading of each blank is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading of each blank that makes sense as a sentence, unless the sound
+says otherwise by more than about 4. Answer with one letter per blank and
+nothing else, like "1=A 2=B".
+--- user message ---
+I mean in ___1___ in our data.
+
+1. A. general
+   B. Redcrawl
+
+How clearly the recogniser heard each spelling over that stretch of
+audio. Closer to zero is clearer, and the vocabulary's own bonus has been
+taken out, so the two are comparable.
+
+  "general" -9.88   "Redcrawl" -9.97   — "Redcrawl" heard 0.1 less clearly
+
+Which letter for each blank?
+--- reply ---
+B
+--- resolved to ---
+['Redcrawl']
+
+------------------------------------------------------------------------------
+clip      14-09-56
+arm       blank
+both      yes — the other arm fails this clip too
+spans     2
+said:     Let's recalibrate some of the words in the vocabulary. Make me dictate a few sentences containing words that are near matches to my vocabulary terms.
+true:     ['matches', 'vocabulary']
+error:    overwrite   'matches' -> 'Matthieu'
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Matthieu, Matthieu's, Praisy — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence with each of
+them blanked and numbered, and every reading each blank might really have been.
+Exactly one reading of each blank is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading of each blank that makes sense as a sentence, unless the sound
+says otherwise by more than about 4. Answer with one letter per blank and
+nothing else, like "1=A 2=B".
+--- user message ---
+Let's recalibrate some of the words in the vocabulary. Make me dictate a few sentences containing words that are near ___1___ to my ___2___ terms.
+
+1. A. matches
+   B. Matthieu
+   C. Matthieu's
+
+2. A. vocabulary
+   B. Praisy
+
+How clearly the recogniser heard each spelling over that stretch of
+audio. Closer to zero is clearer, and the vocabulary's own bonus has been
+taken out, so the two are comparable.
+
+  "matches" -5.74   "Matthieu" -6.93   — "Matthieu" heard 1.2 less clearly
+
+Which letter for each blank?
+--- reply ---
+1=B 2=A
+--- resolved to ---
+['Matthieu', 'vocabulary']
+
+------------------------------------------------------------------------------
+clip      10-23-28
+arm       blank
+both      no — the other arm gets this clip
+spans     3
+said:     So I guess to close that loop, is there a way we can record the final transcription when the user press enters.
+true:     ['close', 'transcription when the', 'press']
+error:    overwrite   'transcription when the' -> 'Praisy'
+error:    overwrite   'press' -> "Praisy's"
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Claude, Praisy, Praisy's — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence with each of
+them blanked and numbered, and every reading each blank might really have been.
+Exactly one reading of each blank is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading of each blank that makes sense as a sentence, unless the sound
+says otherwise by more than about 4. Answer with one letter per blank and
+nothing else, like "1=A 2=B".
+--- user message ---
+So I guess to ___1___ that loop, is there a way we can record the final ___2___ user ___3___ enters.
+
+1. A. close
+   B. Claude
+
+2. A. transcription when the
+   B. Praisy
+
+3. A. press
+   B. Praisy
+   C. Praisy's
+
+How clearly the recogniser heard each spelling over that stretch of
+audio. Closer to zero is clearer, and the vocabulary's own bonus has been
+taken out, so the two are comparable.
+
+  "close" -10.76   "Claude" -9.36   — "close" heard 1.4 less clearly
+  "press" -8.61   "Praisy" -8.63   — "Praisy" heard 0.0 less clearly
+
+Which letter for each blank?
+--- reply ---
+A B C
+--- resolved to ---
+['close', 'Praisy', "Praisy's"]
+
+------------------------------------------------------------------------------
+clip      13-09-46
+arm       blank
+both      yes — the other arm fails this clip too
+spans     1
+said:     The team deserves praise for shipping that fast.
+true:     ['praise for']
+error:    overwrite   'praise for' -> "Praisy's"
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Praisy, Praisy's — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence with each of
+them blanked and numbered, and every reading each blank might really have been.
+Exactly one reading of each blank is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading of each blank that makes sense as a sentence, unless the sound
+says otherwise by more than about 4. Answer with one letter per blank and
+nothing else, like "1=A 2=B".
+--- user message ---
+The team deserves ___1___ shipping that fast.
+
+1. A. praise for
+   B. Praisy
+   C. Praisy's
+
+How clearly the recogniser heard each spelling over that stretch of
+audio. Closer to zero is clearer, and the vocabulary's own bonus has been
+taken out, so the two are comparable.
+
+  "praise" -8.70   "Praisy" -10.49   — "Praisy" heard 1.8 less clearly
+
+Which letter for each blank?
+--- reply ---
+C
+--- resolved to ---
+["Praisy's"]
+
+------------------------------------------------------------------------------
+clip      07-36-58
+arm       blank
+both      no — the other arm gets this clip
+spans     1
+said:     So let's say we have very low floor for Praisy, but with the judge. The judge would the the judge was n would know my terms and see that.
+true:     ['Praisy,']
+error:    name lost   'Praisy,' -> 'Prezi,'
+
+--- system message ---
+The user dictates text. The speech recogniser mangles names they use often.
+Their vocabulary includes: Praisy — colleagues, products and tools they talk
+about every day.
+
+That list is not everyone they know. They also talk about other people,
+products and places that are not in it. A word that is not in the vocabulary
+can simply be a different person or thing, spelled correctly already — but only
+when it is a word or a name you recognise. A spelling that looks like a garbled
+version of a vocabulary term usually is one.
+
+Sometimes the user is not dictating but teaching a correction — "urza spells
+mirza", "Versal spells V E R C E L". The word before "spells" is the one they
+want replaced later, so it has to survive now. Keep those readings as they are.
+
+A name matcher was unsure about some words. Below is the sentence with each of
+them blanked and numbered, and every reading each blank might really have been.
+Exactly one reading of each blank is what the user said.
+
+Some readings come with a measure of how clearly the recogniser heard each
+spelling. A gap under about 1 means the sound cannot tell them apart and the
+sentence has to decide. A gap over about 4 means it can, and only a reading
+that makes no sense should overrule it.
+
+Pick the reading of each blank that makes sense as a sentence, unless the sound
+says otherwise by more than about 4. Answer with one letter per blank and
+nothing else, like "1=A 2=B".
+So let's say we have very low floor for ___1___ but with the judge. The judge would the the judge was n would know my terms and see that.
+
+1. A. Prezi,
+   B. Praisy,
+
+Which letter for each blank?
+--- reply ---
+2=A
+--- resolved to ---
+['Prezi,']
+
+------------------------------------------------------------------------------


### PR DESCRIPTION
**A record of a negative result. Not intended to be merged.**

The blank shape does not work. This branch exists so the measurement, the
prompts and the failures are readable later, and so nobody runs round 3 again.
Everything needed to act on it is in this description — no file needs opening.

**The one-line answer: changing the shape of the judge's question is not the
lever.** Rounds 1, 2 and 3 have now measured ten wordings, two routers and two
shapes. The shipped prompt has not moved off 41/53, or off 0/8 on the class it
fails.

---

**The blanks lose. Do not change the shape. Nothing is shipped here.**

Round 2 measured the blank form and a different question at the same time, so
its 6/8 on the collision class could have been either. Round 3 changes one
thing. Both arms carry the shipped `verify_names.md`, the shipped vocabulary
list and the shipped score block. Only three sentences differ, and all three
describe the shape of the question and of the answer.

53 reachable cached menus, `gemma4:e4b`, temperature 0, nothing else loaded.
Three full runs gave identical totals and identical per-case diffs. No reply
was unreadable. No build, no install.

## The two numbers

| arm | total /53 | multi-slot /18 | single-slot /35 | collision /8 |
|---|---|---|---|---|
| sentence — what ships today | **41** | **12** | **29** | 0 |
| blank | 37 | 9 | 28 | **3** |
| chance | 17.4 | 2.8 | 14.6 | 2.1 |

The control re-measured at 41/53, reproducing rounds 1 and 2 exactly.

Round 2's 6/8 does not survive. With the shipped question the blanks reach
3/8, and 2 of the 3 are single-span clips where the two arms ask nearly the
same question. **The shape is worth about half of what round 2 credited it
with. The other half was the wording.**

## The multi-slot subset

18 of the 53 cases hold more than one uncertain span, 42 spans between them.
35 hold one span. 77 spans in total.

A blank can only differ from a sentence where a case holds more than one span.
It does differ there, and it differs the wrong way: **12/18 as sentences, 9/18
as blanks.** On the 35 single-span cases the arms score 29 and 28, which is one
case and is noise.

## The trade, per span

A case counts only when every one of its spans is right, so a three-span case
scores zero whether it missed one span or three. Per span is where the trade is
legible. An *overwrite* is the error the spike exists for: the speaker said an
ordinary word and the arm wrote a name over it.

| arm | right | wrote a name over an ordinary word | kept what was decoded, losing the name |
|---|---|---|---|
| sentence | **61/77** | 15 | **1** |
| blank | 59/77 | **14** | 4 |

Split by whether the clip is in PR #68's list of 8:

| | collision clips, 16 spans | every other clip, 61 spans |
|---|---|---|
| sentence | 4 right, 12 overwrites, 0 names lost | 57 right, 3 overwrites, 1 name lost |
| blank | **10 right**, **6 overwrites**, 0 names lost | 49 right, **8 overwrites**, 4 names lost |

The blanks halve the overwrites on the 8 clips PR #68 happened to write down
and more than double them on the other 45. **The class did not shrink. It moved
off the list being watched.** The five it adds are the same mistake it fixes:

```
17-27-23   "praise the"             -> "Praisy's"
09-10-32   "Mira va"                -> "Mirza"
23-00-49   "Versailles,"            -> "Vercel,"
10-23-28   "transcription when the" -> "Praisy"
10-23-28   "press"                  -> "Praisy's"
```

`23-00-49` is `alternatives for Versailles, such as Vercel`. The speaker named
both and the blank arm wrote the term over the place. That is `09-35-01` again,
the clip round 1 could never score.

## The blanks are not stable under letter order

A blank must letter its own candidates, and that choice carries no information.
The arm above uses the order the app's own menu introduces them in. Sorting
them changes no word of the question.

| blank arm, letters in | total /53 | multi-slot /18 | collision /8 | spans right | overwrites | names lost |
|---|---|---|---|---|---|---|
| menu order | 37 | 9 | 3 | 59/77 | 14 | 4 |
| sorted | **31** | **5** | **5** | **47/77** | **20** | **10** |
| sentence arm, unaffected | 41 | 12 | 0 | 61/77 | 15 | 1 |

**Letter order moves the blank arm by 6 cases. The shape moves it by 4.** It
also changes *which* clips of the collision class it gets. The sentence arm
scores 41 and 61/77 in both runs, which is the check that the harness varies
only what it says it varies.

## Per case

```
all          +4  17-19-57  11-19-17  10-12-37  15-36-12
             -8  17-39-27  17-27-23  17-05-32  09-10-32
                 14-11-36  23-00-49  10-23-28  07-36-58

multi-slot   +1  10-12-37
             -4  17-05-32  14-11-36  23-00-49  10-23-28

single-slot  +3  17-19-57  11-19-17  15-36-12
             -4  17-39-27  17-27-23  09-10-32  07-36-58
```

Four of the eight losses hold a span wider than one word. `slots` merges
overlapping spans, so a span can be `praise the` or `transcription when the`.
Blanking it leaves a frame no reading completes — `So let's ___ team's work.`
23 of the 77 spans hold a reading of more than one word.

`10-12-37` is the one clip the shape exists for, and both blank arms get it. It
is the only multi-slot collision clip any arm in three rounds has got.

## The cache is stale, and that matters more than any number here

`tests/judge-menus.json` was harvested before PR #70. Its newest clip is
`2026-08-08T01-02-23`. The 15 live collisions PR #70 added were dictated that
afternoon, 16:17 to 17:42, and **none of them are in the cache.**

**Every judge number in rounds 1, 2 and 3 — 41/53, 0/8, 37/53, 3/8, and every
number in F16, F17, F18 and F19 — excludes the live collisions.** Re-harvesting
runs the app, which this spike does not do.

| clip | what the pass did | would it enter the cache? |
|---|---|---|
| `16-17-03` | Vercel over "Versailles" — the replacements stage, not the spotter | no menu |
| `16-18-00` | Arexvy over "retry", Redcrawl over "crawl" | yes, 2 spans |
| `16-18-14` | Supabase over "update" | yes |
| `16-18-23` | Redcrawl over "crawl" | yes |
| `16-18-37` | Matthieu over "matches" | yes |
| `16-18-45` | Praisy over "spray"; the speaker said "praise" | yes, unreachable |
| `16-19-02` | Praisy's over "praise for" | yes |
| `16-19-18` | Praisy over "proprietary" | yes |
| `16-28-54` | nothing fired; NLTagger stayed as decoded | no menu |
| `16-29-26` | Claude over "predicting"; the speaker said "generating" | yes, unreachable |
| `17-32-26` | Arexvy over both Praisy and Prissy | yes, reachability unknown |
| `17-37-39` | Praisy over "work when"; `said` deliberately blank | skipped by the harvest |
| `17-39-32` | Praisy over "train" | yes |
| `17-40-19` | Vercel over "level", Arexvy over "heavy" | yes, 2 spans |
| `17-41-18` | Praisy's over "train as" | yes |

**12 of 15 would enter the cache. 9 of those would be scorable.** Two are
unreachable because the word the speaker said was never decoded. One cannot be
called without running it.

That column is a prediction, not a measurement. It rests on one fact in the
code: `Vocabulary.autoApplies` writes a term in only when the decoded word is
**not** a real word, and `Replacements.applyFuzzy` is gated on the same test.
Every clip above replaced an ordinary English word — "retry", "crawl",
"update", "matches", "praise", "proprietary", "train", "level", "heavy" — so
neither could have fired, and the judge must have been asked, which means a
menu existed. Only a harvest settles it.

Adding 9 scorable collision clips would roughly double a class the shipped
prompt is 0 of 8 on.

## The data gap, still open

Round 2 recorded it and round 3 cannot close it. On all 8 not-a-word spans in
this cache the speaker meant the vocabulary term. There is no clip where the
decoder wrote a non-word and the non-word was right, so **no rule about that
class can be falsified**, and the `--sweep` result that reaches 8/8 at about
1.5 nats is unfalsifiable rather than good.

What would fill it: a clip where the speaker says a proper name that is *not*
in the vocabulary, whose spelling is in no dictionary, and which sounds like a
term that is. A colleague called `Tasmin` beside the vocabulary's `Tasmeen`. A
product called `Prezi` beside `Praisy`. `Arexvi` beside `Arexvy`. The right
answer on that span is "keep what the decoder wrote", and one such clip breaks
the 8/8 unanimity that makes every offset look safe.

## Recommendation

**Ship nothing. There is no trade to hand over.**

It looks like a trade — 3/8 of the collision class against 4 cases of the
total. Per span it is not one. The blank form commits 14 overwrites against the
sentence form's 15, loses 4 names against 1, and its total swings 6 cases on
the alphabet. It does not reduce the failure; it relocates it.

Two things are worth carrying forward.

1. **A blank is right for a span that is one word and wrong for a span that is
   a phrase.** If the blanks are tried again, change the slot recovery and not
   the prompt: a merged span of four words should not be a blank at all.
2. **Re-harvest before the next round.** Nine more collision clips against a
   prompt that scores 0 of 8 on that class will say more than a fourth wording.

## Every failure, verbatim

`tests/judge-failures.txt` holds all 28 failures — 12 sentence-arm, 16
blank-arm, 8 clips both arms fail. One block each: the verbatim system message,
the verbatim user message with the menu or the blanks and the score block
exactly as sent, the raw reply, what it resolved to, the true sentence, and one
line per wrong span naming the error. An index at the top lists clip, span
count and error type.

Regenerate it with `scripts/judge-blanks.py --dump-failures
tests/judge-failures.txt`. It reruns both arms, so it cannot drift from the
numbers above. Text only; `scripts/check-no-voice.sh` passes 5/5.

## What is on this branch

- `scripts/judge-blanks.py` — the harness. Reuses round 2's slot recovery in
  `judge-routing.py` and round 1's prompt edits in `judge-framings.py`; it does
  not rebuild either. Fails loudly if an edit stops matching `verify_names.md`.
- `scripts/tune-judge.py` — one addition, `LAST`, which keeps the exact strings
  of the most recent call so the dump prints them instead of rebuilding them.
- `tests/judge-failures.txt` — the failures.
- `docs/proposals/judge-framings.md` — the round 3 section, verdict first, both
  prompts in full, verbatim cases.
- `docs/proposals/vocabulary-v2.md` — F19 in the findings ledger.

No app change. No prompt shipped. `examples/prompts/verify_names.md` is
untouched.

Not for merge. The branch and this description are the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiQJipvz9Ps9tdDCRdisv
