### PR TITLE
test: one ablation harness for any number of arms

### DIFF
--- a/docs/proposals/vocabulary-v3.md
+++ b/docs/proposals/vocabulary-v3.md
@@ -835,7 +835,8 @@ python3 scripts/reference-ablation.py --runs 3 --out arms.json \
   --arm "noacoustic=$S/cfg-noacoustic"
 ```
 
-`reference-ablation.py` exists only on that branch. PR 3 lands it on `main`.
+`reference-ablation.py` exists only on that branch. PR 3 lands it as
+`scripts/vocab-ablation.py`, with the same arm syntax.
 
 ## PR 2 — confirm it on live dictation
 
@@ -1186,14 +1187,26 @@ that way?
 
 ## PR 3 — land the harnesses on `main`
 
-**Changes.** Ports `vocab-ablation.py` and `vocab-losses.py` from
-`origin/experiment/does-vocabulary-pay` and `reference-ablation.py` from
-`origin/proto/reference-matching` into `scripts/`. Arms are
-`name=CONFIG_DIR[,VAR=VALUE]`, every pair reported against every other, wins and
-losses separately, split by class, majority of `--runs N` with a flip count.
-Documents the three off arms from part 1.
+**Changes.** Two harnesses in `scripts/`, not three. `vocab-ablation.py` is
+`reference-ablation.py` from `origin/proto/reference-matching` with the two-arm
+`vocab-ablation.py` from `origin/experiment/does-vocabulary-pay` folded into it
+— the second was the first with N fixed at 2, so keeping both would have been
+one harness maintained twice. Arms are `name=CONFIG_DIR[,VAR=VALUE]`, every pair
+reported against every other, wins and losses separately, split by class,
+majority of `--runs N` with a flip count. `vocab-losses.py` stays its own
+script: listing the losing clips and classing each as an overwrite or not is a
+different job, and it now takes the two arm names because the harness runs any
+number.
 
-**Size.** About 450 lines of Python. No Swift, no behaviour change.
+Two things PR 1 wanted and did not have. `--only FILE` takes a list of wav
+names, so a second pass can re-run just the clips that disagreed.
+`--check-config` runs under every arm before the first clip, so a config
+directory the app would refuse costs a second instead of the rest of the run. The docstrings carry the
+three off arms from part 1 and the scratch config recipe, `audio.output_dir`
+included.
+
+**Size.** About 450 lines of Python across the two files. No Swift, no
+behaviour change.
 
 **Verified by** reproducing the published baseline: vocabulary off 76/141, today
 84/141, 27 wins and 19 losses, 5 clips flipping.
@@ -1201,6 +1214,75 @@ Documents the three off arms from part 1.
 **Falsified if** the off arm is not near 76, or wins and losses swing further
 than the flip count explains. Then the archive or the case set has moved and
 nothing downstream can be trusted.
+
+### Result, measured 2026-08-09
+
+**The falsifier did not fire. The off arm reproduces exactly, in every block.**
+
+141 labelled clips, `--runs 3`, majority of three replays, `gemma4:e4b-mlx` and
+nothing else loaded, built from `feat/ablation-harnesses` at `d7252a8` and never
+installed. That build is `main` at `78d7ba2` plus this plan and these two
+scripts, so no Swift differs from `main`. Wins and losses are against the `off`
+arm.
+
+| arm | correct | wins | losses | net | flips |
+|---|---|---|---|---|---|
+| off (empty `terms:`) | 76 | — | — | — | 0 |
+| today | 88 | 29 | 17 | +12 | 2 |
+
+By class:
+
+| class | clips | off | today |
+|---|---|---|---|
+| about a term | 68 | 20 | 39 |
+| controls | 73 | 56 | 49 |
+
+**The off arm is exact in all three blocks.** 76 of 141, 20 of the 68 term
+clips, 56 of the 73 controls — the prototype's numbers to the clip — and it
+flipped on nothing over three replays. It is the arm with no acoustic pass and
+no judge call in it, so that is what it should do. The archive and the case set
+have not moved.
+
+**Today's arm is three clips above PR 1 and four above the published table.**
+88 against 85 and 84, 29 wins against 28 and 27, 17 losses against 19 and 19.
+The same arm flipped 8 clips in the prototype's run, 3 in PR 1's and 2 here, so
+a four-clip move is inside the noise those three runs measured between them.
+Nothing else moved: the same 141 clips, the same config files, and the
+prototype's extra Swift is gated on `PARROTFLOW_REFERENCE_MATCH`, which no arm
+here sets.
+
+**Both headline shapes hold.** All 17 losses are overwrites — a term written
+over an ordinary word the speaker meant — and none is anything else, which is
+what part 1 §1 says of the 19. And the controls take **0 wins and 7 losses**:
+the pass still wins nothing on the clips it can only damage. Counted by the
+name written, the losses are `Praisy` 7, `Redcrawl` 5, `Supabase` 3, `Vercel`,
+`Matthieu` and `Arexvy` 2 each, `Ollama` and `Mirza` 1 each — `Redcrawl`,
+`Supabase` and `Ollama` again costing clips and rescuing none.
+
+**Cost.** 846 transcriptions, 9 minutes of wall clock at 3.8 s/clip for two
+arms. PR 1's 10.7 s/clip was five arms over the same clips.
+
+**Only the two arms `main` can run were scored.** The reference-matching arms
+need `ReferenceMatch.swift`, which exists only on
+`origin/proto/reference-matching`. The harness's support for `VAR=VALUE` arms is
+ported and unexercised here; PR 1's command line is the test of it, and it ran
+against the same code.
+
+### How to reproduce
+
+Two scratch config directories, copied from `~/.config/parrotflow-dev`. Never
+run against the live one. The recipe is in the script's docstring; PR 1's
+version above adds the third directory.
+
+```sh
+make app                                   # never `make install`
+
+python3 scripts/vocab-ablation.py --runs 3 --out arms.json \
+  --arm "off=$S/cfg-off" \
+  --arm "today=$S/cfg-on"
+
+python3 scripts/vocab-losses.py arms.json --vocabulary $S/cfg-on/vocabulary.yaml
+```
 
 ## PR 4 — a correction keeps the audio
 
@@ -1355,7 +1437,7 @@ weak point, §7's argument is wrong, and 6b and 6c are not worth doing.
 **Size.** Small in the prototype for 1 and 2. `ReferenceMatch` already computes
 everything they need. 3 waits on 6c.
 
-**Verified by** the three-arm ablation, not by AUC. `reference-ablation.py
+**Verified by** the three-arm ablation, not by AUC. `vocab-ablation.py
 --runs 3` with arms `off`, `today`, `veto everything`, `new rule`. **The bar is
 the blind veto's 103, not today's 84.** Report wins and losses separately, split
 by class, with the flip count.
@@ -1463,7 +1545,7 @@ recordings over 781 span-term pairs took four minutes of a dynamic program.
 Scoring every span of every sentence multiplies that by the number of words, so
 6d is also the first place the representation ladder in *Still open* would pay.
 
-**Verified by** the plan's standing bar — `reference-ablation.py --runs 3` with
+**Verified by** the plan's standing bar — `vocab-ablation.py --runs 3` with
 arms `off`, `today`, `veto everything` and the proposer, beating the blind
 veto's 103 by more than the flip count explains. **And beaten as a proposer**,
 which means wins and losses against the `off` arm reported separately, never
@@ -1737,8 +1819,8 @@ the sweep on 141 clips with `--runs 3`.
 | `spike/raw-score-separation` | **No.** The AUC 0.318 result, `PARROTFLOW_CBW` and the spotter-floor sweep exist only there. |
 | `spike/reference-matching` | **No.** Round 6, `scripts/reference-matching.py` and the per-proposal distance table exist only there. |
 | `spike/exemplars-round-2` | **No.** Round 7, the 48 scripted clips, the mining changes and the 122-recording corpus exist only there. The most valuable unmerged branch, and PR 6a starts from its `scripts/reference-matching.py`. |
-| `experiment/does-vocabulary-pay` | **No.** The ablation, `vocab-ablation.py`, `vocab-losses.py` and the 19-loss list exist only there. |
-| `proto/reference-matching` | **No.** The prototype and the control arm that settled this plan's direction. PR 6b changes `ReferenceMatch.swift`, which exists only here. |
+| `experiment/does-vocabulary-pay` | **No.** The ablation, `vocab-ablation.py`, `vocab-losses.py` and the 19-loss list exist only there. PR 3 lands both harnesses. |
+| `proto/reference-matching` | **No.** The prototype and the control arm that settled this plan's direction. PR 6b changes `ReferenceMatch.swift`, which exists only here. PR 3 lands `reference-ablation.py`, merged into `vocab-ablation.py`. |
 | `spike/onset-pilot` | **No.** Code only — `PARROTFLOW_LOGPROB_DUMP`. Already re-ported into `spike/ctc-06b`, so nothing is lost if that one survives. |
 
 Eight of the nine carry something that exists nowhere else. Land the findings —

--- a/scripts/vocab-ablation.py
+++ b/scripts/vocab-ablation.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Replay the labelled clips through any number of arms and count the damage.
+
+    scripts/vocab-ablation.py --arm off=DIR --arm today=DIR [--runs 3] [--out FILE]
+
+An arm is a config directory, plus any environment variables that arm needs:
+
+    name=CONFIG_DIR[,VAR=VALUE...]
+
+Every pair of arms is reported against every other, wins and losses apart,
+split by class, as the majority of `--runs N` replays with a flip count. Give
+it two arms and it answers "does the vocabulary pass pay for itself"; give it
+five and it answers "which of these five is best", which is the question the
+reference-matching prototype asked.
+
+Three counts, fixed before the run:
+
+    correct   clips whose majority transcript matches the hand label
+    wins      B right where A is wrong
+    losses    A right where B is wrong
+
+**Read wins and losses together, and read the correct count beside them.** A
+filter that removes as many wins as losses has switched the feature off, and
+the net alone hides that. An arm that vetoes everything looks excellent on net.
+Put the arm that does nothing first, so every pair is reported against it.
+
+## Switching the pass off honestly — three different off arms
+
+They are not the same measurement. Know which one you want.
+
+    no vocabulary at all       empty `terms:` in a scratch `vocabulary.yaml`.
+                               No acoustic context, no rules,
+                               `vocabulary.count == 0`, so the judge stage's
+                               `when:` skips it too.
+    the acoustic path off,     `acoustic: false` in `vocabulary.yaml`, with
+    the rules kept             every term and every `heard:` list left in place.
+    a third of the pass off    `--transcribe --no-vocab`, which is almost never
+                               what you meant.
+
+`--no-vocab` sets `config.vocabulary.acoustic = false` and nothing else
+(`TranscribeCommand.swift`). The `heard:`/`pronunciations:` lists still become
+`Config.vocabularyRules`, those rules still write names in `replacements`, and
+they still raise `vocabulary.count`, so the `vocabulary:` judge stage still
+fires. This harness never passes it; arms differ by config directory instead.
+
+## The scratch config recipe
+
+Never run against `~/.config/parrotflow-dev`. Copy it once per arm:
+
+    S=/tmp/ablation
+    for d in cfg-on cfg-off; do
+      mkdir -p $S/$d
+      cp ~/.config/parrotflow-dev/{config.yaml,vocabulary.yaml,verify_names.md} $S/$d/
+      cp -R ~/.config/parrotflow-dev/transforms $S/$d/
+      printf '\\naudio:\\n  output_dir: %s\\n' "$S/audio" >> $S/$d/config.yaml
+    done
+
+The `audio.output_dir` line is not optional. Without it a 2000-clip run appends
+2000 entries to the speaker's own `trace.jsonl` and writes 2000 wavs beside
+their real dictations. Anything that reads `voice/samples/<Term>/` — the
+reference-matching arms do — needs `voice/` copied in as well. None of it is
+committable: `scripts/check-no-voice.sh` refuses a repository carrying any of
+it.
+
+Then edit each copy to be the arm it is named after. This harness runs
+`--check-config` under every arm before the first clip, so a directory the app
+would refuse costs a second rather than the whole run.
+
+## Noise
+
+Replay is nondeterministic (F12a): the same clip replayed ten times gives term
+scores spread over 5 nats on a long clip. So `--runs N` replays each clip N
+times per arm and keeps the per-clip majority, and a clip that did not agree
+with itself is counted as a flip. **The flip count is what says whether a small
+difference means anything.** A single-run number within two cases of the one it
+is compared with decides nothing.
+
+## The split
+
+Read off the case file, not guessed from the text. Every clip carries a
+`# picked up:` line saying how it entered the set, and the 73 controls say so
+in words: "No vocabulary term, a control". A single total hides a control
+moving wrong while a term clip moves right, so the totals are always split.
+
+## Re-running part of a set
+
+`--limit N` takes the first N clips, which is for smoke tests. `--only FILE`
+takes a list of wav names, one per line, `#` comments allowed — that is how you
+re-run just the clips two arms disagreed on without paying for the whole set
+again.
+
+Ported from `scripts/vocab-ablation.py` on
+`origin/experiment/does-vocabulary-pay` and `scripts/reference-ablation.py` on
+`origin/proto/reference-matching`, which were the same harness with two arms
+and with N. `scripts/vocab-losses.py` reads the `--out` JSON this writes and
+prints the losing clips one by one.
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from importlib.machinery import SourceFileLoader
+
+ROOT = Path(__file__).resolve().parent.parent
+recall = SourceFileLoader("recall", str(ROOT / "scripts/menu-recall.py")).load_module()
+
+
+def classes():
+    """{wav: is_control}, read off the `# picked up:` line of each entry.
+
+    The class is in the case file because it was decided when the clip entered
+    the set. Guessing it from the text — "does a term appear?" — would put a
+    clip the pass wrongly wrote a name into on the wrong side of the split,
+    which is exactly the clip the split exists to find.
+    """
+    out, wav = {}, None
+    for line in recall.CASES.read_text().splitlines():
+        s = line.strip()
+        if s.startswith("- wav:"):
+            wav = s.split(":", 1)[1].strip()
+            out[wav] = False
+        elif wav and s.startswith("# picked up:"):
+            out[wav] = "a control" in s
+    return out
+
+
+def cases_with_class(only=None):
+    """(wav, said, is_term) for every labelled clip, in file order."""
+    control = classes()
+    cases = [(wav, said, not control.get(wav, False))
+             for wav, said in recall.load_cases() if said]
+    if only is None:
+        return cases
+    missing = only - {wav for wav, _, _ in cases}
+    if missing:
+        raise SystemExit(f"✗ not a labelled clip in {recall.CASES.name}: "
+                         + ", ".join(sorted(missing)))
+    return [c for c in cases if c[0] in only]
+
+
+def read_only(path):
+    """The wav names in a `--only` file: one per line, `#` comments allowed."""
+    names = set()
+    for line in Path(path).read_text().splitlines():
+        s = line.split("#")[0].strip()
+        if s:
+            # The first field, so a line copied out of a progress log works.
+            names.add(s.split()[0])
+    if not names:
+        raise SystemExit(f"✗ {path} names no clips")
+    return names
+
+
+def parse_arm(spec):
+    if "=" not in spec:
+        raise SystemExit(f"✗ --arm {spec}: expected name=CONFIG_DIR[,VAR=VALUE]")
+    name, rest = spec.split("=", 1)
+    parts = rest.split(",")
+    env = {}
+    for extra in parts[1:]:
+        if "=" not in extra:
+            raise SystemExit(f"✗ --arm {spec}: `{extra}` is not VAR=VALUE")
+        key, value = extra.split("=", 1)
+        env[key] = value
+    if not Path(parts[0]).is_dir():
+        raise SystemExit(f"✗ --arm {name}: {parts[0]} is not a directory")
+    return {"name": name, "dir": parts[0], "env": env}
+
+
+def environment_for(arm, dump):
+    environment = dict(os.environ)
+    environment["PARROTFLOW_CONFIG_DIR"] = arm["dir"]
+    environment.update(arm["env"])
+    # Not read here. It is set so the judge's menu lands in scratch rather than
+    # wherever an inherited PARROTFLOW_JUDGE_DUMP points.
+    environment["PARROTFLOW_JUDGE_DUMP"] = str(dump)
+    return environment
+
+
+def check_config(arm, dump):
+    """`--check-config` under this arm, before the first clip of a long run.
+
+    A config the app refuses fails at the first clip anyway. Failing here costs
+    a second; failing there costs however long the run had left. The vocabulary
+    lines are printed because they are how you tell the arms apart — an arm
+    named `off` whose directory was never edited says so here and nowhere else.
+    """
+    done = subprocess.run(
+        [recall.APP, "--check-config"], capture_output=True, text=True,
+        env=environment_for(arm, dump), timeout=120,
+    )
+    said = [line.strip() for line in (done.stdout + done.stderr).splitlines()
+            if "vocabulary:" in line]
+    print(f"  {arm['name']:<12} {arm['dir']}")
+    for line in said or ["(no vocabulary line — no terms in this arm)"]:
+        print(f"    {line}")
+    if done.returncode != 0:
+        print(f"✗ arm {arm['name']}: --check-config refused {arm['dir']}")
+        print((done.stdout + done.stderr).strip())
+        return False
+    return True
+
+
+def transcribe(wav, arm, dump):
+    """One clip through the app under one arm. Returns the final transcript."""
+    done = subprocess.run(
+        [recall.APP, "--transcribe", str(recall.CLIPS / wav)],
+        capture_output=True, text=True, env=environment_for(arm, dump),
+        timeout=600,
+    )
+    lines = (done.stdout + done.stderr).splitlines()
+    final = None
+    for i, line in enumerate(lines):
+        if "transcript" in line and "─" in line and i + 1 < len(lines):
+            final = lines[i + 1].strip()
+    return final or ""
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--arm", action="append", required=True,
+                    help="name=CONFIG_DIR[,VAR=VALUE...]; put the arm that "
+                         "does nothing first")
+    ap.add_argument("--runs", type=int, default=3,
+                    help="replays per clip per arm; the majority decides (F12a)")
+    ap.add_argument("--limit", type=int, default=0,
+                    help="the first N clips — for a smoke test, not a number")
+    ap.add_argument("--only", default="",
+                    help="a file of wav names to re-run, one per line")
+    ap.add_argument("--out", default="", help="write per-clip JSON here")
+    args = ap.parse_args()
+
+    if args.runs < 1:
+        print("✗ --runs must be at least 1")
+        return 2
+    if not Path(recall.APP).exists():
+        print(f"✗ {recall.APP} not found — run `make app` first")
+        return 2
+
+    arms = [parse_arm(spec) for spec in args.arm]
+    if len({a["name"] for a in arms}) != len(arms):
+        print("✗ two arms share a name — the report could not tell them apart")
+        return 2
+    cases = cases_with_class(read_only(args.only) if args.only else None)
+    if args.limit:
+        cases = cases[:args.limit]
+    if not cases:
+        print("✗ no labelled clips selected")
+        return 2
+
+    dump = Path(tempfile.mkdtemp()) / "menu.txt"
+    print(f"{len(arms)} arm(s), {len(cases)} clip(s), {args.runs} run(s) each:")
+    # Every arm, not the first bad one: a run is about to cost 25 minutes, so
+    # the operator should learn about both broken directories at once.
+    if not all([check_config(arm, dump) for arm in arms]):
+        return 2
+
+    rows = []
+    started = time.time()
+    for n, (wav, said, is_term) in enumerate(cases, 1):
+        truth = recall.normalise(said)
+        row = {"wav": wav, "said": said, "term": is_term, "runs": {}}
+        for arm in arms:
+            texts = [transcribe(wav, arm, dump) for _ in range(args.runs)]
+            ok, moved = recall.majority(
+                [recall.normalise(t) == truth for t in texts])
+            row["runs"][arm["name"]] = {"texts": texts, "ok": ok, "flipped": moved}
+        rows.append(row)
+        marks = " ".join(
+            f"{a['name']}={'ok' if row['runs'][a['name']]['ok'] else '--'}"
+            for a in arms)
+        rate = (time.time() - started) / n
+        print(f"  {n:>3}/{len(cases)}  {marks}  {wav}"
+              f"  [{rate:.1f}s/clip, {(len(cases) - n) * rate / 60:.0f} min left]",
+              file=sys.stderr, flush=True)
+        # Written every clip, not at the end: a run interrupted at clip 90 of
+        # 141 still has 90 clips of evidence, and this is a 25-minute run.
+        if args.out:
+            Path(args.out).write_text(json.dumps(rows, indent=1))
+
+    report(rows, [a["name"] for a in arms], args.runs)
+    return 0
+
+
+def report(rows, names, runs):
+    def block(label, subset):
+        print(f"\n{label}  ({len(subset)} clips)")
+        print(f"  {'arm':<12} {'correct':>8} {'flips':>7}")
+        for name in names:
+            correct = sum(1 for r in subset if r["runs"][name]["ok"])
+            flips = sum(1 for r in subset if r["runs"][name]["flipped"])
+            print(f"  {name:<12} {correct:>8} {flips:>7}")
+        if len(names) < 2:
+            return
+        print(f"\n  {'A -> B':<26} {'wins':>6} {'losses':>7} {'net':>6}")
+        for i, a in enumerate(names):
+            for b in names[i + 1:]:
+                wins = sum(1 for r in subset
+                           if r["runs"][b]["ok"] and not r["runs"][a]["ok"])
+                losses = sum(1 for r in subset
+                             if r["runs"][a]["ok"] and not r["runs"][b]["ok"])
+                print(f"  {a + ' -> ' + b:<26} {wins:>6} {losses:>7} "
+                      f"{wins - losses:>+6}")
+
+    block("ALL", rows)
+    block("about a term", [r for r in rows if r["term"]])
+    block("controls", [r for r in rows if not r["term"]])
+
+    print(f"\n  correct is out of the clips in that block, majority of {runs} "
+          "run(s) per clip.")
+    print("  wins and losses are B against A. Read them beside the correct "
+          "count and beside")
+    print(f"  {names[0]}, the first arm — an arm that removes everything wins "
+          "on net.")
+    if runs == 1:
+        print("  one run per clip — these numbers carry replay noise (F12a);"
+              " use --runs 3 before quoting them")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/vocab-ablation.py
+++ b/scripts/vocab-ablation.py
@@ -206,7 +206,21 @@ def check_config(arm, dump):
 
 
 def transcribe(wav, arm, dump):
-    """One clip through the app under one arm. Returns the final transcript."""
+    """One clip through the app under one arm. Returns the final transcript.
+
+    A replay that did not happen is not a wrong answer, and the difference has
+    to be kept. The app exits 0 and prints a transcript block whenever it ran;
+    a non-zero exit, or no block at all, means there is no measurement for this
+    clip. Scoring that as "the arm got it wrong" would move a real count by a
+    real clip for a reason that has nothing to do with the arm, and nothing in
+    the report would say so — which is how a harness lies quietly. So it stops.
+    `--out` is written every clip, so an abort at clip 90 of 141 still leaves
+    90 clips of evidence behind.
+
+    A clip that decodes to nothing is a different thing and is a measurement:
+    the app prints its block with `(empty)` in it, which no label matches, so
+    the clip counts wrong under that arm. That is the answer, not a failure.
+    """
     done = subprocess.run(
         [recall.APP, "--transcribe", str(recall.CLIPS / wav)],
         capture_output=True, text=True, env=environment_for(arm, dump),
@@ -217,7 +231,12 @@ def transcribe(wav, arm, dump):
     for i, line in enumerate(lines):
         if "transcript" in line and "─" in line and i + 1 < len(lines):
             final = lines[i + 1].strip()
-    return final or ""
+    if done.returncode != 0 or final is None:
+        why = (f"exit {done.returncode}" if done.returncode
+               else "no transcript in its output")
+        raise SystemExit(f"✗ arm {arm['name']} on {wav}: the app gave {why}\n"
+                         + (done.stdout + done.stderr).strip())
+    return final
 
 
 def main():

--- a/scripts/vocab-losses.py
+++ b/scripts/vocab-losses.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""The clips the vocabulary pass took away, written out one by one.
+
+    scripts/vocab-losses.py <ablation.json> --vocabulary FILE \\
+        [--off off] [--on today] [--out tests/vocabulary-losses.txt]
+
+Reads what `scripts/vocab-ablation.py --out` wrote and prints every loss — a
+clip the app got right under the `--off` arm and wrong under the `--on` arm —
+with the hand label, both transcripts, and which terms were written in.
+
+A total says how many clips an arm cost. It does not say what the arm did to
+them, and the remedy depends on that. So each loss is also classed.
+**Overwrite** means a vocabulary term stands in the `--on` transcript that is
+not in what the speaker said: the pass wrote a name over an ordinary word.
+Anything else is **other**, and other is worth reading twice — it is the class
+where the pass broke a clip without writing a term into it, which no floor and
+no judge prompt can reach.
+
+Ported from `origin/experiment/does-vocabulary-pay`, where the harness had one
+pair of arms and this script knew their names. It now takes them, because
+`vocab-ablation.py` runs any number.
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from importlib.machinery import SourceFileLoader
+
+ROOT = Path(__file__).resolve().parent.parent
+recall = SourceFileLoader("recall", str(ROOT / "scripts/menu-recall.py")).load_module()
+
+
+def terms_of(vocabulary_yaml):
+    """The term names, read off the `terms:` block by indentation."""
+    names, inside = [], False
+    for line in Path(vocabulary_yaml).read_text().splitlines():
+        if line.startswith("terms:"):
+            inside = True
+            continue
+        if inside:
+            m = re.match(r"  (\w[\w.'-]*):\s*$", line)
+            if m:
+                names.append(m.group(1))
+            elif line and not line.startswith(" "):
+                break
+    return names
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("rows", help="the JSON `vocab-ablation.py --out` wrote")
+    ap.add_argument("--vocabulary", required=True,
+                    help="the vocabulary.yaml the `--on` arm ran with")
+    ap.add_argument("--off", default="off", help="the arm that is the baseline")
+    ap.add_argument("--on", default="today", help="the arm being scored")
+    ap.add_argument("--out", default="")
+    args = ap.parse_args()
+
+    rows = json.loads(Path(args.rows).read_text())
+    if not rows:
+        print(f"✗ {args.rows} has no clips in it")
+        return 2
+    for arm in (args.off, args.on):
+        if arm not in rows[0]["runs"]:
+            print(f"✗ no arm named {arm} in {args.rows} — it has "
+                  + ", ".join(rows[0]["runs"]))
+            return 2
+    names = terms_of(args.vocabulary)
+
+    def wrote_a_term(row, text):
+        """Terms in the transcript that are not in what the speaker said."""
+        said = recall.normalise(row["said"])
+        got = recall.normalise(text)
+        return [n for n in names
+                if re.search(rf"\b{n.lower()}\b", got)
+                and not re.search(rf"\b{n.lower()}\b", said)]
+
+    def pick(row, arm, want):
+        """A transcript from a run that agreed with the majority verdict.
+
+        The transcript printed has to be evidence for the verdict beside it. A
+        clip that flipped has runs on both sides, and the flattering one is not
+        the one the reader should act on.
+        """
+        truth = recall.normalise(row["said"])
+        for text in row["runs"][arm]["texts"]:
+            if (recall.normalise(text) == truth) == want:
+                return text
+        return row["runs"][arm]["texts"][0]
+
+    def ok(row, arm):
+        return row["runs"][arm]["ok"]
+
+    losses = [r for r in rows if ok(r, args.off) and not ok(r, args.on)]
+    wins = [r for r in rows if ok(r, args.on) and not ok(r, args.off)]
+
+    out = []
+    out.append("Every clip the vocabulary pass took away.")
+    out.append("")
+    out.append(f"`{args.off}` is the baseline arm and `{args.on}` is the arm being")
+    out.append("scored. Both are replays of the same audio through the same build,")
+    out.append("majority of the runs `scripts/vocab-ablation.py` was given.")
+    out.append("Written by scripts/vocab-losses.py.")
+    out.append("")
+    out.append(f"{len(losses)} losses, against {len(wins)} wins over {len(rows)} clips.")
+    out.append("")
+
+    overwrites, others = [], []
+    for row in losses:
+        on_text = pick(row, args.on, False)
+        off_text = pick(row, args.off, True)
+        written = wrote_a_term(row, on_text)
+        (overwrites if written else others).append((row, on_text, off_text, written))
+
+    out.append(f"{len(overwrites)} overwrites — a term written over a word the speaker meant.")
+    out.append(f"{len(others)} other — the pass broke the clip without writing a term in.")
+    out.append("")
+
+    for title, group in (("OVERWRITES", overwrites), ("OTHER", others)):
+        if not group:
+            continue
+        out.append("=" * 72)
+        out.append(f"{title}  ({len(group)})")
+        out.append("=" * 72)
+        for row, on_text, off_text, written in group:
+            klass = "term" if row["term"] else "control"
+            out.append("")
+            out.append(f"{row['wav']}  [{klass}]"
+                       + (f"  wrote: {', '.join(written)}" if written else ""))
+            out.append(f"  said: {row['said']}")
+            out.append(f"  {args.off + ':':<8}{off_text}")
+            out.append(f"  {args.on + ':':<8}{on_text}")
+        out.append("")
+
+    text = "\n".join(out) + "\n"
+    if args.out:
+        Path(args.out).write_text(text)
+        print(f"wrote {args.out}  ({len(losses)} losses)")
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
The plan's baseline numbers live in two near-duplicate ablation scripts on unmerged spike branches, and re-running only the clips two arms disagreed on meant re-running the whole 141-clip set.
This PR lands one merged harness (`vocab-ablation.py`) that runs any number of arms, adds `--only FILE` to re-run a specific clip list, and adds a `--check-config` preflight so a bad config directory fails in a second instead of after a 25-minute run.
The baseline reproduces exactly: the `off` arm holds at 76/141, and today's config scores 88 — within the noise the earlier runs already showed between them (85, 84).

## Issue
Part of #74. Stacks on #74 → #75 → #76 → #77 → this PR.

## What changed

**One harness merged from two.** `reference-ablation.py` and `vocab-ablation.py` on two different spike branches were the same code with the arm count fixed at 2 on one of them. The N-arm version lands, under the name `vocab-ablation.py`.

**`scripts/vocab-losses.py` stays separate.** It lists losing clips one by one and classes each as an overwrite or not — a different job from counting them, and the answer decides which remedy could reach the loss. It now takes arbitrary arm names instead of a hardcoded `on`/`off` pair.

**Two things PR 1 needed and didn't have:** `--only FILE` (a wav-name list, so re-running disputed clips doesn't cost the whole set again) and `--check-config`, which runs before the first clip under every arm and prints that arm's vocabulary lines.

## Reproduction — the falsifier did not fire

141 labelled clips, `--runs 3`, `gemma4:e4b-mlx`, built from this branch (`main` at `78d7ba2` plus the plan and these scripts — no Swift differs from `main`).

| arm | correct | wins | losses | net | flips |
|---|---|---|---|---|---|
| off (empty `terms:`) | 76 | — | — | — | 0 |
| today | 88 | 29 | 17 | +12 | 2 |

The off arm reproduces exactly in all three blocks (76/141, 20/68, 56/73) with zero flips — the archive and case set haven't moved. Today's arm is 3–4 clips above the earlier runs (85, 84), which is inside the noise those runs already measured between them (8 flips, 3 flips, 2 flips respectively). All 17 losses are overwrites; the controls take 0 wins and 7 losses — the pass still only damages control clips, never helps them.

<details>
<summary><b>How to Test</b></summary>

846 transcriptions, 9 minutes at 3.8s/clip for two arms. No `.wav`, no `voice/`, no transcripts, no copy of any real `config.yaml` or `vocabulary.yaml` — the scratch config directories used are in `/tmp`. `scripts/check-no-voice.sh` passes 5/5.

Not verified here: the reference-matching arms need `ReferenceMatch.swift`, which only exists on an unmerged spike branch, so they can't run from this branch. The harness's `VAR=VALUE` arm syntax is ported but unexercised.

</details>
