### PR TITLE
feat: the menu opens the config folder, not one folder inside it

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2515,8 +2515,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         menu.addItem(.separator())
 
-        // One row for the two files you configure this app by: the config, and
-        // the folder of transforms beside it. A submenu rather than two lines
+        // One row for the two doors you configure this app by: the config file,
+        // and the folder it sits in. A submenu rather than two lines
         // because they are the same errand, and this menu is mostly state —
         // every row spent on a door is a row not spent saying what is happening.
         let settingsItem = NSMenuItem(title: "Settings", action: nil, keyEquivalent: "")
@@ -2532,13 +2532,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         editConfigItem.target = self
         settingsMenu.addItem(editConfigItem)
 
-        let transformsItem = NSMenuItem(
-            title: "View Transforms",
-            action: #selector(openTransformsFolder),
+        let folderItem = NSMenuItem(
+            title: "Open Config Folder",
+            action: #selector(openConfigFolder),
             keyEquivalent: ""
         )
-        transformsItem.target = self
-        settingsMenu.addItem(transformsItem)
+        folderItem.target = self
+        settingsMenu.addItem(folderItem)
 
         settingsItem.submenu = settingsMenu
         menu.addItem(settingsItem)
@@ -2688,13 +2688,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Self.openInEditor(ConfigStore.fileURL)
     }
 
-    /// The transforms folder — the layout is the documentation, so opening the
-    /// directory says more than a list of names would.
+    /// The config folder, not the transforms folder inside it.
+    ///
+    /// Everything you own lives here: `config.yaml`, `vocabulary.yaml`, the
+    /// `transforms/` folder and the `voice/` recordings. One door reaches all
+    /// of them, where the old row reached one subfolder and left the rest with
+    /// no way in from the menu.
     ///
     /// Created if it is not there, because an empty folder is an answer ("this
     /// is where they go") and a window that never opened is not.
-    @objc private func openTransformsFolder() {
-        let dir = ConfigStore.transformsDirectory
+    @objc private func openConfigFolder() {
+        let dir = ConfigStore.directory
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         Self.openInEditor(dir)
     }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,7 +59,8 @@ feedback:
 
 The menu bar item shows the current state and offers *Correct a Word…*, *Open
 Recordings Folder* — the wavs and `trace.jsonl` — *Settings*, which holds *Edit
-Config…* (`config.yaml`) and *View Transforms* (the `transforms/` folder), and
+Config…* (`config.yaml`) and *Open Config Folder* — everything you own, so
+`vocabulary.yaml`, `transforms/` and `voice/` too — and
 *Permissions…*. Both open in VS Code if it is installed, and in whatever the
 system would otherwise use if it is not.
 


### PR DESCRIPTION
## Summary

The menu's *View Transforms* row opened `transforms/` and nothing else, so `vocabulary.yaml`, `voice/` and the config backups had no way in from the menu. This changes the row to *Open Config Folder*, which reaches all of them.

`transforms/` is one double-click further in.

## Issue

Part of the vocabulary work — `voice/` now holds recordings a person may want to play (see #92), and nothing in the app pointed at it.

<details>
<summary><b>How to Test</b></summary>

1. `make install`
2. Click the menu bar item → Settings → *Open Config Folder*
3. It opens `~/.config/parrotflow-dev/` in VS Code if installed, otherwise Finder
4. The folder is created first if it does not exist

</details>