### PR TITLE
test: review a term's clip bank by ear, in groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,11 @@ voice/
 # inside this repository. Untracked it turns every `git status` into a warning
 # about a directory that is already under version control by another route.
 .claude/worktrees/
+
+# Where scripts/clip-review.py records the groups the speaker marked
+# not-counted, and the distance matrix it caches. The marks are a decision
+# about one person's recordings; the cache is derived from the audio itself.
+# Neither is source. In production the marks live at `voice/excluded.json`
+# beside `observations.jsonl`, which `voice/` above already keeps out.
+clip-review-marks.json
+clip-review-cache.npz

--- a/docs/proposals/vocabulary-v3.md
+++ b/docs/proposals/vocabulary-v3.md
@@ -2235,7 +2235,10 @@ clusters, not one truth and one outlier. The bilingual verification criteria
 below are unchanged. What is dropped is ranking by distance from the pack, and
 deleting anything.
 
-**This section is a design. Nothing in it is measured.**
+**Built and measured, 2026-08-10.** The tool is
+[`scripts/clip-review.py`](../../scripts/clip-review.py) and the result block
+is below. Read the design first; the result says which parts of it survived.
+The falsifier fired on accuracy and did not fire on review burden.
 
 **Changes.** A review tool, not a pruner.
 
@@ -2295,6 +2298,311 @@ this to a false-flag rate. 6a supplies the answer instead — the statistic that
 would drive an automatic pruner deletes real recordings, and one of its two
 deletions made the bank worse. So the speaker confirms by ear, and the tool
 never removes a file.
+
+### Result, measured 2026-08-10
+
+**The falsifier fired. Flagging is at chance against 6a's poisoned clips, and
+the tool is still worth having.** Both halves are the result and neither
+cancels the other.
+
+The chance half: over 1220 injections the duration rule flags 22.8% of the
+labelled bad clips and 18.0% of the genuine ones, AUC **0.526**. On 6a's own two
+named clips, injected into the nine clean folders, it is 0.629 over 20
+injections. The section's strongest signal is not available at all — **122 of
+122 recordings carry `from: mined`**, so provenance ranks nothing today and the
+whole ranking rests on duration.
+
+The other half: the review itself is finishable and it is the only thing that
+can label a clip. **33 groups over 11 terms and 122 recordings, 86.4 seconds of
+audio in total.** 6c's second falsifier — "so many groups that nobody would
+finish it" — does not fire. `scripts/clip-review.py` is the tool.
+
+No app, no build, no model, no Ollama. 122 recordings, 7381 recording-to-
+recording distances, computed once in about thirty seconds and cached.
+Deterministic: no decoder, no replay, so every number here is exact for this
+data. **Nothing under `~/.config/parrotflow-dev/` was written.** The store's
+checksum is unchanged and the tool has no code path that writes to it; marks go
+to a separate file named by `--marks`.
+
+**The distances reproduce 6a exactly.** Every per-term spread printed by the
+new tool matches 6a's table to three decimals: `Supabase` 2.919, `Redrock`
+2.999, `Arexvy` 3.031, `Matthieu` 3.053, `Redcrawl` 3.098, `Vercel` 3.178,
+`Praisy` 3.235, `Mirza` 3.257, `Tasmeen` 3.268, `Ollama` 3.313, `Claude` 3.436.
+That is the check that the MFCC and DTW imported from
+`scripts/reference-matching.py` are the same ones.
+
+#### The provenance distribution, which bounds what this can do
+
+| `from` | recordings |
+|---|---|
+| `mined` | 122 |
+| `correction` | 0 |
+| `calibration` | 0 |
+| `legacy` | 0 |
+| absent | 0 |
+
+Every clip is mined, and every clip has a `span`. So the field exists, is
+populated, and carries exactly one value. **A signal that is constant ranks
+nothing**, and the tool says so in its own first screen rather than flagging all
+122. PR 4 is what writes `correction` on a clip the speaker confirmed. Until it
+lands, 6c has one signal and not two.
+
+#### The falsifier, in full
+
+Two arms. `--falsify` runs both.
+
+| arm | injections | flagged | flagged, genuine | AUC | median rank | alone in a group |
+|---|---|---|---|---|---|---|
+| cross-term | 1220 | 22.8% | 18.0% | **0.526** | 0.43 | 44.4% |
+| known bad | 20 | 15.0% | 17.7% | **0.629** | 0.36 | 50.0% |
+| chance | | | | 0.500 | 0.50 | 4.1% |
+
+`cross-term` puts every recording of another term into each bank; a recording
+of another word is a bad clip by construction. `known bad` is 6a's exact arm —
+`Vercel/09-brazil.wav` and `Tasmeen/06-that'smeanssend.wav` into the folders
+that do not already hold them. "Median rank" is where the injected clip lands in
+the review order, 0.00 first and 0.50 chance, with ties sharing their block.
+
+**Why duration is at chance here, and it is not because duration is useless.**
+Injecting a recording of another term makes a bad *word*. It does not make a
+bad *cut*: names in this archive run 0.48s to 0.88s at the median, so a foreign
+clip is usually an ordinary length. Both clips 6c names are bad words too.
+Duration catches a cut that swallowed a neighbouring word, and **there is no
+labelled example of one in the archive** — which is the thing the review exists
+to produce. The 22 clips it does flag, `Vercel/14-versal.wav` at 2.72s (×3.78 of
+the term's median) and `Praisy/07-prezi.wav` at 2.32s (×3.62) at the top, have
+never been listened to by anybody.
+
+**So the honest reading is narrower than the falsifier's wording.** What is
+measured at chance is duration against bad *words*. Duration against bad *cuts*
+is unmeasured, because labelling one needs the review. 6c does not become a
+verified mechanism on this result and it does not get to claim one.
+
+#### The geometry finds the injected clip and misses the real one
+
+This is 6a's finding again, through a different statistic, and it is the
+clearest reason the ranking has no geometry in it.
+
+An injected foreign clip lands alone in a group **44.4%** of the time, against
+**4.1%** for a genuine clip — 5 of 122. Read alone, that says group membership
+is a strong detector. Then look at the two clips that are really wrong, in the
+folders they are really in: `Vercel/09-brazil.wav` sits in a group of 6 and
+`Tasmeen/06-that'smeanssend.wav` sits in a group of 6. **Neither is ever
+alone.** A bad clip with company is invisible to any per-clip geometry, and the
+44.4% is an artefact of injecting one clip at a time into a bank that has none.
+
+#### The three verification criteria
+
+**1. Surfaced, not flagged — and both are, in the top third.** Neither is a
+geometric outlier, so as 6c requires this is the ranking putting them in front
+of a person.
+
+| clip | cut | ×median | flagged | position | tie-adjusted rank | group |
+|---|---|---|---|---|---|---|
+| `Vercel/09-brazil.wav` | 0.48s | ×0.67 | yes | 5 of 16 | 0.27 | 2 of 4 |
+| `Tasmeen/06-that'smeanssend.wav` | 0.88s | ×1.38 | no | 2 of 8 | 0.14 | 2 of 2 |
+
+**Read the `Vercel` row with its caveat.** 0.48s against a 0.72s median is
+exactly ×1.5, exactly the band edge, so whether it is flagged was being decided
+by the last bit of a float. The tool now counts the edge as outside, for the
+reason in its own comment: cut lengths here are multiples of 0.08s so exact
+ratios happen, and a review tool should err towards surfacing. The band itself
+was not moved. `Tasmeen`'s clip is not flagged at all and is surfaced only by
+its position in the order.
+
+**2. Cannot be checked. Still owed.** A deliberately bilingual term needs
+recordings that do not exist. 6a looked and found none: no observation carries
+`lang`, all eleven `Matthieu` recordings come from dictations `trace.jsonl`
+marks `en`, and splitting by rendering gives one cluster and AUC 0.513. This
+experiment adds nothing to that and did not try to. **No arm was fabricated and
+no TTS was used** — a previous session's `say` output came back blank at −0.0 on
+every CTC frame and cost a round of results.
+
+*What would settle it.* One recording session: the speaker reads `Matthieu` in
+a French sentence and in an English sentence, six of each, in one sitting, and
+the clips are mined with `lang` written on the observation. Twelve clips against
+the existing eleven is enough to ask whether the tool keeps both groups and
+whether a thin second cluster inflates `spread` the way §7 predicts. PR 4 is
+the dependency: without `lang` on the observation the two groups cannot be told
+apart afterwards, which is exactly what 6a ran into.
+
+**3. Checkable, and it passes.** "A term that keeps all its clips and rejects
+nothing has failed." Keeping every clip is what this tool does by default —
+nothing is deleted, ever. Every one of the eleven terms still rejects. The
+weakest is `Claude` at 18 of 70 B spans under the per-term spread, and no term
+is at zero under either statistic.
+
+#### 6b's third change, measured as a side effect
+
+Per-cluster spread needed 6c's clustering, so it is measured here. Same spans,
+same per-clip hold-out, same tolerance 1.0, abstain under three usable
+recordings. The only change is that the span is compared against the width of
+the group it is nearest instead of the width of the whole bank.
+
+| term | groups | veto B per-term | per-cluster | veto A per-term | per-cluster |
+|---|---|---|---|---|---|
+| arexvy | 2 | 55/66 | 66/66 | 1/6 | 3/6 |
+| claude | 2 | 18/70 | 54/70 | 1/6 | 6/6 |
+| matthieu | 3 | 50/67 | 66/67 | 2/10 | 5/10 |
+| mirza | 4 | 36/67 | 67/67 | 1/8 | 3/8 |
+| ollama | 2 | 34/67 | 61/67 | 0/7 | 4/7 |
+| praisy | 7 | 66/108 | 93/108 | 1/21 | 7/21 |
+| redcrawl | 2 | 58/66 | 65/66 | 1/8 | 2/8 |
+| redrock | 2 | 62/65 | 65/65 | 1/7 | 4/7 |
+| supabase | 3 | 62/64 | 64/64 | 0/10 | 2/10 |
+| tasmeen | 2 | 42/68 | 42/68 | 1/7 | 2/7 |
+| vercel | 4 | 71/76 | 73/76 | 1/6 | 1/6 |
+| **total** | | **554** | **716** | **10** | **39** |
+| reject everything | | 784 | 784 | 96 | 96 |
+
+**It moves towards the blind veto, and that is the warning §2 wrote.** 716 of
+784 true rejections is 91% of rejecting everything, bought with 39 of 96 false
+ones. As a ratio of true to false rejections it is worse than both alternatives:
+the maximum is 55.4 true per false, 6b's 90th percentile is 38.2 (6a's 649/17),
+and per-cluster spread is **18.4**. A smaller bank has a smaller width, so it
+rejects more; that is arithmetic, not discrimination. **Per-cluster spread as
+built here is not an improvement.** §7 argued for it from correctness on a
+bilingual term, and criterion 2 is exactly the case nobody can measure yet — so
+this number rules out the robustness argument for it and leaves the correctness
+argument untouched.
+
+#### The review, and what it costs the speaker
+
+| term | clips | groups | spread |
+|---|---|---|---|
+| arexvy | 7 | 2 | 3.031 |
+| claude | 6 | 2 | 3.436 |
+| matthieu | 11 | 3 | 3.053 |
+| mirza | 15 | 4 | 3.257 |
+| ollama | 7 | 2 | 3.313 |
+| praisy | 26 | 7 | 3.235 |
+| redcrawl | 8 | 2 | 3.098 |
+| redrock | 7 | 2 | 2.999 |
+| supabase | 11 | 3 | 2.919 |
+| tasmeen | 8 | 2 | 3.268 |
+| vercel | 16 | 4 | 3.178 |
+| **total** | **122** | **33** | |
+
+Group sizes run 1 to 6: five singletons, four pairs, seven of three, five of
+four, four of five and eight of six. **86.4 seconds of audio over the whole
+archive**, so the whole review is a few minutes including the thinking. A term
+of 8 to 26 clips produces 2 to 7 groups, which is the count 6c asked for before
+building the playback.
+
+**The grouping is a review order, not a pronunciation split, and the tool says
+so.** These banks have almost no cluster structure: within a term the median
+pairwise distance is 3.10 to 3.68 and across terms it is 3.57 to 3.64, so the
+two distributions sit on top of each other. Any distance threshold near the bulk
+of that produces singletons and nothing else, which is why the cut is a count —
+about four clips per group, six at most — and not a distance. The printed
+separation AUC (0.805 to 1.000) is what an agglomerative cut always gives and is
+there to be read against 0.500, not as evidence of two pronunciations.
+
+#### Marking has a consequence, and on the clips duration flags it is often none
+
+`--mark Vercel/g3` marks the three longest cuts in that bank, including the
+2.72s one. What it does:
+
+| | before | after |
+|---|---|---|
+| clips counted | 16 | 13 |
+| spread | 3.178 | 3.178 |
+| veto B | 71/76 | 71/76 |
+| veto A | 1/6 | 1/6 |
+
+**Nothing moves.** That is 6a's result showing up in the user's hands: the
+clips a person would most want to remove are not the clips that set the
+threshold. The tool reports it either way, which is the point — the decision has
+a visible consequence and here the consequence is "no effect on the rule, and
+the files are still there".
+
+Marking a large group does move it, and the tool warns before it becomes a
+problem. `--mark Tasmeen/g1` takes that bank from 8 counted clips to 2, and
+prints `⚠ Tasmeen is down to 2 counted clip(s). 6e puts the abstain floor at 5,
+so this term will stop deciding.` The veto column then reads `42/68 -> abstains`
+rather than a zero, because a bank that stopped deciding is not a bank that
+decided and rejected nothing.
+
+#### What is weak about this
+
+**The falsifier's labelled set is the wrong failure mode, and this is the main
+one.** Cross-term injection produces bad words. Duration is a detector of bad
+cuts. The two do not meet, and there is no labelled bad cut in the archive to
+close the gap. The 0.526 is honest and it is not a measurement of the thing 6c
+is for.
+
+**Provenance is untested, not weak.** With 122 of 122 mined there is no arm to
+run. Whether `from: correction` outranks `from: mined` in practice is a question
+for PR 4's data. It is arithmetic that it would separate perfectly on a bank
+where the two are mixed and the mined ones are the bad ones; it is not
+arithmetic that the bad ones are the mined ones.
+
+**Nobody has reviewed anything yet.** Every number here is about the tool, not
+about the archive. The 22 flagged clips are unlabelled until the speaker listens.
+
+**The per-cluster arm inherits every caveat 6a and 6e carry.** Rejection counts
+are not the ablation. They say what the rule would drop on these spans; they do
+not say what the app would write, and 6b's bar is still the blind veto's 103 on
+141 clips.
+
+**In-sample, like everything else in PR 6.** The recordings were mined from the
+corpus the spans come from. The per-clip hold-out is applied throughout and does
+not cover the corpus-level fit.
+
+**The duration band is a convention.** ×1.5 either way, chosen from the shape of
+the archive — a 0.64s median makes the band 0.43s to 0.96s — and not tuned on
+either named clip. Twenty-two of 122 clips fall outside it. A different band
+moves that count and moves the falsifier's flag rates; it does not move the AUC,
+which is computed on the risk and not on the flag.
+
+#### How to run it
+
+Against the speaker's own bank, read-only:
+
+```sh
+python3 scripts/clip-review.py --cache /tmp/clips.npz --concat /tmp/groups
+```
+
+That prints, per term: how many groups, how many clips in each, each group's
+tightness, its provenance mix, which groups are suspect and why, an `afplay`
+line for the clips, and a second `afplay` line for the whole group as one wav
+under `--concat`. `--term Vercel` narrows it. Nothing is written to
+`voice/`; `--concat` writes only to the directory named.
+
+To act on it:
+
+```sh
+python3 scripts/clip-review.py --mark Vercel/g3 --why "two words, not the name"
+python3 scripts/clip-review.py --unmark Vercel/g3
+```
+
+Marks go to `clip-review-marks.json` in the working directory, or wherever
+`--marks` says. **In production this file is `voice/excluded.json` beside
+`observations.jsonl`**, read by whatever builds a bank. Nothing is deleted and
+nothing in the voice store is touched, so a mark is undone by ear.
+
+Add `--veto-cache FILE --veto` to see what a mark does to
+`ReferenceMatch.verdict`'s own rejection counts. That arm needs the harness data
+`reference-matching.py` uses — `~/Recordings/ParrotFlow Dev/` and round 5's
+cached proposals — and says so and stops when they are absent. The spread half
+of the effect needs neither.
+
+#### How to reproduce
+
+```sh
+S=$(mktemp -d) && cp -R ~/.config/parrotflow-dev/voice "$S/voice"   # read only
+
+PARROTFLOW_CONFIG_DIR=$S python3 scripts/clip-review.py --cache "$S/clips.npz"
+PARROTFLOW_CONFIG_DIR=$S python3 scripts/clip-review.py --cache "$S/clips.npz" \
+  --falsify                                  # the accuracy number
+PARROTFLOW_CONFIG_DIR=$S python3 scripts/clip-review.py --cache "$S/clips.npz" \
+  --veto-cache "$S/dist.npz" --clusters      # 6b's per-cluster spread
+```
+
+The first run computes every recording-to-recording distance and caches it,
+about thirty seconds. `--falsify` and the report then return at once.
+`--clusters` builds `reference-matching.py`'s span matrix on its first run,
+about five minutes, and reuses 6a's cache file if one is given.
 
 ### 6d — the spotter generates, the bank decides
 

--- a/scripts/clip-review.py
+++ b/scripts/clip-review.py
@@ -369,28 +369,42 @@ def group_key(members, scores):
 def load_marks(path):
     """The groups already marked not-counted.
 
-    A file that does not parse stops the run. It must not read as an empty
-    list: the next `--mark` writes the whole file back, so treating a corrupt
-    file as "no marks" throws away every decision the speaker has made. Those
-    decisions came from listening, and nothing here can reconstruct them. A
-    missing file is different and is genuinely no marks.
+    Anything the file says that this cannot read stops the run — a bad parse, a
+    `not_counted` that is not a list, an entry that is not an object, an entry
+    with no clip names. It must not read as an empty list: the next `--mark`
+    writes the whole file back, so treating a corrupt file as "no marks" throws
+    away every decision the speaker has made. Those decisions came from
+    listening, and nothing here can reconstruct them. A missing file is
+    different and is genuinely no marks.
+
+    Refusing the whole file rather than the bad entry is the point. Dropping
+    one entry and saving would delete it, which is the same loss in smaller
+    pieces.
     """
+    def refuse(why):
+        print(f"✗ {path}: {why}", file=sys.stderr)
+        print("  It has not been changed. Fix it or move it aside; marking "
+              "now would overwrite every decision in it.", file=sys.stderr)
+        raise SystemExit(2)
+
     if not path or not Path(path).exists():
         return []
     try:
         blob = json.loads(Path(path).read_text())
     except ValueError as error:
-        print(f"✗ {path} is not readable JSON: {error}", file=sys.stderr)
-        print("  It has not been changed. Fix it or move it aside; marking "
-              "now would overwrite every decision in it.", file=sys.stderr)
-        raise SystemExit(2)
-    marks = blob.get("not_counted")
-    if not isinstance(marks, list):
-        print(f"✗ {path} has no `not_counted` list.", file=sys.stderr)
-        print("  It has not been changed. Same reason as above.",
-              file=sys.stderr)
-        raise SystemExit(2)
-    return marks
+        refuse(f"not readable JSON: {error}")
+    if not isinstance(blob, dict) or not isinstance(blob.get("not_counted"), list):
+        refuse("no `not_counted` list")
+    for n, mark in enumerate(blob["not_counted"]):
+        if not isinstance(mark, dict):
+            refuse(f"entry {n} is {type(mark).__name__}, not an object")
+        clips = mark.get("clips")
+        if not isinstance(clips, list) or not clips:
+            refuse(f"entry {n} ({mark.get('id') or mark.get('group') or '?'}) "
+                   "has no `clips` list")
+        if not all(isinstance(name, str) for name in clips):
+            refuse(f"entry {n} has a clip name that is not a string")
+    return blob["not_counted"]
 
 
 def save_marks(path, marks):
@@ -528,13 +542,15 @@ def report(clips, ee, terms, marks, out_dir, robust, marks_path):
 
 # ------------------------------------------------------- what a mark would cost
 
-def effect(clips, ee, marks, terms, veto_cache, robust):
+def effect(clips, ee, marks, terms, veto_cache, robust, with_veto):
     """What marking a group not-counted does, so the decision has a consequence.
 
-    Two levels. The spread is computable from the clips alone and is always
-    printed. The veto is the rule's own decision and needs labelled spans, so
-    it needs the harness data `reference-matching.py` uses; without it the
-    section says so and stops.
+    Two levels, and the second is opt-in for a reason. The spread comes off the
+    clips alone, is already computed, and is always printed. The veto is the
+    rule's own decision on labelled spans, which means a 170 × 122 distance
+    matrix — five minutes the first time, and it needs harness data the voice
+    store does not contain. Running it on every report would make marking one
+    group slow down every run after it, so it waits for `--veto`.
     """
     excluded = marked_names(marks)
     if not excluded:
@@ -557,6 +573,12 @@ def effect(clips, ee, marks, terms, veto_cache, robust):
         before, after = spread(bank, ee, robust), spread(kept, ee, robust)
         print(f"  {term:<12} {len(bank):>4} -> {len(kept):<4}  "
               f"{before:>7.3f} -> {after:<7.3f}")
+
+    if not with_veto:
+        print("\n  `--veto` adds what this does to the rule's own rejection")
+        print("  counts. It builds a 170 × 122 span matrix, so it is opt-in;")
+        print("  `--veto-cache FILE` keeps it between runs.")
+        return
 
     print("\n  and what that does to the rule, on the labelled spans")
     got = veto_arms(clips, marks, veto_cache, robust)
@@ -957,7 +979,7 @@ def main():
         save_marks(args.marks, marks)
         print(f"unmarked {gone} clip(s); they count again")
         effect(clips, ee, marks, sorted({c["term"] for c in clips}),
-               args.veto_cache, args.robust)
+               args.veto_cache, args.robust, args.veto)
         return 0
 
     if args.mark:
@@ -996,7 +1018,7 @@ def main():
         print(f"In production this file is `voice/excluded.json` beside "
               f"`observations.jsonl`, read by whatever builds a bank.")
         effect(clips, ee, marks, sorted({c["term"] for c in clips}),
-               args.veto_cache, args.robust)
+               args.veto_cache, args.robust, args.veto)
         return 0
 
     terms = sorted({c["term"] for c in clips})
@@ -1018,7 +1040,7 @@ def main():
 
     report(clips, ee, terms, marks, args.concat, args.robust, args.marks)
     if marks or args.veto:
-        effect(clips, ee, marks, terms, args.veto_cache, args.robust)
+        effect(clips, ee, marks, terms, args.veto_cache, args.robust, args.veto)
     return 0
 
 

--- a/scripts/clip-review.py
+++ b/scripts/clip-review.py
@@ -367,14 +367,30 @@ def group_key(members, scores):
 # ------------------------------------------------------------------- the marks
 
 def load_marks(path):
+    """The groups already marked not-counted.
+
+    A file that does not parse stops the run. It must not read as an empty
+    list: the next `--mark` writes the whole file back, so treating a corrupt
+    file as "no marks" throws away every decision the speaker has made. Those
+    decisions came from listening, and nothing here can reconstruct them. A
+    missing file is different and is genuinely no marks.
+    """
     if not path or not Path(path).exists():
         return []
     try:
         blob = json.loads(Path(path).read_text())
-    except ValueError:
-        print(f"✗ {path} is not readable JSON", file=sys.stderr)
-        return []
-    return blob.get("not_counted", [])
+    except ValueError as error:
+        print(f"✗ {path} is not readable JSON: {error}", file=sys.stderr)
+        print("  It has not been changed. Fix it or move it aside; marking "
+              "now would overwrite every decision in it.", file=sys.stderr)
+        raise SystemExit(2)
+    marks = blob.get("not_counted")
+    if not isinstance(marks, list):
+        print(f"✗ {path} has no `not_counted` list.", file=sys.stderr)
+        print("  It has not been changed. Same reason as above.",
+              file=sys.stderr)
+        raise SystemExit(2)
+    return marks
 
 
 def save_marks(path, marks):
@@ -428,7 +444,7 @@ def concat(clips, members, out, label, gap=0.25):
     return path
 
 
-def report(clips, ee, terms, marks, out_dir, robust):
+def report(clips, ee, terms, marks, out_dir, robust, marks_path):
     excluded = marked_names(marks)
     by_term = defaultdict(list)
     for i, c in enumerate(clips):
@@ -448,7 +464,7 @@ def report(clips, ee, terms, marks, out_dir, robust):
         print("  clip the speaker confirmed. Until corrections land, the whole")
         print("  ranking below rests on duration.")
     if excluded:
-        print(f"\n  {len(excluded)} clip(s) marked not counted in {out_dir}")
+        print(f"\n  {len(excluded)} clip(s) marked not counted in {marks_path}")
 
     total_groups = 0
     for term in terms:
@@ -1000,7 +1016,7 @@ def main():
         per_cluster_veto(clips, ee, args.veto_cache, args.robust)
         return 0
 
-    report(clips, ee, terms, marks, args.concat, args.robust)
+    report(clips, ee, terms, marks, args.concat, args.robust, args.marks)
     if marks or args.veto:
         effect(clips, ee, marks, terms, args.veto_cache, args.robust)
     return 0

--- a/scripts/clip-review.py
+++ b/scripts/clip-review.py
@@ -437,6 +437,23 @@ def save_marks(path, marks):
     except BaseException:
         Path(temporary).unlink(missing_ok=True)
         raise
+    # And the directory entry the rename created. Flushing the file's own
+    # bytes is not enough: until the directory is flushed too, a power cut
+    # after `os.replace` returns can leave the name pointing at the old file,
+    # or at nothing at all on the first write. The rename is still atomic
+    # either way — the file is never half a file — so this decides whether the
+    # last mark survives, not whether the archive does.
+    try:
+        fd = os.open(str(path.parent), os.O_RDONLY)
+        try:
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+    except OSError:
+        # Some filesystems refuse to fsync a directory. The rename has already
+        # happened and the file is intact; only the durability of this one
+        # write is weaker. Not worth failing a review over.
+        pass
 
 
 def marked_names(marks):

--- a/scripts/clip-review.py
+++ b/scripts/clip-review.py
@@ -56,10 +56,12 @@ import hashlib
 import importlib.util
 import json
 import math
+import os
 import random
 import shlex
 import statistics
 import sys
+import tempfile
 import wave
 from collections import Counter, defaultdict
 from pathlib import Path
@@ -408,7 +410,33 @@ def load_marks(path):
 
 
 def save_marks(path, marks):
-    Path(path).write_text(json.dumps({"not_counted": marks}, indent=2) + "\n")
+    """Write the marks, and never leave a half-written file behind.
+
+    This is the only copy of decisions that came from listening. A plain
+    `write_text` truncates first, so a crash or a full disk in the middle
+    leaves the file unreadable — and `load_marks` then correctly refuses it,
+    which turns a lost write into a lost archive.
+
+    So: write a temporary file in the same directory, flush it to the disk,
+    then rename over the target. `os.replace` is atomic within a filesystem,
+    which is why the temporary has to be a sibling and not in `/tmp`. Any
+    reader sees the old file or the new one, never a mixture. If the write
+    fails the temporary is removed and the original is untouched.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = json.dumps({"not_counted": marks}, indent=2) + "\n"
+    handle, temporary = tempfile.mkstemp(dir=str(path.parent),
+                                         prefix=path.name + ".", suffix=".tmp")
+    try:
+        with os.fdopen(handle, "w", encoding="utf-8") as out:
+            out.write(body)
+            out.flush()
+            os.fsync(out.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        Path(temporary).unlink(missing_ok=True)
+        raise
 
 
 def marked_names(marks):

--- a/scripts/clip-review.py
+++ b/scripts/clip-review.py
@@ -1,0 +1,1010 @@
+#!/usr/bin/env python3
+"""Review a term's recordings by ear, in groups. PR 6c.
+
+    scripts/clip-review.py                       # the report, every term
+    scripts/clip-review.py --term Vercel         # one term
+    scripts/clip-review.py --concat DIR          # one wav per group, to play
+    scripts/clip-review.py --mark Vercel/g4      # mark a group not counted
+    scripts/clip-review.py --unmark Vercel/g4    # and take it back
+    scripts/clip-review.py --veto                # what a mark does to the rule
+    scripts/clip-review.py --falsify             # the accuracy number
+
+**This never writes to the voice store.** It reads `voice/samples/` and
+`voice/observations.jsonl` and writes nothing back — not a marking, not a move,
+not a rename. A mark goes to a separate file (`--marks`), so a mistake is
+undone by deleting a line. `PARROTFLOW_CONFIG_DIR` moves the store the same way
+it does for every other harness here.
+
+**Why this is not a pruner, and this is the whole design.** 6a measured what
+the old 6c proposed. Bad clips arrive in groups and vouch for each other, so
+the statistic that would drive an automatic pruner — leave-one-out distance
+from the pack — points at real recordings. `Tasmeen`'s leave-one-out maximum is
+held by `01-tasmin.wav`, a genuine recording; the bad `06-that'smeanssend.wav`
+is 5th of 8. Removing `Vercel/09-brazil.wav` makes that term's spread *worse*,
+3.178 to 3.235, and costs 6 true rejections, because the bad clip was another
+recording's nearest neighbour. So distance from the pack is not a ranking, and
+nothing here deletes a file.
+
+What is left is two signals with no geometry in them, and one use for the
+geometry that is not ranking:
+
+    provenance  `Observation.from` — `correction`, `mined`, `calibration` or
+                `legacy`. A correction is vouched for by the speaker. A mined
+                clip is only as good as the decode that produced it, and both
+                clips PR 6c names as bad are mined.
+    duration    `Observation.span` — a cut much longer or much shorter than the
+                term's typical span is a bad cut, not a bad pronunciation. PR 4
+                found 2 of 60 correction spans over 2s, worst 6.4s, where a word
+                timing swallowed the pause after it.
+    groups      the geometry decides what is played *together*, not what is
+                suspected. Four half-second clips is under three seconds, so a
+                group is one question instead of four.
+
+**A group's tightness says how much of the reviewer's attention to ask for. It
+is not proof the group is one thing.** One mispronunciation can sit inside a
+tight group by accident, which is exactly what `Tasmeen` does — the four
+mutually-near clips there include `06-that'smeanssend`. Tight means "answer it
+as a unit"; loose means "play it clip by clip". Neither means "it is fine".
+
+The MFCC and the DTW are `scripts/reference-matching.py`'s, imported rather
+than copied, so a distance printed here is the same number 6a and 6e printed.
+numpy only. No app, no model, no Ollama, no decode.
+"""
+import argparse
+import datetime
+import hashlib
+import importlib.util
+import json
+import math
+import random
+import shlex
+import statistics
+import sys
+import wave
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def reference_matching():
+    """`scripts/reference-matching.py`, whose name is not an identifier.
+
+    Everything acoustic in this file is that module's: `read`, `mfcc`, `dtw`,
+    `quantile`, `auc`, and the voice-store paths. Two copies of a DTW would
+    drift, and then a distance here would not be a distance there.
+    """
+    path = ROOT / "scripts/reference-matching.py"
+    spec = importlib.util.spec_from_file_location("reference_matching", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+RM = reference_matching()
+
+# How much a cut may differ from the term's median cut before it is called out.
+# 1.5× either way. A name is about half a second in this archive, so this is
+# 0.75s against 0.43s on a 0.64s median — well outside the jitter of a word
+# boundary, and well inside the 6.4s cut PR 4 found.
+RATIO = 1.5
+
+# A cut exactly at the band edge counts as outside it. Cut lengths in this
+# archive are multiples of 0.08s, so exact ratios of 1.5 happen — 0.48s against
+# a 0.72s median is one, and `Vercel/09-brazil.wav` is that clip. Without the
+# tolerance the last bit of a float decides whether it is surfaced, which is a
+# coin flip and not a rule. Erring towards surfacing is the right side for a
+# tool whose output a person reads.
+EDGE = 1.0 - 1e-9
+
+# What each provenance is worth, as risk: 0 is vouched for, 1 is not vouched
+# for at all. `correction` is the speaker confirming the word. `calibration` is
+# a read line, so the word is known but nobody checked the cut. `legacy`
+# predates the field. `mined` is a guess from a decode that may itself have
+# been wrong, which is what both clips PR 6c names as bad are.
+RISK = {"correction": 0.0, "calibration": 0.3, "legacy": 0.6, "mined": 1.0}
+UNKNOWN = 1.0
+
+# Clips per group, and the most a group may hold. Four half-second clips is
+# under three seconds with the gaps, which is the point: a group is one
+# question. Six is the ceiling, so a big bank gets more groups rather than one
+# unplayable one.
+TARGET = 4
+MAX_GROUP = 6
+
+# 6e's abstain point. Under five counted recordings a bank throws away over
+# half of the term's own correct spans too often to be allowed to decide.
+# Marking is the fastest way to walk a bank off that edge, so this is checked
+# at the moment a mark is made.
+FLOOR = 5
+
+
+# --------------------------------------------------------------- the clip bank
+
+def load_clips():
+    """Every recording in the voice store, with what is known about it.
+
+    `observations.jsonl` is the only place provenance and the span live, so a
+    wav with no row is loaded anyway and reported as unlabelled rather than
+    dropped. Its duration comes off the file, which is the same number for
+    every other clip: `mine-pronunciations.py` writes exactly the span it
+    records.
+    """
+    voice = RM.voice_dir()
+    samples = voice / "samples"
+    if not samples.exists():
+        print(f"✗ no recordings under {samples}", file=sys.stderr)
+        return []
+    rows = {}
+    log = voice / "observations.jsonl"
+    if log.exists():
+        for line in log.read_text(encoding="utf-8").splitlines():
+            try:
+                row = json.loads(line)
+            except ValueError:
+                continue
+            name = (row.get("sample") or "").replace("samples/", "")
+            if name:
+                rows[name] = row
+    clips = []
+    for path in sorted(samples.rglob("*.wav")):
+        name = f"{path.parent.name}/{path.name}"
+        row = rows.get(name, {})
+        span = row.get("span") or []
+        samples_read = RM.read(path)
+        clips.append({
+            "name": name,
+            "term": path.parent.name,
+            "path": path,
+            "from": row.get("from"),
+            "seconds": (span[1] - span[0]) if len(span) == 2
+                       else samples_read.size / RM.RATE,
+            "timed": len(span) == 2,
+            "heard": row.get("heard"),
+            "wav": row.get("wav"),
+            "at": row.get("at"),
+            "mfcc": RM.mfcc(samples_read),
+        })
+    kept = [c for c in clips if c["mfcc"] is not None]
+    if len(kept) != len(clips):
+        print(f"  {len(clips) - len(kept)} clip(s) are shorter than one MFCC "
+              "frame and cannot be compared", file=sys.stderr)
+    return kept
+
+
+def fingerprint(clips):
+    """A digest of the exact audio the cached matrix was computed from.
+
+    Names and counts are not enough — a recording can be replaced without its
+    path changing. So the MFCCs themselves go in, in order, with the name of
+    the row they belong to. This is `reference-matching.py`'s rule and the
+    reason for it is the same: anything the cache cannot vouch for is rebuilt.
+    """
+    digest = hashlib.sha256()
+    for c in clips:
+        digest.update(f"C|{c['name']}|".encode())
+        digest.update(np.ascontiguousarray(c["mfcc"], dtype=np.float64).tobytes())
+    return digest.hexdigest()
+
+
+def distances(clips, cache):
+    """Every recording-to-recording DTW distance, once.
+
+    122 recordings is 7381 pairs and about thirty seconds. Every arm after
+    that — grouping, marking, the falsifier's twelve hundred injections — is
+    indexing this matrix.
+    """
+    stamp = fingerprint(clips)
+    if cache and Path(cache).exists():
+        # No pickle: this reads a cache this script wrote and nothing else.
+        blob = np.load(cache)
+        if {"stamp", "ee"} <= set(blob.files) and str(blob["stamp"]) == stamp:
+            return blob["ee"]
+        print("  the cache does not match this audio; rebuilding", file=sys.stderr)
+    n = len(clips)
+    ee = np.zeros((n, n))
+    for i in range(n):
+        for j in range(i + 1, n):
+            ee[i, j] = ee[j, i] = RM.dtw(clips[i]["mfcc"], clips[j]["mfcc"])
+        print(f"  recordings {i + 1}/{n}", end="\r", file=sys.stderr)
+    if cache:
+        np.savez(cache, stamp=stamp, ee=ee,
+                 names=np.array([c["name"] for c in clips]))
+    return ee
+
+
+# ------------------------------------------------------------------ the groups
+
+def group(bank, ee, target=TARGET, cap=MAX_GROUP):
+    """Average-linkage groups of `bank`, no bigger than `cap`.
+
+    Average linkage, not single linkage: single linkage chains, and a bank with
+    almost no cluster structure — which is what these are, see the report's own
+    separation number — chains into one group and a pile of singletons.
+
+    The cut is a count, not a distance, and that is deliberate. A distance cut
+    needs a threshold, the distance scale differs per term (part 1 §3), and on
+    these banks any threshold near the bulk of the distribution produces mostly
+    singletons. A count produces a bounded review whatever the geometry does.
+    The cost is that the groups are always *something*; the separation number
+    printed beside them is what says whether they are anything.
+    """
+    if not bank:
+        return []
+    want = max(1, math.ceil(len(bank) / target))
+    groups = [[i] for i in bank]
+    while len(groups) > want:
+        best = None
+        for a in range(len(groups)):
+            for b in range(a + 1, len(groups)):
+                if len(groups[a]) + len(groups[b]) > cap:
+                    continue
+                d = sum(ee[i][j] for i in groups[a] for j in groups[b])
+                d /= len(groups[a]) * len(groups[b])
+                if best is None or d < best[0]:
+                    best = (d, a, b)
+        if best is None:
+            break                      # every legal merge would break the cap
+        _, a, b = best
+        groups[a] = groups[a] + groups[b]
+        groups.pop(b)
+    return sorted(groups, key=lambda g: (-len(g), g[0]))
+
+
+def leave_one_out(members, ee):
+    """Each member's distance to its nearest other member.
+
+    `ReferenceMatch.verdict` step 2, computed over whatever set it is given.
+    Over a whole bank its maximum is `spread`. Over a group it is the group's
+    tightness, which is the same number asking a smaller question.
+    """
+    if len(members) < 2:
+        return []
+    return [min(ee[i][j] for j in members if j != i) for i in members]
+
+
+def spread(members, ee, robust=False):
+    """The width of the cloud: the maximum, or 6b's 90th percentile."""
+    loo = leave_one_out(members, ee)
+    if not loo:
+        return float("nan")
+    return RM.quantile(loo, 0.9) if robust else max(loo)
+
+
+def separation(groups, ee):
+    """AUC(a between-group distance > a within-group distance).
+
+    0.500 means the groups are a review order and nothing else. 1.000 means
+    they never touch. This is the honest label on the grouping, and it is the
+    same check 6a ran on `Matthieu`'s two renderings, where it came back 0.513.
+    """
+    within = [ee[i][j] for g in groups for a, i in enumerate(g) for j in g[a + 1:]]
+    between = [ee[i][j] for x, g in enumerate(groups)
+               for h in groups[x + 1:] for i in g for j in h]
+    return RM.auc(between, within)
+
+
+# -------------------------------------------------------------- the suspicions
+
+def duration_risk(clip, median):
+    """How far outside the term's typical cut this one is, in units of RATIO.
+
+    1.0 is exactly at the band edge. The log makes twice as long and half as
+    long the same size of oddity, which is what they are: both are the cut
+    being wrong, not the pronunciation.
+    """
+    if not (median > 0) or not (clip["seconds"] > 0):
+        return float("nan")
+    return abs(math.log(clip["seconds"] / median)) / math.log(RATIO)
+
+
+def score_bank(bank, clips):
+    """Provenance and duration risk for every clip in one term's bank.
+
+    Both are computed against the bank the clip sits in, never against the
+    archive: `Arexvy` is a longer name than `Claude`, so a cut is long or short
+    only relative to its own term.
+    """
+    median = statistics.median([clips[i]["seconds"] for i in bank])
+    kinds = {clips[i]["from"] for i in bank}
+    # A signal that is the same on every clip in the bank ranks nothing. Say so
+    # rather than flagging all of them, which is the same as flagging none.
+    informative = len(kinds) > 1
+    out = {}
+    for i in bank:
+        c = clips[i]
+        out[i] = {
+            "duration": duration_risk(c, median),
+            "provenance": RISK.get(c["from"], UNKNOWN),
+            "provenance_ranks": informative,
+        }
+    return out, median, informative
+
+
+def group_reasons(members, scores, tightness, term_spread):
+    """Why this group is worth a person's time, in the order they should read.
+
+    Provenance first — it is the strongest signal and it involves no geometry
+    at all. Then duration. Then the two things about the group itself, which
+    say how to review it rather than whether to.
+    """
+    reasons = []
+    ranks = any(scores[i]["provenance_ranks"] for i in members)
+    worst_provenance = max(scores[i]["provenance"] for i in members)
+    if ranks and worst_provenance >= RISK["mined"]:
+        n = sum(1 for i in members if scores[i]["provenance"] >= RISK["mined"])
+        reasons.append(f"provenance: {n} of {len(members)} mined, "
+                       "not confirmed by the speaker")
+    odd = [i for i in members if scores[i]["duration"] == scores[i]["duration"]
+           and scores[i]["duration"] >= EDGE]
+    if odd:
+        reasons.append(f"duration: {len(odd)} cut(s) outside ×{RATIO} of the "
+                       "term's median")
+    if len(members) == 1:
+        reasons.append("singleton: no other recording in the bank vouches for it")
+    elif tightness == tightness and term_spread == term_spread \
+            and tightness >= term_spread:
+        reasons.append("loose: no tighter than the whole bank — play it clip "
+                       "by clip")
+    return reasons
+
+
+def group_key(members, scores):
+    """The review order. Provenance, then duration. No geometry in it.
+
+    6a is the reason: the geometric statistic points at real recordings, so it
+    orders the review by the wrong thing.
+    """
+    provenance = max(scores[i]["provenance"] for i in members) \
+        if any(scores[i]["provenance_ranks"] for i in members) else 0.0
+    risks = [scores[i]["duration"] for i in members
+             if scores[i]["duration"] == scores[i]["duration"]]
+    return (-provenance, -(max(risks) if risks else 0.0))
+
+
+# ------------------------------------------------------------------- the marks
+
+def load_marks(path):
+    if not path or not Path(path).exists():
+        return []
+    try:
+        blob = json.loads(Path(path).read_text())
+    except ValueError:
+        print(f"✗ {path} is not readable JSON", file=sys.stderr)
+        return []
+    return blob.get("not_counted", [])
+
+
+def save_marks(path, marks):
+    Path(path).write_text(json.dumps({"not_counted": marks}, indent=2) + "\n")
+
+
+def marked_names(marks):
+    """Every clip any mark covers.
+
+    A mark stores the clip names, not the group id. Group ids are positions in
+    a grouping and they move the moment a recording is added; a clip name does
+    not. So a mark made today still names the same audio tomorrow.
+    """
+    return {name for m in marks for name in m.get("clips", [])}
+
+
+# ------------------------------------------------------------------- the report
+
+def playback(clips, members):
+    """A line to paste. `afplay` takes one file, so this is a chain of them.
+
+    `shlex.quote`, because `Tasmeen/06-that'smeanssend.wav` is a real filename
+    in this archive and a naive single quote around it ends the quoting halfway
+    through the word. What comes out is safe in bash, zsh and fish.
+    """
+    return "; ".join(f"afplay {shlex.quote(str(clips[i]['path']))}"
+                     for i in members)
+
+
+def concat(clips, members, out, label, gap=0.25):
+    """One wav per group, so a group is one keystroke instead of four.
+
+    Written to `out`, which is never the archive. The gap is what makes four
+    clips hearable as four clips rather than one smear.
+    """
+    out = Path(out)
+    out.mkdir(parents=True, exist_ok=True)
+    silence = np.zeros(int(gap * RM.RATE), dtype=np.int16)
+    data = []
+    for k, i in enumerate(members):
+        if k:
+            data.append(silence)
+        data.append(RM.read(clips[i]["path"]).astype(np.int16))
+    joined = np.concatenate(data) if data else np.zeros(0, dtype=np.int16)
+    path = out / f"{clips[members[0]]['term']}-{label}.wav"
+    with wave.open(str(path), "wb") as dst:
+        dst.setnchannels(1)
+        dst.setsampwidth(2)
+        dst.setframerate(RM.RATE)
+        dst.writeframes(joined.astype("<i2").tobytes())
+    return path
+
+
+def report(clips, ee, terms, marks, out_dir, robust):
+    excluded = marked_names(marks)
+    by_term = defaultdict(list)
+    for i, c in enumerate(clips):
+        by_term[c["term"]].append(i)
+
+    kinds = Counter(c["from"] or "unlabelled" for c in clips)
+    print(f"\n=== the bank ===  {len(clips)} recordings over "
+          f"{len(by_term)} terms, {RM.voice_dir()}")
+    print("  provenance across the whole archive:")
+    for kind, n in kinds.most_common():
+        print(f"    {kind:<14} {n:>4}  ({n / len(clips) * 100:.0f}%)")
+    if len(kinds) == 1:
+        only = next(iter(kinds))
+        print(f"\n  Every clip is `{only}`, so provenance ranks nothing today.")
+        print("  It is the strongest of the two signals and it is the one this")
+        print("  archive cannot use yet: PR 4 is what writes `correction` on a")
+        print("  clip the speaker confirmed. Until corrections land, the whole")
+        print("  ranking below rests on duration.")
+    if excluded:
+        print(f"\n  {len(excluded)} clip(s) marked not counted in {out_dir}")
+
+    total_groups = 0
+    for term in terms:
+        bank = [i for i in by_term[term] if clips[i]["name"] not in excluded]
+        dropped = [i for i in by_term[term] if clips[i]["name"] in excluded]
+        if not bank:
+            print(f"\n=== {term} ===  every clip is marked not counted")
+            continue
+        scores, median, _ = score_bank(bank, clips)
+        groups = group(bank, ee)
+        total_groups += len(groups)
+        term_spread = spread(bank, ee, robust)
+        sep = separation(groups, ee) if len(groups) > 1 else float("nan")
+        where = "90th percentile" if robust else "maximum"
+        print(f"\n=== {term} ===  {len(bank)} clips, {len(groups)} groups, "
+              f"spread {term_spread:.3f} ({where})")
+        if dropped:
+            print(f"  {len(dropped)} clip(s) not counted: "
+                  f"{', '.join(clips[i]['name'].split('/')[-1] for i in dropped)}")
+        print(f"  median cut {median:.2f}s; provenance "
+              f"{', '.join(f'{k} {v}' for k, v in sorted(Counter(clips[i]['from'] or 'unlabelled' for i in bank).items()))}")
+        print(f"  group separation AUC "
+              f"{format(sep, '.3f') if sep == sep else '  -  '}"
+              "   0.500 is one cluster cut in pieces, 1.000 is groups that "
+              "never touch")
+
+        ordered = sorted(groups, key=lambda g: group_key(g, scores))
+        labels = {id(g): f"g{n + 1}" for n, g in enumerate(groups)}
+        for g in ordered:
+            tight = spread(g, ee, robust)
+            reasons = group_reasons(g, scores, tight, term_spread)
+            members = sorted(g, key=lambda i: -(scores[i]["duration"]
+                                                if scores[i]["duration"] == scores[i]["duration"]
+                                                else -1))
+            seconds = sum(clips[i]["seconds"] for i in g)
+            print(f"\n  {labels[id(g)]}  {len(g)} clip(s), {seconds:.1f}s of audio, "
+                  f"tightness {format(tight, '.3f') if tight == tight else '  -  '}")
+            for i in members:
+                s = scores[i]
+                ratio = clips[i]["seconds"] / median if median else float("nan")
+                flag = "  <- cut" if s["duration"] == s["duration"] \
+                    and s["duration"] >= EDGE else ""
+                print(f"      {clips[i]['name'].split('/')[-1]:<26} "
+                      f"{clips[i]['seconds']:.2f}s ×{ratio:.2f}  "
+                      f"{clips[i]['from'] or 'unlabelled':<12}{flag}")
+            for r in reasons:
+                print(f"      why: {r}")
+            print(f"      play: {playback(clips, members)}")
+            if out_dir:
+                path = concat(clips, members, out_dir, labels[id(g)])
+                print(f"      or:   afplay {shlex.quote(str(path))}")
+            print(f"      mark: scripts/clip-review.py --mark "
+                  f"{term}/{labels[id(g)]}")
+
+    print(f"\n=== the review ===  {total_groups} groups over {len(terms)} terms")
+    print("  A group is one question. Tightness says how much attention to ask")
+    print("  for, not whether the group is one thing: a mispronunciation can")
+    print("  sit inside a tight group, which is what Tasmeen does.")
+    return total_groups
+
+
+# ------------------------------------------------------- what a mark would cost
+
+def effect(clips, ee, marks, terms, veto_cache, robust):
+    """What marking a group not-counted does, so the decision has a consequence.
+
+    Two levels. The spread is computable from the clips alone and is always
+    printed. The veto is the rule's own decision and needs labelled spans, so
+    it needs the harness data `reference-matching.py` uses; without it the
+    section says so and stops.
+    """
+    excluded = marked_names(marks)
+    if not excluded:
+        print("\n=== the effect of the marks ===  nothing is marked")
+        return
+    by_term = defaultdict(list)
+    for i, c in enumerate(clips):
+        by_term[c["term"]].append(i)
+    where = "90th percentile" if robust else "maximum"
+    print(f"\n=== the effect of the marks ===  spread is the {where} of the")
+    print("  leave-one-out distances, which is what `ReferenceMatch.verdict`")
+    print("  compares a span against. Nothing is deleted: these clips are still")
+    print("  on disk and unmarking puts them back.")
+    print(f"\n  {'term':<12} {'clips':>11}  {'spread':>17}")
+    for term in terms:
+        bank = by_term[term]
+        kept = [i for i in bank if clips[i]["name"] not in excluded]
+        if len(kept) == len(bank):
+            continue
+        before, after = spread(bank, ee, robust), spread(kept, ee, robust)
+        print(f"  {term:<12} {len(bank):>4} -> {len(kept):<4}  "
+              f"{before:>7.3f} -> {after:<7.3f}")
+
+    print("\n  and what that does to the rule, on the labelled spans")
+    got = veto_arms(clips, marks, veto_cache, robust)
+    if got is None:
+        return
+    print(f"\n  {'term':<12} {'veto B (the rule working)':<28} "
+          f"{'veto A (the rule costing)':<24}")
+    for term, before, after in got:
+        b0, b1 = before["veto"]["B"], after["veto"]["B"]
+        a0, a1 = before["veto"]["A"], after["veto"]["A"]
+        # "abstains", not "-". A zero denominator means the bank fell under the
+        # abstain floor and stopped deciding at all, which is a different thing
+        # from deciding and rejecting nothing.
+        rate = lambda p: f"{p[0]}/{p[1]}" if p[1] else "abstains"
+        print(f"  {term:<12} {rate(b0):>8} -> {rate(b1):<8}          "
+              f"{rate(a0):>6} -> {rate(a1):<6}")
+    print("\n  B is a span where the name was NOT said, so dropping it is the")
+    print("  rule working. A is the name really being said, so dropping it is")
+    print("  the cost. These are rejection counts on 6a's spans, not the")
+    print("  141-clip ablation, and they do not say what the app would write.")
+
+
+def veto_arms(clips, marks, cache, robust):
+    """`ReferenceMatch.verdict`'s own counts, before and after the marks.
+
+    Straight out of `reference-matching.py`: the same spans, the same per-clip
+    hold-out, the same abstain floor. Only the bank changes.
+    """
+    try:
+        exemplars, spans = RM.poison_rows("all")
+        span_census(spans)
+        se, ee = RM.poison_matrices(exemplars, spans, cache)
+    except Exception as error:                       # noqa: BLE001 — reported
+        print(f"\n  the labelled spans are not available here: {error}")
+        print("  they need ~/Recordings/ParrotFlow Dev/ and round 5's cached")
+        print("  proposals, which is harness data and not part of the voice")
+        print("  store. The spread above needs neither.")
+        return None
+    excluded = marked_names(marks)
+    by_term = RM.banks(exemplars)
+    out = []
+    for term in sorted(by_term):
+        bank = by_term[term]
+        kept = [i for i in bank if exemplars[i]["name"] not in excluded]
+        if len(kept) == len(bank):
+            continue
+        before = RM.arm(bank, exemplars, spans, se, ee, term, robust)
+        after = RM.arm(kept, exemplars, spans, se, ee, term, robust)
+        out.append((term, before, after))
+    return out
+
+
+def per_cluster_veto(clips, ee, cache, robust):
+    """6b's third change, and PR 6c's third verification criterion.
+
+    §7 argues the spread must be computed per cluster, because one number over
+    two pronunciations describes neither. That needs 6c's grouping, so it is
+    measured here. The criterion it answers is the sharp one: **a term that
+    keeps all its clips and rejects nothing has failed.** Keeping every clip is
+    what this tool does by default, so the question is whether the term still
+    vetoes — under the per-term spread it has, and under the per-cluster spread
+    6b proposes.
+    """
+    try:
+        exemplars, spans = RM.poison_rows("all")
+    except Exception as error:                       # noqa: BLE001 — reported
+        print(f"\n=== per-cluster spread ===  not available here: {error}")
+        return
+    span_census(spans)
+    se, ee_ref = RM.poison_matrices(exemplars, spans, cache)
+    # The grouping is computed on this script's own clip list, so it has to be
+    # carried across by name. Anything the two disagree about is skipped and
+    # counted rather than guessed at.
+    index = {e["name"]: i for i, e in enumerate(exemplars)}
+    mine = {c["name"]: i for i, c in enumerate(clips)}
+    by_term = RM.banks(exemplars)
+    where = "90th percentile" if robust else "maximum"
+    print(f"\n=== per-cluster spread ===  6b's third change, on 6c's groups.")
+    print(f"  spread is the {where} of the leave-one-out distances, taken over")
+    print("  the whole bank on the left and over the group the span is nearest")
+    print("  on the right. Tolerance 1.0, abstain under 3 usable recordings.")
+    print(f"\n  {'term':<12} {'groups':>6}  {'veto B per-term':>16} "
+          f"{'per-cluster':>12}  {'veto A per-term':>16} {'per-cluster':>12}")
+    totals = [0, 0, 0, 0]
+    for term in sorted(by_term):
+        bank = by_term[term]
+        # Group in this script's index space, then translate to the reference
+        # module's. A name in one and not the other drops the whole term rather
+        # than silently grouping a subset.
+        names = [exemplars[i]["name"] for i in bank]
+        if any(n not in mine for n in names):
+            print(f"  {term:<12} skipped: a recording is not in both banks")
+            continue
+        groups = group([mine[n] for n in names], ee)
+        clusters = [[index[clips[i]["name"]] for i in g] for g in groups]
+        flat = RM.arm(bank, exemplars, spans, se, ee_ref, term, robust)
+        split = cluster_arm(clusters, exemplars, spans, se, ee_ref, term, robust)
+        rate = lambda p: f"{p[0]}/{p[1]}" if p[1] else "abstains"
+        print(f"  {term:<12} {len(clusters):>6}  {rate(flat['veto']['B']):>16} "
+              f"{rate(split['veto']['B']):>12}  {rate(flat['veto']['A']):>16} "
+              f"{rate(split['veto']['A']):>12}")
+        totals = [totals[0] + flat["veto"]["B"][0], totals[1] + split["veto"]["B"][0],
+                  totals[2] + flat["veto"]["A"][0], totals[3] + split["veto"]["A"][0]]
+    print(f"  {'all terms':<12} {'':>6}  {totals[0]:>16} {totals[1]:>12}  "
+          f"{totals[2]:>16} {totals[3]:>12}")
+    print("\n  A term whose per-cluster column is 0 on B keeps every clip and")
+    print("  rejects nothing, which PR 6c calls a failure.")
+
+
+def cluster_arm(clusters, exemplars, spans, se, ee, term, robust,
+                tolerance=1.0, floor=3):
+    """`ReferenceMatch.verdict` with the spread taken inside one cluster.
+
+    The span picks its cluster the same way it picks its recording — the
+    nearest one — and is then compared against that cluster's own width. The
+    per-clip hold-out runs first, so a cluster can lose a member to the span it
+    is judging and fall under the abstain floor, in which case it does not
+    decide and the next-nearest cluster that can decide does.
+    """
+    veto = {"A": [0, 0], "B": [0, 0]}
+    for k, s in enumerate(spans):
+        if s["set"] == "scripted":
+            group_name = "A" if s["stem"] == term else "B"
+        elif s["stem"] == term:
+            group_name = s["group"]
+        else:
+            continue
+        usable = []
+        for c in clusters:
+            keep = [i for i in c if exemplars[i]["from"] != s["wav"]]
+            if len(keep) >= floor:
+                usable.append(keep)
+        if not usable:
+            continue
+        best = min(usable, key=lambda c: min(se[k][i] for i in c))
+        distance = min(se[k][i] for i in best)
+        width = spread_over(best, ee, robust)
+        if not (width > 0):
+            continue
+        veto[group_name][1] += 1
+        if distance > tolerance * width:
+            veto[group_name][0] += 1
+    return {"veto": veto}
+
+
+def span_census(spans):
+    """What the veto arms are actually scoring, said out loud.
+
+    Both span sets come from files outside the voice store — the clip archive
+    and round 5's cached proposals. When one is missing it does not raise: the
+    set silently shrinks and the rejection counts come out lower, which reads
+    as the rule getting worse rather than as the measurement changing. So the
+    count is printed every time and a missing set is named.
+    """
+    kinds = Counter(s["set"] for s in spans)
+    print(f"  scoring {len(spans)} span(s): {kinds['scripted']} from the 48 "
+          f"scripted clips, {kinds['proposals']} from round 5's proposals")
+    for name, where in (("scripted", "~/Recordings/ParrotFlow Dev/"),
+                        ("proposals", "tests/raw-score-separation.json")):
+        if not kinds[name]:
+            print(f"  ⚠ no {name} spans. {where} is missing, so these counts "
+                  "are not comparable with 6a's.")
+
+
+def spread_over(members, ee, robust):
+    loo = [min(ee[i][j] for j in members if j != i) for i in members] \
+        if len(members) > 1 else []
+    if not loo:
+        return float("nan")
+    return RM.quantile(loo, 0.9) if robust else max(loo)
+
+
+# --------------------------------------------------------------- the falsifier
+
+def falsify(clips, ee, donors, seed):
+    """Does this ranking find a clip that is known to be wrong?
+
+    6a's `--poison` arm is what makes a labelled bad clip: take a recording of
+    one term, put it in another term's folder, and it is by construction not
+    that term. Two arms, because they are not the same claim:
+
+        cross-term   every recording of another term, injected into each bank.
+                     A thousand-odd labelled bad clips, and the only accuracy
+                     number this data can produce.
+        known bad    the two clips PR 6c names, injected into the nine folders
+                     that have no known bad clip. 6a's exact arm.
+
+    **Read the cross-term number with its flaw.** A `Claude` clip is short and
+    an `Arexvy` clip is long, so part of what duration catches there is that
+    different names take different times to say. That is a real property of a
+    bad cut — a cut of the wrong word is the wrong length — but it flatters the
+    number, and the known-bad arm is the one with no such help.
+
+    Reported beside it: how often the injected clip lands in a group of its
+    own. That is the geometric signal, and 6a is the reason it is a contrast
+    and not the method.
+    """
+    by_term = defaultdict(list)
+    for i, c in enumerate(clips):
+        by_term[c["term"]].append(i)
+
+    print("\n=== the falsifier ===  labelled bad clips, from 6a's --poison")
+    print("  A method that finds these at chance is falsified. Chance is the")
+    print("  share of genuine clips the same rule flags, printed beside it.")
+
+    # The base rate for the geometric contrast: how often a *genuine* clip is
+    # alone in its group with nothing injected. Without it "44% land alone"
+    # is a number with no scale.
+    alone_base = sum(1 for term in by_term
+                     for g in group(by_term[term], ee) if len(g) == 1)
+    print(f"\n  base rates on the untouched archive: {alone_base} of "
+          f"{len(clips)} genuine clips "
+          f"({alone_base / len(clips) * 100:.1f}%) are alone in their group")
+    named = {"Vercel/09-brazil.wav", "Tasmeen/06-that'smeanssend.wav"}
+    for name in sorted(named):
+        home = name.split("/")[0]
+        if home not in by_term:
+            continue
+        index = {clips[i]["name"]: i for i in by_term[home]}
+        if name not in index:
+            continue
+        mine = next(g for g in group(by_term[home], ee) if index[name] in g)
+        print(f"  in its own folder {name} sits in a group of {len(mine)}")
+    print("  — which is 6a's finding through a different statistic: a bad clip")
+    print("  with company is invisible to any per-clip geometry.")
+
+    for label, pairs in (("cross-term", cross_term(by_term, donors, seed)),
+                         ("known bad", known_bad(clips, by_term))):
+        rows = []
+        for term, donor in pairs:
+            bank = by_term[term] + [donor]
+            scores, median, _ = score_bank(bank, clips)
+            groups = group(bank, ee)
+            home = next(g for g in groups if donor in g)
+            rows.append({
+                "term": term,
+                "donor": clips[donor]["name"],
+                "risk": scores[donor]["duration"],
+                "flagged": scores[donor]["duration"] >= EDGE,
+                "genuine": [scores[i]["duration"] for i in by_term[term]],
+                "genuine_flagged": sum(1 for i in by_term[term]
+                                       if scores[i]["duration"] >= EDGE),
+                "genuine_n": len(by_term[term]),
+                "alone": len(home) == 1,
+                "rank": rank_of(donor, bank, scores),
+            })
+        if not rows:
+            print(f"\n  {label}: no injections available")
+            continue
+        flagged = sum(1 for r in rows if r["flagged"]) / len(rows) * 100
+        base = (sum(r["genuine_flagged"] for r in rows)
+                / sum(r["genuine_n"] for r in rows) * 100)
+        value = RM.auc([r["risk"] for r in rows],
+                       [d for r in rows for d in r["genuine"]])
+        alone = sum(1 for r in rows if r["alone"]) / len(rows) * 100
+        median_rank = statistics.median(r["rank"] for r in rows)
+        print(f"\n  {label}: {len(rows)} injections over "
+              f"{len({r['term'] for r in rows})} terms")
+        print(f"    flagged by duration        {flagged:5.1f}%")
+        print(f"    the same rule on genuine   {base:5.1f}%   <- chance")
+        print(f"    AUC(bad vs genuine)        {value:.3f}   0.500 is chance")
+        print(f"    median rank in the review  {median_rank:.2f}   "
+              "0.00 is first, 1.00 is last, 0.50 is chance")
+        print(f"    lands in a group of one    {alone:5.1f}%   <- the geometric")
+        print("                                       signal, for contrast only")
+        if label == "known bad":
+            for r in sorted(rows, key=lambda r: r["rank"]):
+                print(f"      {r['donor']:<32} into {r['term']:<10} "
+                      f"risk {r['risk']:.2f}  rank {r['rank']:.2f}"
+                      f"{'  flagged' if r['flagged'] else ''}")
+
+
+def rank_of(donor, bank, scores):
+    """Where the donor sits in the review order, 0 first and 1 last.
+
+    Ties share the middle of the block they are in, so a clip that is
+    indistinguishable from four others does not get credit for being first.
+    """
+    risk = lambda i: (scores[i]["duration"]
+                      if scores[i]["duration"] == scores[i]["duration"] else -1.0)
+    mine = risk(donor)
+    above = sum(1 for i in bank if risk(i) > mine)
+    tied = sum(1 for i in bank if risk(i) == mine)
+    middle = above + (tied - 1) / 2.0
+    return middle / max(1, len(bank) - 1)
+
+
+def cross_term(by_term, donors, seed):
+    """Every recording of another term, injected into each bank."""
+    rng = random.Random(seed)
+    pairs = []
+    for term in sorted(by_term):
+        pool = [i for other, bank in by_term.items() if other != term
+                for i in bank]
+        if donors and donors < len(pool):
+            pool = rng.sample(pool, donors)
+        pairs += [(term, i) for i in sorted(pool)]
+    return pairs
+
+
+def known_bad(clips, by_term):
+    """PR 6c's two clips, into the nine folders that have no known bad one."""
+    named = ["Vercel/09-brazil.wav", "Tasmeen/06-that'smeanssend.wav"]
+    index = {c["name"]: i for i, c in enumerate(clips)}
+    pairs = []
+    for name in named:
+        if name not in index:
+            continue
+        home = name.split("/")[0]
+        for term in sorted(by_term):
+            if term != home:
+                pairs.append((term, index[name]))
+    return pairs
+
+
+# ---------------------------------------------------------------------- the CLI
+
+def resolve(clips, ee, marks, spec):
+    """`Term/g2` to the clips that group holds, in the current grouping."""
+    if "/" not in spec:
+        return None, f"{spec!r} is not <Term>/<group>, e.g. Vercel/g4"
+    term, label = spec.split("/", 1)
+    excluded = marked_names(marks)
+    bank = [i for i, c in enumerate(clips)
+            if c["term"] == term and c["name"] not in excluded]
+    if not bank:
+        known = sorted({c["term"] for c in clips})
+        return None, f"no unmarked clips for {term!r}. Terms: {', '.join(known)}"
+    groups = group(bank, ee)
+    labels = {f"g{n + 1}": g for n, g in enumerate(groups)}
+    if label not in labels:
+        return None, (f"{term} has {len(groups)} group(s): "
+                      f"{', '.join(sorted(labels))}")
+    return [clips[i]["name"] for i in labels[label]], None
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Review a term's recordings by ear, in groups. PR 6c.")
+    ap.add_argument("--term", action="append",
+                    help="only this term; repeatable. Default is every term")
+    ap.add_argument("--marks", default="clip-review-marks.json",
+                    help="where groups marked not-counted are recorded. This "
+                         "file, and never the voice store")
+    ap.add_argument("--mark", help="mark <Term>/<group> not counted")
+    ap.add_argument("--unmark",
+                    help="take a mark back, by the id --mark printed "
+                         "or by any clip name the mark covers")
+    ap.add_argument("--why", default="", help="a note to store with a --mark")
+    ap.add_argument("--concat", metavar="DIR",
+                    help="write one wav per group here, so a group is one "
+                         "keystroke. Never the archive")
+    ap.add_argument("--cache", default=None,
+                    help="npz for the recording-to-recording distances")
+    ap.add_argument("--veto-cache", default=None,
+                    help="npz for reference-matching.py's span distances, "
+                         "used by --veto and --clusters")
+    ap.add_argument("--veto", action="store_true",
+                    help="what the marks do to ReferenceMatch.verdict's own "
+                         "rejection counts")
+    ap.add_argument("--clusters", action="store_true",
+                    help="6b's per-cluster spread on 6c's groups, and PR 6c's "
+                         "third verification criterion")
+    ap.add_argument("--falsify", action="store_true",
+                    help="the accuracy number: inject labelled bad clips and "
+                         "measure whether the ranking finds them")
+    ap.add_argument("--donors", type=int, default=0,
+                    help="--falsify: cap the donors per term. 0 is all of them")
+    ap.add_argument("--seed", default="6c-2026-08-10",
+                    help="--falsify: the sampling seed, when --donors caps")
+    ap.add_argument("--robust", action="store_true",
+                    help="6b's statistic: the 90th percentile of the "
+                         "leave-one-out distances instead of the maximum")
+    args = ap.parse_args()
+
+    clips = load_clips()
+    if not clips:
+        return 2
+    ee = distances(clips, args.cache)
+    marks = load_marks(args.marks)
+
+    if args.unmark:
+        # Resolved against the marks file, never against a fresh grouping.
+        # Marking takes clips out of the bank, so the bank regroups and the
+        # `g3` that exists after a mark is not the `g3` that was marked.
+        # Matching what was recorded is the only reading that means what the
+        # user typed. A clip name works too, for a mark whose label has since
+        # been reused.
+        keep = [m for m in marks if args.unmark != m.get("id")
+                and args.unmark not in m.get("clips", [])]
+        if len(keep) == len(marks):
+            print(f"✗ nothing marked as {args.unmark!r}.", file=sys.stderr)
+            print(f"  marked: {', '.join(m.get('id', '?') for m in marks) or 'nothing'}",
+                  file=sys.stderr)
+            return 2
+        gone = sum(len(m.get("clips", [])) for m in marks if m not in keep)
+        marks = keep
+        save_marks(args.marks, marks)
+        print(f"unmarked {gone} clip(s); they count again")
+        effect(clips, ee, marks, sorted({c["term"] for c in clips}),
+               args.veto_cache, args.robust)
+        return 0
+
+    if args.mark:
+        spec = args.mark
+        names, error = resolve(clips, ee, marks, spec)
+        if error:
+            print(f"✗ {error}", file=sys.stderr)
+            return 2
+        # A label is a position in the current grouping, and the grouping moves
+        # every time something is marked. So the same label can name two
+        # different groups over a session; the id keeps them apart, and it is
+        # what `--unmark` takes.
+        taken = {m.get("id") for m in marks}
+        mark_id = spec
+        n = 1
+        while mark_id in taken:
+            n += 1
+            mark_id = f"{spec}#{n}"
+        marks.append({"id": mark_id, "group": spec, "clips": sorted(names),
+                      "why": args.why,
+                      "at": datetime.datetime.now().isoformat(timespec="seconds")})
+        print(f"marked {len(names)} clip(s) not counted, in {args.marks}")
+        print(f"undo with: scripts/clip-review.py --unmark {mark_id}")
+        term = spec.split("/")[0]
+        left = sum(1 for c in clips if c["term"] == term
+                   and c["name"] not in marked_names(marks))
+        if left < FLOOR:
+            # 6e measured this: under five recordings a bank throws away over
+            # half the term's own correct spans too often to be allowed to
+            # decide. Marking is the fastest way to walk a bank off that edge,
+            # so say it at the moment it happens rather than in a table later.
+            print(f"⚠ {term} is down to {left} counted clip(s). 6e puts the "
+                  f"abstain floor at {FLOOR}, so this term will stop deciding.")
+        save_marks(args.marks, marks)
+        print("Nothing was deleted. The wavs are where they were.")
+        print(f"In production this file is `voice/excluded.json` beside "
+              f"`observations.jsonl`, read by whatever builds a bank.")
+        effect(clips, ee, marks, sorted({c["term"] for c in clips}),
+               args.veto_cache, args.robust)
+        return 0
+
+    terms = sorted({c["term"] for c in clips})
+    if args.term:
+        wanted = set(args.term)
+        missing = wanted - set(terms)
+        if missing:
+            print(f"✗ no clips for {', '.join(sorted(missing))}. "
+                  f"Terms: {', '.join(terms)}", file=sys.stderr)
+            return 2
+        terms = [t for t in terms if t in wanted]
+
+    if args.falsify:
+        falsify(clips, ee, args.donors, args.seed)
+        return 0
+    if args.clusters:
+        per_cluster_veto(clips, ee, args.veto_cache, args.robust)
+        return 0
+
+    report(clips, ee, terms, marks, args.concat, args.robust)
+    if marks or args.veto:
+        effect(clips, ee, marks, terms, args.veto_cache, args.robust)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
PR 6c of the plan needed a tool to review a term's stored recordings for bad clips, but the standard approach — rank each clip by how far it sits from its neighbors — had never been tested against a labelled case.
This PR builds `clip-review.py`, which groups a term's recordings and lets a person mark a whole group excluded by ear (never deleted) rather than judging individual clips.
The falsifier fired: the per-clip distance ranking scores AUC 0.526 on 1,220 injected bad clips, no better than chance, because the archive has no labelled bad *cut* — only bad *words* — and lacks the provenance signal the ranking needs; the tool is still worth having, since review burden stays low (86.4 seconds of audio across 33 groups).

## Issue
Part of #74. PR 6c of the plan (#83). Targets #87 (`test/abstain-curve`), which carries PR 6e. Do not merge as-is.

## The headline: the falsifier fired, and the tool is still worth having

Over 1,220 injected bad clips, the per-clip ranking scores AUC **0.526** — chance. Two reasons: **all 122 recordings in the archive carry `from: mined`**, so the strongest available signal (was this clip confirmed by a person) doesn't exist yet — that's what #81 (PR 4) starts writing. And **injecting a recording of another term makes a bad *word*, not a bad *cut*** — duration-based detection targets bad cuts, and there's no labelled bad cut in the archive to test against.

**Review burden is not chance**, though: 33 groups across 11 terms and 122 recordings, 86.4 seconds of audio total. The plan's second falsifier — too many groups for anyone to finish — does not fire.

## The three verification criteria

1. Surfaced correctly for both named clips from #82.
2. Cannot be checked — a bilingual term needs recordings that don't exist yet; no arm was faked or synthesized to fill the gap.
3. Checkable, and passes: every term keeps every clip, and every term still rejects correctly on its own bank.

## Measured on the way

**#82's finding shows up again through a different statistic**: an injected foreign clip lands alone in its own group 44.4% of the time versus 4.1% for a genuine clip — but both clips the plan names as bad sit in groups of 6, invisible to per-clip geometry.

**A per-cluster spread variant was tried and made things worse**: true rejections move 554 → 716 but false ones move 10 → 39 — a shift toward the blind veto, not an improvement.

## Two bugs found while testing this tool

- Unmarking a group by label silently did nothing, because marking a group changes the grouping the label refers to.
- Without the clip archive present, the veto arm silently scored a smaller span set and printed a misleadingly lower number; it now reports the span count and names what's missing.

## Review history

Five review rounds found and fixed four real bugs in how marks are saved to disk — a malformed marks file that silently erased every prior decision, malformed entries not caught by validation, a non-atomic write that could lose the whole file on a crash, and a missing directory fsync that could lose the last write after a power cut. All four are fixed; the fifth round found nothing. Every measured number (AUC 0.526/0.629, 33 groups, 554→716/10→39) is unchanged across all five fix commits.

<details>
<summary><b>How to Test</b></summary>

```sh
python3 scripts/clip-review.py --cache /tmp/clips.npz --concat /tmp/groups
python3 scripts/clip-review.py --mark Vercel/g3 --why "two words, not the name"
python3 scripts/clip-review.py --falsify
```

Nothing under the live config or voice store is written by this tool; marks go to a file named by `--marks` (in production, `voice/excluded.json`). `scripts/check-no-voice.sh` passes 5/5. Per-term spreads reproduce #82's table to three decimals, confirming the imported distance code is unchanged.

</details>
