### PR TITLE
fix: the judge counts a term's rules together, not one at a time

### DIFF
--- a/Sources/ParrotFlow/VocabularyJudge.swift
+++ b/Sources/ParrotFlow/VocabularyJudge.swift
@@ -281,23 +281,37 @@ enum VocabularyJudge {
     ///
     /// `before` is the transcript `replacements` was handed, and it says which
     /// occurrence is which. A rule rewrites in place and reorders nothing, so
-    /// the terms standing in the text now are, in order, the occurrences of
-    /// `heard` and of `term` in `before` — and only the first kind is a
+    /// the terms standing in the text now are, in order, the occurrences of the
+    /// rule sources and of `term` in `before` — and only the first kind is a
     /// substitution to offer back. See `rewritten(_:_:in:became:)`.
     ///
-    /// When the two do not line up, some other rule wrote the term as well and
-    /// nothing here can say which occurrence came from where. Then none of them
-    /// are offered, and the log says so. That is the common case for two
-    /// renderings of one term in one sentence — `Versal` and `Versailles` both
-    /// becoming `Vercel` — because each pair is counted on its own and each
-    /// accounts for one of the two terms standing. A `before` does not decide
-    /// that shape; only reading the pairs per term would.
+    /// **The pairs are read per term, not one at a time.** Two rules can write
+    /// the same term in one sentence: `Versal -> Vercel; Versailles -> Vercel`
+    /// for "deployed on Vercel against the Versailles Castle". A pair counted on
+    /// its own accounts for one of the two `Vercel`s standing, so it fails its
+    /// count and takes its reading down with it, and the sentence gets no menu.
+    /// Counted together the two pairs account for both occurrences, and each one
+    /// is offered its own spelling back.
+    ///
+    /// When the counts still do not line up, something else wrote the term as
+    /// well — a pattern rule, or a rule whose target contains it — and nothing
+    /// here can say which occurrence came from where. Then none of them are
+    /// offered, and the log says so.
     ///
     /// A rule whose source is a pattern is skipped. `/(\w+) dot (\w+)/` names
     /// no spelling to offer back, and putting the pattern on a menu would ask
-    /// the model to choose a regular expression.
+    /// the model to choose a regular expression. It still wrote the term, so the
+    /// count above is what stops the literal rules beside it from claiming its
+    /// occurrence.
     static func ruleParts(_ changes: String, in text: String, before: String?) -> [Part] {
-        var parts: [Part] = []
+        // Grouped before anything is counted, because the count is per term and
+        // not per pair. First-seen order is kept so the parts still come out in
+        // the order the rules are reported in. The key is lowercased because
+        // `spans` finds the term that way — two pairs naming it in different
+        // case are one term here, as they are in the text.
+        var order: [String] = []
+        var sources: [String: [String]] = [:]
+        var spelled: [String: String] = [:]
         for pair in changes.split(separator: ";") {
             let pairText = pair.split(separator: "@").first.map(String.init) ?? String(pair)
             guard let arrow = pairText.range(of: "->") else { continue }
@@ -306,6 +320,17 @@ enum VocabularyJudge {
             guard !heard.isEmpty, !term.isEmpty, heard != term,
                   !heard.hasPrefix("/"), !term.contains("$")
             else { continue }
+            let key = term.lowercased()
+            if sources[key] == nil {
+                order.append(key)
+                spelled[key] = term
+            }
+            sources[key, default: []].append(heard)
+        }
+
+        var parts: [Part] = []
+        for key in order {
+            guard let term = spelled[key], let heard = sources[key] else { continue }
             let stands = Vocabulary.spans(of: term, in: text, ignoringCase: true)
             guard let before else {
                 // No earlier text to compare against. `replacements` publishes
@@ -317,28 +342,35 @@ enum VocabularyJudge {
                 // One occurrence is still decidable without it: the rule is in
                 // `changes`, so it fired at least once, and a pre-existing term
                 // would be a second occurrence. More than one and nothing here
-                // can say which, so none are offered.
+                // can say which, so none are offered. Grouping does not help
+                // here — with no earlier text there is nothing to line the
+                // occurrences up against.
                 if stands.count == 1 {
-                    parts.append(Part(
-                        range: stands[0], decoded: heard, other: heard, term: term,
-                        standing: .rule
-                    ))
+                    for source in heard {
+                        parts.append(Part(
+                            range: stands[0], decoded: source, other: source, term: term,
+                            standing: .rule
+                        ))
+                    }
                 } else if stands.count > 1 {
-                    Log.write("vocabulary judge: \"\(term)\" stands \(stands.count) time(s)"
-                        + " and no acoustic pass ran, so which one \"\(heard)\" became"
-                        + " cannot be told; that reading is not offered")
+                    for source in heard {
+                        Log.write("vocabulary judge: \"\(term)\" stands \(stands.count) time(s)"
+                            + " and no acoustic pass ran, so which one \"\(source)\" became"
+                            + " cannot be told; that reading is not offered")
+                    }
                 }
                 continue
             }
             guard let mine = rewritten(heard, term, in: before, became: stands.count) else {
                 Log.write("vocabulary judge: \"\(term)\" stands \(stands.count) time(s) and"
                     + " the transcript before the rules cannot account for that many;"
-                    + " \"\(heard)\" is not offered back")
+                    + " not offering \(heard.map { "\"\($0)\"" }.joined(separator: ", ")) back")
                 continue
             }
-            for index in mine {
+            for (index, source) in mine.enumerated() {
+                guard let source else { continue }
                 parts.append(Part(
-                    range: stands[index], decoded: heard, other: heard, term: term,
+                    range: stands[index], decoded: source, other: source, term: term,
                     standing: .rule
                 ))
             }
@@ -346,29 +378,46 @@ enum VocabularyJudge {
         return parts
     }
 
-    /// Which of the terms standing in the text now were written by this rule.
+    /// Which of the terms standing in the text now were written by a rule, and
+    /// by which one.
     ///
-    /// The rule turns every `heard` into `term` and leaves every `term` where
-    /// it was. It rewrites in place, so the order is preserved: the *i*-th term
-    /// in the text now is the *i*-th of those two kinds of occurrence in the
-    /// text before. The ones that were `heard` are the substitutions; the rest
+    /// Each rule turns its own source into `term` and leaves every `term` where
+    /// it was. Rules rewrite in place, so the order is preserved: the *i*-th
+    /// term in the text now is the *i*-th of those occurrences in the text
+    /// before. The ones that were a rule source are the substitutions; the rest
     /// were already right and must not be offered a reading the decoder never
     /// produced.
     ///
-    /// Nil when the counts disagree, which means something other than this rule
-    /// also wrote the term. Guessing there is how a correct word gets a wrong
-    /// spelling put first on the menu.
+    /// **Every rule that wrote this term is counted at once.** One at a time,
+    /// two rules writing one term each account for a single occurrence, both
+    /// fail the count, and the sentence gets no menu at all.
+    ///
+    /// Nil when the counts disagree, which means something other than these
+    /// rules also wrote the term. Guessing there is how a correct word gets a
+    /// wrong spelling put first on the menu.
+    ///
+    /// Nil as well when two of the marks overlap. Only one rule can have fired
+    /// on a given span, so a count that lines up across an overlap lined up by
+    /// accident, and matching the marks to the occurrences by position past that
+    /// point would hand a reading to a span it does not own.
+    ///
+    /// - Returns: one entry per term standing in the text now, in order — the
+    ///   rule source that wrote it, or nil where the decoder wrote it itself.
     static func rewritten(
-        _ heard: String, _ term: String, in before: String, became stands: Int
-    ) -> [Int]? {
-        var marks: [(at: String.Index, rule: Bool)] =
-            Vocabulary.spans(of: heard, in: before, ignoringCase: true)
-                .map { ($0.lowerBound, true) }
-            + Vocabulary.spans(of: term, in: before, ignoringCase: true)
-                .map { ($0.lowerBound, false) }
-        marks.sort { $0.at < $1.at }
+        _ heard: [String], _ term: String, in before: String, became stands: Int
+    ) -> [String?]? {
+        var marks: [(at: Range<String.Index>, rule: String?)] =
+            Vocabulary.spans(of: term, in: before, ignoringCase: true).map { ($0, nil) }
+        for source in heard {
+            marks += Vocabulary.spans(of: source, in: before, ignoringCase: true)
+                .map { ($0, source) }
+        }
+        marks.sort { $0.at.lowerBound < $1.at.lowerBound }
         guard marks.count == stands else { return nil }
-        return marks.indices.filter { marks[$0].rule }
+        guard !marks.indices.dropFirst().contains(where: {
+            marks[$0].at.lowerBound < marks[$0 - 1].at.upperBound
+        }) else { return nil }
+        return marks.map(\.rule)
     }
 
     // MARK: - Slots and readings

--- a/tests/pipeline-cases.yaml
+++ b/tests/pipeline-cases.yaml
@@ -540,13 +540,29 @@ cases:
       replacements.changes: ""
       vocabulary.slots: 0
 
-  # Two renderings of one term in one sentence, and the stage declines. Each
-  # pair in `changes` is counted on its own, so each accounts for one of the two
-  # terms standing and neither can claim its own. The earlier text does not
-  # settle this shape; only reading the pairs per term would. This is the live
-  # sentence from the 2026-08-09 dictation pass, and it is still not attributed.
-  - name: two rules writing one term in one sentence decline rather than guess
+  # Two renderings of one term in one sentence. The pairs are counted per term,
+  # so together they account for both `Vercel`s standing and each occurrence is
+  # offered its own spelling back. Counted one at a time each accounted for one
+  # of the two, each failed, and the sentence got no menu at all. This is the
+  # live sentence from the 2026-08-09 dictation pass.
+  #
+  # Two slots is the opportunity, not the answer. What the judge picks at them
+  # is a different question and this case says nothing about it.
+  - name: two rules writing one term in one sentence open a slot each
     pipeline: vocabulary-rules-two-renderings
+    input: deployed on Versal against the Versailles Castle
+    expect: deployed on Vercel against the Vercel Castle
+    expect_vars:
+      replacements.before: deployed on Versal against the Versailles Castle
+      vocabulary.slots: 2
+
+  # And the counts still have to add up. A pattern rule wrote the second
+  # `Vercel` and names no spelling to offer back, so the literal rule beside it
+  # is one occurrence short however the pairs are grouped. Declining is the
+  # point: the literal's own occurrence is still there to be claimed, and
+  # claiming it would put `Versal` on the menu at a place the pattern wrote.
+  - name: a term a pattern also wrote is still declined rather than guessed
+    pipeline: vocabulary-rules-pattern
     input: deployed on Versal against the Versailles Castle
     expect: deployed on Vercel against the Vercel Castle
     expect_vars:

--- a/tests/pipelines/vocabulary-rules-pattern.yaml
+++ b/tests/pipelines/vocabulary-rules-pattern.yaml
@@ -1,0 +1,13 @@
+# The same stage, with one literal rendering and one pattern beside it.
+#
+# A pattern names no spelling to offer back, so the judge skips its pair — but
+# the pattern still wrote a `Vercel`. The literal rule cannot account for that
+# occurrence, grouped or not, and the stage has to decline rather than hand the
+# literal's spelling to a place some other rule wrote. See the cases.
+languages: [en]
+replacements:
+  Vercel: [Versal, '/Versa\w+/']
+pipeline:
+  - replacements
+  - vocabulary: ../../examples/prompts/verify_names.md
+    max_readings: 1


### PR DESCRIPTION
## Summary
This is the second half of the bug #86 found: the vocabulary judge read `heard:` rules pair by pair, so when two different rules wrote the same term in one sentence, each pair failed its own occurrence count and the whole sentence was declined.
This PR groups the rules by term before counting, so the judge gets a slot for each occurrence a rule actually wrote.
Exactly 2 of 141 clips reach this path and both go from 0 slots to 2 — restoring the judge's opportunity to pick correctly — but both are still wrong afterward, because the judge itself keeps the same wrong term at both slots.

## Issue
Part of #74. Targets #86 (`fix/rule-parts-pre-rules-text`).

## The change

One file, `VocabularyJudge.swift`. `ruleParts` now groups rule pairs by term (case-insensitive) before counting, keeping first-seen order. `rewritten` takes a term's rule sources as a list and returns one entry per occurrence standing now — the source that wrote it, or nil where the decoder wrote it itself. It also declines when two rule matches overlap in the pre-rules text, since only one rule can have fired on a given span.

Nothing changes when one rule writes one term, and nothing changes when the counts still don't add up.

## What this does not do

**It does not make the sentence come out right.** Replayed under both builds, the transcript is identical — the judge is handed both readings and keeps the same wrong term at both places, the same failure #79 found live. This restores the judge's *opportunity* to be right, not its correctness. It still matters: the clip-bank-as-gate proposal (PR 13, #83) needs the slots to exist before it can veto one of them.

## Verification

**Unit**: `scripts/check-pipeline.sh`, 63/63. The case #86 added to pin the old (declining) behavior is updated, not duplicated, since the expectation flipped — renamed to describe the new behavior. One new fixture holds the shape that must still decline (a pattern rule with no spelling to offer back).

**Ablation** — two builds of the same tree (#86's head, and that plus this commit), one session, same clips, same config:

| build | arm | correct | wins vs `off` | losses | flips |
|---|---|---|---|---|---|
| before | `acoustic: false` | 104 | 28 | 0 | 0 |
| this PR | `acoustic: false` | **104** | 28 | 0 | 0 |

Head to head: 0 wins, 0 losses, 0 flips at the aggregate level — but that's not "the fix does nothing." Replaying every clip and comparing log lines shows **exactly 2 of 141 clips reach this code path, and both move from 0 slots to 2**. Re-measured at `--runs 9` on their own, both stay wrong 0-of-2 with 0 flips before and after — the menu is restored, but the judge spends it the same way each time. The controls can't be reached at all; this only fires where two rules write one term.

**Read the absolute numbers with care**: `acoustic: false` was measured at 102/103/104 across sessions on this same corpus — normal drift. The comparison that decides this PR is the within-session one described above.

<details>
<summary><b>How to Test</b></summary>

`scripts/check-pipeline.sh` for the unit cases. For the ablation: `scripts/vocab-ablation.py --runs 3` over the 141-clip set, two builds, `gemma4:e4b-mlx` as judge. `scripts/check-no-voice.sh` passes 5/5. `docs/proposals/vocabulary-v3.md` is not touched by this PR.

</details>
