### PR TITLE
fix: a correction that landed is no longer undone by the check behind it

### DIFF
--- a/Sources/ParrotFlow/Surface.swift
+++ b/Sources/ParrotFlow/Surface.swift
@@ -591,11 +591,35 @@ struct Surface {
     /// concluding failure from that is worse than not checking at all: the
     /// recovery then destroys work that was fine.
     private func settled(on fragment: String) -> Bool {
-        let deadline = Date().addingTimeInterval(1.0)
+        // Two and a half seconds, not one.
+        //
+        // Measured in Outlook: the paste landed and was on screen, and this
+        // said it had not within the second — so the repair undid an edit that
+        // had worked, and the message said the app would not allow one. The
+        // read is the slow part. Outlook's message body reported 395,489
+        // characters, and every poll copies all of them out of another process
+        // that is busy laying the paste out, so a single read can eat most of
+        // the old budget and only two or three ever happened.
+        let deadline = Date().addingTimeInterval(2.5)
         repeat {
             if landed(fragment) { return true }
             Thread.sleep(forTimeInterval: 0.05)
         } while Date() < deadline
+
+        // Which of the three failures this was. They look identical from the
+        // outside and want opposite fixes: text that never arrived is a write
+        // that did not happen, text that arrived without its surroundings is
+        // this check being too literal, and neither is a paste that went to the
+        // wrong place.
+        if let value = SelectionReader.visibleText(of: element) {
+            let replacement = fragment.trimmingCharacters(in: .whitespacesAndNewlines)
+            Log.write(folded(value).contains(folded(replacement))
+                ? "surface: the text is there but not in the context expected;"
+                    + " the read-back is stricter than the edit"
+                : "surface: the text has not appeared in the field")
+        } else {
+            Log.write("surface: cannot read the field back to check the edit")
+        }
         return false
     }
 
@@ -622,6 +646,14 @@ struct Surface {
             .replacingOccurrences(of: "\u{2018}", with: "'")
             .replacingOccurrences(of: "\u{201C}", with: "\"")
             .replacingOccurrences(of: "\u{201D}", with: "\"")
+            // What a rich-text editor does to text on the way in. Outlook and
+            // Mail put non-breaking spaces around pasted runs and keep carriage
+            // returns in the value; both make a literal comparison fail on text
+            // that is plainly correct on screen.
+            .replacingOccurrences(of: "\u{00A0}", with: " ")
+            .replacingOccurrences(of: "\u{202F}", with: " ")
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
     }
 
     private func select(_ range: NSRange) -> Bool {

--- a/Sources/ParrotFlow/Surface.swift
+++ b/Sources/ParrotFlow/Surface.swift
@@ -466,7 +466,7 @@ struct Surface {
     /// Nil rather than a refusal when the walk is too long to be worth taking,
     /// so the caller can fall through to its own last resort.
     private func writeByWalkingTheCaret(
-        _ target: NSRange, replacement: String, fragment: String, undo: Undo
+        _ target: NSRange, replacement: String, fragment: Fragment, undo: Undo
     ) -> Outcome? {
         guard var caret = caretOffset() else {
             Log.write("surface: the app will not say where the caret is; cannot walk to the span")
@@ -592,7 +592,7 @@ struct Surface {
     /// Reading once after a guessed delay measures the delay, not the write, and
     /// concluding failure from that is worse than not checking at all: the
     /// recovery then destroys work that was fine.
-    private func settled(on fragment: String) -> Bool {
+    private func settled(on fragment: Fragment) -> Bool {
         // Two and a half seconds, not one.
         //
         // Measured in Outlook: the paste landed and was on screen, and this
@@ -614,7 +614,7 @@ struct Surface {
         // this check being too literal, and neither is a paste that went to the
         // wrong place.
         if let value = SelectionReader.visibleText(of: element) {
-            let replacement = fragment.trimmingCharacters(in: .whitespacesAndNewlines)
+            let replacement = fragment.text.trimmingCharacters(in: .whitespacesAndNewlines)
             Log.write(folded(value).contains(folded(replacement))
                 ? "surface: the text is there but not in the context expected;"
                     + " the read-back is stricter than the edit"
@@ -646,10 +646,12 @@ struct Surface {
     /// text really does repeat itself, the window grows until it does not.
     ///
     /// Folded, because the folded text is what `landed` compares. Capped at the
-    /// whole text before the span, which is as positional as this can get.
+    /// whole text before the span — at which point the leading context reaches
+    /// the start of the value, and `atStart` says so rather than pretending a
+    /// contains still places it.
     private func fragment(
         around range: Range<String.Index>, replacement: String, in updated: String
-    ) -> String {
+    ) -> Fragment {
         let before = content[..<range.lowerBound]
         let beforeCount = before.count
         let trailing = String(content[range.upperBound...].prefix(12))
@@ -658,11 +660,28 @@ struct Surface {
         var context = 12
         while true {
             let leading = String(before.suffix(context))
-            if context >= beforeCount || standsAlone(folded(leading), in: target) {
-                return leading + replacement + trailing
+            // Nothing left to widen with, so the value's own start is the
+            // anchor. This is also the span that begins the field, where there
+            // is no leading context at all and a contains would accept the same
+            // words written anywhere further down.
+            if context >= beforeCount {
+                return Fragment(text: leading + replacement + trailing, atStart: true)
+            }
+            if standsAlone(folded(leading), in: target) {
+                return Fragment(text: leading + replacement + trailing, atStart: false)
             }
             context *= 2
         }
+    }
+
+    /// The text the value must hold for the edit to have happened, and where.
+    private struct Fragment {
+        let text: String
+        /// The leading context reaches the start of the content, so the value
+        /// has to *begin* with this. Containing it is not enough: a span at
+        /// offset zero has nothing in front of it to be recognised by, and an
+        /// identical run later in the field would answer for it.
+        let atStart: Bool
     }
 
     /// Whether `needle` stands in exactly one place in `text`.
@@ -671,9 +690,15 @@ struct Surface {
         return text.range(of: needle, range: first.upperBound..<text.endIndex) == nil
     }
 
-    private func landed(_ fragment: String) -> Bool {
+    private func landed(_ fragment: Fragment) -> Bool {
         guard let value = SelectionReader.visibleText(of: element) else { return false }
-        return folded(value).contains(folded(fragment))
+        let text = folded(value)
+        let needle = folded(fragment.text)
+        guard fragment.atStart else { return text.contains(needle) }
+        // Leading whitespace on both sides, because a rich-text editor can put
+        // a blank line above what it holds and that is not a failed write.
+        return text.drop(while: \.isWhitespace)
+            .starts(with: needle.drop(while: \.isWhitespace))
     }
 
     /// Typographic substitution is not a failed write. Most apps turn a straight

--- a/Sources/ParrotFlow/Surface.swift
+++ b/Sources/ParrotFlow/Surface.swift
@@ -402,8 +402,10 @@ struct Surface {
         // The replacement in the company it is meant to keep. Checking for the
         // replacement alone would accept an append — "…the storethey're"
         // contains "they're" quite happily — so the surrounding characters are
-        // what make this a check rather than a formality.
-        let fragment = self.fragment(around: range, replacement: replacement)
+        // what make this a check rather than a formality. `updated` is what the
+        // value should read afterwards, and the fragment is widened against it
+        // until it names one place there.
+        let fragment = self.fragment(around: range, replacement: replacement, in: updated)
 
         // 1. Set the range, then write the text into it. Disturbs nothing, and
         //    is what a native field accepts.
@@ -623,14 +625,50 @@ struct Surface {
         return false
     }
 
-    /// The replacement with up to 12 characters of its surroundings on each
-    /// side — the shape the value must take for the edit to have happened in
-    /// the place it was asked to happen. An append does not produce it.
-    private func fragment(around range: Range<String.Index>, replacement: String) -> String {
-        let context = 12
-        return String(content[..<range.lowerBound].suffix(context))
-            + replacement
-            + String(content[range.upperBound...].prefix(context))
+    /// The replacement with its surroundings — the shape the value must take for
+    /// the edit to have happened in the place it was asked to happen. An append
+    /// does not produce it.
+    ///
+    /// Twelve characters after the replacement, and at least twelve before it.
+    /// The leading context is widened until it stands in exactly one place in
+    /// the text the edit should produce.
+    ///
+    /// Why widen. `landed` asks whether the value *contains* this, and a
+    /// contains cannot tell one place from another. Twelve characters repeat —
+    /// a list, a table, the same line quoted further down — and a paste that
+    /// misses and lands on the twin then satisfies the check while the place we
+    /// aimed at is untouched. That is the failure this file exists to prevent.
+    /// A leading context standing in one place pins the position, so the
+    /// contains is a question about position again.
+    ///
+    /// Ordinary prose is already unique after twelve characters, so this
+    /// usually returns on the first pass and nothing gets stricter. Where the
+    /// text really does repeat itself, the window grows until it does not.
+    ///
+    /// Folded, because the folded text is what `landed` compares. Capped at the
+    /// whole text before the span, which is as positional as this can get.
+    private func fragment(
+        around range: Range<String.Index>, replacement: String, in updated: String
+    ) -> String {
+        let before = content[..<range.lowerBound]
+        let beforeCount = before.count
+        let trailing = String(content[range.upperBound...].prefix(12))
+        let target = folded(updated)
+
+        var context = 12
+        while true {
+            let leading = String(before.suffix(context))
+            if context >= beforeCount || standsAlone(folded(leading), in: target) {
+                return leading + replacement + trailing
+            }
+            context *= 2
+        }
+    }
+
+    /// Whether `needle` stands in exactly one place in `text`.
+    private func standsAlone(_ needle: String, in text: String) -> Bool {
+        guard !needle.isEmpty, let first = text.range(of: needle) else { return false }
+        return text.range(of: needle, range: first.upperBound..<text.endIndex) == nil
     }
 
     private func landed(_ fragment: String) -> Bool {

--- a/docs/proposals/hud-placement-and-offer.md
+++ b/docs/proposals/hud-placement-and-offer.md
@@ -1,0 +1,465 @@
+# The HUD, where it goes, and what it offers
+
+Status: **prototyped on `feat/hud-placement-and-offer`, not yet landed.**
+Everything below works in a build. None of it has been split into reviewable
+pieces; section 7 names the order to do that in.
+
+This is the spec to implement against, PR by PR. Each section says what the
+behaviour is, why, and what was measured to get there — because most of these
+decisions were arrived at by being wrong first, and the wrong versions are the
+part worth writing down.
+
+Design mockup: <https://claude.ai/code/artifact/4b31fdb8-192f-40df-9e42-64efcb93665d>
+
+---
+
+## 1. The pill opens where the words will land
+
+The pill used to appear 96pt off the bottom of the screen, always. It now opens
+next to the place the dictation is about to go, and stays there for the whole of
+it — recording, transcribing, and the offer, one position.
+
+### Read it at the press, not at the end
+
+This is the whole reason it works. An earlier version read the position *after*
+the transcript was inserted and found the words by searching the field for them.
+It worked about half the time — six dictations into a terminal, three found and
+three fell back.
+
+The cause was not accessibility being unreliable. It was asking at the worst
+possible moment: the offer is raised the instant the insertion returns, and an
+app redraws when it gets round to it, so half the time the words were not on
+screen yet. Everything built on top of that — a 120ms retry, matching
+progressively shorter tails of the sentence — was scaffolding around a race.
+
+At key-down there is no race. Nothing has been inserted, nothing is redrawing,
+and the caret is sitting exactly where the words are going to start.
+
+### The ladder
+
+In order, first answer wins:
+
+| Rung | Source | What it is |
+|---|---|---|
+| 1 | `caret` | `AXBoundsForRange` over the selected range, read at the press |
+| 2 | `field` | The focused control's own frame, **only if under 120pt tall** |
+| 3 | `remembered` | Where the last dictation into this same element landed, **if the pane has not changed since** |
+| 4 | `landed` | Worked out after the fact, by diffing the screen |
+| — | none | The bottom of the screen, exactly as before |
+
+### Measured, five apps, one Mac
+
+```
+iTerm2         AXBoundsForRange → 7x17, one character cell
+Terminal.app   AXBoundsForRange → 546x14, the whole line
+Notes          AXBoundsForRange → 466x16, the whole line
+Ghostty        no bounds (AXError -25213); AXSelectedTextRange is always 0
+VS Code        no focused element at all, only a window
+```
+
+Two findings that shaped the code:
+
+**`kAXFocusedUIElementAttribute` on the system-wide element returned nothing for
+all five apps.** The application element has to be asked directly. Ask both.
+
+**A reported range of `0+0` is not always a caret.** Outlook reports `0+0` in a
+text area holding 395,489 characters, and Ghostty reports it always. Believed, it
+puts the pill at the first character of the document *and calls that a caret*,
+which stops any lower rung from being tried — confidently wrong, and worse than
+having no anchor. So a zero range in a field with more than 200 characters is not
+trusted. The false negative is a document whose caret genuinely sits at the
+start, and it costs nothing: the words are found afterwards instead.
+
+### The row is the caret's; the column is not
+
+Take the vertical position from the text and the horizontal from the **left edge
+of the pane**.
+
+Two versions chased the horizontal — centred on the inserted text, then aligned
+to where it starts — and both moved for reasons invisible from outside: what an
+app returns for a range is a line in one app and a cell in another, a wrapped
+sentence starts somewhere other than where it appears to, and a terminal's column
+count can only be inferred from the longest line on screen. Each answer was
+correct; the result read as random. The left edge of the pane does not move.
+
+### Under, not over
+
+The caret is where you are looking, and a surface above it covers what you just
+wrote. When there is no room below — the last line of a full-height window — it
+goes above instead.
+
+### Two rungs that need their reasons kept
+
+**`field` is capped at 120pt.** A search box is 22pt tall and its rectangle is as
+good as its caret. A terminal's text view is 915pt tall and its rectangle puts
+the pill under the *window*, halfway down the screen — a third place for it to
+be, and less predictable than either of the other two. Two predictable positions
+beat three unpredictable ones.
+
+**`landed` diffs, it does not search.** Capture the field's text at the press,
+compare after. Nothing has to match, so it survives a pipeline stage rewriting
+the sentence, a wrap putting a newline through the middle of it, and a terminal
+padding it with spaces — all three broke the search. Bound the diff at **both**
+ends: a spinner or clock ticking above would poison a common prefix on its own,
+so take the common suffix too and the change sits between two fixed points. A
+change spanning more than half the screen is a repaint, not an insertion, and is
+refused.
+
+Then ask the app for the bounds of *that* range. An app can keep no caret and
+still measure text perfectly well — Outlook does — and the two failings are
+unrelated. Only where there are no bounds fall back to the terminal grid:
+`AXLineForIndex` on the last character gives the row count, and the height over
+it gives the pitch. Measured on Ghostty at 53 rows of 17.3pt, a real line height
+rather than a fit.
+
+**A remembered anchor goes stale, and looks confident while it is.** A terminal
+scrolls between dictations, so last time's row belongs to something else — often
+the input box you are about to type into, which is where the pill was seen
+sitting. Two things invalidate it: the pane's character count must match (one
+cheap attribute, and it changes the moment anything is printed) and the landing
+must be under a minute old. Refused, the pill opens at the bottom of the screen
+and `landed` moves it a moment later — starting nowhere in particular beats
+starting somewhere wrong.
+
+**Poll, do not retry once.** Every 80ms for half a second, off the main thread —
+Outlook's message pane reported 395,489 characters, copied out of another process
+on every look. And nothing waits for it: the offer appears immediately at the old
+position and moves if and when there is somewhere better to be, so a miss is not
+a delay.
+
+### Ghostty and VS Code cannot be fixed from here
+
+Ghostty has no caret to report at any moment. It *does* know where it is — it
+implements `firstRectForCharacterRange:actualRange:` for input methods — but that
+is published to the text input system, not to accessibility. VS Code builds no
+accessibility tree unless it detects a screen reader.
+
+Two routes were considered and rejected: patching Ghostty upstream (means running
+a private build until it lands) and shipping an Input Method Kit component (works
+everywhere, but the user must select ParrotFlow as their input source and all
+their typing routes through us). Ghostty gets rung 3 and 4 instead.
+
+---
+
+## 2. The dictating HUD
+
+- **Near-black at 95%, no glass.** The last 5% is a hairline of what is
+  underneath, so the surface reads as sitting *over* something rather than cut
+  out of the screen. Below about 90% the text starts fighting the backdrop,
+  which is the thing glass never solved.
+- **The plumage loses a step of chroma** against near-black. The mockup's values
+  are `#c25f59 / #c29a5c / #5fa383 / #5a89b5`. **Not yet done in the app** —
+  `ParrotStyle` still carries the saturated set, which reads as neon on the new
+  ground.
+- **The meter is a triangle, not a diamond.** Rising to the middle and falling
+  away reads as a shape with a peak — something that already happened. Rising
+  the whole way reads as still opening, which is what a live microphone is.
+- Everything else stands: pulsing dot, live meter, destination icon, and the
+  narrow no-icon pill that says the words have nowhere to go.
+
+---
+
+## 3. The offer
+
+### It shows commands, not the sentence
+
+The dictated text is gone from the pill. It was there because the pill appeared
+at the bottom of the screen with no connection to the words it was about; sitting
+under them, the words are the subject and the pill has only to name what can be
+done to them. For the same reason the old wording — *"Wrong? Right ⌘ to fix
+it"* — is gone. It was a whole question because it had to be.
+
+### The commands come from the config
+
+```
+["Correct"] + transforms where offer: true
+```
+
+`Correct` is first and is not a transform: it is the one command about the words
+rather than about rewriting them, it needs no model, it cannot fail, and it is
+where the selection starts. `offer: true` is a new key on a transform. Off by
+default — the offer is on screen briefly and every entry costs the others room.
+
+### Letters and the mouse, and nothing else
+
+| | Does |
+|---|---|
+| a chip's letter — `C`, `F` | Runs that command |
+| a click on a chip | Runs that command |
+| hovering a chip | Lights it, and stops the clock |
+| `esc` | Dismisses |
+| `↩` | Dismisses, and is passed straight through |
+| the hotkey | Starts a new dictation — **never** taken by the offer |
+
+Three earlier versions are worth recording, because each was a key taken from
+the system that had not earned it.
+
+**The hotkey was the confirm.** That cost it its one job: pressing it while the
+offer was up opened a panel instead of starting the dictation you had just
+asked for.
+
+**Then `↩`.** Wrong for a plainer reason — it is the key you press to *send*
+what you just dictated, so accepting the offer cost you the thing the dictation
+was for. It now means the errand is over: the offer vanishes at once, and the
+keystroke is passed through untouched. Dismissing is a decision, and a decision
+that took two more seconds to show on screen would read as the key not working.
+
+**Then arrows to select and `space` to confirm.** Selecting with one key and
+confirming with another is a menu, and this is two buttons. A letter on each
+chip says how to press it and the pointer says the same thing again, so the
+selection step was ceremony. Space in particular was the worst key to be
+swallowing for nine seconds.
+
+**Nothing is preselected.** The highlight is only ever the pointer's mark, and
+it does not outlive the pointer — leaving the pill clears it. Nothing runs
+without a letter or a click, so a chip lit before you have touched anything is
+saying something about a command that is not about to happen.
+
+**The letters come from the config.** `key: f` beside `offer: true`. A command
+with no letter is still clickable.
+
+### Taking a key without holding focus
+
+The pill is a `nonactivatingPanel` and never takes keyboard focus — deliberately,
+because it appears while you are typing into somebody else's window. A global
+monitor can hear a key in that state but cannot swallow one, so a letter would
+also be typed into your document. Only a `CGEvent` tap can consume without
+focus.
+
+Three fences on the tap, all required:
+
+1. It exists only while the offer is up.
+2. It consumes Escape and the letters the offer has claimed, and passes
+   everything else through. A **modified** key goes through too — `⌘C` copies,
+   `⇧F` types a capital F. Only the bare key belongs to the offer.
+3. It carries its own expiry, so if it is ever not torn down the next key past
+   the deadline kills it and goes through. It must also handle
+   `tapDisabledByTimeout`, or macOS switches it off and the keys stop working
+   with nothing in the log.
+
+The failure mode has to be a key that works, not a keyboard that stops.
+
+**The cost of bare letters, stated plainly.** For as long as the offer is up, a
+bare `C` or `F` is swallowed. Finish dictating and immediately type a word
+starting with one of those and the first keystroke runs a command instead. If
+that turns out to bite, the fix is to dismiss the offer on the first keystroke
+that is not one of its own, which cuts the exposure to a single keypress.
+
+### The mouse
+
+The pill ignores the mouse in **every state but this one**. It sits over
+whatever you are working in, so a surface that swallowed clicks for the length
+of a dictation would be a hole in your screen — but the offer is made of
+buttons, and a button you cannot click is a picture of a button.
+
+Two details that are not optional:
+
+**The chips are not `Button`s.** The pill is never the key window, and SwiftUI
+draws controls in an inactive window at reduced emphasis — so the lit chip came
+up washed out until the pointer landed on it, which read as nothing being lit at
+all. A tap gesture with an explicit `contentShape` draws the same whatever the
+window is doing.
+
+**Hover is bound to the whole pill, not to each chip.** Moving from one chip to
+the other must not read as leaving.
+
+### A command substitutes directly
+
+No preview, whatever the transform's `confirm:` says. That flag is right for its
+own case — reached by voice, over a selection you cannot see, a dialog is the
+only thing between a model and text you did not check. From the offer there is
+nothing left to confirm: the pill is under the sentence, you can read it, and you
+chose the command with a key.
+
+It goes down the same path a correction takes, and inherits its care: hand focus
+back first, replace rather than paste after, refuse to write unless the field is
+still the one that was dictated into, and update `lastTranscript` so a second
+command works on the new text.
+
+The target is captured when you **choose**, not when the model answers. A grammar
+pass takes seconds and focus can move; the sentence it rewrites must be the one
+that was on screen when you pressed the key.
+
+---
+
+## 4. Correct opens the correction panel
+
+Not the preview panel. The offer names one thing and that is the surface that
+does it.
+
+**Save is deliberately unwired.** It logs what it would have written and does
+nothing. Where a rule should go is settled — see the end of this section — but
+writing it is a piece of work of its own.
+
+### The panel, now built
+
+Prototyped in `CorrectionSpans.swift`, `CorrectionSpansView.swift` and
+`CorrectionPanel.swift`.
+
+**The word field is AppKit, and has to be.** Half the gestures are about *where
+in the word* the caret is — space splits at it, backspace joins only from the
+start, the arrows cross only from an edge — and SwiftUI's `TextField` will not
+say. `NSTextField` hands over its field editor, which reports its selection
+exactly. Commands are intercepted through
+`control(_:textView:doCommandBy:)`.
+
+**`Context` is already taken.** The app has a `Context` of its own, so a bare
+`Context` inside an `NSViewRepresentable` resolves to that and conformance
+fails with a message about a "non-matching type" that names the right method
+and the wrong reason. Spell out `NSViewRepresentableContext<…>`.
+
+A rule's left side is a **span**, not a word. A span owns two lists — the words
+that were heard and the words that replace them — and that is what lets one word
+become two and two become one without either side losing the other.
+
+Everything below the panel already works this way: the fuzzy pass scans two-word
+windows, `Vocabulary.widerSpans` offers the wider span for a name the decoder
+split, and `autoApplies` has a branch for exactly this. The panel is the only
+place still counting in words.
+
+Four gestures, all of them ones a text field already has:
+
+| Gesture | Does |
+|---|---|
+| type | change a word |
+| `space` | split one word into two, both under one heard term |
+| `⌫` at the start | join a word to the word before |
+| clear the field | remove the word |
+| `⌘Z` | undo |
+
+Details that matter:
+
+- **The heard text sits above the word it became**, struck through, absolutely
+  positioned so a word changing never moves the line it is in.
+- **State lives on the underline.** Faint is untouched, sky is where you are,
+  leaf is what will change. The bar also runs unbroken under a multi-word span,
+  which is how "these are one thing you said" is said without adding anything.
+- **Clearing a word just removes it.** It does not nest under the word before,
+  and it teaches nothing — a rule mapping an ordinary word to nothing would fire
+  on every dictation.
+- **Arrows keep their edge.** From before the first character, `←` goes to before
+  the first character of the word to the left; from after the last, `→` goes to
+  after the last character of the word to the right. Tab is the exception: it is
+  arriving somewhere to change it, so it lands on the last character.
+- **The keys hint appears only after the first edit**, with a single linear
+  left-to-right sweep across it — an event, not an ambience.
+- **No gesture of its own.** An earlier pass had "click a struck word to release
+  it"; needing a sentence to explain it was the argument against it. `⌘Z` is the
+  only way back.
+- Each heard word keeps its own trailing punctuation, so folding `his.` into
+  `praise` does not cost the sentence its full stop.
+
+### Where a taught rule should be written
+
+A single term of five letters or more goes to `vocabulary.yaml` as a
+pronunciation — which makes it a sound the spotter can search for **and** a rule,
+since `Config.vocabularyRules` turns every pronunciation into one. Anything else
+is a plain rule in `config.yaml`.
+
+Today the panel only ever writes `transcription.replacements` in `config.yaml`.
+Nothing in the app writes `vocabulary.yaml`; `ForgetCommand` only removes from it.
+
+---
+
+## 5. Also here
+
+**A Bluetooth microphone is warned about, once.** Said instead of the offer, the
+first time a given input is used — the moment it means something, because you
+have just watched a transcript come back and if it lost your trailing words this
+is why. At launch it would be advice about a thing you were not doing; every
+dictation would be nagging.
+
+Detected by asking CoreAudio for `kAudioDevicePropertyTransportType`, not by
+matching names. A list of brands is wrong the day somebody buys a headset nobody
+thought of, and it was the wrong question anyway: what costs you the ends of
+your words is the transport, and a Bluetooth voice profile narrows the band and
+gates quiet sound whatever is printed on the case.
+
+> *<device> drops soft and trailing words — the built-in mic hears you better*
+
+## 6. Not done
+
+- The plumage is still the saturated set; only the pill went near-black. The
+  correction and preview panels are still glass, so the surfaces have drifted
+  apart — which is the one thing `ParrotStyle` exists to prevent.
+- The correction panel's Save writes nothing.
+- The launch panel from the design pass is not built at all, and its lettering
+  was never chosen — Serif (New York, `design: .serif`), Rounded, or Wide caps.
+- `--panels` sheet has not been reviewed since the pill changed shape.
+
+## 7. The PRs
+
+Fourteen, in this order. The rule for the boundaries: **each one is safe to
+merge alone and can be judged on its own**. Where that meant splitting something
+that was written together, it is split — the spike is one commit and does not
+have to stay that shape.
+
+Two run first because they are independent of everything else and one of them is
+a live bug. Two more are independent enough to reorder if something is urgent:
+**11** and the pair **1–2**.
+
+### Ground
+
+| # | Title | Why it is separate |
+|---|---|---|
+| 0 | `docs: what the HUD does, and where it goes` | This file. Lands first so every PR after it has a place to be argued against. |
+| 1 | `fix: a read-back that undid a correction that had worked` | `Surface.swift` only. A real bug with a real reproduction — Outlook, 395k characters, the paste landed and the check said it had not. Nothing to do with the HUD; do not hold it behind this stack. |
+| 2 | `feat: --peek says where the caret is` | `PeekCommand` only. Small, and it is the tool a reviewer needs to check #3 on their own machine. |
+
+### Where the pill goes
+
+| # | Title | Contains | Depends on |
+|---|---|---|---|
+| 3 | `feat: the pill opens where the words will land` | `CaretAnchor` rungs 1–2, the `0+0` trust rule, `across`, `flipped`, `PillHUD.aim`/`beside`, the press-time read | 2 for review |
+| 4 | `feat: the pill finds the words in an app with no caret` | `landed` — the diff, the poll off the main thread, the terminal grid — and `remembered` with its staleness check | 3 |
+
+**Why the split.** #3 is a complete feature on its own: it works in iTerm2,
+Terminal.app, Notes and ordinary fields, and everywhere else it falls back to
+exactly today's behaviour, so the blast radius is nil. #4 is the half with the
+guesswork in it — a diff, a poll, an inferred row pitch — and it deserves its own
+argument. Landing them together would make one reviewer judge both.
+
+### How it looks
+
+| # | Title | Contains |
+|---|---|---|
+| 5 | `feat: the floating surfaces are near-black` | `parrotSurface(solid:)`, the pill, **and** the correction and preview panels, plus the plumage's step of chroma |
+
+**All the surfaces in one PR, not just the pill.** Drift between them is the one
+thing `ParrotStyle` exists to prevent, and the spike has already caused some: the
+pill is near-black and the panels are still glass. A PR that fixed only the pill
+would be shipping that drift on purpose.
+
+### What the pill offers
+
+| # | Title | Contains | Depends on |
+|---|---|---|---|
+| 6 | `feat: the offer names what can be done` | Chips, `offer:` and `key:` in config, no sentence, no preselection, clicks, `ignoresMouseEvents` per state | — |
+| 7 | `feat: the offer takes its own keys` | `OfferKeys` and the tap, letters, `esc` consumed, `↩` watched, the hotkey freed | 6 |
+| 8 | `feat: the offer fades rather than vanishing` | Linear decay, nine seconds, held by the pointer, cut by a decision, the generation guard | 6, 7 |
+| 9 | `feat: the offer follows every dictation` | All four endings; the clipboard messages move to the menu bar | 6 |
+| 10 | `feat: a command from the offer rewrites in place` | `runOfferedTransform`, no preview whatever `confirm:` says | 6 |
+
+**Why 6 before 7.** #6 is clickable on its own, so it is a working feature
+without a system-wide event tap in it. #7 is the one PR that swallows keys from
+every app on the machine, and it should be reviewed as exactly that and nothing
+else.
+
+### The rest
+
+| # | Title | Notes |
+|---|---|---|
+| 11 | `feat: a Bluetooth microphone says so, once` | `Recorder.inputIsBluetooth` and `MicNotice`. Independent — reorder freely. |
+| 12 | `feat: the correction panel works in spans` | `CorrectionSpans`, `CorrectionSpansView`, `CorrectionPanel`, the panels sheet. Save still writes nothing. The largest of these; expect it to want a second pass. |
+| 13 | `feat: teaching a word writes it down` | Save. A single term of five letters or more becomes a pronunciation in `vocabulary.yaml` — which `Config.vocabularyRules` turns into a rule as well — and anything else is a rule in `config.yaml`. Nothing in the app writes `vocabulary.yaml` today. |
+
+### What each one has to show
+
+- **3, 4** — the `pill:` log line, and which rung answered, in at least a
+  terminal and a native text field.
+- **5, 6, 12** — `--panels-sheet`. Drift between surfaces is obvious side by
+  side and invisible a week apart, which is what that sheet is for.
+- **7** — that a modified key still reaches the app, and that the tap is gone
+  the moment the offer is.
+- **9, 10** — a dictation down each of the four endings.
+- **13** — the file on disk, and a second dictation proving the rule fires.


### PR DESCRIPTION
A correction that had worked was being undone by the check that runs behind it.

## The bug

`Surface.writeEditable` branch 2 selects a range, pastes over it, then reads the
value back with `settled(on:)` to confirm. If that read fails,
`repairedAfterStrayPaste()` presses ⌘Z and the person is told the app would not
let it edit. So a wrong read does not merely lose the correction — it destroys
one that had already landed.

Observed in Outlook, with the pasted text plainly on screen:

```
surface: the range write was ignored; pasting over a confirmed selection
surface: the paste landed somewhere unintended; undoing it
surface: the stray paste is undone; the text is as it was
in-place: refused — this app would not let me edit it
```

The check was wrong twice over.

**Too impatient.** `settled` polled for 1.0s with a 50ms sleep. The read is the
slow part, not the sleep: Outlook's message body reported 395,489 characters,
and every poll copies all of them out of another process that is busy laying the
paste out. A single read can eat most of the old budget, so only two or three
ever happened. The deadline is 2.5s now.

**Too literal.** `folded` normalised smart quotes and nothing else. A rich-text
editor puts non-breaking spaces around a pasted run and keeps carriage returns
in the value, so a literal `contains` failed on text that was correct on screen.
`U+00A0`, `U+202F`, `\r\n` and `\r` are folded as well.

## The diagnostic

When `settled` does give up, it now logs which of three failures it was: the
text never appeared, the text is there but not in the context expected, or the
field cannot be read at all. They look identical from outside and want opposite
fixes — the log above could not tell them apart, which is why this took a
reproduction in a 395,489-character mail body to find.

## The opposite failure, found in review

Greptile found the other half of the same check, and it is the worse half.
`landed` asks whether the value *contains* the replacement with twelve
characters of its surroundings, and a contains cannot tell one place from
another. Twelve characters repeat — a list, a table, the same line quoted
further down. A paste that misses and lands on the twin satisfies the check
while the place we aimed at is untouched, so the write is recorded as a success
and the repair never runs.

Two changes, one for each shape of it.

`fragment` widens its leading context until that context stands in exactly one
place in the text the edit should produce. One place means any occurrence of the
fragment is at the place we asked for, so the contains is positional again. The
trailing twelve characters are unchanged — they rule out a truncated paste, not
a misplaced one. Ordinary prose is already unique after twelve characters, so
this returns on the first pass and nothing gets stricter; it widens only where
the text really does repeat itself.

A span at offset zero has no leading context to widen, so widening cannot place
it. `fragment` now also reports whether the text has to stand at the *start* of
the value, and `landed` uses `starts(with:)` rather than `contains` for those.
Leading whitespace is skipped on both sides, because a rich-text editor can put
a blank line above what it holds and that is not a failed write. The same flag
covers the far end of the widening, where the context has reached the whole text
before the span and there is nothing left to widen with.

Modelled against both cases Greptile ran — a repeated line with the edit aimed
at the first, and a first word that appears again later in the field. The old
fragment accepts the paste that landed on the twin in both. This one refuses
both, and the intended paste, an append, a curly-quote substitution, a
rich-text read-back with non-breaking spaces and CRLF, and a value with a blank
line prepended all still answer as they did.

## The spec

`docs/proposals/hud-placement-and-offer.md` lands with it, verbatim from the
prototype branch. It is what the rest of the HUD work is written against, and it
records what was measured for each decision, including the versions that were
wrong first. It lands first so the eleven pull requests behind it have something
to be argued against.

## Checked

- `swift build -c release` clean; no new warnings, none from `Surface.swift`.
- `swiftlint lint` — no violation in `Surface.swift`.
- Every deterministic script `checks.yml` runs, locally: numbers 97/97,
  replacements 23/23, pipeline 71/71, wake 24/24, split 14/14, dotted 54/54,
  dates 26/26, transform folders 12/12, eval 25/25, audio recovery 11/11,
  possessive 35/35, default config, vocabulary config 61/61, seeded transform,
  pinned certificate, no voice 5/5. Replacements scored 22/23 on one run and
  23/23 on the next, which is the NSSpellChecker timeout `checks.yml` warns
  about.

`scripts/check-inplace.sh` and `scripts/check-span.sh` are the two that exercise
this path, and neither was run: both need `/Applications/ParrotFlowDev.app`
replaced with a build of this branch, a real screen, the Accessibility grant,
and control of the keyboard. CI cannot run them either, for the reason stated at
the top of `checks.yml`. The change wants a human at a Mac with an Outlook
message body open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
