### PR TITLE
fix: a microphone that changes no longer records silence in the dark

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -132,6 +132,14 @@ jobs:
       - name: The eval harness
         run: scripts/check-eval.sh
 
+      # What the recorder does when the microphone changes underneath it. No
+      # microphone is opened and no audio setting is touched — the input
+      # binding is moved inside the process — so this runs on a headless
+      # runner and beside somebody who is dictating. What it cannot prove is
+      # the hardware; see #95 and the note at the top of the command.
+      - name: Recovery from a device change
+        run: scripts/check-audio-recovery.sh
+
       # Whether a possessive survives a substitution. Pure string work, no audio
       # and no model, so it runs here. The direction that matters is a `'s`
       # written where the speaker said none: these substitutions auto-apply and

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -28,6 +28,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// and not on every save of an unrelated setting.
     private var announcedProblems: [String] = []
 
+    /// What went wrong with the last recording, held until one goes right.
+    ///
+    /// A notice fades after four seconds, and the failure this exists for is
+    /// one you find out about by looking up from what you were dictating into.
+    /// AirPods connect and disconnect on their own all day, so the state that
+    /// matters is "the last thing you said was not recorded" — and it has to
+    /// still be on screen when you go looking for it. Shown in the menu bar
+    /// beside the other standing problems.
+    private var standingCaptureProblem: String?
+
     /// Resolved once per config load, never in `updateUI`.
     ///
     /// `problems()` re-resolves and re-validates every pipeline for every
@@ -175,7 +185,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.pill.model.level = level
         }
         recorder.onUnexpectedStop = { [weak self] _ in
-            self?.stopRecording(reason: "The audio device changed.")
+            self?.stopRecording(reason: "The microphone changed — that take stopped early.")
+        }
+        recorder.onCaptureProblem = { [weak self] problem in
+            self?.captureProblem(problem)
         }
 
         Log.write(
@@ -676,7 +689,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // microphone changed underneath it. Logged as well, because this
             // path used to leave the log showing a press and then silence.
             Log.write("could not start recording: \(error.localizedDescription)")
-            flash(error.localizedDescription, tone: .failure)
+            // Standing, not only flashed. A press that starts nothing is the
+            // failure people describe as "the app stopped working", and a
+            // notice that fades in four seconds is gone by the time they look.
+            captureProblem(error.localizedDescription)
             return
         }
 
@@ -834,9 +850,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         if let reason {
-            presentAlert(title: "Recording stopped", message: reason)
+            // A notice, not an alert, for the reason already written above
+            // `startRecording`'s catch: `runModal` holds the main run loop, the
+            // hotkey is delivered on it, and one modal behind a device change
+            // makes every press after it do nothing — which is exactly the
+            // sequence in #95, an alert saying the device changed followed by a
+            // hotkey that answers nothing. The message outlives the notice in
+            // the menu bar, so nothing is lost by not blocking for it.
+            Log.write("recording stopped: \(reason)")
+            captureProblem(reason)
         }
 
+        updateUI()
+    }
+
+    /// A capture that went wrong, said twice: once on screen now, and once in
+    /// the menu bar until a recording goes right.
+    ///
+    /// Nil is the recording that went right, which is what clears it. The
+    /// recorder reports every stop, so a device change that ended a take which
+    /// nonetheless captured real audio clears itself — nothing was lost, and a
+    /// standing warning about a dictation that arrived is a warning people
+    /// learn to ignore.
+    private func captureProblem(_ problem: String?) {
+        standingCaptureProblem = problem
+        if let problem {
+            flash(problem, tone: .failure)
+        }
         updateUI()
     }
 
@@ -2608,6 +2648,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         } else if recording {
             let elapsed = Int(pill.model.elapsed)
             statusInfoItem.title = String(format: "Recording  %d:%02d", elapsed / 60, elapsed % 60)
+        } else if let standingCaptureProblem {
+            // Under the live clock, so it never covers a recording in progress,
+            // and over "Idle", which is the row it contradicts: a hotkey that
+            // captures nothing looks idle from here.
+            statusInfoItem.title = "⚠︎ \(standingCaptureProblem)"
         } else {
             statusInfoItem.title = "Idle  ·  \(shortcut)"
         }

--- a/Sources/ParrotFlow/AudioRecoveryCommand.swift
+++ b/Sources/ParrotFlow/AudioRecoveryCommand.swift
@@ -59,16 +59,17 @@ enum AudioRecoveryCommand {
 
         print("")
         print("Capture after a device change")
-        failures += checkCaptureSurvivesTheChange(config: config) ? 0 : 1
-        failures += checkStaleFormatIsReported(config: config) ? 0 : 1
+        var capture = 0
+        capture += checkCaptureSurvivesTheChange(config: config) ? 0 : 1
+        capture += checkStaleFormatIsReported(config: config) ? 0 : 1
+        capture += checkPartialLossIsRefused(config: config) ? 0 : 1
+        capture += checkOneLostBufferIsForgiven(config: config) ? 0 : 1
+        failures += capture
 
+        let total = cases.count + 4
         print("")
-        if failures == 0 {
-            print("  \(cases.count + 2)/\(cases.count + 2)")
-            return 0
-        }
-        print("  \(cases.count + 2 - failures)/\(cases.count + 2)")
-        return 1
+        print("  \(total - failures)/\(total)")
+        return failures == 0 ? 0 : 1
     }
 
     /// What the two sides of the comparison say about the microphone in front
@@ -252,6 +253,91 @@ enum AudioRecoveryCommand {
         }
         print("  ✓ \("a stale format is reported, not swallowed".padding(toLength: 46, withPad: " ", startingAt: 0)) \"\(reported)\"")
         return true
+    }
+
+    /// How much audio one refused buffer below is worth: 4096 frames at 48 kHz,
+    /// 85 ms. Worked out here from the buffer rather than read off the recorder,
+    /// so the expected number and the measured one come from different places.
+    private static let lostPerBuffer: Double = 4096 / 48000
+
+    /// A recording that lost more than `droppedAudioTolerance` is not handed on.
+    ///
+    /// Good buffers first, then buffers at a format the converter cannot use —
+    /// a device that changed halfway through a sentence. What is on disk is the
+    /// first half. Transcribing it would type half a sentence with nothing to
+    /// say which half is missing.
+    private static func checkPartialLossIsRefused(config: Config) -> Bool {
+        let buffers = 8
+        let name = String(
+            format: "a clip that lost %.2fs is not transcribed",
+            Double(buffers) * lostPerBuffer
+        )
+        let outcome = recordThenLose(buffers: buffers, config: config)
+        if let recording = outcome.recording {
+            try? FileManager.default.removeItem(at: recording.url)
+            return say(false, name, "it was handed on anyway")
+        }
+        guard let reported = outcome.reported else {
+            return say(false, name, "nothing was said")
+        }
+        return say(true, name, "\"\(reported)\"")
+    }
+
+    /// And one that lost a single buffer still is.
+    ///
+    /// This is the ordinary headset disconnect. The recording is stopped by the
+    /// device change, and one buffer can arrive in the new format before that
+    /// stop reaches the main queue. Every word is in the part that was written,
+    /// so refusing the clip would cost the whole dictation to save nothing.
+    private static func checkOneLostBufferIsForgiven(config: Config) -> Bool {
+        let name = String(
+            format: "a clip that lost %.2fs is still transcribed", lostPerBuffer
+        )
+        let outcome = recordThenLose(buffers: 1, config: config)
+        guard let recording = outcome.recording else {
+            return say(false, name, "it was refused")
+        }
+        try? FileManager.default.removeItem(at: recording.url)
+        guard recording.rms >= Recorder.silenceFloor else {
+            return say(false, name, String(format: "rms %.5f", recording.rms))
+        }
+        return say(true, name, String(format: "rms %.3f", recording.rms))
+    }
+
+    /// Twenty good buffers, then `buffers` at a format the converter refuses.
+    private static func recordThenLose(
+        buffers: Int, config: Config
+    ) -> (recording: Recorder.Recording?, reported: String?) {
+        guard let live = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32, sampleRate: 24000, channels: 1, interleaved: false
+        ), let other = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32, sampleRate: 48000, channels: 1, interleaved: false
+        ) else {
+            return (nil, nil)
+        }
+
+        let recorder = Recorder()
+        var reported: String?
+        recorder.onCaptureProblem = { reported = $0 }
+        recorder.currentInput = { nil }
+
+        guard (try? recorder.openCapture(
+            inputFormat: live, config: config, markRecording: true
+        )) != nil else {
+            return (nil, nil)
+        }
+        for _ in 0..<20 { recorder.process(buffer: tone(live, frames: 4096)) }
+        for _ in 0..<buffers { recorder.process(buffer: tone(other, frames: 4096)) }
+
+        let recording = recorder.stop(config: config)
+        settle(untilTrue: { reported != nil }, seconds: 1)
+        return (recording, reported)
+    }
+
+    private static func say(_ ok: Bool, _ name: String, _ detail: String) -> Bool {
+        let padded = name.padding(toLength: 46, withPad: " ", startingAt: 0)
+        print("  \(ok ? "✓" : "✗") \(padded) \(detail)")
+        return ok
     }
 
     // MARK: - Helpers

--- a/Sources/ParrotFlow/AudioRecoveryCommand.swift
+++ b/Sources/ParrotFlow/AudioRecoveryCommand.swift
@@ -1,0 +1,326 @@
+import AVFoundation
+import CoreAudio
+import Foundation
+import Yams
+
+/// `--audio-recovery` — drives a device change past the recorder and checks it
+/// comes back, without touching the machine's audio settings.
+///
+/// The bug in #95 is a microphone that changes underneath a running app: the
+/// engine keeps converting from the format the old device was running at, every
+/// buffer is refused, and the clip is silence that nothing reports. Reproducing
+/// that for real means switching the default input device, which takes the
+/// microphone away from whoever is dictating — so this moves the *binding*
+/// instead. `Recorder.currentInput` is the one place the recorder asks what the
+/// system would hand it; replacing it is enough to make the recorder believe a
+/// headset arrived, and every path below that is the real one.
+///
+/// What it does not cover: the hardware. No input device is opened here, so
+/// "the buffers that arrive are the ones the new device sends" is still a claim
+/// a human has to check. See docs/cli.md.
+enum AudioRecoveryCommand {
+
+    /// One line of `tests/audio-recovery-cases.yaml`.
+    private struct Case {
+        let name: String
+        let from: Recorder.InputBinding?
+        let to: Recorder.InputBinding?
+        let rebuild: Bool
+        let why: String
+    }
+
+    static func run(casesPath: String?) -> Int32 {
+        let config: Config
+        do {
+            config = try ConfigStore.load()
+        } catch {
+            print("✗ config: \(CheckConfigCommand.describe(error))")
+            return 1
+        }
+
+        let path = casesPath ?? defaultCasesPath()
+        let cases: [Case]
+        do {
+            cases = try loadCases(at: path)
+        } catch {
+            print("✗ cases: \(error.localizedDescription)")
+            return 1
+        }
+
+        var failures = 0
+
+        print("Device changes")
+        for testCase in cases {
+            failures += check(testCase) ? 0 : 1
+        }
+
+        print("")
+        thisMachine()
+
+        print("")
+        print("Capture after a device change")
+        failures += checkCaptureSurvivesTheChange(config: config) ? 0 : 1
+        failures += checkStaleFormatIsReported(config: config) ? 0 : 1
+
+        print("")
+        if failures == 0 {
+            print("  \(cases.count + 2)/\(cases.count + 2)")
+            return 0
+        }
+        print("  \(cases.count + 2 - failures)/\(cases.count + 2)")
+        return 1
+    }
+
+    /// What the two sides of the comparison say about the microphone in front
+    /// of you right now.
+    ///
+    /// Printed, never scored. A build machine has no microphone and a laptop
+    /// has whatever is plugged into it, so there is no number here to pass or
+    /// fail — but if a device ever makes the engine and the stream disagree
+    /// while everything is healthy, this is the line that says so, and it is
+    /// the first thing to paste into an issue about a silent recording.
+    private static func thisMachine() {
+        print("This machine")
+        guard let binding = Recorder.InputBinding.system() else {
+            print("  no input device")
+            return
+        }
+        // Held in a local, not asked of a temporary: an input node outlives
+        // nothing, and reading the format off an engine that is already being
+        // released segfaults. No engine is started, so the microphone
+        // indicator stays off — the same promise `Recorder.warmUp` makes.
+        let engine = AVAudioEngine()
+        let engineFormat = engine.inputNode.outputFormat(forBus: 0)
+        print("  device   \(Recorder.inputDeviceName ?? "unnamed") — \(binding.described)")
+        print("  engine   \(Int(engineFormat.sampleRate)) Hz, \(engineFormat.channelCount) ch")
+        print(
+            "  agree    "
+            + (engineFormat.sampleRate == binding.sampleRate
+               ? "yes"
+               : "NO — a press would rebuild the engine before recording")
+        )
+    }
+
+    // MARK: - The decision
+
+    /// Moves the binding under an idle recorder and checks whether it rebuilt.
+    ///
+    /// The change is delivered as the notification the engine posts, not as a
+    /// direct call, so the observer has to have been moved onto each new engine
+    /// for the second case in a row to be seen at all.
+    private static func check(_ testCase: Case) -> Bool {
+        let recorder = Recorder()
+        recorder.currentInput = { testCase.from }
+        recorder.warmUp()
+
+        let before = recorder.rebuilds
+        recorder.currentInput = { testCase.to }
+        recorder.simulateConfigurationChange()
+
+        // The notification hops to the main queue and the rebuild runs on its
+        // own; both need the run loop to turn. Two seconds is well over the
+        // 0.1s a settled device costs and well under the timeout that would
+        // make a red result ambiguous.
+        settle(untilTrue: { recorder.rebuilds > before }, seconds: 2)
+
+        let rebuilt = recorder.rebuilds > before
+        guard rebuilt == testCase.rebuild else {
+            print("  ✗ \(testCase.name)")
+            print("      got   \(rebuilt ? "rebuilt" : "no rebuild")")
+            print("      want  \(testCase.rebuild ? "rebuilt" : "no rebuild") — \(testCase.why)")
+            return false
+        }
+        print("  ✓ \(testCase.name.padding(toLength: 46, withPad: " ", startingAt: 0)) \(rebuilt ? "rebuilt" : "left alone")")
+        return true
+    }
+
+    // MARK: - The capture
+
+    /// #95's acceptance criterion, one level under the hardware: after a
+    /// simulated switch, the capture path converts and writes a real signal.
+    ///
+    /// The change is the one from #95 — the same device at a new rate, which is
+    /// what a headset does while its link settles — so the rebuild has to fire
+    /// for this to get as far as measuring anything. The buffers are a 440 Hz
+    /// tone rather than a microphone, so what is measured after that is the
+    /// conversion and the write: the half that was silently dropping
+    /// everything. It has to come out with non-trivial RMS.
+    private static func checkCaptureSurvivesTheChange(config: Config) -> Bool {
+        let settling = Recorder.InputBinding(device: 2, sampleRate: 48000, channels: 1)
+        let settled = Recorder.InputBinding(device: 2, sampleRate: 24000, channels: 1)
+
+        let recorder = Recorder()
+        recorder.currentInput = { settling }
+        recorder.warmUp()
+
+        recorder.currentInput = { settled }
+        recorder.simulateConfigurationChange()
+        settle(untilTrue: { recorder.rebuilds > 0 }, seconds: 2)
+
+        guard recorder.rebuilds > 0 else {
+            print("  ✗ a tone at the new rate is written")
+            print("      got   the format change was ignored, so the engine still holds 48000 Hz")
+            print("      want  a rebuild, then a clip with signal in it")
+            return false
+        }
+
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32, sampleRate: settled.sampleRate,
+            channels: AVAudioChannelCount(settled.channels), interleaved: false
+        ) else {
+            print("  ✗ a tone at the new rate is written  — could not build the format")
+            return false
+        }
+
+        do {
+            try recorder.openCapture(inputFormat: format, config: config, markRecording: true)
+        } catch {
+            print("  ✗ a tone at the new rate is written  — \(error.localizedDescription)")
+            return false
+        }
+        for _ in 0..<20 { recorder.process(buffer: tone(format, frames: 4096)) }
+
+        guard let recording = recorder.stop(config: config) else {
+            print("  ✗ a tone at the new rate is written  — nothing was written")
+            return false
+        }
+        defer { try? FileManager.default.removeItem(at: recording.url) }
+
+        guard recording.rms >= Recorder.silenceFloor else {
+            print("  ✗ a tone at the new rate is written")
+            print(String(format: "      got   rms %.5f", recording.rms))
+            print(String(format: "      want  at least %.5f", Recorder.silenceFloor))
+            return false
+        }
+        print(String(
+            format: "  ✓ %@ rms %.3f",
+            "a tone at the new rate is written".padding(toLength: 46, withPad: " ", startingAt: 0),
+            recording.rms
+        ))
+        return true
+    }
+
+    /// The bug itself, and the fact that it is no longer silent.
+    ///
+    /// A converter built from the format the *old* device was running at, handed
+    /// buffers at the new one. `AVAudioConverter` reports an error and still
+    /// hands back the right number of zeroed frames, so a length check cannot
+    /// see it — this is what wrote the empty clips in #95. Nothing must be
+    /// written, and the recorder must say so rather than returning nil in
+    /// silence.
+    private static func checkStaleFormatIsReported(config: Config) -> Bool {
+        guard let stale = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32, sampleRate: 48000, channels: 1, interleaved: false
+        ), let live = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32, sampleRate: 24000, channels: 1, interleaved: false
+        ) else {
+            print("  ✗ a stale format is reported, not swallowed  — could not build the formats")
+            return false
+        }
+
+        let recorder = Recorder()
+        var reported: String?
+        recorder.onCaptureProblem = { reported = $0 }
+        // No device at either end, so stopping does not send this recorder off
+        // to rebuild against whatever the machine is really plugged into. What
+        // is under test here is the conversion, not the acquisition.
+        recorder.currentInput = { nil }
+
+        do {
+            try recorder.openCapture(inputFormat: stale, config: config, markRecording: true)
+        } catch {
+            print("  ✗ a stale format is reported, not swallowed  — \(error.localizedDescription)")
+            return false
+        }
+        for _ in 0..<20 { recorder.process(buffer: tone(live, frames: 4096)) }
+
+        let recording = recorder.stop(config: config)
+        settle(untilTrue: { reported != nil }, seconds: 2)
+
+        if let recording {
+            try? FileManager.default.removeItem(at: recording.url)
+            print("  ✗ a stale format is reported, not swallowed")
+            print(String(format: "      got   a clip at rms %.5f", recording.rms))
+            print("      want  nothing, because the converter refused every buffer")
+            return false
+        }
+        guard let reported else {
+            print("  ✗ a stale format is reported, not swallowed")
+            print("      got   nothing said")
+            print("      want  a message through onCaptureProblem")
+            return false
+        }
+        print("  ✓ \("a stale format is reported, not swallowed".padding(toLength: 46, withPad: " ", startingAt: 0)) \"\(reported)\"")
+        return true
+    }
+
+    // MARK: - Helpers
+
+    /// A 440 Hz tone at a third of full scale — loud enough that no floor in
+    /// the app could mistake it for a room.
+    private static func tone(_ format: AVAudioFormat, frames: AVAudioFrameCount) -> AVAudioPCMBuffer {
+        // The format is built above with a channel count of at least one, so
+        // the buffer and its float data are there.
+        // swiftlint:disable:next force_unwrapping
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frames)!
+        buffer.frameLength = frames
+        if let channel = buffer.floatChannelData?[0] {
+            for i in 0..<Int(frames) {
+                channel[i] = 0.3 * sinf(2 * .pi * 440 * Float(i) / Float(format.sampleRate))
+            }
+        }
+        return buffer
+    }
+
+    /// Turns the run loop until the condition holds or the time is up.
+    private static func settle(untilTrue condition: () -> Bool, seconds: TimeInterval) {
+        let deadline = Date().addingTimeInterval(seconds)
+        while !condition(), Date() < deadline {
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+    }
+
+    // MARK: - Cases
+
+    private static func defaultCasesPath() -> String {
+        // Beside the binary when it is run out of .build, and beside the repo
+        // otherwise — the same shape the other check scripts assume.
+        FileManager.default.currentDirectoryPath + "/tests/audio-recovery-cases.yaml"
+    }
+
+    private static func loadCases(at path: String) throws -> [Case] {
+        let text = try String(contentsOfFile: path, encoding: .utf8)
+        let raw = try YAMLDecoder().decode([RawCase].self, from: text)
+        return raw.map {
+            Case(
+                name: $0.name,
+                from: binding($0.from),
+                to: binding($0.to),
+                rebuild: $0.rebuild,
+                why: $0.why
+            )
+        }
+    }
+
+    private struct RawCase: Decodable {
+        let name: String
+        let from: RawBinding?
+        let to: RawBinding?
+        let rebuild: Bool
+        let why: String
+    }
+
+    private struct RawBinding: Decodable {
+        let device: UInt32
+        let rate: Double
+        let channels: UInt32
+    }
+
+    private static func binding(_ raw: RawBinding?) -> Recorder.InputBinding? {
+        raw.map {
+            Recorder.InputBinding(
+                device: AudioDeviceID($0.device), sampleRate: $0.rate, channels: $0.channels
+            )
+        }
+    }
+}

--- a/Sources/ParrotFlow/AudioRecoveryCommand.swift
+++ b/Sources/ParrotFlow/AudioRecoveryCommand.swift
@@ -283,15 +283,20 @@ enum AudioRecoveryCommand {
         return say(true, name, "\"\(reported)\"")
     }
 
-    /// And one that lost a single buffer still is.
+    /// And one that lost a single buffer still is — but says so.
     ///
     /// This is the ordinary headset disconnect. The recording is stopped by the
     /// device change, and one buffer can arrive in the new format before that
     /// stop reaches the main queue. Every word is in the part that was written,
     /// so refusing the clip would cost the whole dictation to save nothing.
+    ///
+    /// Both halves are checked, because passing the clip on *quietly* is its own
+    /// bug: the sentence arrives a syllable short with nothing saying so. The
+    /// tolerance decides whether it is transcribed, never whether it is
+    /// mentioned.
     private static func checkOneLostBufferIsForgiven(config: Config) -> Bool {
         let name = String(
-            format: "a clip that lost %.2fs is still transcribed", lostPerBuffer
+            format: "a clip that lost %.2fs is transcribed and said", lostPerBuffer
         )
         let outcome = recordThenLose(buffers: 1, config: config)
         guard let recording = outcome.recording else {
@@ -301,7 +306,10 @@ enum AudioRecoveryCommand {
         guard recording.rms >= Recorder.silenceFloor else {
             return say(false, name, String(format: "rms %.5f", recording.rms))
         }
-        return say(true, name, String(format: "rms %.3f", recording.rms))
+        guard let reported = outcome.reported else {
+            return say(false, name, "it was handed on with nothing said about the loss")
+        }
+        return say(true, name, "\"\(reported)\"")
     }
 
     /// Twenty good buffers, then `buffers` at a format the converter refuses.

--- a/Sources/ParrotFlow/RecordTestCommand.swift
+++ b/Sources/ParrotFlow/RecordTestCommand.swift
@@ -52,6 +52,10 @@ enum RecordTestCommand {
         print("✓ wrote \(recording.url.path)")
         print("  duration   \(String(format: "%.2f", recording.duration))s")
         print("  size       \(bytes) bytes")
+        // The same number the app judges a clip by, so what this prints and
+        // what the menu bar would warn about are one measurement.
+        print("  rms        \(String(format: "%.5f", recording.rms))"
+              + (recording.rms < Recorder.silenceFloor ? "  — silence" : ""))
 
         guard let file = try? AVAudioFile(forReading: recording.url) else {
             print("✗ the file is not readable as audio")

--- a/Sources/ParrotFlow/Recorder.swift
+++ b/Sources/ParrotFlow/Recorder.swift
@@ -219,6 +219,7 @@ final class Recorder {
     /// This does not open the input stream — the orange mic indicator stays off
     /// until `start()` actually runs the engine.
     func warmUp() {
+        let engine = currentEngine()
         _ = engine.inputNode.outputFormat(forBus: 0)
         engine.prepare()
         stateLock.lock()

--- a/Sources/ParrotFlow/Recorder.swift
+++ b/Sources/ParrotFlow/Recorder.swift
@@ -373,10 +373,15 @@ final class Recorder {
 
     // MARK: - Stop
 
-    /// Returns nil if the clip was shorter than `min_duration_seconds` (the file
-    /// is deleted in that case), if nothing was recording, or if nothing was
-    /// captured at all — and in that last case says so through
-    /// `onCaptureProblem`.
+    /// Returns nil if nothing was recording, if the clip was shorter than
+    /// `min_duration_seconds`, if nothing was captured at all, or if part of
+    /// what was captured never reached the file.
+    ///
+    /// The last two say so through `onCaptureProblem`, because they are the
+    /// ones where a sentence was spoken and lost. Only a clip whose audio is
+    /// whole is handed back to be transcribed: half a sentence typed into
+    /// somebody's editor, with nothing to say which half is missing, is the
+    /// failure this is here to stop, not a lesser version of it.
     @discardableResult
     func stop(config: Config) -> Recording? {
         guard isRecording else { return nil }
@@ -432,14 +437,26 @@ final class Recorder {
             return nil
         }
 
-        let rms = Float((energy / Double(frames)).squareRoot())
+        // Some buffers were converted and never reached the file. What is on
+        // disk is shorter than what was said, so transcribing it would type a
+        // sentence with words missing and nothing to say which ones — the
+        // silent failure this whole change is about, delivered as text instead
+        // of as nothing. It is not handed on.
+        //
+        // The file stays where it is. It is the evidence of what went wrong,
+        // and deleting it is the opposite of useful — the same reason
+        // `cancelDictation` leaves a cancelled clip alone.
         if failed > 0 {
-            // Some buffers were converted and never reached the file. What is on
-            // disk is shorter than what was said, and a transcript of it would
-            // be missing words with nothing to say which ones.
-            Log.write("recording dropped \(failed) buffer(s) on the way to the file")
-            report("Part of that recording could not be written to disk.")
-        } else if rms < Self.silenceFloor {
+            Log.write(
+                "recording dropped \(failed) buffer(s) on the way to the file — "
+                + "\(url.lastPathComponent) is short and will not be transcribed"
+            )
+            report("Part of that recording was lost. Say it again.")
+            return nil
+        }
+
+        let rms = Float((energy / Double(frames)).squareRoot())
+        if rms < Self.silenceFloor {
             // Frames arrived and they are all silence. A different fault again —
             // a muted device, the wrong microphone, a headset that connected
             // without its microphone — and the same cost to the person talking,

--- a/Sources/ParrotFlow/Recorder.swift
+++ b/Sources/ParrotFlow/Recorder.swift
@@ -630,21 +630,29 @@ final class Recorder {
         rebuildGroup.enter()
         let started = Date()
 
+        // Held strongly and left in a `defer`, so the group empties however this
+        // block ends — including with the recorder already gone. A rebuild that
+        // finishes without leaving it makes every later press wait 1.5s and
+        // then refuse, forever, which is the wedge this whole change is about.
+        let group = rebuildGroup
         engineQueue.async { [weak self] in
+            defer {
+                self?.finishRebuilding()
+                group.leave()
+            }
             let fresh = AVAudioEngine()
             // The expensive line: instantiating the input node opens the
             // device. Everything after it is cheap.
             _ = fresh.inputNode.outputFormat(forBus: 0)
             fresh.prepare()
-            // If the recorder is gone nobody is left to wait on the group, so
-            // skipping `leave()` here strands nothing.
-            guard let self else { return }
-            self.adopt(fresh, took: Date().timeIntervalSince(started))
-            self.stateLock.lock()
-            self.rebuilding = false
-            self.stateLock.unlock()
-            self.rebuildGroup.leave()
+            self?.adopt(fresh, took: Date().timeIntervalSince(started))
         }
+    }
+
+    private func finishRebuilding() {
+        stateLock.lock()
+        rebuilding = false
+        stateLock.unlock()
     }
 
     /// Waits for an engine that is still being built, and gives up in time to

--- a/Sources/ParrotFlow/Recorder.swift
+++ b/Sources/ParrotFlow/Recorder.swift
@@ -120,6 +120,23 @@ final class Recorder {
     /// silence: it cannot fire on speech and cannot miss a dead clip.
     static let silenceFloor: Float = 0.001
 
+    /// How much lost audio a clip can carry and still be worth transcribing.
+    ///
+    /// Neither zero nor unbounded, and both ends have a cost.
+    ///
+    /// Not zero, because a device change ends a recording through
+    /// `onUnexpectedStop`, and the tap can deliver a buffer in the new format
+    /// before that hop reaches the main queue — one 4096-frame buffer, about
+    /// 85 ms at 48 kHz and 170 ms at 24 kHz. Refusing a whole dictation over
+    /// that would throw away every word of a take whose words all arrived, on
+    /// every headset that disconnects itself.
+    ///
+    /// Not unbounded, because past a certain hole the transcript is a sentence
+    /// with words missing and nothing to say which — the failure this file is
+    /// about, delivered as text instead of as nothing. 0.3s is two of those
+    /// buffers and no more.
+    static let droppedAudioTolerance: TimeInterval = 0.3
+
     /// How long a hotkey press waits for an engine that is still being built.
     ///
     /// A settled device rebuilds in about 0.1s, so this covers every rebuild
@@ -193,16 +210,18 @@ final class Recorder {
     private var targetFormat: AVAudioFormat?
     private var currentURL: URL?
     private var smoothedLevel: Float = 0
-    /// Frames written, sum of squares, buffers the converter refused and buffers
-    /// the file refused — all guarded by `writeLock`, so `stop` reads totals
-    /// that match the file it is about to hand back.
+    /// What reached disk, what did not, and why — all guarded by `writeLock`, so
+    /// `stop` reads totals that match the file it is about to hand back.
     ///
     /// `capturedFrames` counts what reached disk, not what reached the
-    /// converter. The two are the same until a write fails, and on that day the
-    /// difference is a clip that reports a healthy level and holds less audio
-    /// than was spoken.
+    /// converter. The two are the same until something fails, and on that day
+    /// the difference is a clip that reports a healthy level and holds less
+    /// audio than was spoken. `droppedFrames` is that difference, in frames at
+    /// the output rate, so `stop` can say how many seconds went missing rather
+    /// than how many buffers.
     private var capturedFrames: Int64 = 0
     private var capturedEnergy: Double = 0
+    private var droppedFrames: Int64 = 0
     private var refusedBuffers: Int = 0
     private var failedWrites: Int = 0
 
@@ -358,6 +377,7 @@ final class Recorder {
         writeLock.lock()
         capturedFrames = 0
         capturedEnergy = 0
+        droppedFrames = 0
         refusedBuffers = 0
         failedWrites = 0
         writeLock.unlock()
@@ -399,6 +419,7 @@ final class Recorder {
         let energy = capturedEnergy
         let refused = refusedBuffers
         let failed = failedWrites
+        let dropped = droppedFrames
         writeLock.unlock()
 
         teardown()
@@ -437,20 +458,30 @@ final class Recorder {
             return nil
         }
 
-        // Some buffers were converted and never reached the file. What is on
-        // disk is shorter than what was said, so transcribing it would type a
-        // sentence with words missing and nothing to say which ones — the
-        // silent failure this whole change is about, delivered as text instead
-        // of as nothing. It is not handed on.
+        // Audio that was spoken and is not in the file. Two ways to lose it and
+        // the same consequence: the converter refused a buffer because its
+        // input format is no longer the device's, or the file refused a write.
+        // Both leave the clip shorter than what was said.
+        //
+        // Always said out loud, however little was lost — the whole point of
+        // #95 is that this used to be the silent path.
+        let lost = Double(dropped) / config.audio.sampleRate
+        if dropped > 0 {
+            Log.write(String(
+                format: "recording lost %.2fs — %d buffer(s) refused by the converter,"
+                + " %d by the file", lost, refused, failed
+            ))
+        }
+        // Past the tolerance the hole is big enough to be a word, and a
+        // transcript with a word missing and nothing to say which one is the
+        // failure this file is about, delivered as text instead of as nothing.
+        // So it is not handed on.
         //
         // The file stays where it is. It is the evidence of what went wrong,
         // and deleting it is the opposite of useful — the same reason
         // `cancelDictation` leaves a cancelled clip alone.
-        if failed > 0 {
-            Log.write(
-                "recording dropped \(failed) buffer(s) on the way to the file — "
-                + "\(url.lastPathComponent) is short and will not be transcribed"
-            )
+        if lost > Self.droppedAudioTolerance {
+            Log.write("\(url.lastPathComponent) is short and will not be transcribed")
             report("Part of that recording was lost. Say it again.")
             return nil
         }
@@ -535,8 +566,13 @@ final class Recorder {
             // so a length check cannot see it — measured 3754 frames at rms
             // 0.00000 converting a 24 kHz buffer through a 48 kHz converter.
             // Counted rather than dropped in silence: this is #95.
+            //
+            // The frame count comes from the input buffer and the ratio, not
+            // from `outBuffer`, whose length on this path describes a
+            // conversion that did not happen.
             writeLock.lock()
             refusedBuffers += 1
+            droppedFrames += Int64(Double(buffer.frameLength) * ratio)
             writeLock.unlock()
             return
         }
@@ -558,6 +594,7 @@ final class Recorder {
                 capturedEnergy += Double(rms) * Double(rms) * Double(outBuffer.frameLength)
             } catch {
                 failedWrites += 1
+                droppedFrames += Int64(outBuffer.frameLength)
             }
         }
         writeLock.unlock()

--- a/Sources/ParrotFlow/Recorder.swift
+++ b/Sources/ParrotFlow/Recorder.swift
@@ -9,12 +9,93 @@ final class Recorder {
     struct Recording {
         let url: URL
         let duration: TimeInterval
+        /// Root-mean-square of the whole clip, 0...1. Says whether anything was
+        /// heard, which the duration cannot: a lost take and a good one are the
+        /// same length. See `silenceFloor`.
+        let rms: Float
+    }
+
+    /// What the engine is bound to: which input device, and the format that
+    /// device is running at.
+    ///
+    /// Both halves matter, and only the first one used to be checked. A device
+    /// can keep its identity and change its format — AirPods do it a second or
+    /// two after they become the input, while the Bluetooth link settles — and
+    /// an identity test alone reads that as "nothing moved". It is the change
+    /// that costs the most: `AVAudioConverter` built from the old format
+    /// returns `.error` for every buffer at the new one, `process` drops them
+    /// all, and the clip is silence with no error anywhere. See #95.
+    struct InputBinding: Equatable {
+        let device: AudioDeviceID
+        let sampleRate: Double
+        let channels: UInt32
+
+        var described: String {
+            "device \(device) at \(Int(sampleRate)) Hz, \(channels) ch"
+        }
+
+        /// What CoreAudio would hand the engine right now. Nil when the machine
+        /// has no input device at all.
+        ///
+        /// The format comes from the input stream's virtual format, which is
+        /// the same fact `AVAudioEngine`'s input node reports — measured equal
+        /// on every input device on this machine, including an aggregate one.
+        /// That equality is what lets `formatProblem` compare the two and call
+        /// a difference stale rather than a unit mismatch.
+        static func system() -> InputBinding? {
+            guard let device = Recorder.defaultInputDeviceID else { return nil }
+            guard let format = inputStreamFormat(of: device) else {
+                // A device with no input stream to ask. Zeroes still compare,
+                // which is all the change detection needs, and `formatProblem`
+                // treats a rate of zero as nothing to say.
+                return InputBinding(device: device, sampleRate: 0, channels: 0)
+            }
+            return InputBinding(
+                device: device,
+                sampleRate: format.mSampleRate,
+                channels: format.mChannelsPerFrame
+            )
+        }
+
+        private static func inputStreamFormat(
+            of device: AudioDeviceID
+        ) -> AudioStreamBasicDescription? {
+            var streamsAddress = AudioObjectPropertyAddress(
+                mSelector: kAudioDevicePropertyStreams,
+                mScope: kAudioObjectPropertyScopeInput,
+                mElement: kAudioObjectPropertyElementMain
+            )
+            var size: UInt32 = 0
+            guard AudioObjectGetPropertyDataSize(
+                device, &streamsAddress, 0, nil, &size
+            ) == noErr, size > 0 else { return nil }
+
+            var streams = [AudioStreamID](
+                repeating: 0, count: Int(size) / MemoryLayout<AudioStreamID>.size
+            )
+            guard AudioObjectGetPropertyData(
+                device, &streamsAddress, 0, nil, &size, &streams
+            ) == noErr, let first = streams.first else { return nil }
+
+            var formatAddress = AudioObjectPropertyAddress(
+                mSelector: kAudioStreamPropertyVirtualFormat,
+                mScope: kAudioObjectPropertyScopeGlobal,
+                mElement: kAudioObjectPropertyElementMain
+            )
+            var format = AudioStreamBasicDescription()
+            var formatSize = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+            guard AudioObjectGetPropertyData(
+                first, &formatAddress, 0, nil, &formatSize, &format
+            ) == noErr else { return nil }
+            return format
+        }
     }
 
     enum RecorderError: LocalizedError {
         case noInputDevice
         case unsupportedFormat
         case converterUnavailable
+        case inputStillConnecting
 
         var errorDescription: String? {
             switch self {
@@ -24,37 +105,106 @@ final class Recorder {
                 return "Could not build a 16 kHz mono format."
             case .converterUnavailable:
                 return "Could not convert the microphone's format to 16 kHz mono."
+            case .inputStillConnecting:
+                return "The microphone is still connecting — press again in a moment."
             }
         }
     }
 
+    /// Below this, a clip is silence rather than a quiet room.
+    ///
+    /// -60 dBFS. The lost takes in #95 measured 2.9 to 4.3 RMS in 16-bit units,
+    /// which is 0.0001 here; the working takes beside them measured 682 to 917,
+    /// or 0.021. A live microphone in a quiet room sits around 0.003. So the
+    /// floor is twenty times under a quiet room and ten times over true
+    /// silence: it cannot fire on speech and cannot miss a dead clip.
+    static let silenceFloor: Float = 0.001
+
+    /// How long a hotkey press waits for an engine that is still being built.
+    ///
+    /// A settled device rebuilds in about 0.1s, so this covers every rebuild
+    /// worth waiting for. Past it the device is still negotiating — Bluetooth
+    /// took 4s twice and 30s once on 2026-08-10 — and the honest answer is a
+    /// message you can act on, not an app that stops answering the hotkey.
+    private static let rebuildWaitSeconds: Double = 1.5
+
     private(set) var isRecording = false
     private(set) var startedAt: Date?
+
+    /// How many engines this recorder has been through. Read by
+    /// `--audio-recovery` to see whether a device change was acted on, from a
+    /// different thread than the one that counts them.
+    var rebuilds: Int {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return rebuildCount
+    }
+    private var rebuildCount = 0
 
     /// 0...1, already smoothed — drive a meter with it. Called on the main queue.
     var onLevel: ((Float) -> Void)?
     /// Fired when recording stops on its own (e.g. the audio device changed).
     var onUnexpectedStop: ((Error?) -> Void)?
+    /// What was wrong with the last recording, or nil if nothing was.
+    ///
+    /// A dictation that captures nothing is worse than one that fails loudly:
+    /// the sentence is gone either way, and only one of them tells you to say
+    /// it again. Called on the main queue after every `stop`.
+    var onCaptureProblem: ((String?) -> Void)?
+
+    /// What the system would hand us right now.
+    ///
+    /// A property rather than a direct call so `--audio-recovery` can move the
+    /// input under the recorder without moving the machine's audio settings.
+    /// Nothing in the app replaces it.
+    var currentInput: () -> InputBinding? = InputBinding.system
 
     /// Recreated when the audio device changes — an engine holds on to the
-    /// device it was prepared against.
+    /// device it was prepared against. Guarded by `stateLock`.
     private var engine = AVAudioEngine()
+    /// The binding the engine was last prepared against — what it will actually
+    /// record through, which is not always what the system would hand us today.
+    /// See `reacquireIfInputMoved` and `start`. Guarded by `stateLock`.
+    private var bound: InputBinding?
+    /// True while an engine is being built on `engineQueue`. Guarded by
+    /// `stateLock`.
+    private var rebuilding = false
+    private let stateLock = NSLock()
+
+    /// A format disagreement a rebuild has already been spent on. Main thread
+    /// only — `start` is the only thing that reads or writes it.
+    private var acceptedFormatMismatch: String?
+
+    /// Builds engines off the main thread.
+    ///
+    /// Instantiating an input node opens the device. On Bluetooth that has been
+    /// measured at 4s twice and once at 30s — the gaps between "rebuilding the
+    /// capture engine" and "capture engine rebuilt" in the log of 2026-08-10,
+    /// 17:00:23 to 17:01:05. Those were main-thread seconds: the hotkey was not
+    /// delivered, no recording started, and not one line was written. The app
+    /// looked dead, and quitting it was the only way out.
+    private let engineQueue = DispatchQueue(label: "com.parrotflow.recorder.engine")
+    /// Empty unless a rebuild is under way. `start` waits on it, briefly.
+    private let rebuildGroup = DispatchGroup()
+
     private let writeLock = NSLock()
     private var audioFile: AVAudioFile?
     private var converter: AVAudioConverter?
     private var targetFormat: AVAudioFormat?
     private var currentURL: URL?
     private var smoothedLevel: Float = 0
-    /// The input device the engine was last prepared against — what it will
-    /// actually record from, which is not always what the system would hand us
-    /// today. See `configurationChanged` and `start`.
-    private var boundDevice: AudioDeviceID?
+    /// Frames written, sum of squares, and buffers the converter refused — all
+    /// guarded by `writeLock`, so `stop` reads totals that match the file it is
+    /// about to hand back.
+    private var capturedFrames: Int64 = 0
+    private var capturedEnergy: Double = 0
+    private var refusedBuffers: Int = 0
 
     init() {
-        observeConfigurationChanges()
+        observeConfigurationChanges(on: engine)
     }
 
-    private func observeConfigurationChanges() {
+    private func observeConfigurationChanges(on engine: AVAudioEngine) {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(configurationChanged),
@@ -71,7 +221,9 @@ final class Recorder {
     func warmUp() {
         _ = engine.inputNode.outputFormat(forBus: 0)
         engine.prepare()
-        boundDevice = Self.defaultInputDeviceID
+        stateLock.lock()
+        bound = currentInput()
+        stateLock.unlock()
     }
 
     // MARK: - Start
@@ -80,33 +232,86 @@ final class Recorder {
     func start(config: Config) throws -> URL {
         guard !isRecording else { return currentURL! }
 
-        // The engine keeps the device it was prepared against. If the default
-        // input has moved since — AirPods in, AirPods back out — it is holding
-        // one that is no longer there: the format below comes back empty and
-        // the throw reads as "no audio input device" on a Mac that plainly has
-        // one. The notification that announces the change is not enough by
-        // itself, so the device is checked here too, at the one moment it has
+        // The engine keeps the device *and the format* it was prepared against.
+        // If either has moved since — AirPods in, AirPods back out, or AirPods
+        // simply settling their link — it is holding a format the hardware has
+        // left. The notification that announces the change is not enough by
+        // itself, so the binding is checked here too, at the one moment it has
         // to be right.
-        if let current = Self.defaultInputDeviceID, current != boundDevice {
-            Log.write("input device moved since the engine was prepared; re-acquiring")
-            rebuildEngine()
-        }
+        reacquireIfInputMoved()
+        try waitForRebuild()
 
+        var engine = currentEngine()
         var inputFormat = engine.inputNode.outputFormat(forBus: 0)
-        if inputFormat.sampleRate <= 0 || inputFormat.channelCount == 0 {
-            // A second chance rather than an error. An empty format means the
-            // engine is pointing at nothing, which a fresh one may well fix —
-            // and the alternative is telling someone their microphone is
-            // missing at the exact moment they are talking into it.
-            Log.write("input format came back empty; rebuilding the capture engine")
-            rebuildEngine()
+
+        if let problem = Self.formatProblem(inputFormat, against: currentInput()),
+           problem != acceptedFormatMismatch {
+            // A second chance rather than an error, for both shapes of the
+            // problem. An empty format means the engine is pointing at nothing;
+            // a format that disagrees with the device means it is pointing at
+            // what the device used to be. A fresh engine fixes both, and the
+            // alternative is telling someone their microphone is missing at the
+            // exact moment they are talking into it.
+            Log.write("\(problem); rebuilding the capture engine")
+            rebuildEngine(because: problem)
+            try waitForRebuild()
+            engine = currentEngine()
             inputFormat = engine.inputNode.outputFormat(forBus: 0)
+
+            let remaining = Self.formatProblem(inputFormat, against: currentInput())
+            // Remembered whether it cleared or not. A device whose engine and
+            // stream never agree would otherwise buy a rebuild on every single
+            // press, which is a second bug wearing the first one's clothes.
+            acceptedFormatMismatch = remaining
+            if let remaining {
+                // Fail open. A recording that may be wrong beats refusing to
+                // record — but said out loud, because the whole point of #95 is
+                // that this used to be the silent path.
+                Log.write("after the rebuild, \(remaining) — recording anyway")
+                report("The microphone is not answering as expected.")
+            }
         }
         guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
             throw RecorderError.noInputDevice
         }
         let inputNode = engine.inputNode
 
+        let url = try openCapture(inputFormat: inputFormat, config: config)
+
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
+            self?.process(buffer: buffer)
+        }
+
+        do {
+            engine.prepare()
+            try engine.start()
+        } catch {
+            inputNode.removeTap(onBus: 0)
+            teardown()
+            try? FileManager.default.removeItem(at: url)
+            throw error
+        }
+
+        beginRecording()
+        return url
+    }
+
+    /// Builds what the tap writes through — the converter to 16 kHz mono and the
+    /// file on disk.
+    ///
+    /// Split out of `start` so `--audio-recovery` can push buffers through the
+    /// exact conversion the tap uses without opening the microphone. Nothing in
+    /// the app calls it directly.
+    ///
+    /// - Parameter markRecording: whether to enter the recording state here.
+    ///   `start` leaves it false and calls `beginRecording` only once the engine
+    ///   is running. `prepare()` posts a configuration change of its own, and a
+    ///   recorder that already calls itself recording answers that by stopping
+    ///   the take it is halfway through starting.
+    @discardableResult
+    func openCapture(
+        inputFormat: AVAudioFormat, config: Config, markRecording: Bool = false
+    ) throws -> URL {
         guard let target = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
             sampleRate: config.audio.sampleRate,
@@ -143,42 +348,53 @@ final class Recorder {
         audioFile = file
         currentURL = url
 
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
-            self?.process(buffer: buffer)
-        }
+        writeLock.lock()
+        capturedFrames = 0
+        capturedEnergy = 0
+        refusedBuffers = 0
+        writeLock.unlock()
 
-        do {
-            engine.prepare()
-            try engine.start()
-        } catch {
-            inputNode.removeTap(onBus: 0)
-            teardown()
-            try? FileManager.default.removeItem(at: url)
-            throw error
-        }
-
-        isRecording = true
-        startedAt = Date()
+        if markRecording { beginRecording() }
         return url
+    }
+
+    private func beginRecording() {
+        startedAt = Date()
+        setRecording(true)
     }
 
     // MARK: - Stop
 
     /// Returns nil if the clip was shorter than `min_duration_seconds` (the file
-    /// is deleted in that case) or if nothing was recording.
+    /// is deleted in that case), if nothing was recording, or if nothing was
+    /// captured at all — and in that last case says so through
+    /// `onCaptureProblem`.
     @discardableResult
     func stop(config: Config) -> Recording? {
         guard isRecording else { return nil }
-        isRecording = false
+        setRecording(false)
 
+        let engine = currentEngine()
         engine.stop()
         engine.inputNode.removeTap(onBus: 0)
 
         let duration = startedAt.map { Date().timeIntervalSince($0) } ?? 0
         let url = currentURL
+
+        writeLock.lock()
+        let frames = capturedFrames
+        let energy = capturedEnergy
+        let refused = refusedBuffers
+        writeLock.unlock()
+
         teardown()
 
         DispatchQueue.main.async { [weak self] in self?.onLevel?(0) }
+
+        // The device may have moved while this recording was running — that is
+        // one of the things that ends one early. Re-acquire now rather than at
+        // the next press, so the press finds an engine that is already right.
+        reacquireIfInputMoved()
 
         guard let url else { return nil }
         guard duration >= config.audio.minDurationSeconds else {
@@ -186,16 +402,34 @@ final class Recorder {
             return nil
         }
 
-        // No frames despite a real duration means the engine was bound to a
-        // device that is no longer there. Silent failure looks identical to a
-        // silent room, so say it and re-acquire.
-        if let file = try? AVAudioFile(forReading: url), file.length == 0 {
-            Log.write("recording captured 0 frames — rebuilding the capture engine")
+        // Nothing at all. The engine was bound to a device that is no longer
+        // there, or to a format that device has left — `refused` tells the two
+        // apart, because a format the converter cannot use is the one that
+        // reports an error on every buffer.
+        if frames == 0 {
+            let why = refused > 0
+                ? "the converter refused all \(refused) buffer(s) — its input format is not the device's"
+                : "the microphone delivered nothing"
+            Log.write("recording captured 0 frames — \(why)")
             try? FileManager.default.removeItem(at: url)
-            DispatchQueue.main.async { [weak self] in self?.rebuildEngine() }
+            report("Recorded nothing — the microphone was not ready. Press again.")
+            rebuildEngine(because: "the last recording captured nothing")
             return nil
         }
-        return Recording(url: url, duration: duration)
+
+        let rms = Float((energy / Double(frames)).squareRoot())
+        if rms < Self.silenceFloor {
+            // Frames arrived and they are all silence. A different fault from
+            // the one above — a muted device, the wrong microphone, a headset
+            // that connected without its microphone — and the same cost to the
+            // person talking, so it gets the same treatment.
+            Log.write(String(format: "recording is silence — rms %.5f over %.2fs", rms, duration))
+            report("Recorded silence — check which microphone is selected.")
+        } else {
+            report(nil)
+        }
+
+        return Recording(url: url, duration: duration, rms: rms)
     }
 
     private func teardown() {
@@ -209,9 +443,31 @@ final class Recorder {
         smoothedLevel = 0
     }
 
+    private func setRecording(_ value: Bool) {
+        stateLock.lock()
+        isRecording = value
+        stateLock.unlock()
+    }
+
+    private func currentEngine() -> AVAudioEngine {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return engine
+    }
+
+    /// Says whether the last recording was usable. Nil clears a standing
+    /// warning, so one good dictation puts the menu bar back.
+    private func report(_ problem: String?) {
+        DispatchQueue.main.async { [weak self] in self?.onCaptureProblem?(problem) }
+    }
+
     // MARK: - Audio path
 
-    private func process(buffer: AVAudioPCMBuffer) {
+    /// Converts one tap buffer to 16 kHz mono and writes it.
+    ///
+    /// Not private: `--audio-recovery` pushes synthetic buffers through it to
+    /// check the conversion without opening the microphone.
+    func process(buffer: AVAudioPCMBuffer) {
         guard let converter, let targetFormat else { return }
 
         let ratio = targetFormat.sampleRate / buffer.format.sampleRate
@@ -234,27 +490,45 @@ final class Recorder {
             return buffer
         }
 
-        guard status != .error, outBuffer.frameLength > 0 else { return }
+        guard status != .error else {
+            // Every buffer takes this path when the converter was built from a
+            // format the device has since left. `convert` reports `.error` and
+            // still fills `outBuffer` with the right *number* of zeroed frames,
+            // so a length check cannot see it — measured 3754 frames at rms
+            // 0.00000 converting a 24 kHz buffer through a 48 kHz converter.
+            // Counted rather than dropped in silence: this is #95.
+            writeLock.lock()
+            refusedBuffers += 1
+            writeLock.unlock()
+            return
+        }
+        guard outBuffer.frameLength > 0 else { return }
+
+        let rms = Self.rootMeanSquare(of: outBuffer)
 
         writeLock.lock()
         try? audioFile?.write(from: outBuffer)
+        capturedFrames += Int64(outBuffer.frameLength)
+        capturedEnergy += Double(rms) * Double(rms) * Double(outBuffer.frameLength)
         writeLock.unlock()
 
-        publishLevel(from: outBuffer)
+        publishLevel(rms)
     }
 
-    private func publishLevel(from buffer: AVAudioPCMBuffer) {
-        guard let channel = buffer.floatChannelData?[0] else { return }
+    private static func rootMeanSquare(of buffer: AVAudioPCMBuffer) -> Float {
+        guard let channel = buffer.floatChannelData?[0] else { return 0 }
         let frames = Int(buffer.frameLength)
-        guard frames > 0 else { return }
+        guard frames > 0 else { return 0 }
 
         var sum: Float = 0
         for i in 0..<frames {
             let sample = channel[i]
             sum += sample * sample
         }
-        let rms = sqrt(sum / Float(frames))
+        return sqrt(sum / Float(frames))
+    }
 
+    private func publishLevel(_ rms: Float) {
         // -60 dB floor, then a fast-attack / slow-release smooth so the meter
         // tracks speech instead of flickering on every buffer.
         let db = 20 * log10(max(rms, 1e-7))
@@ -266,28 +540,11 @@ final class Recorder {
         DispatchQueue.main.async { [weak self] in self?.onLevel?(level) }
     }
 
+    // MARK: - Device changes
+
     @objc private func configurationChanged(_ note: Notification) {
         guard isRecording else {
-            // Idle when the device changed. The engine is still bound to the
-            // one it was prepared against, so it starts happily and captures
-            // nothing — a recording that produces a 0-frame file and no error.
-            // Plugging in AirPods was enough to do it.
-            //
-            // Rebuilding prepares a fresh engine, and preparing one posts this
-            // same notification, which would rebuild again. That used to be
-            // held off with a two-second window, which cannot tell our own
-            // echo from the change that follows it: switching back to the
-            // built-in microphone within two seconds of plugging a headset in
-            // was dropped on the floor, and the engine stayed pointed at a
-            // device that had left. Comparing the device answers both at once
-            // — our own prepare() leaves the default input where it was, and a
-            // headset that announces itself five times still only moves it
-            // once — with no clock to be on the wrong side of.
-            DispatchQueue.main.async { [weak self] in
-                guard let self, !self.isRecording else { return }
-                guard Self.defaultInputDeviceID != self.boundDevice else { return }
-                self.rebuildEngine()
-            }
+            DispatchQueue.main.async { [weak self] in self?.reacquireIfInputMoved() }
             return
         }
         DispatchQueue.main.async { [weak self] in
@@ -296,29 +553,146 @@ final class Recorder {
         }
     }
 
+    /// Delivers the notification the engine posts when its configuration
+    /// changes, as if the engine had posted it.
+    ///
+    /// `--audio-recovery` drives the whole path with it — the observer, the
+    /// comparison and the rebuild — rather than only the decision, so a change
+    /// that forgets to move the observer onto the new engine still fails the
+    /// check. Nothing in the app calls it.
+    func simulateConfigurationChange() {
+        NotificationCenter.default.post(
+            name: .AVAudioEngineConfigurationChange, object: currentEngine()
+        )
+    }
+
+    /// Rebuilds if what the system would hand us now differs from what the
+    /// engine is bound to.
+    ///
+    /// The comparison is the whole binding, not just the device. Our own
+    /// `prepare()` posts this notification and moves neither field, so the echo
+    /// is still dropped — with no clock to be on the wrong side of, and a
+    /// headset that announces itself five times still only moves the binding
+    /// once. What is new is that a format moving on a device that stayed put
+    /// now counts. That is what AirPods do while their link settles, and
+    /// ignoring it is what left the engine converting from a format the
+    /// hardware had left. See #95.
+    private func reacquireIfInputMoved() {
+        guard !isRecording else { return }
+
+        stateLock.lock()
+        let bound = self.bound
+        stateLock.unlock()
+
+        let current = currentInput()
+        guard current != bound else { return }
+        rebuildEngine(because: "input moved: \(Self.describe(bound)) → \(Self.describe(current))")
+    }
+
+    private static func describe(_ binding: InputBinding?) -> String {
+        binding?.described ?? "no input device"
+    }
+
+    /// Why this format cannot be recorded through, or nil if it can.
+    ///
+    /// The second test is the one #95 needed. A format that disagrees with the
+    /// device is not a broken format — it passes every guard, builds a
+    /// converter, installs a tap — it is a format that used to be true.
+    private static func formatProblem(
+        _ format: AVAudioFormat, against input: InputBinding?
+    ) -> String? {
+        if format.sampleRate <= 0 || format.channelCount == 0 {
+            return "the input format came back empty"
+        }
+        guard let input, input.sampleRate > 0 else { return nil }
+        guard format.sampleRate != input.sampleRate else { return nil }
+        return String(
+            format: "the engine is at %.0f Hz and the device is at %.0f Hz",
+            format.sampleRate, input.sampleRate
+        )
+    }
+
     /// Replaces the engine so the next recording acquires the current device.
     /// Re-preparing the existing one is not enough; it keeps the old device.
-    private func rebuildEngine() {
-        guard !isRecording else { return }
+    ///
+    /// The building happens on `engineQueue`, off the main thread — see that
+    /// property for what it used to cost. Callers that need the new engine wait
+    /// through `waitForRebuild`.
+    private func rebuildEngine(because reason: String) {
+        stateLock.lock()
+        let busy = isRecording || rebuilding
+        if !busy { rebuilding = true }
+        stateLock.unlock()
+        guard !busy else { return }
+
+        Log.write("rebuilding the capture engine — \(reason)")
+        rebuildGroup.enter()
+        let started = Date()
+
+        engineQueue.async { [weak self] in
+            let fresh = AVAudioEngine()
+            // The expensive line: instantiating the input node opens the
+            // device. Everything after it is cheap.
+            _ = fresh.inputNode.outputFormat(forBus: 0)
+            fresh.prepare()
+            // If the recorder is gone nobody is left to wait on the group, so
+            // skipping `leave()` here strands nothing.
+            guard let self else { return }
+            self.adopt(fresh, took: Date().timeIntervalSince(started))
+            self.stateLock.lock()
+            self.rebuilding = false
+            self.stateLock.unlock()
+            self.rebuildGroup.leave()
+        }
+    }
+
+    /// Waits for an engine that is still being built, and gives up in time to
+    /// be useful. See `rebuildWaitSeconds`.
+    private func waitForRebuild() throws {
+        guard rebuildGroup.wait(timeout: .now() + Self.rebuildWaitSeconds) == .timedOut else {
+            return
+        }
+        Log.write("the input device is still connecting after \(Self.rebuildWaitSeconds)s")
+        throw RecorderError.inputStillConnecting
+    }
+
+    /// Swaps a freshly built engine in. Runs on `engineQueue`.
+    private func adopt(_ fresh: AVAudioEngine, took: TimeInterval) {
+        let binding = currentInput()
+
+        stateLock.lock()
+        // A recording started while this was being built. It is running through
+        // the old engine, so the old engine stays and `bound` is left alone —
+        // the next `start` then sees a stale binding and builds another.
+        guard !isRecording else {
+            stateLock.unlock()
+            Log.write("capture engine rebuilt while recording — kept the running one")
+            return
+        }
+        let old = engine
+        engine = fresh
+        bound = binding
+        rebuildCount += 1
+        stateLock.unlock()
+
         NotificationCenter.default.removeObserver(
-            self, name: .AVAudioEngineConfigurationChange, object: engine
+            self, name: .AVAudioEngineConfigurationChange, object: old
         )
-        engine.stop()
-        engine = AVAudioEngine()
-        observeConfigurationChanges()
-        warmUp()
-        Log.write("capture engine rebuilt — mic=\(Self.inputDeviceName ?? "none")")
+        observeConfigurationChanges(on: fresh)
+        old.stop()
+
+        Log.write(String(
+            format: "capture engine rebuilt in %.1fs — mic=%@, %@",
+            took, Self.inputDeviceName ?? "none", Self.describe(binding)
+        ))
     }
 
     // MARK: - Device
 
     /// Which input device the system would hand us right now.
     ///
-    /// The authority on whether the microphone has moved. The engine's own
-    /// notification cannot answer that — it fires for a format change and for
-    /// our own `prepare()` as readily as for a headset arriving — whereas this
-    /// is the identity the engine will bind to, so comparing it against
-    /// `boundDevice` says exactly whether a rebuild is owed.
+    /// Half of `InputBinding`, and kept on its own because the menu bar asks
+    /// for the name and not the format.
     static var defaultInputDeviceID: AudioDeviceID? {
         var deviceID = AudioDeviceID(kAudioObjectUnknown)
         var deviceSize = UInt32(MemoryLayout<AudioDeviceID>.size)

--- a/Sources/ParrotFlow/Recorder.swift
+++ b/Sources/ParrotFlow/Recorder.swift
@@ -193,12 +193,18 @@ final class Recorder {
     private var targetFormat: AVAudioFormat?
     private var currentURL: URL?
     private var smoothedLevel: Float = 0
-    /// Frames written, sum of squares, and buffers the converter refused — all
-    /// guarded by `writeLock`, so `stop` reads totals that match the file it is
-    /// about to hand back.
+    /// Frames written, sum of squares, buffers the converter refused and buffers
+    /// the file refused — all guarded by `writeLock`, so `stop` reads totals
+    /// that match the file it is about to hand back.
+    ///
+    /// `capturedFrames` counts what reached disk, not what reached the
+    /// converter. The two are the same until a write fails, and on that day the
+    /// difference is a clip that reports a healthy level and holds less audio
+    /// than was spoken.
     private var capturedFrames: Int64 = 0
     private var capturedEnergy: Double = 0
     private var refusedBuffers: Int = 0
+    private var failedWrites: Int = 0
 
     init() {
         observeConfigurationChanges(on: engine)
@@ -353,6 +359,7 @@ final class Recorder {
         capturedFrames = 0
         capturedEnergy = 0
         refusedBuffers = 0
+        failedWrites = 0
         writeLock.unlock()
 
         if markRecording { beginRecording() }
@@ -386,6 +393,7 @@ final class Recorder {
         let frames = capturedFrames
         let energy = capturedEnergy
         let refused = refusedBuffers
+        let failed = failedWrites
         writeLock.unlock()
 
         teardown()
@@ -403,14 +411,20 @@ final class Recorder {
             return nil
         }
 
-        // Nothing at all. The engine was bound to a device that is no longer
-        // there, or to a format that device has left — `refused` tells the two
-        // apart, because a format the converter cannot use is the one that
-        // reports an error on every buffer.
+        // Nothing landed on disk. Three ways to get here, and the counters say
+        // which: the file refused every write, the converter refused every
+        // buffer because its input format is not the device's, or the
+        // microphone sent nothing at all.
         if frames == 0 {
-            let why = refused > 0
-                ? "the converter refused all \(refused) buffer(s) — its input format is not the device's"
-                : "the microphone delivered nothing"
+            let why: String
+            if failed > 0 {
+                why = "none of the \(failed) buffer(s) could be written to the file"
+            } else if refused > 0 {
+                why = "the converter refused all \(refused) buffer(s)"
+                    + " — its input format is not the device's"
+            } else {
+                why = "the microphone delivered nothing"
+            }
             Log.write("recording captured 0 frames — \(why)")
             try? FileManager.default.removeItem(at: url)
             report("Recorded nothing — the microphone was not ready. Press again.")
@@ -419,11 +433,17 @@ final class Recorder {
         }
 
         let rms = Float((energy / Double(frames)).squareRoot())
-        if rms < Self.silenceFloor {
-            // Frames arrived and they are all silence. A different fault from
-            // the one above — a muted device, the wrong microphone, a headset
-            // that connected without its microphone — and the same cost to the
-            // person talking, so it gets the same treatment.
+        if failed > 0 {
+            // Some buffers were converted and never reached the file. What is on
+            // disk is shorter than what was said, and a transcript of it would
+            // be missing words with nothing to say which ones.
+            Log.write("recording dropped \(failed) buffer(s) on the way to the file")
+            report("Part of that recording could not be written to disk.")
+        } else if rms < Self.silenceFloor {
+            // Frames arrived and they are all silence. A different fault again —
+            // a muted device, the wrong microphone, a headset that connected
+            // without its microphone — and the same cost to the person talking,
+            // so it gets the same treatment.
             Log.write(String(format: "recording is silence — rms %.5f over %.2fs", rms, duration))
             report("Recorded silence — check which microphone is selected.")
         } else {
@@ -508,9 +528,21 @@ final class Recorder {
         let rms = Self.rootMeanSquare(of: outBuffer)
 
         writeLock.lock()
-        try? audioFile?.write(from: outBuffer)
-        capturedFrames += Int64(outBuffer.frameLength)
-        capturedEnergy += Double(rms) * Double(rms) * Double(outBuffer.frameLength)
+        // Counted only once it is on disk. Counting a buffer the file refused
+        // would let `stop` report a healthy RMS over a clip that is empty or
+        // short, and hand it to transcription — a silent failure of exactly
+        // the kind this change exists to end, one layer along.
+        // No file at all is a buffer arriving after `teardown`, not a failure:
+        // the recording is already over and `stop` has read these totals.
+        if let audioFile {
+            do {
+                try audioFile.write(from: outBuffer)
+                capturedFrames += Int64(outBuffer.frameLength)
+                capturedEnergy += Double(rms) * Double(rms) * Double(outBuffer.frameLength)
+            } catch {
+                failedWrites += 1
+            }
+        }
         writeLock.unlock()
 
         publishLevel(rms)

--- a/Sources/ParrotFlow/Recorder.swift
+++ b/Sources/ParrotFlow/Recorder.swift
@@ -126,15 +126,19 @@ final class Recorder {
     ///
     /// Not zero, because a device change ends a recording through
     /// `onUnexpectedStop`, and the tap can deliver a buffer in the new format
-    /// before that hop reaches the main queue — one 4096-frame buffer, about
-    /// 85 ms at 48 kHz and 170 ms at 24 kHz. Refusing a whole dictation over
-    /// that would throw away every word of a take whose words all arrived, on
-    /// every headset that disconnects itself.
+    /// before that hop reaches the main queue. One 4096-frame buffer is
+    /// 4096/rate seconds however the conversion goes: 85 ms at 48 kHz, 171 ms
+    /// at 24 kHz, 256 ms at 16 kHz. Refusing a whole dictation over that would
+    /// throw away every word of a take whose words all arrived, on every
+    /// headset that disconnects itself.
     ///
     /// Not unbounded, because past a certain hole the transcript is a sentence
     /// with words missing and nothing to say which — the failure this file is
-    /// about, delivered as text instead of as nothing. 0.3s is two of those
-    /// buffers and no more.
+    /// about, delivered as text instead of as nothing. 0.3s covers one buffer
+    /// at every rate a microphone runs at, and two at 48 kHz.
+    ///
+    /// A loss under it is still said out loud. The tolerance decides whether
+    /// the clip is transcribed, never whether the person is told.
     static let droppedAudioTolerance: TimeInterval = 0.3
 
     /// How long a hotkey press waits for an engine that is still being built.
@@ -487,7 +491,14 @@ final class Recorder {
         }
 
         let rms = Float((energy / Double(frames)).squareRoot())
-        if rms < Self.silenceFloor {
+        if dropped > 0 {
+            // Under the tolerance, so the clip is still worth transcribing —
+            // but not worth passing off as whole. Clearing the warning here
+            // would deliver a sentence missing its last syllable with nothing
+            // on screen saying so, which is this file's own failure in a
+            // smaller size. Transcribe it and say what went.
+            report(String(format: "The last %.1fs of that recording was lost.", lost))
+        } else if rms < Self.silenceFloor {
             // Frames arrived and they are all silence. A different fault again —
             // a muted device, the wrong microphone, a headset that connected
             // without its microphone — and the same cost to the person talking,

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -72,6 +72,13 @@ if let index = arguments.firstIndex(of: "--record") {
     exit(RecordTestCommand.run(seconds: seconds ?? 3))
 }
 
+if arguments.contains("--audio-recovery") {
+    let casesPath = arguments.firstIndex(of: "--cases").flatMap {
+        arguments.indices.contains($0 + 1) ? arguments[$0 + 1] : nil
+    }
+    exit(AudioRecoveryCommand.run(casesPath: casesPath))
+}
+
 if let index = arguments.firstIndex(of: "--transcribe") {
     guard arguments.indices.contains(index + 1) else {
         print("usage: ParrotFlow --transcribe <file.wav> [--no-vocab]")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -244,6 +244,7 @@ $ ParrotFlow --forget Praisy
 $PF --record 3           # record 3s and verify the file it produced
 $PF --transcribe a.wav   # transcribe a clip
 $PF --watch-modifiers    # print which modifier keys are physically down, live
+$PF --audio-recovery     # what the recorder does when the microphone changes
 ```
 
 `--record` checks the result, not just that it ran: sample rate, channel count,
@@ -253,6 +254,16 @@ A silent clip or a short file gets a non-zero exit.
 `--watch-modifiers` is the one to reach for if a bare-modifier hotkey seems
 dead — it shows whether the key is reaching the app at all, and whether left
 and right are distinguishable on your keyboard.
+
+`--audio-recovery` is for the other kind of dead: the microphone changed —
+AirPods connected, a headset came out — and dictation has been recording
+silence ever since. It moves the input binding inside the process instead of
+switching your real input device, so it is safe to run while somebody is
+dictating and it never opens the microphone. That is also its limit: it proves
+the recorder replaces its engine and that the capture path writes a real signal
+afterwards, and it proves nothing about what the hardware then sends. The cases
+are in `tests/audio-recovery-cases.yaml`; `scripts/check-audio-recovery.sh` runs
+it against a scratch config.
 
 You can make a test clip without a microphone at all — `say` writes exactly the
 format the model wants:
@@ -331,6 +342,7 @@ scripts/check-possessive.sh        # whether a possessive survives a substitutio
 scripts/check-verdicts.sh          # what the name judge reads out of a reply
 scripts/check-judge-prompt.sh      # the judge's prompt is one its parser can read
 scripts/check-no-voice.sh          # nothing in git is one person's voice
+scripts/check-audio-recovery.sh    # a microphone that changes leaves a usable engine
 
 PF_VIEWPORT=Ghostty scripts/check-inplace.sh   # the same set, in another terminal
 $PF --peek 3 --via-copy                        # what Select All + Copy hands back

--- a/scripts/check-audio-recovery.sh
+++ b/scripts/check-audio-recovery.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Checks that a change of audio input device leaves the recorder usable.
+#
+#   scripts/check-audio-recovery.sh
+#
+# The cases are in tests/audio-recovery-cases.yaml. Nothing here touches the
+# machine's audio settings: the input binding is moved inside the process, so
+# this is safe to run while somebody is dictating. It does not open the
+# microphone either, which is also the limit of what it proves — see the note at
+# the top of Sources/ParrotFlow/AudioRecoveryCommand.swift.
+#
+# The config is a scratch one. `audio.output_dir` decides where clips go *and*
+# where the trace is written (main.swift), so a run against the real config
+# would write into the recordings folder this app exists to keep clean.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/release/ParrotFlow"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/parrotflow-audio-recovery.XXXXXX")"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+mkdir -p "$SCRATCH/config" "$SCRATCH/clips"
+cat > "$SCRATCH/config/config.yaml" <<YAML
+# Written by scripts/check-audio-recovery.sh. Nothing reads it but this run.
+audio:
+  sample_rate: 16000
+  output_dir: $SCRATCH/clips
+  # The synthetic clips below are a few hundred milliseconds of wall clock, and
+  # a floor would delete them before they could be measured.
+  min_duration_seconds: 0
+transcription:
+  enabled: false
+YAML
+
+cd "$ROOT" || exit 1
+PARROTFLOW_CONFIG_DIR="$SCRATCH/config" "$BIN" --audio-recovery --cases "$ROOT/tests/audio-recovery-cases.yaml"

--- a/tests/audio-recovery-cases.yaml
+++ b/tests/audio-recovery-cases.yaml
@@ -1,0 +1,61 @@
+# What the recorder must do when the audio configuration changes under it.
+#
+# Run with scripts/check-audio-recovery.sh. Each case moves the input binding —
+# which device, at what format — and says whether the capture engine has to be
+# replaced. The binding is moved inside the process, so running this does not
+# touch the machine's audio settings and does not take anyone's microphone away.
+#
+# `from` and `to` are the binding before and after. `null` is a machine with no
+# input device at all. The device numbers are arbitrary — only whether two of
+# them match matters. The rates are ordinary input rates and are there to be
+# told apart, not to name a particular microphone.
+
+- name: nothing moved
+  from: {device: 2, rate: 24000, channels: 1}
+  to: {device: 2, rate: 24000, channels: 1}
+  rebuild: false
+  why: >
+    preparing an engine posts this same notification. Rebuilding on it would
+    rebuild again, forever. This is the case the device check was added for.
+
+- name: the device moved
+  from: {device: 1, rate: 48000, channels: 1}
+  to: {device: 2, rate: 24000, channels: 1}
+  rebuild: true
+  why: the RØDE went out and AirPods came in; the engine holds a device that left
+
+- name: the device moved back
+  from: {device: 2, rate: 24000, channels: 1}
+  to: {device: 1, rate: 48000, channels: 1}
+  rebuild: true
+  why: >
+    and within a moment of the change before it. A time window cannot tell this
+    from our own echo, which is why the binding is compared instead.
+
+- name: same device, the format moved
+  from: {device: 2, rate: 16000, channels: 1}
+  to: {device: 2, rate: 24000, channels: 1}
+  rebuild: true
+  why: >
+    #95. AirPods keep their identity and renegotiate their format a second or
+    two after they become the input. A check on the device alone calls this
+    "nothing moved", the engine keeps converting from 16000, and every buffer at
+    24000 is refused — a clip of pure silence that nothing reports.
+
+- name: same device, the channel count moved
+  from: {device: 3, rate: 48000, channels: 2}
+  to: {device: 3, rate: 48000, channels: 1}
+  rebuild: true
+  why: an interface that dropped a channel is holding a tap built for two
+
+- name: the device went away
+  from: {device: 2, rate: 24000, channels: 1}
+  to: null
+  rebuild: true
+  why: nothing to record through, and a fresh engine is the only way back
+
+- name: a device arrived where there was none
+  from: null
+  to: {device: 1, rate: 48000, channels: 1}
+  rebuild: true
+  why: the engine was prepared against nothing and would keep recording nothing


### PR DESCRIPTION
## Summary

A microphone that changed while the app was running left it recording silence, and nothing said so — no error, no log line, and sometimes no hotkey either. A device change should never produce a silent recording, and when one happens anyway the app should say it happened.

> **Not verified against real hardware.** Nothing in this branch opened an input
> device. The unit suite is 11/11 and #95's RMS criterion is met through the real
> converter on synthetic buffers, but an actual AirPods switch has never been
> tested — the owner was dictating, and switching the default input is both
> forbidden here and the trigger for the bug. The steps a human has to run are in
> "What a human still has to check" below.

## Acceptance criteria

- [x] A change of input device is acted on even when the device identity does not move — the format moving on the same device counts, which is what AirPods do.
- [x] A regression test drives a device change and asserts the capture path afterwards writes a signal with non-trivial RMS. `scripts/check-audio-recovery.sh`, 11/11, and it fails if the comparison is put back to device identity only.
- [x] A recording that captures nothing, that is nothing but silence, or that lost audio is logged with the reason, shown on screen, and left standing in the menu bar until a recording goes right. Losing more than 0.3s means the clip is not transcribed at all; losing less means it is transcribed and the loss is still named. Nothing lost is ever passed off as a whole recording.
- [x] A hotkey press can no longer freeze the app. The rebuild is off the main thread and a press waits 1.5s at most before saying the microphone is still connecting.
- [ ] Verified against real hardware. **Not done — a human has to do this.** Steps below.

<details>
<summary>What was actually wrong</summary>

Two outcomes came from the same event, and the difference is which field moved.

**Recovering.** The device *identity* changed — a headset out, a wired microphone in. `configurationChanged` compared `defaultInputDeviceID` against `boundDevice`, saw a difference, and rebuilt. The log says `capture engine rebuilt`. This happened on this machine at 17:27 today: AirPods (device 129, 24000 Hz) went away, the RØDE (device 115, 48000 Hz) became the input, and the old code recovered.

**Wedged.** The device identity stayed the same and only the *format* moved. AirPods do this: they become the input, then renegotiate a second or two later while the Bluetooth link settles. `Self.defaultInputDeviceID != self.boundDevice` is false, so the handler returned — with no log line, which is why nothing said why. The engine kept the old format. The tap and the converter were built from it.

That is the whole bug, and it is silent by construction. Measured directly:

```
converter 48k → 16k, buffer at 48k : status=1 (inputRanDry) frames=1360 rms=0.21232
converter 48k → 16k, buffer at 24k : status=3 (error)       frames=3754 rms=0.00000
converter 24k → 16k, buffer at 48k : status=3 (error)       frames=2389 rms=0.00000
```

`AVAudioConverter.convert` reports an error *and still hands back the right number of zeroed frames*, so `outBuffer.frameLength > 0` passes. `process` returned on `status != .error` and wrote nothing. Every buffer. The file ends at 0 frames, `stop` deleted it and returned nil, and `stopRecording` had nothing to show. Exactly the 0.5–0.9s dead takes at peak ≤ 52 in the issue.

The rest of the report follows from there.

*Why the hotkey went dead.* `rebuildEngine` ran on the main thread. From `~/Library/Logs/ParrotFlow-Dev.log`, the gap between `rebuilding the capture engine` and `capture engine rebuilt`:

```
17:00:22  destination: terminal (Ghostty)
17:00:23  recording captured 0 frames — rebuilding the capture engine
17:00:27  capture engine rebuilt                                        4s
17:00:29  destination: terminal (Ghostty)
17:00:29  recording captured 0 frames — rebuilding the capture engine
17:00:33  capture engine rebuilt                                        4s
17:00:34  destination: terminal (Ghostty)
17:00:35  recording captured 0 frames — rebuilding the capture engine
17:01:05  capture engine rebuilt                                       30s
17:01:16  launched —                                                   relaunched
```

Nothing runs between those two `Log.write` calls but `engine.stop()`, `AVAudioEngine()` and `warmUp()`. So those are main-thread seconds inside CoreAudio: the hotkey is not delivered, nothing starts, nothing is logged. That is "press and hold, no recording, no error, no log line", and the relaunch at the end is the only way out.

Note the shape of it: rebuilding to the *same* device did not help. Three 0-frame takes in a row, each bought with a 4-second freeze. Re-acquiring the device was never the missing piece; the format was.

*Why the alert made it worse.* `stopRecording(reason:)` called `presentAlert`, which is `runModal`. The comment above `startRecording`'s catch already says what that does — "one failed press behind a modal and every press after it does nothing, which is indistinguishable from the app having died". The same trap was still in the device-change path.

</details>

<details>
<summary>The changes</summary>

**`Recorder.InputBinding`** — device, sample rate, channel count. The format is read from the input stream's virtual format (`kAudioDevicePropertyStreams` → `kAudioStreamPropertyVirtualFormat`), which is the same fact `AVAudioEngine`'s input node reports. Measured equal on all four input devices on this machine, including an aggregate one. That equality is what lets a difference be called stale rather than a unit mismatch.

`reacquireIfInputMoved` compares the whole binding. The echo protection still holds: `prepare()` moves neither field, so our own notification is still dropped — with no clock to be on the wrong side of, which was the point of the device check in the first place.

**The rebuild moved off the main thread.** `engineQueue` builds the engine; `adopt` swaps it under a lock and moves the notification observer onto it. `start` waits on a `DispatchGroup` for 1.5s — enough for a settled device, which rebuilds in about 0.1s — and past that throws `inputStillConnecting`, which `startRecording` logs and shows. A 30-second dead app becomes a 1.5-second wait and a sentence.

**Failures are visible.** `process` counts the buffers the converter refused instead of dropping them in silence. `stop` counts frames and energy as it writes, so it knows the RMS of what it just captured without re-reading the file. Nothing captured, or nothing but silence, gets a log line with the reason, a notice, and `standingCaptureProblem` — a `⚠︎` row in the menu bar that stays until a recording goes right. `Recording` carries its `rms`, and `--record` prints it, so what the command reports and what the app warns about are one measurement.

The silence floor is `0.001`, -60 dBFS. The lost takes in #95 measured 2.9 to 4.3 RMS in 16-bit units (0.0001 here) and the working takes beside them 682 to 917 (0.021). A live microphone in a quiet room sits around 0.003. Twenty times under a quiet room, ten times over true silence.

**`presentAlert` in the device-change path is a notice now**, for the reason already written in the file.

**One guard against my own fix.** If a device's engine format and stream format never agree, the format check would buy a rebuild on every press. `acceptedFormatMismatch` remembers a disagreement one rebuild has already been spent on, so it is paid for once and then reported, not repeated.

</details>

<details>
<summary>How this was reproduced, and what was not</summary>

**Reproduced at unit level.** `scripts/check-audio-recovery.sh` → `--audio-recovery`. It moves `Recorder.currentInput` — the one place the recorder asks what the system would hand it — so the recorder believes a headset arrived. Everything below that is the real path: the real `AVAudioEngineConfigurationChange` notification, the real observer, the real comparison, the real rebuild, the real converter and the real file write.

```
Device changes
  ✓ nothing moved                                  left alone
  ✓ the device moved                               rebuilt
  ✓ the device moved back                          rebuilt
  ✓ same device, the format moved                  rebuilt
  ✓ same device, the channel count moved           rebuilt
  ✓ the device went away                           rebuilt
  ✓ a device arrived where there was none          rebuilt

This machine
  device   RØDE VideoMic GO II — device 115 at 48000 Hz, 1 ch
  engine   48000 Hz, 1 ch
  agree    yes

Capture after a device change
  ✓ a tone at the new rate is written              rms 0.212
  ✓ a stale format is reported, not swallowed      "Recorded nothing — the microphone was not ready. Press again."
  ✓ a clip that lost 0.68s is not transcribed      "Part of that recording was lost. Say it again."
  ✓ a clip that lost 0.09s is still transcribed    rms 0.212

  11/11
```

Every case is pinned from both sides, so none of them can pass by accident:

| put back | reports |
|---|---|
| `current?.device != bound?.device` — the bug | 6/11 |
| `droppedAudioTolerance = 0` — lose nothing at all | 10/11 |
| `droppedAudioTolerance` high — lose anything | 10/11 |

The cases are in `tests/audio-recovery-cases.yaml`. The check runs in CI: it touches no audio setting, opens no microphone, and writes into a scratch config with its own `audio.output_dir` — which is also where the trace goes, per #96. Confirmed by file count and mtime that a run leaves `~/Recordings/ParrotFlow Dev/` untouched.

**Not reproduced.** The hardware. Nothing here opens an input device, because the person this was written for was dictating at the time and switching their default input is both forbidden and the trigger. So this proves the recorder replaces its engine when the binding moves, and that the capture path writes a real signal afterwards. It does not prove what the hardware sends after a real AirPods switch, and it does not prove the 1.5-second budget is the right number on a slow Bluetooth link.

**#95's second acceptance criterion, honestly.** It asks for a check on non-trivial RMS after a simulated switch. That is what "a tone at the new rate is written" does — a 440 Hz tone at the new device's rate, through the real converter, out at rms 0.212 against a floor of 0.001 — but the buffers are synthetic, not a microphone. It fits the criterion one level under the hardware, and no further.

</details>

<details>
<summary>What a human still has to check</summary>

Not run here, on purpose. Someone with the machine to spare should do this:

1. `make install`, then dictate once. Confirm it works and note the microphone in the menu bar.
2. `tail -f ~/Library/Logs/ParrotFlow-Dev.log` in another window.
3. Connect AirPods so macOS makes them the default input. Wait for `rebuilding the capture engine — input moved: …` followed by `capture engine rebuilt in Xs`. **Note X** — that is the number the 1.5s budget has to cover.
4. Press the hotkey and speak, on the first attempt after the switch. Expected: the dictation arrives. If it does not, the menu bar must read `⚠︎ Recorded nothing …` or `⚠︎ The microphone is still connecting …`, and the log must have the matching line. A press that does nothing and says nothing is still a failure.
5. Take the AirPods back out and repeat 3 and 4.
6. Do it again with the hotkey held *through* the switch, so the change lands mid-recording. Expected: a notice, not a modal alert, and the next press records.
7. `ParrotFlow --record 3` and check the `rms` line reads something over 0.001 for ordinary speech.

If step 3 reports a rebuild taking more than 1.5s and step 4 then fails with "still connecting" on every attempt, the budget is too small for that link and `rebuildWaitSeconds` needs raising.

</details>

<details>
<summary>Checks</summary>

- `scripts/check-audio-recovery.sh` 11/11, stable across runs, and green in CI against `Apple Virtual Sound Device` on the runner
- `check-no-voice` 5/5, `check-numbers` 97/97, `check-pipeline` 71/71, `check-wake` 24/24, `check-split` 14/14, `check-dotted` 54/54, `check-dates`, `check-transform-folders` 12/12, `check-eval` 25/25, `check-default-config`, `check-vocabulary-config` 61/61, `check-seeded-transform`, `check-pinned-certificate` — all pass
- Swift 6 concurrency warnings: 20 before, 20 after, all in `AppDelegate.swift`, none added. `Recorder.swift` and `AudioRecoveryCommand.swift` are at zero. PR #49 still owns those 20.
- SwiftLint: 32 before, 32 after

</details>

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiQJipvz9Ps9tdDCRdisv


