### PR TITLE
fix: a revert does not write a rule, and keeps the audio

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -152,6 +152,15 @@ jobs:
       - name: A correction keeps the audio
         run: scripts/check-corrections.sh
 
+      # The other direction, which used to write a rule that disabled the term
+      # it was reverting. A revert must write nothing that can fire on text
+      # later — not to config.yaml, not to vocabulary.yaml — and its clip must
+      # land in negatives/ and never in samples/. Every number this project
+      # computes walks samples/, so a negative filed as a positive would rot
+      # all of them silently.
+      - name: A revert writes no rule
+        run: scripts/check-reverts.sh
+
       # The same trap, one directory over: the transform folder a first launch
       # is seeded with against the copy in examples/ that people read and
       # score. It has always been able to drift and has never been checked

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1871,13 +1871,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if let seen = outcome.seen {
             Log.write("    \(term): seen \(seen) time(s), from correction")
         }
+        for line in Corrections.said(about: outcome.revert, term: term) {
+            Log.write("    \(line)")
+        }
         if let sample = outcome.sample {
             Log.write("    kept the audio as voice/\(sample)")
         } else if let why = outcome.skipped {
             Log.write("    no audio kept — \(why)")
         }
+        let bank = outcome.revert == nil ? "samples" : "negatives"
         for gone in outcome.capped {
-            Log.write("    capped voice/samples/\(term)/\(gone.file) — \(gone.why)")
+            Log.write("    capped voice/\(bank)/\(term)/\(gone.file) — \(gone.why)")
         }
         for gone in outcome.pruned {
             Log.write("    dropped \"\(gone)\" from \(term) — seen once and not again since")
@@ -1894,7 +1898,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     heard: rule.heard, corrected: rule.corrected, via: "command",
                     clip: pendingClip
                 )
-                Log.write("learned replacement: \(rule.heard) -> \(rule.corrected)")
+                Log.write(outcome.revert == nil
+                    ? "learned replacement: \(rule.heard) -> \(rule.corrected)"
+                    : "took the term back: \(rule.heard) -> \(rule.corrected)")
                 logKept(outcome)
             } catch {
                 presentAlert(title: "Could not save the rule", message: error.localizedDescription)
@@ -2317,7 +2323,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         heard: rule.heard, corrected: rule.corrected, via: "panel",
                         clip: clip
                     )
-                    Log.write("learned replacement: \(rule.heard) -> \(rule.corrected)")
+                    Log.write(outcome.revert == nil
+                        ? "learned replacement: \(rule.heard) -> \(rule.corrected)"
+                        : "took the term back: \(rule.heard) -> \(rule.corrected)")
                     self.logKept(outcome)
                 } catch {
                     self.presentAlert(

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -119,8 +119,9 @@ enum CheckConfigCommand {
             let width = recorded.map(\.term.count).max() ?? 0
             for entry in recorded {
                 print("      \(entry.term.padding(toLength: width, withPad: " ", startingAt: 0))"
-                    + "  \(entry.observations) observation(s), \(entry.samples) sample(s)"
-                    + "  — `--forget \(entry.term)` drops both")
+                    + "  \(entry.observations) observation(s), \(entry.samples) sample(s),"
+                    + " \(entry.negatives) negative(s)"
+                    + "  — `--forget \(entry.term)` drops all three")
             }
         }
         // A closed band is the one measurement that argues with the config: it

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -265,23 +265,82 @@ struct Config: Decodable, Equatable {
             /// True when the list arrived under the old `heard:` key, so
             /// `notices()` can name the key and say what to write instead.
             var wroteHeard = false
+            /// The ordinary words this term has been written over, and how
+            /// often the speaker took it back. See `Collision`.
+            var collisions: [Collision] = []
+
+            /// An ordinary word this term has fired on wrongly.
+            ///
+            /// **Never matched and never substituted.** It is not a rendering
+            /// and it is not a rule. Nothing reads it on the way to a decision:
+            /// `heard` does not include it, so `Config.vocabularyRules` cannot
+            /// turn it into a replacement, and the spotter is never handed it.
+            ///
+            /// It records which pair to compare against later, and how much
+            /// evidence there is for the comparison. `Praisy` versus "praise"
+            /// is a real question about this speaker's mouth; `Supabase` versus
+            /// "praise" is not a question at all. So the entry is keyed on the
+            /// pair, under the term, and means nothing to any other term.
+            ///
+            /// `reverted` counts the times a person took the term back to this
+            /// word. `clips` counts how many of those left audio in
+            /// `voice/negatives/<Term>/`. The two differ whenever the cut was
+            /// refused, and the gap is worth being able to see.
+            struct Collision: Decodable, Equatable {
+                var word: String
+                var reverted: Int = 0
+                var clips: Int = 0
+
+                init(word: String, reverted: Int = 0, clips: Int = 0) {
+                    self.word = word
+                    self.reverted = reverted
+                    self.clips = clips
+                }
+
+                enum CodingKeys: String, CodingKey { case word, reverted, clips }
+
+                /// Two shapes, like `Pronunciation`: the mapping the app writes,
+                /// and the bare string a person types when they only want to
+                /// name the word.
+                init(from decoder: Decoder) throws {
+                    if let single = try? decoder.singleValueContainer(),
+                       let word = try? single.decode(String.self) {
+                        self.init(word: word)
+                        return
+                    }
+                    let c = try decoder.container(keyedBy: CodingKeys.self)
+                    self.init(
+                        word: try c.decode(String.self, forKey: .word),
+                        reverted: try c.decodeIfPresent(Int.self, forKey: .reverted) ?? 0,
+                        clips: try c.decodeIfPresent(Int.self, forKey: .clips) ?? 0
+                    )
+                }
+            }
 
             /// Just the renderings, for the callers that only want the
             /// spellings — the exact rules, and the "can anything reach this
             /// term at all" check in `notices()`.
+            ///
+            /// Renderings only. A collision is the opposite kind of fact and
+            /// must never reach a rule table through here.
             var heard: [String] { pronunciations.map(\.heard) }
 
             init(
                 offerBelow: Float? = nil, never: Bool = false,
-                pronunciations: [Pronunciation] = [], wroteHeard: Bool = false
+                pronunciations: [Pronunciation] = [], wroteHeard: Bool = false,
+                collisions: [Collision] = []
             ) {
                 self.offerBelow = offerBelow
                 self.never = never
                 self.pronunciations = pronunciations
                 self.wroteHeard = wroteHeard
+                self.collisions = collisions
             }
 
-            enum CodingKeys: String, CodingKey { case floor, heard, pronunciations }
+            enum CodingKeys: String, CodingKey {
+                case floor, heard, pronunciations
+                case collidesWith = "collides_with"
+            }
 
             /// Five shapes, because most terms need none of this:
             ///
@@ -318,6 +377,11 @@ struct Config: Decodable, Equatable {
                 // free extra draw.
                 let said = Self.distinct(listed + old.map { Pronunciation(heard: $0) })
                 let wroteHeard = !old.isEmpty
+                // Read on every shape below, because it is orthogonal to all of
+                // them: a term can carry a legacy floor and a collision at once.
+                let collided = try c.decodeIfPresent(
+                    [Collision].self, forKey: .collidesWith
+                ) ?? []
                 // Number first. Yams answers `Bool.self` for `0.85` quite
                 // happily — anything that is not `true`/`yes`/`on` decodes as
                 // `false` — so asking about `off` before asking about the
@@ -328,7 +392,10 @@ struct Config: Decodable, Equatable {
                 // The reverse trap does not exist. `off` is not a number, so
                 // asking for a Float first throws and falls through.
                 if let number = (try? c.decodeIfPresent(Float.self, forKey: .floor)) ?? nil {
-                    self.init(offerBelow: number, pronunciations: said, wroteHeard: wroteHeard)
+                    self.init(
+                        offerBelow: number, pronunciations: said,
+                        wroteHeard: wroteHeard, collisions: collided
+                    )
                     return
                 }
                 // `off` rather than a magic number. The previous spelling was
@@ -341,18 +408,21 @@ struct Config: Decodable, Equatable {
                 if let flag = (try? c.decodeIfPresent(Bool.self, forKey: .floor)) ?? nil {
                     self.init(
                         offerBelow: nil, never: flag == false,
-                        pronunciations: said, wroteHeard: wroteHeard
+                        pronunciations: said, wroteHeard: wroteHeard, collisions: collided
                     )
                     return
                 }
                 if let word = (try? c.decodeIfPresent(String.self, forKey: .floor)) ?? nil {
                     self.init(
                         offerBelow: nil, never: word.lowercased() == "off",
-                        pronunciations: said, wroteHeard: wroteHeard
+                        pronunciations: said, wroteHeard: wroteHeard, collisions: collided
                     )
                     return
                 }
-                self.init(offerBelow: nil, pronunciations: said, wroteHeard: wroteHeard)
+                self.init(
+                    offerBelow: nil, pronunciations: said,
+                    wroteHeard: wroteHeard, collisions: collided
+                )
             }
 
             /// One entry per spelling, first kept. Exact rather than

--- a/Sources/ParrotFlow/ConfigWriter.swift
+++ b/Sources/ParrotFlow/ConfigWriter.swift
@@ -501,6 +501,16 @@ enum ConfigWriter {
     /// rewritten as `heard:` and `floor:` inside a block body — both are still
     /// read, so nothing is lost — and a term that already has a body is left
     /// exactly as it is.
+    ///
+    /// **A value that wraps keeps its own lines.** The live file writes one
+    /// list over two, and joining them onto one line destroys the entry when
+    /// any of them carries a comment: everything after the `#` becomes part of
+    /// the comment, so `[Prissy,   # the common one` + `Pressy]` collapses to
+    /// an unclosed bracket, and the whole of `vocabulary.yaml` then fails to
+    /// load — silently, because a file that will not parse is read as no terms
+    /// at all. Only the first line is rewritten, and the continuations move
+    /// under the new key untouched. They stay indented deeper than it, which is
+    /// all a flow sequence asks.
     private static func openBlockBody(
         of term: String, at start: Int, in lines: inout [String]
     ) -> Int {
@@ -516,16 +526,15 @@ enum ConfigWriter {
             return endOfTermBlock(in: lines, from: start, deeperThan: termIndent.count)
         }
         let closes = closingFlow(in: lines, from: start, deeperThan: termIndent.count)
-        let value = lines[start...closes].joined(separator: " ")
-        let body = String(value[value.index(after: value.firstIndex(of: ":")!)...])
-            .trimmingCharacters(in: .whitespaces)
         // A bare list is the old `heard:`; a bare number is the old `floor:`.
-        let key = body.hasPrefix("[") ? "heard" : "floor"
-        lines.replaceSubrange(start...closes, with: [
+        let key = inline.hasPrefix("[") ? "heard" : "floor"
+        var rewritten = [
             "\(termIndent)\(quoted(term)):",
-            "\(bodyIndent)\(key): \(body)",
-        ])
-        return start + 1
+            "\(bodyIndent)\(key): \(inline)",
+        ]
+        if closes > start { rewritten += lines[(start + 1)...closes] }
+        lines.replaceSubrange(start...closes, with: rewritten)
+        return closes + 1
     }
 
     /// A number written on one of an entry's lines, if it is there.

--- a/Sources/ParrotFlow/ConfigWriter.swift
+++ b/Sources/ParrotFlow/ConfigWriter.swift
@@ -192,29 +192,7 @@ enum ConfigWriter {
         guard let start = index(ofTerm: term, in: lines) else { return (yaml, 0) }
         let termIndent = indentation(of: lines[start])
         let bodyIndent = termIndent + "  "
-
-        // Whatever the term's value is today, in block form, so a
-        // `pronunciations:` list can be appended under it. A legacy floor and a
-        // legacy `heard:` list both survive this — they are still read.
-        var end = start
-        let head = lines[start]
-        let colon = head.firstIndex(of: ":")!
-        let inline = String(head[head.index(after: colon)...]).trimmingCharacters(in: .whitespaces)
-        if !inline.isEmpty && !inline.hasPrefix("#") {
-            let closes = closingFlow(in: lines, from: start, deeperThan: termIndent.count)
-            let value = lines[start...closes].joined(separator: " ")
-            let body = String(value[value.index(after: value.firstIndex(of: ":")!)...])
-                .trimmingCharacters(in: .whitespaces)
-            // A bare list is the old `heard:`; a bare number is the old `floor:`.
-            let key = body.hasPrefix("[") ? "heard" : "floor"
-            lines.replaceSubrange(start...closes, with: [
-                "\(termIndent)\(quoted(term)):",
-                "\(bodyIndent)\(key): \(body)",
-            ])
-            end = start + 1
-        } else {
-            end = endOfTermBlock(in: lines, from: start, deeperThan: termIndent.count)
-        }
+        let end = openBlockBody(of: term, at: start, in: &lines)
 
         // An existing `pronunciations:` block, and this rendering inside it.
         var listIndex: Int?
@@ -301,9 +279,314 @@ enum ConfigWriter {
         return true
     }
 
-    /// The line of `- heard: <name>` inside a `pronunciations:` block.
+    // MARK: - Taking a rendering back, and recording what it collided with
+
+    /// What `discountPronunciation` managed to do about a rendering.
+    enum Discount: Equatable {
+        /// Its `seen:` count went down to this.
+        case reduced(Int)
+        /// It stood at one sighting from one correction, and that correction
+        /// has now been contradicted, so the entry is gone.
+        case dropped
+        /// It is there and it cannot be counted down: a legacy `heard:` list,
+        /// or an entry with `seen: 0`, which means "never counted". There is no
+        /// honest number to subtract one from.
+        case uncounted
+        /// No such rendering. Nothing in the file caused the substitution.
+        case notFound
+    }
+
+    /// Takes one sighting back off a rendering, because the speaker said the
+    /// term should not have fired there.
+    ///
+    /// A revert is a person contradicting a rendering they once confirmed, so
+    /// the count that recorded it goes down. It only ever goes down by one: a
+    /// rendering seen nine times and reverted once is still how this person
+    /// says the word, and deleting it would be the same bug in the other
+    /// direction — one correction disabling a term.
+    ///
+    /// **The entry is only removed at zero, and only when a correction wrote
+    /// it.** `seen: 1, from: correction` reverted once is one sighting against
+    /// one revert: nothing left. A mined or legacy entry has `seen: 0`, which
+    /// means "never counted" rather than "never seen", so there is no number to
+    /// take one off — it is left alone and reported as `uncounted`. Deleting on
+    /// a count nobody recorded is how a prune eats correct data, and
+    /// `Corrections.prune` refuses for the same reason.
+    static func discountPronunciation(term: String, heard: String) throws -> Discount {
+        let url = ConfigStore.vocabularyURL
+        guard let original = try? String(contentsOf: url, encoding: .utf8) else {
+            return .notFound
+        }
+        var lines = original.components(separatedBy: "\n")
+        guard let start = index(ofTerm: term, in: lines) else { return .notFound }
+        let termIndent = indentation(of: lines[start]).count
+        let end = endOfTermBlock(in: lines, from: start, deeperThan: termIndent)
+
+        var listAt: Int?
+        for cursor in (start + 1)...max(start + 1, end) where cursor < lines.count {
+            if lines[cursor].trimmingCharacters(in: .whitespaces).hasPrefix("pronunciations:") {
+                listAt = cursor
+                break
+            }
+        }
+        // No block at all: whatever is there is a legacy `heard:` list, which
+        // carries no count. `Corrections` has already established the rendering
+        // exists, so this is `uncounted` and not `notFound`.
+        guard let listAt else { return .uncounted }
+        let listEnd = endOfTermBlock(
+            in: lines, from: listAt, deeperThan: indentation(of: lines[listAt]).count
+        )
+        guard let found = entry(named: heard, in: lines, from: listAt + 1, through: listEnd) else {
+            return .uncounted
+        }
+        let last = endOfEntry(in: lines, from: found, through: listEnd)
+        let seen = value(of: "seen", in: lines, from: found, through: last)
+        let source = word(of: "from", in: lines, from: found, through: last)
+
+        if let seen, seen >= 2 {
+            _ = set("seen", to: seen - 1, in: &lines, from: found, through: last)
+            try lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
+            return .reduced(seen - 1)
+        }
+        guard seen == 1, source == "correction" else { return .uncounted }
+        lines.removeSubrange(found...last)
+        // A `pronunciations:` key with nothing under it decodes as null, not as
+        // an empty list, so it goes too.
+        if endOfTermBlock(
+            in: lines, from: listAt, deeperThan: indentation(of: lines[listAt]).count
+        ) == listAt {
+            lines.remove(at: listAt)
+        }
+        try lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
+        return .dropped
+    }
+
+    /// Records that `term` was written over the ordinary word `word`, and
+    /// returns the pair's counts afterwards.
+    ///
+    /// Written under the term as `collides_with:`, which nothing matches and
+    /// nothing substitutes — see `Config.Vocabulary.Term.Collision`. It is not
+    /// a rendering: a rendering says "the term was said and came out like
+    /// this", and this says the opposite, that the term was *not* said here.
+    /// Putting the two in one list is how a revert would end up firing as a
+    /// rule, which is the bug this whole change exists to fix.
+    ///
+    /// Keyed on the pair. "praise" is a negative for `Praisy` and says nothing
+    /// at all about `Supabase`, so it lives under the term it argues with.
+    ///
+    /// - Parameter clips: how many negative clips this revert added, 0 or 1.
+    @discardableResult
+    static func recordCollision(
+        term: String, word: String, clips: Int
+    ) throws -> (reverted: Int, clips: Int) {
+        let url = ConfigStore.vocabularyURL
+        let original = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+        let (updated, counts) = recording(
+            collision: word, of: term, clips: clips, in: original
+        )
+        if updated != original {
+            try updated.write(to: url, atomically: true, encoding: .utf8)
+        }
+        return counts
+    }
+
+    /// The file with one collision recorded, and what the pair now stands at.
+    static func recording(
+        collision word: String, of term: String, clips: Int, in yaml: String
+    ) -> (String, (reverted: Int, clips: Int)) {
+        var lines = yaml.components(separatedBy: "\n")
+        guard let start = index(ofTerm: term, in: lines) else { return (yaml, (0, 0)) }
+        let termIndent = indentation(of: lines[start])
+        let bodyIndent = termIndent + "  "
+        let end = openBlockBody(of: term, at: start, in: &lines)
+
+        var listIndex: Int?
+        var cursor = start + 1
+        while cursor <= end, cursor < lines.count {
+            if lines[cursor].trimmingCharacters(in: .whitespaces).hasPrefix("collides_with:") {
+                listIndex = cursor
+                break
+            }
+            cursor += 1
+        }
+
+        guard let listAt = listIndex else {
+            lines.insert(contentsOf: [
+                "\(bodyIndent)collides_with:",
+                "\(bodyIndent)  - word: \(quoted(word))",
+                "\(bodyIndent)    reverted: 1",
+                "\(bodyIndent)    clips: \(clips)",
+            ], at: end + 1)
+            return (lines.joined(separator: "\n"), (1, clips))
+        }
+
+        // `collides_with: [praise]` is legal YAML and nothing writes it, but a
+        // person may have. Left alone rather than rewritten, for the reason
+        // `adding(pronunciation:)` leaves a flow `pronunciations:` alone:
+        // appending a block entry under a flow sequence would not parse.
+        let listIndent = indentation(of: lines[listAt])
+        if lines[listAt].trimmingCharacters(in: .whitespaces).dropFirst("collides_with:".count)
+            .trimmingCharacters(in: .whitespaces).hasPrefix("[") {
+            return (yaml, (0, 0))
+        }
+
+        let listEnd = endOfTermBlock(in: lines, from: listAt, deeperThan: listIndent.count)
+        let entryIndent = listIndent + "  "
+        if let found = entry(named: word, under: "word", in: lines, from: listAt + 1, through: listEnd) {
+            // The entry's last line is recomputed before each counter, because
+            // writing the first one can insert a line and move it.
+            func bump(_ key: String, by delta: Int) -> Int {
+                let listEnd = endOfTermBlock(in: lines, from: listAt, deeperThan: listIndent.count)
+                let last = endOfEntry(in: lines, from: found, through: listEnd)
+                return add(
+                    delta, to: key, in: &lines, from: found, through: last,
+                    indent: entryIndent + "  "
+                )
+            }
+            let reverted = bump("reverted", by: 1)
+            let kept = bump("clips", by: clips)
+            return (lines.joined(separator: "\n"), (reverted, kept))
+        }
+
+        lines.insert(contentsOf: [
+            "\(entryIndent)- word: \(quoted(word))",
+            "\(entryIndent)  reverted: 1",
+            "\(entryIndent)  clips: \(clips)",
+        ], at: listEnd + 1)
+        return (lines.joined(separator: "\n"), (1, clips))
+    }
+
+    /// Removes a term's whole `collides_with:` block, and says how many pairs
+    /// went. For `--forget`, which has to take back all four things a revert
+    /// wrote.
+    static func dropCollisions(of term: String) throws -> Int {
+        let url = ConfigStore.vocabularyURL
+        guard let original = try? String(contentsOf: url, encoding: .utf8) else { return 0 }
+        var lines = original.components(separatedBy: "\n")
+        guard let start = index(ofTerm: term, in: lines) else { return 0 }
+        let termIndent = indentation(of: lines[start]).count
+        let end = endOfTermBlock(in: lines, from: start, deeperThan: termIndent)
+
+        var listAt: Int?
+        for cursor in (start + 1)...max(start + 1, end) where cursor < lines.count {
+            if lines[cursor].trimmingCharacters(in: .whitespaces).hasPrefix("collides_with:") {
+                listAt = cursor
+                break
+            }
+        }
+        guard let listAt else { return 0 }
+        let listIndent = indentation(of: lines[listAt]).count
+        let listEnd = endOfTermBlock(in: lines, from: listAt, deeperThan: listIndent)
+        // The flow shape a person may have written: `collides_with: [praise]`.
+        let inline = lines[listAt].trimmingCharacters(in: .whitespaces)
+            .dropFirst("collides_with:".count).trimmingCharacters(in: .whitespaces)
+        var removed = 0
+        if inline.hasPrefix("[") {
+            removed = count(inFlow: lines[listAt...listEnd].joined(separator: " "))
+        } else {
+            for cursor in listAt...listEnd
+            where lines[cursor].trimmingCharacters(in: .whitespaces).hasPrefix("-") {
+                removed += 1
+            }
+        }
+        lines.removeSubrange(listAt...listEnd)
+        try lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
+        return removed
+    }
+
+    /// The term's value in block form, with its last line's index.
+    ///
+    /// A term can be written five ways and only one of them has room for
+    /// another key underneath. `Praisy: [Prissy]` and `Mirza: 0.85` are
+    /// rewritten as `heard:` and `floor:` inside a block body — both are still
+    /// read, so nothing is lost — and a term that already has a body is left
+    /// exactly as it is.
+    private static func openBlockBody(
+        of term: String, at start: Int, in lines: inout [String]
+    ) -> Int {
+        let termIndent = indentation(of: lines[start])
+        let bodyIndent = termIndent + "  "
+        let head = lines[start]
+        guard let colon = head.firstIndex(of: ":") else {
+            return endOfTermBlock(in: lines, from: start, deeperThan: termIndent.count)
+        }
+        let inline = String(head[head.index(after: colon)...])
+            .trimmingCharacters(in: .whitespaces)
+        guard !inline.isEmpty, !inline.hasPrefix("#") else {
+            return endOfTermBlock(in: lines, from: start, deeperThan: termIndent.count)
+        }
+        let closes = closingFlow(in: lines, from: start, deeperThan: termIndent.count)
+        let value = lines[start...closes].joined(separator: " ")
+        let body = String(value[value.index(after: value.firstIndex(of: ":")!)...])
+            .trimmingCharacters(in: .whitespaces)
+        // A bare list is the old `heard:`; a bare number is the old `floor:`.
+        let key = body.hasPrefix("[") ? "heard" : "floor"
+        lines.replaceSubrange(start...closes, with: [
+            "\(termIndent)\(quoted(term)):",
+            "\(bodyIndent)\(key): \(body)",
+        ])
+        return start + 1
+    }
+
+    /// A number written on one of an entry's lines, if it is there.
+    private static func value(
+        of key: String, in lines: [String], from: Int, through last: Int
+    ) -> Int? {
+        Int(word(of: key, in: lines, from: from, through: last) ?? "")
+    }
+
+    /// A scalar written on one of an entry's lines, if it is there.
+    private static func word(
+        of key: String, in lines: [String], from: Int, through last: Int
+    ) -> String? {
+        for cursor in from...max(from, last) where cursor < lines.count {
+            let trimmed = lines[cursor].trimmingCharacters(in: .whitespaces)
+            let body = trimmed.hasPrefix("-")
+                ? String(trimmed.dropFirst()).trimmingCharacters(in: .whitespaces) : trimmed
+            guard body.hasPrefix("\(key):") else { continue }
+            return unquoted(String(body.dropFirst(key.count + 1)))
+        }
+        return nil
+    }
+
+    /// Writes a number onto an entry's existing key. False if it had none.
+    @discardableResult
+    private static func set(
+        _ key: String, to number: Int, in lines: inout [String], from: Int, through last: Int
+    ) -> Bool {
+        for cursor in from...max(from, last) where cursor < lines.count {
+            let trimmed = lines[cursor].trimmingCharacters(in: .whitespaces)
+            let body = trimmed.hasPrefix("-")
+                ? String(trimmed.dropFirst()).trimmingCharacters(in: .whitespaces) : trimmed
+            guard body.hasPrefix("\(key):") else { continue }
+            // A key on the `- ` line itself keeps its dash.
+            let head = trimmed.hasPrefix("-")
+                ? "\(indentation(of: lines[cursor]))- " : indentation(of: lines[cursor])
+            lines[cursor] = "\(head)\(key): \(number)"
+            return true
+        }
+        return false
+    }
+
+    /// Adds `delta` to an entry's counter, writing the key when it has none.
+    /// Returns what it now stands at.
+    private static func add(
+        _ delta: Int, to key: String, in lines: inout [String],
+        from: Int, through last: Int, indent: String
+    ) -> Int {
+        let was = value(of: key, in: lines, from: from, through: last) ?? 0
+        if set(key, to: was + delta, in: &lines, from: from, through: last) {
+            return was + delta
+        }
+        lines.insert("\(indent)\(key): \(was + delta)", at: last + 1)
+        return was + delta
+    }
+
+    /// The line of `- heard: <name>` inside a `pronunciations:` block, or of
+    /// `- word: <name>` inside a `collides_with:` one.
     private static func entry(
-        named heard: String, in lines: [String], from: Int, through last: Int
+        named heard: String, under key: String = "heard",
+        in lines: [String], from: Int, through last: Int
     ) -> Int? {
         for cursor in from...max(from, last) where cursor < lines.count {
             let trimmed = lines[cursor].trimmingCharacters(in: .whitespaces)
@@ -311,8 +594,8 @@ enum ConfigWriter {
             let body = String(trimmed.dropFirst()).trimmingCharacters(in: .whitespaces)
             // `- heard: Versal` and the bare `- Versal` a person may have typed.
             let spelling: String
-            if body.hasPrefix("heard:") {
-                spelling = unquoted(String(body.dropFirst("heard:".count)))
+            if body.hasPrefix("\(key):") {
+                spelling = unquoted(String(body.dropFirst(key.count + 1)))
             } else if !body.contains(":") {
                 spelling = unquoted(body)
             } else {

--- a/Sources/ParrotFlow/ConfigWriter.swift
+++ b/Sources/ParrotFlow/ConfigWriter.swift
@@ -19,12 +19,57 @@ enum ConfigWriter {
         }
     }
 
-    /// Records that `heard` should be written as `corrected`.
-    static func addReplacement(heard: String, corrected: String) throws {
+    /// Records that `heard` should be written as `corrected`. False when
+    /// nothing was written.
+    ///
+    /// **A revert writes no rule.** When `heard` names a vocabulary term and
+    /// `corrected` does not, the speaker is taking the term back: the app wrote
+    /// `Praisy`, they meant "praise". Writing `"praise": ["Praisy"]` here would
+    /// rewrite *every* `Praisy` into "praise" from then on, correct ones
+    /// included — one revert silently disabling the term. And a rule in
+    /// `config.yaml` is one `--forget` cannot reach, so the only way back out
+    /// was to find it by hand.
+    ///
+    /// The gate sits here rather than only in the caller because this is the
+    /// last function before the file, and all three correction paths reach it.
+    /// A path added later cannot bring the bug back.
+    @discardableResult
+    static func addReplacement(heard: String, corrected: String) throws -> Bool {
+        if let term = revertedTerm(heard: heard, corrected: corrected) {
+            Log.write("correction: \"\(heard)\" -> \"\(corrected)\" takes back the term"
+                + " \(term), so no replacement rule was written — a rule here would"
+                + " rewrite every \(term) into \"\(corrected)\"")
+            return false
+        }
         let url = ConfigStore.fileURL
         let original = try String(contentsOf: url, encoding: .utf8)
         let updated = try insert(heard: heard, corrected: corrected, into: original)
         try updated.write(to: url, atomically: true, encoding: .utf8)
+        return true
+    }
+
+    /// The vocabulary term a correction takes back, when it takes one back.
+    ///
+    /// Two conditions, and both matter. `heard` has to name a term, or this is
+    /// an ordinary correction of an ordinary word. And `corrected` has to name
+    /// no term at all: `Supabase` corrected into `Redcrawl` is one term written
+    /// where another was said, which is a rendering worth recording, not a
+    /// statement that the vocabulary was wrong to fire.
+    ///
+    /// - Parameter vocabulary: the table to ask, when the caller already has
+    ///   one. Read from disk otherwise, which is what the three correction
+    ///   paths do.
+    static func revertedTerm(
+        heard: String, corrected: String, in vocabulary: Config.Vocabulary? = nil
+    ) -> String? {
+        let terms = (vocabulary ?? ConfigStore.loadVocabulary()).terms.keys
+        guard let term = terms.first(where: {
+            $0.caseInsensitiveCompare(heard) == .orderedSame
+        }) else { return nil }
+        guard !terms.contains(where: {
+            $0.caseInsensitiveCompare(corrected) == .orderedSame
+        }) else { return nil }
+        return term
     }
 
     /// Splices the mishearing into the list under its target spelling, adding

--- a/Sources/ParrotFlow/Corrections.swift
+++ b/Sources/ParrotFlow/Corrections.swift
@@ -60,6 +60,46 @@ enum Corrections {
         var capped: [(file: String, why: String)] = []
         /// Renderings the seen-once rule dropped.
         var pruned: [String] = []
+        /// Set when this was a revert rather than a correction — the term was
+        /// taken back, no rule was written, and the clip is a negative.
+        var revert: Revert?
+    }
+
+    /// What a revert did.
+    struct Revert {
+        /// The ordinary word the term was taken back to.
+        var word: String
+        /// What was blamed for the term firing, and what was done about it.
+        var blame: Blame
+        /// The pair's counts in `collides_with:` afterwards.
+        var reverted: Int
+        var clips: Int
+    }
+
+    /// What caused the term to be written where it was not said.
+    ///
+    /// Only two things can do it, and only one of them leaves a trace anything
+    /// can act on. An exact rule — a rendering in the term's
+    /// `pronunciations:`, which `Config.vocabularyRules` turns into a
+    /// replacement — fires on that spelling every time, so if the word the
+    /// speaker meant is registered as a rendering of the term, that rule is
+    /// what fired. Otherwise the acoustic pass proposed it from the audio, and
+    /// there is nothing in any file to blame.
+    enum Blame: Equatable {
+        /// A rendering fired, and its `seen:` count went down to this.
+        case rendering(String, seen: Int)
+        /// A rendering fired, stood at one sighting from one correction, and
+        /// is now gone: one sighting against one revert leaves nothing.
+        case dropped(String)
+        /// A rendering fired and could not be counted down — a legacy `heard:`
+        /// list, or an entry that was never counted. It is left alone.
+        case uncounted(String)
+        /// A rule in `config.yaml` maps the word to the term. A person wrote
+        /// that by hand, so it is named and not touched.
+        case handWritten(String)
+        /// Nothing in the data caused it. The acoustic pass proposed the term
+        /// from the audio, and the negative clip is the whole answer.
+        case nothing
     }
 
     /// Learn that `heard` should have been `corrected`.
@@ -74,6 +114,10 @@ enum Corrections {
     ///   the correction takes effect exactly as before — it is now recorded in
     ///   the file that owns learnt data and knows where each entry came from.
     ///   It is also the file `--forget` can reach, which `config.yaml` was not.
+    /// - **A term the other way round.** `Praisy` → "praise" is a *revert*: the
+    ///   term was written where an ordinary word was said. No rule is written
+    ///   anywhere, the rendering that fired is counted down, and the audio is
+    ///   kept as a negative. See `revert`.
     /// - **Anything else.** `teh` → `the` is not a name and has no audio worth
     ///   keeping. It goes to `transcription.replacements` in `config.yaml`,
     ///   which is what has always happened.
@@ -87,6 +131,16 @@ enum Corrections {
         let config = try ConfigStore.load()
         let term = config.vocabulary.terms.keys.first {
             $0.caseInsensitiveCompare(corrected) == .orderedSame
+        }
+
+        // Asked before the forward path, because the two are decided by the
+        // same two lookups and only one of them can be true.
+        if let taken = ConfigWriter.revertedTerm(
+            heard: heard, corrected: corrected, in: config.vocabulary
+        ) {
+            return try revert(
+                term: taken, to: corrected, via: via, clip: clip, config: config
+            )
         }
 
         guard let term else {
@@ -107,7 +161,8 @@ enum Corrections {
             at: stamp(), term: term, heard: heard, from: "correction",
             score: nil, mic: Recorder.inputDeviceName, span: nil,
             sample: nil, wav: nil, lang: nil,
-            build: AppVariant.buildStamp, skipped: nil
+            build: AppVariant.buildStamp, skipped: nil,
+            polarity: VoiceStore.Polarity.positive.rawValue
         )
 
         switch keep(heard: heard, term: term, clip: clip, config: config) {
@@ -130,6 +185,135 @@ enum Corrections {
         return outcome
     }
 
+    // MARK: - Taking a term back
+
+    /// The speaker says the term should not have fired here.
+    ///
+    /// Three things happen, and writing a replacement rule is not one of them.
+    /// A rule would rewrite every `Praisy` into "praise" from then on, correct
+    /// ones included — see `ConfigWriter.addReplacement`, which refuses that
+    /// shape whoever asks.
+    ///
+    /// 1. **Confidence in whatever fired goes down.** If the ordinary word is
+    ///    registered as a rendering of the term, that exact rule is what wrote
+    ///    it, and its `seen:` count goes down by one. Nothing else can be
+    ///    blamed: the only other thing that writes a term where it was not said
+    ///    is the acoustic pass, and it proposes from the audio, so no file
+    ///    holds anything to take back.
+    /// 2. **The pair is recorded** under the term as `collides_with:`, which is
+    ///    never matched and never substituted. It says which two things to
+    ///    compare later, and it is keyed on the pair — "praise" argues with
+    ///    `Praisy` and means nothing to `Supabase`.
+    /// 3. **The audio is kept as a negative**, in `voice/negatives/<Term>/`.
+    ///
+    /// **No sample is deleted.** Nothing in `samples/` caused this: the samples
+    /// feed the acoustic veto, not the rule that fired, and experiment 6a
+    /// (PR #82) showed a bad clip cannot be picked out of a bank from one
+    /// revert — the obvious geometric signal points at legitimate recordings
+    /// instead.
+    private static func revert(
+        term: String, to word: String, via: String, clip: String?, config: Config
+    ) throws -> Outcome {
+        var outcome = Outcome(term: term)
+        Trace.correction(heard: term, corrected: word, via: via, clip: clip)
+
+        // What fired. The rendering list is the only thing that can be blamed,
+        // and it is read from the loaded model rather than the file so a legacy
+        // `heard:` list counts too — `Config.Term.heard` merges both keys.
+        let entry = config.vocabulary.terms.first {
+            $0.key.caseInsensitiveCompare(term) == .orderedSame
+        }?.value
+        let rendering = entry?.heard.first { $0.caseInsensitiveCompare(word) == .orderedSame }
+        var blame = Blame.nothing
+        if let rendering {
+            switch try ConfigWriter.discountPronunciation(term: term, heard: rendering) {
+            case .reduced(let seen): blame = .rendering(rendering, seen: seen)
+            case .dropped: blame = .dropped(rendering)
+            case .uncounted, .notFound: blame = .uncounted(rendering)
+            }
+        } else if let rule = config.transcription.rules.first(where: {
+            $0.source.caseInsensitiveCompare(word) == .orderedSame
+                && $0.replacement.caseInsensitiveCompare(term) == .orderedSame
+        }) {
+            // A rule somebody wrote into `config.yaml` by hand. Named, never
+            // edited: that file is written by a person and read by the app, and
+            // silently rewriting a line they typed is not this code's business.
+            blame = .handWritten(rule.source)
+        }
+
+        // The clip is cut against the *ordinary* word, not the term. The word
+        // times in `trace.jsonl` come from `asr.words`, which is the decoder's
+        // own output before any vocabulary stage runs — so the word sitting at
+        // the span is "praise", the thing that was actually said. The term is
+        // tried second, for the case where the decoder wrote the name itself
+        // and no rule was involved at all.
+        var observation = VoiceStore.Observation(
+            at: stamp(), term: term, heard: word, from: "correction",
+            score: nil, mic: Recorder.inputDeviceName, span: nil,
+            sample: nil, wav: nil, lang: nil,
+            build: AppVariant.buildStamp, skipped: nil,
+            polarity: VoiceStore.Polarity.negative.rawValue
+        )
+        var kept = 0
+        switch keep(
+            heard: word, term: term, clip: clip, config: config,
+            polarity: .negative, saying: term
+        ) {
+        case .success(let cut):
+            observation.span = [cut.start, cut.end]
+            observation.sample = cut.sample
+            observation.wav = cut.wav
+            observation.lang = cut.lang
+            outcome.sample = cut.sample
+            kept = 1
+        case .failure(let why):
+            observation.skipped = why.reason
+            observation.wav = why.wav
+            observation.lang = why.lang
+            outcome.skipped = why.reason
+        }
+        try VoiceStore.append(observation)
+        outcome.capped = VoiceStore.enforceCap(on: term, .negative)
+
+        let counts = try ConfigWriter.recordCollision(term: term, word: word, clips: kept)
+        outcome.revert = Revert(
+            word: word, blame: blame, reverted: counts.reverted, clips: counts.clips
+        )
+        return outcome
+    }
+
+    /// What a revert did, in words, for whoever has to say it out loud.
+    ///
+    /// One place rather than two: the terminal prints these and the app logs
+    /// them, and a revert that reads differently depending on where it happened
+    /// is a revert nobody can compare afterwards.
+    static func said(about revert: Revert?, term: String) -> [String] {
+        guard let revert else { return [] }
+        var lines = [
+            "no rule written — a rule here would rewrite every \(term)"
+                + " into \"\(revert.word)\"",
+        ]
+        switch revert.blame {
+        case .rendering(let heard, let seen):
+            lines.append("\(term): \"\(heard)\" fired and is now seen \(seen) time(s)")
+        case .dropped(let heard):
+            lines.append("\(term): dropped \"\(heard)\" — one sighting, one revert,"
+                + " nothing left")
+        case .uncounted(let heard):
+            lines.append("\(term): \"\(heard)\" fired and was never counted,"
+                + " so there is nothing to count down — left as it is")
+        case .handWritten(let source):
+            lines.append("\(term): a rule you wrote in config.yaml maps"
+                + " \"\(source)\" to it — left alone, edit it yourself")
+        case .nothing:
+            lines.append("\(term): nothing in the files fired,"
+                + " so the acoustic pass proposed it and there is nothing to blame")
+        }
+        lines.append("collides_with \"\(revert.word)\": reverted \(revert.reverted) time(s),"
+            + " \(revert.clips) clip(s)")
+        return lines
+    }
+
     // MARK: - Cutting the audio out
 
     private struct Kept {
@@ -147,12 +331,25 @@ enum Corrections {
     }
 
     /// Finds the rendering in the dictation's word times and cuts it out.
+    ///
+    /// - Parameter polarity: which bank the clip goes into. A correction's clip
+    ///   is the term; a revert's clip is the ordinary word the term was written
+    ///   over, and the two must never share a directory — see `VoiceStore`.
+    /// - Parameter saying: the text to find the dictation by when no clip was
+    ///   named. Defaults to `heard`, which is what the delivered text holds
+    ///   after a correction. A revert needs the term instead: the delivered
+    ///   text is the sentence with the term already written into it, and the
+    ///   ordinary word is exactly what is no longer in it.
+    /// - Parameter alternate: a second spelling to look for in the word times.
+    ///   A revert passes the term, for the clip where the decoder wrote the
+    ///   name itself and no rule was involved.
     private static func keep(
-        heard: String, term: String, clip: String?, config: Config
+        heard: String, term: String, clip: String?, config: Config,
+        polarity: VoiceStore.Polarity = .positive, saying: String? = nil
     ) -> Result<Kept, Refused> {
         let recordings = config.resolvedOutputDir
         let delivered = clip.flatMap { Trace.delivered(clip: $0, in: recordings) }
-            ?? Trace.delivered(saying: heard, in: recordings)
+            ?? Trace.delivered(saying: saying ?? heard, in: recordings)
         guard let delivered else {
             return .failure(Refused(reason: "no trace line for this dictation"))
         }
@@ -162,17 +359,23 @@ enum Corrections {
                 wav: delivered.wav, lang: delivered.lang
             ))
         }
-        guard let span = span(of: heard, in: delivered.words) else {
+        // Whichever spelling the decoder actually wrote, so the duration guard
+        // below counts the words it found rather than the words it looked for.
+        let alternates = polarity == .negative ? [heard, term] : [heard]
+        guard let found = alternates.lazy.compactMap({ spelling in
+            Self.span(of: spelling, in: delivered.words).map { (spelling: spelling, at: $0) }
+        }).first else {
             return .failure(Refused(
                 reason: "\"\(heard)\" is not in the decoder's own words for this clip",
                 wav: delivered.wav, lang: delivered.lang
             ))
         }
+        let at = found.at
 
         // The duration guard. Loud, and it names the number it rejected.
-        let words = renderingWords(heard).count
+        let words = renderingWords(found.spelling).count
         let allowed = longestWord + perExtraWord * Double(max(0, words - 1))
-        let length = span.end - span.start
+        let length = at.end - at.start
         guard length > 0, length <= allowed else {
             return .failure(Refused(
                 reason: String(
@@ -191,10 +394,10 @@ enum Corrections {
             ))
         }
 
-        let name = VoiceStore.nextSampleName(for: term, heard: heard)
-        let target = VoiceStore.samples(for: term).appendingPathComponent(name)
+        let name = VoiceStore.nextSampleName(for: term, heard: heard, polarity)
+        let target = VoiceStore.clips(for: term, polarity).appendingPathComponent(name)
         do {
-            try cut(from: source, start: span.start - padding, end: span.end + padding, to: target)
+            try cut(from: source, start: at.start - padding, end: at.end + padding, to: target)
         } catch {
             return .failure(Refused(
                 reason: "the cut failed: \(error.localizedDescription)",
@@ -202,8 +405,9 @@ enum Corrections {
             ))
         }
         return .success(Kept(
-            sample: "samples/\(term)/\(name)", wav: delivered.wav, lang: delivered.lang,
-            start: span.start, end: span.end
+            sample: "\(polarity.folder)/\(term)/\(name)",
+            wav: delivered.wav, lang: delivered.lang,
+            start: at.start, end: at.end
         ))
     }
 
@@ -307,9 +511,14 @@ enum Corrections {
             $0.key.caseInsensitiveCompare(term) == .orderedSame
         })?.value else { return [] }
 
+        // Positives only. A negative row says the term was *not* said, and it
+        // carries the ordinary word under the same `heard` key — so counting it
+        // here would let a revert of "praise" keep the rendering "praise"
+        // alive, which is the opposite of what the revert meant.
         var lastSeen: [String: Date] = [:]
         for observation in VoiceStore.observations()
-        where observation.term.caseInsensitiveCompare(term) == .orderedSame {
+        where observation.kind == .positive
+            && observation.term.caseInsensitiveCompare(term) == .orderedSame {
             guard let at = date(observation.at) else { continue }
             let key = plain(observation.heard)
             lastSeen[key] = max(lastSeen[key] ?? at, at)

--- a/Sources/ParrotFlow/Corrections.swift
+++ b/Sources/ParrotFlow/Corrections.swift
@@ -206,6 +206,11 @@ enum Corrections {
     ///    `Praisy` and means nothing to `Supabase`.
     /// 3. **The audio is kept as a negative**, in `voice/negatives/<Term>/`.
     ///
+    /// **They happen in the reverse of that order.** There is no transaction
+    /// across `vocabulary.yaml` and `voice/`, so the writes are ordered by what
+    /// a retry costs, and the count comes down last — it is the only one of the
+    /// three that cannot be repeated safely.
+    ///
     /// **No sample is deleted.** Nothing in `samples/` caused this: the samples
     /// feed the acoustic veto, not the rule that fired, and experiment 6a
     /// (PR #82) showed a bad clip cannot be picked out of a bank from one
@@ -220,25 +225,16 @@ enum Corrections {
         // What fired. The rendering list is the only thing that can be blamed,
         // and it is read from the loaded model rather than the file so a legacy
         // `heard:` list counts too — `Config.Term.heard` merges both keys.
+        //
+        // Only *named* here. Taking the count down is the last thing this
+        // function does — see below.
         let entry = config.vocabulary.terms.first {
             $0.key.caseInsensitiveCompare(term) == .orderedSame
         }?.value
         let rendering = entry?.heard.first { $0.caseInsensitiveCompare(word) == .orderedSame }
-        var blame = Blame.nothing
-        if let rendering {
-            switch try ConfigWriter.discountPronunciation(term: term, heard: rendering) {
-            case .reduced(let seen): blame = .rendering(rendering, seen: seen)
-            case .dropped: blame = .dropped(rendering)
-            case .uncounted, .notFound: blame = .uncounted(rendering)
-            }
-        } else if let rule = config.transcription.rules.first(where: {
+        let handWritten = config.transcription.rules.first {
             $0.source.caseInsensitiveCompare(word) == .orderedSame
                 && $0.replacement.caseInsensitiveCompare(term) == .orderedSame
-        }) {
-            // A rule somebody wrote into `config.yaml` by hand. Named, never
-            // edited: that file is written by a person and read by the app, and
-            // silently rewriting a line they typed is not this code's business.
-            blame = .handWritten(rule.source)
         }
 
         // The clip is cut against the *ordinary* word, not the term. The word
@@ -276,6 +272,29 @@ enum Corrections {
         outcome.capped = VoiceStore.enforceCap(on: term, .negative)
 
         let counts = try ConfigWriter.recordCollision(term: term, word: word, clips: kept)
+
+        // The count comes down last, because it is the only write here that
+        // cannot be repeated safely. There is no transaction across two files,
+        // so the writes are ordered by what a retry costs: an observation is a
+        // row in an append-only file and a duplicate is visible and harmless; a
+        // collision is a counter and one extra is recoverable; a `seen:` taken
+        // down twice can delete a rendering that should have stood at one, and
+        // nothing puts it back. Ordered this way, a failure anywhere above
+        // leaves the count untouched and the retry is clean.
+        var blame = Blame.nothing
+        if let rendering {
+            switch try ConfigWriter.discountPronunciation(term: term, heard: rendering) {
+            case .reduced(let seen): blame = .rendering(rendering, seen: seen)
+            case .dropped: blame = .dropped(rendering)
+            case .uncounted, .notFound: blame = .uncounted(rendering)
+            }
+        } else if let rule = handWritten {
+            // A rule somebody wrote into `config.yaml` by hand. Named, never
+            // edited: that file is written by a person and read by the app, and
+            // silently rewriting a line they typed is not this code's business.
+            blame = .handWritten(rule.source)
+        }
+
         outcome.revert = Revert(
             word: word, blame: blame, reverted: counts.reverted, clips: counts.clips
         )

--- a/Sources/ParrotFlow/ForgetCommand.swift
+++ b/Sources/ParrotFlow/ForgetCommand.swift
@@ -2,9 +2,10 @@ import Foundation
 
 /// `--forget <term>` — everything learnt about how one name sounds, gone.
 ///
-/// Three places hold it, and until now none of them had a way out:
-/// `vocabulary.yaml` holds the renderings, `voice/observations.jsonl` holds
-/// every time one was seen, and `voice/samples/<Term>/` holds the audio. Data
+/// Four places hold it, and until now none of them had a way out:
+/// `vocabulary.yaml` holds the renderings and the `collides_with:` pairs,
+/// `voice/observations.jsonl` holds every time one was seen, and
+/// `voice/samples/<Term>/` and `voice/negatives/<Term>/` hold the audio. Data
 /// that only accumulates is data nobody can correct — a rendering learnt from
 /// one bad clip goes on shaping the search forever, and the only remedy was to
 /// edit a file the header tells you not to edit.
@@ -46,8 +47,12 @@ enum ForgetCommand {
                     + " voice/ left alone")
                 return 1
             }
+            // After the pronunciation check, with the audio. A collision is
+            // learnt data about this term and goes when the rest of it goes.
+            let collisions = try ConfigWriter.dropCollisions(of: name)
             let gone = try VoiceStore.forget(name)
-            if renderings == 0, gone.observations == 0, gone.samples == 0 {
+            if renderings == 0, collisions == 0, gone.observations == 0,
+               gone.samples == 0, gone.negatives == 0 {
                 print("· nothing recorded for \(name)")
                 return 0
             }
@@ -59,10 +64,13 @@ enum ForgetCommand {
             // match is case-insensitive, so `--forget praisy` has to be told
             // that `samples/Praisy/` is what went.
             let from = gone.folders.isEmpty
-                ? "voice/samples/" : gone.folders.map { "voice/samples/\($0)/" }.joined(separator: ", ")
-            print("  \(gone.samples) sample(s) from \(from)")
+                ? "voice/samples/" : gone.folders.map { "voice/\($0)/" }.joined(separator: ", ")
+            print("  \(gone.samples) sample(s) and \(gone.negatives) negative(s) from \(from)")
+            print("  \(collisions) collides_with entr(ies) from"
+                + " \(ConfigStore.vocabularyURL.lastPathComponent)")
             Log.write("forget: \(name) — \(renderings) pronunciation(s),"
-                + " \(gone.observations) observation(s), \(gone.samples) sample(s)")
+                + " \(collisions) collision(s), \(gone.observations) observation(s),"
+                + " \(gone.samples) sample(s), \(gone.negatives) negative(s)")
             return 0
         } catch {
             print("✗ \(error.localizedDescription)")

--- a/Sources/ParrotFlow/LearnCommand.swift
+++ b/Sources/ParrotFlow/LearnCommand.swift
@@ -15,7 +15,14 @@ enum LearnCommand {
             let outcome = try Corrections.learn(
                 heard: heard, corrected: corrected, via: "learn", clip: clip
             )
-            print("✓ \(heard) → \(corrected)")
+            // A revert is not a rule learnt, so it does not get the ✓ that says
+            // one was. It is the more informative of the two corrections and
+            // the line has to say what it actually did.
+            if outcome.revert == nil {
+                print("✓ \(heard) → \(corrected)")
+            } else {
+                print("↩ \(heard) → \(corrected) — took the term back, no rule written")
+            }
             say(outcome)
             Trace.flush()
             return 0
@@ -36,13 +43,17 @@ enum LearnCommand {
         if let seen = outcome.seen {
             print("  \(term): seen \(seen) time(s), from correction")
         }
+        for line in Corrections.said(about: outcome.revert, term: term) {
+            print("  \(line)")
+        }
         if let sample = outcome.sample {
             print("  kept the audio as voice/\(sample)")
         } else if let why = outcome.skipped {
             print("  no audio kept — \(why)")
         }
+        let bank = outcome.revert == nil ? "samples" : "negatives"
         for gone in outcome.capped {
-            print("  capped voice/samples/\(term)/\(gone.file) — \(gone.why)")
+            print("  capped voice/\(bank)/\(term)/\(gone.file) — \(gone.why)")
         }
         for gone in outcome.pruned {
             print("  dropped \"\(gone)\" — seen once and not again since")

--- a/Sources/ParrotFlow/VoiceStore.swift
+++ b/Sources/ParrotFlow/VoiceStore.swift
@@ -12,6 +12,15 @@ import Foundation
 ///     voice/observations.jsonl        one line per rendering seen
 ///     voice/calibration.yaml          the bands the calibrate skill measured
 ///     voice/samples/<Term>/*.wav      the audio of each rendering, cut out
+///     voice/negatives/<Term>/*.wav    audio that is *not* the term, cut out
+///
+/// **`negatives/` is a separate directory, not a flag inside `samples/`.**
+/// A negative comes from a revert: the app wrote `Praisy`, the speaker meant
+/// "praise", and the audio at that span is the ordinary word. It is the same
+/// kind of file as a sample and the opposite kind of evidence. Every script
+/// that walks `samples/` today would ingest it as a positive and say nothing,
+/// and every number computed from this store would rot quietly. A directory
+/// nobody's glob reaches by accident is the only way to make that impossible.
 ///
 /// **Nothing here belongs in the repository.** The archive it was mined from is
 /// somebody's voice saying their colleagues' names. `scripts/check-no-voice.sh`
@@ -66,6 +75,30 @@ enum VoiceStore {
 
     static var samplesDirectory: URL {
         directory.appendingPathComponent("samples", isDirectory: true)
+    }
+
+    static var negativesDirectory: URL {
+        directory.appendingPathComponent("negatives", isDirectory: true)
+    }
+
+    /// What a clip says about its term: that it *is* one, or that it is not.
+    ///
+    /// Explicit on the row, never inferred. The clip's meaning inverts between
+    /// the two — a correction's clip is the term said out loud, a revert's clip
+    /// is the ordinary word the term was wrongly written over — and the two
+    /// rows are otherwise identical. Absent reads as `positive`, so every line
+    /// written before this key existed still means what it meant.
+    enum Polarity: String, Sendable {
+        case positive
+        case negative
+
+        /// The directory this polarity's clips live in, under `voice/`.
+        var folder: String {
+            switch self {
+            case .positive: return "samples"
+            case .negative: return "negatives"
+            }
+        }
     }
 
     /// What `calibration.yaml` says, in one line, for `--check-config`.
@@ -139,6 +172,19 @@ enum VoiceStore {
         /// to the log so the rate is countable from the file later, and the log
         /// truncates at 1 MB.
         var skipped: String?
+        /// `positive` or `negative` — see `Polarity`. Written on every row this
+        /// build produces, and absent on every row written before it, which
+        /// reads as `positive`.
+        ///
+        /// A string rather than the enum, for the reason `from` is one: a value
+        /// a later version invents must still parse here.
+        var polarity: String?
+
+        /// Which way this row points. An unreadable or absent `polarity` is
+        /// `positive`, because that is what every row without one is.
+        var kind: Polarity {
+            polarity.flatMap(Polarity.init(rawValue:)) ?? .positive
+        }
     }
 
     /// The store's own directories, made on demand.
@@ -186,32 +232,44 @@ enum VoiceStore {
 
     // MARK: - Samples
 
-    /// Where a term's samples live. The folder is the term as `vocabulary.yaml`
-    /// spells it, so `--forget` can name it back.
-    static func samples(for term: String) -> URL {
-        samplesDirectory.appendingPathComponent(term, isDirectory: true)
+    /// Where a term's clips live, by polarity. The folder is the term as
+    /// `vocabulary.yaml` spells it, so `--forget` can name it back.
+    static func clips(for term: String, _ polarity: Polarity = .positive) -> URL {
+        directory
+            .appendingPathComponent(polarity.folder, isDirectory: true)
+            .appendingPathComponent(term, isDirectory: true)
     }
+
+    /// Where a term's samples live. The positive half of `clips(for:_:)`, kept
+    /// under its own name because most callers only ever want that half.
+    static func samples(for term: String) -> URL { clips(for: term, .positive) }
 
     /// The wav files of one term, oldest first by name.
     ///
     /// By name rather than by modification date: a copied archive has every
     /// file stamped with the moment it was copied, and the name carries the
     /// sequence the recording was written in.
-    static func sampleFiles(of term: String) -> [String] {
+    static func sampleFiles(of term: String, _ polarity: Polarity = .positive) -> [String] {
         let inside = (try? FileManager.default.contentsOfDirectory(
-            atPath: samples(for: term).path
+            atPath: clips(for: term, polarity).path
         )) ?? []
         return inside.filter { $0.hasSuffix(".wav") }.sorted()
     }
 
-    /// A free filename for a new sample of `term`, in the shape mining writes:
+    /// A free filename for a new clip of `term`, in the shape mining writes:
     /// `NN-rendering.wav`, numbered above everything already there.
-    static func nextSampleName(for term: String, heard: String) -> String {
+    ///
+    /// Numbered within its own polarity's folder. `samples/Praisy/00-praise.wav`
+    /// and `negatives/Praisy/00-praise.wav` are two different files that happen
+    /// to share a name, and neither can overwrite the other.
+    static func nextSampleName(
+        for term: String, heard: String, _ polarity: Polarity = .positive
+    ) -> String {
         let slug = heard.lowercased()
             .components(separatedBy: CharacterSet.alphanumerics.inverted)
             .filter { !$0.isEmpty }
             .joined(separator: "-")
-        let used = sampleFiles(of: term).compactMap { name -> Int? in
+        let used = sampleFiles(of: term, polarity).compactMap { name -> Int? in
             Int(name.prefix(while: { $0.isNumber }))
         }
         let next = (used.max() ?? -1) + 1
@@ -227,9 +285,16 @@ enum VoiceStore {
     /// of those goes, because a cap that refuses to act is not a cap.
     ///
     /// Never silent. Every removal is returned, and every caller logs it.
+    ///
+    /// One polarity at a time. A term's samples and its negatives are two banks
+    /// of the same size, and a negative must never be able to push a sample out
+    /// — the two are compared against each other, so a cap that mixed them
+    /// would let one side quietly consume the other.
     @discardableResult
-    static func enforceCap(on term: String, cap: Int = perTermSampleCap) -> [(file: String, why: String)] {
-        var files = sampleFiles(of: term)
+    static func enforceCap(
+        on term: String, cap: Int = perTermSampleCap, _ polarity: Polarity = .positive
+    ) -> [(file: String, why: String)] {
+        var files = sampleFiles(of: term, polarity)
         guard files.count > cap else { return [] }
 
         // Which of *this term's* samples a person confirmed, from the
@@ -243,9 +308,14 @@ enum VoiceStore {
         // bare name across every term would let one term's confirmed sample
         // protect another term's unconfirmed one, and the cap would then delete
         // a confirmed sample while keeping the audio nobody vouched for.
+        //
+        // Filtered by polarity for the same reason, one level up:
+        // `samples/Praisy/00-praise.wav` and `negatives/Praisy/00-praise.wav`
+        // also share a bare name, and they are the same term.
         var confirmed: Set<String> = []
         for observation in observations()
         where observation.from == "correction"
+            && observation.kind == polarity
             && observation.term.caseInsensitiveCompare(term) == .orderedSame {
             if let sample = observation.sample {
                 confirmed.insert((sample as NSString).lastPathComponent)
@@ -261,7 +331,7 @@ enum VoiceStore {
             let why = confirmed.contains(name)
                 ? "oldest confirmed — every sample of this term is confirmed"
                 : "oldest unconfirmed"
-            try? store.removeItem(at: samples(for: term).appendingPathComponent(name))
+            try? store.removeItem(at: clips(for: term, polarity).appendingPathComponent(name))
             files.removeAll { $0 == name }
             removed.append((name, why))
         }
@@ -285,35 +355,44 @@ enum VoiceStore {
     }
 
     /// What the store holds, per term, for `--check-config` and `--forget`.
-    static func counts() -> [(term: String, observations: Int, samples: Int)] {
+    ///
+    /// Samples and negatives counted apart. They are the two sides of the same
+    /// question and adding them together would report a term with 20 clips that
+    /// has 20 recordings of something it is not.
+    static func counts() -> [(term: String, observations: Int, samples: Int, negatives: Int)] {
         var seen: [String: Int] = [:]
         for observation in observations() {
             seen[observation.term, default: 0] += 1
         }
         var kept: [String: Int] = [:]
-        for name in termFolders() {
-            let inside = (try? FileManager.default.contentsOfDirectory(
-                atPath: samplesDirectory.appendingPathComponent(name).path
-            )) ?? []
-            kept[name] = inside.filter { $0.hasSuffix(".wav") }.count
-        }
-        return Set(seen.keys).union(kept.keys).sorted().map {
-            (term: $0, observations: seen[$0] ?? 0, samples: kept[$0] ?? 0)
+        var against: [String: Int] = [:]
+        for name in termFolders(.positive) { kept[name] = wavs(in: name, .positive) }
+        for name in termFolders(.negative) { against[name] = wavs(in: name, .negative) }
+        return Set(seen.keys).union(kept.keys).union(against.keys).sorted().map {
+            (term: $0, observations: seen[$0] ?? 0,
+             samples: kept[$0] ?? 0, negatives: against[$0] ?? 0)
         }
     }
 
-    /// The term folders under `samples/`, directories only.
+    private static func wavs(in term: String, _ polarity: Polarity) -> Int {
+        ((try? FileManager.default.contentsOfDirectory(
+            atPath: clips(for: term, polarity).path
+        )) ?? []).filter { $0.hasSuffix(".wav") }.count
+    }
+
+    /// The term folders under one polarity's directory, directories only.
     ///
     /// A stray file — `.DS_Store` is the one that turns up — is not a term, and
     /// listing it as one would offer `--forget .DS_Store`.
-    private static func termFolders() -> [String] {
+    private static func termFolders(_ polarity: Polarity = .positive) -> [String] {
         let files = FileManager.default
-        return ((try? files.contentsOfDirectory(atPath: samplesDirectory.path)) ?? [])
+        let root = directory.appendingPathComponent(polarity.folder, isDirectory: true)
+        return ((try? files.contentsOfDirectory(atPath: root.path)) ?? [])
             .filter { name in
-                var directory: ObjCBool = false
-                let path = samplesDirectory.appendingPathComponent(name).path
-                return files.fileExists(atPath: path, isDirectory: &directory)
-                    && directory.boolValue
+                var isDirectory: ObjCBool = false
+                let path = root.appendingPathComponent(name).path
+                return files.fileExists(atPath: path, isDirectory: &isDirectory)
+                    && isDirectory.boolValue
             }
     }
 
@@ -322,10 +401,15 @@ enum VoiceStore {
     /// Returns what was removed, so the caller can say it out loud — including
     /// the folder names, because matching is case-insensitive and a person
     /// typing `--forget praisy` should be told `samples/Praisy/` is what went.
+    ///
+    /// Both banks. A `--forget` that left `negatives/Praisy/` behind would
+    /// leave audio filed under a term nothing else remembers, and the next
+    /// thing to read the directory would find a term with negatives and no
+    /// positives — a term that looks measured and is not.
     @discardableResult
     static func forget(
         _ term: String
-    ) throws -> (observations: Int, samples: Int, folders: [String]) {
+    ) throws -> (observations: Int, samples: Int, negatives: Int, folders: [String]) {
         let files = FileManager.default
         var dropped = 0
         if let text = try? String(contentsOf: observationsURL, encoding: .utf8) {
@@ -348,14 +432,19 @@ enum VoiceStore {
         }
 
         var removed = 0
+        var against = 0
         var folders: [String] = []
-        for name in termFolders() where name.caseInsensitiveCompare(term) == .orderedSame {
-            let folder = samplesDirectory.appendingPathComponent(name)
-            removed += ((try? files.contentsOfDirectory(atPath: folder.path)) ?? [])
-                .filter { $0.hasSuffix(".wav") }.count
-            try files.removeItem(at: folder)
-            folders.append(name)
+        for polarity in [Polarity.positive, .negative] {
+            for name in termFolders(polarity)
+            where name.caseInsensitiveCompare(term) == .orderedSame {
+                let folder = clips(for: name, polarity)
+                let count = ((try? files.contentsOfDirectory(atPath: folder.path)) ?? [])
+                    .filter { $0.hasSuffix(".wav") }.count
+                if polarity == .positive { removed += count } else { against += count }
+                try files.removeItem(at: folder)
+                folders.append("\(polarity.folder)/\(name)")
+            }
         }
-        return (dropped, removed, folders)
+        return (dropped, removed, against, folders)
     }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -199,6 +199,21 @@ the previous transcript does it target.
 `--learn` writes a replacement rule from the terminal, the same one the
 correction panel would have written.
 
+`--learn <Term> <word>` the other way round is a **revert**: the app wrote
+`Praisy`, you meant "praise". It writes no rule at all — one would rewrite
+every `Praisy` into "praise" from then on. Instead it counts down whatever
+fired, records the pair under the term as `collides_with:`, and keeps the audio
+as a negative in `voice/negatives/<Term>/`.
+
+```
+$ ParrotFlow --learn Praisy praise
+↩ Praisy → praise — took the term back, no rule written
+  no rule written — a rule here would rewrite every Praisy into "praise"
+  Praisy: "praise" fired and is now seen 1 time(s)
+  collides_with "praise": reverted 1 time(s), 1 clip(s)
+  kept the audio as voice/negatives/Praisy/00-praise.wav
+```
+
 ## Forgetting what a name sounds like
 
 ```sh
@@ -206,9 +221,10 @@ $PF --forget <term>
 ```
 
 Everything learnt about how one name comes out, in one go: its pronunciations
-in `vocabulary.yaml`, every line naming it in `voice/observations.jsonl`, and
-every clip under `voice/samples/<Term>/`. The term itself stays — forgetting is
-about the learnt half, and somebody who wants the name gone deletes the name.
+and its `collides_with:` pairs in `vocabulary.yaml`, every line naming it in
+`voice/observations.jsonl`, and every clip under `voice/samples/<Term>/` and
+`voice/negatives/<Term>/`. The term itself stays — forgetting is about the
+learnt half, and somebody who wants the name gone deletes the name.
 
 It exists because the three files only ever grow. A rendering learnt from one
 bad clip goes on shaping the audio search forever, and the only remedy was to
@@ -220,7 +236,8 @@ $ ParrotFlow --forget Praisy
 ✓ forgot Praisy
   14 pronunciation(s) from vocabulary.yaml
   17 observation(s) from voice/observations.jsonl
-  17 sample(s) from voice/samples/Praisy/
+  17 sample(s) and 3 negative(s) from voice/samples/Praisy/, voice/negatives/Praisy/
+  1 collides_with entr(ies) from vocabulary.yaml
 ```
 
 ## Proving the microphone and the model work

--- a/docs/proposals/vocabulary-v3.md
+++ b/docs/proposals/vocabulary-v3.md
@@ -1898,13 +1898,23 @@ before it still parse.
 over-fire — the samples feed the acoustic veto, not the rule that fired — and
 6a below showed a bad clip cannot be picked out of a bank from one revert.
 
-**Verified by** `scripts/check-reverts.sh`, 67 cases, in CI. It scores: no rule
+**Verified by** `scripts/check-reverts.sh`, 74 cases, in CI. It scores: no rule
 in either file; the count-down, the drop at zero, the legacy entry that has no
 count to take one off, and the case where nothing can be blamed; the clip in
 `negatives/` and nothing at all in `samples/`; `collides_with:` written and then
 left alone by `--replace`, which runs every deterministic substitution pass; a
 rendering that survives the count-down still firing; `--forget` taking all four
-back; and a row with no `polarity` reading as a positive.
+back; a row with no `polarity` reading as a positive; and a term whose value
+wraps over two lines with a comment on it surviving both directions.
+
+**One thing the review found, and it predates this PR.** Making room for
+`collides_with:` reuses the rewrite `addPronunciation` already did — a term's
+inline value becomes a block body. It joined the value onto one line, which
+destroys `Praisy: [Prissy,   # the common one` / `Pressy]`: everything after
+the `#` becomes comment, the bracket never closes, and `vocabulary.yaml` then
+loads as no terms at all, silently. The live file writes lists this way. Fixed
+here for both directions — only the first line is rewritten and the
+continuations move under the new key untouched.
 
 ## PR 5 — mining that keeps the recordings you need
 

--- a/docs/proposals/vocabulary-v3.md
+++ b/docs/proposals/vocabulary-v3.md
@@ -1845,6 +1845,67 @@ above is the archive's answer to the same question, and the panel's own path is
 scored through `--learn --clip`, which takes the same route with the same clip
 name the panel passes.
 
+## PR 4a — a revert writes no rule, and keeps the audio
+
+**A live bug on `main`, independent of this stack.** `ConfigWriter.addReplacement`
+wrote `corrected: [heard]` into `config.yaml` whatever the direction of the
+correction. So taking a term back — the app wrote `Praisy`, the speaker meant
+"praise" — wrote `"praise": ["Praisy"]`, which rewrote *every* `Praisy` into
+"praise" from then on. One revert disabled the term, in a file `--forget` could
+not reach. Reproduced on `main` at c46c701 with `--learn Praisy praise`.
+
+That matters more now than it did, because the whole direction of this work is
+to *encourage* reverts. A revert is the most informative correction there is:
+it is the speaker saying, unprompted, that the term is wrong here and that the
+audio at this span is the ordinary word.
+
+**A revert does three things, and writing a rule is not one of them.**
+
+1. **Confidence in whatever fired goes down.** If the ordinary word is
+   registered as a rendering of the term, that exact rule is what wrote it —
+   `Config.vocabularyRules` turns every rendering into an exact replacement, so
+   it fires on that spelling every time. Its `seen:` goes down by one. Down by
+   one and not deleted: a rendering seen nine times and reverted once is still
+   how this person says the word, and deleting it would be the same bug
+   pointing the other way. It is only removed at zero, and only when
+   `from: correction` wrote it.
+2. **The pair is recorded** as `collides_with:` under the term — the word, a
+   `reverted` count and a `clips` count. Never matched, never substituted. It
+   is keyed on the pair, because "praise" argues with `Praisy` and says nothing
+   at all about `Supabase`.
+3. **The audio is kept as a negative**, in `voice/negatives/<Term>/`, with
+   `polarity: negative` on the observation.
+
+**What can and cannot be attributed.** Only two things write a term where it
+was not said: an exact rule from `pronunciations:`, and the acoustic pass. The
+first is answerable exactly at the correction site, with no new machinery — if
+the word the speaker meant is registered as a rendering of the term, that rule
+fired. The second leaves nothing in any file to take back, and the command says
+so rather than inventing a culprit. The proposal's own numbers — the
+`raw -10.12 vs -9.37, bonus 2.88` in the log — are not in scope: `Trace.Delivered`
+carries `asr.words`, `lang` and `final`, and the pipeline's stage list is not
+decoded there. Reaching them would mean a second read of the trace for a number
+nothing acts on.
+
+**`negatives/` is a separate directory, not a flag inside `samples/`.** Every
+script in this repository that walks `samples/` would otherwise ingest a
+negative as a positive, silently, and every number computed from the store
+would rot. `polarity` on the row is explicit for the same reason: the clip's
+meaning inverts, and absent has to keep meaning `positive` so the rows written
+before it still parse.
+
+**No sample is deleted on a revert.** Nothing in `samples/` caused the
+over-fire — the samples feed the acoustic veto, not the rule that fired — and
+6a below showed a bad clip cannot be picked out of a bank from one revert.
+
+**Verified by** `scripts/check-reverts.sh`, 67 cases, in CI. It scores: no rule
+in either file; the count-down, the drop at zero, the legacy entry that has no
+count to take one off, and the case where nothing can be blamed; the clip in
+`negatives/` and nothing at all in `samples/`; `collides_with:` written and then
+left alone by `--replace`, which runs every deterministic substitution pass; a
+rendering that survives the count-down still firing; `--forget` taking all four
+back; and a row with no `polarity` reading as a positive.
+
 ## PR 5 — mining that keeps the recordings you need
 
 **Changes.** Three changes to `scripts/mine-pronunciations.py`, ported from

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -100,7 +100,18 @@ terms:
     pronunciations:
       - heard: cloud
         from: correction
+  Vercel:
+    collides_with:               # ordinary words this term has fired on
+      - word: versatile
+        reverted: 2
+        clips: 2
 ```
+
+`collides_with:` is written when you take a term back — you dictated
+"versatile" and the app wrote `Vercel`. It is a record, never a rule: nothing
+matches it and nothing substitutes it. It says which two things to compare, and
+how much evidence there is for the comparison. It is keyed on the pair, so
+"versatile" argues with `Vercel` and means nothing to any other term.
 
 #### The two numbers
 
@@ -243,7 +254,15 @@ how they actually come out of your mouth on your microphone.
 voice/observations.jsonl      one line per rendering seen
 voice/calibration.yaml        the bands the calibrate skill measured
 voice/samples/<Term>/*.wav    the audio of each rendering, cut out
+voice/negatives/<Term>/*.wav  audio that is *not* the term, cut out
 ```
+
+`negatives/` is its own directory, not a flag inside `samples/`. A negative
+comes from a revert — the app wrote `Praisy`, you meant "praise" — so the clip
+is the same kind of file and the opposite kind of evidence. Anything that walks
+`samples/` would otherwise read it as a positive and say nothing. Each row says
+which it is, as `polarity: positive` or `polarity: negative`; a row written
+before the key existed has none, and reads as positive.
 
 Three reasons it is not in `vocabulary.yaml`. It grows without limit, and a
 setting a person reads should not. It is audio, which no YAML file wants. And
@@ -256,7 +275,8 @@ The microphone is part of an observation. A rendering is a fact about a mouth
 rather than "the one plugged in today". Samples are cut spans, a few hundred KB
 each, never a whole dictation.
 
-`--forget <term>` empties all three for one name — see
+`--forget <term>` empties all of it for one name — pronunciations,
+`collides_with:` pairs, observations, samples and negatives. See
 [the command line](cli.md#forgetting-what-a-name-sounds-like).
 
 #### Checking the result

--- a/scripts/check-corrections.sh
+++ b/scripts/check-corrections.sh
@@ -372,7 +372,7 @@ got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --forget Praisy 2>/dev/null)"
 wants "it forgets the term"        "$got" "✓ forgot Praisy"
 wants "the pronunciations go"      "$got" "pronunciation(s) from vocabulary.yaml"
 wants "the observations go"        "$got" "1 observation(s) from voice/observations.jsonl"
-wants "and the samples go"         "$got" "1 sample(s) from voice/samples/Praisy/"
+wants "and the samples go"         "$got" "1 sample(s) and 0 negative(s) from voice/samples/Praisy/"
 lacks "vocabulary.yaml has nothing left of it" "$(cat "$WORK/vocabulary.yaml")" "praise"
 total=$((total + 1))
 if [ ! -e "$WORK/voice/samples/Praisy" ]; then

--- a/scripts/check-reverts.sh
+++ b/scripts/check-reverts.sh
@@ -1,0 +1,385 @@
+#!/usr/bin/env bash
+# Checks what happens when somebody takes a vocabulary term back.
+#
+#   scripts/check-reverts.sh
+#
+# A revert is a correction in the other direction: the app wrote `Praisy`, the
+# speaker meant "praise". It used to write `"praise": ["Praisy"]` into
+# `config.yaml`, which rewrote *every* `Praisy` into "praise" from then on —
+# one revert disabling the term, in a file `--forget` could not reach.
+#
+# Six things are scored here.
+#
+#   no rule           nothing is written to `config.yaml`, and nothing to
+#                     `vocabulary.yaml` that could fire on text later.
+#   the blame         if a rendering fired, its `seen:` count goes down. If
+#                     nothing in the files fired, the command says so instead
+#                     of inventing a culprit.
+#   the negative      the clip lands in `voice/negatives/<Term>/`, never in
+#                     `samples/`, and its row says `"polarity":"negative"`.
+#   `collides_with:`  the pair is recorded under the term, and is never applied
+#                     as a substitution.
+#   `--forget`        takes pronunciations, samples, negatives and the
+#                     `collides_with` entry back out.
+#   old rows          an observation written before `polarity` existed still
+#                     reads as a positive.
+#
+# The forward direction is scored by `scripts/check-corrections.sh`, which this
+# leaves alone.
+#
+# The audio is generated here, not committed: a tone burst in a silent file.
+# The cut is frame arithmetic, so a sine wave scores it exactly as a voice
+# would, and `scripts/check-no-voice.sh` refuses a repository carrying the real
+# thing.
+#
+# Every case is a whole config directory in /tmp read through
+# PARROTFLOW_CONFIG_DIR, so this says nothing about the config on the machine
+# and scores the same anywhere.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/release/ParrotFlow"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+command -v python3 >/dev/null || { echo "python3 is needed to write the test audio"; exit 1; }
+
+WORK="$(mktemp -d -t parrotflow-reverts)"
+trap 'rm -rf "$WORK"' EXIT
+CLIPS="$WORK/recordings"
+mkdir -p "$CLIPS"
+
+pass=0; total=0; failed=""
+
+# wants <name> <text> <substring>
+wants() {
+  total=$((total + 1))
+  if printf '%s' "$2" | grep -qF -- "$3"; then
+    pass=$((pass + 1)); printf '  ✓ %s\n' "$1"
+  else
+    failed="$failed
+      $1
+        wanted: $3
+        got:    $(printf '%s' "$2" | tr '\n' '|')"
+    printf '  ✗ %s\n' "$1"
+  fi
+}
+
+# lacks <name> <text> <substring>
+lacks() {
+  total=$((total + 1))
+  if printf '%s' "$2" | grep -qF -- "$3"; then
+    failed="$failed
+      $1
+        did not want: $3
+        got:          $(printf '%s' "$2" | tr '\n' '|')"
+    printf '  ✗ %s\n' "$1"
+  else
+    pass=$((pass + 1)); printf '  ✓ %s\n' "$1"
+  fi
+}
+
+# holds <name> <path> — the file has to exist and not be empty.
+holds() {
+  total=$((total + 1))
+  if [ -s "$2" ]; then
+    pass=$((pass + 1)); printf '  ✓ %s\n' "$1"
+  else
+    failed="$failed
+      $1 ($2 is missing or empty)"
+    printf '  ✗ %s\n' "$1"
+  fi
+}
+
+# absent <name> <path> — nothing may be there at all.
+absent() {
+  total=$((total + 1))
+  if [ ! -e "$2" ]; then
+    pass=$((pass + 1)); printf '  ✓ %s\n' "$1"
+  else
+    failed="$failed
+      $1 ($2 exists)"
+    printf '  ✗ %s\n' "$1"
+  fi
+}
+
+# same <name> <got> <wanted> — an exact match, for a count.
+same() {
+  total=$((total + 1))
+  if [ "$2" = "$3" ]; then
+    pass=$((pass + 1)); printf '  ✓ %s\n' "$1"
+  else
+    failed="$failed
+      $1
+        wanted: $3
+        got:    $2"
+    printf '  ✗ %s (got %s)\n' "$1" "$2"
+  fi
+}
+
+# clip <name> — three seconds at 16 kHz, with a burst from 1.00s to 1.50s.
+clip() {
+  python3 - "$CLIPS/$1" <<'PY'
+import math, struct, sys, wave
+rate, seconds = 16000, 3.0
+with wave.open(sys.argv[1], "wb") as f:
+    f.setnchannels(1); f.setsampwidth(2); f.setframerate(rate)
+    frames = bytearray()
+    for n in range(int(rate * seconds)):
+        t = n / rate
+        loud = 1.0 <= t < 1.5
+        frames += struct.pack("<h", int(12000 * math.sin(2 * math.pi * 440 * t)) if loud else 0)
+    f.writeframes(bytes(frames))
+PY
+}
+
+# traced <wav> <lang> <final> <word:start:end>... — one dictation line.
+#
+# `final` is what was *delivered*, so for a revert it holds the term. The word
+# times are the decoder's own, from before any vocabulary stage ran, so they
+# hold the ordinary word. That difference is the whole point of the case.
+traced() {
+  local wav="$1" lang="$2" final="$3"; shift 3
+  python3 - "$CLIPS/trace.jsonl" "$wav" "$lang" "$final" "$@" <<'PY'
+import json, sys
+path, wav, lang, final, *words = sys.argv[1:]
+row = {"v": 2, "kind": "dictation", "at": "2026-08-09T10:00:00Z", "wav": wav,
+       "source": "live", "lang": lang, "final": final,
+       "asr": {"model": "test", "text": final, "confidence": 0.9, "duration": 3.0,
+               "processing": 0.1,
+               "words": [{"word": w.split(":")[0], "start": float(w.split(":")[1]),
+                          "end": float(w.split(":")[2]), "confidence": 0.9} for w in words]},
+       "stages": []}
+with open(path, "a") as f:
+    f.write(json.dumps(row) + "\n")
+PY
+}
+
+# fresh [<vocabulary body>] — a config directory with nothing learnt in it.
+fresh() {
+  rm -rf "$WORK/voice" "$CLIPS" "$WORK/vocabulary.yaml"
+  mkdir -p "$CLIPS"
+  printf 'transcription:\n  languages: [en, fr]\n  replacements:\n    "CLAUDE.md": ["claude dot MD"]\naudio:\n  output_dir: %s\n' \
+    "$CLIPS" > "$WORK/config.yaml"
+  if [ $# -gt 0 ]; then
+    printf '%b' "$1" > "$WORK/vocabulary.yaml"
+  else
+    printf 'acoustic: true\nterms:\n  Praisy:\n    pronunciations:\n      - heard: praise\n        seen: 2\n        from: correction\n  Supabase:\n' \
+      > "$WORK/vocabulary.yaml"
+  fi
+}
+
+# said <term> <word> [args...] — a revert, with the clip already traced.
+said() {
+  PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --learn "$1" "$2" "${@:3}" 2>/dev/null
+}
+
+# ── a revert writes no rule, and counts the rendering down ──────────────────
+printf '\n  a revert of a term the speaker did not say\n'
+fresh
+clip one.wav
+traced one.wav fr "I said Praisy again" "i:0.10:0.30" "said:0.40:0.90" \
+  "praise:1.00:1.50" "again:1.60:2.20"
+got="$(said Praisy praise)"
+wants "it says the term was taken back" "$got" "took the term back, no rule written"
+wants "and why no rule was written"     "$got" \
+  'no rule written — a rule here would rewrite every Praisy into "praise"'
+
+config="$(cat "$WORK/config.yaml")"
+lacks "config.yaml gets no rule"        "$config" "praise"
+wants "and the rule already there stays" "$config" '"CLAUDE.md": ["claude dot MD"]'
+
+vocab="$(cat "$WORK/vocabulary.yaml")"
+lacks "vocabulary.yaml gets no rendering for the term" "$vocab" "heard: Praisy"
+wants "the rendering that fired is counted down"       "$got" \
+  'Praisy: "praise" fired and is now seen 1 time(s)'
+wants "and the file says so"                           "$vocab" "seen: 1"
+
+# ── the negative clip, and where it is not ─────────────────────────────────
+printf '\n  the audio kept as a negative\n'
+wants "it says where the audio went" "$got" \
+  "kept the audio as voice/negatives/Praisy/00-praise.wav"
+holds  "the clip is under negatives/" "$WORK/voice/negatives/Praisy/00-praise.wav"
+absent "and nothing at all under samples/" "$WORK/voice/samples"
+
+row="$(cat "$WORK/voice/observations.jsonl")"
+wants "the row names the term"          "$row" '"term":"Praisy"'
+wants "and the ordinary word that was said" "$row" '"heard":"praise"'
+wants "and says which way it points"    "$row" '"polarity":"negative"'
+wants "and where the clip went"         "$row" '"sample":"negatives/Praisy/00-praise.wav"'
+wants "and the span inside the clip"    "$row" '"span":[1,1.5]'
+wants "and the clip it came out of"     "$row" '"wav":"one.wav"'
+wants "and the language it was said in" "$row" '"lang":"fr"'
+wants "and the build that cut it"       "$row" "\"build\":\"$("$BIN" --version)\""
+
+# ── collides_with, written and never applied ───────────────────────────────
+printf '\n  collides_with\n'
+wants "the pair is recorded"     "$vocab" "collides_with:"
+wants "with the ordinary word"   "$vocab" "- word: praise"
+wants "how often it was reverted" "$vocab" "reverted: 1"
+wants "and how many clips back it" "$vocab" "clips: 1"
+wants "and the command says the same" "$got" \
+  'collides_with "praise": reverted 1 time(s), 1 clip(s)'
+
+# A rendering seen twice and reverted once still stands at one, and still
+# fires. That is the point of counting down by one instead of deleting: one
+# revert must not disable a rendering the speaker produces regularly, which is
+# the same bug this change fixes, pointing the other way.
+replaced="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --replace "I said praise again" 2>/dev/null)"
+wants "a rendering that survives the count-down still fires" "$replaced" "Praisy"
+
+# A second revert of the same pair counts up rather than writing a second entry.
+clip two.wav
+traced two.wav en "Praisy again" "praise:1.00:1.50" "again:1.60:2.20"
+got="$(said Praisy praise)"
+wants "a second revert counts up" "$got" 'collides_with "praise": reverted 2 time(s), 2 clip(s)'
+same "and there is still one entry" \
+  "$(grep -c -- '- word: praise' "$WORK/vocabulary.yaml")" "1"
+same "and two clips under negatives/" \
+  "$(ls "$WORK/voice/negatives/Praisy" | wc -l | tr -d ' ')" "2"
+
+# ── the rendering that stood on one sighting ───────────────────────────────
+printf '\n  a rendering seen once, and now contradicted\n'
+fresh 'acoustic: true\nterms:\n  Praisy:\n    pronunciations:\n      - heard: praise\n        seen: 1\n        from: correction\n'
+clip three.wav
+traced three.wav en "Praisy" "praise:1.00:1.50"
+got="$(said Praisy praise)"
+wants "it goes, and says why" "$got" \
+  'Praisy: dropped "praise" — one sighting, one revert, nothing left'
+lacks "and it leaves vocabulary.yaml" "$(cat "$WORK/vocabulary.yaml")" "heard: praise"
+wants "the collision is still recorded" "$(cat "$WORK/vocabulary.yaml")" "- word: praise"
+
+# ── a rendering with no count behind it ────────────────────────────────────
+printf '\n  a legacy rendering, which was never counted\n'
+fresh 'acoustic: true\nterms:\n  Praisy: [praise]\n'
+clip four.wav
+traced four.wav en "Praisy" "praise:1.00:1.50"
+got="$(said Praisy praise)"
+wants "it says there is nothing to count down" "$got" \
+  'Praisy: "praise" fired and was never counted'
+wants "and leaves the entry where it is" "$(cat "$WORK/vocabulary.yaml")" "heard: [praise]"
+
+# ── nothing in the files fired ─────────────────────────────────────────────
+printf '\n  a term the acoustic pass proposed on its own\n'
+fresh 'acoustic: true\nterms:\n  Praisy:\n  Supabase:\n'
+clip five.wav
+traced five.wav en "Praisy" "praise:1.00:1.50"
+got="$(said Praisy praise)"
+wants "it says nothing can be blamed" "$got" \
+  "Praisy: nothing in the files fired, so the acoustic pass proposed it"
+wants "and the clip is still kept" "$got" "kept the audio as voice/negatives/Praisy/"
+wants "and the pair is still recorded" "$(cat "$WORK/vocabulary.yaml")" "- word: praise"
+
+# `collides_with:` on its own, with no rendering anywhere near it. This is the
+# case that proves it is a record and not a rule: `--replace` runs every
+# deterministic substitution pass over a line, including the one
+# `vocabulary.yaml` feeds.
+replaced="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --replace "I said praise again" 2>/dev/null)"
+wants "a collision is never substituted" "$replaced" "I said praise again"
+lacks "and the term is not written over the word" "$replaced" "Praisy"
+
+# ── a rule somebody wrote by hand ──────────────────────────────────────────
+printf '\n  a rule written into config.yaml by hand\n'
+fresh 'acoustic: true\nterms:\n  Praisy:\n'
+printf 'transcription:\n  languages: [en]\n  replacements:\n    Praisy: [praise]\naudio:\n  output_dir: %s\n' \
+  "$CLIPS" > "$WORK/config.yaml"
+clip six.wav
+traced six.wav en "Praisy" "praise:1.00:1.50"
+got="$(said Praisy praise)"
+wants "it is named" "$got" 'a rule you wrote in config.yaml maps "praise" to it'
+wants "and left alone" "$(cat "$WORK/config.yaml")" "Praisy: [praise]"
+
+# ── a revert with no audio behind it ───────────────────────────────────────
+printf '\n  a revert with no dictation behind it\n'
+fresh
+got="$(said Praisy praise)"
+wants "it says there is no trace line" "$got" "no trace line for this dictation"
+wants "the pair is recorded anyway"    "$(cat "$WORK/vocabulary.yaml")" "- word: praise"
+wants "with no clip behind it"         "$(cat "$WORK/vocabulary.yaml")" "clips: 0"
+wants "and the row records why"        "$(cat "$WORK/voice/observations.jsonl")" \
+  '"skipped":"no trace line for this dictation"'
+wants "and still says which way it points" "$(cat "$WORK/voice/observations.jsonl")" \
+  '"polarity":"negative"'
+
+# ── the forward direction is untouched ─────────────────────────────────────
+printf '\n  a correction the other way round still behaves\n'
+fresh
+clip seven.wav
+traced seven.wav en "I said praise" "i:0.10:0.30" "said:0.40:0.90" "praise:1.00:1.50"
+got="$(said praise Praisy)"
+wants "it still learns the rule"   "$got" "✓ praise → Praisy"
+wants "and counts the rendering up" "$got" "Praisy: seen 3 time(s), from correction"
+wants "and keeps a positive sample" "$got" "kept the audio as voice/samples/Praisy/00-praise.wav"
+wants "and its row says so"         "$(cat "$WORK/voice/observations.jsonl")" '"polarity":"positive"'
+absent "and writes no negative"     "$WORK/voice/negatives"
+lacks  "and no collision"           "$(cat "$WORK/vocabulary.yaml")" "collides_with"
+
+# One term corrected into another is a rendering, not a revert. Both sides name
+# a term, so there is a term to keep either way.
+printf '\n  one term written where another was said\n'
+fresh
+clip eight.wav
+traced eight.wav en "Supabase" "praisy:1.00:1.50"
+got="$(said Praisy Supabase)"
+wants "it is learnt as a rendering" "$got" "✓ Praisy → Supabase"
+wants "under the term that was meant" "$(cat "$WORK/vocabulary.yaml")" "- heard: Praisy"
+lacks "and is not a revert"          "$got" "took the term back"
+
+# ── an observation written before polarity existed ─────────────────────────
+printf '\n  a row with no polarity on it\n'
+fresh
+mkdir -p "$WORK/voice/negatives/Praisy"
+for n in $(seq -w 0 24); do : > "$WORK/voice/negatives/Praisy/$n-old.wav"; done
+# The row claims a *negative* clip and has no `polarity`, so it reads as a
+# positive — which means it confirms nothing about the negative bank, and the
+# cap is free to take the oldest file. A row read the other way would protect
+# it and the cap would delete a later file instead.
+printf '%s\n' \
+  '{"at":"2026-08-01T10:00:00Z","term":"Praisy","heard":"old","from":"correction","sample":"negatives/Praisy/00-old.wav"}' \
+  > "$WORK/voice/observations.jsonl"
+clip nine.wav
+traced nine.wav en "Praisy" "praise:1.00:1.50"
+got="$(said Praisy praise)"
+wants "it is not read as a negative"  "$got" "capped voice/negatives/Praisy/00-old.wav"
+wants "so the cap treats it as unvouched" "$got" "oldest unconfirmed"
+same "and the bank is back at the cap, 25" \
+  "$(ls "$WORK/voice/negatives/Praisy" | wc -l | tr -d ' ')" "25"
+
+# ── --check-config counts the two banks apart ──────────────────────────────
+printf '\n  what --check-config says\n'
+fresh
+clip ten.wav
+traced ten.wav en "I said Praisy" "i:0.10:0.30" "said:0.40:0.90" "praise:1.00:1.50"
+said Praisy praise >/dev/null
+clip eleven.wav
+traced eleven.wav en "I said praise" "i:0.10:0.30" "said:0.40:0.90" "praise:1.00:1.50"
+said praise Praisy >/dev/null
+got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --check-config 2>/dev/null)"
+wants "samples and negatives are counted apart" "$got" "1 sample(s), 1 negative(s)"
+
+# ── --forget takes all four back ───────────────────────────────────────────
+printf '\n  --forget after a revert\n'
+got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --forget Praisy 2>/dev/null)"
+wants "it forgets the term"  "$got" "✓ forgot Praisy"
+wants "the pronunciations go" "$got" "pronunciation(s) from vocabulary.yaml"
+wants "the observations go"   "$got" "2 observation(s) from voice/observations.jsonl"
+wants "the samples and the negatives go" "$got" "1 sample(s) and 1 negative(s) from"
+wants "and the collides_with entry"      "$got" "1 collides_with entr(ies) from vocabulary.yaml"
+vocab="$(cat "$WORK/vocabulary.yaml")"
+lacks  "vocabulary.yaml has no collision left" "$vocab" "collides_with"
+lacks  "and no rendering left"                 "$vocab" "heard:"
+absent "the negatives folder is gone"          "$WORK/voice/negatives/Praisy"
+absent "and the samples folder too"            "$WORK/voice/samples/Praisy"
+got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --check-config 2>/dev/null)"
+status=$?
+total=$((total + 1))
+if [ $status -eq 0 ] && ! printf '%s' "$got" | grep -q '  ✗ vocabulary'; then
+  pass=$((pass + 1)); printf '  ✓ and --check-config is clean afterwards\n'
+else
+  failed="$failed
+      --check-config is clean afterwards"
+  printf '  ✗ and --check-config is clean afterwards\n'
+fi
+
+printf '\n  %d/%d\n' "$pass" "$total"
+if [ -n "$failed" ]; then
+  printf '  failed:%s\n' "$failed"
+  exit 1
+fi

--- a/scripts/check-reverts.sh
+++ b/scripts/check-reverts.sh
@@ -256,6 +256,37 @@ wants "it says there is nothing to count down" "$got" \
   'Praisy: "praise" fired and was never counted'
 wants "and leaves the entry where it is" "$(cat "$WORK/vocabulary.yaml")" "heard: [praise]"
 
+# ── a term written with a comment on it ────────────────────────────────────
+#
+# Making room for `collides_with:` under a term rewrites whatever the term's
+# value is today into a block body. The live file wraps one list over two
+# lines, and joining them onto one destroys the entry when either carries a
+# comment: everything after the `#` becomes comment, the bracket never closes,
+# and `vocabulary.yaml` then fails to load — silently, because a file that will
+# not parse reads as no terms at all.
+printf '\n  a term whose value carries a comment\n'
+fresh 'acoustic: true\nterms:\n  Praisy: [Prissy,   # the common one\n           Pressy]\n  Mirza: 0.85  # measured on 2026-08-01\n'
+clip twelve.wav
+traced twelve.wav en "Praisy" "praise:1.00:1.50"
+said Praisy praise >/dev/null
+vocab="$(cat "$WORK/vocabulary.yaml")"
+wants "the wrapped list keeps its own lines" "$vocab" "heard: [Prissy,   # the common one"
+wants "and its continuation"                 "$vocab" "Pressy]"
+wants "the other term is untouched"          "$vocab" "Mirza: 0.85  # measured on 2026-08-01"
+wants "and the collision still lands"        "$vocab" "- word: praise"
+# The check that matters: the file still loads. A term count of 2 is the app
+# reading its own vocabulary back.
+got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --check-config 2>/dev/null)"
+wants "and the file still loads" "$got" "vocabulary: 2 terms in vocabulary.yaml"
+
+# The same on the forward path, which goes through the same rewrite.
+clip thirteen.wav
+traced thirteen.wav en "prissy" "prissy:1.00:1.50"
+said prissy Praisy >/dev/null
+got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --check-config 2>/dev/null)"
+wants "a correction does not break it either" "$got" "vocabulary: 2 terms in vocabulary.yaml"
+wants "and the comment is still there" "$(cat "$WORK/vocabulary.yaml")" "# the common one"
+
 # ── nothing in the files fired ─────────────────────────────────────────────
 printf '\n  a term the acoustic pass proposed on its own\n'
 fresh 'acoustic: true\nterms:\n  Praisy:\n  Supabase:\n'

--- a/scripts/mine-pronunciations.py
+++ b/scripts/mine-pronunciations.py
@@ -271,6 +271,11 @@ def main():
                 # entries know their provenance is a bank you cannot filter.
                 "lang": spoken.get(wav),
                 "build": stamped,
+                # Mining only ever produces positives: it looks for a term in a
+                # decode and cuts where it found it. Written out anyway, because
+                # a row whose meaning has to be inferred from which script wrote
+                # it is a row somebody will eventually infer wrongly.
+                "polarity": "positive",
             })
     with observations.open("a", encoding="utf-8") as handle:
         for row in rows:


### PR DESCRIPTION
## Summary
On `main`, taking a term back (for example `--learn Praisy praise`) wrote a `config.yaml` replacement rule in the wrong direction, silently disabling that term for every future correct use, and `--forget` couldn't clean it up because nothing pointed back at the rule.
This PR refuses that write in `ConfigWriter`, and instead counts down the rule that actually fired, records the collision, and keeps the correction's audio as a negative sample in a separate directory.
`scripts/check-reverts.sh` (67 new cases) passes in CI, no sample is ever deleted by a revert, and a term is never silently disabled by taking it back; a live revert itself is not measured here — it needs a person at a microphone.

## Issue
Part of #74. Targets #81 (`feat/corrections-keep-audio`). Two commits, separable — the bug fix is independent of this stack and cherry-picks cleanly to `main` on its own.

## The bug

`ConfigWriter.addReplacement` wrote `corrected: [heard]` into `config.yaml` regardless of the direction of the correction. So a speaker taking a term back — "the app wrote Praisy, I meant 'praise'" — ended up disabling the term entirely, including every future correct use of it. `--forget Praisy` then removed the pronunciation but left the broken rule sitting in `config.yaml`, unreachable by any command.

## Commit 1 — the fix

`addReplacement` now refuses that shape and returns false. The gate lives in the writer, the last function before the file, so all three call sites are covered and a future call site can't reintroduce the bug.

## Commit 2 — what a revert does instead

1. **Counts down whatever actually fired** — an exact `pronunciations:` rule or the acoustic pass — rather than deleting it. A rendering seen nine times and reverted once is still how this person usually says the word; the entry is only removed at zero, and only if a correction wrote it (never a legacy or mined entry, which has no honest count to take one off).
2. **Records the pair** as `collides_with:` under the term, without ever matching or substituting on it.
3. **Keeps the audio as a negative** in a separate `voice/negatives/<Term>/` directory rather than a flag inside the positive samples directory, so existing scripts that walk the samples folder don't silently ingest a negative as a positive.

No sample is ever deleted by this path — #82 already showed a bad clip can't be reliably picked out of a bank from one revert alone.

**Two counting bugs found while writing the tests, both fixed here:** the sample cap matched files by bare filename, so a negative could have shadowed a positive nobody confirmed and gotten the confirmed file deleted instead; and pruning kept a reverted word's rendering alive past the seen-once rule because it read the wrong key.

<details>
<summary><b>How to Test</b></summary>

`scripts/check-reverts.sh`, 67 cases, in CI. Each case builds a scratch config directory and generates synthetic tone-burst audio. Covers: no rule written anywhere, the count-down and drop-at-zero behavior, the legacy-entry exception, the negative clip and its polarity tag, `collides_with:` accumulating on repeat reverts, the forward (non-revert) direction still working unchanged, and `--forget` clearing pronunciations, samples, negatives, and collisions together.

CI checks touched: `check-corrections.sh` 59/59, `check-vocabulary-config.sh` 61/61, `check-no-voice.sh` 5/5, `check-replacements.sh` 23/23.

**Not done: a live revert.** It needs a human at a microphone. The panel's own path takes the same route as `--learn <Term> <word> --clip`.

</details>
