### PR TITLE
fix: a possessive survives the substitution that spells the name

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -132,6 +132,13 @@ jobs:
       - name: The eval harness
         run: scripts/check-eval.sh
 
+      # Whether a possessive survives a substitution. Pure string work, no audio
+      # and no model, so it runs here. The direction that matters is a `'s`
+      # written where the speaker said none: these substitutions auto-apply and
+      # there is no menu behind them.
+      - name: A possessive across a substitution
+        run: scripts/check-possessive.sh
+
       # Not a validation set: it checks that the file a new install is written
       # with still teaches everything config.example.yaml documents. That has
       # drifted twice, both times silently.

--- a/Sources/ParrotFlow/InflectedCommand.swift
+++ b/Sources/ParrotFlow/InflectedCommand.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// What the vocabulary pass would write where a decoded word stood.
+///
+///     ParrotFlow --inflected Matthieu "Mathieu's"     # -> Matthieu's
+///
+/// `Vocabulary.inflected` is a pure function with no model, no audio and no
+/// config behind it, and it decides whether a possessive survives a
+/// substitution. It had no set until it was found dropping one. This is the
+/// entry point `scripts/check-possessive.sh` scores, so the set runs against
+/// the shipped function rather than against a copy of it — the compromise
+/// `scripts/real-words.swift` had to make and this does not.
+enum InflectedCommand {
+    static func run(term: String, heard: String) -> Int32 {
+        print(Vocabulary.inflected(term, like: heard))
+        return 0
+    }
+}

--- a/Sources/ParrotFlow/Vocabulary.swift
+++ b/Sources/ParrotFlow/Vocabulary.swift
@@ -450,18 +450,47 @@ actor Vocabulary {
     /// and never reaches a menu. The decoder had the grammar right; only the
     /// spelling of the name was in question, and the two are separable.
     ///
-    /// Only a trailing possessive is carried. A word that merely ends in the
-    /// same letters is not a name plus a suffix, so the match is on the term
-    /// followed by an apostrophe.
+    /// Only a trailing possessive is carried, and only where dropping it brings
+    /// the word closer to the term. This used to ask whether the stem was
+    /// spelled exactly like the term, which is the one case where nothing
+    /// needed carrying: a substitution runs *because* the decoder spelled the
+    /// name differently. `mathieu` is not `matthieu`, so the test failed and
+    /// the bare term came back. It carried the possessive only where the
+    /// possessive was never at risk.
+    ///
+    /// The reason that test was narrow still holds — a word that merely ends in
+    /// the same letters is not a name plus a suffix — so something still has to
+    /// refuse. `let's`, `it's` and `he's` all end in `'s` and none is a
+    /// possessive; writing `Praisy's` over one is worse than writing `Praisy`.
+    ///
+    /// A word list is not what separates them. Take the `'s` off a possessive
+    /// and what is left is the name the decoder was trying to spell, so the
+    /// match improves. Take it off a contraction and what is left is a short
+    /// function word that was never the name, so the match gets worse — the
+    /// length penalty in `gluedSimilarity` does that. So the test is a
+    /// comparison, not a threshold: it needs no floor and no list, and it
+    /// cannot fire on a token the rescorer did not already match.
+    ///
+    /// Measured on the 5672 archive tokens ending in `'s` (2026-08-10). 4660
+    /// are contractions, in 14 spellings, and every one is refused — the
+    /// closest is "Here" at 0.41 against `Vercel`. All 32 substitutions the
+    /// pass really made over such a token are name possessives. The old test
+    /// carried 11 of them, all `Mirza's` over `Mirza`; this carries 31.
+    ///
+    /// One shape can still fool it: a term shorter than a contraction's stem,
+    /// where dropping a character helps the length ratio instead of hurting it.
+    /// That needs a two-letter term, and there is none.
     static func inflected(_ term: String, like heard: String) -> String {
         let trimmed = heard.trimmingCharacters(in: CharacterSet.alphanumerics.inverted
             .subtracting(CharacterSet(charactersIn: "'\u{2019}s")))
         let lower = trimmed.lowercased()
-        for suffix in ["'s", "\u{2019}s"] where lower.hasSuffix(suffix) {
-            let stem = String(lower.dropLast(suffix.count))
-            if stem == term.lowercased() { return term + suffix }
-        }
-        return term
+        guard let suffix = ["'s", "\u{2019}s"].first(where: { lower.hasSuffix($0) })
+        else { return term }
+        let stem = String(lower.dropLast(suffix.count))
+        guard !stem.isEmpty,
+              gluedSimilarity(stem, term) >= gluedSimilarity(lower, term)
+        else { return term }
+        return term + suffix
     }
 
     /// The punctuation a replaced word carried, so the sentence keeps its end.

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -168,6 +168,14 @@ if let index = arguments.firstIndex(of: "--normalize") {
     exit(NormalizeCommand.run(text: text))
 }
 
+if let index = arguments.firstIndex(of: "--inflected") {
+    guard arguments.indices.contains(index + 2) else {
+        print("usage: ParrotFlow --inflected <term> <heard>")
+        exit(2)
+    }
+    exit(InflectedCommand.run(term: arguments[index + 1], heard: arguments[index + 2]))
+}
+
 if let index = arguments.firstIndex(of: "--command") {
     guard arguments.indices.contains(index + 1) else {
         print("usage: ParrotFlow --command \"hey parrot, Tasmin spells T A S M E E N\""

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -78,7 +78,14 @@ $PF --replace "we deployed to super base" [--app <name>]
 $PF --numbers "two hundred forty three" [--lang fr]
 $PF --normalize "<text>"
 $PF --dates "<instruction>" "<text>" [--locale FR] [--lang en,fr]
+$PF --inflected <term> <heard>
 ```
+
+`--inflected` asks what the vocabulary pass would write where a decoded word
+stood — `--inflected Matthieu "Mathieu's"` prints `Matthieu's`. It is
+`Vocabulary.inflected` and nothing else: no audio, no model, no config. The
+question it answers is whether a possessive survives a substitution, and
+`scripts/check-possessive.sh` scores it against `tests/possessive-cases.yaml`.
 
 `--pipeline` takes a YAML file holding a pipeline — its own, not your config —
 so a case file states the setup it assumes instead of inheriting this machine's.
@@ -312,6 +319,7 @@ scripts/check-compose.sh           # what a prompt says once the scope is in it
 scripts/check-context.sh           # what the context stage publishes for a screen
 scripts/check-span.sh              # a composer-shaped page, or Slack, or Outlook
 scripts/check-vocabulary-config.sh # what vocabulary.yaml adds up to, old keys included
+scripts/check-possessive.sh        # whether a possessive survives a substitution
 scripts/check-no-voice.sh          # nothing in git is one person's voice
 
 PF_VIEWPORT=Ghostty scripts/check-inplace.sh   # the same set, in another terminal

--- a/scripts/check-possessive.sh
+++ b/scripts/check-possessive.sh
@@ -61,6 +61,14 @@ for case in yaml.safe_load(open(sys.argv[1]))["cases"]:
 ' "$ROOT/tests/possessive-cases.yaml")
 
 echo
+# A set that read no cases is not a passing run. Nothing above fails when the
+# case file is missing or will not parse: the loop simply never runs, and
+# `0 = 0` reports green. That is the one failure this script must not have.
+if [ "$total" -eq 0 ]; then
+  echo "  ✗ no cases read from tests/possessive-cases.yaml"
+  exit 1
+fi
+
 printf '  %d/%d  (tests/possessive-cases.yaml)\n' "$pass" "$total"
 [ "$invented" -gt 0 ] && printf '    %d invented a suffix  ← the expensive direction\n' "$invented"
 [ "$dropped"  -gt 0 ] && printf '    %d dropped a suffix\n' "$dropped"

--- a/scripts/check-possessive.sh
+++ b/scripts/check-possessive.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Scores `Vocabulary.inflected` against tests/possessive-cases.yaml.
+#
+#   scripts/check-possessive.sh
+#
+# The question is whether a possessive survives a substitution. The pass
+# replaces a whole decoded token, so "Mathieu's" becomes "Matthieu" and the
+# grammar is lost — silently, because that substitution auto-applies and never
+# reaches a menu.
+#
+# Failures are split, because they are not equally expensive. A dropped `'s`
+# costs one word in one sentence. An invented `'s` is a word nobody said, on a
+# path with no menu behind it, so it is the direction worth watching.
+#
+# Runs against a scratch PARROTFLOW_CONFIG_DIR, so it says nothing about the
+# config on the machine and scores the same anywhere. `--inflected` reads no
+# config, but the binary creates one on any path that loads it.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/release/ParrotFlow"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+
+CONFIG="$(mktemp -d -t parrotflow-possessive)"
+trap 'rm -rf "$CONFIG"' EXIT
+export PARROTFLOW_CONFIG_DIR="$CONFIG"
+
+pass=0; total=0; dropped=0; invented=0; wrong=0
+
+while IFS=$'\t' read -r name term heard expect miss; do
+  [ -z "$name" ] && continue
+  total=$((total + 1))
+  got="$("$BIN" --inflected "$term" "$heard" 2>/dev/null)"
+
+  if [ "$got" = "$expect" ]; then
+    pass=$((pass + 1))
+    printf '  ✓ %-40s %s\n' "$name" "$got"
+    continue
+  fi
+
+  # A known miss that now carries is good news and still a failure: the case
+  # file is the record of what this function does, and it has stopped being it.
+  if [ -n "$miss" ] && [ "$got" = "$miss" ]; then
+    printf '  ! %-40s now carries: %s — move it out of known-miss\n' "$name" "$got"
+    wrong=$((wrong + 1))
+    continue
+  fi
+
+  case "$got" in
+    "$expect"*) invented=$((invented + 1)); why="invented a suffix  ← nobody said this";;
+    *)          if [ "${#got}" -lt "${#expect}" ]
+                then dropped=$((dropped + 1)); why="dropped the suffix"
+                else wrong=$((wrong + 1)); why="neither"
+                fi;;
+  esac
+  printf '  ✗ %-40s got %s, want %s  (%s)\n' "$name" "$got" "$expect" "$why"
+done < <(python3 -c '
+import sys, yaml
+for case in yaml.safe_load(open(sys.argv[1]))["cases"]:
+    print("\t".join([case["name"], case["term"], case["heard"],
+                     case["expect"], case.get("known-miss", "")]))
+' "$ROOT/tests/possessive-cases.yaml")
+
+echo
+printf '  %d/%d  (tests/possessive-cases.yaml)\n' "$pass" "$total"
+[ "$invented" -gt 0 ] && printf '    %d invented a suffix  ← the expensive direction\n' "$invented"
+[ "$dropped"  -gt 0 ] && printf '    %d dropped a suffix\n' "$dropped"
+[ "$wrong"    -gt 0 ] && printf '    %d neither\n' "$wrong"
+[ "$pass" = "$total" ]

--- a/tests/possessive-cases.yaml
+++ b/tests/possessive-cases.yaml
@@ -1,0 +1,246 @@
+# Does a possessive survive a substitution? Cases for scripts/check-possessive.sh.
+#
+# The vocabulary pass replaces a whole decoded token, so "Mathieu's" is replaced
+# by "Matthieu" and the `'s` is gone. `Vocabulary.inflected` exists to stop that.
+# It had no set until it was found dropping one.
+#
+#   term    the vocabulary term being written in
+#   heard   the token the rescorer matched, exactly as the decoder wrote it
+#   expect  what should be written where that token stood
+#
+# Two failure directions, and they do not cost the same. A dropped `'s` costs
+# one word of grammar in one sentence. A `'s` written where the speaker said
+# none is a word nobody said, and the pass has no menu behind it — these
+# substitutions auto-apply. So a case that must not carry is worth more than a
+# case that must.
+#
+# The numbers below come from `~/Recordings/ParrotFlow Dev/trace.jsonl` on
+# 2026-08-10, over 13961 traced clips: 5672 decoded tokens end in `'s`, 4660 of
+# them are contractions, and the pass really substituted over 32. All 32 are
+# name possessives. The old code carried 11 of them; this carries 31.
+cases:
+  # ── The live bug. PR 2 arm A, 2026-08-09 ────────────────────────────────
+  # "Matthieu's work" came out `Matthieu work.` The old test asked whether the
+  # decoded stem was spelled like the term. A substitution only runs because it
+  # is not, so the test failed on every case it was written for.
+  - name: the live case
+    term: Matthieu
+    heard: Mathieu's
+    expect: Matthieu's
+
+  # The only shape the old test handled: the decoder spelled the name right and
+  # nothing needed carrying. It must still work.
+  - name: the stem is already the term
+    term: Matthieu
+    heard: Matthieu's
+    expect: Matthieu's
+
+  # ── Every rendering the archive shows the pass substituting over ────────
+  - name: a second rendering of the same name
+    term: Matthieu
+    heard: Matthew's
+    expect: Matthieu's
+
+  - name: an exact stem, from the comment that started this
+    term: Mirza
+    heard: Mirza's
+    expect: Mirza's
+
+  - name: one letter out
+    term: Mirza
+    heard: Myrza's
+    expect: Mirza's
+
+  # The whole token is 0.48 from `Mirza` and the stem is 0.61. An absolute floor
+  # of 0.50 on the stem would keep this one; a floor on the token would refuse
+  # it, and the pass substituted it anyway. That is why the test compares the
+  # two rather than testing either against a number.
+  - name: two letters out
+    term: Mirza
+    heard: Mirzen's
+    expect: Mirza's
+
+  - name: a term that is an ordinary word
+    term: Praisy
+    heard: praise's
+    expect: Praisy's
+
+  - name: the same, capitalised
+    term: Praisy
+    heard: Praise's
+    expect: Praisy's
+
+  - name: the most common rendering of that name
+    term: Praisy
+    heard: Pracy's
+    expect: Praisy's
+
+  - name: a doubled letter the decoder dropped
+    term: Ollama
+    heard: Olama's
+    expect: Ollama's
+
+  - name: the term spelled right
+    term: Claude
+    heard: Claude's
+    expect: Claude's
+
+  # ── Contractions. None is a possessive, and the pass must not invent one ──
+  # This is the direction the old narrow test was defending. PR 2 arm A sentence
+  # 7 has the pass writing `Praisy` over the word next to a `Let's`, so a term
+  # landing on a contraction is not hypothetical.
+  #
+  # What refuses them is not a word list. Take the `'s` off `Let's` and what is
+  # left is "Let", which is further from every term than "Lets" was — a
+  # contraction's stem is two to five letters and the length penalty in
+  # `gluedSimilarity` punishes it. All 14 contraction spellings in the archive
+  # behave this way; "Here" against `Vercel` is the closest at 0.41.
+  - name: let's, lower case
+    term: Praisy
+    heard: let's
+    expect: Praisy
+
+  - name: Let's, sentence initial
+    term: Praisy
+    heard: Let's
+    expect: Praisy
+
+  - name: he's
+    term: Matthieu
+    heard: he's
+    expect: Matthieu
+
+  - name: it's
+    term: Mirza
+    heard: it's
+    expect: Mirza
+
+  - name: that's
+    term: Praisy
+    heard: that's
+    expect: Praisy
+
+  - name: there's
+    term: Vercel
+    heard: there's
+    expect: Vercel
+
+  # The closest a contraction gets to any term in this vocabulary.
+  - name: Here's, the closest miss in the archive
+    term: Vercel
+    heard: Here's
+    expect: Vercel
+
+  # ── Both apostrophes ────────────────────────────────────────────────────
+  # The decoder writes U+2019 as often as U+0027, and the one that comes back
+  # has to be the one that was heard.
+  - name: a curly apostrophe carries
+    term: Matthieu
+    heard: Mathieu’s
+    expect: Matthieu’s
+
+  - name: a curly apostrophe on an exact stem
+    term: Mirza
+    heard: Mirza’s
+    expect: Mirza’s
+
+  - name: a curly contraction is still refused
+    term: Praisy
+    heard: Let’s
+    expect: Praisy
+
+  # ── A word that merely ends in s ────────────────────────────────────────
+  # No apostrophe, so no suffix. A plural is not a possessive, and this is the
+  # half of the old comment that is still right.
+  - name: a plural of the term
+    term: Mirza
+    heard: Mirzas
+    expect: Mirza
+
+  - name: an ordinary plural
+    term: Praisy
+    heard: praises
+    expect: Praisy
+
+  - name: the term with an s stuck on
+    term: Ollama
+    heard: Olamas
+    expect: Ollama
+
+  - name: no suffix at all
+    term: Matthieu
+    heard: Mathieu
+    expect: Matthieu
+
+  # ── French ──────────────────────────────────────────────────────────────
+  # French has no `'s` possessive, and the archive agrees: zero tokens ending in
+  # `'s` on any French-tagged clip, against 5672 in English. What French brings
+  # is the other apostrophe — an elision on the front of the word, `l'`, `d'`,
+  # `qu'`, `j'`, `n'`, `c'`. The archive has `qu'on`, `d'assurance`, `J'ai`,
+  # `c'est` and `n'est`. None ends in `'s`, so none may gain a suffix.
+  - name: l' before a term
+    term: Ollama
+    heard: l'Olama
+    expect: Ollama
+
+  - name: d' before a term
+    term: Ollama
+    heard: d'Olama
+    expect: Ollama
+
+  - name: qu', the most common French elision in the archive
+    term: Vercel
+    heard: qu'on
+    expect: Vercel
+
+  # A French plural in s, which is a plural and not a possessive.
+  - name: a French plural
+    term: Vercel
+    heard: versailles
+    expect: Vercel
+
+  # ── Punctuation and degenerate input ────────────────────────────────────
+  # The trailing mark is put back by `trailingMarks`, not here, so the suffix
+  # has to survive a token that carries one.
+  - name: a full stop after the possessive
+    term: Matthieu
+    heard: Mathieu's.
+    expect: Matthieu's
+
+  - name: a comma after the possessive
+    term: Mirza
+    heard: Mirza's,
+    expect: Mirza's
+
+  # Nothing in front of the apostrophe is not a name plus a suffix.
+  - name: a bare suffix
+    term: Praisy
+    heard: "'s"
+    expect: Praisy
+
+  - name: a bare s
+    term: Mirza
+    heard: s
+    expect: Mirza
+
+  # ── Known misses, kept because a set that hides them is worth less ──────
+  # Both are real archive renderings and both lose the possessive. In each the
+  # decoder's spelling is closer to the term *with* the trailing s than without
+  # it, so the comparison refuses to carry. Neither is a regression: today's
+  # code drops them too.
+  #
+  # `Mir's` is the one miss among the 32 substitutions the pass really made.
+  # `Prazi's` was never substituted — it is in the archive as a decoding and is
+  # close enough to `Praisy` to be reachable, so it is here as the shape rather
+  # than as a clip.
+  - name: Mir's, where the stem is three letters
+    term: Mirza
+    heard: Mir's
+    expect: Mirza
+    known-miss: Mirza's
+
+  - name: Prazi's, where the s helps the match
+    term: Praisy
+    heard: Prazi's
+    expect: Praisy
+    known-miss: Praisy's


### PR DESCRIPTION
## Summary
When the acoustic pass corrected a misheard name, it silently dropped a following possessive — "Matthieu's work" came out "Matthieu work" — because the guard meant to preserve the `'s` only fired when the decoder had already spelled the name correctly, which is exactly the case where no fix was needed.
This PR replaces the exact-spelling guard with a similarity comparison: keep the `'s` only when stripping it brings the word closer to the term than keeping it does.
A 35-case unit suite goes from 25/35 on `main` to 35/35 here, and an archive count over 13,961 traced clips shows the fix correctly carries 31 of 32 real name-possessive substitutions while every one of 5,672 decoded contractions (`let's`, `it's`, etc.) is correctly left untouched.

## Issue
Part of #74. Fix B from the plan (#80). Targets `main` directly, not the documentation stack.

## The bug

`Vocabulary.inflected` decided whether to carry a possessive by testing `stem == term.lowercased()`. But a substitution only runs *because* the decoder spelled the name differently from the term — `mathieu` is not `matthieu` — so the test failed on every case that actually needed the fix. Live repro on #79's dictation pass: "Matthieu's work" → "Matthieu work."

## Why the obvious fix is worse than the bug

Just carrying `'s` whenever the token ends in one would break contractions — `let's`, `it's`, `he's`, `that's` all end in `'s` and none is a possessive. The naive fix would turn "Let's Praisy Matthieu work" into "Let's Praisy's Matthieu work."

## What this does instead

Carry the suffix only when the stem (with `'s` stripped) is at least as close to the term as the whole token is, using the same similarity metric this file already uses to score spans. No floor, no word list, no per-language contraction list to maintain.

**The archive count that decides it** (13,961 traced clips, read-only): of 5,672 decoded tokens ending in `'s`, 4,660 are contractions and 1,012 are something else. Of the 755 tokens close enough to a term to reach the rescorer, **zero are contractions**. Of 32 real substitutions the pass made over such a token, all 32 are name possessives — the old code carried 11 of 32 correctly; this carries 31 of 32 (the one miss, "Mir's," is documented as a known edge case with a 3-letter stem).

## The ablation can't measure this fix, and the PR says so plainly

Over 1,305 traced replays in the 141-clip ablation, the acoustic pass fired 76 times and **not once on a token ending in `'s`** — the case set's possessive clips are all handled by `heard:` rules instead, not the acoustic pass. Ablation scores are unchanged (86 correct both before and after; the one apparent win/loss pair is replay noise on a clip today's code already gets wrong 9/9 either way). This is the falsifier not firing, not a confirmation — what actually sizes this fix is the unit suite and the archive count above.

<details>
<summary><b>How to Test</b></summary>

`scripts/check-possessive.sh`, 35 cases, new — the live bug, every archive-observed rendering, seven contractions, both apostrophe characters, non-possessive plurals, French elisions (which take no suffix at all), punctuation, and the two known misses. Added to CI. `origin/main` scores 25/35 on the same set, all 10 failures dropping a needed suffix, none inventing one.

One known limitation, documented in the function's comment: a term shorter than a contraction's stem could still fool the comparison — this needs a two-letter term, and none currently exists in the vocabulary.

</details>
