### PR TITLE
fix: the judge takes the pre-rules transcript from replacements

### DIFF
--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -788,9 +788,24 @@ struct Pipeline: Equatable, Codable {
             // this one did. A stage handed only the finished sentence cannot
             // tell which words were rewritten, and guessing is how a judge
             // starts reverting things nobody changed.
+            //
+            // `before` is the sentence this stage was handed. `changes` says
+            // which rules fired and not *where*, so the judge needs the earlier
+            // text to tell one occurrence of a term from another. It used to
+            // take that from the acoustic pass, which does not run under
+            // `vocabulary.acoustic: false` — a path that has audio and no
+            // earlier text. This stage always has it.
+            //
+            // Two `replacements` steps in one pipeline publish this twice and
+            // the second wins, exactly as `changes` already does. That is safe
+            // because the two move together: a reader gets the last step's
+            // changes beside the last step's input, which is the pair it needs.
+            // What it does not get is the first step's changes, and that was
+            // already true before this line existed.
             return StageResult(text: done.text, vars: [
                 "count": .int(done.count),
                 "changes": .string(done.changes),
+                "before": .string(text),
             ])
         case .fuzzy:
             // From the rules, not from the table's keys. Fuzzy matching
@@ -912,12 +927,23 @@ struct Pipeline: Equatable, Codable {
         // Both sources. The acoustic pass proposes with positions; a
         // `replacements` rule publishes none, so its substitutions are found by
         // searching for the term and told apart from the terms the decoder
-        // already had by comparing against the text the pass returned.
+        // already had by comparing against the text that stage was handed.
+        //
+        // From `replacements` and not from the acoustic pass, because the pass
+        // may not have run. `Vocabulary.wanted` gates it on
+        // `vocabulary.acoustic`, so with that off `findings` is nil and a term
+        // standing twice could not be attributed at all. The two texts are the
+        // same string whenever both exist — no stage that edits text may sit
+        // above `vocabulary` except `replacements` itself — so this changes
+        // nothing on the path where the pass does run. `findings?.text` stays
+        // as the fallback for a pipeline with no `replacements` step in it.
         var rules = ""
+        var beforeRules: String?
         if case .string(let wrote)? = scope["replacements.changes"] { rules = wrote }
+        if case .string(let handed)? = scope["replacements.before"] { beforeRules = handed }
         let parts = VocabularyJudge.acousticParts(
             findings?.proposals ?? [], in: text, measuredOn: findings?.text ?? text
-        ) + VocabularyJudge.ruleParts(rules, in: text, before: findings?.text)
+        ) + VocabularyJudge.ruleParts(rules, in: text, before: beforeRules ?? findings?.text)
 
         let slots = VocabularyJudge.slots(in: text, from: parts, caps: caps)
         // Two numbers on every run, not only when the count is fatal.

--- a/Sources/ParrotFlow/VocabularyJudge.swift
+++ b/Sources/ParrotFlow/VocabularyJudge.swift
@@ -279,16 +279,19 @@ enum VocabularyJudge {
     /// "deployed on Versailles" as the decoder's own reading, which it never
     /// was.
     ///
-    /// `before` is the transcript as the acoustic pass returned it, which is
-    /// what `replacements` was handed, and it says which occurrence is which.
-    /// A rule rewrites in place and reorders nothing, so the terms standing in
-    /// the text now are, in order, the occurrences of `heard` and of `term` in
-    /// `before` — and only the first kind is a substitution to offer back. See
-    /// `rewritten(_:_:in:became:)`.
+    /// `before` is the transcript `replacements` was handed, and it says which
+    /// occurrence is which. A rule rewrites in place and reorders nothing, so
+    /// the terms standing in the text now are, in order, the occurrences of
+    /// `heard` and of `term` in `before` — and only the first kind is a
+    /// substitution to offer back. See `rewritten(_:_:in:became:)`.
     ///
     /// When the two do not line up, some other rule wrote the term as well and
     /// nothing here can say which occurrence came from where. Then none of them
-    /// are offered, and the log says so.
+    /// are offered, and the log says so. That is the common case for two
+    /// renderings of one term in one sentence — `Versal` and `Versailles` both
+    /// becoming `Vercel` — because each pair is counted on its own and each
+    /// accounts for one of the two terms standing. A `before` does not decide
+    /// that shape; only reading the pairs per term would.
     ///
     /// A rule whose source is a pattern is skipped. `/(\w+) dot (\w+)/` names
     /// no spelling to offer back, and putting the pattern on a menu would ask
@@ -305,8 +308,12 @@ enum VocabularyJudge {
             else { continue }
             let stands = Vocabulary.spans(of: term, in: text, ignoringCase: true)
             guard let before else {
-                // No acoustic pass ran, so there is no earlier text to compare
-                // against — `--pipeline`, `--replace`, any path with no audio.
+                // No earlier text to compare against. `replacements` publishes
+                // it whenever that stage ran, so this is now only a pipeline
+                // with a `vocabulary:` stage and no `replacements` above it —
+                // where a rule pair can still arrive from a scope seeded
+                // elsewhere. It used to be every path with no audio, and that
+                // cost the judge a reading under `vocabulary.acoustic: false`.
                 // One occurrence is still decidable without it: the rule is in
                 // `changes`, so it fired at least once, and a pre-existing term
                 // would be a second occurrence. More than one and nothing here

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -676,9 +676,13 @@ They are **derived, never claimed**. A stage cannot forget to report `changed`,
 and cannot report it about the wrong string.
 
 Stages add their own on top. The built-in ones publish `replacements.count`,
-`numbers.language` — which grammar actually read the numbers, and not the same
-answer as the pipeline's language — and, for a prompt stage, `model`. A
-`command:` transform publishes whatever it likes; see
+`replacements.changes` and `replacements.before` — how many rules fired, which
+ones, and the sentence the stage was handed — `numbers.language`, which grammar
+actually read the numbers and is not the same answer as the pipeline's
+language, and, for a prompt stage, `model`. The name judge reads all three of
+the `replacements` ones: `changes` says which rules fired and `before` says
+*where*, because the rules leave no positions behind. A `command:` transform
+publishes whatever it likes; see
 [docs/authoring.md](authoring.md#recipe-a-program-that-reports-what-it-did).
 
 Before any stage runs, the scope already holds `text`, `app`, `bundle_id`,

--- a/tests/pipeline-cases.yaml
+++ b/tests/pipeline-cases.yaml
@@ -500,6 +500,72 @@ cases:
       context.ok: false
       context.changed: false
 
+  # --- the name judge, on what a `replacements` rule did -----------------------
+  #
+  # `--pipeline` has no audio, so these are the path that used to have no earlier
+  # text to compare against. `replacements` publishes its input as
+  # `replacements.before`, and that is what says which `Vercel` a rule wrote.
+  # `vocabulary.slots` counts the places the stage found. See
+  # tests/pipelines/vocabulary-rules.yaml for why no model is called.
+
+  # The case the fix is for. The rule rewrites one `Versailles`, the decoder had
+  # already written the other `Vercel`, and the term now stands twice. Without
+  # the earlier text this offered nothing and logged that it could not tell them
+  # apart. One slot, on the occurrence the rule made.
+  - name: a rule is attributed when the term it wrote stands twice
+    pipeline: vocabulary-rules
+    input: a list of possible alternatives for Versailles, such as Vercel
+    expect: a list of possible alternatives for Vercel, such as Vercel
+    expect_vars:
+      replacements.before: a list of possible alternatives for Versailles, such as Vercel
+      replacements.changes: Versailles -> Vercel
+      vocabulary.slots: 1
+
+  # One occurrence was decidable without the earlier text and still is. Here so
+  # that the path which already worked is held, not only the one that did not.
+  - name: a rule is attributed when the term it wrote stands once
+    pipeline: vocabulary-rules
+    input: our app is deployed on Versailles
+    expect: our app is deployed on Vercel
+    expect_vars:
+      vocabulary.slots: 1
+
+  # A term the decoder wrote itself is not a substitution. No rule fired, so
+  # there is nothing to offer back and no menu to build.
+  - name: a term nothing rewrote opens no slot
+    pipeline: vocabulary-rules
+    input: our app is deployed on Vercel
+    expect: unchanged
+    expect_vars:
+      replacements.changes: ""
+      vocabulary.slots: 0
+
+  # Two renderings of one term in one sentence, and the stage declines. Each
+  # pair in `changes` is counted on its own, so each accounts for one of the two
+  # terms standing and neither can claim its own. The earlier text does not
+  # settle this shape; only reading the pairs per term would. This is the live
+  # sentence from the 2026-08-09 dictation pass, and it is still not attributed.
+  - name: two rules writing one term in one sentence decline rather than guess
+    pipeline: vocabulary-rules-two-renderings
+    input: deployed on Versal against the Versailles Castle
+    expect: deployed on Vercel against the Vercel Castle
+    expect_vars:
+      vocabulary.slots: 0
+
+  # Two `replacements` steps, which a pipeline may have. `before` and `changes`
+  # are both the second step's, so they still describe the same run. The second
+  # step finds nothing left to rewrite, so it publishes no changes and the judge
+  # is offered nothing — the first step's changes are not readable from here,
+  # and never were.
+  - name: a second replacements step republishes its own input
+    pipeline: vocabulary-rules-twice
+    input: a list of possible alternatives for Versailles, such as Vercel
+    expect: a list of possible alternatives for Vercel, such as Vercel
+    expect_vars:
+      replacements.before: a list of possible alternatives for Vercel, such as Vercel
+      replacements.changes: ""
+      vocabulary.slots: 0
+
 # Pipelines that must not load at all.
 #
 # Scored separately because the property is different: these never reach a

--- a/tests/pipelines/vocabulary-rules-twice.yaml
+++ b/tests/pipelines/vocabulary-rules-twice.yaml
@@ -1,0 +1,14 @@
+# Two `replacements` steps above the judge, which a pipeline is allowed to have.
+#
+# Both steps publish under the same namespace and the second wins, for `before`
+# exactly as for `changes`. The pair stays consistent — the judge reads the last
+# step's changes beside the last step's input — and the first step's changes are
+# not readable at all, which was already true before `before` existed.
+languages: [en]
+replacements:
+  Vercel: [Versailles]
+pipeline:
+  - replacements
+  - replacements
+  - vocabulary: ../../examples/prompts/verify_names.md
+    max_readings: 1

--- a/tests/pipelines/vocabulary-rules-two-renderings.yaml
+++ b/tests/pipelines/vocabulary-rules-two-renderings.yaml
@@ -1,0 +1,11 @@
+# The same stage, with two renderings of one term in one sentence.
+#
+# Separate from `vocabulary-rules.yaml` because the table is what differs: two
+# rules write `Vercel` here, and each is counted on its own. See the cases.
+languages: [en]
+replacements:
+  Vercel: [Versailles, Versal]
+pipeline:
+  - replacements
+  - vocabulary: ../../examples/prompts/verify_names.md
+    max_readings: 1

--- a/tests/pipelines/vocabulary-rules.yaml
+++ b/tests/pipelines/vocabulary-rules.yaml
@@ -1,0 +1,21 @@
+# The name judge reading what a `replacements` rule did, with no audio at all.
+#
+# What is scored is attribution: which occurrence of a term a rule wrote.
+# `vocabulary.slots` is the number, and it is the one thing about this stage a
+# fixture can assert — the answer comes from a model and is not deterministic.
+#
+# `max_readings: 1` is how no model is called. The menu is cut to the decoder's
+# own sentence, the stage returns the transcript it was handed, and the run is
+# the same with Ollama up or down. Every case here scores the places the stage
+# found, never what was chosen at them.
+#
+# The prompt is the shipped one, by relative path, because the stage refuses to
+# run without a readable prompt file and a fixture with its own copy would be a
+# second thing to keep in step.
+languages: [en]
+replacements:
+  Vercel: [Versailles]
+pipeline:
+  - replacements
+  - vocabulary: ../../examples/prompts/verify_names.md
+    max_readings: 1


### PR DESCRIPTION
## Summary
With `acoustic: false`, the vocabulary judge couldn't tell which occurrence of a repeated term a `heard:` rule had rewritten, because its only source for the pre-rules text was the acoustic pass — which doesn't run in that mode.
This PR makes the `replacements` stage publish the pre-rules text itself, so the judge always has it regardless of whether the acoustic pass ran.
On the 141-clip ablation, one clip becomes a confirmed real win (9/9 replays) with zero control regressions, but the plan's own repro sentence still comes out wrong afterward — a second bug (rules counted one at a time instead of grouped per term) remains, and is not fixed here.

## Issue
Part of #74. Fix A from the plan (#80). Targets `main` directly rather than the documentation stack.

## The bug and the fix

`VocabularyJudge.ruleParts` needs the text as it stood before the rules ran, to work out which occurrence of a term a `heard:` rule wrote. It read that text from the acoustic pass's output, which only exists when `acoustic: true`. Under `acoustic: false`, a term standing more than once couldn't be attributed at all:

```
vocabulary judge: "Vercel" stands 2 time(s) and no acoustic pass ran, so which one "Versailles" became cannot be told; that reading is not offered
vocabulary judge: 0 slot(s) from 0 proposal(s)
```

The `replacements` stage always has that text — it's what it was handed — so it now publishes it, and the judge reads it from there, falling back to the old source when the acoustic pass did run. No fallback to the current (post-rules) text: that path returns "no substitutions" and logs nothing, which is worse than declining explicitly.

## Finding: the live repro is not fixed by this

Two renderings of the *same* term in one sentence are still not attributed — `Versal -> Vercel; Versailles -> Vercel` in one sentence still fails, because the judge reads rule pairs one at a time and each pair alone can't account for both occurrences. The plan's Fix A section had claimed this fix would make that sentence attributable; it doesn't. That's a separate change (see #89).

## Verification

**Unit**: `scripts/check-pipeline.sh`, 62/62 (5 new cases, 2 of which fail on `main` and pass here).

**Ablation** — two builds (`main` at `78d7ba2`, and `main` plus this PR), same 141 clips, `gemma4:e4b-mlx`, `--runs 3`:

| build | arm | correct | wins | losses | flips |
|---|---|---|---|---|---|
| `main` | `acoustic: false` | 102 | 26 | 0 | 0 |
| this PR | `acoustic: false` | **103** | 27 | 0 | 0 |

Head to head on the changed arm: 2 wins, 1 loss at `--runs 3`, but re-measured at `--runs 9` on the moved clips, the honest count is **1 real win, 0 losses** — the other two moves were replay noise. Controls: 0 wins, 0 losses — this change can't reach a clip where no rule fires.

**Read the absolute numbers with care.** `acoustic: false` was measured at 100 (#75, different build), 102, and 103 across sessions — a few clips of drift is normal between runs on this corpus. The comparison that decides this PR is the within-session one: same clips, same config, one Swift change, zero flips.

<details>
<summary><b>How to Test</b></summary>

`scripts/check-pipeline.sh` (no audio needed, `max_readings: 1` cuts the menu before any model call). For the ablation: `scripts/vocab-ablation.py --runs 3` over `tests/menu-cases.yaml`, two scratch config directories, `gemma4:e4b-mlx` as judge. `scripts/check-no-voice.sh` passes 5/5. Nothing merged, nothing force-pushed; `docs/proposals/vocabulary-v3.md` is not touched by this PR — it's owned by the documentation stack (#74).

</details>
