### PR TITLE
feat: a correction keeps the audio

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -145,6 +145,13 @@ jobs:
       - name: What vocabulary.yaml adds up to
         run: scripts/check-vocabulary-config.sh
 
+      # A correction now writes three files and deletes from two of them. Every
+      # one of those deletions — the duration guard, the per-term cap, the
+      # seen-once rule — is data going away on the app's own initiative, so the
+      # thing worth checking is that each says out loud what it took.
+      - name: A correction keeps the audio
+        run: scripts/check-corrections.sh
+
       # The same trap, one directory over: the transform folder a first launch
       # is seeded with against the copy in examples/ that people read and
       # score. It has always been able to drift and has never been checked

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1844,15 +1844,42 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         correctionPanel.show(selection: selection?.text ?? "")
     }
 
+    /// What the correction kept, or did not keep, of the audio.
+    ///
+    /// Nothing here is silent. A span the guard refused, a sample the cap
+    /// removed and a rendering the seen-once rule dropped are all deletions or
+    /// refusals nobody would otherwise see, and a bank that quietly loses clips
+    /// is a bank whose numbers cannot be explained afterwards.
+    private func logKept(_ outcome: Corrections.Outcome) {
+        guard let term = outcome.term else { return }
+        if let seen = outcome.seen {
+            Log.write("    \(term): seen \(seen) time(s), from correction")
+        }
+        if let sample = outcome.sample {
+            Log.write("    kept the audio as voice/\(sample)")
+        } else if let why = outcome.skipped {
+            Log.write("    no audio kept — \(why)")
+        }
+        for gone in outcome.capped {
+            Log.write("    capped voice/samples/\(term)/\(gone.file) — \(gone.why)")
+        }
+        for gone in outcome.pruned {
+            Log.write("    dropped \"\(gone)\" from \(term) — seen once and not again since")
+        }
+    }
+
     private func saveCorrections(
         _ rules: [(heard: String, corrected: String)],
         correctedText: String
     ) {
         for rule in rules {
             do {
-                try ConfigWriter.addReplacement(heard: rule.heard, corrected: rule.corrected)
+                let outcome = try Corrections.learn(
+                    heard: rule.heard, corrected: rule.corrected, via: "command",
+                    clip: lastRecording?.url.lastPathComponent
+                )
                 Log.write("learned replacement: \(rule.heard) -> \(rule.corrected)")
-                Trace.correction(heard: rule.heard, corrected: rule.corrected, via: "command")
+                logKept(outcome)
             } catch {
                 presentAlert(title: "Could not save the rule", message: error.localizedDescription)
                 pendingSelection = nil
@@ -2263,11 +2290,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             guard let self else { return }
             for rule in rules {
                 do {
-                    try ConfigWriter.addReplacement(heard: rule.heard, corrected: rule.corrected)
-                    Log.write("learned replacement: \(rule.heard) -> \(rule.corrected)")
-                    Trace.correction(
-                        heard: rule.heard, corrected: rule.corrected, via: "panel"
+                    let outcome = try Corrections.learn(
+                        heard: rule.heard, corrected: rule.corrected, via: "panel",
+                        clip: self.lastRecording?.url.lastPathComponent
                     )
+                    Log.write("learned replacement: \(rule.heard) -> \(rule.corrected)")
+                    self.logKept(outcome)
                 } catch {
                     self.presentAlert(
                         title: "Could not save the rule", message: error.localizedDescription

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -59,6 +59,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let correctionPanel = CorrectionPanel()
     private let previewPanel = PreviewPanel()
     private var pendingSelection: SelectionReader.Selection?
+    /// The dictation the open correction panel is about, taken when it opens.
+    ///
+    /// Not read from `lastRecording` at save time. The panel is the longest
+    /// wait in the app — it stays open for as long as somebody takes to think
+    /// about a spelling — and a dictation given in the meantime moves
+    /// `lastRecording`. Reading it late would cut the audio out of the wrong
+    /// clip and file it under the term, which is the one kind of bad sample
+    /// Part 1 §7 says widens a term's cloud and disarms its veto. The same
+    /// reason `pendingSelection` is snapshotted rather than re-read.
+    private var pendingClip: String?
     /// Captured the moment the hotkey goes down — see SelectionReader.snapshot.
     private var selectionAtPress: SelectionReader.Selection?
     /// Where the text was being typed when the hotkey went down, so a rule
@@ -1647,10 +1657,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 Log.write("command proposed rule: \(rule.heard) -> \(rule.corrected)")
             }
             pendingSelection = nil
+            pendingClip = lastRecording?.url.lastPathComponent
             correctionPanel.onSave = { [weak self] rules, text in
                 self?.saveCorrections(rules, correctedText: text)
             }
-            correctionPanel.onCancel = { [weak self] in self?.pendingSelection = nil }
+            correctionPanel.onCancel = { [weak self] in
+                self?.pendingSelection = nil
+                self?.pendingClip = nil
+            }
             correctionPanel.show(rules: rules)
         case .unrecognised(let text):
             Log.write("command not understood: \(text)")
@@ -1835,11 +1849,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         Log.write("correction: selection = \(selection.map { "\"\($0.text)\"" } ?? "none")")
         pendingSelection = selection
+        pendingClip = lastRecording?.url.lastPathComponent
         correctionPanel.onSave = { [weak self] rules, correctedText in
             self?.saveCorrections(rules, correctedText: correctedText)
         }
         correctionPanel.onCancel = { [weak self] in
             self?.pendingSelection = nil
+            self?.pendingClip = nil
         }
         correctionPanel.show(selection: selection?.text ?? "")
     }
@@ -1876,13 +1892,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             do {
                 let outcome = try Corrections.learn(
                     heard: rule.heard, corrected: rule.corrected, via: "command",
-                    clip: lastRecording?.url.lastPathComponent
+                    clip: pendingClip
                 )
                 Log.write("learned replacement: \(rule.heard) -> \(rule.corrected)")
                 logKept(outcome)
             } catch {
                 presentAlert(title: "Could not save the rule", message: error.localizedDescription)
                 pendingSelection = nil
+                pendingClip = nil
                 return
             }
         }
@@ -1930,6 +1947,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             NSPasteboard.general.setString(correctedText, forType: .string)
         }
         pendingSelection = nil
+        pendingClip = nil
         focusAtPress = nil
 
         if config.feedback.sound { NSSound(named: "Glass")?.play() }
@@ -2259,6 +2277,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// started somewhere else in the meantime moves that field. Reading it late
     /// would hand focus to the newer app and paste this sentence into it.
     ///
+    /// The clip is captured on the way in for exactly the same reason. The
+    /// dictation given while this panel was open moves `lastRecording`, and a
+    /// correction that read it late would cut its audio out of the wrong clip.
+    ///
     /// `proposed` is named apart from the panel's own `rules` on purpose. Both
     /// used to be called `rules`, and the closure's parameter shadowed this one
     /// — so the test for "was the panel opened on the sentence rather than on
@@ -2271,6 +2293,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         destination: Destination, focus: SelectionReader.Selection?
     ) {
         pendingSelection = nil
+        let clip = lastRecording?.url.lastPathComponent
 
         /// Hand focus back before writing anything.
         ///
@@ -2292,7 +2315,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 do {
                     let outcome = try Corrections.learn(
                         heard: rule.heard, corrected: rule.corrected, via: "panel",
-                        clip: self.lastRecording?.url.lastPathComponent
+                        clip: clip
                     )
                     Log.write("learned replacement: \(rule.heard) -> \(rule.corrected)")
                     self.logKept(outcome)

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -155,10 +155,13 @@ struct Config: Decodable, Equatable {
         /// mined from the archive can be told from one a person confirmed by
         /// correcting a transcript.
         ///
-        /// Nothing mechanical reads `seen` or `from` yet. They are recorded
-        /// here so PR 8 has something to cap and prune on; a count that starts
-        /// being kept the day it is first used starts at zero for every entry
-        /// that already existed.
+        /// Both are now read. `Corrections` counts a rendering up on every
+        /// correction, and drops one that stands at `seen: 1` a month after the
+        /// only time it was seen — but only when `from` says `correction`. A
+        /// mined or legacy entry has no honest first-seen date, because
+        /// `seen: 0` means "never counted", which is every entry written before
+        /// this key existed. Deleting on a date nobody recorded is how a prune
+        /// eats correct data.
         struct Pronunciation: Decodable, Equatable {
             /// Where an entry came from. `legacy` is not a source, it is the
             /// absence of one: a bare `heard:` list, or a `pronunciations:`

--- a/Sources/ParrotFlow/ConfigWriter.swift
+++ b/Sources/ParrotFlow/ConfigWriter.swift
@@ -108,6 +108,252 @@ enum ConfigWriter {
         return lines.joined(separator: "\n")
     }
 
+    // MARK: - Recording a rendering against its term
+
+    /// Records that `term` came out as `heard`, and returns how many times that
+    /// has now been seen.
+    ///
+    /// Written into `vocabulary.yaml` rather than `config.yaml`, which is where
+    /// a correction used to land. Three reasons, and none of them changes what
+    /// the app does with the rule: `Config.vocabularyRules` turns a rendering
+    /// into the same exact replacement `transcription.replacements` carried, so
+    /// the correction still fires. `vocabulary.yaml` is the file that is written
+    /// by the app and read by a person, which is what a learnt entry is. And it
+    /// is the only one `--forget` can reach — a correction written to
+    /// `config.yaml` could never be taken back.
+    ///
+    /// Always as a `pronunciations:` entry, even when the rendering is already
+    /// in a legacy `heard:` list. That is the shape with `seen:` and `from:` on
+    /// it, `Config.Term` reads both keys as one list and prefers the entry that
+    /// knows something about itself, so this upgrades a bare spelling in place
+    /// rather than duplicating it.
+    @discardableResult
+    static func addPronunciation(term: String, heard: String) throws -> Int {
+        let url = ConfigStore.vocabularyURL
+        let original = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+        let (updated, seen) = adding(pronunciation: heard, to: term, in: original)
+        if updated != original {
+            try updated.write(to: url, atomically: true, encoding: .utf8)
+        }
+        return seen
+    }
+
+    /// The file with one rendering recorded against its term, and the count it
+    /// now stands at.
+    static func adding(
+        pronunciation heard: String, to term: String, in yaml: String
+    ) -> (String, Int) {
+        var lines = yaml.components(separatedBy: "\n")
+        guard let start = index(ofTerm: term, in: lines) else { return (yaml, 0) }
+        let termIndent = indentation(of: lines[start])
+        let bodyIndent = termIndent + "  "
+
+        // Whatever the term's value is today, in block form, so a
+        // `pronunciations:` list can be appended under it. A legacy floor and a
+        // legacy `heard:` list both survive this — they are still read.
+        var end = start
+        let head = lines[start]
+        let colon = head.firstIndex(of: ":")!
+        let inline = String(head[head.index(after: colon)...]).trimmingCharacters(in: .whitespaces)
+        if !inline.isEmpty && !inline.hasPrefix("#") {
+            let closes = closingFlow(in: lines, from: start, deeperThan: termIndent.count)
+            let value = lines[start...closes].joined(separator: " ")
+            let body = String(value[value.index(after: value.firstIndex(of: ":")!)...])
+                .trimmingCharacters(in: .whitespaces)
+            // A bare list is the old `heard:`; a bare number is the old `floor:`.
+            let key = body.hasPrefix("[") ? "heard" : "floor"
+            lines.replaceSubrange(start...closes, with: [
+                "\(termIndent)\(quoted(term)):",
+                "\(bodyIndent)\(key): \(body)",
+            ])
+            end = start + 1
+        } else {
+            end = endOfTermBlock(in: lines, from: start, deeperThan: termIndent.count)
+        }
+
+        // An existing `pronunciations:` block, and this rendering inside it.
+        var listIndex: Int?
+        var cursor = start + 1
+        while cursor <= end, cursor < lines.count {
+            let trimmed = lines[cursor].trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("pronunciations:") { listIndex = cursor; break }
+            cursor += 1
+        }
+
+        guard let listAt = listIndex else {
+            lines.insert(contentsOf: [
+                "\(bodyIndent)pronunciations:",
+                "\(bodyIndent)  - heard: \(quoted(heard))",
+                "\(bodyIndent)    seen: 1",
+                "\(bodyIndent)    from: correction",
+            ], at: end + 1)
+            return (lines.joined(separator: "\n"), 1)
+        }
+
+        // `pronunciations: [a, b]` is legal YAML and nothing writes it, but a
+        // person may have. Left alone rather than rewritten: appending a block
+        // entry under a flow sequence would not parse.
+        let listIndent = indentation(of: lines[listAt])
+        if lines[listAt].trimmingCharacters(in: .whitespaces).dropFirst("pronunciations:".count)
+            .trimmingCharacters(in: .whitespaces).hasPrefix("[") {
+            return (yaml, 0)
+        }
+
+        let listEnd = endOfTermBlock(in: lines, from: listAt, deeperThan: listIndent.count)
+        let entryIndent = listIndent + "  "
+        if let found = entry(named: heard, in: lines, from: listAt + 1, through: listEnd) {
+            let seen = bump(seen: found, in: &lines, through: listEnd, indent: entryIndent)
+            return (lines.joined(separator: "\n"), seen)
+        }
+
+        lines.insert(contentsOf: [
+            "\(entryIndent)- heard: \(quoted(heard))",
+            "\(entryIndent)  seen: 1",
+            "\(entryIndent)  from: correction",
+        ], at: listEnd + 1)
+        return (lines.joined(separator: "\n"), 1)
+    }
+
+    /// Removes one rendering from a term's `pronunciations:`. True if it went.
+    ///
+    /// Only the block shape, which is the only shape this writes. A rendering
+    /// in a legacy `heard:` list is left where it is — that entry records
+    /// nothing about its own provenance, so nothing here knows enough about it
+    /// to delete it.
+    @discardableResult
+    static func dropPronunciation(term: String, heard: String) throws -> Bool {
+        let url = ConfigStore.vocabularyURL
+        guard let original = try? String(contentsOf: url, encoding: .utf8) else { return false }
+        var lines = original.components(separatedBy: "\n")
+        guard let start = index(ofTerm: term, in: lines) else { return false }
+        let termIndent = indentation(of: lines[start]).count
+        let end = endOfTermBlock(in: lines, from: start, deeperThan: termIndent)
+
+        var listAt: Int?
+        for cursor in (start + 1)...max(start + 1, end) where cursor < lines.count {
+            if lines[cursor].trimmingCharacters(in: .whitespaces).hasPrefix("pronunciations:") {
+                listAt = cursor
+                break
+            }
+        }
+        guard let listAt else { return false }
+        let listEnd = endOfTermBlock(
+            in: lines, from: listAt, deeperThan: indentation(of: lines[listAt]).count
+        )
+        guard let found = entry(named: heard, in: lines, from: listAt + 1, through: listEnd) else {
+            return false
+        }
+        let last = endOfEntry(in: lines, from: found, through: listEnd)
+        lines.removeSubrange(found...last)
+        // A `pronunciations:` key with nothing under it decodes as null, not as
+        // an empty list, so it goes too.
+        if endOfTermBlock(
+            in: lines, from: listAt, deeperThan: indentation(of: lines[listAt]).count
+        ) == listAt {
+            lines.remove(at: listAt)
+        }
+        try lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
+        return true
+    }
+
+    /// The line of `- heard: <name>` inside a `pronunciations:` block.
+    private static func entry(
+        named heard: String, in lines: [String], from: Int, through last: Int
+    ) -> Int? {
+        for cursor in from...max(from, last) where cursor < lines.count {
+            let trimmed = lines[cursor].trimmingCharacters(in: .whitespaces)
+            guard trimmed.hasPrefix("-") else { continue }
+            let body = String(trimmed.dropFirst()).trimmingCharacters(in: .whitespaces)
+            // `- heard: Versal` and the bare `- Versal` a person may have typed.
+            let spelling: String
+            if body.hasPrefix("heard:") {
+                spelling = unquoted(String(body.dropFirst("heard:".count)))
+            } else if !body.contains(":") {
+                spelling = unquoted(body)
+            } else {
+                continue
+            }
+            if spelling.caseInsensitiveCompare(heard) == .orderedSame { return cursor }
+        }
+        return nil
+    }
+
+    /// The last line of the `- heard:` entry that starts at `from`.
+    private static func endOfEntry(in lines: [String], from: Int, through last: Int) -> Int {
+        var cursor = from + 1
+        var end = from
+        while cursor <= last, cursor < lines.count {
+            let trimmed = lines[cursor].trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("-") { break }
+            if !trimmed.isEmpty { end = cursor }
+            cursor += 1
+        }
+        return end
+    }
+
+    /// Adds one to an entry's `seen:`, writing the key if it had none.
+    private static func bump(
+        seen entry: Int, in lines: inout [String], through last: Int, indent: String
+    ) -> Int {
+        let end = endOfEntry(in: lines, from: entry, through: last)
+        for cursor in entry...end {
+            let trimmed = lines[cursor].trimmingCharacters(in: .whitespaces)
+            let body = trimmed.hasPrefix("-")
+                ? String(trimmed.dropFirst()).trimmingCharacters(in: .whitespaces) : trimmed
+            guard body.hasPrefix("seen:") else { continue }
+            let was = Int(String(body.dropFirst("seen:".count))
+                .trimmingCharacters(in: .whitespaces)) ?? 0
+            lines[cursor] = "\(indentation(of: lines[cursor]))seen: \(was + 1)"
+            return was + 1
+        }
+        // No `seen:` at all: an entry written before the key existed. It has
+        // been seen at least once before now, hence 2 and not 1.
+        lines.insert("\(indent)  seen: 2", at: end + 1)
+        return 2
+    }
+
+    /// The line a term's key sits on, inside `terms:`.
+    private static func index(ofTerm term: String, in lines: [String]) -> Int? {
+        guard let termsIndex = lines.firstIndex(where: {
+            $0.trimmingCharacters(in: .whitespaces).hasPrefix("terms:")
+                && !$0.trimmingCharacters(in: .whitespaces).hasPrefix("#")
+        }) else { return nil }
+        let outer = indentation(of: lines[termsIndex]).count
+        var index = termsIndex + 1
+        var at: Int?
+        while index < lines.count {
+            let line = lines[index]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty || trimmed.hasPrefix("#") { index += 1; continue }
+            if indentation(of: line).count <= outer { break }
+            // Only a key at the term level, so a `heard:` inside another term's
+            // body cannot be mistaken for a term called `heard`.
+            if indentation(of: line).count == outer + 2, let colon = trimmed.firstIndex(of: ":"),
+               unquoted(String(trimmed[trimmed.startIndex..<colon]))
+                   .caseInsensitiveCompare(term) == .orderedSame {
+                at = index
+                break
+            }
+            index += 1
+        }
+        return at
+    }
+
+    /// The last line indented deeper than `indent`, starting from `start`.
+    private static func endOfTermBlock(in lines: [String], from start: Int, deeperThan indent: Int) -> Int {
+        var index = start + 1
+        var last = start
+        while index < lines.count {
+            let line = lines[index]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty { index += 1; continue }
+            if indentation(of: line).count <= indent { break }
+            last = index
+            index += 1
+        }
+        return last
+    }
+
     // MARK: - Forgetting a term's pronunciations
 
     /// Removes every rendering recorded for `term` from `vocabulary.yaml`.

--- a/Sources/ParrotFlow/Corrections.swift
+++ b/Sources/ParrotFlow/Corrections.swift
@@ -1,0 +1,348 @@
+import AVFoundation
+import Foundation
+
+/// What happens when somebody corrects a word: the rule, the observation, and
+/// the audio.
+///
+/// Until now a correction wrote one line of YAML and threw the rest away. That
+/// is the expensive half being discarded: a correction is a person saying, in
+/// their own voice and unprompted, that a term was said *here* and the decoder
+/// wrote *that* instead. It is a labelled recording, free, and there is no
+/// other source of one.
+///
+/// Why the audio is worth keeping at all, in one number: `Matthieu` separates
+/// its correct utterances from its wrong ones at AUC 0.556 on 2 recordings —
+/// chance — and at 1.000 on 11. Same rows, same hold-out, only the recordings
+/// changed. A thin bank is a shortage of clips, not a verdict on the term, and
+/// this is what makes clips arrive without anybody being asked for them.
+///
+/// **One route to the audio, not two.** The word times come from
+/// `trace.jsonl`, joined to the clip by its filename. The alternative was to
+/// carry the decoder's timings in memory from `Transcriber` to whichever panel
+/// the person eventually saves, and it fails on the case that matters: `--learn`
+/// is a separate process that never saw the dictation, so it would need the
+/// file route anyway and the app would have grown a second mechanism for one
+/// job. The trace is written for every dictation, before any panel can open,
+/// and PR 5 moves mining onto the same read.
+enum Corrections {
+
+    /// A span longer than this is not one word being said.
+    ///
+    /// Measured, not guessed: over 60 real correction spans in the archive the
+    /// median is 0.64s and the 90th percentile 0.88s, and 2 of the 60 run past
+    /// 2s with the worst at 6.4s — a word timing that swallowed the pause after
+    /// it. Cutting one of those files a recording of a name plus a silence
+    /// under that name, which is exactly the bad clip Part 1 §7 says widens a
+    /// term's cloud and disarms its veto.
+    static let longestWord: Double = 2.0
+
+    /// And this much more for each word after the first, because a rendering
+    /// can be two words — `super base`, `red crawl`.
+    static let perExtraWord: Double = 1.0
+
+    /// The word's edges are where it is least clear, so keep a little either
+    /// side. The same 0.05s `scripts/mine-pronunciations.py` cuts with, so a
+    /// mined sample and a corrected one are the same kind of object.
+    static let padding: Double = 0.05
+
+    /// What was written down, for the caller to log.
+    struct Outcome {
+        /// The vocabulary term this was promoted under, if it was one.
+        var term: String?
+        /// How the rendering now stands in `vocabulary.yaml`.
+        var seen: Int?
+        /// The sample written, relative to `voice/`.
+        var sample: String?
+        /// Why there is no sample. Nil when there is one, or when the
+        /// correction was not about a vocabulary term at all.
+        var skipped: String?
+        /// Samples the per-term cap removed, and why each one went.
+        var capped: [(file: String, why: String)] = []
+        /// Renderings the seen-once rule dropped.
+        var pruned: [String] = []
+    }
+
+    /// Learn that `heard` should have been `corrected`.
+    ///
+    /// Two shapes, decided by whether `corrected` names a term in
+    /// `vocabulary.yaml`:
+    ///
+    /// - **A term.** The rendering is promoted into `vocabulary.yaml` under
+    ///   that term's `pronunciations:`, with `from: correction` and a `seen:`
+    ///   count, and the audio is cut. `Config.vocabularyRules` turns that entry
+    ///   into the same exact replacement `config.yaml` would have carried, so
+    ///   the correction takes effect exactly as before — it is now recorded in
+    ///   the file that owns learnt data and knows where each entry came from.
+    ///   It is also the file `--forget` can reach, which `config.yaml` was not.
+    /// - **Anything else.** `teh` → `the` is not a name and has no audio worth
+    ///   keeping. It goes to `transcription.replacements` in `config.yaml`,
+    ///   which is what has always happened.
+    ///
+    /// - Parameter clip: the dictation being corrected, when the caller has it.
+    ///   Without it the newest dictation whose text contains `heard` is used.
+    @discardableResult
+    static func learn(
+        heard: String, corrected: String, via: String, clip: String? = nil
+    ) throws -> Outcome {
+        let config = try ConfigStore.load()
+        let term = config.vocabulary.terms.keys.first {
+            $0.caseInsensitiveCompare(corrected) == .orderedSame
+        }
+
+        guard let term else {
+            try ConfigWriter.addReplacement(heard: heard, corrected: corrected)
+            Trace.correction(heard: heard, corrected: corrected, via: via, clip: clip)
+            return Outcome()
+        }
+
+        var outcome = Outcome(term: term)
+        outcome.seen = try ConfigWriter.addPronunciation(term: term, heard: heard)
+        Trace.correction(heard: heard, corrected: corrected, via: via, clip: clip)
+
+        // The rendering is recorded whether or not the audio can be, so a
+        // correction is never lost to a missing clip. `skipped` says which
+        // happened, and it is on the row rather than only in the log because
+        // the log truncates at 1 MB and this rate is worth counting later.
+        var observation = VoiceStore.Observation(
+            at: stamp(), term: term, heard: heard, from: "correction",
+            score: nil, mic: Recorder.inputDeviceName, span: nil,
+            sample: nil, wav: nil, lang: nil,
+            build: AppVariant.buildStamp, skipped: nil
+        )
+
+        switch keep(heard: heard, term: term, clip: clip, config: config) {
+        case .success(let kept):
+            observation.span = [kept.start, kept.end]
+            observation.sample = kept.sample
+            observation.wav = kept.wav
+            observation.lang = kept.lang
+            outcome.sample = kept.sample
+        case .failure(let why):
+            observation.skipped = why.reason
+            observation.wav = why.wav
+            observation.lang = why.lang
+            outcome.skipped = why.reason
+        }
+
+        try VoiceStore.append(observation)
+        outcome.capped = VoiceStore.enforceCap(on: term)
+        outcome.pruned = try prune(term: term)
+        return outcome
+    }
+
+    // MARK: - Cutting the audio out
+
+    private struct Kept {
+        let sample: String
+        let wav: String
+        let lang: String?
+        let start: Double
+        let end: Double
+    }
+
+    private struct Refused: Error {
+        let reason: String
+        var wav: String?
+        var lang: String?
+    }
+
+    /// Finds the rendering in the dictation's word times and cuts it out.
+    private static func keep(
+        heard: String, term: String, clip: String?, config: Config
+    ) -> Result<Kept, Refused> {
+        let recordings = config.resolvedOutputDir
+        let delivered = clip.flatMap { Trace.delivered(clip: $0, in: recordings) }
+            ?? Trace.delivered(saying: heard, in: recordings)
+        guard let delivered else {
+            return .failure(Refused(reason: "no trace line for this dictation"))
+        }
+        guard !delivered.words.isEmpty else {
+            return .failure(Refused(
+                reason: "the trace line carries no word times",
+                wav: delivered.wav, lang: delivered.lang
+            ))
+        }
+        guard let span = span(of: heard, in: delivered.words) else {
+            return .failure(Refused(
+                reason: "\"\(heard)\" is not in the decoder's own words for this clip",
+                wav: delivered.wav, lang: delivered.lang
+            ))
+        }
+
+        // The duration guard. Loud, and it names the number it rejected.
+        let words = renderingWords(heard).count
+        let allowed = longestWord + perExtraWord * Double(max(0, words - 1))
+        let length = span.end - span.start
+        guard length > 0, length <= allowed else {
+            return .failure(Refused(
+                reason: String(
+                    format: "the span is %.2fs, over the %.2fs allowed for %d word(s)",
+                    length, allowed, words
+                ),
+                wav: delivered.wav, lang: delivered.lang
+            ))
+        }
+
+        let source = recordings.appendingPathComponent(delivered.wav)
+        guard FileManager.default.fileExists(atPath: source.path) else {
+            return .failure(Refused(
+                reason: "the clip is no longer on disk",
+                wav: delivered.wav, lang: delivered.lang
+            ))
+        }
+
+        let name = VoiceStore.nextSampleName(for: term, heard: heard)
+        let target = VoiceStore.samples(for: term).appendingPathComponent(name)
+        do {
+            try cut(from: source, start: span.start - padding, end: span.end + padding, to: target)
+        } catch {
+            return .failure(Refused(
+                reason: "the cut failed: \(error.localizedDescription)",
+                wav: delivered.wav, lang: delivered.lang
+            ))
+        }
+        return .success(Kept(
+            sample: "samples/\(term)/\(name)", wav: delivered.wav, lang: delivered.lang,
+            start: span.start, end: span.end
+        ))
+    }
+
+    /// Where a rendering sits in the decoder's own words.
+    ///
+    /// Matched as a sequence, because a rendering can be more than one word —
+    /// `Supabase` comes back as "super base" and `Redcrawl` as "red crawl" more
+    /// often than not. Punctuation is stripped from both sides: the decoder
+    /// writes "praise." at the end of a sentence and the person correcting it
+    /// types "praise".
+    static func span(of heard: String, in words: [Trace.Word]) -> (start: Double, end: Double)? {
+        let wanted = renderingWords(heard)
+        guard !wanted.isEmpty, words.count >= wanted.count else { return nil }
+        let bare = words.map { plain($0.word) }
+        // The last match, not the first. When a word occurs twice the later one
+        // is the one still on screen when somebody corrects it, and taking the
+        // first would cut a different utterance than the one being talked about.
+        for start in stride(from: bare.count - wanted.count, through: 0, by: -1)
+        where Array(bare[start..<(start + wanted.count)]) == wanted {
+            return (words[start].start, words[start + wanted.count - 1].end)
+        }
+        return nil
+    }
+
+    private static func renderingWords(_ heard: String) -> [String] {
+        heard.split(whereSeparator: { $0 == " " || $0 == "\t" })
+            .map { plain(String($0)) }
+            .filter { !$0.isEmpty }
+    }
+
+    /// A word with nothing on it but its letters, digits and apostrophes,
+    /// folded to lower case.
+    private static func plain(_ word: String) -> String {
+        word.lowercased().filter { $0.isLetter || $0.isNumber || $0 == "'" }
+    }
+
+    /// Writes `[start, end]` of `source` into `target`.
+    ///
+    /// Through `AVAudioFile` rather than by slicing the PCM by hand: the
+    /// recorder's format is whatever the input device gave it, and a hand-rolled
+    /// header that is wrong about the sample rate produces a file that plays and
+    /// scores as a different sound.
+    static func cut(from source: URL, start: Double, end: Double, to target: URL) throws {
+        let input = try AVAudioFile(forReading: source)
+        let format = input.processingFormat
+        let rate = format.sampleRate
+
+        let first = max(0, AVAudioFramePosition(start * rate))
+        let last = min(input.length, AVAudioFramePosition(end * rate))
+        guard last > first else { throw CutError.emptySpan }
+
+        let count = AVAudioFrameCount(last - first)
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: count) else {
+            throw CutError.emptySpan
+        }
+        input.framePosition = first
+        try input.read(into: buffer, frameCount: count)
+
+        try FileManager.default.createDirectory(
+            at: target.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        let output = try AVAudioFile(
+            forWriting: target, settings: input.fileFormat.settings,
+            commonFormat: format.commonFormat, interleaved: format.isInterleaved
+        )
+        try output.write(from: buffer)
+    }
+
+    enum CutError: LocalizedError {
+        case emptySpan
+
+        var errorDescription: String? {
+            switch self {
+            case .emptySpan: return "the span is empty once it is clipped to the recording"
+            }
+        }
+    }
+
+    // MARK: - Dropping a rendering seen once and never again
+
+    /// How long a rendering seen exactly once has to prove itself.
+    ///
+    /// A rendering the decoder produced once is as likely to be a one-off
+    /// mis-decode as a way this person says the word, and the two are
+    /// indistinguishable on the day. Repetition is what tells them apart, so the
+    /// rule is time and not a count: a month of dictation without it happening
+    /// again says it was noise. `heard:` lists only ever grow, and this is the
+    /// only thing in the app that takes an entry back out on its own.
+    static let proveWithin: TimeInterval = 30 * 24 * 60 * 60
+
+    /// Removes this term's renderings that were seen once, long ago, and never
+    /// again. Returns what went, so the caller can say it out loud.
+    ///
+    /// Only ever removes a rendering `from: correction` with `seen: 1`. A mined
+    /// or legacy entry has no honest first-seen date — `seen: 0` means "never
+    /// counted", which is every entry written before the key existed — and
+    /// deleting on a date nobody recorded is how a prune eats correct data.
+    private static func prune(term: String) throws -> [String] {
+        let vocabulary = ConfigStore.loadVocabulary()
+        guard let entry = vocabulary.terms.first(where: {
+            $0.key.caseInsensitiveCompare(term) == .orderedSame
+        })?.value else { return [] }
+
+        var lastSeen: [String: Date] = [:]
+        for observation in VoiceStore.observations()
+        where observation.term.caseInsensitiveCompare(term) == .orderedSame {
+            guard let at = date(observation.at) else { continue }
+            let key = plain(observation.heard)
+            lastSeen[key] = max(lastSeen[key] ?? at, at)
+        }
+
+        var dropped: [String] = []
+        for rendering in entry.pronunciations
+        where rendering.seen == 1 && rendering.from == .correction {
+            guard let at = lastSeen[plain(rendering.heard)],
+                  Date().timeIntervalSince(at) > proveWithin
+            else { continue }
+            if try ConfigWriter.dropPronunciation(term: term, heard: rendering.heard) {
+                dropped.append(rendering.heard)
+            }
+        }
+        return dropped
+    }
+
+    private static func stamp() -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.string(from: Date())
+    }
+
+    private static func date(_ text: String) -> Date? {
+        let full = ISO8601DateFormatter()
+        full.formatOptions = [.withInternetDateTime]
+        if let at = full.date(from: text) { return at }
+        // What mining writes: the clip's own name, which has no zone on it.
+        let bare = ISO8601DateFormatter()
+        bare.formatOptions = [.withFullDate, .withTime, .withColonSeparatorInTime,
+                              .withDashSeparatorInDate]
+        bare.timeZone = TimeZone.current
+        return bare.date(from: text)
+    }
+}

--- a/Sources/ParrotFlow/LearnCommand.swift
+++ b/Sources/ParrotFlow/LearnCommand.swift
@@ -4,16 +4,48 @@ import Foundation
 ///
 /// The same code path the correction panel uses, minus the UI. Useful on its
 /// own, and it makes the config-rewriting logic testable without a GUI.
+///
+/// This process never saw the dictation, so it has no clip to name unless one
+/// is given with `--clip`. Without it `Corrections.learn` falls back to the most
+/// recent dictation whose text contains the rendering, which is the same clip a
+/// person typing this at a terminal has in mind.
 enum LearnCommand {
-    static func run(heard: String, corrected: String) -> Int32 {
+    static func run(heard: String, corrected: String, clip: String? = nil) -> Int32 {
         do {
-            try ConfigWriter.addReplacement(heard: heard, corrected: corrected)
-            Trace.correction(heard: heard, corrected: corrected, via: "learn")
+            let outcome = try Corrections.learn(
+                heard: heard, corrected: corrected, via: "learn", clip: clip
+            )
             print("✓ \(heard) → \(corrected)")
+            say(outcome)
+            Trace.flush()
             return 0
         } catch {
             print("✗ \(error.localizedDescription)")
             return 1
+        }
+    }
+
+    /// What the audio half did, out loud.
+    ///
+    /// Every line here is a thing that was written or deleted. A cut that did
+    /// not happen and a sample that was capped away are both invisible
+    /// otherwise, and a clip nobody knows is missing is the failure this whole
+    /// change is trying to avoid.
+    static func say(_ outcome: Corrections.Outcome) {
+        guard let term = outcome.term else { return }
+        if let seen = outcome.seen {
+            print("  \(term): seen \(seen) time(s), from correction")
+        }
+        if let sample = outcome.sample {
+            print("  kept the audio as voice/\(sample)")
+        } else if let why = outcome.skipped {
+            print("  no audio kept — \(why)")
+        }
+        for gone in outcome.capped {
+            print("  capped voice/samples/\(term)/\(gone.file) — \(gone.why)")
+        }
+        for gone in outcome.pruned {
+            print("  dropped \"\(gone)\" — seen once and not again since")
         }
     }
 }

--- a/Sources/ParrotFlow/Trace.swift
+++ b/Sources/ParrotFlow/Trace.swift
@@ -211,13 +211,178 @@ enum Trace {
     /// question for whoever reads the file, and `at` is enough to do it.
     ///
     /// - Parameter via: which path taught it — `panel`, `inline` or `learn`.
-    static func correction(heard: String, corrected: String, via: String) {
+    /// - Parameter clip: the dictation it is a correction of, when that is
+    ///   known. `at` was the only join and it is a weak one: two corrections
+    ///   saved in the same second are indistinguishable, and a panel left open
+    ///   for a minute stamps the correction nowhere near its dictation. The
+    ///   clip name is exact, free here, and unrecoverable later.
+    static func correction(heard: String, corrected: String, via: String, clip: String? = nil) {
         append(
             Correction(
                 v: version, kind: Kind.correction.rawValue, at: stamp(),
-                heard: heard, corrected: corrected, via: via
+                heard: heard, corrected: corrected, via: via, wav: clip
             ),
             to: directory
+        )
+    }
+
+    // MARK: - Reading it back
+
+    /// What one dictation delivered: the words with their times, the language
+    /// the pipeline was chosen for, and the final text.
+    struct Delivered {
+        let wav: String
+        let lang: String?
+        let final: String
+        let words: [Word]
+    }
+
+    /// The line a clip was delivered on.
+    ///
+    /// **The first entry for the wav, not the newest.** `trace.jsonl` is
+    /// append-only and a clip replayed later appends another line for the same
+    /// audio; the first is the decode the speaker actually got, and the one a
+    /// correction is a correction *of*.
+    ///
+    /// Reads the whole file. It is a few megabytes after a year and this runs
+    /// once, when somebody saves a correction — a person is waiting on a panel,
+    /// not on a loop.
+    /// Asked by name, so no clip but this one is ever decoded. On this
+    /// speaker's 68 MB archive that is the difference between 1.3 seconds and
+    /// nothing, and it is spent with somebody waiting on a correction panel.
+    static func delivered(clip: String, in directory: URL?) -> Delivered? {
+        guard let directory,
+              let data = try? Data(
+                  contentsOf: directory.appendingPathComponent("trace.jsonl"),
+                  options: .mappedIfSafe
+              )
+        else { return nil }
+        let needle = Data(clip.utf8)
+        for line in data.split(separator: 0x0A, omittingEmptySubsequences: true) {
+            // Bytes first. Building a Swift String of every line to look at two
+            // fields costs more than reading the file did.
+            guard line.range(of: needle) != nil else { continue }
+            let text = String(decoding: line, as: UTF8.self)[...]
+            guard string("wav", in: text) == clip,
+                  string("kind", in: text) == Kind.dictation.rawValue,
+                  let row = decode(text)
+            else { continue }
+            // The first line for this clip, which is the decode the speaker got.
+            // A replay appends another and it is not what was corrected.
+            return row
+        }
+        return nil
+    }
+
+    /// The most recent dictation whose delivered text contains `text`.
+    ///
+    /// For the callers that have no clip in hand — `--learn` is a separate
+    /// process and never saw the dictation. Newest first, because a rendering
+    /// this speaker produces often would otherwise match the first time they
+    /// ever said it.
+    static func delivered(saying text: String, in directory: URL?) -> Delivered? {
+        let wanted = text.lowercased()
+        guard !wanted.isEmpty else { return nil }
+        return last(in: directory, containing: text) { $0.final.lowercased().contains(wanted) }
+    }
+
+    /// Every clip's first dictation line, in file order, parsed only when it
+    /// could possibly match.
+    ///
+    /// Reads the whole archive, so it is the slow way in — about 3 seconds on
+    /// 68 MB. Only `delivered(saying:)` needs it, because "the newest clip
+    /// whose text contains this" cannot be answered without looking at every
+    /// clip. `delivered(clip:)` asks a narrower question and does not come
+    /// through here.
+    ///
+    /// - Parameter containing: a string a line must contain to be worth
+    ///   parsing. Only a filter on the work, never on the answer: decoding
+    ///   every line costs about 1.6 seconds of the 3.
+    ///
+    /// **The dedupe runs before the filter, not after.** Which line is a
+    /// clip's *first* is a fact about the file, so it cannot depend on what is
+    /// being looked for. Skipping a line before counting it would let a replay
+    /// of a clip stand in for the decode the speaker actually got. The name is
+    /// read out of the raw text for that, which costs a substring scan instead
+    /// of a parse.
+    private static func candidates(
+        in directory: URL?, containing: String?, body: (Delivered) -> Bool
+    ) -> Delivered? {
+        var seen: Set<String> = []
+        var found: Delivered?
+        for line in lines(in: directory) {
+            guard string("kind", in: line) == Kind.dictation.rawValue,
+                  let wav = string("wav", in: line), seen.insert(wav).inserted
+            else { continue }
+            if let containing, !line.localizedCaseInsensitiveContains(containing) { continue }
+            guard let row = decode(line) else { continue }
+            if body(row) { found = row }
+        }
+        return found
+    }
+
+    /// A top-level string field, read out of the raw line without parsing it.
+    ///
+    /// Tolerates the space a pretty-printer puts after the colon, because this
+    /// file is written by more than one thing — the app's `JSONEncoder` puts
+    /// none, a script's `json.dumps` puts one, and a reader that only knew one
+    /// of them would silently skip half the archive.
+    ///
+    /// Not a JSON parser and not trying to be. It is wrong on a key that
+    /// appears inside a nested object first, which is why the only two keys
+    /// asked for are `kind` and `wav` — both written before `asr` by
+    /// `Record`'s field order, and neither a key of anything nested.
+    private static func string(_ key: String, in line: Substring) -> String? {
+        guard let at = line.range(of: "\"\(key)\":") else { return nil }
+        var cursor = at.upperBound
+        while cursor < line.endIndex, line[cursor] == " " { cursor = line.index(after: cursor) }
+        guard cursor < line.endIndex, line[cursor] == "\"" else { return nil }
+        cursor = line.index(after: cursor)
+        guard let close = line[cursor...].firstIndex(of: "\"") else { return nil }
+        return String(line[cursor..<close])
+    }
+
+    private static func last(
+        in directory: URL?, containing: String? = nil, where matches: (Delivered) -> Bool
+    ) -> Delivered? {
+        candidates(in: directory, containing: containing, body: matches)
+    }
+
+    private static func lines(in directory: URL?) -> [Substring] {
+        guard let directory,
+              let text = try? String(
+                  contentsOf: directory.appendingPathComponent("trace.jsonl"), encoding: .utf8
+              )
+        else { return [] }
+        return text.split(separator: "\n")
+    }
+
+    /// One line, if it is a dictation that produced words.
+    ///
+    /// Hand-read rather than decoded through a `Decodable`: `Record` is an
+    /// encoder-side shape and giving it a decoder would tie every future field
+    /// to being readable by this version. A line written by a later build has
+    /// to keep working here.
+    private static func decode(_ line: Substring) -> Delivered? {
+        guard let data = line.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              object["kind"] as? String == Kind.dictation.rawValue,
+              let wav = object["wav"] as? String
+        else { return nil }
+        let asr = object["asr"] as? [String: Any]
+        let words = (asr?["words"] as? [[String: Any]] ?? []).compactMap { entry -> Word? in
+            guard let word = entry["word"] as? String,
+                  let start = entry["start"] as? Double,
+                  let end = entry["end"] as? Double
+            else { return nil }
+            return Word(
+                word: word, start: start, end: end,
+                confidence: (entry["confidence"] as? Double).map(Float.init) ?? 0
+            )
+        }
+        return Delivered(
+            wav: wav, lang: object["lang"] as? String,
+            final: object["final"] as? String ?? "", words: words
         )
     }
 
@@ -365,6 +530,8 @@ enum Trace {
         let heard: String
         let corrected: String
         let via: String
+        /// The dictation this corrects, when the caller knew it.
+        let wav: String?
     }
 
     fileprivate struct ASR: Encodable {

--- a/Sources/ParrotFlow/VoiceStore.swift
+++ b/Sources/ParrotFlow/VoiceStore.swift
@@ -232,11 +232,21 @@ enum VoiceStore {
         var files = sampleFiles(of: term)
         guard files.count > cap else { return [] }
 
-        // Which samples a person confirmed, from the observations that name
-        // them. A file with no observation is unconfirmed by default — it is
-        // audio nobody wrote anything down about.
+        // Which of *this term's* samples a person confirmed, from the
+        // observations that name them. A file with no observation is
+        // unconfirmed by default — it is audio nobody wrote anything down
+        // about.
+        //
+        // Filtered by term, and that is not tidiness. Sample names are only
+        // unique inside a term's folder, so `Praisy/00-praise.wav` and
+        // `Supabase/00-praise.wav` are both `00-praise.wav`. Matching on the
+        // bare name across every term would let one term's confirmed sample
+        // protect another term's unconfirmed one, and the cap would then delete
+        // a confirmed sample while keeping the audio nobody vouched for.
         var confirmed: Set<String> = []
-        for observation in observations() where observation.from == "correction" {
+        for observation in observations()
+        where observation.from == "correction"
+            && observation.term.caseInsensitiveCompare(term) == .orderedSame {
             if let sample = observation.sample {
                 confirmed.insert((sample as NSString).lastPathComponent)
             }

--- a/Sources/ParrotFlow/VoiceStore.swift
+++ b/Sources/ParrotFlow/VoiceStore.swift
@@ -24,8 +24,26 @@ import Foundation
 /// it genuinely is not known for the clips mined before anything recorded it —
 /// absent means unknown, never "the current one".
 ///
-/// This PR creates and reads the store. Writing on a correction is PR 8.
+/// **Every observation says which build wrote it and which language was being
+/// dictated.** Both are free at write time and neither can be recovered
+/// afterwards. `lang` is the multilingual case: this speaker dictates in two
+/// languages and one name has two pronunciations, so the tag says whether each
+/// way a name is said has clips behind it. It decides nothing on its own — a
+/// French name can be said the French way inside an English sentence. `build`
+/// is the audit trail: a clip cut by a build whose span logic later changes is
+/// a clip you cannot trust, and the stamp is the only way to tell which is
+/// which.
 enum VoiceStore {
+
+    /// How many samples one term keeps.
+    ///
+    /// Not a storage limit — 25 wav files of half a second is nothing. It is a
+    /// limit on how much one week of dictation can dominate a term's cloud.
+    /// Recordings from the same session score about 0.06 AUC higher against
+    /// each other than against another day's, so a term whose bank is 200 clips
+    /// from one afternoon describes that afternoon. The archive's own terms sit
+    /// at 8 to 26 clips, which is where this number comes from.
+    static let perTermSampleCap = 25
 
     static var directory: URL {
         ConfigStore.directory.appendingPathComponent("voice", isDirectory: true)
@@ -105,6 +123,139 @@ enum VoiceStore {
         var sample: String?
         /// The clip it came out of, as a bare filename.
         var wav: String?
+        /// Which language the pipeline was chosen for, from the dictation's own
+        /// `trace.jsonl` line. Absent means the trace did not say — never "the
+        /// current one", for the same reason `mic` is optional.
+        var lang: String?
+        /// The build stamp of whatever wrote this row, e.g. `78d7ba2`.
+        /// `AppVariant.buildStamp`, the same string `--version` prints and the
+        /// app's first log line carries.
+        var build: String?
+        /// Why this row has no `sample`, when it has none.
+        ///
+        /// A row that records a rendering but no audio is normal — the clip may
+        /// be gone, the timings may not cover it, the span may be absurd. What
+        /// is not acceptable is not knowing which. Written here rather than only
+        /// to the log so the rate is countable from the file later, and the log
+        /// truncates at 1 MB.
+        var skipped: String?
+    }
+
+    /// The store's own directories, made on demand.
+    ///
+    /// Nothing creates `voice/` at install: it appears the first time something
+    /// is learnt, so a machine that has never corrected anything has no empty
+    /// folder to explain.
+    private static func makeDirectory(_ url: URL) throws {
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+
+    /// One more line on the end of `observations.jsonl`.
+    ///
+    /// `O_APPEND`, for the reason `Trace.append` gives: seeking to the end and
+    /// then writing is two steps and two processes can interleave them. The app
+    /// and a mining script both write here.
+    static func append(_ observation: Observation) throws {
+        try makeDirectory(directory)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.withoutEscapingSlashes, .sortedKeys]
+        var data = try encoder.encode(observation)
+        data.append(0x0A)
+
+        let fd = open(observationsURL.path, O_WRONLY | O_APPEND | O_CREAT, 0o644)
+        guard fd >= 0 else { throw StoreError.cannotWrite(observationsURL) }
+        defer { close(fd) }
+        try data.withUnsafeBytes { buffer in
+            guard let base = buffer.baseAddress else { return }
+            guard write(fd, base, buffer.count) == buffer.count else {
+                throw StoreError.cannotWrite(observationsURL)
+            }
+        }
+    }
+
+    enum StoreError: LocalizedError {
+        case cannotWrite(URL)
+
+        var errorDescription: String? {
+            switch self {
+            case .cannotWrite(let url):
+                return "could not write \(url.lastPathComponent)"
+            }
+        }
+    }
+
+    // MARK: - Samples
+
+    /// Where a term's samples live. The folder is the term as `vocabulary.yaml`
+    /// spells it, so `--forget` can name it back.
+    static func samples(for term: String) -> URL {
+        samplesDirectory.appendingPathComponent(term, isDirectory: true)
+    }
+
+    /// The wav files of one term, oldest first by name.
+    ///
+    /// By name rather than by modification date: a copied archive has every
+    /// file stamped with the moment it was copied, and the name carries the
+    /// sequence the recording was written in.
+    static func sampleFiles(of term: String) -> [String] {
+        let inside = (try? FileManager.default.contentsOfDirectory(
+            atPath: samples(for: term).path
+        )) ?? []
+        return inside.filter { $0.hasSuffix(".wav") }.sorted()
+    }
+
+    /// A free filename for a new sample of `term`, in the shape mining writes:
+    /// `NN-rendering.wav`, numbered above everything already there.
+    static func nextSampleName(for term: String, heard: String) -> String {
+        let slug = heard.lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+            .joined(separator: "-")
+        let used = sampleFiles(of: term).compactMap { name -> Int? in
+            Int(name.prefix(while: { $0.isNumber }))
+        }
+        let next = (used.max() ?? -1) + 1
+        return String(format: "%02d-%@.wav", next, slug.isEmpty ? "rendering" : slug)
+    }
+
+    /// Holds a term to `perTermSampleCap` files, and says what went.
+    ///
+    /// **The oldest unconfirmed sample goes first.** A sample whose observation
+    /// says `from: correction` is one a person looked at a transcript and
+    /// labelled by hand; a mined one is a guess made from a decode that may
+    /// itself have been wrong. When only confirmed samples are left the oldest
+    /// of those goes, because a cap that refuses to act is not a cap.
+    ///
+    /// Never silent. Every removal is returned, and every caller logs it.
+    @discardableResult
+    static func enforceCap(on term: String, cap: Int = perTermSampleCap) -> [(file: String, why: String)] {
+        var files = sampleFiles(of: term)
+        guard files.count > cap else { return [] }
+
+        // Which samples a person confirmed, from the observations that name
+        // them. A file with no observation is unconfirmed by default — it is
+        // audio nobody wrote anything down about.
+        var confirmed: Set<String> = []
+        for observation in observations() where observation.from == "correction" {
+            if let sample = observation.sample {
+                confirmed.insert((sample as NSString).lastPathComponent)
+            }
+        }
+
+        var removed: [(file: String, why: String)] = []
+        let store = FileManager.default
+        // Unconfirmed first, oldest first within each group.
+        let order = files.filter { !confirmed.contains($0) } + files.filter { confirmed.contains($0) }
+        for name in order {
+            guard files.count > cap else { break }
+            let why = confirmed.contains(name)
+                ? "oldest confirmed — every sample of this term is confirmed"
+                : "oldest unconfirmed"
+            try? store.removeItem(at: samples(for: term).appendingPathComponent(name))
+            files.removeAll { $0 == name }
+            removed.append((name, why))
+        }
+        return removed
     }
 
     /// Every observation on file, oldest first.

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -267,10 +267,19 @@ if let index = arguments.firstIndex(of: "--dates") {
 
 if let index = arguments.firstIndex(of: "--learn") {
     guard arguments.indices.contains(index + 2) else {
-        print("usage: ParrotFlow --learn <heard> <corrected>")
+        print("usage: ParrotFlow --learn <heard> <corrected> [--clip <wav>]")
         exit(2)
     }
-    exit(LearnCommand.run(heard: arguments[index + 1], corrected: arguments[index + 2]))
+    // `--clip` names the dictation this corrects. The panel always knows it and
+    // passes it; a terminal does not, and without it the newest dictation whose
+    // text contains the rendering is used. Exposed here so the panel's path can
+    // be scored without a GUI, which is what this command is for.
+    exit(LearnCommand.run(
+        heard: arguments[index + 1], corrected: arguments[index + 2],
+        clip: arguments.firstIndex(of: "--clip").flatMap { at in
+            arguments.indices.contains(at + 1) ? arguments[at + 1] : nil
+        }
+    ))
 }
 
 if let index = arguments.firstIndex(of: "--forget") {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -312,6 +312,7 @@ scripts/check-compose.sh           # what a prompt says once the scope is in it
 scripts/check-context.sh           # what the context stage publishes for a screen
 scripts/check-span.sh              # a composer-shaped page, or Slack, or Outlook
 scripts/check-vocabulary-config.sh # what vocabulary.yaml adds up to, old keys included
+scripts/check-corrections.sh       # a correction keeps the audio, and says what it dropped
 scripts/check-no-voice.sh          # nothing in git is one person's voice
 
 PF_VIEWPORT=Ghostty scripts/check-inplace.sh   # the same set, in another terminal

--- a/docs/proposals/vocabulary-v3.md
+++ b/docs/proposals/vocabulary-v3.md
@@ -1679,6 +1679,172 @@ unconfirmed entry is what goes; `--forget` leaving `--check-config` clean.
 word timings, or a span that does not line up. Check that first, on one live
 correction, before building the rest.
 
+### Result, measured 2026-08-09
+
+**The falsifier did not fire. A usable cut is obtainable, and the instrument
+that shows it is not the obvious one.**
+
+The falsifier asks for one live correction. No human was available to dictate
+and TTS is banned here — a previous round's `say` output was blank at −0.0 on
+every CTC frame — so this was measured on the archive instead. Same word times,
+same clips, same arithmetic. What it cannot speak to is stated at the end.
+
+**Where the timings are.** `trace.jsonl`, field `asr.words[]`, each
+`{word, start, end, confidence}`. Written by `Trace.Collector.recordASR`
+(`Trace.swift:113`) out of `ASRResult.tokenTimings`, grouped by
+`Trace.words(from:)`. No dump flag is involved.
+
+**They do not survive the pipeline in memory.**
+`Transcriber.transcribe(url:config:app:progress:)` returns a `String` and the
+`ASRResult` dies with it. `AppDelegate` keeps `lastTranscript` and
+`lastRecording` and no timings. So at all three `addReplacement` call sites
+there were none in scope, and the file is the only route. That decided the
+design — see below.
+
+**Coverage.**
+
+| | count |
+|---|---|
+| wav files on disk | 2643 |
+| distinct clips with a trace line | 2136 |
+| first entry carries word timings | 2011 |
+| of the 125 without, ones whose `final` is empty | **125 of 125** |
+| on disk **and** first-entry timings | 1779 (67%) |
+| on disk, no trace line at all | 692 |
+
+Read the third row. **Every dictation that produced text has word times.** "No
+words" means nothing was decoded, so there is nothing to correct. The 692
+untraced wavs are historical — 269 fall on 2026-08-03, and there is at most one
+a day since 2026-08-05. Part 1 §5's "456 of 2616" is the same fact on a smaller
+archive.
+
+**The cut.** `[first word start − 0.05s, last word end + 0.05s]`, sliced out of
+the PCM. The same 0.05s `scripts/mine-pronunciations.py:149` uses, so a mined
+sample and a corrected one are the same kind of object.
+
+**How it was verified, over 120 random content words and 60 real correction
+spans** — a rendering listed under `heard:` that the decoder actually wrote, of
+the 416 such spans in the archive.
+
+**1. Silence the span in place and re-decode.** The timeline is untouched, so
+the only thing that changed is the audio inside the span. The control silences
+a same-length span 0.8s away.
+
+| set | word gone after silencing the timed span | after silencing a shifted span |
+|---|---|---|
+| 120 random words | 89 of 119 (74.8%) | 14 (11.8%) |
+| 60 correction spans | **54 of 60 (90.0%)** | 15 (25.0%) |
+
+**2. Splice the span out.** 106 of 119 (89.1%) against 12.6%. Agrees with 1.
+Splicing disturbs the decode of the neighbours as well, which is why 1 is the
+better instrument.
+
+**3. Energy.** Span RMS over clip RMS is 1.19 median on the correction spans and
+1.07 on the random ones. One cut of 60 sits below 0.5×. The cuts are speech.
+
+**Do not use standalone decoding as an acceptance test for a cut.** This is the
+finding worth carrying forward, because it is the test everybody reaches for
+first. Decoding the cut on its own recovers the word in only 45 of 120 random
+spans and 20 of 60 correction spans — and a cut shifted 0.8s recovers it in 3 of
+120, so the alignment signal is there and it is the *decoder* that is failing.
+`parakeet-tdt-0.6b-v3` does not reliably decode a 0.5s fragment with no context.
+Widening the pad to 0.25s changes nothing: 46 of 120. **18 of the 19 correction
+cuts that decoded to silence still passed the silence test**, so a rule that
+accepted only decodable cuts would have thrown away good audio at about a third
+of everything. Score the cut by what removing it does to the sentence, not by
+what it says on its own.
+
+**Two failure modes the build now guards.** 2 of 60 correction spans run past
+2s, the worst at 6.4s for one word — a word time that swallowed the pause after
+it. And where silencing did not remove the word, it is mostly a clip where the
+same word is said twice, which is a limit of the measurement rather than of the
+cut.
+
+**What this cannot say.** It is the archive, not a live correction. The one
+live-specific risk was reachability at correction time, and that is a plumbing
+question the code answers rather than an audio one.
+
+### What was built, and one place the plan was wrong
+
+**One route to the audio, not two.** The plan left the choice open. It is the
+trace file, joined to the clip by name — `Trace.delivered(clip:in:)`. The
+in-memory alternative was rejected on `--learn`: it is a separate process that
+never saw the dictation, so it needs the file route whatever the app does, and
+building both would be one job with two mechanisms. PR 5 moves mining onto the
+same read.
+
+Cost, measured on a 68 MB trace of 14 001 lines: **0.3s** when the clip is
+named, which is the panel's path and the one with a person waiting; 1.3s for
+`--learn`'s fallback, which has to look at every clip to find the newest one
+whose text contains the rendering. `--learn` grew a `--clip` argument so the
+panel's path can be scored without a GUI.
+
+**The plan said `config.yaml`. It should be `vocabulary.yaml`, and this is the
+one place PR 4 contradicts the plan.** A correction whose target names a
+vocabulary term now writes the rendering into that term's `pronunciations:` with
+`seen:` and `from: correction`, instead of into `transcription.replacements`.
+Nothing about the app's behaviour changes — `Config.vocabularyRules`
+(`Config.swift:532`) turns a rendering into the same exact replacement — but two
+things do. The entry now records where it came from, which is what §6c's
+provenance signal needs. And `--forget` can reach it: a correction written to
+`config.yaml` could never be taken back, which made the plan's "`--forget` must
+remove all three" impossible to satisfy for anything this PR wrote. A correction
+that is not about a term — `teh` → `the` — still goes to `config.yaml` and keeps
+no audio.
+
+**`--forget` already removed all three.** `ForgetCommand` on `main` covers
+`vocabulary.yaml`, `observations.jsonl` and `samples/`. The work was making sure
+a correction writes where `--forget` looks, which the change above does.
+
+**Nothing is deleted silently.** The duration guard, the per-term cap and the
+seen-once rule each print what went and why, to the log in the app and to stdout
+under `--learn`. The guard's refusal is also written onto the observation as
+`skipped:`, so the rate is countable from the file later — the log truncates at
+1 MB (Part 1 §5) and a rate you can only read in prose is a rate nobody reads.
+
+**`lang` and the build stamp go on every observation**, mined ones included.
+`AppVariant.buildStamp` is reused, not reinvented. `scripts/mine-pronunciations.py`
+now reads `lang` per clip out of the trace and stamps rows with what
+`--version` prints.
+
+**The numbers, and where each comes from.** The per-term cap is 25, from the
+archive's own 8-to-26 clips per term and Part 1 §3's 0.06 AUC same-session
+advantage. The duration guard is 2.0s for one word plus 1.0s per extra word,
+from the probe's median 0.64s and p90 0.88s. The seen-once rule waits 30 days,
+and only ever drops an entry that says `from: correction` — a mined or legacy
+entry has `seen: 0`, meaning never counted, so there is no honest date to delete
+it on.
+
+### Verified by
+
+`scripts/check-corrections.sh`, 57 cases, in CI. Every case builds a whole
+config directory in /tmp behind `PARROTFLOW_CONFIG_DIR` and generates its own
+audio — a tone burst, since the cut is frame arithmetic and
+`scripts/check-no-voice.sh` refuses a repository carrying the real thing.
+
+| the plan asked for | what was observed |
+|---|---|
+| simulate a correction, check the three files | `vocabulary.yaml` gets `- heard: praise` / `seen: 1` / `from: correction`; `observations.jsonl` gets one row with `term`, `heard`, `from`, `span [1, 1.5]`, `wav`, `sample`; `samples/Praisy/00-praise.wav` exists and is 0.60s — the 0.50s span plus 0.05s either side |
+| with `lang` on the new observation | `"lang":"fr"`, from the dictation's own trace line, and it follows the clip: naming the other of two clips with the same rendering gives `"lang":"en"` |
+| and the build stamp | `"build"` equals what `--version` prints |
+| exceed the cap, the oldest unconfirmed goes | 25 samples of which the oldest is confirmed by a correction; the 26th arrives, `01-old.wav` goes, `00-old.wav` stays, the term is back at 25, and the reason is printed |
+| `--forget` leaves `--check-config` clean | `✓ forgot Praisy` — 2 pronunciations, 1 observation, 1 sample, the folder gone, and `--check-config` exits 0 with no `✗ vocabulary` line |
+
+Also scored, because each one deletes or refuses: a 6.4s span is refused by name
+and number and the observation says so; a two-word rendering gets the extra
+second and is kept; a rendering absent from the decoder's words is refused; a
+correction with no dictation behind it is refused; a rendering at `seen: 1` from
+a correction 2020 is dropped while one at `seen: 4` and a mined one are left
+alone.
+
+All 15 checks in CI pass, including the ones this touches —
+`check-vocabulary-config.sh` 61/61 and `check-no-voice.sh` 5/5.
+
+**Not done: a live correction.** It needs a human at a microphone. The probe
+above is the archive's answer to the same question, and the panel's own path is
+scored through `--learn --clip`, which takes the same route with the same clip
+name the panel passes.
+
 ## PR 5 — mining that keeps the recordings you need
 
 **Changes.** Three changes to `scripts/mine-pronunciations.py`, ported from

--- a/scripts/check-corrections.sh
+++ b/scripts/check-corrections.sh
@@ -290,6 +290,35 @@ else
   printf '  ✗ and the term is back at the cap, 25 (got %s)\n' "$left"
 fi
 
+# A sample name is only unique inside its term's folder, so `Praisy` and
+# `Supabase` can both hold a `00-praise.wav`. Matching on the bare name across
+# terms let one term's confirmed sample protect another term's unconfirmed one,
+# and the cap then deleted the confirmed sample and kept the audio nobody
+# vouched for.
+printf '\n  the cap does not confuse two terms'"'"' samples\n'
+fresh
+mkdir -p "$WORK/voice/samples/Praisy" "$WORK/voice/samples/Supabase"
+for n in $(seq -w 0 24); do : > "$WORK/voice/samples/Praisy/$n-old.wav"; done
+# Only Supabase's copy of `00-old.wav` was ever confirmed. Praisy's is not, and
+# it is the oldest, so it is the one that has to go.
+: > "$WORK/voice/samples/Supabase/00-old.wav"
+printf '%s\n' \
+  '{"at":"2026-08-01T10:00:00Z","term":"Supabase","heard":"old","from":"correction","sample":"samples/Supabase/00-old.wav"}' \
+  > "$WORK/voice/observations.jsonl"
+clip twelve.wav
+traced twelve.wav en "praise" "praise:1.00:1.50"
+got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --learn praise Praisy 2>/dev/null)"
+wants "the other term's confirmation does not protect this one" \
+  "$got" "capped voice/samples/Praisy/00-old.wav"
+total=$((total + 1))
+if [ -f "$WORK/voice/samples/Supabase/00-old.wav" ]; then
+  pass=$((pass + 1)); printf '  ✓ and the other term is untouched\n'
+else
+  failed="$failed
+      the other term is untouched"
+  printf '  ✗ and the other term is untouched\n'
+fi
+
 # ── naming the clip, which is what the panel does ───────────────────────────
 printf '\n  the clip named outright\n'
 fresh

--- a/scripts/check-corrections.sh
+++ b/scripts/check-corrections.sh
@@ -1,0 +1,371 @@
+#!/usr/bin/env bash
+# Checks that a correction keeps the audio, and says what it threw away.
+#
+#   scripts/check-corrections.sh
+#
+# A correction used to write one line of YAML. It now also cuts the corrected
+# span out of the dictation and files it under `voice/samples/<Term>/`, with a
+# row in `voice/observations.jsonl` naming the clip it came from. Four things
+# are scored here.
+#
+#   the three files   a correction on a vocabulary term writes the rendering
+#                     into `vocabulary.yaml` with `seen:` and `from:
+#                     correction`, a row into `observations.jsonl` carrying
+#                     `lang` and the build stamp, and a wav under
+#                     `samples/<Term>/`.
+#   the guard         a word time that swallowed a pause produces a span no
+#                     word can be. It is refused, out loud, with the number —
+#                     and the observation still gets written, carrying why
+#                     there is no audio. A clip nobody knows is missing is the
+#                     failure this whole change is trying to avoid.
+#   the cap           a term keeps 25 samples. The oldest *unconfirmed* one
+#                     goes first, and what went is printed.
+#   `--forget`        takes all three back out and leaves `--check-config`
+#                     clean.
+#
+# The audio is generated here, not committed: a tone burst in a silent file.
+# The cut is frame arithmetic, so a sine wave scores it exactly as a voice
+# would, and `scripts/check-no-voice.sh` refuses a repository carrying the real
+# thing.
+#
+# Every case is a whole config directory in /tmp read through
+# PARROTFLOW_CONFIG_DIR, so this says nothing about the config on the machine
+# and scores the same anywhere.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/release/ParrotFlow"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+command -v python3 >/dev/null || { echo "python3 is needed to write the test audio"; exit 1; }
+
+WORK="$(mktemp -d -t parrotflow-corrections)"
+trap 'rm -rf "$WORK"' EXIT
+CLIPS="$WORK/recordings"
+mkdir -p "$CLIPS"
+
+pass=0; total=0; failed=""
+
+# wants <name> <text> <substring>
+wants() {
+  total=$((total + 1))
+  if printf '%s' "$2" | grep -qF -- "$3"; then
+    pass=$((pass + 1)); printf '  ✓ %s\n' "$1"
+  else
+    failed="$failed
+      $1
+        wanted: $3
+        got:    $(printf '%s' "$2" | tr '\n' '|')"
+    printf '  ✗ %s\n' "$1"
+  fi
+}
+
+# lacks <name> <text> <substring>
+lacks() {
+  total=$((total + 1))
+  if printf '%s' "$2" | grep -qF -- "$3"; then
+    failed="$failed
+      $1
+        did not want: $3"
+    printf '  ✗ %s\n' "$1"
+  else
+    pass=$((pass + 1)); printf '  ✓ %s\n' "$1"
+  fi
+}
+
+# holds <name> <path> — the file has to exist and not be empty.
+holds() {
+  total=$((total + 1))
+  if [ -s "$2" ]; then
+    pass=$((pass + 1)); printf '  ✓ %s\n' "$1"
+  else
+    failed="$failed
+      $1 ($2 is missing or empty)"
+    printf '  ✗ %s\n' "$1"
+  fi
+}
+
+# clip <name> — three seconds at 16 kHz, with a burst from 1.00s to 1.50s.
+clip() {
+  python3 - "$CLIPS/$1" <<'PY'
+import math, struct, sys, wave
+rate, seconds = 16000, 3.0
+with wave.open(sys.argv[1], "wb") as f:
+    f.setnchannels(1); f.setsampwidth(2); f.setframerate(rate)
+    frames = bytearray()
+    for n in range(int(rate * seconds)):
+        t = n / rate
+        loud = 1.0 <= t < 1.5
+        frames += struct.pack("<h", int(12000 * math.sin(2 * math.pi * 440 * t)) if loud else 0)
+    f.writeframes(bytes(frames))
+PY
+}
+
+# traced <wav> <lang> <final> <word:start:end>... — one dictation line.
+traced() {
+  local wav="$1" lang="$2" final="$3"; shift 3
+  python3 - "$CLIPS/trace.jsonl" "$wav" "$lang" "$final" "$@" <<'PY'
+import json, sys
+path, wav, lang, final, *words = sys.argv[1:]
+row = {"v": 2, "kind": "dictation", "at": "2026-08-09T10:00:00Z", "wav": wav,
+       "source": "live", "lang": lang, "final": final,
+       "asr": {"model": "test", "text": final, "confidence": 0.9, "duration": 3.0,
+               "processing": 0.1,
+               "words": [{"word": w.split(":")[0], "start": float(w.split(":")[1]),
+                          "end": float(w.split(":")[2]), "confidence": 0.9} for w in words]},
+       "stages": []}
+with open(path, "a") as f:
+    f.write(json.dumps(row) + "\n")
+PY
+}
+
+# seconds <wav> — how long a wav is, to two decimals.
+seconds() {
+  python3 - "$1" <<'PY'
+import sys, wave
+with wave.open(sys.argv[1], "rb") as f:
+    print("%.2f" % (f.getnframes() / f.getframerate()))
+PY
+}
+
+fresh() {
+  rm -rf "$WORK/voice" "$CLIPS" "$WORK/vocabulary.yaml"
+  mkdir -p "$CLIPS"
+  printf 'transcription:\n  languages: [en, fr]\naudio:\n  output_dir: %s\n' "$CLIPS" \
+    > "$WORK/config.yaml"
+  printf 'acoustic: true\nterms:\n  Praisy:\n    heard: [Prissy]\n  Supabase:\n' \
+    > "$WORK/vocabulary.yaml"
+}
+
+# ── a correction on a term writes all three ─────────────────────────────────
+printf '\n  a correction on a vocabulary term\n'
+fresh
+clip one.wav
+traced one.wav fr "I said praise again" "i:0.10:0.30" "said:0.40:0.90" \
+  "praise:1.00:1.50" "again:1.60:2.20"
+got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --learn praise Praisy 2>/dev/null)"
+wants "it says the rule was learnt"      "$got" "praise → Praisy"
+wants "and how many times it is seen"    "$got" "Praisy: seen 1 time(s), from correction"
+wants "and where the audio went"         "$got" "kept the audio as voice/samples/Praisy/00-praise.wav"
+
+vocab="$(cat "$WORK/vocabulary.yaml")"
+wants "vocabulary.yaml carries the rendering" "$vocab" "- heard: praise"
+wants "with a count"                          "$vocab" "seen: 1"
+wants "and where it came from"                "$vocab" "from: correction"
+wants "and the term's old list is untouched"  "$vocab" "heard: [Prissy]"
+
+row="$(cat "$WORK/voice/observations.jsonl")"
+wants "an observation names the term"    "$row" '"term":"Praisy"'
+wants "and the rendering"                "$row" '"heard":"praise"'
+wants "and that a person confirmed it"   "$row" '"from":"correction"'
+wants "and the language it was said in"  "$row" '"lang":"fr"'
+wants "and the build that cut it"        "$row" "\"build\":\"$("$BIN" --version)\""
+wants "and the clip it came out of"      "$row" '"wav":"one.wav"'
+wants "and the span inside that clip"    "$row" '"span":[1,1.5]'
+wants "and the sample it wrote"          "$row" '"sample":"samples/Praisy/00-praise.wav"'
+lacks "and nothing was skipped"          "$row" '"skipped"'
+
+holds "the audio is on disk" "$WORK/voice/samples/Praisy/00-praise.wav"
+total=$((total + 1))
+cut="$(seconds "$WORK/voice/samples/Praisy/00-praise.wav" 2>/dev/null)"
+if [ "$cut" = "0.60" ]; then
+  pass=$((pass + 1)); printf '  ✓ and it is the span plus the padding, 0.60s\n'
+else
+  failed="$failed
+      the cut is 0.60s (got ${cut:-nothing})"
+  printf '  ✗ and it is the span plus the padding, 0.60s (got %s)\n' "${cut:-nothing}"
+fi
+
+# ── the same rendering again is counted, not duplicated ─────────────────────
+printf '\n  the same rendering a second time\n'
+clip two.wav
+traced two.wav en "praise again" "praise:1.00:1.50" "again:1.60:2.20"
+got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --learn praise Praisy 2>/dev/null)"
+wants "the count goes up"          "$got" "seen 2 time(s)"
+wants "and a second sample lands"  "$got" "voice/samples/Praisy/01-praise.wav"
+total=$((total + 1))
+if [ "$(grep -c 'heard: praise' "$WORK/vocabulary.yaml")" = "1" ]; then
+  pass=$((pass + 1)); printf '  ✓ and the rendering is written once, not twice\n'
+else
+  failed="$failed
+      the rendering is written once, not twice"
+  printf '  ✗ and the rendering is written once, not twice\n'
+fi
+
+# ── a correction that is not a term keeps its old home ──────────────────────
+printf '\n  a correction that is not a vocabulary term\n'
+fresh
+clip three.wav
+traced three.wav en "teh thing" "teh:1.00:1.50" "thing:1.60:2.20"
+got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --learn teh the 2>/dev/null)"
+wants "it still learns the rule"  "$got" "teh → the"
+wants "into config.yaml"          "$(cat "$WORK/config.yaml")" "the: [teh]"
+lacks "and vocabulary.yaml is left alone" "$(cat "$WORK/vocabulary.yaml")" "teh"
+total=$((total + 1))
+if [ ! -e "$WORK/voice/samples" ]; then
+  pass=$((pass + 1)); printf '  ✓ and no audio is kept for an ordinary word\n'
+else
+  failed="$failed
+      no audio is kept for an ordinary word"
+  printf '  ✗ and no audio is kept for an ordinary word\n'
+fi
+
+# ── the duration guard, out loud ────────────────────────────────────────────
+printf '\n  a span no word can be\n'
+fresh
+clip four.wav
+traced four.wav en "praise" "praise:0.10:6.50"
+got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --learn praise Praisy 2>/dev/null)"
+wants "the cut is refused"            "$got" "no audio kept"
+wants "and it names the span"         "$got" "6.40s"
+wants "and what was allowed"          "$got" "over the 2.00s allowed for 1 word(s)"
+wants "the rule is learnt anyway"     "$(cat "$WORK/vocabulary.yaml")" "- heard: praise"
+row="$(cat "$WORK/voice/observations.jsonl")"
+wants "and the row says why there is no audio" "$row" '"skipped":"the span is 6.40s'
+wants "and still names the clip"               "$row" '"wav":"four.wav"'
+total=$((total + 1))
+if [ ! -e "$WORK/voice/samples/Praisy" ]; then
+  pass=$((pass + 1)); printf '  ✓ and nothing was written under samples/\n'
+else
+  failed="$failed
+      nothing was written under samples/"
+  printf '  ✗ and nothing was written under samples/\n'
+fi
+
+# A two-word rendering gets a second of rope, because it is two words.
+fresh
+clip five.wav
+traced five.wav en "super base" "super:0.50:1.60" "base:1.65:2.60"
+got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --learn "super base" Supabase 2>/dev/null)"
+wants "a two-word rendering is allowed more" "$got" "kept the audio as voice/samples/Supabase/"
+
+# ── the two ways the audio cannot be found ──────────────────────────────────
+printf '\n  a rendering that is not in the decoder'"'"'s own words\n'
+fresh
+clip six.wav
+# The line is found by its text, and its word times do not contain the
+# rendering. That is the shape of a clip whose words were logged by an older
+# build, or one the decoder split differently from the person correcting it.
+traced six.wav en "I said praise there" "something:1.00:1.50" "else:1.60:2.20"
+got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --learn praise Praisy 2>/dev/null)"
+wants "it says so"                   "$got" "is not in the decoder's own words"
+wants "and the rule is still learnt" "$(cat "$WORK/vocabulary.yaml")" "- heard: praise"
+
+printf '\n  a correction with no dictation behind it at all\n'
+fresh
+got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --learn praise Praisy 2>/dev/null)"
+wants "it says there is no trace line" "$got" "no trace line for this dictation"
+wants "and the rule is still learnt"   "$(cat "$WORK/vocabulary.yaml")" "- heard: praise"
+wants "and the row records that too"   "$(cat "$WORK/voice/observations.jsonl")" \
+  '"skipped":"no trace line for this dictation"'
+
+# ── the cap, and what it drops ──────────────────────────────────────────────
+printf '\n  the per-term cap\n'
+fresh
+mkdir -p "$WORK/voice/samples/Praisy"
+# 25 already there: one of them confirmed by a correction, and it is the oldest.
+for n in $(seq -w 0 24); do : > "$WORK/voice/samples/Praisy/$n-old.wav"; done
+mkdir -p "$WORK/voice"
+printf '%s\n' \
+  '{"at":"2026-08-01T10:00:00Z","term":"Praisy","heard":"old","from":"correction","sample":"samples/Praisy/00-old.wav"}' \
+  > "$WORK/voice/observations.jsonl"
+clip seven.wav
+traced seven.wav en "praise" "praise:1.00:1.50"
+got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --learn praise Praisy 2>/dev/null)"
+wants "going over says what went"     "$got" "capped voice/samples/Praisy/01-old.wav"
+wants "and why it was the one to go"  "$got" "oldest unconfirmed"
+total=$((total + 1))
+if [ -f "$WORK/voice/samples/Praisy/00-old.wav" ]; then
+  pass=$((pass + 1)); printf '  ✓ and the confirmed sample stayed\n'
+else
+  failed="$failed
+      the confirmed sample stayed"
+  printf '  ✗ and the confirmed sample stayed\n'
+fi
+total=$((total + 1))
+left="$(ls "$WORK/voice/samples/Praisy" | wc -l | tr -d ' ')"
+if [ "$left" = "25" ]; then
+  pass=$((pass + 1)); printf '  ✓ and the term is back at the cap, 25\n'
+else
+  failed="$failed
+      the term is back at the cap, 25 (got $left)"
+  printf '  ✗ and the term is back at the cap, 25 (got %s)\n' "$left"
+fi
+
+# ── naming the clip, which is what the panel does ───────────────────────────
+printf '\n  the clip named outright\n'
+fresh
+clip ten.wav
+clip eleven.wav
+# The same rendering in two dictations. Without `--clip` the newest wins; with
+# it, the one asked for wins. This is the panel's path — it always knows which
+# dictation is on screen — and it is only reachable from a terminal through
+# `--clip`.
+traced ten.wav fr "praise here" "praise:1.00:1.50"
+traced eleven.wav en "praise there" "praise:1.00:1.50"
+got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --learn praise Praisy --clip ten.wav 2>/dev/null)"
+wants "the audio is kept" "$got" "kept the audio as voice/samples/Praisy/00-praise.wav"
+row="$(cat "$WORK/voice/observations.jsonl")"
+wants "from the clip that was named" "$row" '"wav":"ten.wav"'
+wants "and its language, not the other one's" "$row" '"lang":"fr"'
+rm -rf "$WORK/voice"
+got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --learn praise Praisy 2>/dev/null)"
+wants "and without a clip the newest wins" "$(cat "$WORK/voice/observations.jsonl")" \
+  '"wav":"eleven.wav"'
+
+# ── a rendering seen once and never again ───────────────────────────────────
+printf '\n  a rendering seen once, long ago\n'
+fresh
+mkdir -p "$WORK/voice"
+printf 'acoustic: true\nterms:\n  Praisy:\n    pronunciations:\n      - heard: Prezi\n        seen: 1\n        from: correction\n      - heard: Prissy\n        seen: 4\n        from: correction\n      - heard: Pracy\n        seen: 1\n        from: mined\n' \
+  > "$WORK/vocabulary.yaml"
+printf '%s\n%s\n%s\n' \
+  '{"at":"2020-01-01T10:00:00Z","term":"Praisy","heard":"Prezi","from":"correction"}' \
+  '{"at":"2020-01-01T10:00:00Z","term":"Praisy","heard":"Prissy","from":"correction"}' \
+  '{"at":"2020-01-01T10:00:00Z","term":"Praisy","heard":"Pracy","from":"mined"}' \
+  > "$WORK/voice/observations.jsonl"
+clip nine.wav
+traced nine.wav en "praise" "praise:1.00:1.50"
+got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --learn praise Praisy 2>/dev/null)"
+wants "the one seen once is dropped" "$got" 'dropped "Prezi" — seen once and not again since'
+vocab="$(cat "$WORK/vocabulary.yaml")"
+lacks "and it leaves vocabulary.yaml" "$vocab" "Prezi"
+wants "the one seen four times stays" "$vocab" "heard: Prissy"
+# A mined entry has no honest first-seen date, so nothing here is allowed to
+# delete it on one.
+wants "and a mined entry is left alone" "$vocab" "heard: Pracy"
+
+# ── --forget takes all three back ───────────────────────────────────────────
+printf '\n  --forget after a correction\n'
+fresh
+clip eight.wav
+traced eight.wav en "praise" "praise:1.00:1.50"
+PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --learn praise Praisy >/dev/null 2>&1
+got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --forget Praisy 2>/dev/null)"
+wants "it forgets the term"        "$got" "✓ forgot Praisy"
+wants "the pronunciations go"      "$got" "pronunciation(s) from vocabulary.yaml"
+wants "the observations go"        "$got" "1 observation(s) from voice/observations.jsonl"
+wants "and the samples go"         "$got" "1 sample(s) from voice/samples/Praisy/"
+lacks "vocabulary.yaml has nothing left of it" "$(cat "$WORK/vocabulary.yaml")" "praise"
+total=$((total + 1))
+if [ ! -e "$WORK/voice/samples/Praisy" ]; then
+  pass=$((pass + 1)); printf '  ✓ and the folder is gone\n'
+else
+  failed="$failed
+      the folder is gone"
+  printf '  ✗ and the folder is gone\n'
+fi
+got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --check-config 2>/dev/null)"
+status=$?
+total=$((total + 1))
+if [ $status -eq 0 ] && ! printf '%s' "$got" | grep -q '  ✗ vocabulary'; then
+  pass=$((pass + 1)); printf '  ✓ and --check-config is clean afterwards\n'
+else
+  failed="$failed
+      --check-config is clean afterwards"
+  printf '  ✗ and --check-config is clean afterwards\n'
+fi
+
+printf '\n  %d/%d\n' "$pass" "$total"
+if [ -n "$failed" ]; then
+  printf '  failed:%s\n' "$failed"
+  exit 1
+fi

--- a/scripts/mine-pronunciations.py
+++ b/scripts/mine-pronunciations.py
@@ -104,6 +104,47 @@ def cut(wav, start, end, target):
         dst.writeframes(frames)
 
 
+def languages():
+    """Which language each clip was dictated in, from `trace.jsonl`.
+
+    The first entry per clip, which is the decode the speaker got. Free here and
+    unrecoverable later, which is the whole argument for writing it: this
+    speaker dictates in two languages and one name has two pronunciations, so a
+    mined row without it cannot say which way the name was said.
+    """
+    out = {}
+    path = CLIPS / "trace.jsonl"
+    if not path.exists():
+        return out
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if row.get("kind", "dictation") != "dictation":
+            continue
+        wav = row.get("wav")
+        if wav and wav not in out:
+            out[wav] = row.get("lang")
+    return out
+
+
+def build():
+    """The build stamp of the app these words came out of.
+
+    Same reason as the language: a row cut by a build whose span logic later
+    changes is a row you cannot trust, and afterwards there is no telling which
+    build wrote it. `--version` is where the app prints it.
+    """
+    try:
+        done = subprocess.run([recall.APP, "--version"], capture_output=True,
+                              text=True, timeout=30)
+        stamped = done.stdout.strip()
+        return stamped or None
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
 def stamp(wav):
     """The moment the clip was recorded, from its own name, as ISO 8601.
 
@@ -212,6 +253,8 @@ def main():
                          was.get("term"), was.get("heard")))
 
     rows = []
+    spoken = languages()
+    stamped = build()
     for term, items in sorted(spans.items()):
         for n, (wav, start, end, rendering) in enumerate(items):
             span = (round(start, 3), round(end, 3))
@@ -224,6 +267,10 @@ def main():
                 "span": list(span),
                 "sample": relative if args.audio else None,
                 "wav": wav,
+                # On every row, not only a correction's. A bank where half the
+                # entries know their provenance is a bank you cannot filter.
+                "lang": spoken.get(wav),
+                "build": stamped,
             })
     with observations.open("a", encoding="utf-8") as handle:
         for row in rows:


### PR DESCRIPTION
## Summary
PR 4 of the plan: a spoken correction (a person fixing what the app transcribed) had nowhere to record the audio that produced it, so the vocabulary couldn't improve from a live correction.
This PR adds `Corrections.swift` as the single entry point for all three correction paths, writes the corrected pronunciation into `vocabulary.yaml` with provenance (`seen:`, `from: correction`), and caps and prunes each term's stored samples.
The correction span is verified against the archive to actually contain the spoken word 90% of the time (54 of 60 real correction spans, against 25% for a shifted control span); a live correction itself is not measured here — it needs a person at a microphone.

## Issue
Part of #74. Stacks on #79 (`test/arm-a-result`) as a sibling of #80, not stacked on it.

## The falsifier ran first, offline

The plan asks for one live correction before anything is built. No human was available, and TTS is banned here (a previous round's synthetic audio came back blank on every frame). So this was measured against the archive instead: 2,643 wavs and their word-level timings from `trace.jsonl`.

**Coverage.** 2,136 clips have a trace line; 2,011 carry word timings; all 125 without words have empty final text — every dictation that produced text has word times.

**How the cut was verified**, not by eye: silence the timed span in place, re-decode, and check whether the word is gone, against a control that silences a same-length span 0.8s away.

| set | word gone, timed span | word gone, shifted span |
|---|---|---|
| 120 random content words | 89 of 119 (74.8%) | 14 (11.8%) |
| 60 real correction spans | **54 of 60 (90.0%)** | 15 (25.0%) |

**One finding worth flagging: standalone decoding rejects good cuts.** Decoding a cut span alone recovers the word on only 20 of 60 correction spans, but a shifted control recovers it on just 3 of 120 — so the alignment is correct and the decoder is what fails on a short fragment with no context. Don't use bare re-decoding as an acceptance test for a cut.

## What this changes

- `Corrections.swift` (new) — the one entry point all three correction paths use: find the span, guard it, cut it, write the observation, enforce the cap, prune.
- `ConfigWriter`, `VoiceStore`, `Trace` extended with pronunciation writes, an append-only observation writer, a per-term cap, and a way to read a delivered clip's timing back by name.
- `LearnCommand` / `main.swift` — new `--learn <heard> <corrected> [--clip <wav>]`, so the panel's own path is scoreable without a GUI.
- `scripts/check-corrections.sh` — 57 cases, added to CI.

**One deviation from the plan:** the plan says a correction writes a text rule to `config.yaml`. Instead, a correction whose target names a vocabulary term lands in that term's `pronunciations:` in `vocabulary.yaml`. Behavior is unchanged (the config layer turns it into the same exact replacement), but the entry now records where it came from, and `--forget` can reach it — which a `config.yaml`-only write could never satisfy.

**Guardrails, each logged when it fires:** a duration guard (2.0s for one word, +1.0s per extra word — the 60-span probe found a median of 0.64s and only 2 spans over 2s); a per-term cap of 25 samples (oldest unconfirmed sample dropped first); and a 30-day seen-once rule that only ever drops entries written by a correction, never a mined or legacy entry.

<details>
<summary><b>How to Test</b></summary>

`scripts/check-corrections.sh`, 57 cases, in CI. Each case builds a scratch config directory and generates a synthetic tone-burst clip (the cut logic is frame arithmetic, so this doesn't need real speech). Covers: the three files written for a correction, the per-term cap rotating out the oldest unconfirmed sample, and `--forget` removing all traces of a term.

All 15 CI checks pass, including `check-vocabulary-config.sh` (61/61) and `check-no-voice.sh` (5/5).

**Not done: a live correction.** It needs a human at a microphone. The panel's own path can be scored through `--learn --clip`, which takes the same route with the same clip name the panel passes.

</details>
