### PR TITLE
test: the judge does not beat its own absence

### DIFF
--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -788,9 +788,24 @@ struct Pipeline: Equatable, Codable {
             // this one did. A stage handed only the finished sentence cannot
             // tell which words were rewritten, and guessing is how a judge
             // starts reverting things nobody changed.
+            //
+            // `before` is the sentence this stage was handed. `changes` says
+            // which rules fired and not *where*, so the judge needs the earlier
+            // text to tell one occurrence of a term from another. It used to
+            // take that from the acoustic pass, which does not run under
+            // `vocabulary.acoustic: false` — a path that has audio and no
+            // earlier text. This stage always has it.
+            //
+            // Two `replacements` steps in one pipeline publish this twice and
+            // the second wins, exactly as `changes` already does. That is safe
+            // because the two move together: a reader gets the last step's
+            // changes beside the last step's input, which is the pair it needs.
+            // What it does not get is the first step's changes, and that was
+            // already true before this line existed.
             return StageResult(text: done.text, vars: [
                 "count": .int(done.count),
                 "changes": .string(done.changes),
+                "before": .string(text),
             ])
         case .fuzzy:
             // From the rules, not from the table's keys. Fuzzy matching
@@ -912,12 +927,23 @@ struct Pipeline: Equatable, Codable {
         // Both sources. The acoustic pass proposes with positions; a
         // `replacements` rule publishes none, so its substitutions are found by
         // searching for the term and told apart from the terms the decoder
-        // already had by comparing against the text the pass returned.
+        // already had by comparing against the text that stage was handed.
+        //
+        // From `replacements` and not from the acoustic pass, because the pass
+        // may not have run. `Vocabulary.wanted` gates it on
+        // `vocabulary.acoustic`, so with that off `findings` is nil and a term
+        // standing twice could not be attributed at all. The two texts are the
+        // same string whenever both exist — no stage that edits text may sit
+        // above `vocabulary` except `replacements` itself — so this changes
+        // nothing on the path where the pass does run. `findings?.text` stays
+        // as the fallback for a pipeline with no `replacements` step in it.
         var rules = ""
+        var beforeRules: String?
         if case .string(let wrote)? = scope["replacements.changes"] { rules = wrote }
+        if case .string(let handed)? = scope["replacements.before"] { beforeRules = handed }
         let parts = VocabularyJudge.acousticParts(
             findings?.proposals ?? [], in: text, measuredOn: findings?.text ?? text
-        ) + VocabularyJudge.ruleParts(rules, in: text, before: findings?.text)
+        ) + VocabularyJudge.ruleParts(rules, in: text, before: beforeRules ?? findings?.text)
 
         let slots = VocabularyJudge.slots(in: text, from: parts, caps: caps)
         // Two numbers on every run, not only when the count is fatal.

--- a/Sources/ParrotFlow/VocabularyJudge.swift
+++ b/Sources/ParrotFlow/VocabularyJudge.swift
@@ -279,16 +279,19 @@ enum VocabularyJudge {
     /// "deployed on Versailles" as the decoder's own reading, which it never
     /// was.
     ///
-    /// `before` is the transcript as the acoustic pass returned it, which is
-    /// what `replacements` was handed, and it says which occurrence is which.
-    /// A rule rewrites in place and reorders nothing, so the terms standing in
-    /// the text now are, in order, the occurrences of `heard` and of `term` in
-    /// `before` — and only the first kind is a substitution to offer back. See
-    /// `rewritten(_:_:in:became:)`.
+    /// `before` is the transcript `replacements` was handed, and it says which
+    /// occurrence is which. A rule rewrites in place and reorders nothing, so
+    /// the terms standing in the text now are, in order, the occurrences of
+    /// `heard` and of `term` in `before` — and only the first kind is a
+    /// substitution to offer back. See `rewritten(_:_:in:became:)`.
     ///
     /// When the two do not line up, some other rule wrote the term as well and
     /// nothing here can say which occurrence came from where. Then none of them
-    /// are offered, and the log says so.
+    /// are offered, and the log says so. That is the common case for two
+    /// renderings of one term in one sentence — `Versal` and `Versailles` both
+    /// becoming `Vercel` — because each pair is counted on its own and each
+    /// accounts for one of the two terms standing. A `before` does not decide
+    /// that shape; only reading the pairs per term would.
     ///
     /// A rule whose source is a pattern is skipped. `/(\w+) dot (\w+)/` names
     /// no spelling to offer back, and putting the pattern on a menu would ask
@@ -305,8 +308,12 @@ enum VocabularyJudge {
             else { continue }
             let stands = Vocabulary.spans(of: term, in: text, ignoringCase: true)
             guard let before else {
-                // No acoustic pass ran, so there is no earlier text to compare
-                // against — `--pipeline`, `--replace`, any path with no audio.
+                // No earlier text to compare against. `replacements` publishes
+                // it whenever that stage ran, so this is now only a pipeline
+                // with a `vocabulary:` stage and no `replacements` above it —
+                // where a rule pair can still arrive from a scope seeded
+                // elsewhere. It used to be every path with no audio, and that
+                // cost the judge a reading under `vocabulary.acoustic: false`.
                 // One occurrence is still decidable without it: the rule is in
                 // `changes`, so it fired at least once, and a pre-existing term
                 // would be a second occurrence. More than one and nothing here

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -676,9 +676,13 @@ They are **derived, never claimed**. A stage cannot forget to report `changed`,
 and cannot report it about the wrong string.
 
 Stages add their own on top. The built-in ones publish `replacements.count`,
-`numbers.language` — which grammar actually read the numbers, and not the same
-answer as the pipeline's language — and, for a prompt stage, `model`. A
-`command:` transform publishes whatever it likes; see
+`replacements.changes` and `replacements.before` — how many rules fired, which
+ones, and the sentence the stage was handed — `numbers.language`, which grammar
+actually read the numbers and is not the same answer as the pipeline's
+language, and, for a prompt stage, `model`. The name judge reads all three of
+the `replacements` ones: `changes` says which rules fired and `before` says
+*where*, because the rules leave no positions behind. A `command:` transform
+publishes whatever it likes; see
 [docs/authoring.md](authoring.md#recipe-a-program-that-reports-what-it-did).
 
 Before any stage runs, the scope already holds `text`, `app`, `bundle_id`,

--- a/scripts/vocab-ablation.py
+++ b/scripts/vocab-ablation.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Replay the labelled clips through any number of arms and count the damage.
+
+    scripts/vocab-ablation.py --arm off=DIR --arm today=DIR [--runs 3] [--out FILE]
+
+An arm is a config directory, plus any environment variables that arm needs:
+
+    name=CONFIG_DIR[,VAR=VALUE...]
+
+Every pair of arms is reported against every other, wins and losses apart,
+split by class, as the majority of `--runs N` replays with a flip count. Give
+it two arms and it answers "does the vocabulary pass pay for itself"; give it
+five and it answers "which of these five is best", which is the question the
+reference-matching prototype asked.
+
+Three counts, fixed before the run:
+
+    correct   clips whose majority transcript matches the hand label
+    wins      B right where A is wrong
+    losses    A right where B is wrong
+
+**Read wins and losses together, and read the correct count beside them.** A
+filter that removes as many wins as losses has switched the feature off, and
+the net alone hides that. An arm that vetoes everything looks excellent on net.
+Put the arm that does nothing first, so every pair is reported against it.
+
+## Switching the pass off honestly — three different off arms
+
+They are not the same measurement. Know which one you want.
+
+    no vocabulary at all       empty `terms:` in a scratch `vocabulary.yaml`.
+                               No acoustic context, no rules,
+                               `vocabulary.count == 0`, so the judge stage's
+                               `when:` skips it too.
+    the acoustic path off,     `acoustic: false` in `vocabulary.yaml`, with
+    the rules kept             every term and every `heard:` list left in place.
+    a third of the pass off    `--transcribe --no-vocab`, which is almost never
+                               what you meant.
+
+`--no-vocab` sets `config.vocabulary.acoustic = false` and nothing else
+(`TranscribeCommand.swift`). The `heard:`/`pronunciations:` lists still become
+`Config.vocabularyRules`, those rules still write names in `replacements`, and
+they still raise `vocabulary.count`, so the `vocabulary:` judge stage still
+fires. This harness never passes it; arms differ by config directory instead.
+
+## The scratch config recipe
+
+Never run against `~/.config/parrotflow-dev`. Copy it once per arm:
+
+    S=/tmp/ablation
+    for d in cfg-on cfg-off; do
+      mkdir -p $S/$d
+      cp ~/.config/parrotflow-dev/{config.yaml,vocabulary.yaml,verify_names.md} $S/$d/
+      cp -R ~/.config/parrotflow-dev/transforms $S/$d/
+      printf '\\naudio:\\n  output_dir: %s\\n' "$S/audio" >> $S/$d/config.yaml
+    done
+
+The `audio.output_dir` line is not optional. Without it a 2000-clip run appends
+2000 entries to the speaker's own `trace.jsonl` and writes 2000 wavs beside
+their real dictations. Anything that reads `voice/samples/<Term>/` — the
+reference-matching arms do — needs `voice/` copied in as well. None of it is
+committable: `scripts/check-no-voice.sh` refuses a repository carrying any of
+it.
+
+Then edit each copy to be the arm it is named after. This harness runs
+`--check-config` under every arm before the first clip, so a directory the app
+would refuse costs a second rather than the whole run.
+
+## Noise
+
+Replay is nondeterministic (F12a): the same clip replayed ten times gives term
+scores spread over 5 nats on a long clip. So `--runs N` replays each clip N
+times per arm and keeps the per-clip majority, and a clip that did not agree
+with itself is counted as a flip. **The flip count is what says whether a small
+difference means anything.** A single-run number within two cases of the one it
+is compared with decides nothing.
+
+## The split
+
+Read off the case file, not guessed from the text. Every clip carries a
+`# picked up:` line saying how it entered the set, and the 73 controls say so
+in words: "No vocabulary term, a control". A single total hides a control
+moving wrong while a term clip moves right, so the totals are always split.
+
+## Re-running part of a set
+
+`--limit N` takes the first N clips, which is for smoke tests. `--only FILE`
+takes a list of wav names, one per line, `#` comments allowed — that is how you
+re-run just the clips two arms disagreed on without paying for the whole set
+again.
+
+Ported from `scripts/vocab-ablation.py` on
+`origin/experiment/does-vocabulary-pay` and `scripts/reference-ablation.py` on
+`origin/proto/reference-matching`, which were the same harness with two arms
+and with N. `scripts/vocab-losses.py` reads the `--out` JSON this writes and
+prints the losing clips one by one.
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from importlib.machinery import SourceFileLoader
+
+ROOT = Path(__file__).resolve().parent.parent
+recall = SourceFileLoader("recall", str(ROOT / "scripts/menu-recall.py")).load_module()
+
+
+def classes():
+    """{wav: is_control}, read off the `# picked up:` line of each entry.
+
+    The class is in the case file because it was decided when the clip entered
+    the set. Guessing it from the text — "does a term appear?" — would put a
+    clip the pass wrongly wrote a name into on the wrong side of the split,
+    which is exactly the clip the split exists to find.
+    """
+    out, wav = {}, None
+    for line in recall.CASES.read_text().splitlines():
+        s = line.strip()
+        if s.startswith("- wav:"):
+            wav = s.split(":", 1)[1].strip()
+            out[wav] = False
+        elif wav and s.startswith("# picked up:"):
+            out[wav] = "a control" in s
+    return out
+
+
+def cases_with_class(only=None):
+    """(wav, said, is_term) for every labelled clip, in file order."""
+    control = classes()
+    cases = [(wav, said, not control.get(wav, False))
+             for wav, said in recall.load_cases() if said]
+    if only is None:
+        return cases
+    missing = only - {wav for wav, _, _ in cases}
+    if missing:
+        raise SystemExit(f"✗ not a labelled clip in {recall.CASES.name}: "
+                         + ", ".join(sorted(missing)))
+    return [c for c in cases if c[0] in only]
+
+
+def read_only(path):
+    """The wav names in a `--only` file: one per line, `#` comments allowed."""
+    names = set()
+    for line in Path(path).read_text().splitlines():
+        s = line.split("#")[0].strip()
+        if s:
+            # The first field, so a line copied out of a progress log works.
+            names.add(s.split()[0])
+    if not names:
+        raise SystemExit(f"✗ {path} names no clips")
+    return names
+
+
+def parse_arm(spec):
+    if "=" not in spec:
+        raise SystemExit(f"✗ --arm {spec}: expected name=CONFIG_DIR[,VAR=VALUE]")
+    name, rest = spec.split("=", 1)
+    parts = rest.split(",")
+    env = {}
+    for extra in parts[1:]:
+        if "=" not in extra:
+            raise SystemExit(f"✗ --arm {spec}: `{extra}` is not VAR=VALUE")
+        key, value = extra.split("=", 1)
+        env[key] = value
+    if not Path(parts[0]).is_dir():
+        raise SystemExit(f"✗ --arm {name}: {parts[0]} is not a directory")
+    return {"name": name, "dir": parts[0], "env": env}
+
+
+def environment_for(arm, dump):
+    environment = dict(os.environ)
+    environment["PARROTFLOW_CONFIG_DIR"] = arm["dir"]
+    environment.update(arm["env"])
+    # Not read here. It is set so the judge's menu lands in scratch rather than
+    # wherever an inherited PARROTFLOW_JUDGE_DUMP points.
+    environment["PARROTFLOW_JUDGE_DUMP"] = str(dump)
+    return environment
+
+
+def check_config(arm, dump):
+    """`--check-config` under this arm, before the first clip of a long run.
+
+    A config the app refuses fails at the first clip anyway. Failing here costs
+    a second; failing there costs however long the run had left. The vocabulary
+    lines are printed because they are how you tell the arms apart — an arm
+    named `off` whose directory was never edited says so here and nowhere else.
+    """
+    done = subprocess.run(
+        [recall.APP, "--check-config"], capture_output=True, text=True,
+        env=environment_for(arm, dump), timeout=120,
+    )
+    said = [line.strip() for line in (done.stdout + done.stderr).splitlines()
+            if "vocabulary:" in line]
+    print(f"  {arm['name']:<12} {arm['dir']}")
+    for line in said or ["(no vocabulary line — no terms in this arm)"]:
+        print(f"    {line}")
+    if done.returncode != 0:
+        print(f"✗ arm {arm['name']}: --check-config refused {arm['dir']}")
+        print((done.stdout + done.stderr).strip())
+        return False
+    return True
+
+
+def transcribe(wav, arm, dump):
+    """One clip through the app under one arm. Returns the final transcript.
+
+    A replay that did not happen is not a wrong answer, and the difference has
+    to be kept. The app exits 0 and prints a transcript block whenever it ran;
+    a non-zero exit, or no block at all, means there is no measurement for this
+    clip. Scoring that as "the arm got it wrong" would move a real count by a
+    real clip for a reason that has nothing to do with the arm, and nothing in
+    the report would say so — which is how a harness lies quietly. So it stops.
+    `--out` is written every clip, so an abort at clip 90 of 141 still leaves
+    90 clips of evidence behind.
+
+    A clip that decodes to nothing is a different thing and is a measurement:
+    the app prints its block with `(empty)` in it, which no label matches, so
+    the clip counts wrong under that arm. That is the answer, not a failure.
+    """
+    done = subprocess.run(
+        [recall.APP, "--transcribe", str(recall.CLIPS / wav)],
+        capture_output=True, text=True, env=environment_for(arm, dump),
+        timeout=600,
+    )
+    lines = (done.stdout + done.stderr).splitlines()
+    final = None
+    for i, line in enumerate(lines):
+        if "transcript" in line and "─" in line and i + 1 < len(lines):
+            final = lines[i + 1].strip()
+    if done.returncode != 0 or final is None:
+        why = (f"exit {done.returncode}" if done.returncode
+               else "no transcript in its output")
+        raise SystemExit(f"✗ arm {arm['name']} on {wav}: the app gave {why}\n"
+                         + (done.stdout + done.stderr).strip())
+    return final
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--arm", action="append", required=True,
+                    help="name=CONFIG_DIR[,VAR=VALUE...]; put the arm that "
+                         "does nothing first")
+    ap.add_argument("--runs", type=int, default=3,
+                    help="replays per clip per arm; the majority decides (F12a)")
+    ap.add_argument("--limit", type=int, default=0,
+                    help="the first N clips — for a smoke test, not a number")
+    ap.add_argument("--only", default="",
+                    help="a file of wav names to re-run, one per line")
+    ap.add_argument("--out", default="", help="write per-clip JSON here")
+    args = ap.parse_args()
+
+    if args.runs < 1:
+        print("✗ --runs must be at least 1")
+        return 2
+    if not Path(recall.APP).exists():
+        print(f"✗ {recall.APP} not found — run `make app` first")
+        return 2
+
+    arms = [parse_arm(spec) for spec in args.arm]
+    if len({a["name"] for a in arms}) != len(arms):
+        print("✗ two arms share a name — the report could not tell them apart")
+        return 2
+    cases = cases_with_class(read_only(args.only) if args.only else None)
+    if args.limit:
+        cases = cases[:args.limit]
+    if not cases:
+        print("✗ no labelled clips selected")
+        return 2
+
+    dump = Path(tempfile.mkdtemp()) / "menu.txt"
+    print(f"{len(arms)} arm(s), {len(cases)} clip(s), {args.runs} run(s) each:")
+    # Every arm, not the first bad one: a run is about to cost 25 minutes, so
+    # the operator should learn about both broken directories at once.
+    if not all([check_config(arm, dump) for arm in arms]):
+        return 2
+
+    rows = []
+    started = time.time()
+    for n, (wav, said, is_term) in enumerate(cases, 1):
+        truth = recall.normalise(said)
+        row = {"wav": wav, "said": said, "term": is_term, "runs": {}}
+        for arm in arms:
+            texts = [transcribe(wav, arm, dump) for _ in range(args.runs)]
+            ok, moved = recall.majority(
+                [recall.normalise(t) == truth for t in texts])
+            row["runs"][arm["name"]] = {"texts": texts, "ok": ok, "flipped": moved}
+        rows.append(row)
+        marks = " ".join(
+            f"{a['name']}={'ok' if row['runs'][a['name']]['ok'] else '--'}"
+            for a in arms)
+        rate = (time.time() - started) / n
+        print(f"  {n:>3}/{len(cases)}  {marks}  {wav}"
+              f"  [{rate:.1f}s/clip, {(len(cases) - n) * rate / 60:.0f} min left]",
+              file=sys.stderr, flush=True)
+        # Written every clip, not at the end: a run interrupted at clip 90 of
+        # 141 still has 90 clips of evidence, and this is a 25-minute run.
+        if args.out:
+            Path(args.out).write_text(json.dumps(rows, indent=1))
+
+    report(rows, [a["name"] for a in arms], args.runs)
+    return 0
+
+
+def report(rows, names, runs):
+    def block(label, subset):
+        print(f"\n{label}  ({len(subset)} clips)")
+        print(f"  {'arm':<12} {'correct':>8} {'flips':>7}")
+        for name in names:
+            correct = sum(1 for r in subset if r["runs"][name]["ok"])
+            flips = sum(1 for r in subset if r["runs"][name]["flipped"])
+            print(f"  {name:<12} {correct:>8} {flips:>7}")
+        if len(names) < 2:
+            return
+        print(f"\n  {'A -> B':<26} {'wins':>6} {'losses':>7} {'net':>6}")
+        for i, a in enumerate(names):
+            for b in names[i + 1:]:
+                wins = sum(1 for r in subset
+                           if r["runs"][b]["ok"] and not r["runs"][a]["ok"])
+                losses = sum(1 for r in subset
+                             if r["runs"][a]["ok"] and not r["runs"][b]["ok"])
+                print(f"  {a + ' -> ' + b:<26} {wins:>6} {losses:>7} "
+                      f"{wins - losses:>+6}")
+
+    block("ALL", rows)
+    block("about a term", [r for r in rows if r["term"]])
+    block("controls", [r for r in rows if not r["term"]])
+
+    print(f"\n  correct is out of the clips in that block, majority of {runs} "
+          "run(s) per clip.")
+    print("  wins and losses are B against A. Read them beside the correct "
+          "count and beside")
+    print(f"  {names[0]}, the first arm — an arm that removes everything wins "
+          "on net.")
+    if runs == 1:
+        print("  one run per clip — these numbers carry replay noise (F12a);"
+              " use --runs 3 before quoting them")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/vocab-losses.py
+++ b/scripts/vocab-losses.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""The clips the vocabulary pass took away, written out one by one.
+
+    scripts/vocab-losses.py <ablation.json> --vocabulary FILE \\
+        [--off off] [--on today] [--out tests/vocabulary-losses.txt]
+
+Reads what `scripts/vocab-ablation.py --out` wrote and prints every loss — a
+clip the app got right under the `--off` arm and wrong under the `--on` arm —
+with the hand label, both transcripts, and which terms were written in.
+
+A total says how many clips an arm cost. It does not say what the arm did to
+them, and the remedy depends on that. So each loss is also classed.
+**Overwrite** means a vocabulary term stands in the `--on` transcript that is
+not in what the speaker said: the pass wrote a name over an ordinary word.
+Anything else is **other**, and other is worth reading twice — it is the class
+where the pass broke a clip without writing a term into it, which no floor and
+no judge prompt can reach.
+
+Ported from `origin/experiment/does-vocabulary-pay`, where the harness had one
+pair of arms and this script knew their names. It now takes them, because
+`vocab-ablation.py` runs any number.
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from importlib.machinery import SourceFileLoader
+
+ROOT = Path(__file__).resolve().parent.parent
+recall = SourceFileLoader("recall", str(ROOT / "scripts/menu-recall.py")).load_module()
+
+
+def terms_of(vocabulary_yaml):
+    """The term names, read off the `terms:` block by indentation."""
+    names, inside = [], False
+    for line in Path(vocabulary_yaml).read_text().splitlines():
+        if line.startswith("terms:"):
+            inside = True
+            continue
+        if inside:
+            m = re.match(r"  (\w[\w.'-]*):\s*$", line)
+            if m:
+                names.append(m.group(1))
+            elif line and not line.startswith(" "):
+                break
+    return names
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("rows", help="the JSON `vocab-ablation.py --out` wrote")
+    ap.add_argument("--vocabulary", required=True,
+                    help="the vocabulary.yaml the `--on` arm ran with")
+    ap.add_argument("--off", default="off", help="the arm that is the baseline")
+    ap.add_argument("--on", default="today", help="the arm being scored")
+    ap.add_argument("--out", default="")
+    args = ap.parse_args()
+
+    rows = json.loads(Path(args.rows).read_text())
+    if not rows:
+        print(f"✗ {args.rows} has no clips in it")
+        return 2
+    for arm in (args.off, args.on):
+        if arm not in rows[0]["runs"]:
+            print(f"✗ no arm named {arm} in {args.rows} — it has "
+                  + ", ".join(rows[0]["runs"]))
+            return 2
+    names = terms_of(args.vocabulary)
+
+    def wrote_a_term(row, text):
+        """Terms in the transcript that are not in what the speaker said."""
+        said = recall.normalise(row["said"])
+        got = recall.normalise(text)
+        return [n for n in names
+                if re.search(rf"\b{n.lower()}\b", got)
+                and not re.search(rf"\b{n.lower()}\b", said)]
+
+    def pick(row, arm, want):
+        """A transcript from a run that agreed with the majority verdict.
+
+        The transcript printed has to be evidence for the verdict beside it. A
+        clip that flipped has runs on both sides, and the flattering one is not
+        the one the reader should act on.
+        """
+        truth = recall.normalise(row["said"])
+        for text in row["runs"][arm]["texts"]:
+            if (recall.normalise(text) == truth) == want:
+                return text
+        return row["runs"][arm]["texts"][0]
+
+    def ok(row, arm):
+        return row["runs"][arm]["ok"]
+
+    losses = [r for r in rows if ok(r, args.off) and not ok(r, args.on)]
+    wins = [r for r in rows if ok(r, args.on) and not ok(r, args.off)]
+
+    out = []
+    out.append("Every clip the vocabulary pass took away.")
+    out.append("")
+    out.append(f"`{args.off}` is the baseline arm and `{args.on}` is the arm being")
+    out.append("scored. Both are replays of the same audio through the same build,")
+    out.append("majority of the runs `scripts/vocab-ablation.py` was given.")
+    out.append("Written by scripts/vocab-losses.py.")
+    out.append("")
+    out.append(f"{len(losses)} losses, against {len(wins)} wins over {len(rows)} clips.")
+    out.append("")
+
+    overwrites, others = [], []
+    for row in losses:
+        on_text = pick(row, args.on, False)
+        off_text = pick(row, args.off, True)
+        written = wrote_a_term(row, on_text)
+        (overwrites if written else others).append((row, on_text, off_text, written))
+
+    out.append(f"{len(overwrites)} overwrites — a term written over a word the speaker meant.")
+    out.append(f"{len(others)} other — the pass broke the clip without writing a term in.")
+    out.append("")
+
+    for title, group in (("OVERWRITES", overwrites), ("OTHER", others)):
+        if not group:
+            continue
+        out.append("=" * 72)
+        out.append(f"{title}  ({len(group)})")
+        out.append("=" * 72)
+        for row, on_text, off_text, written in group:
+            klass = "term" if row["term"] else "control"
+            out.append("")
+            out.append(f"{row['wav']}  [{klass}]"
+                       + (f"  wrote: {', '.join(written)}" if written else ""))
+            out.append(f"  said: {row['said']}")
+            out.append(f"  {args.off + ':':<8}{off_text}")
+            out.append(f"  {args.on + ':':<8}{on_text}")
+        out.append("")
+
+    text = "\n".join(out) + "\n"
+    if args.out:
+        Path(args.out).write_text(text)
+        print(f"wrote {args.out}  ({len(losses)} losses)")
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/pipeline-cases.yaml
+++ b/tests/pipeline-cases.yaml
@@ -500,6 +500,72 @@ cases:
       context.ok: false
       context.changed: false
 
+  # --- the name judge, on what a `replacements` rule did -----------------------
+  #
+  # `--pipeline` has no audio, so these are the path that used to have no earlier
+  # text to compare against. `replacements` publishes its input as
+  # `replacements.before`, and that is what says which `Vercel` a rule wrote.
+  # `vocabulary.slots` counts the places the stage found. See
+  # tests/pipelines/vocabulary-rules.yaml for why no model is called.
+
+  # The case the fix is for. The rule rewrites one `Versailles`, the decoder had
+  # already written the other `Vercel`, and the term now stands twice. Without
+  # the earlier text this offered nothing and logged that it could not tell them
+  # apart. One slot, on the occurrence the rule made.
+  - name: a rule is attributed when the term it wrote stands twice
+    pipeline: vocabulary-rules
+    input: a list of possible alternatives for Versailles, such as Vercel
+    expect: a list of possible alternatives for Vercel, such as Vercel
+    expect_vars:
+      replacements.before: a list of possible alternatives for Versailles, such as Vercel
+      replacements.changes: Versailles -> Vercel
+      vocabulary.slots: 1
+
+  # One occurrence was decidable without the earlier text and still is. Here so
+  # that the path which already worked is held, not only the one that did not.
+  - name: a rule is attributed when the term it wrote stands once
+    pipeline: vocabulary-rules
+    input: our app is deployed on Versailles
+    expect: our app is deployed on Vercel
+    expect_vars:
+      vocabulary.slots: 1
+
+  # A term the decoder wrote itself is not a substitution. No rule fired, so
+  # there is nothing to offer back and no menu to build.
+  - name: a term nothing rewrote opens no slot
+    pipeline: vocabulary-rules
+    input: our app is deployed on Vercel
+    expect: unchanged
+    expect_vars:
+      replacements.changes: ""
+      vocabulary.slots: 0
+
+  # Two renderings of one term in one sentence, and the stage declines. Each
+  # pair in `changes` is counted on its own, so each accounts for one of the two
+  # terms standing and neither can claim its own. The earlier text does not
+  # settle this shape; only reading the pairs per term would. This is the live
+  # sentence from the 2026-08-09 dictation pass, and it is still not attributed.
+  - name: two rules writing one term in one sentence decline rather than guess
+    pipeline: vocabulary-rules-two-renderings
+    input: deployed on Versal against the Versailles Castle
+    expect: deployed on Vercel against the Vercel Castle
+    expect_vars:
+      vocabulary.slots: 0
+
+  # Two `replacements` steps, which a pipeline may have. `before` and `changes`
+  # are both the second step's, so they still describe the same run. The second
+  # step finds nothing left to rewrite, so it publishes no changes and the judge
+  # is offered nothing — the first step's changes are not readable from here,
+  # and never were.
+  - name: a second replacements step republishes its own input
+    pipeline: vocabulary-rules-twice
+    input: a list of possible alternatives for Versailles, such as Vercel
+    expect: a list of possible alternatives for Vercel, such as Vercel
+    expect_vars:
+      replacements.before: a list of possible alternatives for Vercel, such as Vercel
+      replacements.changes: ""
+      vocabulary.slots: 0
+
 # Pipelines that must not load at all.
 #
 # Scored separately because the property is different: these never reach a

--- a/tests/pipelines/vocabulary-rules-twice.yaml
+++ b/tests/pipelines/vocabulary-rules-twice.yaml
@@ -1,0 +1,14 @@
+# Two `replacements` steps above the judge, which a pipeline is allowed to have.
+#
+# Both steps publish under the same namespace and the second wins, for `before`
+# exactly as for `changes`. The pair stays consistent — the judge reads the last
+# step's changes beside the last step's input — and the first step's changes are
+# not readable at all, which was already true before `before` existed.
+languages: [en]
+replacements:
+  Vercel: [Versailles]
+pipeline:
+  - replacements
+  - replacements
+  - vocabulary: ../../examples/prompts/verify_names.md
+    max_readings: 1

--- a/tests/pipelines/vocabulary-rules-two-renderings.yaml
+++ b/tests/pipelines/vocabulary-rules-two-renderings.yaml
@@ -1,0 +1,11 @@
+# The same stage, with two renderings of one term in one sentence.
+#
+# Separate from `vocabulary-rules.yaml` because the table is what differs: two
+# rules write `Vercel` here, and each is counted on its own. See the cases.
+languages: [en]
+replacements:
+  Vercel: [Versailles, Versal]
+pipeline:
+  - replacements
+  - vocabulary: ../../examples/prompts/verify_names.md
+    max_readings: 1

--- a/tests/pipelines/vocabulary-rules.yaml
+++ b/tests/pipelines/vocabulary-rules.yaml
@@ -1,0 +1,21 @@
+# The name judge reading what a `replacements` rule did, with no audio at all.
+#
+# What is scored is attribution: which occurrence of a term a rule wrote.
+# `vocabulary.slots` is the number, and it is the one thing about this stage a
+# fixture can assert — the answer comes from a model and is not deterministic.
+#
+# `max_readings: 1` is how no model is called. The menu is cut to the decoder's
+# own sentence, the stage returns the transcript it was handed, and the run is
+# the same with Ollama up or down. Every case here scores the places the stage
+# found, never what was chosen at them.
+#
+# The prompt is the shipped one, by relative path, because the stage refuses to
+# run without a readable prompt file and a fixture with its own copy would be a
+# second thing to keep in step.
+languages: [en]
+replacements:
+  Vercel: [Versailles]
+pipeline:
+  - replacements
+  - vocabulary: ../../examples/prompts/verify_names.md
+    max_readings: 1


### PR DESCRIPTION
## Summary
PR 15 of the plan: nobody had measured whether the LLM judge, with the acoustic pass off, actually does better than not running it at all.
This PR runs that blind control — the same 141 clips, with and without the judge stage — head to head.
The judge does not beat its own absence: 1 win and 1 loss, both deterministic and real, for a net of zero, and it also has a real cost when it does run — a median 174ms model call on about a quarter of dictations, changing a word on only 2% of clips.

## Issue
Part of #74. Targets #86 (`fix/rule-parts-pre-rules-text`).

## The result

**It does not win.** 141 labelled clips, `--runs 3`, built on Fix A (#86):

| arm | correct | wins | losses | net | flips |
|---|---|---|---|---|---|
| `off` (empty `terms:`) | 76 | — | — | — | 0 |
| `today` (`acoustic: true`) | 87 | 30 | 19 | +11 | 1 |
| `noacoustic-judge` | 104 | 28 | 0 | +28 | 0 |
| `noacoustic-nojudge` | 104 | 28 | 0 | +28 | 0 |

**Head to head, judge vs. no judge: 1 win, 1 loss.** Neither arm flipped on any clip over three replays, so this is a real tie, not noise cancelling out. Both are the same sentence shape (`Vercel` beside `Versailles`) — the one case in this corpus where a rule writes a term the decoder already had correct.

- **The win**: the judge correctly undoes the rule where it fired wrongly.
- **The loss**: same mechanism, opposite direction — here the rule fired correctly and the judge undid it anyway. One prompt, two conflicting jobs, paying on whichever side it isn't tuned for at that moment.

## What it costs

Counted from each arm's own trace data over 141 clips × 3 replays: the vocabulary stage runs on 37/141 clips (26%), the model is actually called on 35/141 (25%), and the judge changes a word on only 3/141 (2%). **On 34 of the 37 clips it reached, the judge just returned what the rules had already written** — the default outcome, 92% of the time it ran.

**Latency**: 105 model calls, median **174ms**, p90 230ms, max 2,350ms — about 7.3s total added across a full 141-clip pass. Live figures elsewhere in this work show a median of 1,213ms over 77 real dictations, which is closer to what a user actually pays per call.

## Verdict

**The judge does not earn its place with the acoustic path off.** Same correct count, same class split, one win against one loss. This doesn't mean Fix A (#86) was wasted — the judge's one win here depends on Fix A's pre-rules text — and it doesn't generalize past this corpus's one rule that writes a term the decoder already had; a vocabulary with more such rules would give the judge more to do, in both directions.

**Read the absolute numbers with care.** `acoustic: false` has been measured at 100/102/103/104 across sessions on this corpus — normal drift. What decides this PR is the within-session pair: same clips, same build, same config, one line of YAML between the two arms, zero flips in either.

<details>
<summary><b>How to Test</b></summary>

Four scratch config directories (off / today / no-acoustic-with-judge / no-acoustic-without-judge), each with `audio.output_dir` pointed at scratch so a run never appends to the live trace file.

```sh
make app   # never make install
python3 scripts/vocab-ablation.py --runs 3 --out arms.json \
  --arm "off=$S/cfg-off" \
  --arm "today=$S/cfg-on" \
  --arm "noacoustic-judge=$S/cfg-noac-judge" \
  --arm "noacoustic-nojudge=$S/cfg-noac-nojudge"
```

The judge's cost is read from each arm's own trace file — no extra pass over the clips needed. `scripts/check-no-voice.sh` passes 5/5. Nothing merged, nothing force-pushed; no product Swift changed. `docs/proposals/vocabulary-v3.md` is untouched by this PR — the result lives here instead.

</details>
