### PR TITLE
test: how much of the veto one bad clip destroys (PR 6a)

### DIFF
--- a/docs/proposals/vocabulary-v3.md
+++ b/docs/proposals/vocabulary-v3.md
@@ -544,6 +544,17 @@ term. **One bad clip disarms the veto for that whole term.** The code's own
 comment says so and names two, both mined automatically:
 `Vercel/09-brazil.wav` and `Tasmeen/06-that'smeanssend.wav`.
 
+**Measured, 6a.** The mechanism is real and it is large. One bad clip injected
+into each of the nine clean folders takes the veto from 554 true rejections to
+228 across the eleven terms, and widens the tightest banks by about half a unit
+— `Supabase` 2.919 to 3.430, `Arexvy` 3.031 to 3.603. **But the two clips named
+above are not the clips that set the spread.** `Tasmeen`'s maximum is held by
+`01-tasmin.wav` and `Vercel`'s by `13-versal.wav`, both real recordings of the
+term. `06-that'smeanssend.wav` is 5th of 8 and `09-brazil.wav` is 8th of 16.
+Removing them changes nothing and makes it worse: taking `09-brazil.wav` out
+*raises* `Vercel`'s spread, 3.178 to 3.235. A bad clip with company never sets a
+maximum. The result block under 6a has the numbers.
+
 **The query side is far safer, and that asymmetry matters.** `distance` is a
 `min`, so a bad clip only counts when it is the nearest thing to the span being
 judged. A bad clip is by definition unlike the term, so for a genuine utterance
@@ -575,8 +586,13 @@ correctness, not from robustness. Round 7 found the distance scale differs per
 term. It differs per pronunciation for the same reason, and one number over both
 clusters describes neither.
 
-**This part is arithmetic, not a measurement.** Nobody has measured a bilingual
-term's spread. In the prototype log `Matthieu` sits at 3.053 over 10 recordings,
+**This part is arithmetic, not a measurement, and 6a could not measure it.**
+Nobody has measured a bilingual term's spread. 6a looked and found no second
+pronunciation in the archive to measure: no observation carries `lang`, all
+eleven `Matthieu` recordings come from dictations `trace.jsonl` marks `en`, and
+splitting them by what the decoder wrote gives one cluster, not two — 3.216
+within a group against 3.250 between, AUC 0.513. It needs a recording session,
+which is 6c's second verification. In the prototype log `Matthieu` sits at 3.053 over 10 recordings,
 which is unremarkable next to `Claude` at 3.436 over 6 — so either both its
 clusters are covered or the effect is smaller than the variation between terms.
 PR 6a should measure it.
@@ -1781,6 +1797,261 @@ rises. The same pair with the robust statistic says how much robustness buys.
 
 **Falsified if** poisoning a term barely moves its AUC. Then `spread` is not the
 weak point, §7's argument is wrong, and 6b and 6c are not worth doing.
+
+### Result, measured 2026-08-09
+
+**The falsifier's condition fired and its conclusion is false. Build 6b and
+6c.** Poisoning a term does barely move its AUC — nine of the eleven arms do not
+move it at all. That is arithmetic, not evidence. Inside one term `spread` is a
+constant, so an AUC over that term's spans cannot see it, whatever it does. The
+number that can see it is the rule's own decision, and it collapses: over the
+eleven arms one clip takes the veto from **554 true rejections to 228**, and
+buys back 8 of its 10 false ones. §7 is right about the mechanism and the
+falsifier was written against a statistic that cannot detect it.
+
+**And the two clips §7 names are not the clips that set the spread.** That is
+new, and it changes what 6c has to find.
+
+No app, no build, no model. `scripts/reference-matching.py` with a `--poison`
+arm, 122 recordings, 170 spans, every distance computed once. It is
+deterministic — no decoder, no replay, so a number here is exact for this data.
+Nothing under `~/.config/parrotflow-dev/` was written: the arms run on a copy.
+
+**This is in-sample and the plan says so twice already.** The recordings were
+mined from the clips they are scored on. The per-clip hold-out is applied
+throughout, and it does not cover the corpus-level fit. Read every absolute
+number below as better than the truth by an unknown margin. The *deltas* are
+what this experiment is for.
+
+#### The baseline reproduces round 7 exactly
+
+`--set scripted --source all`: `Supabase` 1.000, `Redrock` 0.993, `Tasmeen`
+0.985, `Redcrawl` 0.966, `Mirza` 0.940, `Arexvy` 0.936, `Ollama` 0.874,
+`Matthieu` 0.848, `Claude` 0.844, pooled **0.935** over 63 A and 718 B. The
+control is 0.832 on A and 0.076 on B, 58/63 and 13/718. Duration alone is
+0.535. Every figure matches the round 7 table to three decimals. The archive is
+still 122 recordings over 11 terms.
+
+#### AUC and spread, one bad clip added
+
+`Vercel/09-brazil.wav` injected into the nine folders that have no known bad
+clip. `Vercel` and `Tasmeen` run backwards: their own bad clip is removed.
+AUC is on the scripted set, except `Praisy` and `Vercel`, which have no scripted
+recording and so no A row there — those two are on round 5's proposal set and
+are marked.
+
+| term | rec | AUC before | AUC after | spread before | spread after |
+|---|---|---|---|---|---|
+| arexvy | 7→8 | 0.936 | 0.936 | 3.031 | **3.603** |
+| claude | 6→7 | 0.844 | 0.844 | 3.436 | 3.576 |
+| matthieu | 11→12 | 0.848 | 0.844 | 3.053 | **3.570** |
+| mirza | 15→16 | 0.940 | 0.940 | 3.257 | 3.257 |
+| ollama | 7→8 | 0.874 | 0.874 | 3.313 | 3.516 |
+| praisy | 26→27 | 0.869 † | 0.869 † | 3.235 | 3.425 |
+| redcrawl | 8→9 | 0.966 | 0.966 | 3.098 | 3.338 |
+| redrock | 7→8 | 0.993 | 0.993 | 2.999 | **3.438** |
+| supabase | 11→12 | 1.000 | 1.000 | 2.919 | **3.430** |
+| tasmeen ‡ | 8→7 | 0.985 | 0.987 | 3.268 | 3.268 |
+| vercel ‡ | 16→15 | 0.933 † | 0.933 † | 3.178 | 3.235 |
+
+† on the proposal set, 21 A / 37 B for `Praisy` and 6 A / 5 B for `Vercel`.
+‡ the bad clip removed, not added.
+
+**AUC does not move and it cannot.** Nine of the eleven arms are identical to
+three decimals. `Matthieu` moves 0.004 on 448 A-B pairs and `Tasmeen` 0.002 on
+390, which is two pair-flips and one. The reason is in the arithmetic: AUC ranks spans inside one term, and
+`spread` is one number for the whole term, so it divides out. The only route
+from a bad clip to AUC is the query side — `distance` is a `min`, so a bad clip
+lowers it when it happens to be nearest. §7 predicted that route would be small.
+Measured, it is between nothing and 0.004.
+
+**Spread moves a lot, on a clean bank.** The four bold rows are the four
+tightest banks. `Supabase` widens 0.511, `Arexvy` 0.572, `Redrock` 0.439,
+`Matthieu` 0.517. One clip, and the cloud is half a unit wider.
+
+#### The veto, which is what the spread decides
+
+Same arms, scored as `ReferenceMatch.verdict` scores them: reject when
+`distance > 1.0 × spread`, abstain under three recordings, hold out any
+recording cut from the span's own clip. A count pools both sets — every span the
+term is scored against.
+
+| term | veto B before | veto B after | veto A before | veto A after |
+|---|---|---|---|---|
+| arexvy | 55/66 (83%) | **1/66 (2%)** | 1/6 | 0/6 |
+| claude | 18/70 (26%) | 5/70 (7%) | 1/6 | 0/6 |
+| matthieu | 50/67 (75%) | **2/67 (3%)** | 2/10 | 0/10 |
+| mirza | 36/67 (54%) | 35/67 (52%) | 1/8 | 1/8 |
+| ollama | 34/67 (51%) | 10/67 (15%) | 0/7 | 0/7 |
+| praisy | 66/108 (61%) | 12/108 (11%) | 1/21 | 0/21 |
+| redcrawl | 58/66 (88%) | 25/66 (38%) | 1/8 | 0/8 |
+| redrock | 62/65 (95%) | 14/65 (22%) | 1/7 | 0/7 |
+| supabase | 62/64 (97%) | **16/64 (25%)** | 0/10 | 0/10 |
+| tasmeen ‡ | 42/68 (62%) | 43/68 (63%) | 1/7 | 1/7 |
+| vercel ‡ | 71/76 (93%) | 65/76 (86%) | 1/6 | 0/6 |
+| **total** | **554** | **228** | **10** | **2** |
+| reject everything | 784 | 784 | 96 | 96 |
+
+**B is the rule working and A is the rule costing.** A B span is a name that was
+not said, or an ordinary word the app wrote a name over. Dropping it is the
+whole point. An A span is the name really being said, and dropping it is a loss.
+
+**One clip disarms the veto.** `Arexvy` goes from catching 83% of the spans it
+should catch to 2%. `Matthieu` 75% to 3%. `Supabase`, the term with a perfect
+AUC, 97% to 25%. Across the eleven arms 326 of 554 true rejections go, and 8 of
+the 10 false ones go with them. Forty true rejections lost for each false one
+saved.
+
+**The blind control is in the table.** Rejecting everything takes all 784 B
+spans and all 96 A spans. So the clean rule at 554/10 sits well inside it and
+the poisoned rule at 228/2 has moved a long way towards doing nothing. This is
+an offline count of rejections, not the three-arm ablation. It does not say what
+any of this scores on 141 clips. That is 6b's job and 6b's bar is still 103.
+
+#### The two clips §7 names are not the clips that set the spread
+
+This is the surprise, and it was measurable only because the arm was run
+backwards.
+
+| term | the clip that holds the leave-one-out maximum | where the named bad clip ranks |
+|---|---|---|
+| tasmeen | `01-tasmin.wav` at 3.268 | `06-that'smeanssend.wav` is #5 of 8, at 2.462 |
+| vercel | `13-versal.wav` at 3.178 | `09-brazil.wav` is #8 of 16, at 3.005 |
+
+Both maxima are held by real recordings of the term. Removing
+`Tasmeen/06-that'smeanssend.wav` changes the spread by nothing at all, 3.268 to
+3.268, and the veto by one span. Removing `Vercel/09-brazil.wav` makes the
+spread **worse**, 3.178 to 3.235, and costs 6 true rejections — the clip was
+some other recording's nearest neighbour, so taking it out pushed that
+recording's leave-one-out distance up.
+
+**Why:** a bad clip with company is invisible to a maximum. `Tasmeen`'s eight
+recordings include `06-that'smeanssend`, `07-thatmeans`, `03-dasmean` and
+`04-dasmean`. Those sit near each other, so each has a close neighbour and none
+of them is ever the largest leave-one-out distance. The same shape explains
+`Mirza`, whose spread does not move when a bad clip is added: `13-mirza's.wav`
+already sits at 3.257, farther out than the injected clip.
+
+**Three things follow for 6c.** First, leave-one-out self-consistency is the
+first signal in 6c's list and it does not find either named clip. Second, a
+pruner that deletes the farthest recording deletes a real one — `01-tasmin.wav`
+and `13-versal.wav` are the term. Third, pruning one bad clip out of a group of
+bad clips can raise the spread, so 6c must handle groups, not singletons. 6c
+already says "suspect only a far singleton"; this says the singleton assumption
+is wrong on the two clips it was written for.
+
+#### The robust statistic buys most of it back
+
+The same arms with the 90th percentile of the leave-one-out distances in place
+of the maximum. Nothing else changes.
+
+| statistic | veto B clean | veto B poisoned | kept | veto A clean | veto A poisoned |
+|---|---|---|---|---|---|
+| maximum | 554 | 228 | 41% | 10 | 2 |
+| 90th percentile | 649 | 551 | 85% | 17 | 8 |
+| reject everything | 784 | 784 | — | 96 | 96 |
+
+**It is better on both a clean bank and a poisoned one.** Clean, it takes 649
+true rejections against the maximum's 554, at a cost of 7 more false ones — 17
+of 96 rather than 10 of 96. Poisoned, it holds 551 where the maximum holds 228.
+
+Per term, poisoned, the collapses stop being collapses: `Arexvy` 86%→68% rather
+than 83%→2%, `Matthieu` 75%→75% rather than 75%→3%, `Supabase` 100%→97% rather
+than 97%→25%. `Claude` is the one that still falls hard, 66%→16%, and it is the
+term with six recordings — at n=6 the 90th percentile is nearly the maximum.
+`Redrock` falls 98%→65%, and it has seven.
+
+**So the robust statistic is worth building, and it does not finish the job.**
+Below about eight recordings a high quantile is the maximum again. That is an
+argument for PR 4 and PR 5 — more clips per term — as much as for 6b.
+
+#### The second pronunciation arm could not be run. The data is not there.
+
+**Do not read the sweep below as a bilingual result.** The archive holds no
+identified second pronunciation of any term, and this is the honest report of
+looking for one.
+
+**`lang` is absent and would not have helped.** No observation carries it — PR 4
+is what would write it and PR 4 is not built. Joining
+`voice/observations.jsonl` to `trace.jsonl` by the source clip recovers the tag
+anyway, and all eleven `Matthieu` recordings come from dictations marked `en`.
+That includes the one clip where the speaker plainly says the name twice:
+`parrotflow-2026-08-09T14-04-44.wav`, decoded "That was Matthew that was
+Mathieu's idea, to be fair", which produced `09-matthew.wav` and
+`10-mathieu's.wav`.
+
+**Splitting by what the decoder wrote does not give two clusters.** Six
+recordings are rendered `matthew`, `matsu` or `match's` and five `mathieu` or
+`mathieu's`. Measured, the two groups sit on top of each other: mean distance
+within a group 3.216 over 25 pairs, between groups 3.250 over 30, AUC 0.513
+against 0.500 for one cluster. So either the speaker says it one way, or MFCC
+and DTW cannot tell the two apart on a half-second name. This method cannot
+distinguish those, and neither can any number in this plan.
+
+That leaves §7's prediction — that a thin second cluster inflates `spread` and
+the damage peaks at one or two clips — **unmeasured**. The sweep runs, but with
+groups that are not clusters it only says what adding any clip does:
+
+| bank | rec | AUC | spread | veto B | veto A |
+|---|---|---|---|---|---|
+| 6 anglicised + 0 | 6 | 0.844 | 3.253 | 36/67 | 2/10 |
+| 6 anglicised + 1 | 7 | 0.842 | 3.253 | 37/67 | 2/10 |
+| 6 anglicised + 2 | 8 | 0.855 | 3.189 | 43/67 | 2/10 |
+| 6 anglicised + 3 | 9 | 0.866 | 3.189 | 43/67 | 2/10 |
+| 6 anglicised + 4 | 10 | 0.855 | 3.189 | 39/67 | 2/10 |
+| 6 anglicised + 5 | 11 | 0.848 | 3.053 | 50/67 | 2/10 |
+
+Spread falls and the veto strengthens as clips arrive. There is no peak at one
+or two. That is what adding *correct* clips does to a maximum, and it is the
+mirror of the poison result: a clip near the bank can only shorten somebody's
+leave-one-out distance, and a clip far from it sets a new maximum.
+
+**To measure §7's prediction somebody has to record the second pronunciation on
+purpose.** 6c's second verification asks for exactly that — read `Matthieu` both
+ways, several of each. Until that session happens, "a bilingual term poisons its
+own threshold" stays an argument. No `say`-generated clip: TTS output has come
+back blank on every CTC frame before and cost a round of results.
+
+#### What is weak about this
+
+**In-sample, and the poison is one clip.** Every arm injects the same recording,
+`Vercel/09-brazil.wav`. A different bad clip would move a different amount. The
+direction is not in doubt — eight of the nine injected banks widened — but the
+size of the move is one clip's worth of evidence per term.
+
+**Rejection counts are not the ablation.** They say what the rule would drop on
+these spans. They do not say what the app would write, and the 141-clip score is
+the only thing that settles 6b.
+
+**A one-span move means nothing.** `Mirza` 36→35 and `Tasmeen` 42→43 are one
+span on a denominator near 67. Read only the large moves: the seven terms that
+lost more than 20 true rejections each.
+
+**`Claude`, `Redcrawl` and `Redrock` have no spontaneous recording**, so their
+rows are read speech against read speech from one session. Round 7 already flags
+that, and the poison deltas inherit it.
+
+#### How to reproduce
+
+```sh
+S=$(mktemp -d) && cp -R ~/.config/parrotflow-dev/voice "$S/voice"   # read only
+
+git show origin/spike/exemplars-round-2:scripts/reference-matching.py \
+  > scripts/reference-matching.py          # then the --poison arm on top
+
+PARROTFLOW_CONFIG_DIR=$S python3 scripts/reference-matching.py \
+  --set scripted --source all              # the baseline that must reproduce
+
+PARROTFLOW_CONFIG_DIR=$S python3 scripts/reference-matching.py \
+  --poison --pronunciation --cache "$S/dist.npz"
+PARROTFLOW_CONFIG_DIR=$S python3 scripts/reference-matching.py \
+  --poison --pronunciation --robust --cache "$S/dist.npz"
+```
+
+The first `--poison` run computes every span-to-recording and
+recording-to-recording distance and caches them, under ten minutes. Every arm
+after that is indexing and returns at once. `--inject` picks a different bad
+clip.
 
 ### 6b — a rule that is not decided by one clip
 

--- a/scripts/reference-matching.py
+++ b/scripts/reference-matching.py
@@ -1,0 +1,1123 @@
+#!/usr/bin/env python3
+"""Does a span of audio sound like a recording of the term it was offered?
+
+    scripts/reference-matching.py                  # the report
+    scripts/reference-matching.py --table FILE     # the per-proposal distances
+    scripts/reference-matching.py --source round6  # only round 6's recordings
+    scripts/reference-matching.py --poison         # PR 6a, below
+
+**PR 6a lives at the bottom of this file, under `--poison`.** It asks a
+different question from the rest: not how well the distance separates, but how
+much of the *rule* one bad recording destroys. `ReferenceMatch.verdict` sets
+`spread` to the largest leave-one-out distance between a term's recordings, so
+one clip that is not the term widens the cloud for every proposal of that term.
+`--poison` adds such a clip to each folder and re-measures; where a folder
+already holds one it takes it out instead. `--robust` swaps the maximum for the
+90th percentile, which is what PR 6b proposes. Nothing is written to the voice
+store: point `PARROTFLOW_CONFIG_DIR` at a copy.
+
+Everything acoustic tried so far scores a *spelling* against audio. Round 5
+measured that and it is inverted: AUC 0.318 separating "the term was said"
+from "the term was not said". This asks the other question. Compare the span
+to **real recordings of the speaker saying the term**, and skip the model's
+opinion about the spelling entirely.
+
+    A   the term was said       the label puts the term at this span
+    B   the term was NOT said   the label puts an ordinary word there
+
+Both groups come from `tests/raw-score-separation.json`, condition `cbw0`
+(vocabulary bonus at zero), deduplicated the same way round 5 deduplicates:
+one row per clip, term stem, word range and proposal kind, so three replays
+of the same proposal count once.
+
+The recordings come from the voice store, `voice/samples/<Term>/`, mined by
+`scripts/mine-pronunciations.py`. Round 6 had four terms with any recording —
+Praisy (17), Vercel (7), Matthieu (2), Supabase (1) — and dropped every other
+term, including the two that actually cost clips. Round 7 has eleven terms,
+from two sources:
+
+    spontaneous   mined from the archive of ordinary dictation
+    scripted      mined from 48 lines read from a script on 2026-08-09
+
+`--source` picks between them. `all` is the default, `scripted` and
+`spontaneous` isolate one, and `round6` reads `tests/acoustic/` off the frozen
+branch instead, which is what round 6 measured. Read speech is more careful
+than dictation, so `scripted` against `spontaneous` on the terms both cover is
+the honest way to ask whether the new recordings flatter the result.
+
+The measurement, per proposal:
+
+    1. cut the span out of its clip, padded 0.05s each side, the same cut
+       mine-pronunciations.py makes — a word's edges are where it is least
+       clear;
+    2. MFCCs for the span and for every exemplar;
+    3. DTW distance to each exemplar, take the nearest.
+
+**The exemplars were mined from these same clips**, so an exemplar can be the
+very span it is being compared to. Any exemplar from the proposal's own clip is
+held out. Without that the A group scores against copies of itself.
+
+The hold-out needs to know which clip each exemplar came from.
+`voice/observations.jsonl` records it, one row per sample. The frozen
+`tests/acoustic/` predates that file, so those are traced the way round 6
+traced them: the cut copies frames straight out of the clip, so the exemplar's
+bytes appear verbatim in exactly one archive file.
+
+The hold-out still bites. The scripted recordings come from clips the proposal
+set does not contain, so nothing there can compare against itself — but the
+spontaneous ones are mined from the very archive the proposals come from, and
+without the hold-out Praisy and Vercel would score against copies of
+themselves. It is checked and reported below, per source.
+
+The control that decides whether the headline means anything is the distance
+to exemplars of a *different* term. If a Praisy span sits as close to Vercel
+recordings as to Praisy recordings there is no discrimination and the A/B
+number was luck.
+
+numpy only. The MFCC and the DTW are written out below rather than pulled in
+from librosa: forty lines against a heavy dependency for a spike.
+
+**No model call anywhere.** No app, no decoder, no Ollama. Reads wavs.
+"""
+import argparse
+import json
+import os
+import re
+import statistics
+import subprocess
+import sys
+import wave
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parent.parent
+CLIPS = Path.home() / "Recordings/ParrotFlow Dev"
+CACHE = ROOT / "tests/raw-score-separation.json"
+CACHE_REF = "origin/spike/raw-score-separation:tests/raw-score-separation.json"
+FROZEN = ROOT / "tests/acoustic"             # gitignored: this is a voice
+FROZEN_REF = "origin/feat/vocabulary-skills-only"
+CONDITION = "cbw0"
+PAD = 0.05
+RATE = 16000
+# The day the 48 lines were read from the script. Everything mined from a clip
+# recorded that day is read speech; everything else is dictation.
+SCRIPTED_DAY = "2026-08-09"
+
+
+def config_dir():
+    override = os.environ.get("PARROTFLOW_CONFIG_DIR", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".config/parrotflow-dev"
+
+
+def voice_dir():
+    return config_dir() / "voice"
+
+
+# ------------------------------------------------------------------- the cache
+
+def norm(word):
+    return re.sub(r"[^\w']", "", word or "").lower()
+
+
+def stem(word):
+    """A term and its possessive or plural are the same name."""
+    w = norm(word)
+    for suffix in ("'s", "s'", "s"):
+        if len(w) > 3 and w.endswith(suffix):
+            return w[: -len(suffix)]
+    return w
+
+
+def load_proposals():
+    """Round 5's A and B rows, deduplicated round 5's way."""
+    if not CACHE.exists():
+        blob = subprocess.run(["git", "show", CACHE_REF], cwd=ROOT,
+                              capture_output=True, text=True)
+        if blob.returncode:
+            print(f"✗ no {CACHE} and no {CACHE_REF}", file=sys.stderr)
+            return []
+        CACHE.write_text(blob.stdout)
+    block = json.loads(CACHE.read_text())["proposals"]
+    rows = [dict(zip(block["columns"], r)) for r in block["rows"]]
+    seen = {}
+    for r in rows:
+        if r["condition"] != CONDITION or r["kind"] == "wider":
+            continue
+        if r.get("spot") is None:
+            continue
+        key = (r["wav"], stem(r["term"]), r["first"], r["last"], r["kind"])
+        seen.setdefault(key, []).append(r)
+    return [group[0] for group in seen.values()]
+
+
+def load_frozen():
+    """Round 6's recordings: tests/acoustic/ off the frozen branch, once."""
+    if not FROZEN.exists():
+        listed = subprocess.run(
+            ["git", "ls-tree", "-r", "--name-only", FROZEN_REF, "tests/acoustic/"],
+            cwd=ROOT, capture_output=True, text=True)
+        for name in listed.stdout.split():
+            if not name.endswith(".wav"):
+                continue
+            blob = subprocess.run(["git", "show", f"{FROZEN_REF}:{name}"],
+                                  cwd=ROOT, capture_output=True)
+            target = ROOT / name
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(blob.stdout)
+    out = []
+    for path in sorted(FROZEN.rglob("*.wav")):
+        out.append({"term": stem(path.parent.name), "source": "round6",
+                    "name": f"{path.parent.name}/{path.name}",
+                    "from": None, "samples": read(path)})
+    return out
+
+
+def load_voice():
+    """The voice store, with the clip each sample was cut from.
+
+    `observations.jsonl` names it, so nothing has to be searched for. A row
+    whose sample was never cut, or was cut and then deleted, is skipped.
+    """
+    voice = voice_dir()
+    log = voice / "observations.jsonl"
+    if not log.exists():
+        return []
+    out = []
+    for line in log.read_text(encoding="utf-8").splitlines():
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        relative = row.get("sample")
+        if not relative or not (voice / relative).exists():
+            continue
+        out.append({"term": stem(row["term"]),
+                    "source": "scripted" if SCRIPTED_DAY in (row.get("wav") or "")
+                              else "spontaneous",
+                    "name": relative.replace("samples/", ""),
+                    "from": row.get("wav"),
+                    "samples": read(voice / relative)})
+    return out
+
+
+def load_exemplars(source):
+    if source == "round6":
+        return load_frozen()
+    got = load_voice()
+    if source != "all":
+        got = [e for e in got if e["source"] == source]
+    return got
+
+
+def read(path, start=None, end=None):
+    """int16 mono samples, optionally the span between two times in seconds."""
+    with wave.open(str(path), "rb") as src:
+        rate, frames = src.getframerate(), src.getnframes()
+        first = 0 if start is None else max(0, int(start * rate))
+        last = frames if end is None else min(frames, int(end * rate))
+        if last <= first:
+            return np.zeros(0, dtype=np.float64)
+        src.setpos(first)
+        raw = src.readframes(last - first)
+    data = np.frombuffer(raw, dtype="<i2").astype(np.float64)
+    if src.getnchannels() > 1:
+        data = data.reshape(-1, src.getnchannels()).mean(axis=1)
+    return data
+
+
+def provenance(exemplars, wavs):
+    """Which clip each exemplar was cut from, by searching for its samples.
+
+    mine-pronunciations.py copies frames straight out of the clip, so the
+    exemplar's bytes appear verbatim in exactly one archive file. Only the
+    frozen `tests/acoustic/` needs this: the voice store records the clip in
+    `observations.jsonl` and is already answered. Without one or the other an
+    exemplar can be compared against itself.
+    """
+    exemplars = [e for e in exemplars if not e.get("from")]
+    if not exemplars:
+        return {}
+    source = {}
+    buffers = {}
+    for wav in wavs:
+        path = CLIPS / wav
+        if path.exists():
+            with wave.open(str(path), "rb") as src:
+                buffers[wav] = src.readframes(src.getnframes())
+    for ex in exemplars:
+        needle = ex["samples"].astype("<i2").tobytes()
+        for wav, buf in buffers.items():
+            if buf.find(needle) >= 0:
+                source[ex["name"]] = wav
+                break
+    return source
+
+
+# -------------------------------------------------------------------- the MFCC
+
+def mel(hz):
+    return 2595.0 * np.log10(1.0 + hz / 700.0)
+
+
+def hz(m):
+    return 700.0 * (10.0 ** (m / 2595.0) - 1.0)
+
+
+def filterbank(count=26, nfft=512, rate=RATE, low=0.0, high=None):
+    high = high or rate / 2
+    points = hz(np.linspace(mel(low), mel(high), count + 2))
+    bins = np.floor((nfft + 1) * points / rate).astype(int)
+    bank = np.zeros((count, nfft // 2 + 1))
+    for i in range(count):
+        left, middle, right = bins[i], bins[i + 1], bins[i + 2]
+        for k in range(left, middle):
+            bank[i, k] = (k - left) / max(1, middle - left)
+        for k in range(middle, right):
+            bank[i, k] = (right - k) / max(1, right - middle)
+    return bank
+
+
+BANK = filterbank()
+DCT = np.cos(np.pi / 26 * (np.arange(26) + 0.5)[None, :] * np.arange(13)[:, None])
+
+
+def mfcc(samples, rate=RATE, window=0.025, hop=0.010, keep=12):
+    """13 cepstra, c0 dropped, mean and variance normalised over the segment.
+
+    c0 is loudness. Two recordings of the same word at different distances
+    from the microphone differ in it and in nothing that matters here, so it
+    goes. The normalisation does the same job for the rest: it takes out the
+    channel, and leaves the shape of the spectrum over time.
+    """
+    if samples.size < int(window * rate):
+        return None
+    emphasised = np.append(samples[0], samples[1:] - 0.97 * samples[:-1])
+    length, step = int(window * rate), int(hop * rate)
+    count = 1 + (emphasised.size - length) // step
+    index = np.arange(length)[None, :] + step * np.arange(count)[:, None]
+    frames = emphasised[index] * np.hamming(length)
+    power = np.abs(np.fft.rfft(frames, 512)) ** 2 / 512
+    energy = np.log(np.maximum(power @ BANK.T, 1e-10))
+    cepstra = (energy @ DCT.T)[:, 1:keep + 1]
+    cepstra = cepstra - cepstra.mean(axis=0)
+    spread = cepstra.std(axis=0)
+    return cepstra / np.where(spread < 1e-6, 1.0, spread)
+
+
+def dtw(a, b):
+    """Normalised DTW distance between two MFCC sequences.
+
+    Symmetric step pattern, diagonal weighted 2, so the accumulated cost
+    divides exactly by n + m and sequences of different length compare.
+    """
+    cost = np.sqrt(np.maximum(
+        (a * a).sum(1)[:, None] + (b * b).sum(1)[None, :] - 2 * a @ b.T, 0.0))
+    n, m = cost.shape
+    total = np.full((n + 1, m + 1), np.inf)
+    total[0, 0] = 0.0
+    for i in range(1, n + 1):
+        row, previous, here = total[i], total[i - 1], cost[i - 1]
+        for j in range(1, m + 1):
+            row[j] = min(previous[j] + here[j - 1],
+                         row[j - 1] + here[j - 1],
+                         previous[j - 1] + 2 * here[j - 1])
+    return total[n, m] / (n + m)
+
+
+# --------------------------------------------------------------- the statistics
+
+def quantile(values, q):
+    if not values:
+        return float("nan")
+    ordered = sorted(values)
+    position = q * (len(ordered) - 1)
+    low = int(position)
+    high = min(low + 1, len(ordered) - 1)
+    return ordered[low] + (ordered[high] - ordered[low]) * (position - low)
+
+
+def describe(name, values):
+    if not values:
+        return f"  {name:<30} n=0"
+    return ("  {:<30} n={:<4} min {:>6.3f}  q1 {:>6.3f}  med {:>6.3f}  "
+            "q3 {:>6.3f}  max {:>6.3f}".format(
+                name, len(values), min(values), quantile(values, .25),
+                statistics.median(values), quantile(values, .75), max(values)))
+
+
+def auc(positive, negative):
+    """P(a random positive scores above a random negative). Ties count half."""
+    if not positive or not negative:
+        return float("nan")
+    wins = 0.0
+    for p in positive:
+        for n in negative:
+            wins += 1.0 if p > n else (0.5 if p == n else 0.0)
+    return wins / (len(positive) * len(negative))
+
+
+def conditional(positive, negative, score, hold, tol):
+    """AUC over only the pairs whose `hold` values agree to within `tol`.
+
+    The way to ask whether a rival explanation is doing the work: keep the
+    rival fixed inside each pair, and see what is left of the separation.
+    """
+    pairs = wins = 0.0
+    for p in positive:
+        for n in negative:
+            if abs(hold(p) - hold(n)) > tol:
+                continue
+            pairs += 1
+            wins += 1.0 if score(p) > score(n) else (
+                0.5 if score(p) == score(n) else 0.0)
+    return (wins / pairs if pairs else float("nan")), int(pairs)
+
+
+# -------------------------------------------------- the scripted clips as a set
+
+# The words the vocabulary pass actually wrote a term over in the 48 scripted
+# clips, with the term it wrote. Read off `trace.jsonl`: these are live
+# overwrites, not negatives anybody chose. They are the hardest kind, because
+# the app already mistook each of them for the name.
+OVERWRITTEN = [
+    ("parrotflow-2026-08-09T14-02-01.wav", "slide", "claude"),
+    ("parrotflow-2026-08-09T14-02-28.wav", "ready", "arexvy"),
+    ("parrotflow-2026-08-09T14-02-49.wav", "already", "arexvy"),
+    ("parrotflow-2026-08-09T14-04-51.wav", "update", "supabase"),
+    ("parrotflow-2026-08-09T14-04-55.wav", "general", "redcrawl"),
+    ("parrotflow-2026-08-09T14-05-08.wav", "train", "praisy"),
+    ("parrotflow-2026-08-09T14-05-15.wav", "retry", "arexvy"),
+    ("parrotflow-2026-08-09T14-05-15.wav", "crawl", "redcrawl"),
+]
+
+
+def scripted_spans(exemplars):
+    """Every span in the scripted clips, with the term it is or is not.
+
+    The proposal set round 5 built has no A row for Redcrawl at all: the
+    vocabulary pass never once offered Redcrawl where Redcrawl was said, so
+    however many recordings the term now has there is no pair to rank. The
+    scripted clips answer that directly. The label says where each name is, so
+    A and B can be read off it without any proposal, and without a model.
+
+        A(term)   the spans of that name
+        B(term)   the spans of the other ten names, and the ordinary words the
+                  app wrote a name over
+
+    Nothing easy is in B. Every negative is either a name in its own right or a
+    word the spotter has already confused with one, so `redrock` is a negative
+    for `redcrawl` and `praise` is a negative for `praisy`.
+    """
+    spans = []
+    for ex in exemplars:
+        if ex["source"] != "scripted" or not ex.get("from"):
+            continue
+        spans.append({"wav": ex["from"], "stem": ex["term"],
+                      "heard": ex["name"].split("/")[-1],
+                      "samples": ex["samples"], "kind": "name"})
+    words = decoder_words()
+    for wav, word, term in OVERWRITTEN:
+        for token, start, end in words.get(wav, []):
+            if re.sub(r"[^\w']", "", token).lower() == word:
+                spans.append({"wav": wav, "stem": f"~{word}", "heard": word,
+                              "samples": read(CLIPS / wav, start - PAD, end + PAD),
+                              "kind": "ordinary", "wrote": term})
+                break
+    return spans
+
+
+def decoder_words():
+    """Word times from `trace.jsonl`, first line per clip. No app, no decode."""
+    out = {}
+    path = CLIPS / "trace.jsonl"
+    if not path.exists():
+        return out
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        wav = row.get("wav")
+        got = (row.get("asr") or {}).get("words") or []
+        if wav and got and wav not in out:
+            out[wav] = [(w["word"], float(w["start"]), float(w["end"]))
+                        for w in got if w.get("word")]
+    return out
+
+
+def measure_scripted(source_name):
+    exemplars = load_exemplars(source_name)
+    for ex in exemplars:
+        ex["mfcc"] = mfcc(ex["samples"])
+    spans = scripted_spans(load_exemplars("all"))
+    for s in spans:
+        s["mfcc"] = mfcc(s["samples"])
+    spans = [s for s in spans if s["mfcc"] is not None]
+
+    terms = sorted({e["term"] for e in exemplars})
+    rows = []
+    for term in terms:
+        for s in spans:
+            # The same hold-out, by clip and for both groups. A recording cut
+            # from this clip is the same speech in the same session; comparing
+            # a span to it measures the file, not the name.
+            usable = [e for e in exemplars if e["term"] == term
+                      and e["mfcc"] is not None and e["from"] != s["wav"]]
+            if not usable:
+                continue
+            other = [e for e in exemplars if e["term"] != term
+                     and e["mfcc"] is not None and e["from"] != s["wav"]]
+            matched = min(dtw(s["mfcc"], e["mfcc"]) for e in usable)
+            row = {"term": term, "wav": s["wav"], "heard": s["heard"],
+                   "group": "A" if s["stem"] == term else "B",
+                   "kind": s["kind"], "matched": matched,
+                   "exemplars": len(usable),
+                   "seconds": s["samples"].size / RATE}
+            if other:
+                row["mismatched"] = min(dtw(s["mfcc"], e["mfcc"]) for e in other)
+            rows.append(row)
+    return rows
+
+
+def report_scripted(rows, source_name):
+    have = recordings(source_name)
+    A = [r for r in rows if r["group"] == "A"]
+    B = [r for r in rows if r["group"] == "B"]
+    print(f"\n=== the scripted set ===  source {source_name}, "
+          f"{len(rows)} span-term pairs over "
+          f"{len({r['wav'] for r in rows})} clips")
+    print("  A is the name said, B is one of the other names or a word the app")
+    print("  wrote a name over. Every recording from the span's own clip is out.")
+    print(f"\n  {'term':<12} {'rec':>4} {'A':>4} {'B':>4}   AUC")
+    overall = auc([-r["matched"] for r in A], [-r["matched"] for r in B])
+    for term in sorted({r["term"] for r in rows}):
+        a = [-r["matched"] for r in A if r["term"] == term]
+        b = [-r["matched"] for r in B if r["term"] == term]
+        got = auc(a, b)
+        counts = have.get(term, Counter())
+        print(f"  {term:<12} {sum(counts.values()):>4} {len(a):>4} {len(b):>4}   "
+              f"{format(got, '.3f') if got == got else 'no pair'}")
+    print(f"  {'pooled':<12} {'':>4} {len(A):>4} {len(B):>4}   {overall:.3f}")
+    print("\n    0.500  chance")
+    print("    0.812  round 6, on round 5's proposals, four terms")
+
+    print("\n=== the control: matched term against mismatched term ===")
+    for name, group in (("A", A), ("B", B)):
+        both = [r for r in group if "mismatched" in r]
+        if not both:
+            continue
+        closer = sum(1 for r in both if r["matched"] < r["mismatched"])
+        print(f"  group {name}, n={len(both)}   "
+              f"AUC(matched vs mismatched) "
+              f"{auc([-r['matched'] for r in both], [-r['mismatched'] for r in both]):.3f}"
+              f"   matched closer {closer}/{len(both)} "
+              f"({closer / len(both) * 100:.0f}%)")
+    print("  A should sit closer to its own name, B should not. B at about 50%")
+    print("  is the control passing, not failing.")
+
+    print("\n=== is it length? ===")
+    print(f"  AUC(A vs B) on span duration alone   "
+          f"{auc([r['seconds'] for r in A], [r['seconds'] for r in B]):.3f}")
+
+    print("\n=== the ordinary words the app wrote a name over ===")
+    print("  each against the very name the app wrote, and where it ranks")
+    print("  among that name's own spans")
+    for r in sorted(rows, key=lambda r: (r["heard"], r["term"])):
+        if r["kind"] != "ordinary":
+            continue
+        own = sorted(x["matched"] for x in rows
+                     if x["term"] == r["term"] and x["group"] == "A")
+        if not own:
+            continue
+        worse = sum(1 for d in own if d < r["matched"])
+        print(f"  {r['heard']:<10} as {r['term']:<10} {r['matched']:.3f}   "
+              f"nearer than {len(own) - worse}/{len(own)} real ones")
+
+    print("\n=== the distances ===")
+    print(describe("A  nearest matched", [r["matched"] for r in A]))
+    print(describe("B  nearest matched", [r["matched"] for r in B]))
+    return 0
+
+
+# ------------------------------------------------------------------- the measure
+
+def measure(source_name="all"):
+    proposals = load_proposals()
+    exemplars = load_exemplars(source_name)
+    if not exemplars:
+        where = FROZEN if source_name == "round6" else voice_dir() / "samples"
+        print(f"✗ no exemplars under {where}", file=sys.stderr)
+        return None, None
+    terms = {ex["term"] for ex in exemplars}
+    traced = provenance(exemplars, sorted({p["wav"] for p in proposals}))
+
+    for ex in exemplars:
+        ex["mfcc"] = mfcc(ex["samples"])
+        if not ex.get("from"):
+            ex["from"] = traced.get(ex["name"])
+
+    kept, dropped = [], []
+    for p in proposals:
+        term = stem(p["term"])
+        row = {"wav": p["wav"], "term": p["term"], "stem": term,
+               "group": p["group"], "kind": p["kind"], "heard": p["heard"],
+               "start": p["start"], "end": p["end"], "spot": p["spot"]}
+        if p["group"] not in ("A", "B"):
+            continue                                    # `unclear`, not a group
+        if term not in terms:
+            dropped.append(dict(row, why="no exemplar for the term"))
+            continue
+        path = CLIPS / p["wav"]
+        if not path.exists():
+            dropped.append(dict(row, why="clip missing from the archive"))
+            continue
+        if p["start"] is None or p["end"] is None or p["end"] <= p["start"]:
+            dropped.append(dict(row, why="no usable span"))
+            continue
+        samples = read(path, p["start"] - PAD, p["end"] + PAD)
+        span = mfcc(samples)
+        if span is None:
+            dropped.append(dict(row, why="span shorter than one frame"))
+            continue
+        row["seconds"] = samples.size / RATE
+
+        usable = [e for e in exemplars
+                  if e["mfcc"] is not None and e["from"] != p["wav"]]
+        matched = [(dtw(span, e["mfcc"]), e["name"])
+                   for e in usable if e["term"] == term]
+        other = [(dtw(span, e["mfcc"]), e["name"])
+                 for e in usable if e["term"] != term]
+        if not matched:
+            dropped.append(dict(row, why="every exemplar is from this clip"))
+            continue
+        row["lengths"] = min(
+            abs(row["seconds"] - e["samples"].size / RATE)
+            for e in usable if e["term"] == term)
+        row["matched"], row["nearest"] = min(matched)
+        row["matched_mean"] = sum(d for d, _ in matched) / len(matched)
+        row["exemplars"] = len(matched)
+        row["held_out"] = sum(1 for e in exemplars
+                              if e["term"] == term and e["from"] == p["wav"])
+        if other:
+            row["mismatched"], row["nearest_other"] = min(other)
+        kept.append(row)
+    return kept, dropped
+
+
+def recordings(source_name):
+    """How many recordings each term has, and where they came from."""
+    counts = defaultdict(Counter)
+    for ex in load_exemplars(source_name):
+        counts[ex["term"]][ex["source"]] += 1
+    return counts
+
+
+def report(kept, dropped, source_name="all"):
+    A = [r for r in kept if r["group"] == "A"]
+    B = [r for r in kept if r["group"] == "B"]
+    have = recordings(source_name)
+
+    print(f"\n=== the set ===  condition {CONDITION}, source {source_name}, "
+          f"{len(kept)} proposals over {len({r['wav'] for r in kept})} clips")
+    print(f"  {'term':<12} {'rec':>4} {'spont':>6} {'script':>7} "
+          f"{'A':>4} {'B':>4}   in after the hold-out")
+    for term in sorted(set(have) | {r["stem"] for r in kept}):
+        a = [r for r in A if r["stem"] == term]
+        b = [r for r in B if r["stem"] == term]
+        held = sorted({r["exemplars"] for r in a + b}) or [0]
+        counts = have.get(term, Counter())
+        print(f"  {term:<12} {sum(counts.values()):>4} "
+              f"{counts['spontaneous'] + counts['round6']:>6} "
+              f"{counts['scripted']:>7} {len(a):>4} {len(b):>4}   "
+              f"{held[0] if len(held) == 1 else f'{held[0]}-{held[-1]}'}")
+    print(f"  {'total':<12} {sum(sum(c.values()) for c in have.values()):>4} "
+          f"{'':>6} {'':>7} {len(A):>4} {len(B):>4}")
+
+    lost = sum(r["held_out"] for r in kept)
+    print(f"\n  the hold-out removed {lost} exemplar-comparison(s) over "
+          f"{sum(1 for r in kept if r['held_out'])} proposal(s)")
+    print("  a proposal never scores against a recording cut from its own clip")
+
+    print("\n=== dropped ===")
+    for why, n in Counter(r["why"] for r in dropped).most_common():
+        rows = [r for r in dropped if r["why"] == why]
+        groups = Counter(r["group"] for r in rows)
+        print(f"  {n:>4}  {why:<34} A {groups['A']:>2}  B {groups['B']:>2}")
+    if not dropped:
+        print("  none")
+
+    print("\n=== the headline: nearest matched exemplar, A against B ===")
+    print("  a term that was said should sit closer to recordings of itself")
+    value = auc([-r["matched"] for r in A], [-r["matched"] for r in B])
+    print(f"\n  AUC(A vs B), nearest exemplar      {value:.3f}")
+    print(f"  AUC(A vs B), mean over exemplars   "
+          f"{auc([-r['matched_mean'] for r in A], [-r['matched_mean'] for r in B]):.3f}")
+    print("\n    0.500  chance")
+    print("    0.318  the raw acoustic score, round 5, over all 33 A / 66 B")
+    print("    0.812  round 6, four terms, 27 recordings")
+    print("    0.814  the spotter score on its own path, round 5")
+    print(f"    {auc([r['spot'] for r in A], [r['spot'] for r in B]):.3f}  "
+          "the raw acoustic score on these same rows — like for like")
+
+    print("\n  per term (rec, A n / B n). A term with no A row or no B row has")
+    print("  no pair to rank, so it has no AUC however many recordings it has")
+    for term in sorted({r["stem"] for r in kept}):
+        a = [-r["matched"] for r in A if r["stem"] == term]
+        b = [-r["matched"] for r in B if r["stem"] == term]
+        got = auc(a, b)
+        counts = have.get(term, Counter())
+        print(f"    {term:<12} {sum(counts.values()):>3} rec  "
+              f"{len(a):>3} / {len(b):<3}  "
+              f"{'AUC ' + format(got, '.3f') if got == got else 'no pair'}")
+
+    print("\n=== the control: matched term against mismatched term ===")
+    print("  if a Praisy span sits as close to Vercel recordings as to Praisy")
+    print("  recordings, the headline was luck")
+    for name, rows in (("A", A), ("B", B)):
+        both = [r for r in rows if "mismatched" in r]
+        if not both:
+            continue
+        closer = sum(1 for r in both if r["matched"] < r["mismatched"])
+        print(f"\n  group {name}, n={len(both)}")
+        print(f"    AUC(matched vs mismatched)       "
+              f"{auc([-r['matched'] for r in both], [-r['mismatched'] for r in both]):.3f}")
+        print(f"    matched is the closer of the two {closer}/{len(both)} "
+              f"({closer / len(both) * 100:.0f}%, chance is 50%)")
+        delta = [r["mismatched"] - r["matched"] for r in both]
+        print(describe("    mismatched - matched", delta))
+
+    print("\n=== blending the two acoustic numbers ===")
+    print("  the raw score is inverted here, so averaging can only cost")
+    order = lambda values: [sorted(values).index(v) / max(1, len(values) - 1)
+                            for v in values]
+    both = A + B
+    blend = [a + b for a, b in zip(order([-r["matched"] for r in both]),
+                                   order([r["spot"] for r in both]))]
+    print(f"  AUC(A vs B) on rank(-distance) + rank(score)  "
+          f"{auc(blend[:len(A)], blend[len(A):]):.3f}")
+
+    print("\n=== two rival explanations ===")
+    print("  1. the span is just cleaner speech, and any recording would do")
+    mA = [r for r in A if "mismatched" in r]
+    mB = [r for r in B if "mismatched" in r]
+    print(f"     AUC(A vs B) on the mismatched distance   "
+          f"{auc([-r['mismatched'] for r in mA], [-r['mismatched'] for r in mB]):.3f}")
+    print(f"     AUC(A vs B) on mismatched minus matched  "
+          f"{auc([r['mismatched'] - r['matched'] for r in mA], [r['mismatched'] - r['matched'] for r in mB]):.3f}")
+    print("     the second number is term-specific by construction: the generic")
+    print("     part of the distance cancels in the subtraction")
+
+    print("\n  2. it is length. DTW pays for stretching, and a name has a length")
+    print(f"     AUC(A vs B) on span duration alone       "
+          f"{auc([r['seconds'] for r in A], [r['seconds'] for r in B]):.3f}")
+    print(f"     AUC(A vs B) on |span - nearest exemplar| "
+          f"{auc([-r['lengths'] for r in A], [-r['lengths'] for r in B]):.3f}")
+    got, n = conditional(A, B, lambda r: -r["matched"], lambda r: r["lengths"], 0.05)
+    print(f"     AUC(matched), length gap held equal ±.05s   {got:.3f}  ({n} pairs)")
+    got, n = conditional(A, B, lambda r: -r["lengths"], lambda r: r["matched"], 0.10)
+    print(f"     AUC(length gap), distance held equal ±.10   {got:.3f}  ({n} pairs)")
+
+    print("\n=== the distances ===")
+    print(describe("A  nearest matched", [r["matched"] for r in A]))
+    print(describe("B  nearest matched", [r["matched"] for r in B]))
+    print(describe("A  nearest mismatched",
+                   [r["mismatched"] for r in A if "mismatched" in r]))
+    print(describe("B  nearest mismatched",
+                   [r["mismatched"] for r in B if "mismatched" in r]))
+    for term in sorted({r["stem"] for r in kept}):
+        print(describe(f"A  {term}",
+                       [r["matched"] for r in A if r["stem"] == term]))
+        print(describe(f"B  {term}",
+                       [r["matched"] for r in B if r["stem"] == term]))
+
+    print("\n=== does the nearest exemplar's identity carry anything? ===")
+    print("  do A spans land on the same few recordings, or spread out?")
+    for name, rows in (("A", A), ("B", B)):
+        by_term = defaultdict(Counter)
+        for r in rows:
+            by_term[r["stem"]][r["nearest"]] += 1
+        for term in sorted(by_term):
+            counts = by_term[term]
+            top = ", ".join(f"{k.split('/')[-1]} ×{v}"
+                            for k, v in counts.most_common(3))
+            print(f"  {name} {term:<10} {sum(counts.values()):>3} spans over "
+                  f"{len(counts):>2} exemplars   {top}")
+    return 0
+
+
+def table(kept, dropped, path):
+    lines = ["# Every proposal, with its distance to the nearest recording",
+             "",
+             "Produced by `scripts/reference-matching.py --table`. Read the",
+             "round in [judge-framings.md](judge-framings.md) first — this",
+             "file is the evidence under it, not an argument.",
+             "",
+             "`matched` is the DTW distance from the span to the nearest",
+             "recording of the same term, over MFCCs, with any recording cut",
+             "from this same clip held out. `mismatched` is the same number",
+             "against recordings of every other term. Lower is nearer.",
+             "`held` is how many recordings of the term survived the hold-out.",
+             "",
+             "| clip | group | kind | term | heard | span | held | matched | "
+             "nearest | mismatched |",
+             "|---|---|---|---|---|---|---|---|---|---|"]
+    short = lambda w: w.replace("parrotflow-2026-08-", "").replace(".wav", "")
+    for r in sorted(kept, key=lambda r: (r["group"], r["stem"], r["matched"])):
+        lines.append(
+            f"| {short(r['wav'])} | {r['group']} | {r['kind']} | {r['term']} "
+            f"| {(r['heard'] or '').replace('|', '/')} "
+            f"| {r['start']:.2f}-{r['end']:.2f} | {r['exemplars']} "
+            f"| {r['matched']:.3f} | {r['nearest'].split('/')[-1]} "
+            f"| {'' if 'mismatched' not in r else format(r['mismatched'], '.3f')} |")
+    lines += ["", "## Dropped", "",
+              "| clip | group | term | why |", "|---|---|---|---|"]
+    for r in sorted(dropped, key=lambda r: (r["why"], r["group"], r["wav"])):
+        lines.append(f"| {short(r['wav'])} | {r['group']} | {r['term']} "
+                     f"| {r['why']} |")
+    Path(path).write_text("\n".join(lines) + "\n")
+    print(f"wrote {path}")
+    return 0
+
+
+# -------------------------------------------------------------- the poison arm
+
+# The two recordings the archive already holds that are not the term at all,
+# both mined automatically. `ReferenceMatch.swift` names them in its own
+# comment as the reason its tolerance cannot be 1.0.
+BAD = {"vercel": "Vercel/09-brazil.wav",
+       "tasmeen": "Tasmeen/06-that'smeanssend.wav"}
+
+
+def poison_rows(source_name="all"):
+    """Every scored span, the term it is scored against, and its group.
+
+    Two sets, because neither alone covers the eleven terms. The scripted set
+    reads A and B off the labels, so every term with a scripted recording has
+    an A row. `Praisy` and `Vercel` have no scripted recording and so no A row
+    there; the proposal set is the only place they can be ranked.
+    """
+    exemplars = [e for e in load_exemplars(source_name)]
+    for ex in exemplars:
+        ex["mfcc"] = mfcc(ex["samples"])
+    exemplars = [e for e in exemplars if e["mfcc"] is not None]
+
+    spans = []
+    for s in scripted_spans(load_exemplars("all")):
+        s["set"] = "scripted"
+        spans.append(s)
+    for p in load_proposals():
+        if p["group"] not in ("A", "B"):
+            continue
+        path = CLIPS / p["wav"]
+        if not path.exists() or p["start"] is None or p["end"] is None:
+            continue
+        if p["end"] <= p["start"]:
+            continue
+        spans.append({"wav": p["wav"], "stem": stem(p["term"]), "set": "proposals",
+                      "heard": p["heard"], "group": p["group"],
+                      "samples": read(path, p["start"] - PAD, p["end"] + PAD)})
+    for s in spans:
+        s["mfcc"] = mfcc(s["samples"])
+    spans = [s for s in spans if s["mfcc"] is not None]
+    return exemplars, spans
+
+
+def poison_matrices(exemplars, spans, cache):
+    """Every span-to-recording and recording-to-recording distance, once.
+
+    A poison arm only ever adds a recording to a folder or takes one out. It
+    never changes a distance. So both matrices are computed once and every arm
+    after that is indexing, which is what makes twenty-odd arms affordable.
+    """
+    names = [e["name"] for e in exemplars]
+    if cache and Path(cache).exists():
+        # No pickle: the names go in as a fixed-width unicode array, so this
+        # reads a cache written by this script and nothing else.
+        blob = np.load(cache)
+        if [str(n) for n in blob["names"]] == names and int(blob["spans"]) == len(spans):
+            return blob["se"], blob["ee"]
+        print("  the cache does not match this data; rebuilding", file=sys.stderr)
+    se = np.zeros((len(spans), len(exemplars)))
+    for i, s in enumerate(spans):
+        for j, e in enumerate(exemplars):
+            se[i, j] = dtw(s["mfcc"], e["mfcc"])
+        print(f"  spans {i + 1}/{len(spans)}", end="\r", file=sys.stderr)
+    ee = np.zeros((len(exemplars), len(exemplars)))
+    for i in range(len(exemplars)):
+        for j in range(i + 1, len(exemplars)):
+            ee[i, j] = ee[j, i] = dtw(exemplars[i]["mfcc"], exemplars[j]["mfcc"])
+        print(f"  recordings {i + 1}/{len(exemplars)}", end="\r", file=sys.stderr)
+    if cache:
+        np.savez(cache, names=np.array(names), spans=len(spans), se=se, ee=ee)
+    return se, ee
+
+
+def summarise(values, robust):
+    """The width of the cloud: `nearest.max()`, or the 90th percentile of it.
+
+    `ReferenceMatch.verdict` step 3 takes the maximum, so one recording sets
+    it. 6b's proposal is to take a high quantile instead.
+    """
+    if not values:
+        return float("nan")
+    return quantile(values, 0.9) if robust else max(values)
+
+
+def arm(bank, exemplars, spans, se, ee, term, robust, tolerance=1.0):
+    """One term, one bank of recordings: its AUC, its spread and its veto.
+
+    `bank` is the list of exemplar indices that count as recordings of the
+    term. The per-clip hold-out is applied inside, the same way
+    `measure_scripted` and `ReferenceMatch.verdict` apply it: a span never
+    scores against a recording cut from its own clip.
+    """
+    out = {"term": term, "recordings": len(bank)}
+    # The spread over the whole bank, with nothing held out. This is the number
+    # the app computes on live dictation, where the audio has no clip name.
+    loo = [min(ee[i][j] for j in bank if j != i) for i in bank] if len(bank) > 1 else []
+    out["spread"] = summarise(loo, robust)
+
+    rows = {"scripted": {"A": [], "B": []}, "proposals": {"A": [], "B": []}}
+    veto = {"A": [0, 0], "B": [0, 0]}
+    for k, s in enumerate(spans):
+        if s["set"] == "scripted":
+            group = "A" if s["stem"] == term else "B"
+        elif s["stem"] == term:
+            group = s["group"]
+        else:
+            continue
+        usable = [i for i in bank if exemplars[i]["from"] != s["wav"]]
+        if not usable:
+            continue
+        distance = min(se[k][i] for i in usable)
+        rows[s["set"]][group].append(distance)
+        if len(usable) < 3:
+            continue                       # ReferenceMatch abstains under three
+        held = [min(ee[i][j] for j in usable if j != i) for i in usable]
+        width = summarise(held, robust)
+        if not (width > 0):
+            continue
+        veto[group][1] += 1
+        if distance > tolerance * width:
+            veto[group][0] += 1
+
+    for name in ("scripted", "proposals"):
+        a = [-d for d in rows[name]["A"]]
+        b = [-d for d in rows[name]["B"]]
+        out[f"auc_{name}"] = auc(a, b)
+        out[f"n_{name}"] = (len(a), len(b))
+    out["veto"] = veto
+    out["A"] = rows["scripted"]["A"] + rows["proposals"]["A"]
+    out["B"] = rows["scripted"]["B"] + rows["proposals"]["B"]
+    return out
+
+
+def banks(exemplars):
+    by_term = defaultdict(list)
+    for i, e in enumerate(exemplars):
+        by_term[e["term"]].append(i)
+    return by_term
+
+
+def poison_report(source_name, cache, robust, injected):
+    exemplars, spans = poison_rows(source_name)
+    se, ee = poison_matrices(exemplars, spans, cache)
+    by_term = banks(exemplars)
+    index = {e["name"]: i for i, e in enumerate(exemplars)}
+    where = "the 90th percentile" if robust else "the maximum"
+
+    print(f"\n=== 6a: what one bad clip costs ===  spread is {where} of the")
+    print("  leave-one-out distances. `veto B` is spans the rule drops where the")
+    print("  term was NOT said — the rule working. `veto A` is the same rule")
+    print("  dropping a span where the term WAS said. Tolerance 1.0 throughout.")
+    print(f"  {len(exemplars)} recordings, {len(spans)} spans, source {source_name}.")
+
+    def fmt(v):
+        return f"{v:.3f}" if v == v else "  -  "
+
+    def rate(pair):
+        return f"{pair[0]}/{pair[1]}" if pair[1] else "-"
+
+    print(f"\n  {'term':<26} {'rec':>7}  {'AUC scripted':^16}  "
+          f"{'AUC proposals':^16}  {'spread':^16}")
+    rows = []
+    for term in sorted(by_term):
+        base = arm(by_term[term], exemplars, spans, se, ee, term, robust)
+        bad = BAD.get(term)
+        if bad and bad in [exemplars[i]["name"] for i in by_term[term]]:
+            # The bad clip is already in this folder, so the experiment runs
+            # backwards: take it out and see what the term gets back.
+            keep = [i for i in by_term[term] if exemplars[i]["name"] != bad]
+            after = arm(keep, exemplars, spans, se, ee, term, robust)
+            label, moved = f"{term} - {Path(bad).name[:14]}", bad
+        else:
+            after = arm(by_term[term] + [index[injected]], exemplars, spans,
+                        se, ee, term, robust)
+            label, moved = f"{term} + {Path(injected).name[:14]}", injected
+        print(f"  {label:<26} {base['recordings']:>3}->{after['recordings']:<3}  "
+              f"{fmt(base['auc_scripted'])} -> {fmt(after['auc_scripted'])}  "
+              f"{str(base['n_scripted']):>8}  "
+              f"{fmt(base['auc_proposals'])} -> {fmt(after['auc_proposals'])}  "
+              f"{base['spread']:.3f} -> {after['spread']:.3f}")
+        rows.append((term, base, after, moved))
+
+    print("\n  the same arms, as the rule's own decision at tolerance 1.0")
+    print(f"\n  {'term':<26} {'veto B  (the rule working)':<30} "
+          f"{'veto A  (the rule costing)':<26}")
+    print("  a veto count pools both sets: every span the term is scored")
+    print("  against, from the 48 scripted clips and from round 5's proposals")
+    totals = [0, 0, 0, 0, 0, 0]
+    for term, base, after, _ in rows:
+        b0, b1 = base["veto"]["B"], after["veto"]["B"]
+        a0, a1 = base["veto"]["A"], after["veto"]["A"]
+        totals = [totals[0] + b0[0], totals[1] + b1[0], totals[2] + b0[1],
+                  totals[3] + a0[0], totals[4] + a1[0], totals[5] + a0[1]]
+        share = lambda p: f"{p[0] / p[1] * 100:3.0f}%" if p[1] else "   -"
+        print(f"  {term:<26} {rate(b0):>7} ({share(b0)}) -> {rate(b1):>7} "
+              f"({share(b1)})   {rate(a0):>6} -> {rate(a1):>6}")
+    print(f"  {'all eleven arms':<26} {totals[0]:>7}        -> {totals[1]:>7}"
+          f"          {totals[3]:>6} -> {totals[4]:>6}")
+    # §2: build the stupid control. Rejecting every span takes every B and
+    # every A with it, so it is the ceiling on one column and the floor on
+    # the other.
+    print(f"  {'reject everything':<26} {totals[2]:>7}        -> {totals[2]:>7}"
+          f"          {totals[5]:>6} -> {totals[5]:>6}")
+
+    print("\n  which recording holds the leave-one-out maximum — the clip that")
+    print("  sets `spread` in `ReferenceMatch.verdict` — and where the clip this")
+    print("  arm added or removed ranks among the same distances")
+    for term, base, _, moved in rows:
+        bank = by_term[term]
+        loo = sorted(((min(ee[i][j] for j in bank if j != i), exemplars[i]["name"])
+                      for i in bank), reverse=True)
+        names = [name for _, name in loo]
+        if moved in names:
+            rank = names.index(moved)
+            note = (f"{Path(moved).name} is #{rank + 1} of {len(loo)} "
+                    f"at {loo[rank][0]:.3f}")
+        else:
+            note = "the injected clip is not in this bank"
+        print(f"  {term:<12} spread {loo[0][0]:.3f} set by "
+              f"{names[0].split('/')[-1]:<24} {note}")
+    return rows, exemplars, spans, se, ee
+
+
+def pronunciation_split(exemplars):
+    """The two ways this speaker says `Matthieu`, as far as the data can say.
+
+    PR 4 is what would put `lang` on an observation, and it is not built, so
+    there is no language tag on any recording. The tag would not have helped:
+    all eleven `Matthieu` clips come from dictations `trace.jsonl` marks `en`,
+    including the one sentence where the speaker says the name both ways.
+
+    What the archive does carry is what the decoder wrote, in the sample's own
+    filename. `matthew`, `matsu` and `match's` are anglicised renderings;
+    `mathieu` is the French one. That is a proxy — a decoder's opinion about a
+    sound, not a label anybody checked — so the arm prints the within-group and
+    between-group distances beside it. If the two groups are not two clusters,
+    the split is not real and the arm says nothing.
+    """
+    french, english = [], []
+    for e in exemplars:
+        if e["term"] != "matthieu":
+            continue
+        heard = e["name"].split("/")[-1].split("-", 1)[-1].replace(".wav", "")
+        (french if heard.startswith("mathieu") else english).append(e["name"])
+    return {"first": sorted(english), "second": sorted(french),
+            "first_label": "anglicised", "second_label": "French",
+            "why": "labelled by what the decoder wrote, not by `lang`"}
+
+
+def cluster_check(exemplars, ee, split):
+    """Are the two labelled groups actually two clusters?"""
+    index = {e["name"]: i for i, e in enumerate(exemplars)}
+    first = [index[n] for n in split["first"]]
+    second = [index[n] for n in split["second"]]
+    within = [ee[i][j] for g in (first, second) for i in g for j in g if i < j]
+    between = [ee[i][j] for i in first for j in second]
+    print(f"  within a group  n={len(within):<3} mean {sum(within)/len(within):.3f}"
+          f"   between groups n={len(between):<3} "
+          f"mean {sum(between)/len(between):.3f}")
+    print(f"  AUC(between > within) {auc(between, within):.3f}  "
+          "0.500 is one cluster, 1.000 is two that never touch")
+
+
+def poison_pronunciation(exemplars, spans, se, ee, robust, split):
+    """The second-pronunciation arm, on `Matthieu`.
+
+    §7 predicts a thin second cluster inflates `spread` the same way a bad clip
+    does, and that the damage peaks at one or two clips and falls away as the
+    cluster fills. `split` names the recordings of the second pronunciation.
+    """
+    index = {e["name"]: i for i, e in enumerate(exemplars)}
+    first = [index[n] for n in split["first"]]
+    second = [index[n] for n in split["second"]]
+    print(f"\n=== 6a: the second pronunciation ===  {split['why']}")
+    cluster_check(exemplars, ee, split)
+    print(f"  bank starts as {len(first)} × {split['first_label']}; "
+          f"{split['second_label']} clips are added one at a time")
+    print(f"\n  {'bank':<34} {'rec':>3}  {'AUC':>6}  {'spread':>6}  "
+          f"{'veto B':>9}  {'veto A':>7}")
+    for take in range(len(second) + 1):
+        bank = first + second[:take]
+        got = arm(bank, exemplars, spans, se, ee, "matthieu", robust)
+        label = f"{len(first)} {split['first_label']} + {take} {split['second_label']}"
+        auc_value = got["auc_scripted"]
+        print(f"  {label:<34} {got['recordings']:>3}  "
+              f"{format(auc_value, '.3f') if auc_value == auc_value else '   -  '}  "
+              f"{got['spread']:.3f}  "
+              f"{got['veto']['B'][0]}/{got['veto']['B'][1]:<7} "
+              f"{got['veto']['A'][0]}/{got['veto']['A'][1]}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--table", metavar="FILE", help="write the per-proposal table")
+    ap.add_argument("--source", default="all",
+                    choices=["all", "scripted", "spontaneous", "round6"],
+                    help="which recordings to compare against")
+    ap.add_argument("--set", default="proposals",
+                    choices=["proposals", "scripted"],
+                    help="proposals: round 5's A and B rows, what round 6 "
+                         "measured. scripted: A and B read off the labels of "
+                         "the 48 scripted clips, which is the only set with an "
+                         "A row for Redcrawl")
+    ap.add_argument("--poison", action="store_true",
+                    help="6a: add one clip of the wrong word to each term's "
+                         "folder and re-measure. Where the folder already "
+                         "holds a bad clip the arm runs backwards and takes "
+                         "it out")
+    ap.add_argument("--robust", action="store_true",
+                    help="6b's statistic: the 90th percentile of the "
+                         "leave-one-out distances instead of the maximum")
+    ap.add_argument("--inject", default="Vercel/09-brazil.wav",
+                    help="the recording to inject as the bad clip")
+    ap.add_argument("--cache", default=None,
+                    help="npz file for the two distance matrices")
+    ap.add_argument("--pronunciation", action="store_true",
+                    help="6a's second arm: fill a thin second pronunciation "
+                         "cluster one clip at a time")
+    args = ap.parse_args()
+    if args.poison or args.pronunciation:
+        _, exemplars, spans, se, ee = poison_report(
+            args.source, args.cache, args.robust, args.inject)
+        if args.pronunciation:
+            poison_pronunciation(exemplars, spans, se, ee, args.robust,
+                                 pronunciation_split(exemplars))
+        return 0
+    if args.set == "scripted":
+        return report_scripted(measure_scripted(args.source), args.source)
+    kept, dropped = measure(args.source)
+    if kept is None:
+        return 2
+    if args.table:
+        return table(kept, dropped, args.table)
+    return report(kept, dropped, args.source)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/reference-matching.py
+++ b/scripts/reference-matching.py
@@ -80,6 +80,7 @@ from librosa: forty lines against a heavy dependency for a spike.
 **No model call anywhere.** No app, no decoder, no Ollama. Reads wavs.
 """
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -826,6 +827,26 @@ def poison_rows(source_name="all"):
     return exemplars, spans
 
 
+def fingerprint(exemplars, spans):
+    """A hash of the exact audio these matrices were computed from.
+
+    Names and counts are not enough. A recording can be replaced without its
+    path changing, and a span can move without the number of spans changing;
+    either would make a cached matrix describe different audio while still
+    looking valid. So the MFCCs themselves go into the digest, in order, with
+    the identity of the row they belong to. Any change anywhere rebuilds.
+    """
+    digest = hashlib.sha256()
+    for e in exemplars:
+        digest.update(f"E|{e['name']}|{e['term']}|{e['from']}|".encode())
+        digest.update(np.ascontiguousarray(e["mfcc"], dtype=np.float64).tobytes())
+    for s in spans:
+        digest.update(
+            f"S|{s['wav']}|{s['set']}|{s['stem']}|{s.get('group', '')}|".encode())
+        digest.update(np.ascontiguousarray(s["mfcc"], dtype=np.float64).tobytes())
+    return digest.hexdigest()
+
+
 def poison_matrices(exemplars, spans, cache):
     """Every span-to-recording and recording-to-recording distance, once.
 
@@ -834,13 +855,14 @@ def poison_matrices(exemplars, spans, cache):
     after that is indexing, which is what makes twenty-odd arms affordable.
     """
     names = [e["name"] for e in exemplars]
+    stamp = fingerprint(exemplars, spans)
     if cache and Path(cache).exists():
-        # No pickle: the names go in as a fixed-width unicode array, so this
-        # reads a cache written by this script and nothing else.
+        # No pickle: everything in here is a number or a fixed-width unicode
+        # array, so this reads a cache written by this script and nothing else.
         blob = np.load(cache)
-        if [str(n) for n in blob["names"]] == names and int(blob["spans"]) == len(spans):
+        if str(blob["stamp"]) == stamp:
             return blob["se"], blob["ee"]
-        print("  the cache does not match this data; rebuilding", file=sys.stderr)
+        print("  the cache does not match this audio; rebuilding", file=sys.stderr)
     se = np.zeros((len(spans), len(exemplars)))
     for i, s in enumerate(spans):
         for j, e in enumerate(exemplars):
@@ -852,7 +874,8 @@ def poison_matrices(exemplars, spans, cache):
             ee[i, j] = ee[j, i] = dtw(exemplars[i]["mfcc"], exemplars[j]["mfcc"])
         print(f"  recordings {i + 1}/{len(exemplars)}", end="\r", file=sys.stderr)
     if cache:
-        np.savez(cache, names=np.array(names), spans=len(spans), se=se, ee=ee)
+        np.savez(cache, stamp=stamp, names=np.array(names), spans=len(spans),
+                 se=se, ee=ee)
     return se, ee
 
 
@@ -925,9 +948,18 @@ def banks(exemplars):
 
 def poison_report(source_name, cache, robust, injected):
     exemplars, spans = poison_rows(source_name)
+    index = {e["name"]: i for i, e in enumerate(exemplars)}
+    if injected not in index:
+        # `--source` drops recordings, and `--inject` is a path somebody typed.
+        # Say which one is wrong rather than raising a KeyError halfway through
+        # a nine-minute run.
+        print(f"✗ no recording {injected} under source {source_name}.",
+              file=sys.stderr)
+        print(f"  {len(index)} recording(s) are in scope. `--source all` keeps "
+              "every one of them.", file=sys.stderr)
+        return None
     se, ee = poison_matrices(exemplars, spans, cache)
     by_term = banks(exemplars)
-    index = {e["name"]: i for i, e in enumerate(exemplars)}
     where = "the 90th percentile" if robust else "the maximum"
 
     print(f"\n=== 6a: what one bad clip costs ===  spread is {where} of the")
@@ -954,6 +986,12 @@ def poison_report(source_name, cache, robust, injected):
             keep = [i for i in by_term[term] if exemplars[i]["name"] != bad]
             after = arm(keep, exemplars, spans, se, ee, term, robust)
             label, moved = f"{term} - {Path(bad).name[:14]}", bad
+        elif index[injected] in by_term[term]:
+            # Injecting a recording the folder already holds would put the same
+            # index in the bank twice, and a leave-one-out distance cannot see
+            # the difference between the copy and the original.
+            print(f"  {term:<26} skipped: {injected} is already in this folder")
+            continue
         else:
             after = arm(by_term[term] + [index[injected]], exemplars, spans,
                         se, ee, term, robust)
@@ -1103,8 +1141,10 @@ def main():
                          "cluster one clip at a time")
     args = ap.parse_args()
     if args.poison or args.pronunciation:
-        _, exemplars, spans, se, ee = poison_report(
-            args.source, args.cache, args.robust, args.inject)
+        got = poison_report(args.source, args.cache, args.robust, args.inject)
+        if got is None:
+            return 2
+        _, exemplars, spans, se, ee = got
         if args.pronunciation:
             poison_pronunciation(exemplars, spans, se, ee, args.robust,
                                  pronunciation_split(exemplars))

--- a/scripts/reference-matching.py
+++ b/scripts/reference-matching.py
@@ -860,7 +860,10 @@ def poison_matrices(exemplars, spans, cache):
         # No pickle: everything in here is a number or a fixed-width unicode
         # array, so this reads a cache written by this script and nothing else.
         blob = np.load(cache)
-        if str(blob["stamp"]) == stamp:
+        # A cache written before the fingerprint existed has no `stamp`, and
+        # asking for one raises rather than rebuilding. Anything this script
+        # cannot vouch for is rebuilt, never trusted.
+        if {"stamp", "se", "ee"} <= set(blob.files) and str(blob["stamp"]) == stamp:
             return blob["se"], blob["ee"]
         print("  the cache does not match this audio; rebuilding", file=sys.stderr)
     se = np.zeros((len(spans), len(exemplars)))
@@ -958,6 +961,7 @@ def poison_report(source_name, cache, robust, injected):
         print(f"  {len(index)} recording(s) are in scope. `--source all` keeps "
               "every one of them.", file=sys.stderr)
         return None
+    poison = index[injected]           # checked above; never looked up again
     se, ee = poison_matrices(exemplars, spans, cache)
     by_term = banks(exemplars)
     where = "the 90th percentile" if robust else "the maximum"
@@ -986,14 +990,14 @@ def poison_report(source_name, cache, robust, injected):
             keep = [i for i in by_term[term] if exemplars[i]["name"] != bad]
             after = arm(keep, exemplars, spans, se, ee, term, robust)
             label, moved = f"{term} - {Path(bad).name[:14]}", bad
-        elif index[injected] in by_term[term]:
+        elif poison in by_term[term]:
             # Injecting a recording the folder already holds would put the same
             # index in the bank twice, and a leave-one-out distance cannot see
             # the difference between the copy and the original.
             print(f"  {term:<26} skipped: {injected} is already in this folder")
             continue
         else:
-            after = arm(by_term[term] + [index[injected]], exemplars, spans,
+            after = arm(by_term[term] + [poison], exemplars, spans,
                         se, ee, term, robust)
             label, moved = f"{term} + {Path(injected).name[:14]}", injected
         print(f"  {label:<26} {base['recordings']:>3}->{after['recordings']:<3}  "


### PR DESCRIPTION
## Summary
PR 6a of the plan asks whether one mislabeled clip in the reference bank can quietly wreck the veto's accuracy, and the plan's own falsifier for this was written against a statistic (AUC) that can't see the effect at all.
This PR measures the veto's actual true/false rejection counts under a poisoned clip, across eleven terms, instead of only AUC.
One bad clip drops true rejections from 554 to 228 while buying back only 8 of 10 false ones — 40 true rejections lost per false one saved — so the falsifier's condition fired and its AUC-based conclusion was wrong.

## Issue
Part of #74. Stacks on #80 (`docs/missing-prs`), the tip of the stack.

## What it measured

**The falsifier's condition fired, and its conclusion is false.** Nine of eleven terms show no AUC movement at all under poisoning — that's arithmetic, not evidence, because a term's spread is a constant that divides out of any ranking inside that term. The veto's actual decision can see it, and it collapses: true rejections go from 554 to 228 across the eleven terms, while only 8 of 10 false rejections are bought back. `Arexvy` goes from catching 83% of the spans it should catch to 2%.

## What is new

**The two clips the plan named as the likely culprits are not the clips that actually set the spread.** Both terms' actual maximum-distance clips are real recordings of the term, not mislabeled ones. Removing one of the named clips *raises* its term's spread, because it was another recording's nearest neighbor. A bad clip with company never sets a maximum, so a pruner that just deletes the farthest recording would delete a real one.

**The 90th percentile is worth building instead of the maximum.** It keeps 551 of 649 true rejections under the same poison (against the maximum's 228 of 554), at a cost of seven more false rejections out of 96. It stops being robust below about eight recordings per term.

**The second-pronunciation arm could not be run, and was not faked.** No observation in the archive carries a language tag distinguishing pronunciations, so this part of the plan (§7) stays unmeasured — it needs a dedicated recording session.

## How

`scripts/reference-matching.py` gets a `--poison` arm. Deterministic: no app, no build, no decoder, no model. Every distance is computed once and cached, so each arm after the first is just an index lookup. The baseline reproduces round 7 exactly (`Supabase` 1.000, `Redcrawl` 0.966, pooled 0.935).

The measurement is in-sample, and the PR says so: recordings were mined from the clips they're scored on. The per-clip hold-out is applied throughout but doesn't cover the corpus-level fit — the deltas between arms are the point, not the absolute numbers.

<details>
<summary><b>How to Test</b></summary>

No Swift changed. Nothing under the live config or voice store was written — the arms run on a copy under `PARROTFLOW_CONFIG_DIR`. No wav and no transcript is committed; `scripts/check-no-voice.sh` passes 5/5.

</details>
