### PR TITLE
feat: the pill opens where the words will land

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -84,6 +84,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `Pipeline.App` is what the pipeline matches on and has no business
     /// carrying an image around.
     private var appIconAtPress: NSImage?
+
+    /// Where the caret was when the key went down, so the pill can open next to
+    /// it. Nil when the app would not say, which is when the pill opens where
+    /// it always has. See `CaretAnchor`.
+    private var anchorAtPress: CaretAnchor.Found?
     /// Whether there was anywhere to type when the hotkey went down — see
     /// `Destination`. Decides whether the pill shows the icon, and is handed to
     /// the transcription it belongs to so that the same press decides, a few
@@ -524,6 +529,31 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Log.write(String(format: "selection snapshot was slow: %.2fs", elapsed))
         }
 
+        // Where the words are about to go, so the pill can open there and say
+        // so before a single one of them has been said.
+        //
+        // Here rather than after the insertion, and the difference is the whole
+        // reason it works: at this moment the target app is idle and its caret
+        // is sitting exactly where the sentence will start. Asked at the other
+        // end it is a race against a redraw, which is what it was, and it
+        // answered about half the time. See `CaretAnchor`.
+        //
+        // On this thread rather than a background one, because the pill is
+        // raised a few lines from here and an anchor that arrives after it is
+        // an anchor that makes it jump. The read is capped at 80ms and this
+        // element has just been read from twice by the snapshot above.
+        anchorAtPress = nil
+        if destinationAtPress.acceptsText {
+            switch CaretAnchor.read(at: focusAtPress?.element) {
+            case .found(let found):
+                anchorAtPress = found
+            case .missed(let why):
+                // The pill opens at the bottom of the screen, exactly as it did
+                // before any of this. That is the whole of the fallback.
+                Log.write("pill: no caret — \(why)")
+            }
+        }
+
         // The screen as it was when you started talking — which is the screen
         // the sentence is about. Taken here rather than in the pipeline because
         // this is the last moment the pane is *known*: by the time the stage
@@ -700,6 +730,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         if config.feedback.sound { NSSound(named: "Tink")?.play() }
         if config.feedback.overlay {
+            pill.aim(at: anchorAtPress)
             pill.recording(icon: appIconAtPress)
         }
 

--- a/Sources/ParrotFlow/CaretAnchor.swift
+++ b/Sources/ParrotFlow/CaretAnchor.swift
@@ -1,0 +1,206 @@
+import AppKit
+import ApplicationServices
+
+/// Where the words are about to go, read at the moment the key goes down.
+///
+/// The pill then opens there instead of at the bottom of the screen, so the
+/// first thing a dictation does is point at the place it is going to land.
+///
+/// ## Why at the press and not at the end
+///
+/// An earlier version read this when the transcript had been inserted, and
+/// found the words by searching the field for them. It worked about half the
+/// time. The reason is not accessibility being unreliable — it is that the
+/// question was asked at the worst possible moment. The offer is raised the
+/// instant the insertion returns, and an app redraws when it gets round to it,
+/// so half the time the words were not on screen yet to be found. Everything
+/// built on top of that — a 120ms retry, matching progressively shorter tails
+/// of the sentence — was scaffolding around a race.
+///
+/// At key-down there is no race. Nothing has been inserted, nothing is
+/// redrawing, and the caret is sitting exactly where the words are going to
+/// start. The same question asked here is simply answered.
+///
+/// ## What the system will actually tell us
+///
+/// Measured on one Mac, five apps, asking for the bounds of the selected range:
+///
+///     iTerm2         7x17, one character cell
+///     Terminal.app   546x14, the whole line
+///     Notes          466x16, the whole line
+///     Ghostty        no bounds, and its selected range is 0 whatever the
+///                    caret is doing — so there is nothing to place
+///     VS Code        no focused element at all, only a window
+///
+/// Three of five, and the two that do not answer cannot be made to: Ghostty has
+/// no caret to report and VS Code builds no accessibility tree unless it
+/// detects a screen reader. Where this returns nothing the pill opens where it
+/// always has, which is the whole of the fallback.
+enum CaretAnchor {
+
+    /// Which rung answered. Logged, because "the pill opened in the wrong
+    /// place" is a different bug for each of these.
+    enum Source: String {
+        /// The app gave the rectangle of its caret, at the press.
+        case caret
+        /// The focused control's own rectangle — only taken when the control is
+        /// small enough that its box and its caret mean the same thing.
+        case field
+    }
+
+    struct Found {
+        /// In Cocoa screen coordinates — origin bottom-left, y upward. The
+        /// accessibility API works top-left with y downward, and the flip
+        /// happens here so no caller has to remember it.
+        let rect: NSRect
+        let source: Source
+    }
+
+    enum Outcome {
+        case found(Found)
+        case missed(String)
+    }
+
+    /// Short, because this runs inside the key-down handler.
+    ///
+    /// The one thing that handler may not do is delay the recording. The
+    /// element has already been resolved and read from by the selection
+    /// snapshot a few lines above the call, so an app that is going to answer
+    /// has answered by now; this cap is for the app that is not.
+    private static let timeout: Float = 0.08
+
+    /// Where the caret is, for the element focus was on when the key went down.
+    static func read(at element: AXUIElement?) -> Outcome {
+        guard Permissions.accessibility == .granted else {
+            return .missed("accessibility is not granted")
+        }
+        guard let element else { return .missed("nothing was focused") }
+        guard !SelectionReader.isOurs(element) else { return .missed("our own window") }
+        AXUIElementSetMessagingTimeout(element, timeout)
+
+        let pane = frame(of: element)
+
+        if let selection = selectedRange(of: element), trust(selection, in: element),
+           let rect = bounds(of: selection, in: element) {
+            return .found(Found(rect: flipped(across(rect, pane)), source: .caret))
+        }
+
+        // The control's own rectangle, but only when it is small enough to be
+        // one. A search box is 22pt tall and its box is as good as its caret; a
+        // terminal's text view is 915pt tall and its box puts the pill under
+        // the *window*, halfway down the screen — a third place for the pill to
+        // be, and less predictable than either of the other two.
+        if let pane, pane.height <= 120 {
+            return .found(Found(rect: flipped(pane), source: .field))
+        }
+        return .missed(pane == nil ? "no geometry" : "no caret, and the pane is too big to stand in for one")
+    }
+
+    // MARK: - The questions
+
+    /// Whether a reported range is a caret or a value nobody is maintaining.
+    ///
+    /// Some apps implement `AXSelectedTextRange` by returning the *selection*
+    /// and leaving it empty when there is none — so the answer is `0` wherever
+    /// the caret actually is. Believed, that puts the pill at the first
+    /// character of the document and calls it the caret, which is worse than
+    /// having no anchor: it is confidently wrong, and it stops anything else
+    /// from being tried.
+    ///
+    /// Measured: Outlook reports `0+0` in a text area holding 395,489
+    /// characters, and Ghostty reports `0+0` always. Meanwhile iTerm2 reported
+    /// 163, Terminal.app 479 and Notes 232 with far less text in them.
+    ///
+    /// So: zero, in a field with real content in it, is not a caret. A document
+    /// whose caret genuinely sits at the start is the false negative, and it
+    /// costs nothing — the pill opens at the bottom of the screen, which is
+    /// where it opened before any of this.
+    private static func trust(_ range: CFRange, in element: AXUIElement) -> Bool {
+        guard range.location == 0, range.length == 0 else { return true }
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            element, kAXNumberOfCharactersAttribute as CFString, &value
+        ) == .success, let count = value as? Int else { return true }
+        return count < 200
+    }
+
+    private static func selectedRange(of element: AXUIElement) -> CFRange? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            element, kAXSelectedTextRangeAttribute as CFString, &value
+        ) == .success, let wrapped = value, CFGetTypeID(wrapped) == AXValueGetTypeID()
+        else { return nil }
+        var range = CFRange()
+        guard AXValueGetValue(wrapped as! AXValue, .cfRange, &range) else { return nil }
+        return range
+    }
+
+    private static func bounds(of range: CFRange, in element: AXUIElement) -> CGRect? {
+        // Length is never zero: some apps answer an empty rect for a collapsed
+        // range and a real one for a character, and an empty rect cannot be
+        // told apart from a refusal.
+        var asked = CFRange(location: range.location, length: max(1, range.length))
+        guard let parameter = AXValueCreate(.cfRange, &asked) else { return nil }
+
+        var box: CFTypeRef?
+        guard AXUIElementCopyParameterizedAttributeValue(
+            element, kAXBoundsForRangeParameterizedAttribute as CFString, parameter, &box
+        ) == .success, let value = box, CFGetTypeID(value) == AXValueGetTypeID()
+        else { return nil }
+
+        var rect = CGRect.zero
+        guard AXValueGetValue(value as! AXValue, .cgRect, &rect),
+              rect.width > 0 || rect.height > 0
+        else { return nil }
+        return rect
+    }
+
+    private static func frame(of element: AXUIElement) -> CGRect? {
+        var origin = CGPoint.zero
+        var size = CGSize.zero
+        var position: CFTypeRef?
+        var extent: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+                  element, kAXPositionAttribute as CFString, &position) == .success,
+              AXUIElementCopyAttributeValue(
+                  element, kAXSizeAttribute as CFString, &extent) == .success,
+              let positionValue = position, CFGetTypeID(positionValue) == AXValueGetTypeID(),
+              let extentValue = extent, CFGetTypeID(extentValue) == AXValueGetTypeID(),
+              AXValueGetValue(positionValue as! AXValue, .cgPoint, &origin),
+              AXValueGetValue(extentValue as! AXValue, .cgSize, &size),
+              size.width > 0, size.height > 0
+        else { return nil }
+        return CGRect(origin: origin, size: size)
+    }
+
+    // MARK: - Helpers
+
+    /// The row from the caret, the left edge from the pane it is in.
+    ///
+    /// The column is deliberately thrown away. What an app returns for a range
+    /// is one character in iTerm2 and a whole line in Terminal.app, so the same
+    /// call means different things in different apps, and lining the pill up
+    /// with any of them put it in a place that moved for reasons invisible from
+    /// outside — correct every time, arbitrary-looking every time. The left
+    /// edge of the pane does not move. It is not where the caret is, and it is
+    /// the same place on every dictation, which is the property that matters
+    /// for a surface you glance at.
+    private static func across(_ rect: CGRect, _ pane: CGRect?) -> CGRect {
+        guard let pane else { return rect }
+        return CGRect(x: pane.minX, y: rect.minY, width: pane.width, height: rect.height)
+    }
+
+    /// Accessibility measures from the top-left of the primary display with y
+    /// growing downward; `NSWindow` measures from its bottom-left with y
+    /// growing upward. Everything above this line is in the first system and
+    /// everything outside this file is in the second.
+    private static func flipped(_ rect: CGRect) -> NSRect {
+        guard let primary = NSScreen.screens.first else { return rect }
+        return NSRect(
+            x: rect.minX,
+            y: primary.frame.maxY - rect.maxY,
+            width: rect.width,
+            height: rect.height
+        )
+    }
+}

--- a/Sources/ParrotFlow/CaretAnchor.swift
+++ b/Sources/ParrotFlow/CaretAnchor.swift
@@ -49,10 +49,20 @@ enum CaretAnchor {
     }
 
     struct Found {
+        /// Where the pill goes: the caret's row, the pane's left edge and
+        /// width. See `across`.
+        ///
         /// In Cocoa screen coordinates — origin bottom-left, y upward. The
         /// accessibility API works top-left with y downward, and the flip
         /// happens here so no caller has to remember it.
         let rect: NSRect
+        /// The text's own rectangle, before the column was taken from the pane.
+        ///
+        /// Which display the pill belongs on is decided from this and not from
+        /// `rect`: a pane can straddle two monitors, the caret is only ever on
+        /// one of them, and the wider rectangle can have most of its area on
+        /// the monitor the words are not on. Same coordinates as `rect`.
+        let text: NSRect
         let source: Source
     }
 
@@ -82,7 +92,10 @@ enum CaretAnchor {
 
         if let selection = selectedRange(of: element), trust(selection, in: element),
            let rect = bounds(of: selection, in: element) {
-            return .found(Found(rect: flipped(across(rect, pane)), source: .caret))
+            let text = flipped(rect)
+            return .found(Found(
+                rect: across(text, pane.map(flipped)), text: text, source: .caret
+            ))
         }
 
         // The control's own rectangle, but only when it is small enough to be
@@ -91,7 +104,9 @@ enum CaretAnchor {
         // the *window*, halfway down the screen — a third place for the pill to
         // be, and less predictable than either of the other two.
         if let pane, pane.height <= 120 {
-            return .found(Found(rect: flipped(pane), source: .field))
+            // The box is standing in for the caret, so it is both.
+            let box = flipped(pane)
+            return .found(Found(rect: box, text: box, source: .field))
         }
         return .missed(pane == nil ? "no geometry" : "no caret, and the pane is too big to stand in for one")
     }
@@ -185,9 +200,12 @@ enum CaretAnchor {
     /// edge of the pane does not move. It is not where the caret is, and it is
     /// the same place on every dictation, which is the property that matters
     /// for a surface you glance at.
-    private static func across(_ rect: CGRect, _ pane: CGRect?) -> CGRect {
+    ///
+    /// Both rectangles are already flipped, and flipping only moves y, so
+    /// widening before the flip and after it give the same answer.
+    private static func across(_ rect: NSRect, _ pane: NSRect?) -> NSRect {
         guard let pane else { return rect }
-        return CGRect(x: pane.minX, y: rect.minY, width: pane.width, height: rect.height)
+        return NSRect(x: pane.minX, y: rect.minY, width: pane.width, height: rect.height)
     }
 
     /// Accessibility measures from the top-left of the primary display with y

--- a/Sources/ParrotFlow/PeekCommand.swift
+++ b/Sources/ParrotFlow/PeekCommand.swift
@@ -124,6 +124,11 @@ enum PeekCommand {
         }
         report("selected  \(selected.map { "\"\(preview($0))\"" } ?? "none")")
         report("range     \(rangeDescription(of: element))")
+        // Whether the pill can be put next to the text rather than at a fixed
+        // place on the display. Optional, so this is the line that says which
+        // apps it will work in — see `caretDescription`.
+        report("caret     \(caretDescription(of: element))")
+        report("field     \(fieldDescription(of: element))")
 
         // What the write path will actually be handed. Everything above is raw
         // accessibility; this is the one coordinate space the app edits in, and
@@ -295,6 +300,91 @@ enum PeekCommand {
         var range = CFRange()
         guard AXValueGetValue(wrapped as! AXValue, .cfRange, &range) else { return "unreadable" }
         return "location \(range.location), length \(range.length)"
+    }
+
+    /// Where the caret is on screen, if the app will say.
+    ///
+    /// `kAXBoundsForRange` is a parameterized attribute: hand it the selected
+    /// range and it hands back a screen rect. It is the only way to put a
+    /// surface next to the text rather than at a fixed place on the display,
+    /// and it is optional — an app that draws its own glyphs usually has no
+    /// text tree to answer from, which is most terminals that are not
+    /// Terminal.app or iTerm2.
+    ///
+    /// Reported here rather than measured in a scratch binary because
+    /// Accessibility is granted per app: this one already has it, and a
+    /// freshly built probe run from a terminal only works if that terminal was
+    /// granted too.
+    ///
+    /// The rect is in accessibility's coordinates — origin top-left of the
+    /// primary display, y growing downward. `NSWindow` wants bottom-left, so
+    /// anything that consumes this has a flip to do first. `CaretAnchor` does.
+    private static func caretDescription(of element: AXUIElement) -> String {
+        var names: CFArray?
+        let advertised = AXUIElementCopyParameterizedAttributeNames(element, &names) == .success
+            ? ((names as? [String]) ?? []) : []
+        let listed = advertised.contains(kAXBoundsForRangeParameterizedAttribute as String)
+
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            element, kAXSelectedTextRangeAttribute as CFString, &value
+        ) == .success, let wrapped = value, CFGetTypeID(wrapped) == AXValueGetTypeID()
+        else { return "no — no selected range to ask about (advertised: \(listed))" }
+
+        var range = CFRange()
+        guard AXValueGetValue(wrapped as! AXValue, .cfRange, &range) else {
+            return "no — the range is unreadable (advertised: \(listed))"
+        }
+
+        // Length zero is a caret rather than a selection, and some apps answer
+        // an empty rect for it. Asking for one character covers both.
+        var asked = CFRange(location: range.location, length: max(1, range.length))
+        guard let parameter = AXValueCreate(.cfRange, &asked) else { return "no — cannot ask" }
+
+        var bounds: CFTypeRef?
+        let error = AXUIElementCopyParameterizedAttributeValue(
+            element, kAXBoundsForRangeParameterizedAttribute as CFString, parameter, &bounds
+        )
+        guard error == .success, let box = bounds, CFGetTypeID(box) == AXValueGetTypeID() else {
+            return "no — AXError \(error.rawValue) (advertised: \(listed))"
+        }
+
+        var rect = CGRect.zero
+        guard AXValueGetValue(box as! AXValue, .cgRect, &rect) else {
+            return "no — answered, but not a rect"
+        }
+        guard rect.width > 0 || rect.height > 0 else {
+            return "no — answered an empty rect at \(Int(rect.minX)),\(Int(rect.minY))"
+        }
+        return String(
+            format: "yes — %d,%d %dx%d",
+            Int(rect.minX), Int(rect.minY), Int(rect.width), Int(rect.height)
+        )
+    }
+
+    /// The fallback if there is no caret: the focused field's own rectangle.
+    /// Enough to put a surface under a one-line input, useless for a document —
+    /// which is why `CaretAnchor` only takes it under 120pt tall.
+    private static func fieldDescription(of element: AXUIElement) -> String {
+        var origin = CGPoint.zero
+        var size = CGSize.zero
+        var position: CFTypeRef?
+        var extent: CFTypeRef?
+        let gotPosition = AXUIElementCopyAttributeValue(
+            element, kAXPositionAttribute as CFString, &position
+        ) == .success, gotSize = AXUIElementCopyAttributeValue(
+            element, kAXSizeAttribute as CFString, &extent
+        ) == .success
+        guard gotPosition, gotSize,
+              let positionValue = position, CFGetTypeID(positionValue) == AXValueGetTypeID(),
+              let extentValue = extent, CFGetTypeID(extentValue) == AXValueGetTypeID(),
+              AXValueGetValue(positionValue as! AXValue, .cgPoint, &origin),
+              AXValueGetValue(extentValue as! AXValue, .cgSize, &size)
+        else { return "unavailable" }
+        return String(
+            format: "%d,%d %dx%d",
+            Int(origin.x), Int(origin.y), Int(size.width), Int(size.height)
+        )
     }
 
     private static func preview(_ text: String) -> String {

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -86,7 +86,7 @@ final class PillHUD {
     /// Where this dictation's words are going, set at the press by `aim(at:)`.
     /// Every state reads it while the pill is up, and `fadeOut` clears it, so
     /// one dictation never inherits the aim of the last.
-    private var near: NSRect?
+    private var near: CaretAnchor.Found?
 
     /// One number for the whole surface: the rise, the morph and the fade.
     ///
@@ -137,7 +137,7 @@ final class PillHUD {
     /// stayed where the dictation started is easier to explain than one that
     /// jumps halfway through.
     func aim(at anchor: CaretAnchor.Found?) {
-        near = anchor?.rect
+        near = anchor
         guard let anchor else { return }
         Log.write(String(
             format: "pill: %@ at %.0f,%.0f %.0fx%.0f",
@@ -364,10 +364,15 @@ final class PillHUD {
         // screen would put the pill on a display the words are not on. Worse,
         // the frame is recomputed on every state change, so the pill would
         // change monitors mid-dictation because the mouse was nudged.
+        //
+        // Chosen from `text` rather than from `rect`, because `rect` is as wide
+        // as the pane and a pane can straddle two monitors — most of it can be
+        // on the display the caret is not on. `beside` then clamps the pane's
+        // left edge into the screen that does hold the caret.
         if let near {
-            guard let visible = screen(showing: near)?.visibleFrame
+            guard let visible = screen(showing: near.text)?.visibleFrame
             else { return panel?.frame.origin ?? .zero }
-            return beside(near, size: size, on: visible)
+            return beside(near.rect, size: size, on: visible)
         }
         guard let visible = screenUnderPointer()?.visibleFrame
         else { return panel?.frame.origin ?? .zero }

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -339,9 +339,9 @@ final class PillHUD {
     }
 
     /// Where a pill of this window size sits: next to the words when this
-    /// dictation has an anchor, and otherwise the capsule centred 96pt off the
-    /// bottom, on the screen the pointer is on — which is the screen you are
-    /// typing into.
+    /// dictation has an anchor, on the screen those words are on. With no
+    /// anchor, the capsule centred 96pt off the bottom of the screen the
+    /// pointer is on — which is the screen you are typing into.
     ///
     /// `size` is the window's, bleed included, so the margin is taken back off
     /// both axes: what has to land at 96pt is the capsule you can see, not the
@@ -351,20 +351,64 @@ final class PillHUD {
     /// that grows stays centred and one that arrives after you have moved to
     /// the other monitor arrives on that one.
     private func anchor(_ size: NSSize) -> NSPoint {
-        let mouse = NSEvent.mouseLocation
-        let screen = NSScreen.screens.first { NSMouseInRect(mouse, $0.frame, false) } ?? NSScreen.main
-        guard let visible = screen?.visibleFrame else { return panel?.frame.origin ?? .zero }
-
         // Every state of a dictation that has an anchor, not just the last one.
         // The point of aiming the pill is that it says where the words are
         // going *before* they go there, and a pill that pointed at the caret
         // only once the words had landed would be reporting rather than
         // telling you.
+        //
+        // The caret decides the screen too, not the pointer. They are the same
+        // screen in the ordinary case and the pointer is only a stand-in for
+        // "where you are working" — but with the caret in a window on one
+        // monitor and the pointer parked on another, clamping to the pointer's
+        // screen would put the pill on a display the words are not on. Worse,
+        // the frame is recomputed on every state change, so the pill would
+        // change monitors mid-dictation because the mouse was nudged.
         if let near {
+            guard let visible = screen(showing: near)?.visibleFrame
+            else { return panel?.frame.origin ?? .zero }
             return beside(near, size: size, on: visible)
         }
+        guard let visible = screenUnderPointer()?.visibleFrame
+        else { return panel?.frame.origin ?? .zero }
         return NSPoint(x: visible.midX - size.width / 2,
                        y: visible.minY + 96 - PillMetrics.bleed)
+    }
+
+    /// The screen the caret is on: the one it overlaps most.
+    ///
+    /// Most, rather than the first that contains a corner, because a window
+    /// straddling two monitors has a line of text on both and only one of them
+    /// has most of it. A caret rectangle that lands on none of them — a window
+    /// dragged off the edge, a display unplugged between the press and the
+    /// pill — falls back to the pointer, which is the old behaviour.
+    private func screen(showing rect: NSRect) -> NSScreen? {
+        // At least a point across before anything is measured. An app is free
+        // to report a caret with no width, and `intersection` calls an empty
+        // rectangle a miss however far inside a screen it sits — so a caret
+        // that is plainly on a display would match none of them.
+        let probe = NSRect(
+            x: rect.minX, y: rect.minY,
+            width: max(rect.width, 1), height: max(rect.height, 1)
+        )
+        var best: NSScreen?
+        var bestArea: CGFloat = 0
+        for candidate in NSScreen.screens {
+            let shared = candidate.frame.intersection(probe)
+            guard !shared.isNull else { continue }
+            let area = shared.width * shared.height
+            if area > bestArea {
+                bestArea = area
+                best = candidate
+            }
+        }
+        return best ?? screenUnderPointer()
+    }
+
+    /// The screen the pointer is on, which is the screen you are typing into.
+    private func screenUnderPointer() -> NSScreen? {
+        let mouse = NSEvent.mouseLocation
+        return NSScreen.screens.first { NSMouseInRect(mouse, $0.frame, false) } ?? NSScreen.main
     }
 
     /// Under the line the words are going to land on, at the left edge of the

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -83,6 +83,11 @@ final class PillHUD {
     private var pendingDismiss: DispatchWorkItem?
     private var isFading = false
 
+    /// Where this dictation's words are going, set at the press by `aim(at:)`.
+    /// Every state reads it while the pill is up, and `fadeOut` clears it, so
+    /// one dictation never inherits the aim of the last.
+    private var near: NSRect?
+
     /// One number for the whole surface: the rise, the morph and the fade.
     ///
     /// The panel frame animates in AppKit and the words crossfade in SwiftUI,
@@ -119,6 +124,28 @@ final class PillHUD {
         set(.offer(label), for: duration)
     }
 
+    /// Point the pill at where the words are going, for this dictation.
+    ///
+    /// Set once, at the press, and read by every state until the pill goes
+    /// away: the recording, the transcribing, and the offer all appear in the
+    /// same place, so nothing moves while you are watching it. Nil puts it back
+    /// at the bottom of the screen, which is where it opened before any of
+    /// this and is the whole of the fallback.
+    ///
+    /// Not re-read later, deliberately. Scroll the window or move focus while
+    /// you are talking and the anchor is stale — but you moved, and a pill that
+    /// stayed where the dictation started is easier to explain than one that
+    /// jumps halfway through.
+    func aim(at anchor: CaretAnchor.Found?) {
+        near = anchor?.rect
+        guard let anchor else { return }
+        Log.write(String(
+            format: "pill: %@ at %.0f,%.0f %.0fx%.0f",
+            anchor.source.rawValue,
+            anchor.rect.minX, anchor.rect.minY, anchor.rect.width, anchor.rect.height
+        ))
+    }
+
     // MARK: - Coming and going
 
     /// Put a state on screen, and take the surface away again after `duration`.
@@ -152,7 +179,7 @@ final class PillHUD {
             morph(to: size)
         } else {
             panel.setContentSize(size)
-            panel.setFrameOrigin(anchor(width: size.width))
+            panel.setFrameOrigin(anchor(size))
             fadeIn(panel)
         }
 
@@ -223,6 +250,11 @@ final class PillHUD {
         } completionHandler: { [weak self] in
             guard let self, self.isFading else { return }
             self.isFading = false
+            // The aim belonged to the dictation that has just ended. A notice
+            // raised later — a config reloaded, an update ready — is about the
+            // app rather than about a place in somebody's document, and would
+            // otherwise inherit a caret that has long since moved.
+            self.near = nil
             panel.orderOut(nil)
             // Back to full strength while off screen, or the next appearance
             // starts from a panel that is already invisible and stays that way.
@@ -239,7 +271,7 @@ final class PillHUD {
     /// resting on.
     private func morph(to size: NSSize) {
         guard let panel else { return }
-        let frame = NSRect(origin: anchor(width: size.width), size: size)
+        let frame = NSRect(origin: anchor(size), size: size)
         guard frame != panel.frame else { return }
 
         NSAnimationContext.runAnimationGroup { context in
@@ -306,23 +338,68 @@ final class PillHUD {
         self.panel = panel
     }
 
-    /// Where a pill of this window width sits: the capsule centred, 96pt off
-    /// the bottom, on the screen the pointer is on — which is the screen you
-    /// are typing into.
+    /// Where a pill of this window size sits: next to the words when this
+    /// dictation has an anchor, and otherwise the capsule centred 96pt off the
+    /// bottom, on the screen the pointer is on — which is the screen you are
+    /// typing into.
     ///
-    /// `width` is the window's, bleed included, so the margin is taken back off
+    /// `size` is the window's, bleed included, so the margin is taken back off
     /// both axes: what has to land at 96pt is the capsule you can see, not the
     /// transparent border the glow spills into.
     ///
     /// Recomputed at every state rather than once at the first show, so a pill
     /// that grows stays centred and one that arrives after you have moved to
     /// the other monitor arrives on that one.
-    private func anchor(width: CGFloat) -> NSPoint {
+    private func anchor(_ size: NSSize) -> NSPoint {
         let mouse = NSEvent.mouseLocation
         let screen = NSScreen.screens.first { NSMouseInRect(mouse, $0.frame, false) } ?? NSScreen.main
         guard let visible = screen?.visibleFrame else { return panel?.frame.origin ?? .zero }
-        return NSPoint(x: visible.midX - width / 2,
+
+        // Every state of a dictation that has an anchor, not just the last one.
+        // The point of aiming the pill is that it says where the words are
+        // going *before* they go there, and a pill that pointed at the caret
+        // only once the words had landed would be reporting rather than
+        // telling you.
+        if let near {
+            return beside(near, size: size, on: visible)
+        }
+        return NSPoint(x: visible.midX - size.width / 2,
                        y: visible.minY + 96 - PillMetrics.bleed)
+    }
+
+    /// Under the line the words are going to land on, at the left edge of the
+    /// pane.
+    ///
+    /// Under rather than over because that is where you are looking and a
+    /// surface above it covers what you just wrote. When there is no room below
+    /// — the last line of a full-height window — it goes above instead, which
+    /// is the one case where covering something is better than being cut off.
+    ///
+    /// The row is the caret's; the column is not. Two versions of this chased
+    /// the horizontal position — centred on the text, then aligned to where it
+    /// starts — and both moved for reasons invisible from outside: what an app
+    /// returns for a range is a line in one app and a cell in another, a
+    /// wrapped sentence starts somewhere other than where it appears to, and a
+    /// terminal's column width can only be guessed. Correct each time,
+    /// arbitrary-looking every time. The left edge of the pane is not where the
+    /// caret is and is the same place on every dictation, which is the property
+    /// that matters for something on screen for two seconds.
+    ///
+    /// `bleed` is taken off because it is transparent: what has to line up with
+    /// the pane is the capsule, not the window the glow spills into.
+    private func beside(_ target: NSRect, size: NSSize, on visible: NSRect) -> NSPoint {
+        let gap: CGFloat = 10
+
+        var y = target.minY - gap - size.height + PillMetrics.bleed
+        if y < visible.minY {
+            y = target.maxY + gap - PillMetrics.bleed
+        }
+        let x = target.minX - PillMetrics.bleed
+
+        return NSPoint(
+            x: min(max(x, visible.minX), visible.maxX - size.width),
+            y: min(max(y, visible.minY), visible.maxY - size.height)
+        )
     }
 }
 


### PR DESCRIPTION
The pill appeared 96pt off the bottom of the screen, always. It now opens next to
the place the dictation is about to go, read at the moment the hotkey goes down,
and stays there for the whole dictation — recording, transcribing, and the offer,
one position.

Section 1 of `docs/proposals/hud-placement-and-offer.md`. Stacked on
`fix/in-place-read-back` (#105); review this diff only.

## Read at the press, not after the insertion

This is the whole reason it works. An earlier version read the position *after*
the transcript was inserted and found the words by searching the field for them.
It worked about half the time — six dictations into a terminal, three found and
three fell back.

The cause was not accessibility being unreliable. It was asking at the worst
moment: the offer is raised the instant the insertion returns, and an app redraws
when it gets round to it, so half the time the words were not on screen yet.
Everything built on top of that — a 120ms retry, matching shorter and shorter
tails of the sentence — was scaffolding around a race.

At key-down there is no race. Nothing has been inserted, nothing is redrawing,
and the caret sits exactly where the words will start.

## The ladder

| Rung | Source | What it is |
|---|---|---|
| 1 | `caret` | `AXBoundsForRange` over the selected range, read at the press |
| 2 | `field` | The focused control's own frame, **only if under 120pt tall** |
| — | none | The bottom of the screen, exactly as before |

Measured, five apps, one Mac:

```
iTerm2         AXBoundsForRange → 7x17, one character cell
Terminal.app   AXBoundsForRange → 546x14, the whole line
Notes          AXBoundsForRange → 466x16, the whole line
Ghostty        no bounds (AXError -25213); AXSelectedTextRange is always 0
VS Code        no focused element at all, only a window
```

Ghostty and VS Code cannot be fixed from here. Ghostty has no caret to report at
any moment; VS Code builds no accessibility tree unless it detects a screen
reader. Both get the fallback, which is today's behaviour — so the blast radius
of this PR is nil.

## The decisions that were arrived at by being wrong first

**A reported range of `0+0` is not always a caret.** Outlook reports it for a
text area holding 395,489 characters, and Ghostty reports it always. Believed, it
anchors to the first character of the document *and calls that a caret*, which
stops the lower rung being tried — confidently wrong, and worse than no anchor.
So a zero range in a field with more than 200 characters is not trusted. The
false negative is a document whose caret genuinely sits at the start, and it
costs the bottom of the screen.

**The row is the caret's, the column is the pane's.** What an app returns for a
range is one character in iTerm2 and a whole line in Terminal.app. Two earlier
versions chased the horizontal — centred on the text, then aligned to where it
starts — and both moved for reasons invisible from outside. The left edge of the
pane does not move.

**`field` is capped at 120pt.** A search box is 22pt tall and its rectangle is as
good as its caret. A terminal's text view is 915pt tall and its rectangle puts
the pill under the *window*, halfway down the screen. Two predictable positions
beat three unpredictable ones.

**Under, not over.** The caret is where you are looking, and a surface above it
covers what you just wrote. When there is no room below — the last line of a
full-height window — it goes above instead.

## What is here

- **`CaretAnchor.swift`** (new) — the two rungs, the trust rule, `across` and the
  coordinate flip. Accessibility measures top-left with y downward and `NSWindow`
  bottom-left with y upward; the flip happens in this file so no caller has to
  remember it.
- **`PillHUD.swift`** — `near`, `aim(at:)`, `beside(_:size:on:)`, and `anchor`
  now taking the whole size because the vertical placement needs the height.
  `fadeOut` clears `near`, so a notice raised later — a config reloaded, an
  update ready — does not inherit a caret that has long since moved.

An anchored pill picks its display from the caret, not from the pointer. Two
things follow from getting that wrong, both found in review: the pill opens on
the monitor the mouse is parked on, and — because the frame is recomputed at
every state change — it changes monitor mid-dictation when the mouse is nudged.
The display is chosen from the caret's own rectangle rather than from the placed
one, because the placed one is as wide as the pane and a pane can straddle two
monitors with most of its area on the wrong one. `beside` then clamps the pane's
left edge into the caret's screen.
- **`AppDelegate.swift`** — `anchorAtPress`, the read in the key-down handler
  gated on `destinationAtPress.acceptsText`, and `pill.aim(at:)` immediately
  before `pill.recording(...)`.
- **`PeekCommand.swift`** — a `caret` and a `field` line. This is the diagnostic
  for the feature, which is why it rides along rather than going first: a
  reviewer needs it to check the rest on their own machine.

The read is on the main thread with an 80ms messaging timeout. It has to be: the
pill is raised a few lines later, and an anchor that arrived after it would make
the pill jump. The element has just been read from twice by the selection
snapshot above, so an app that is going to answer has answered.

## Checked

- `swift build -c release`, no new warnings.
- SwiftLint clean on the three touched files and the new one.
- Every deterministic script in `.github/workflows/checks.yml` run locally, all
  green. `check-inplace.sh` was not run: it replaces the installed app and takes
  over the keyboard.

## Not verified

The five-app table is from the spike, not re-measured on this branch. `--peek`
is how a reviewer re-measures it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
