### PR TITLE
test: the abstain curve says five recordings, not three

### DIFF
--- a/docs/proposals/vocabulary-v3.md
+++ b/docs/proposals/vocabulary-v3.md
@@ -2433,8 +2433,10 @@ is for, not the height.
 
 **Abstain below five recordings, not three. One number covers ten of the eleven
 terms, and it is the same number for both statistics.** At n=3 a draw still
-throws away over half of a term's own correct spans between 4% and 11% of the
-time. At n=5 that is 0% to 2.5%. The prototype's floor of 3 was arithmetic —
+throws away over half of a term's own correct spans between 4% and 15% of the
+time, depending on the term and the statistic. At n=5 that is 0% to 3.5%. The
+worst case is the number to read: an abstain rule exists for the bad draw, not
+for the median one. The prototype's floor of 3 was arithmetic —
 "two recordings give one distance" — and it is a floor on *computability*, not
 on usefulness. Usefulness arrives two clips later.
 
@@ -2485,25 +2487,25 @@ percentile gives the identical table** — see below.
 | term | rec | n=2 | n=3 | n=4 | n=5 | n=6 | n=8 | n=12 | full |
 |---|---|---|---|---|---|---|---|---|---|
 | arexvy | 7 | 0.895 | 0.921 | 0.923 | 0.936 | 0.936 | — | — | 0.936 |
-| | | .862–1.000 | .887–1.000 | .897–1.000 | .913–.985 | .921–.985 | | | |
+| | | .862–1.000 | .887–1.000 | .897–1.000 | .913–.985 | .921–.985 |  |  | |
 | claude | 6 | **0.582** | **0.635** | 0.736 | 0.851 | — | — | — | 0.844 |
-| | | .480–.654 | .539–.759 | .610–.885 | .726–.867 | | | | |
+| | | .479–.654 | .538–.759 | .610–.885 | .726–.867 |  |  |  | |
 | matthieu | 11 | 0.806 | 0.842 | 0.850 | 0.855 | 0.853 | 0.853 | — | 0.848 |
-| | | .605–.935 | .594–.940 | .705–.931 | .757–.917 | .804–.897 | .815–.877 | | |
-| mirza | 15 | 0.950 | 0.954 | 0.954 | 0.952 | 0.950 | 0.948 | 0.943 | 0.940 |
+| | | .605–.935 | .594–.940 | .705–.931 | .757–.917 | .804–.897 | .815–.877 |  | |
+| mirza | 15 | 0.950 | 0.954 | 0.954 | 0.952 | 0.950 | 0.948 | 0.942 | 0.940 |
 | | | .823–1.000 | .821–.996 | .871–.992 | .927–.992 | .927–.990 | .929–.974 | .929–.950 | |
 | ollama | 7 | 0.797 | 0.851 | 0.869 | 0.874 | 0.874 | — | — | 0.874 |
-| | | .562–.900 | .685–.903 | .697–.903 | .828–.892 | .854–.885 | | | |
+| | | .562–.900 | .685–.903 | .697–.903 | .828–.892 | .854–.885 |  |  | |
 | praisy † | 26 | 0.736 | 0.761 | 0.770 | 0.789 | 0.798 | 0.804 | 0.827 | 0.869 |
-| | | .469–.851 | .476–.874 | .593–.882 | .642–.887 | .650–.887 | .704–.892 | .726–.898 | |
+| | | .468–.851 | .476–.874 | .593–.882 | .642–.887 | .650–.887 | .704–.892 | .726–.898 | |
 | redcrawl | 8 | 0.955 | 0.966 | 0.964 | 0.962 | 0.963 | — | — | 0.966 |
-| | | .736–.998 | .818–1.000 | .867–1.000 | .879–1.000 | .897–1.000 | | | |
+| | | .736–.998 | .817–1.000 | .867–1.000 | .879–1.000 | .897–1.000 |  |  | |
 | redrock | 7 | 0.866 | 0.917 | 0.951 | 0.973 | 0.993 | — | — | 0.993 |
-| | | .723–.980 | .779–.980 | .875–.996 | .920–.996 | .958–.996 | | | |
-| supabase | 11 | 0.946 | 0.962 | 0.973 | 0.979 | 0.989 | 0.996 | — | 1.000 |
-| | | .636–.998 | .733–1.000 | .842–1.000 | .880–1.000 | .898–1.000 | .927–1.000 | | |
-| tasmeen | 8 | 0.880 | 0.926 | 0.931 | 0.981 | 0.985 | — | — | 0.985 |
-| | | .726–.987 | .756–.995 | .803–.995 | .851–.995 | .869–.992 | | | |
+| | | .723–.980 | .779–.980 | .875–.996 | .920–.996 | .958–.996 |  |  | |
+| supabase | 11 | 0.946 | 0.962 | 0.973 | 0.978 | 0.989 | 0.996 | — | 1.000 |
+| | | .636–.998 | .733–1.000 | .842–1.000 | .880–1.000 | .898–1.000 | .927–1.000 |  | |
+| tasmeen | 8 | 0.879 | 0.926 | 0.931 | 0.981 | 0.985 | — | — | 0.985 |
+| | | .726–.987 | .756–.995 | .803–.995 | .851–.995 | .869–.992 |  |  | |
 | vercel † | 16 | 0.700 | 0.767 | 0.767 | 0.800 | 0.833 | 0.833 | 0.900 | 0.933 |
 | | | .467–.933 | .500–.933 | .500–.933 | .600–.933 | .567–.933 | .633–.933 | .733–.933 | |
 
@@ -2515,8 +2517,9 @@ percentile gives the identical table** — see below.
 **A single draw at n=2 is worth nothing, which is why nobody should have
 quoted `Matthieu` 0.556.** `Matthieu` at n=2 has a median of 0.806 and a range
 of 0.605 to 0.935. Round 6's 0.556 was one draw of two clips out of the 55
-possible. `Supabase` runs .636 to .998 at n=2 and `Claude` .480 to .654.
-`Praisy` and `Vercel` have draws below chance at n=2 *and* at n=3.
+possible. `Supabase` runs .636 to .998 at n=2 and `Claude` .479 to .654.
+`Claude`, `Praisy` and `Vercel` all have draws below chance at n=2, and
+`Praisy` still does at n=3, where `Vercel`'s worst draw is exactly chance.
 
 **Nine of eleven flatten. `Praisy` and `Vercel` do not.** Both are still
 climbing at n=12, and both are the terms scored on the proposal set rather than
@@ -2535,6 +2538,14 @@ rejects under 25% of the B spans it should. **Cost**: the draw rejects over 50%
 of the A spans — the term really being said, thrown away. Both read off the
 rule's own verdict, which is what 6a found an AUC cannot see. Maximum on the
 left of each pair, 90th percentile on the right.
+
+**This table and the one above disagree about where abstain sits, and this one
+wins.** At n=3 the AUC median is inside 0.016 of the full-bank value for
+`Redcrawl`, `Matthieu`, `Mirza` and `Arexvy` — read the AUC alone and three
+clips look finished for four of the eleven terms. Those same four banks at n=3
+throw away over half of the term's own correct spans in 4% to 7.3% of draws, and
+`Mirza` is disarmed in 5% of them. The rule's behaviour is the thing an abstain
+key controls, so it is the thing that sets the number.
 
 | term | n=2 | n=3 | n=4 | n=5 | n=6 | n=8 |
 |---|---|---|---|---|---|---|

--- a/docs/proposals/vocabulary-v3.md
+++ b/docs/proposals/vocabulary-v3.md
@@ -2588,26 +2588,27 @@ for the same reason.
 
 #### Pooled, in 6a's units
 
-Every term's bank cut to n at once, rejections summed. Median over the draws,
-range under it. n=2 to 5 is all eleven terms; the last two rows change the set
-and say so.
+Every term's bank cut to n at once, rejections summed, on the maximum. The
+cohort is resampled independently per term per draw, so a row is a joint sample
+of that cohort's banks. Median over 200 joint draws, range under it. n=2 to 6 is
+all eleven terms; the last two rows change the set and say so.
 
-| n | terms | true rejections (B) | false rejections (A) | maximum |
+| n | terms | true rejections (B) | false rejections (A) | |
 |---|---|---|---|---|
-| 2 | 11 | 558 [323–703] of 773 | 26 [6–46] of 77 | |
-| 3 | 11 | 504 [361–628] of 784 | 22 [10–41] of 96 | |
-| 5 | 11 | 563 [415–652] of 784 | 16 [8–29] of 96 | |
+| 2 | 11 | 555 [394–726] of 772 | 26 [9–52] of 77 | |
+| 3 | 11 | 507 [349–673] of 784 | 23 [12–39] of 96 | |
+| 5 | 11 | 560 [465–684] of 784 | 16 [6–26] of 96 | |
 | all | 11 | **554** of 784 | **10** of 96 | ← 6a's row |
-| 8 | 7 | 377 [306–448] of 516 | 10 [4–19] of 70 | |
-| 12 | 3 | 172 [128–227] of 251 | 4 [2–10] of 35 | |
+| 8 | 7 | 382 [300–460] of 516 | 10 [5–16] of 70 | |
+| 12 | 3 | 175 [129–230] of 251 | 5 [2–9] of 35 | |
 
-The same three rows with the 90th percentile: 570 [419–668] at n=3, 622
-[523–707] at n=5, 649 at the full bank. The denominator column is the blind
+The eleven-term rows with the 90th percentile: 577 [436–716] at n=3, 624
+[529–715] at n=5, 649 at the full bank. The denominator column is the blind
 control — reject every span — and every arm here sits inside it.
 
 **The pooled true-rejection count is a trap and the range says why.** Its median
-barely moves: 558 at n=2, 554 at the full bank. A reader could conclude two
-clips are as good as twenty-six. The range is 323 to 703 at n=2 and a single
+barely moves: 555 at n=2, 554 at the full bank. A reader could conclude two
+clips are as good as twenty-six. The range is 394 to 726 at n=2 and a single
 number at the full bank. The count is not lower at n=2; it is unknowable at n=2.
 This is §2's "watch for a flat response curve" in another shape.
 

--- a/docs/proposals/vocabulary-v3.md
+++ b/docs/proposals/vocabulary-v3.md
@@ -448,6 +448,16 @@ pair is a shortage of clips, not a verdict on the term: `Matthieu` was 0.556 on
 2 recordings in round 6 and is 1.000 on 11. PR 4 carries that number, because it
 is the argument for keeping the audio from every correction.
 
+**Measured, 6e: the floor is 5, and "must not reject" starts well above three.**
+Subsampling every term's bank says two recordings are indefensible for all
+eleven — 18% to 40% of two-clip banks throw away over half the term's own
+correct spans — and three are not safe either, at 4% to 15%. At five it is 0% to
+3.5%. Both statistics need the same five. **Each of the two numbers above is one
+draw and neither is the term.** `Matthieu` at 2 recordings has a median AUC of
+0.806 over its 55 possible pairs, running 0.605 to 0.935; `Supabase` at 2 runs
+0.636 to 0.998. 6e's result block, and its own caveat: subsampling a good bank
+is not the same as a new term's first five corrections.
+
 **Some terms have never once been proposed correctly, so they cannot be evaluated
 on the proposal set at all.** Five of eleven have no correct-proposal row in the
 whole spontaneous archive: `Redcrawl`, `Arexvy`, `Claude`, `Mirza`, `Redrock`.
@@ -2419,6 +2429,298 @@ the recordings were mined from the corpus they are scored on, so the curve is
 better than the truth by an unknown margin. It is the *shape* of the curve this
 is for, not the height.
 
+### Result, measured 2026-08-10
+
+**Abstain below five recordings, not three. One number covers ten of the eleven
+terms, and it is the same number for both statistics.** At n=3 a draw still
+throws away over half of a term's own correct spans between 4% and 11% of the
+time. At n=5 that is 0% to 2.5%. The prototype's floor of 3 was arithmetic —
+"two recordings give one distance" — and it is a floor on *computability*, not
+on usefulness. Usefulness arrives two clips later.
+
+**The falsifier half fired, and on the statistic that cannot see the
+decision.** It fires on the AUC clause: `Praisy` and `Vercel` do not flatten,
+they are still climbing at n=12. It does not fire on the clause that matters —
+the per-term decision curves agree closely, and one n describes ten of eleven
+terms. This is 6a's lesson again. 6a's falsifier was written against an AUC
+that cannot see `spread`; 6e's first clause is written against the same AUC. PR
+10's config key is the right shape. Its value is 5, not 3.
+
+No app, no build, no model, no Ollama. `scripts/reference-matching.py` with a
+`--subsample` arm on top of 6a's, 122 recordings, 170 spans, every distance
+already in 6a's `--cache`. Deterministic given the seed: `6e-2026-08-10`, up to
+200 distinct subsets per point, every subset enumerated where a bank has fewer
+than 200. Nothing under `~/.config/parrotflow-dev/` was written; the arms run on
+a copy.
+
+#### Both baselines reproduce
+
+`--set scripted --source all` gives `Supabase` 1.000, `Redrock` 0.993,
+`Tasmeen` 0.985, `Redcrawl` 0.966, `Mirza` 0.940, `Arexvy` 0.936, `Ollama`
+0.874, `Matthieu` 0.848, `Claude` 0.844, pooled **0.935** over 63 A and 718 B.
+The control is 0.832 on A and 0.076 on B, 58/63 and 13/718. Duration alone is
+0.535. 6a's `--poison` table reproduces byte for byte as well, including the
+554 → 228 true rejections. The archive is still 122 recordings over 11 terms.
+
+#### What the archive supports — the plan had this wrong
+
+6e's own text says "n = 12 exists for four terms and n = 8 for six". Counted:
+**n = 8 exists for seven terms and n = 12 for three.**
+
+| n | terms that reach it |
+|---|---|
+| 2, 3, 4, 5 | all eleven |
+| 6 | all eleven — `Claude` has exactly six |
+| 8 | seven: `Matthieu` 11, `Mirza` 15, `Praisy` 26, `Redcrawl` 8, `Supabase` 11, `Tasmeen` 8, `Vercel` 16 |
+| 12 | three: `Mirza` 15, `Praisy` 26, `Vercel` 16 |
+
+`Claude` cannot reach n = 8, as the plan says.
+
+#### The AUC curve, per term
+
+Median over the draws, with the full range under it. `Praisy` and `Vercel` have
+no scripted A row, so they are on the proposal set and marked †. **The 90th
+percentile gives the identical table** — see below.
+
+| term | rec | n=2 | n=3 | n=4 | n=5 | n=6 | n=8 | n=12 | full |
+|---|---|---|---|---|---|---|---|---|---|
+| arexvy | 7 | 0.895 | 0.921 | 0.923 | 0.936 | 0.936 | — | — | 0.936 |
+| | | .862–1.000 | .887–1.000 | .897–1.000 | .913–.985 | .921–.985 | | | |
+| claude | 6 | **0.582** | **0.635** | 0.736 | 0.851 | — | — | — | 0.844 |
+| | | .480–.654 | .539–.759 | .610–.885 | .726–.867 | | | | |
+| matthieu | 11 | 0.806 | 0.842 | 0.850 | 0.855 | 0.853 | 0.853 | — | 0.848 |
+| | | .605–.935 | .594–.940 | .705–.931 | .757–.917 | .804–.897 | .815–.877 | | |
+| mirza | 15 | 0.950 | 0.954 | 0.954 | 0.952 | 0.950 | 0.948 | 0.943 | 0.940 |
+| | | .823–1.000 | .821–.996 | .871–.992 | .927–.992 | .927–.990 | .929–.974 | .929–.950 | |
+| ollama | 7 | 0.797 | 0.851 | 0.869 | 0.874 | 0.874 | — | — | 0.874 |
+| | | .562–.900 | .685–.903 | .697–.903 | .828–.892 | .854–.885 | | | |
+| praisy † | 26 | 0.736 | 0.761 | 0.770 | 0.789 | 0.798 | 0.804 | 0.827 | 0.869 |
+| | | .469–.851 | .476–.874 | .593–.882 | .642–.887 | .650–.887 | .704–.892 | .726–.898 | |
+| redcrawl | 8 | 0.955 | 0.966 | 0.964 | 0.962 | 0.963 | — | — | 0.966 |
+| | | .736–.998 | .818–1.000 | .867–1.000 | .879–1.000 | .897–1.000 | | | |
+| redrock | 7 | 0.866 | 0.917 | 0.951 | 0.973 | 0.993 | — | — | 0.993 |
+| | | .723–.980 | .779–.980 | .875–.996 | .920–.996 | .958–.996 | | | |
+| supabase | 11 | 0.946 | 0.962 | 0.973 | 0.979 | 0.989 | 0.996 | — | 1.000 |
+| | | .636–.998 | .733–1.000 | .842–1.000 | .880–1.000 | .898–1.000 | .927–1.000 | | |
+| tasmeen | 8 | 0.880 | 0.926 | 0.931 | 0.981 | 0.985 | — | — | 0.985 |
+| | | .726–.987 | .756–.995 | .803–.995 | .851–.995 | .869–.992 | | | |
+| vercel † | 16 | 0.700 | 0.767 | 0.767 | 0.800 | 0.833 | 0.833 | 0.900 | 0.933 |
+| | | .467–.933 | .500–.933 | .500–.933 | .600–.933 | .567–.933 | .633–.933 | .733–.933 | |
+
+† on the proposal set, 21 A / 37 B for `Praisy` and 6 A / 5 B for `Vercel`.
+`Vercel`'s AUC moves in steps of 1/30, so read its column as coarse.
+
+**Three things in that table.**
+
+**A single draw at n=2 is worth nothing, which is why nobody should have
+quoted `Matthieu` 0.556.** `Matthieu` at n=2 has a median of 0.806 and a range
+of 0.605 to 0.935. Round 6's 0.556 was one draw of two clips out of the 55
+possible. `Supabase` runs .636 to .998 at n=2 and `Claude` .480 to .654.
+`Praisy` and `Vercel` have draws below chance at n=2 *and* at n=3.
+
+**Nine of eleven flatten. `Praisy` and `Vercel` do not.** Both are still
+climbing at n=12, and both are the terms scored on the proposal set rather than
+the scripted one. Whether that is the term or the set, this experiment cannot
+say. `Redcrawl` is flat from n=2, `Mirza` from n=2, and `Mirza` *falls* slightly
+as clips arrive, 0.954 at n=3 against 0.940 at 15.
+
+**The median hides everything.** `Arexvy`'s median at n=2 is 0.895 against
+0.936 at its full seven. Read only that and n=2 looks nearly free. The range is
+what says otherwise, and the veto below says it louder.
+
+#### The decision, which is the number that decides abstain
+
+Two shares, per term and per n, at tolerance 1.00. **Disarmed**: the draw
+rejects under 25% of the B spans it should. **Cost**: the draw rejects over 50%
+of the A spans — the term really being said, thrown away. Both read off the
+rule's own verdict, which is what 6a found an AUC cannot see. Maximum on the
+left of each pair, 90th percentile on the right.
+
+| term | n=2 | n=3 | n=4 | n=5 | n=6 | n=8 |
+|---|---|---|---|---|---|---|
+| **disarmed %** | | | | | | |
+| arexvy | 0 / 0 | 0 / 0 | 0 / 0 | 0 / 0 | 0 / 0 | — |
+| claude | **60 / 60** | **90 / 55** | **46.7 / 26.7** | **16.7 / 16.7** | 0 / 0 | — |
+| matthieu | 12.7 / 12.7 | 7.9 / 1.2 | 1.5 / 0 | 0 / 0 | 0 / 0 | 0 / 0 |
+| mirza | 6.7 / 6.7 | 5 / 2 | 1.5 / 0.5 | 0 / 0 | 0 / 0 | 0 / 0 |
+| ollama | **33.3 / 33.3** | **40 / 17.1** | 17.1 / 2.9 | 4.8 / 0 | 0 / 0 | — |
+| praisy | **19.5 / 19.5** | 21.5 / 9 | 15 / 6.5 | 8.5 / 0.5 | 10.5 / 0.5 | 6 / 0.5 |
+| redcrawl | 3.6 / 3.6 | 1.8 / 0 | 0 / 0 | 0 / 0 | 0 / 0 | 0 / 0 |
+| redrock | 0 / 0 | 0 / 0 | 0 / 0 | 0 / 0 | 0 / 0 | — |
+| supabase | 5.5 / 5.5 | 2.4 / 1.2 | 1 / 0 | 0 / 0 | 0 / 0 | 0 / 0 |
+| tasmeen | 10.7 / 10.7 | 16.1 / 0 | 5.7 / 0 | 1.8 / 0 | 0 / 0 | 0 / 0 |
+| vercel | 7.5 / 7.5 | 4 / 3.5 | 4.5 / 2 | 1.5 / 0 | 0.5 / 0 | 0 / 0 |
+| **cost %** | | | | | | |
+| arexvy | **28.6 / 28.6** | 5.7 / 5.7 | 0 / 0 | 0 / 0 | 0 / 0 | — |
+| claude | **40 / 40** | 10 / 10 | 0 / 0 | 0 / 0 | 0 / 0 | — |
+| matthieu | **27.3 / 27.3** | 7.3 / 7.9 | 2 / 2.5 | 0 / 0 | 0 / 0.5 | 0 / 0 |
+| mirza | **18.1 / 18.1** | 4 / 4 | 0 / 0 | 0 / 0 | 0 / 0 | 0 / 0 |
+| ollama | **33.3 / 33.3** | 11.4 / 14.3 | 2.9 / 5.7 | 0 / 0 | 0 / 0 | — |
+| praisy | **30 / 30** | 11 / 15 | 7.5 / 9 | 2.5 / 3 | 0 / 0.5 | 0.5 / 0.5 |
+| redcrawl | **28.6 / 28.6** | 5.4 / 7.1 | 0 / 1.4 | 0 / 0 | 0 / 0 | 0 / 0 |
+| redrock | **38.1 / 38.1** | 11.4 / 14.3 | 2.9 / 5.7 | 0 / 0 | 0 / 0 | — |
+| supabase | **20 / 20** | 3.6 / 9.7 | 1.5 / 4 | 0 / 0.5 | 0 / 0 | 0 / 0 |
+| tasmeen | **25 / 25** | 7.1 / 8.9 | 1.4 / 2.9 | 0 / 0 | 0 / 0 | 0 / 0 |
+| vercel | **25 / 25** | 8 / 10.5 | 4.5 / 5 | 1.5 / 3.5 | 2 / 2.5 | 0 / 0.5 |
+
+**n=2 is indefensible for every term in the archive.** Between 18% and 40% of
+draws throw away over half of the term's own correct spans. That is one bank in
+four to one in three, on the tightest terms as much as the loosest — `Supabase`,
+which scores AUC 1.000 at eleven clips, is at 20%. Two clips is a coin flip
+about which two.
+
+**n=3 is not safe either, and this is what replaces the guess.** The cost share
+is 4% to 11% under the maximum and 4% to 15% under the 90th percentile.
+`Claude` is disarmed in 90% of its n=3 draws. The prototype abstains here.
+
+**n=5 is where both sides settle.** The worst cost share over eleven terms is
+2.5% under the maximum and 3.5% under the 90th percentile. The worst disarm
+share is `Claude` at 17% and then `Praisy` at 9% (maximum) or 0.5% (90th
+percentile).
+
+**`Claude` is the one term a single n does not cover.** It is only clean at
+n=6, which is its whole bank, so 6e cannot say whether 6 is `Claude`'s answer or
+just the end of its data. `Claude` is the shortest name in the set, has the
+fewest recordings, has the widest bank — spread 3.436 against `Supabase`'s
+2.919 — and is the one term the veto never worked well on: 26% of true
+rejections at its full bank against `Supabase`'s 97%. 6a already singled it out
+for the same reason.
+
+#### Pooled, in 6a's units
+
+Every term's bank cut to n at once, rejections summed. Median over the draws,
+range under it. n=2 to 5 is all eleven terms; the last two rows change the set
+and say so.
+
+| n | terms | true rejections (B) | false rejections (A) | maximum |
+|---|---|---|---|---|
+| 2 | 11 | 558 [323–703] of 773 | 26 [6–46] of 77 | |
+| 3 | 11 | 504 [361–628] of 784 | 22 [10–41] of 96 | |
+| 5 | 11 | 563 [415–652] of 784 | 16 [8–29] of 96 | |
+| all | 11 | **554** of 784 | **10** of 96 | ← 6a's row |
+| 8 | 7 | 377 [306–448] of 516 | 10 [4–19] of 70 | |
+| 12 | 3 | 172 [128–227] of 251 | 4 [2–10] of 35 | |
+
+The same three rows with the 90th percentile: 570 [419–668] at n=3, 622
+[523–707] at n=5, 649 at the full bank. The denominator column is the blind
+control — reject every span — and every arm here sits inside it.
+
+**The pooled true-rejection count is a trap and the range says why.** Its median
+barely moves: 558 at n=2, 554 at the full bank. A reader could conclude two
+clips are as good as twenty-six. The range is 323 to 703 at n=2 and a single
+number at the full bank. The count is not lower at n=2; it is unknowable at n=2.
+This is §2's "watch for a flat response curve" in another shape.
+
+#### The two statistics need the same abstain point
+
+**The AUC table is identical for the maximum and the 90th percentile, to every
+digit.** Verified by diffing the two runs. That is not a coincidence and it is
+not an experimental result — `spread` enters only the veto, never `distance`, so
+no ranking of spans inside a term can depend on it. It is 6a's arithmetic
+restated: the statistic is invisible to the AUC.
+
+**At n=2 the two statistics are the same statistic.** Two recordings give one
+leave-one-out distance, so the maximum of it and the 90th percentile of it are
+that one number. The n=2 rows of both runs are identical throughout, veto counts
+included. Anyone tuning a robust summary should know it has no effect at all
+until the third clip.
+
+**From n=3 the 90th percentile disarms less and costs slightly more.** It is
+uniformly better on the disarm side — `Tasmeen` 16% → 0% at n=3, `Ollama` 40% →
+17%, `Matthieu` 8% → 1%. It is a little worse on the cost side — `Supabase` 4% →
+10% at n=3, `Praisy` 11% → 15%. Both are the same trade 6a measured: the higher
+threshold rejects more, which catches more true rejections and more false ones.
+
+**So the abstain threshold does not differ between them, and that settles one
+6b question.** Both need about 5. The 90th percentile does not let the bank
+decide sooner. What it buys is a better decision at the same n — 6a's result —
+and it does not buy a lower floor. If 6b adopts it, the abstain key stays where
+6e puts it.
+
+#### Does one n work for all terms?
+
+**Yes, at n=5, for ten of eleven.** `Claude` is the exception and its own bank
+runs out at 6.
+
+**Clip count does not predict which terms need more.** `Arexvy` and `Redrock`
+have seven recordings each and are at 0% disarmed from n=2. `Ollama` also has
+seven and is at 40% at n=3. `Praisy` has twenty-six and is the second-worst term
+at every n.
+
+**The bank's own width predicts it better, and the evidence is thin.** Ranking
+terms by the smallest n at which both shares fall under a fixed bar gives
+Spearman +0.54 against the full-bank `spread` and −0.24 against the clip count.
+**Do not build on those two numbers.** The ranked variable takes three or four
+distinct values over eleven terms, so nearly every pair is a tie and one term
+moves the coefficient. The honest statement is the one above: one n covers ten
+of eleven, so there is almost nothing left to predict. The direction is the
+sensible one — `Claude` has the widest bank at 3.436 and needs the most clips,
+`Supabase` the tightest at 2.919 and needs the fewest — and `spread` is the
+right kind of predictor because it is computable from the clips alone, where a
+per-term AUC needs labelled spans a new term does not have.
+
+#### What is weak about this
+
+**It is in-sample in a second way, and this one is specific to 6e.**
+Part 1 §7's warning is that the recordings were mined from the corpus they are
+scored on. 6e adds another. **Subsampling a bank measures how *that* bank
+degrades. It does not measure how a *new* term with n clips behaves.** A
+subsample of `Praisy` at n=3 is three clips drawn from twenty-six that are
+already known to separate this corpus well — same speaker, same sessions, same
+microphone, mined by the same script from the same archive. A new term's first
+three clips come from three corrections in three unrelated sentences, on
+whatever days they happen, with nothing having checked that they are the term at
+all. **A real n=3 bank is worse than an n=3 subsample of a good bank, by an
+amount nobody here has measured.** So 5 is a lower bound on the abstain point,
+not an estimate of it. Measuring the real thing needs terms whose banks grew one
+correction at a time, which is PR 4's data and does not exist yet.
+
+**The thresholds in the decision table are conventions.** 25% for disarmed and
+50% for cost. The per-draw rates are in the script's output and can be read
+against another pair. The n=2 verdict survives any reasonable choice; the
+difference between n=4 and n=5 does not — `Praisy` moves between safe-at-5 and
+safe-at-8 under the maximum when a single grid point is added, because it sits
+on the bar.
+
+**The A denominator shrinks at small n.** The per-clip hold-out can take a
+subsampled bank under the abstain floor, and then that span is judged by nobody.
+`Arexvy` judges 4 A spans at n=2 against 6 at its full bank. So the cost share
+at n=2 is a share of four or five spans per term, not of six to ten. It is the
+noisiest column in the table and it is also the most extreme, which is a reason
+to read the direction and not the digits.
+
+**One seed.** `6e-2026-08-10`. Every point below 200 subsets is exhaustive and
+so seed-independent; the points at 200 draws are not. Nothing here rests on a
+gap of one or two draws.
+
+**Two terms are scored on the proposal set and nine on the scripted set.** They
+are not the same measurement, and the two terms that fail to flatten are exactly
+the two on the proposal set. 6e cannot separate those.
+
+**Rejection counts are not the ablation.** Same caveat as 6a. These say what the
+rule would drop on these spans. They do not say what the app would write.
+
+#### How to reproduce
+
+```sh
+S=$(mktemp -d) && cp -R ~/.config/parrotflow-dev/voice "$S/voice"   # read only
+
+PARROTFLOW_CONFIG_DIR=$S python3 scripts/reference-matching.py \
+  --set scripted --source all                    # the baseline that must hold
+
+PARROTFLOW_CONFIG_DIR=$S python3 scripts/reference-matching.py \
+  --poison --cache "$S/dist.npz"                 # builds the cache, ~5 minutes
+
+PARROTFLOW_CONFIG_DIR=$S python3 scripts/reference-matching.py \
+  --subsample --ns 2,3,4,5,6,8,12 --cache "$S/dist.npz" --csv "$S/max.csv"
+PARROTFLOW_CONFIG_DIR=$S python3 scripts/reference-matching.py \
+  --subsample --robust --ns 2,3,4,5,6,8,12 --cache "$S/dist.npz" --csv "$S/p90.csv"
+```
+
+The `--poison` run computes every distance once. The two `--subsample` runs
+index that cache and take about two seconds each. `--csv` writes every number
+in the tables above, so none of them is transcribed by hand.
+
 ## PR 7 — ask the speaker for fewer clips
 
 **Design the burden down instead of absorbing it.** Every clip in the bank
@@ -2656,7 +2958,9 @@ before this became real code".
    a term, because two recordings give one exemplar-to-exemplar distance and so
    no spread. Make that number a config key and print the abstaining terms in
    `--check-config`, so a speaker can see which of their terms the filter is
-   not deciding.
+   not deciding. **6e measured the value: 5, not 3.** Three is where a spread
+   becomes computable; five is where the decision stops depending on which
+   clips arrived. Read 6e's result before choosing the default.
 3. **One log line per decision.** The prototype writes two. The `dropped:` line
    says "audio prefers what was written by …" with a margin nobody computed,
    and the `reference:` line above it says the truth. The proto doc calls this
@@ -2922,8 +3226,10 @@ today has nothing behind it. The map is what covers a term's first days.
 after "about three corrections". That number is not supported. It came from the
 prototype's abstain floor of 3, which is about having a spread to compare
 against at all, and from `Matthieu` scoring 0.556 on 2 recordings in round 6 —
-one term at one count. **6e is the experiment that produces the real number.**
-Do not quote three.
+one term at one count. **6e ran and the number is 5.** It is a lower bound: a
+subsample of a good bank is not a new term's first five corrections, and 6e's
+result block says why. `Matthieu` at 2 recordings has a median AUC of 0.806 over
+its 55 possible pairs, so 0.556 was one draw and not the term.
 
 **Size.** No code of its own. It is a constraint on PR 10's abstain key and on
 whatever PR 13 ships.

--- a/scripts/reference-matching.py
+++ b/scripts/reference-matching.py
@@ -1394,7 +1394,10 @@ def subsample_report(source_name, cache, robust, ns, draws, seed, floor,
                 got = vetoes[term][n]
                 row = [where.split()[-1], term, sizes[term], n, len(got),
                        full_bank[term][1]]
-                row += [f"{v:.4f}" for v in band(curves[term][n])]
+                # Six decimals, not three. A table built from this file rounds
+                # once, from the real number; rounding a rounded number moves
+                # the last digit on any value that lands on a half.
+                row += [f"{v:.6f}" for v in band(curves[term][n])]
                 for group, test in (("B", lambda r: r < DISARMED),
                                     ("A", lambda r: r > OVERCOST)):
                     counts = band([g["veto"][group][0] for g in got])

--- a/scripts/reference-matching.py
+++ b/scripts/reference-matching.py
@@ -1166,6 +1166,22 @@ def subsets(count, size, draws, rng):
     return out
 
 
+def joint_draws(members, pool, count, rng):
+    """`count` independent joint draws: one subset index per term, per draw.
+
+    A cohort row cuts every term's bank to n at once, so it needs a *joint*
+    sample. Pairing draw r of one term with draw r of another by index would
+    make the pool ordering part of the answer: a term small enough to be
+    enumerated exhaustively always contributes its subsets in
+    `itertools.combinations` order, and a short pool cycled against a long one
+    meets the same positions every time. The marginals survive that. The range
+    of the pooled number does not, and the range is what these rows are for.
+    So each term is resampled independently here.
+    """
+    return [{term: rng.randrange(pool[term]) for term in members}
+            for _ in range(count)]
+
+
 def band(values):
     """median and range, the only honest summary of a set of draws.
 
@@ -1282,18 +1298,24 @@ def subsample_report(source_name, cache, robust, ns, draws, seed, floor,
         members = tuple(sorted(t for t in sizes if sizes[t] >= floor_n))
         if members:
             seen[members] = floor_n
+    # The same joint draws serve the AUC rows and the decision rows below, so
+    # the two tables describe the same cohort banks and not two samples of them.
+    joint = {}
+    for members, floor_n in seen.items():
+        for n in [x for x in ns if x <= floor_n] + ["all"]:
+            rng = random.Random(f"{seed}|cohort|{len(members)}|{n}")
+            pool = {t: len(vetoes[t][sizes[t] if n == "all" else n])
+                    for t in members}
+            joint[(members, n)] = joint_draws(members, pool, draws, rng)
+
     for members, floor_n in seen.items():
         print(f"\n  the {len(members)} terms with at least {floor_n} recordings: "
               f"{', '.join(members)}")
         print(f"  {'n':>4}  {'mean per-term AUC over the cohort':^25}")
         for n in [x for x in ns if x <= floor_n]:
-            # One draw index per term, averaged. A term with fewer draws than
-            # the widest cycles, so every draw of the small bank is used and
-            # none is used twice before all of them are used once.
-            width = max(len(curves[t][n]) for t in members)
             means = []
-            for r in range(width):
-                take = [curves[t][n][r % len(curves[t][n])] for t in members]
+            for draw in joint[(members, n)]:
+                take = [curves[t][n][draw[t]] for t in members]
                 take = [v for v in take if v == v]
                 if take:
                     means.append(sum(take) / len(take))
@@ -1308,12 +1330,10 @@ def subsample_report(source_name, cache, robust, ns, draws, seed, floor,
         print(f"  {'n':>4}  {'true rejections (B)':^26}  "
               f"{'false rejections (A)':^26}")
         for n in [x for x in ns if x <= floor_n] + ["all"]:
-            pick = (lambda t: vetoes[t][sizes[t]]) if n == "all" \
-                else (lambda t: vetoes[t][n])
-            width = max(len(pick(t)) for t in members)
+            size = (lambda t: sizes[t]) if n == "all" else (lambda t: n)
             sums = {"A": [], "B": [], "dA": [], "dB": []}
-            for r in range(width):
-                draw = [pick(t)[r % len(pick(t))] for t in members]
+            for pick in joint[(members, n)]:
+                draw = [vetoes[t][size(t)][pick[t]] for t in members]
                 for group in ("A", "B"):
                     sums[group].append(sum(g["veto"][group][0] for g in draw))
                     sums["d" + group].append(
@@ -1529,6 +1549,13 @@ def main():
         if args.floor < 2:
             print("✗ --floor must be at least 2: a bank of one recording has "
                   "no leave-one-out distance and so no spread", file=sys.stderr)
+            return 2
+        if args.draws < 1:
+            # Zero draws produces no subsets, and every summary below is a
+            # median over them. Say so here rather than raising from
+            # statistics.median() nine screens later.
+            print(f"✗ --draws must be at least 1, got {args.draws}",
+                  file=sys.stderr)
             return 2
         try:
             ns = sorted({int(x) for x in args.ns.split(",") if x.strip()})

--- a/scripts/reference-matching.py
+++ b/scripts/reference-matching.py
@@ -5,6 +5,17 @@
     scripts/reference-matching.py --table FILE     # the per-proposal distances
     scripts/reference-matching.py --source round6  # only round 6's recordings
     scripts/reference-matching.py --poison         # PR 6a, below
+    scripts/reference-matching.py --subsample      # PR 6e, below
+
+**PR 6e lives under `--subsample`.** It asks how many recordings a bank needs
+before it may decide. For each term it draws random subsets of that term's
+folder at n = 2, 3, 5, 8, 12 and re-scores the same spans against the smaller
+bank, many draws per n, and reports the median and the range. It reports the
+AUC and the rule's own veto counts side by side, because 6a found the AUC
+cannot see the threshold: `spread` is one number per term, so it divides out
+of any ranking inside that term. The veto counts are what an abstain rule is
+about. Subsampling measures how *this* bank degrades — not how a new term with
+n clips behaves, which nothing here can measure.
 
 **PR 6a lives at the bottom of this file, under `--poison`.** It asks a
 different question from the rest: not how well the distance separates, but how
@@ -81,8 +92,11 @@ from librosa: forty lines against a heavy dependency for a spike.
 """
 import argparse
 import hashlib
+import itertools
 import json
+import math
 import os
+import random
 import re
 import statistics
 import subprocess
@@ -893,13 +907,19 @@ def summarise(values, robust):
     return quantile(values, 0.9) if robust else max(values)
 
 
-def arm(bank, exemplars, spans, se, ee, term, robust, tolerance=1.0):
+def arm(bank, exemplars, spans, se, ee, term, robust, tolerance=1.0, floor=3):
     """One term, one bank of recordings: its AUC, its spread and its veto.
 
     `bank` is the list of exemplar indices that count as recordings of the
     term. The per-clip hold-out is applied inside, the same way
     `measure_scripted` and `ReferenceMatch.verdict` apply it: a span never
     scores against a recording cut from its own clip.
+
+    `floor` is the abstain rule: under this many usable recordings the bank
+    does not decide and the span is scored by nobody. `ReferenceMatch.verdict`
+    abstains under three, which is the default here. 6e sweeps it, so it is a
+    parameter and not a literal — a curve of what the rule does at n=2 cannot
+    be drawn by a rule that refuses to run at n=2.
     """
     out = {"term": term, "recordings": len(bank)}
     # The spread over the whole bank, with nothing held out. This is the number
@@ -909,6 +929,10 @@ def arm(bank, exemplars, spans, se, ee, term, robust, tolerance=1.0):
 
     rows = {"scripted": {"A": [], "B": []}, "proposals": {"A": [], "B": []}}
     veto = {"A": [0, 0], "B": [0, 0]}
+    # Most spans hold nothing out, so most of them share one `usable` set and
+    # one width. 6e calls this function tens of thousands of times; recomputing
+    # an O(n²) leave-one-out per span is the whole cost. Same numbers, memoised.
+    widths = {}
     for k, s in enumerate(spans):
         if s["set"] == "scripted":
             group = "A" if s["stem"] == term else "B"
@@ -921,10 +945,13 @@ def arm(bank, exemplars, spans, se, ee, term, robust, tolerance=1.0):
             continue
         distance = min(se[k][i] for i in usable)
         rows[s["set"]][group].append(distance)
-        if len(usable) < 3:
-            continue                       # ReferenceMatch abstains under three
-        held = [min(ee[i][j] for j in usable if j != i) for i in usable]
-        width = summarise(held, robust)
+        if len(usable) < floor:
+            continue                       # the bank abstains: too few clips
+        key = tuple(usable)
+        if key not in widths:
+            held = [min(ee[i][j] for j in usable if j != i) for i in usable]
+            widths[key] = summarise(held, robust)
+        width = widths[key]
         if not (width > 0):
             continue
         veto[group][1] += 1
@@ -1116,6 +1143,340 @@ def poison_pronunciation(exemplars, spans, se, ee, robust, split):
               f"{got['veto']['A'][0]}/{got['veto']['A'][1]}")
 
 
+# --------------------------------------------------- the subsample arm, PR 6e
+
+def subsets(count, size, draws, rng):
+    """`draws` distinct subsets of `size` indices out of `count`.
+
+    Exhaustive when there are few enough. `Claude` has six recordings, so at
+    n=5 there are six possible banks in total; drawing 200 of them would
+    report the same six subsets with invented weights. Above the cut it
+    samples without replacement, so no bank is counted twice.
+    """
+    total = math.comb(count, size)
+    if total <= draws:
+        return [list(pick) for pick in itertools.combinations(range(count), size)]
+    seen, out = set(), []
+    while len(out) < draws:
+        pick = tuple(sorted(rng.sample(range(count), size)))
+        if pick in seen:
+            continue
+        seen.add(pick)
+        out.append(list(pick))
+    return out
+
+
+def band(values):
+    """median and range, the only honest summary of a set of draws.
+
+    §2's rule about single runs applies to sampling too. Which two clips you
+    happen to pick decides the answer at n=2, so one draw is worth nothing.
+    """
+    got = [v for v in values if v == v]
+    if not got:
+        return float("nan"), float("nan"), float("nan")
+    return statistics.median(got), min(got), max(got)
+
+
+def inner(values):
+    """The 10th and 90th percentile of the draws, beside the outer range.
+
+    A min-max range over 200 draws is set by two draws. It says how bad it can
+    get, which is the question here, but it says nothing about how often. The
+    inner band says that.
+    """
+    got = [v for v in values if v == v]
+    if not got:
+        return float("nan"), float("nan")
+    return quantile(got, 0.1), quantile(got, 0.9)
+
+
+def share(values, test):
+    """What fraction of the draws satisfy `test`, as a percentage."""
+    got = [v for v in values if v == v]
+    if not got:
+        return float("nan")
+    return sum(1 for v in got if test(v)) / len(got) * 100
+
+
+def subsample_report(source_name, cache, robust, ns, draws, seed, floor,
+                     tolerance, csv=None):
+    """6e: per-term AUC and per-term veto against the number of recordings.
+
+    For each term, take random subsets of its bank at each n, and score the
+    same spans against the smaller bank. The per-clip hold-out runs inside
+    `arm` exactly as before, so a subsampled bank can still lose a recording
+    to the span it is judging.
+
+    Two numbers per point, because 6a found they disagree. The AUC ranks spans
+    inside one term, and `spread` is a constant inside one term, so the AUC
+    cannot see the threshold at all. The veto counts are the rule's own
+    decision, and they are what an abstain rule is for.
+    """
+    exemplars, spans = poison_rows(source_name)
+    se, ee = poison_matrices(exemplars, spans, cache)
+    by_term = banks(exemplars)
+    where = "the 90th percentile" if robust else "the maximum"
+
+    print(f"\n=== 6e: the abstain curve ===  spread is {where} of the")
+    print("  leave-one-out distances. `veto B` is spans the rule drops where the")
+    print("  term was NOT said — true rejections, the rule working. `veto A` is")
+    print("  the same rule dropping a span where the term WAS said — false")
+    print(f"  rejections, the rule costing. Tolerance {tolerance}, abstain under")
+    print(f"  {floor} usable recordings, seed {seed}, up to {draws} draws per point.")
+    print(f"  {len(exemplars)} recordings, {len(spans)} spans, source {source_name}.")
+    print("\n  Every cell is a median over the draws with a band, never one draw.")
+    print("  AUC carries its full range. The veto rates carry the inner 10–90")
+    print("  band, because a min-max over 200 draws is set by two of them.")
+    print(f"  `dis` is how often a draw leaves the rule disarmed — under "
+          f"{DISARMED:.0f}% of the")
+    print("  true rejections it should make. `cost` is how often a draw throws")
+    print(f"  away more than {OVERCOST:.0f}% of the spans where the term really "
+          "was said.")
+
+    curves = defaultdict(dict)               # term -> n -> list of AUCs
+    vetoes = defaultdict(dict)               # term -> n -> list of arm results
+    full_bank = {}
+    sizes = {}
+    for term in sorted(by_term):
+        bank = by_term[term]
+        sizes[term] = len(bank)
+        full = arm(bank, exemplars, spans, se, ee, term, robust,
+                   tolerance=tolerance, floor=floor)
+        # `Praisy` and `Vercel` have no scripted recording and so no A row on
+        # the scripted set. The proposal set is the only place they rank at all.
+        which = "scripted" if full["n_scripted"][0] else "proposals"
+        full_bank[term] = (full, which)
+        print(f"\n  {term}  —  {len(bank)} recordings, AUC on the {which} set, "
+              f"{full['n_' + which][0]} A / {full['n_' + which][1]} B at full bank")
+        print(f"  {'n':>4} {'draws':>6}  {'AUC med [min-max]':^25}  "
+              f"{'veto B %':^22} {'dis':>4}  {'veto A %':^22} {'cost':>4}  "
+              f"{'spread':^9}")
+        # The whole bank is the row 6a reports, and it is the reference every
+        # subsample is read against. Adding it twice when it is already in `ns`
+        # would print the same single draw as if it were two measurements.
+        for n in sorted({x for x in ns if x <= len(bank)} | {len(bank)}):
+            rng = random.Random(f"{seed}|{term}|{n}")
+            picks = subsets(len(bank), n, draws, rng)
+            got = [arm([bank[i] for i in pick], exemplars, spans, se, ee, term,
+                       robust, tolerance=tolerance, floor=floor)
+                   for pick in picks]
+            aucs = [g[f"auc_{which}"] for g in got]
+            curves[term][n] = aucs
+            vetoes[term][n] = got
+            label = f"{n}" + ("*" if n == len(bank) else "")
+            print(f"  {label:>4} {len(picks):>6}  "
+                  f"{fmt_band(band(aucs), '.3f'):<25}  "
+                  f"{fmt_veto(got, 'B')}  {fmt_veto(got, 'A')}  "
+                  f"{fmt_one(band([g['spread'] for g in got])[0], '.3f'):>9}")
+        print("  * the whole bank: one draw, and the row 6a's tables report")
+
+    print("\n=== the cohorts ===  a mean over a changing set of terms is not a")
+    print("  curve. These are fixed sets: every term in a cohort reaches every n")
+    print("  in its row, so the columns compare.")
+    # One block per distinct set of terms, not one per n. Every n between 2 and
+    # 5 keeps the same eleven terms, so they are one cohort with four rows and
+    # not four cohorts. The block is labelled by the largest n they all reach.
+    seen = {}
+    for floor_n in ns:
+        members = tuple(sorted(t for t in sizes if sizes[t] >= floor_n))
+        if members:
+            seen[members] = floor_n
+    for members, floor_n in seen.items():
+        print(f"\n  the {len(members)} terms with at least {floor_n} recordings: "
+              f"{', '.join(members)}")
+        print(f"  {'n':>4}  {'mean per-term AUC over the cohort':^25}")
+        for n in [x for x in ns if x <= floor_n]:
+            # One draw index per term, averaged. A term with fewer draws than
+            # the widest cycles, so every draw of the small bank is used and
+            # none is used twice before all of them are used once.
+            width = max(len(curves[t][n]) for t in members)
+            means = []
+            for r in range(width):
+                take = [curves[t][n][r % len(curves[t][n])] for t in members]
+                take = [v for v in take if v == v]
+                if take:
+                    means.append(sum(take) / len(take))
+            print(f"  {n:>4}  {fmt_band(band(means), '.3f')}")
+
+    print("\n=== the same cohorts, as the rule's own decision ===  6a's table,")
+    print("  one row per n. A whole cohort's banks are cut to n at once and the")
+    print("  rejections are summed, so this is directly comparable to 6a's")
+    print("  '554 true rejections' — and to the blind control under it.")
+    for members, floor_n in seen.items():
+        print(f"\n  the {len(members)} terms with at least {floor_n} recordings")
+        print(f"  {'n':>4}  {'true rejections (B)':^26}  "
+              f"{'false rejections (A)':^26}")
+        for n in [x for x in ns if x <= floor_n] + ["all"]:
+            pick = (lambda t: vetoes[t][sizes[t]]) if n == "all" \
+                else (lambda t: vetoes[t][n])
+            width = max(len(pick(t)) for t in members)
+            sums = {"A": [], "B": [], "dA": [], "dB": []}
+            for r in range(width):
+                draw = [pick(t)[r % len(pick(t))] for t in members]
+                for group in ("A", "B"):
+                    sums[group].append(sum(g["veto"][group][0] for g in draw))
+                    sums["d" + group].append(
+                        sum(g["veto"][group][1] for g in draw))
+            print(f"  {str(n):>4}  "
+                  f"{fmt_total(sums['B'], sums['dB']):^26}  "
+                  f"{fmt_total(sums['A'], sums['dA']):^26}")
+        print("  'all' is every term at its whole bank — the 6a row, one draw.")
+        print("  The denominator is the blind control: reject every span.")
+
+    print("\n=== the smallest n a term is safe at ===  safe means the rule is")
+    print(f"  disarmed in at most {SAFE_DIS:.0f}% of draws and throws away over "
+          f"{OVERCOST:.0f}% of")
+    print(f"  the true spans in at most {SAFE_COST:.0f}% of them, at this n and "
+          "every larger n")
+    print("  measured. Those two shares are a convention; the per-draw rates are")
+    print("  in the tables above and can be read against another one.")
+    print(f"\n  {'term':<10} {'rec':>4} {'safe n':>7}  {'full-bank AUC':>13}  "
+          f"{'full-bank spread':>17}")
+    safe = {}
+    for term in sorted(sizes):
+        got = [n for n in sorted(curves[term]) if n <= max(ns)]
+        answer = None
+        for i, n in enumerate(got):
+            if all(is_safe(vetoes[term][m]) for m in got[i:]):
+                answer = n
+                break
+        safe[term] = answer
+        full, which = full_bank[term]
+        print(f"  {term:<10} {sizes[term]:>4} "
+              f"{(str(answer) if answer else '> ' + str(max(got))):>7}  "
+              f"{fmt_one(full[f'auc_{which}'], '.3f'):>13}  "
+              f"{full['spread']:>17.3f}")
+    ranked = [t for t in sorted(sizes) if safe[t]]
+    if len(ranked) > 2:
+        counts = Counter(safe[t] for t in ranked)
+        print("\n  safe n takes "
+              f"{', '.join(f'{v} term(s) at {k}' for k, v in sorted(counts.items()))}")
+        print("  what predicts it, over the terms that reach a safe n:")
+        print(f"    Spearman(safe n, recordings)        "
+              f"{spearman([safe[t] for t in ranked], [sizes[t] for t in ranked]):+.2f}")
+        print(f"    Spearman(safe n, full-bank spread)  "
+              f"{spearman([safe[t] for t in ranked], [full_bank[t][0]['spread'] for t in ranked]):+.2f}")
+        print("  Read those two numbers as nothing. Safe n is nearly a constant")
+        print("  here, so almost every pair is a tie and the rank correlation is")
+        print("  carried by the one or two terms that differ. There is no")
+        print("  per-term threshold to predict, which is the result.")
+
+    if csv:
+        # The printed tables are for reading. This is for building the result
+        # block out of, so no number in it is transcribed by hand.
+        lines = ["statistic,term,recordings,n,draws,auc_set,auc_median,auc_min,"
+                 "auc_max,veto_b_median,veto_b_min,veto_b_max,veto_b_scored,"
+                 "veto_b_rate,veto_b_disarmed,veto_a_median,veto_a_min,"
+                 "veto_a_max,veto_a_scored,veto_a_rate,veto_a_overcost,spread"]
+        for term in sorted(sizes):
+            for n in sorted(curves[term]):
+                got = vetoes[term][n]
+                row = [where.split()[-1], term, sizes[term], n, len(got),
+                       full_bank[term][1]]
+                row += [f"{v:.4f}" for v in band(curves[term][n])]
+                for group, test in (("B", lambda r: r < DISARMED),
+                                    ("A", lambda r: r > OVERCOST)):
+                    counts = band([g["veto"][group][0] for g in got])
+                    scored = [g["veto"][group][1] for g in got]
+                    rates = [g["veto"][group][0] / g["veto"][group][1] * 100
+                             for g in got if g["veto"][group][1]]
+                    row += [f"{v:.0f}" for v in counts]
+                    row += [f"{statistics.median(scored):.0f}",
+                            f"{statistics.median(rates):.1f}" if rates else "",
+                            f"{share(rates, test):.1f}" if rates else ""]
+                row.append(f"{band([g['spread'] for g in got])[0]:.4f}")
+                lines.append(",".join(str(v) for v in row))
+        Path(csv).write_text("\n".join(lines) + "\n")
+        print(f"\n  wrote {csv}")
+
+
+# `safe` in the last table: the rule is disarmed in at most SAFE_DIS% of draws
+# and over-rejects in at most SAFE_COST% of them.
+SAFE_DIS = 10.0
+SAFE_COST = 5.0
+
+
+def is_safe(got):
+    rates = lambda group: [g["veto"][group][0] / g["veto"][group][1] * 100
+                           for g in got if g["veto"][group][1]]
+    b, a = rates("B"), rates("A")
+    if not b or not a:
+        return False
+    return (share(b, lambda r: r < DISARMED) <= SAFE_DIS
+            and share(a, lambda r: r > OVERCOST) <= SAFE_COST)
+
+
+def spearman(x, y):
+    """Rank correlation, ties averaged. Eleven points, so read the sign."""
+    def ranks(values):
+        order = sorted(range(len(values)), key=lambda i: values[i])
+        out = [0.0] * len(values)
+        i = 0
+        while i < len(order):
+            j = i
+            while j + 1 < len(order) and values[order[j + 1]] == values[order[i]]:
+                j += 1
+            for k in range(i, j + 1):
+                out[order[k]] = (i + j) / 2.0
+            i = j + 1
+        return out
+    rx, ry = ranks(x), ranks(y)
+    mx, my = sum(rx) / len(rx), sum(ry) / len(ry)
+    top = sum((a - mx) * (b - my) for a, b in zip(rx, ry))
+    left = sum((a - mx) ** 2 for a in rx) ** 0.5
+    right = sum((b - my) ** 2 for b in ry) ** 0.5
+    return top / (left * right) if left and right else float("nan")
+
+
+def fmt_total(counts, denominators):
+    got = band(counts)
+    return (f"{got[0]:.0f} [{got[1]:.0f}–{got[2]:.0f}] of "
+            f"{statistics.median(denominators):.0f}")
+
+
+# A draw is "disarmed" when the rule drops under this share of the spans it
+# should drop, and "costing" when it drops over this share of the spans where
+# the term really was said. Both are read off the rule's own decision, which is
+# the number 6a found an AUC cannot see. The thresholds are conventions, so the
+# per-draw rates are printed beside them and can be re-read against others.
+DISARMED = 25.0
+OVERCOST = 50.0
+
+
+def fmt_one(value, spec):
+    return format(value, spec) if value == value else "  -  "
+
+
+def fmt_band(triple, spec):
+    median, low, high = triple
+    if median != median:
+        return f"{'-':^25}"
+    return (f"{format(median, spec):>6} "
+            f"[{format(low, spec)}–{format(high, spec)}]")
+
+
+def fmt_veto(got, group):
+    """The rule's own decision at this n: how much it rejects, and how surely.
+
+    The denominator moves between draws, because the per-clip hold-out can take
+    a subsampled bank under the abstain floor and then that span is judged by
+    nobody. So the rate is computed inside each draw and summarised after,
+    never as one ratio of two medians.
+    """
+    scored = [g["veto"][group][1] for g in got]
+    if not any(scored):
+        return f"{'abstained':^22} {'-':>4}"
+    rates = [g["veto"][group][0] / g["veto"][group][1] * 100
+             for g in got if g["veto"][group][1]]
+    counts = band([g["veto"][group][0] for g in got])
+    low, high = inner(rates)
+    body = (f"{statistics.median(rates):>3.0f} [{low:.0f}-{high:.0f}] "
+            f"{counts[0]:.0f}/{statistics.median(scored):.0f}")
+    test = (lambda r: r < DISARMED) if group == "B" else (lambda r: r > OVERCOST)
+    return f"{body:^22} {share(rates, test):>3.0f}%"
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--table", metavar="FILE", help="write the per-proposal table")
@@ -1143,7 +1504,43 @@ def main():
     ap.add_argument("--pronunciation", action="store_true",
                     help="6a's second arm: fill a thin second pronunciation "
                          "cluster one clip at a time")
+    ap.add_argument("--subsample", action="store_true",
+                    help="6e: subsample each term's bank at several sizes and "
+                         "report AUC and veto against the number of recordings")
+    ap.add_argument("--ns", default="2,3,5,8,12",
+                    help="6e: the bank sizes to draw, comma separated")
+    ap.add_argument("--draws", type=int, default=200,
+                    help="6e: how many distinct subsets per point. Fewer are "
+                         "used when the bank has fewer subsets than that, and "
+                         "then every subset is measured")
+    ap.add_argument("--seed", default="6e-2026-08-10",
+                    help="6e: the sampling seed. Recorded in the output")
+    ap.add_argument("--floor", type=int, default=2,
+                    help="abstain under this many usable recordings. "
+                         "ReferenceMatch uses 3; 6e uses 2 so that n=2 has a "
+                         "decision to report at all. Two is the arithmetic "
+                         "minimum: one recording has no leave-one-out distance")
+    ap.add_argument("--tolerance", type=float, default=1.0,
+                    help="reject when distance > tolerance × spread")
+    ap.add_argument("--csv", default=None,
+                    help="6e: write every number in the tables to this file")
     args = ap.parse_args()
+    if args.subsample:
+        if args.floor < 2:
+            print("✗ --floor must be at least 2: a bank of one recording has "
+                  "no leave-one-out distance and so no spread", file=sys.stderr)
+            return 2
+        try:
+            ns = sorted({int(x) for x in args.ns.split(",") if x.strip()})
+        except ValueError:
+            print(f"✗ --ns wants integers, got {args.ns!r}", file=sys.stderr)
+            return 2
+        if not ns or ns[0] < 2:
+            print("✗ --ns wants sizes of 2 or more", file=sys.stderr)
+            return 2
+        subsample_report(args.source, args.cache, args.robust, ns, args.draws,
+                         args.seed, args.floor, args.tolerance, args.csv)
+        return 0
     if args.poison or args.pronunciation:
         got = poison_report(args.source, args.cache, args.robust, args.inject)
         if got is None:


### PR DESCRIPTION
## Summary
The clip bank's abstain threshold — don't trust a term with too few recordings — was a guess of 3, chosen because that's when a spread becomes computable, not when it becomes useful.
This PR subsamples each term's bank at increasing sizes and measures the veto's actual false-rejection rate against clip count, instead of relying on AUC, which the veto's own decision rule can't see (per #82).
The real abstain point is 5, not 3: at n=3 four terms still throw away over half their true spans one draw in ten, and two terms are still climbing at n=12, so 5 is a lower bound, not a settled estimate.

## Issue
Part of #74. PR 6e of the plan (#83).

## What it does

`scripts/reference-matching.py` gets a `--subsample` arm on top of #82's `--poison`. For each term, it draws random subsets of that term's bank at n = 2, 3, 4, 5, 6, 8, 12 (up to 200 draws per point) and re-scores the same spans against the smaller bank, reporting both AUC and the veto's actual counts.

## The answer: 5

| n | worst term: draws that throw away over half its true spans |
|---|---|
| 2 | 18% to 40%, all eleven terms |
| 3 | 4% to 15% |
| 4 | 0% to 9% |
| 5 | 0% to 3.5% |
| 8 | 0% to 0.5% |

One `Claude` is the exception, clean only at n=6 (its whole bank), so this PR can't say whether 6 is `Claude`'s real answer or just the end of its data.

## The AUC and the decision disagree, and the decision wins

At n=3, AUC medians already sit at the full-bank value for four terms — but the veto's actual counts say those same banks fail one draw in ten. This is #82's finding again: a term's spread is one number, so it divides out of any ranking inside that term. The AUC tables for the maximum and the 90th-percentile statistics are identical to every digit; AUC cannot see the difference between them at all.

## The falsifier partly fired

The plan said this would be falsified if the curves didn't flatten, or if per-term curves disagreed too much for one number to describe them. The first clause fires: `Praisy` and `Vercel` are still climbing at n=12, so the conclusion (one number, 5) is only a lower bound, not a settled answer.

## In-sample twice over

Subsampling a bank measures how that specific bank degrades, not how a brand-new term with n clips would behave — three clips drawn from a term with 26 recordings already known to separate well is not the same as a new term's first three corrections from three unrelated sentences. So **5 is a lower bound on the abstain point, not an estimate of it.**

<details>
<summary><b>How to Test</b></summary>

Both baselines reproduce exactly before anything else runs (round 7's table and #82's full `--poison` output). No app, no build, no model, no Ollama — deterministic given a fixed seed. Nothing under the live config or voice store was written; the arms run on a copy. `scripts/check-no-voice.sh` passes 5/5. `--csv` writes every number in the result tables, so none is transcribed by hand.

</details>
