### PR TITLE
feat: the pill finds the words in an app that has no caret

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -121,16 +121,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// would be frozen empty. And not one slot, because dictations overlap and
     /// an older one still needs the pane it started with.
     ///
-    /// A press's pane lives until its dictation is delivered, and
-    /// `insertDictation` takes it out — used or not. The cap is only for the
-    /// dictations that never get that far, cancelled with Escape or heard as a
-    /// command: a value here has been seen at 395,489 characters, so the
-    /// newest few are kept and the rest dropped.
-    private var screenAtPress: [Int: String] = [:]
+    /// A press's pane lives until its dictation ends, and every way one ends
+    /// takes it out. Never evicted to make room: however many dictations are in
+    /// flight, each one still needs the pane it started with.
+    ///
+    /// The age is the backstop, for a dictation that ends a way nobody thought
+    /// of. A value here has been seen at 395,489 characters, so nothing is kept
+    /// on the chance that a transcript from five minutes ago is still coming.
+    private var screenAtPress: [Int: (text: String, at: Date)] = [:]
 
-    /// How many panes to keep. Past what anyone can have in flight at once —
-    /// each one is a hotkey press whose transcript has not landed yet.
-    private static let panesKept = 4
+    /// How long a pane is worth keeping. Nothing waits this long: the whole
+    /// chain is a decoder and at most a prompt stage.
+    private static let paneLifetime: TimeInterval = 300
 
     /// Bumped by every press that starts a dictation. It is what a `Press`
     /// carries, and what a snapshot that took a moment to copy is stamped with
@@ -713,9 +715,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     // presses have started since: each of those has its own,
                     // and this one is still going to be transcribed.
                     guard let self, let before else { return }
-                    self.screenAtPress[run] = before
-                    for stale in self.screenAtPress.keys.sorted().dropLast(Self.panesKept) {
-                        self.screenAtPress.removeValue(forKey: stale)
+                    let now = Date()
+                    self.screenAtPress[run] = (before, now)
+                    self.screenAtPress = self.screenAtPress.filter {
+                        now.timeIntervalSince($0.value.at) < Self.paneLifetime
                     }
 
                     // A short dictation can be transcribed and written while
@@ -1924,7 +1927,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // by run, so it is this dictation's own pane and nobody else's. A
         // remembered anchor is still a guess, and this is what replaces it with
         // the answer.
-        if let pane = screenAtPress.removeValue(forKey: press.run), let element = press.element {
+        if let pane = screenAtPress.removeValue(forKey: press.run)?.text,
+           let element = press.element {
             findWhereTheWordsLanded(comparedWith: pane, in: element, for: press.run)
         }
     }
@@ -2280,14 +2284,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     ) {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
 
+        // Heard as a command, or nothing at all: no words are going to land,
+        // so there is nothing to compare a pane against.
         if let command = commandAfterWakePhrase(trimmed) {
             Log.write("command heard: \"\(command)\"")
+            screenAtPress.removeValue(forKey: press.run)
             handleVoiceCommand(command)
             return
         }
 
         guard !trimmed.isEmpty else {
             Log.write("transcription produced no text")
+            screenAtPress.removeValue(forKey: press.run)
             updateUI()
             return
         }
@@ -2670,6 +2678,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         _ text: String, to destination: Destination, for press: Press
     ) {
         let element = press.element
+        // However this ends, this dictation is over and nothing wants the pane
+        // it started with. The path that makes the offer takes it before this
+        // runs; every other path here is a clipboard, and those make no offer.
+        defer { screenAtPress.removeValue(forKey: press.run) }
         // Confirmed the same field, or nothing to confirm against. Anything
         // else copies.
         //
@@ -2743,10 +2755,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Log.write("Accessibility not granted; left transcript on the clipboard")
             setLabel("Copied — grant Accessibility to auto-paste", clearAfter: 4)
         }
-        // Delivered, so nothing wants this dictation's pane any more. Already
-        // gone on the path that made the offer. The clipboard paths above
-        // return before this and leave theirs to the cap, which is what the
-        // cap is for.
         screenAtPress.removeValue(forKey: press.run)
         updateUI()
     }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -192,10 +192,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// instead of at the bottom of the screen, and the real answer replaces it
     /// a few seconds later when the words arrive.
     ///
-    /// Held per element and briefly, because both are what make it a fair guess
-    /// rather than a stale one. See the `remembered` rung in `handleHotKeyPress`
-    /// for what invalidates it.
-    private var lastLanding: (element: AXUIElement, found: CaretAnchor.Found, at: Date, chars: Int)?
+    /// Held per element, briefly, and against what the pane was showing when
+    /// the words landed — all three are what make it a fair guess rather than
+    /// a stale one. See `readTheAnchor` for what invalidates it, and
+    /// `CaretAnchor.paneDigest` for why the digest is of the text.
+    private var lastLanding: (element: AXUIElement, found: CaretAnchor.Found, at: Date, digest: Int)?
 
     /// Whether there was anywhere to type when the hotkey went down — see
     /// `Destination`. Decides whether the pill shows the icon, and is handed to
@@ -716,12 +717,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // landed. Two things have to hold, and both exist because a
             // remembered anchor looks confident while it is stale.
             //
-            // The pane's character count must match. A terminal scrolls
-            // between dictations, so last time's row then belongs to somebody
-            // else's line — which is how the pill ends up sitting over the
-            // input box you are about to type into. The count is one cheap
-            // attribute and it changes the moment anything is printed, which
-            // is exactly when the guess goes bad.
+            // The pane must still be showing what it showed when the words
+            // landed. A terminal scrolls between dictations, so last time's
+            // row then belongs to somebody else's line — which is how the pill
+            // ends up sitting over the input box you are about to type into.
+            //
+            // Checked against the text and not against `AXNumberOfCharacters`,
+            // which was the first answer and does not describe the screen at
+            // all. See `CaretAnchor.paneDigest` for the measurement, and for
+            // why a read that does not finish in time refuses.
             //
             // And the landing must be under a minute old. Refused, the pill
             // opens at the bottom of the screen and rung 4 moves it a moment
@@ -730,7 +734,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             if let last = lastLanding, let now = focusAtPress?.element,
                CFEqual(last.element, now),
                Date().timeIntervalSince(last.at) < 60,
-               CaretAnchor.characterCount(of: now) == last.chars {
+               CaretAnchor.paneDigest(of: now) == last.digest {
                 anchorAtPress = CaretAnchor.Found(
                     rect: last.found.rect, text: last.found.text, source: .remembered
                 )
@@ -2056,6 +2060,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         func look() {
             let outcome = CaretAnchor.landed(after: before, at: element)
+            // The screen the words landed on, for the next dictation into this
+            // element to check `remembered` against. Read here rather than at
+            // the press, where the same string would be a delay: this queue is
+            // reading the pane anyway and nothing is waiting on it. Only for a
+            // look that found something, so a search that misses costs nothing.
+            var digest: Int?
+            if case .found = outcome { digest = CaretAnchor.snapshot(of: element)?.hashValue }
             DispatchQueue.main.async { [weak self] in
                 // Only while this press still owns what is on screen. The
                 // offer may have expired, or another dictation may have raised
@@ -2067,11 +2078,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 case .found(let found):
                     self.pill.aim(at: found)
                     // Remembered for the next dictation into this same element,
-                    // but only when the pane will say how big it is — that
-                    // count is the only thing that can tell the guess it has
-                    // gone stale, so without it there is no guess worth making.
-                    if let chars = CaretAnchor.characterCount(of: element) {
-                        self.lastLanding = (element, found, Date(), chars)
+                    // against the screen the words landed on. Without that
+                    // there is nothing to tell the guess it has gone stale, so
+                    // a pane that would not be read is a landing not worth
+                    // keeping.
+                    if let digest {
+                        self.lastLanding = (element, found, Date(), digest)
                     }
                 case .missed(let why):
                     guard Date() < deadline else {

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -112,23 +112,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// The focused element's text as it was at the press, for an app that gave
     /// no caret. What changed in it afterwards is where the words went.
     ///
-    /// Nil whenever there was a caret to aim at, so the search below only ever
-    /// runs for the apps that need it.
+    /// Empty whenever there was a caret to aim at, so the search below only
+    /// ever runs for the apps that need it.
     ///
-    /// Stamped with the press that took it, and read by that press alone. Not
-    /// frozen onto the `Press` the way the element is: the copy runs on a
-    /// background queue and a short dictation can be transcribed before it
-    /// lands, so frozen early it would be frozen empty. The run is unique to
-    /// one press, so matching on it is the same guarantee, made later.
-    private var screenAtPress: (run: Int, text: String)?
+    /// Kept per press, and read by that press alone. Not frozen onto the
+    /// `Press` the way the element is: the copy runs on a background queue and
+    /// a short dictation can be transcribed before it lands, so frozen early it
+    /// would be frozen empty. And not one slot, because two dictations are
+    /// ordinarily in flight and the older one still needs the pane it started
+    /// with. Bounded to the press in hand and the one before it — a value here
+    /// has been seen at 395,489 characters — and each is taken out when it is
+    /// used.
+    private var screenAtPress: [Int: String] = [:]
 
     /// Bumped by every press that starts a dictation. It is what a `Press`
     /// carries, and what a snapshot that took a moment to copy is stamped with
     /// so it cannot be mistaken for a later one's.
     private var pressRun = 0
 
-    /// The press whose offer is on screen. The landing search only moves the
-    /// pill while its own press still owns it.
+    /// The newest press that has had the pill for an offer.
+    ///
+    /// Two things read it: the landing search, which only moves the pill while
+    /// its own press still owns it, and `showCorrectOffer`, which refuses a
+    /// press older than this one. A watermark, so it is never cleared — a later
+    /// press always has a higher run and passes on its own.
     private var offerPressRun: Int?
 
     /// Where the last dictation into a given element ended up.
@@ -604,8 +611,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // would throw away the one the running dictation is going to need.
         if !recorder.isRecording {
             anchorAtPress = nil
-            screenAtPress = nil
             pressRun += 1
+            // The press before this one may still be waiting on a transcript,
+            // so its pane stays; anything older cannot be.
+            screenAtPress = screenAtPress.filter { pressRun - $0.key <= 1 }
             readTheAnchor()
         }
 
@@ -632,7 +641,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // offer off the screen.
         pressTookTheOffer = offerIsUp
         offerUntil = nil
-        offerPressRun = nil
         keyDownDuringPress = false
 
         switch config.hotkey.mode {
@@ -697,12 +705,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             DispatchQueue.global(qos: .utility).async { [weak self] in
                 let before = CaretAnchor.snapshot(of: element)
                 DispatchQueue.main.async {
-                    // Stamped with the press it was taken for. A copy slow
-                    // enough to outlive its own dictation describes a pane
-                    // nobody is waiting on, and must not be left where the
-                    // next one would pick it up.
-                    guard let self, self.pressRun == run, let before else { return }
-                    self.screenAtPress = (run, before)
+                    // Kept for the press it was taken for, whether or not a
+                    // newer press has started since: that press takes its own
+                    // and this one is still going to be transcribed. Two
+                    // presses back, nothing is waiting on it any more.
+                    guard let self, let before, self.pressRun - run <= 1
+                    else { return }
+                    self.screenAtPress[run] = before
 
                     // A short dictation can be transcribed and written while
                     // this copy is still running, so the offer can already be
@@ -1894,10 +1903,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Two dictations can finish out of order — a long prompt stage on the
         // first, none on the second. The newer one's offer is the one about the
         // words you are looking at, so an older one arriving after it never
-        // gets the pill: not while that offer is up, and not after it has
+        // gets the pill: not while that offer is up, and not once it has
         // expired either, because reappearing to talk about older text is the
-        // same mistake made a few seconds later. `offerPressRun` is cleared by
-        // the next press, which is what ends the ordering.
+        // same mistake made a few seconds later.
         if let owner = offerPressRun, owner > press.run {
             Log.write("offer: a newer dictation has already had the pill")
             return
@@ -1911,8 +1919,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // by run, so it is this dictation's own pane and nobody else's. A
         // remembered anchor is still a guess, and this is what replaces it with
         // the answer.
-        if let screen = screenAtPress, screen.run == press.run, let element = press.element {
-            findWhereTheWordsLanded(comparedWith: screen.text, in: element, for: press.run)
+        if let pane = screenAtPress.removeValue(forKey: press.run), let element = press.element {
+            findWhereTheWordsLanded(comparedWith: pane, in: element, for: press.run)
         }
     }
 
@@ -2008,7 +2016,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         pressTookTheOffer = false
         offerUntil = nil
-        offerPressRun = nil
 
         // Under the minimum, so the recorder deletes the clip and gives back
         // nothing. Nothing to transcribe, nothing to deliver.

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -131,6 +131,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// pill while its own press still owns it.
     private var offerPressRun: Int?
 
+    /// When a press's words were written. What makes a pane snapshot a
+    /// *before*: read after this and it already holds the words, so it is not
+    /// a baseline and cannot be diffed against anything.
+    private var wroteAt: (run: Int, at: Date)?
+
     /// Where the last dictation into a given element ended up.
     ///
     /// The only thing worth knowing at the press about an app that keeps no
@@ -696,19 +701,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let run = pressRun
             DispatchQueue.global(qos: .utility).async { [weak self] in
                 let before = CaretAnchor.snapshot(of: element)
+                // When the pane was read, not when this hop lands. The two are
+                // the same moment nine times out of ten and only the first one
+                // says whether the words were there yet.
+                let read = Date()
                 DispatchQueue.main.async {
                     // Stamped with the press it was taken for. A copy slow
                     // enough to outlive its own dictation describes a pane
                     // nobody is waiting on, and must not be left where the
                     // next one would pick it up.
                     guard let self, self.pressRun == run, let before else { return }
+
+                    // And it has to be a *before*. A short dictation can be
+                    // transcribed and written while this copy is still running,
+                    // and a pane read after that already holds the words: diffed
+                    // against itself it finds nothing, forever. Dropped, and the
+                    // pill stays where it opened.
+                    if let wrote = self.wroteAt, wrote.run == run, read > wrote.at {
+                        Log.write("pill: the pane was read after the words landed; no baseline")
+                        return
+                    }
                     self.screenAtPress = (run, before)
 
-                    // A short dictation can be transcribed and pasted before
-                    // this copy finishes, and then the offer went up without a
-                    // pane to compare against. This is the only other moment
-                    // the search can start, so it starts here — for this press
-                    // alone, and only while this press still owns the offer.
+                    // Written already, and the offer up, but the read got in
+                    // first: this is the one other moment the search can start.
                     guard self.offerIsUp, self.offerPressRun == run, let element
                     else { return }
                     self.findWhereTheWordsLanded(comparedWith: before, in: element, for: run)
@@ -1881,6 +1897,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard let text = lastTranscript?.trimmingCharacters(in: .whitespacesAndNewlines),
               !text.isEmpty else { return }
 
+        // Two dictations can finish out of order — a long prompt stage on the
+        // first, none on the second. The newer one's offer is the one under the
+        // words you are looking at, so an older one arriving after it does not
+        // take the pill back off it.
+        if offerIsUp, let owner = offerPressRun, owner > press.run {
+            Log.write("offer: a newer dictation already has the pill")
+            return
+        }
+
         offerUntil = Date().addingTimeInterval(Self.offerSeconds)
         offerPressRun = press.run
         pill.offer(key, for: Self.offerSeconds)
@@ -2693,6 +2718,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
+        // Noted before the write, not after: from here on the pane holds this
+        // dictation's words, so a snapshot read later is not a before. See
+        // `wroteAt`.
+        wroteAt = (press.run, Date())
         switch TextInserter.insert(text, mode: config.transcription.insertMode) {
         case .pasted:
             if config.feedback.sound { NSSound(named: "Glass")?.play() }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -89,6 +89,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// it. Nil when the app would not say, which is when the pill opens where
     /// it always has. See `CaretAnchor`.
     private var anchorAtPress: CaretAnchor.Found?
+
+    /// The focused element's text as it was at the press, for an app that gave
+    /// no caret. What changed in it afterwards is where the words went.
+    ///
+    /// Nil whenever there was a caret to aim at, so the search below only ever
+    /// runs for the apps that need it.
+    private var screenAtPress: String?
+
+    /// Bumped by every press, so a snapshot that took a moment to copy cannot
+    /// end up describing the dictation after the one it was taken for.
+    ///
+    /// Push-to-talk does not wait for the previous transcript, so two presses
+    /// can be a fraction of a second apart — the same overlap `transcriptionRun`
+    /// exists for.
+    private var pressRun = 0
+
+    /// Where the last dictation into a given element ended up.
+    ///
+    /// The only thing worth knowing at the press about an app that keeps no
+    /// caret: you dictate into the same box several times running, and the box
+    /// does not move between them. So the pill opens where the last one landed
+    /// instead of at the bottom of the screen, and the real answer replaces it
+    /// a few seconds later when the words arrive.
+    ///
+    /// Held per element and briefly, because both are what make it a fair guess
+    /// rather than a stale one. See the `remembered` rung in `handleHotKeyPress`
+    /// for what invalidates it.
+    private var lastLanding: (element: AXUIElement, found: CaretAnchor.Found, at: Date, chars: Int)?
+
     /// Whether there was anywhere to type when the hotkey went down — see
     /// `Destination`. Decides whether the pill shows the icon, and is handed to
     /// the transcription it belongs to so that the same press decides, a few
@@ -538,19 +567,58 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // end it is a race against a redraw, which is what it was, and it
         // answered about half the time. See `CaretAnchor`.
         //
-        // On this thread rather than a background one, because the pill is
-        // raised a few lines from here and an anchor that arrives after it is
-        // an anchor that makes it jump. The read is capped at 80ms and this
+        // On this thread rather than the background one below, because the pill
+        // is raised a few lines from here and an anchor that arrives after it
+        // is an anchor that makes it jump. The read is capped at 80ms and this
         // element has just been read from twice by the snapshot above.
         anchorAtPress = nil
+        screenAtPress = nil
+        pressRun += 1
         if destinationAtPress.acceptsText {
             switch CaretAnchor.read(at: focusAtPress?.element) {
             case .found(let found):
                 anchorAtPress = found
             case .missed(let why):
-                // The pill opens at the bottom of the screen, exactly as it did
-                // before any of this. That is the whole of the fallback.
-                Log.write("pill: no caret — \(why)")
+                // Rung 3: open where the last dictation into this same element
+                // landed. Two things have to hold, and both exist because a
+                // remembered anchor looks confident while it is stale.
+                //
+                // The pane's character count must match. A terminal scrolls
+                // between dictations, so last time's row then belongs to
+                // somebody else's line — which is how the pill ends up sitting
+                // over the input box you are about to type into. The count is
+                // one cheap attribute and it changes the moment anything is
+                // printed, which is exactly when the guess goes bad.
+                //
+                // And the landing must be under a minute old. Refused, the pill
+                // opens at the bottom of the screen and rung 4 moves it a moment
+                // later: starting nowhere in particular beats starting somewhere
+                // wrong.
+                if let last = lastLanding, let now = focusAtPress?.element,
+                   CFEqual(last.element, now),
+                   Date().timeIntervalSince(last.at) < 60,
+                   CaretAnchor.characterCount(of: now) == last.chars {
+                    anchorAtPress = CaretAnchor.Found(
+                        rect: last.found.rect, text: last.found.text, source: .remembered
+                    )
+                } else {
+                    Log.write("pill: no caret — \(why); will look for the words afterwards")
+                }
+
+                // Rung 4: no caret to aim at, so take the pane as it is now and
+                // find the words by what changed once they have landed. Off the
+                // main thread and after everything above, because this reads a
+                // value that has been observed at 237k characters — and there
+                // are seconds of dictation before anything needs it.
+                let element = focusAtPress?.element
+                let run = pressRun
+                DispatchQueue.global(qos: .utility).async { [weak self] in
+                    let before = CaretAnchor.snapshot(of: element)
+                    DispatchQueue.main.async {
+                        guard let self, self.pressRun == run else { return }
+                        self.screenAtPress = before
+                    }
+                }
             }
         }
 
@@ -1756,6 +1824,62 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         offerUntil = Date().addingTimeInterval(Self.offerSeconds)
         pill.offer(key, for: Self.offerSeconds)
+
+        // Set only when there was no caret at the press. A remembered anchor is
+        // still a guess, and this is what replaces it with the answer.
+        if let before = screenAtPress {
+            findWhereTheWordsLanded(comparedWith: before)
+        }
+    }
+
+    /// For an app with no caret: keep asking what changed until the words show
+    /// up, then move the pill there.
+    ///
+    /// Asked repeatedly rather than once, and that is the whole of what made
+    /// the first version unreliable. The offer is raised the instant the
+    /// insertion call returns; an app redraws when it gets round to it. A
+    /// single read caught it about half the time, and a single retry a fixed
+    /// 120ms later was the same bet with a different number on it. Six looks
+    /// over half a second cost nothing and do not care how slow the app was.
+    ///
+    /// Nothing waits for this. The offer is already on screen at the position
+    /// the pill opened with, and it moves if and when there is somewhere better
+    /// to be — so a miss is not a delay, it is simply the old behaviour.
+    private func findWhereTheWordsLanded(comparedWith before: String) {
+        let element = focusAtPress?.element
+        let deadline = Date().addingTimeInterval(0.5)
+        // Off the main thread, because the thing being read can be enormous:
+        // Outlook's message pane reported 395,489 characters, and every look
+        // copies all of them out of a busy process. Six of those on the main
+        // thread is a stutter in whatever the user is actually doing.
+        let queue = DispatchQueue.global(qos: .userInitiated)
+
+        func look() {
+            let outcome = CaretAnchor.landed(after: before, at: element)
+            DispatchQueue.main.async { [weak self] in
+                // Stop the moment the offer is gone: the pill it would move is
+                // no longer on screen, and the next dictation has its own aim.
+                guard let self, self.offerIsUp else { return }
+                switch outcome {
+                case .found(let found):
+                    self.pill.aim(at: found)
+                    // Remembered for the next dictation into this same element,
+                    // but only when the pane will say how big it is — that
+                    // count is the only thing that can tell the guess it has
+                    // gone stale, so without it there is no guess worth making.
+                    if let element, let chars = CaretAnchor.characterCount(of: element) {
+                        self.lastLanding = (element, found, Date(), chars)
+                    }
+                case .missed(let why):
+                    guard Date() < deadline else {
+                        Log.write("pill: never found the words — \(why)")
+                        return
+                    }
+                    queue.asyncAfter(deadline: .now() + 0.08) { look() }
+                }
+            }
+        }
+        queue.asyncAfter(deadline: .now() + 0.04) { look() }
     }
 
     /// A press on the dictation key that was too short to be a dictation, made

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -90,27 +90,44 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// it always has. See `CaretAnchor`.
     private var anchorAtPress: CaretAnchor.Found?
 
+    /// Everything one press knows about where its words are going, frozen when
+    /// the recording starts and carried down the whole delivery chain.
+    ///
+    /// Carried rather than read off `self` at the end, for the reason
+    /// `destination` and `focus` already are: push-to-talk does not wait for
+    /// the previous transcript, so two dictations are ordinarily in flight and
+    /// anything read at the end belongs to the newer press. This is what lets
+    /// the offer be certain that the pane it is diffing, and the pill it is
+    /// moving, are its own.
+    private struct Press {
+        /// `pressRun` at the time. Identifies this dictation among the ones in
+        /// flight; nothing else is unique, since two presses in a row are
+        /// ordinarily into the same field.
+        let run: Int
+        /// What was focused when the key went down. The same element `focus`
+        /// carries, held here as well so the offer needs nothing but the press.
+        let element: AXUIElement?
+        /// The pane's text before a word was said, for an app that gave no
+        /// caret. Nil everywhere else — see `screenAtPress`.
+        let pane: String?
+    }
+
     /// The focused element's text as it was at the press, for an app that gave
     /// no caret. What changed in it afterwards is where the words went.
     ///
     /// Nil whenever there was a caret to aim at, so the search below only ever
-    /// runs for the apps that need it.
-    ///
-    /// Kept with the element it was read from, because it is only about that
-    /// element. Push-to-talk does not wait for the previous transcript, so two
-    /// dictations are ordinarily in flight and this field holds the newer
-    /// press's pane. `showCorrectOffer` is handed the element its own dictation
-    /// was aimed at and refuses a snapshot from any other one — the same rule,
-    /// and the same `CFEqual`, that decides whether that dictation may paste.
-    private var screenAtPress: (element: AXUIElement, text: String)?
+    /// runs for the apps that need it. Read out of here once, into the `Press`
+    /// of the dictation that took it, and never again.
+    private var screenAtPress: (run: Int, text: String)?
 
-    /// Bumped by every press, so a snapshot that took a moment to copy cannot
-    /// end up describing the dictation after the one it was taken for.
-    ///
-    /// Push-to-talk does not wait for the previous transcript, so two presses
-    /// can be a fraction of a second apart — the same overlap `transcriptionRun`
-    /// exists for.
+    /// Bumped by every press that starts a dictation. It is what a `Press`
+    /// carries, and what a snapshot that took a moment to copy is stamped with
+    /// so it cannot be mistaken for a later one's.
     private var pressRun = 0
+
+    /// The press whose offer is on screen. The landing search only moves the
+    /// pill while its own press still owns it.
+    private var offerPressRun: Int?
 
     /// Where the last dictation into a given element ended up.
     ///
@@ -578,59 +595,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // is raised a few lines from here and an anchor that arrives after it
         // is an anchor that makes it jump. The read is capped at 80ms and this
         // element has just been read from twice by the snapshot above.
-        anchorAtPress = nil
-        screenAtPress = nil
-        pressRun += 1
-        if destinationAtPress.acceptsText {
-            switch CaretAnchor.read(at: focusAtPress?.element) {
-            case .found(let found):
-                anchorAtPress = found
-            case .missed(let why):
-                // Rung 3: open where the last dictation into this same element
-                // landed. Two things have to hold, and both exist because a
-                // remembered anchor looks confident while it is stale.
-                //
-                // The pane's character count must match. A terminal scrolls
-                // between dictations, so last time's row then belongs to
-                // somebody else's line — which is how the pill ends up sitting
-                // over the input box you are about to type into. The count is
-                // one cheap attribute and it changes the moment anything is
-                // printed, which is exactly when the guess goes bad.
-                //
-                // And the landing must be under a minute old. Refused, the pill
-                // opens at the bottom of the screen and rung 4 moves it a moment
-                // later: starting nowhere in particular beats starting somewhere
-                // wrong.
-                if let last = lastLanding, let now = focusAtPress?.element,
-                   CFEqual(last.element, now),
-                   Date().timeIntervalSince(last.at) < 60,
-                   CaretAnchor.characterCount(of: now) == last.chars {
-                    anchorAtPress = CaretAnchor.Found(
-                        rect: last.found.rect, text: last.found.text, source: .remembered
-                    )
-                } else {
-                    Log.write("pill: no caret — \(why); will look for the words afterwards")
-                }
-
-                // Rung 4: no caret to aim at, so take the pane as it is now and
-                // find the words by what changed once they have landed. Off the
-                // main thread and after everything above, because this reads a
-                // value that has been observed at 237k characters — and there
-                // are seconds of dictation before anything needs it.
-                let element = focusAtPress?.element
-                let run = pressRun
-                DispatchQueue.global(qos: .utility).async { [weak self] in
-                    let before = CaretAnchor.snapshot(of: element)
-                    DispatchQueue.main.async {
-                        // A snapshot that took long enough for the next press to
-                        // happen describes a dictation nobody is waiting on any
-                        // more, and would overwrite the one that is current.
-                        guard let self, self.pressRun == run,
-                              let element, let before else { return }
-                        self.screenAtPress = (element, before)
-                    }
-                }
-            }
+        //
+        // Only for a press that is going to start a dictation. A press that
+        // ends one — the second press of a toggle, a stutter inside the release
+        // tail — is not aiming a new pill, and taking a fresh snapshot there
+        // would throw away the one the running dictation is going to need.
+        if !recorder.isRecording {
+            anchorAtPress = nil
+            screenAtPress = nil
+            pressRun += 1
+            readTheAnchor()
         }
 
         // The screen as it was when you started talking — which is the screen
@@ -656,6 +630,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // offer off the screen.
         pressTookTheOffer = offerIsUp
         offerUntil = nil
+        offerPressRun = nil
         keyDownDuringPress = false
 
         switch config.hotkey.mode {
@@ -673,6 +648,61 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             guard !recorder.isRecording else { return }
             startRecording()
             startPushToTalkPoll()
+        }
+    }
+
+    /// Climb the ladder in `CaretAnchor`, at the press. Called only from
+    /// `handleHotKeyPress`, and only for a press that starts a dictation.
+    private func readTheAnchor() {
+        guard destinationAtPress.acceptsText else { return }
+        switch CaretAnchor.read(at: focusAtPress?.element) {
+        case .found(let found):
+            anchorAtPress = found
+        case .missed(let why):
+            // Rung 3: open where the last dictation into this same element
+            // landed. Two things have to hold, and both exist because a
+            // remembered anchor looks confident while it is stale.
+            //
+            // The pane's character count must match. A terminal scrolls
+            // between dictations, so last time's row then belongs to somebody
+            // else's line — which is how the pill ends up sitting over the
+            // input box you are about to type into. The count is one cheap
+            // attribute and it changes the moment anything is printed, which
+            // is exactly when the guess goes bad.
+            //
+            // And the landing must be under a minute old. Refused, the pill
+            // opens at the bottom of the screen and rung 4 moves it a moment
+            // later: starting nowhere in particular beats starting somewhere
+            // wrong.
+            if let last = lastLanding, let now = focusAtPress?.element,
+               CFEqual(last.element, now),
+               Date().timeIntervalSince(last.at) < 60,
+               CaretAnchor.characterCount(of: now) == last.chars {
+                anchorAtPress = CaretAnchor.Found(
+                    rect: last.found.rect, text: last.found.text, source: .remembered
+                )
+            } else {
+                Log.write("pill: no caret — \(why); will look for the words afterwards")
+            }
+
+            // Rung 4: no caret to aim at, so take the pane as it is now and
+            // find the words by what changed once they have landed. Off the
+            // main thread, because this reads a value that has been observed
+            // at 237k characters — and there are seconds of dictation before
+            // anything needs it.
+            let element = focusAtPress?.element
+            let run = pressRun
+            DispatchQueue.global(qos: .utility).async { [weak self] in
+                let before = CaretAnchor.snapshot(of: element)
+                DispatchQueue.main.async {
+                    // Stamped with the press it was taken for. A copy slow
+                    // enough to outlive its own dictation describes a pane
+                    // nobody is waiting on, and must not be left where the
+                    // next one would pick it up.
+                    guard let self, self.pressRun == run, let before else { return }
+                    self.screenAtPress = (run, before)
+                }
+            }
         }
     }
 
@@ -1042,6 +1072,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // longer than any other wait in the app, and long enough to start
         // another dictation somewhere else while it sits there.
         let focus = focusAtPress
+        // And the press itself, frozen the same way and for the same reason.
+        // `pressRun` is still this dictation's here: a press that ends a
+        // recording does not bump it — see `handleHotKeyPress`.
+        let press = Press(
+            run: pressRun, element: focus?.element,
+            pane: screenAtPress.flatMap { $0.run == pressRun ? $0.text : nil }
+        )
         Task { [weak self] in
             do {
                 // "Transcribing…" is the truth until the decoder is done, and
@@ -1094,7 +1131,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     }
                     self.stopWatchingForEscapeIfIdle()
                     self.finishTranscription(
-                        text: text, destination: destination, focus: focus
+                        text: text, destination: destination, focus: focus, for: press
                     )
                 }
             } catch {
@@ -1827,24 +1864,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// written down here, so a config that moved the hotkey moves what this
     /// advertises. A modifier-only binding has a name too. If registration
     /// failed there is no key to offer and nothing is shown.
-    /// `aimedAt` is the element this dictation was aimed at, carried down from
-    /// its own press — see `insertDictation`. Everything the search below uses
-    /// is checked against it, so an offer for one dictation can never be moved
-    /// by the press-time state of another.
-    private func showCorrectOffer(aimedAt element: AXUIElement?) {
+    /// `press` is the dictation this offer is about, carried down from its own
+    /// key-down — see `insertDictation`. Nothing below reads press-time state
+    /// off `self`, so an offer can never be moved by another dictation's press.
+    private func showCorrectOffer(for press: Press) {
         guard config.feedback.correctOffer else { return }
         guard let key = hotKeys.binding?.displayName else { return }
         guard let text = lastTranscript?.trimmingCharacters(in: .whitespacesAndNewlines),
               !text.isEmpty else { return }
 
         offerUntil = Date().addingTimeInterval(Self.offerSeconds)
+        offerPressRun = press.run
         pill.offer(key, for: Self.offerSeconds)
 
-        // Set only when there was no caret at the press, and only used when it
-        // is a snapshot of this dictation's own field. A remembered anchor is
-        // still a guess, and this is what replaces it with the answer.
-        if let screen = screenAtPress, let element, CFEqual(screen.element, element) {
-            findWhereTheWordsLanded(comparedWith: screen.text, in: element)
+        // Carried on the press, and set only when that press found no caret. A
+        // remembered anchor is still a guess, and this is what replaces it with
+        // the answer.
+        if let pane = press.pane, let element = press.element {
+            findWhereTheWordsLanded(comparedWith: pane, in: element, for: press)
         }
     }
 
@@ -1862,24 +1899,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// the pill opened with, and it moves if and when there is somewhere better
     /// to be — so a miss is not a delay, it is simply the old behaviour.
     ///
-    /// The element is passed in rather than read off `self`, so a second
-    /// dictation started while this one is still looking cannot redirect it.
-    private func findWhereTheWordsLanded(comparedWith before: String, in element: AXUIElement) {
+    /// Everything it needs comes from its own press, so a second dictation
+    /// started while this one is still looking cannot redirect it — and the
+    /// offer it moves has to still be the one that press raised.
+    private func findWhereTheWordsLanded(
+        comparedWith before: String, in element: AXUIElement, for press: Press
+    ) {
         let deadline = Date().addingTimeInterval(0.5)
         // Off the main thread, because the thing being read can be enormous:
         // Outlook's message pane reported 395,489 characters, and every look
         // copies all of them out of a busy process. Six of those on the main
         // thread is a stutter in whatever the user is actually doing.
         let queue = DispatchQueue.global(qos: .userInitiated)
-        let run = pressRun
 
         func look() {
             let outcome = CaretAnchor.landed(after: before, at: element)
             DispatchQueue.main.async { [weak self] in
-                // Stop the moment the offer is gone, or the moment another
-                // press takes the pill: this is looking for one dictation's
-                // words, and the pill it would move now belongs to a newer one.
-                guard let self, self.offerIsUp, self.pressRun == run else { return }
+                // Only while this press still owns what is on screen. The
+                // offer may have expired, or another dictation may have raised
+                // its own — and then the pill this would move is not the one
+                // these words are under.
+                guard let self, self.offerIsUp, self.offerPressRun == press.run
+                else { return }
                 switch outcome {
                 case .found(let found):
                     self.pill.aim(at: found)
@@ -1936,6 +1977,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         pressTookTheOffer = false
         offerUntil = nil
+        offerPressRun = nil
 
         // Under the minimum, so the recorder deletes the clip and gives back
         // nothing. Nothing to transcribe, nothing to deliver.
@@ -2190,7 +2232,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// down — passed along rather than looked up, so a second press landing
     /// mid-transcription cannot redirect this one. See `transcribe`.
     private func finishTranscription(
-        text: String, destination: Destination, focus: SelectionReader.Selection?
+        text: String, destination: Destination, focus: SelectionReader.Selection?,
+        for press: Press
     ) {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -2216,14 +2259,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             lastTranscript = split.text
             runInline(
                 text: split.text, instruction: split.instruction,
-                destination: destination, focus: focus
+                destination: destination, focus: focus, for: press
             )
             return
         }
 
         Log.write("transcribed: \(trimmed)")
         lastTranscript = trimmed
-        insertDictation(trimmed, to: destination, aimedAt: focus?.element)
+        insertDictation(trimmed, to: destination, for: press)
     }
 
     /// An instruction found inside a dictation: route it, run it over the words
@@ -2243,7 +2286,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// with its before and after, as pipeline transforms do.
     private func runInline(
         text: String, instruction: String, destination: Destination,
-        focus: SelectionReader.Selection?
+        focus: SelectionReader.Selection?, for press: Press
     ) {
         let catalogue = Catalogue(transforms: config.transforms)
 
@@ -2251,7 +2294,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         func giveUp(_ why: String, tone: NoticeTone = .caution) {
             endProgress()
             Log.write("inline: \(why); wrote the text as dictated")
-            insertDictation(text, to: destination, aimedAt: focus?.element)
+            insertDictation(text, to: destination, for: press)
             pill.notice(why, tone: tone, duration: 7)
             setLabel(why, clearAfter: 7)
         }
@@ -2277,7 +2320,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                             Log.write("    after:  \(cleaned)")
                         }
                         self.lastTranscript = cleaned
-                        self.insertDictation(cleaned, to: destination, aimedAt: focus?.element)
+                        self.insertDictation(cleaned, to: destination, for: press)
                     }
                 } catch {
                     await MainActor.run {
@@ -2294,7 +2337,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             case .action(let action):
                 runInlineAction(
                     action, text: text, instruction: instruction,
-                    destination: destination, focus: focus
+                    destination: destination, focus: focus, for: press
                 )
             }
             return
@@ -2323,7 +2366,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     case .matched(.action(let action)):
                         self.runInlineAction(
                             action, text: text, instruction: instruction,
-                            destination: destination, focus: focus
+                            destination: destination, focus: focus, for: press
                         )
                     case .anything:
                         Log.write("inline router: \"\(instruction)\" → \(FreeForm.name)")
@@ -2352,7 +2395,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// mind about a rule.
     private func runInlineAction(
         _ action: Capability.Action, text: String, instruction: String,
-        destination: Destination, focus: SelectionReader.Selection?
+        destination: Destination, focus: SelectionReader.Selection?, for press: Press
     ) {
         switch action {
         case .vocabulary:
@@ -2361,7 +2404,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             endProgress()
             Log.write("inline: correction panel over \"\(text)\"")
             showInlineCorrection(
-                over: text, rules: nil, destination: destination, focus: focus
+                over: text, rules: nil, destination: destination, focus: focus, for: press
             )
 
         case .spelling:
@@ -2372,7 +2415,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 giveUpInline(
                     text,
                     why: "\"\(instruction)\" needs the local model to read the spelling",
-                    destination: destination, focus: focus
+                    destination: destination, focus: focus, for: press
                 )
                 return
             }
@@ -2400,12 +2443,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                             }
                             self.showInlineCorrection(
                                 over: text, rules: rules,
-                                destination: destination, focus: focus
+                                destination: destination, focus: focus, for: press
                             )
                         case .openCorrectionPanel:
                             self.showInlineCorrection(
                                 over: text, rules: nil,
-                                destination: destination, focus: focus
+                                destination: destination, focus: focus, for: press
                             )
                         case .undo, .unrecognised:
                             // Undo cannot be reached from here: this path is
@@ -2416,7 +2459,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                             // — the text is still in this function.
                             self.giveUpInline(
                                 text, why: "Didn't understand \"\(instruction)\"",
-                                destination: destination, focus: focus
+                                destination: destination, focus: focus, for: press
                             )
                         }
                     }
@@ -2426,7 +2469,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         self.endProgress()
                         self.giveUpInline(
                             text, why: error.localizedDescription, tone: .failure,
-                            destination: destination, focus: focus
+                            destination: destination, focus: focus, for: press
                         )
                     }
                 }
@@ -2456,7 +2499,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// proposed on the way in, and what was confirmed on the way out.
     private func showInlineCorrection(
         over text: String, rules proposed: [(heard: String, corrected: String)]?,
-        destination: Destination, focus: SelectionReader.Selection?
+        destination: Destination, focus: SelectionReader.Selection?, for press: Press
     ) {
         pendingSelection = nil
 
@@ -2513,13 +2556,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self.lastTranscript = final
             handBack()
             Log.write("inline: writing into \(focus?.owner?.localizedName ?? "the frontmost app")")
-            self.insertDictation(final, to: destination, aimedAt: focus?.element)
+            self.insertDictation(final, to: destination, for: press)
         }
         correctionPanel.onCancel = { [weak self] in
             guard let self else { return }
             Log.write("inline: correction dismissed; wrote the text as dictated")
             handBack()
-            self.insertDictation(text, to: destination, aimedAt: focus?.element)
+            self.insertDictation(text, to: destination, for: press)
         }
 
         if let proposed {
@@ -2532,11 +2575,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Write what was said, and say why it is not what was asked for.
     private func giveUpInline(
         _ text: String, why: String, tone: NoticeTone = .caution,
-        destination: Destination, focus: SelectionReader.Selection?
+        destination: Destination, focus: SelectionReader.Selection?, for press: Press
     ) {
         endProgress()
         Log.write("inline: \(why); wrote the text as dictated")
-        insertDictation(text, to: destination, aimedAt: focus?.element)
+        insertDictation(text, to: destination, for: press)
         pill.notice(why, tone: tone, duration: 7)
         setLabel(why, clearAfter: 7)
     }
@@ -2556,8 +2599,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Write the transcript where it was aimed, or put it on the clipboard and
     /// say so.
     ///
-    /// `aimedAt` is the element that had focus when the hotkey went down. A
-    /// transcript arrives seconds later — a decoder, then any prompt stage —
+    /// `press.element` is the element that had focus when the hotkey went down.
+    /// A transcript arrives seconds later — a decoder, then any prompt stage —
     /// and `TextInserter` posts ⌘V into whatever is frontmost by then. Dictate
     /// an instruction into one terminal pane, switch to the next while it works,
     /// and the sentence lands in the wrong session. Nothing in this app has ever
@@ -2568,12 +2611,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Putting focus back would mean setting `kAXFocused` and trusting an app to
     /// honour it, which is a guess; the clipboard is not.
     ///
-    /// A nil `aimedAt` means there was nothing to compare against — no focus was
-    /// resolved at the press at all — and the paste goes ahead as it always did.
-    /// That is different from failing to read focus *now*, which counts as
-    /// moved: not knowing is not the same as knowing it is fine. Passed
-    /// explicitly at every call rather than defaulted, so a new path has to say
-    /// which it is.
+    /// A nil `press.element` means there was nothing to compare against — no
+    /// focus was resolved at the press at all — and the paste goes ahead as it
+    /// always did. That is different from failing to read focus *now*, which
+    /// counts as moved: not knowing is not the same as knowing it is fine. The
+    /// press is passed explicitly at every call rather than defaulted, so a new
+    /// path has to say which dictation it is writing for.
     ///
     /// False positives would make this unusable: guard too eagerly and every
     /// dictation ends up on the clipboard. The comparison was measured before it
@@ -2581,8 +2624,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// this same `CFEqual` across 17 real dictations and the element was equal
     /// every time.
     private func insertDictation(
-        _ text: String, to destination: Destination, aimedAt element: AXUIElement?
+        _ text: String, to destination: Destination, for press: Press
     ) {
+        let element = press.element
         // Confirmed the same field, or nothing to confirm against. Anything
         // else copies.
         //
@@ -2645,7 +2689,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             if config.feedback.sound { NSSound(named: "Glass")?.play() }
             // The words are in the field and you are looking at them. This is
             // the only second in which correcting one is free.
-            showCorrectOffer(aimedAt: element)
+            showCorrectOffer(for: press)
         case .copied:
             // Deliberate clipboard mode — confirm it landed.
             if config.feedback.sound { NSSound(named: "Glass")?.play() }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -95,7 +95,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     ///
     /// Nil whenever there was a caret to aim at, so the search below only ever
     /// runs for the apps that need it.
-    private var screenAtPress: String?
+    ///
+    /// Kept with the element it was read from, because it is only about that
+    /// element. Push-to-talk does not wait for the previous transcript, so two
+    /// dictations are ordinarily in flight and this field holds the newer
+    /// press's pane. `showCorrectOffer` is handed the element its own dictation
+    /// was aimed at and refuses a snapshot from any other one — the same rule,
+    /// and the same `CFEqual`, that decides whether that dictation may paste.
+    private var screenAtPress: (element: AXUIElement, text: String)?
 
     /// Bumped by every press, so a snapshot that took a moment to copy cannot
     /// end up describing the dictation after the one it was taken for.
@@ -615,8 +622,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 DispatchQueue.global(qos: .utility).async { [weak self] in
                     let before = CaretAnchor.snapshot(of: element)
                     DispatchQueue.main.async {
-                        guard let self, self.pressRun == run else { return }
-                        self.screenAtPress = before
+                        // A snapshot that took long enough for the next press to
+                        // happen describes a dictation nobody is waiting on any
+                        // more, and would overwrite the one that is current.
+                        guard let self, self.pressRun == run,
+                              let element, let before else { return }
+                        self.screenAtPress = (element, before)
                     }
                 }
             }
@@ -1816,7 +1827,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// written down here, so a config that moved the hotkey moves what this
     /// advertises. A modifier-only binding has a name too. If registration
     /// failed there is no key to offer and nothing is shown.
-    private func showCorrectOffer() {
+    /// `aimedAt` is the element this dictation was aimed at, carried down from
+    /// its own press — see `insertDictation`. Everything the search below uses
+    /// is checked against it, so an offer for one dictation can never be moved
+    /// by the press-time state of another.
+    private func showCorrectOffer(aimedAt element: AXUIElement?) {
         guard config.feedback.correctOffer else { return }
         guard let key = hotKeys.binding?.displayName else { return }
         guard let text = lastTranscript?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -1825,10 +1840,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         offerUntil = Date().addingTimeInterval(Self.offerSeconds)
         pill.offer(key, for: Self.offerSeconds)
 
-        // Set only when there was no caret at the press. A remembered anchor is
+        // Set only when there was no caret at the press, and only used when it
+        // is a snapshot of this dictation's own field. A remembered anchor is
         // still a guess, and this is what replaces it with the answer.
-        if let before = screenAtPress {
-            findWhereTheWordsLanded(comparedWith: before)
+        if let screen = screenAtPress, let element, CFEqual(screen.element, element) {
+            findWhereTheWordsLanded(comparedWith: screen.text, in: element)
         }
     }
 
@@ -1845,21 +1861,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Nothing waits for this. The offer is already on screen at the position
     /// the pill opened with, and it moves if and when there is somewhere better
     /// to be — so a miss is not a delay, it is simply the old behaviour.
-    private func findWhereTheWordsLanded(comparedWith before: String) {
-        let element = focusAtPress?.element
+    ///
+    /// The element is passed in rather than read off `self`, so a second
+    /// dictation started while this one is still looking cannot redirect it.
+    private func findWhereTheWordsLanded(comparedWith before: String, in element: AXUIElement) {
         let deadline = Date().addingTimeInterval(0.5)
         // Off the main thread, because the thing being read can be enormous:
         // Outlook's message pane reported 395,489 characters, and every look
         // copies all of them out of a busy process. Six of those on the main
         // thread is a stutter in whatever the user is actually doing.
         let queue = DispatchQueue.global(qos: .userInitiated)
+        let run = pressRun
 
         func look() {
             let outcome = CaretAnchor.landed(after: before, at: element)
             DispatchQueue.main.async { [weak self] in
-                // Stop the moment the offer is gone: the pill it would move is
-                // no longer on screen, and the next dictation has its own aim.
-                guard let self, self.offerIsUp else { return }
+                // Stop the moment the offer is gone, or the moment another
+                // press takes the pill: this is looking for one dictation's
+                // words, and the pill it would move now belongs to a newer one.
+                guard let self, self.offerIsUp, self.pressRun == run else { return }
                 switch outcome {
                 case .found(let found):
                     self.pill.aim(at: found)
@@ -1867,7 +1887,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     // but only when the pane will say how big it is — that
                     // count is the only thing that can tell the guess it has
                     // gone stale, so without it there is no guess worth making.
-                    if let element, let chars = CaretAnchor.characterCount(of: element) {
+                    if let chars = CaretAnchor.characterCount(of: element) {
                         self.lastLanding = (element, found, Date(), chars)
                     }
                 case .missed(let why):
@@ -2625,7 +2645,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             if config.feedback.sound { NSSound(named: "Glass")?.play() }
             // The words are in the field and you are looking at them. This is
             // the only second in which correcting one is free.
-            showCorrectOffer()
+            showCorrectOffer(aimedAt: element)
         case .copied:
             // Deliberate clipboard mode — confirm it landed.
             if config.feedback.sound { NSSound(named: "Glass")?.play() }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -131,11 +131,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// pill while its own press still owns it.
     private var offerPressRun: Int?
 
-    /// When a press's words were written. What makes a pane snapshot a
-    /// *before*: read after this and it already holds the words, so it is not
-    /// a baseline and cannot be diffed against anything.
-    private var wroteAt: (run: Int, at: Date)?
-
     /// Where the last dictation into a given element ended up.
     ///
     /// The only thing worth knowing at the press about an app that keeps no
@@ -701,30 +696,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let run = pressRun
             DispatchQueue.global(qos: .utility).async { [weak self] in
                 let before = CaretAnchor.snapshot(of: element)
-                // When the pane was read, not when this hop lands. The two are
-                // the same moment nine times out of ten and only the first one
-                // says whether the words were there yet.
-                let read = Date()
                 DispatchQueue.main.async {
                     // Stamped with the press it was taken for. A copy slow
                     // enough to outlive its own dictation describes a pane
                     // nobody is waiting on, and must not be left where the
                     // next one would pick it up.
                     guard let self, self.pressRun == run, let before else { return }
-
-                    // And it has to be a *before*. A short dictation can be
-                    // transcribed and written while this copy is still running,
-                    // and a pane read after that already holds the words: diffed
-                    // against itself it finds nothing, forever. Dropped, and the
-                    // pill stays where it opened.
-                    if let wrote = self.wroteAt, wrote.run == run, read > wrote.at {
-                        Log.write("pill: the pane was read after the words landed; no baseline")
-                        return
-                    }
                     self.screenAtPress = (run, before)
 
-                    // Written already, and the offer up, but the read got in
-                    // first: this is the one other moment the search can start.
+                    // A short dictation can be transcribed and written while
+                    // this copy is still running, so the offer can already be
+                    // up. Then this is the one other moment the search can
+                    // start, and it starts here — for this press alone, and
+                    // only while this press still owns the offer.
+                    //
+                    // Whether this snapshot is a *before* is left to the diff.
+                    // Nothing here can know: the paste is a posted ⌘V and the
+                    // app reads the pasteboard when it gets round to it, so the
+                    // moment the words appear is not a moment this process can
+                    // observe. A snapshot taken too late simply looks like an
+                    // app that has not redrawn, which is the case the poll
+                    // exists for — it times out and the pill stays where it
+                    // opened. Rejecting on a clock instead would throw away the
+                    // baselines that were in time as well.
                     guard self.offerIsUp, self.offerPressRun == run, let element
                     else { return }
                     self.findWhereTheWordsLanded(comparedWith: before, in: element, for: run)
@@ -2718,10 +2712,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        // Noted before the write, not after: from here on the pane holds this
-        // dictation's words, so a snapshot read later is not a before. See
-        // `wroteAt`.
-        wroteAt = (press.run, Date())
         switch TextInserter.insert(text, mode: config.transcription.insertMode) {
         case .pasted:
             if config.feedback.sound { NSSound(named: "Glass")?.play() }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -107,7 +107,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         /// What was focused when the key went down. The same element `focus`
         /// carries, held here as well so the offer needs nothing but the press.
         let element: AXUIElement?
+        /// And the app it belonged to, for the same reason: an offer taken
+        /// later has to write back into the window that was dictated into.
+        let owner: NSRunningApplication?
     }
+
+    /// The words the offer on screen is about, and the field they went into.
+    ///
+    /// Stored when the offer is raised because `lastTranscript` and
+    /// `focusAtPress` are one slot each and dictations overlap: an older one
+    /// finishing while the offer is up overwrites the transcript, and the press
+    /// that taps to accept overwrites the focus. Taking the offer then edits
+    /// one dictation's words against another's field. This is the same
+    /// ownership `offerPressRun` already asserts, carrying what it is about.
+    private var offeredCorrection: (run: Int, target: Correction)?
 
     /// The focused element's text as it was at the press, for an app that gave
     /// no caret. What changed in it afterwards is where the words went.
@@ -1145,7 +1158,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // And the press itself, frozen the same way and for the same reason.
         // `pressRun` is still this dictation's here: a press that ends a
         // recording does not bump it — see `handleHotKeyPress`.
-        let press = Press(run: pressRun, element: focus?.element)
+        let press = Press(run: pressRun, element: focus?.element, owner: focus?.owner)
         Task { [weak self] in
             do {
                 // "Transcribing…" is the truth until the decoder is done, and
@@ -1956,6 +1969,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         offerUntil = Date().addingTimeInterval(Self.offerSeconds)
         offerPressRun = press.run
+        // This dictation's own words and its own field, frozen with the offer.
+        offeredCorrection = (press.run, Correction(
+            original: text, element: press.element, owner: press.owner
+        ))
         pill.offer(key, for: Self.offerSeconds)
 
         // Taken at the press, and only when that press found no caret. Matched
@@ -2063,7 +2080,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func takeTheOfferIfTapped() -> Bool {
         guard pressTookTheOffer, recorder.isRecording, !keyDownDuringPress,
               let started = recorder.startedAt,
-              Date().timeIntervalSince(started) < config.audio.minDurationSeconds
+              Date().timeIntervalSince(started) < config.audio.minDurationSeconds,
+              let offered = offeredCorrection, offered.run == offerPressRun
         else { return false }
 
         pressTookTheOffer = false
@@ -2079,12 +2097,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         stopWatchingForEscapeIfIdle()
         pill.hide()
 
-        // Captured here, not read again when Replace is pressed. See `Correction`.
-        let target = Correction(
-            original: lastTranscript ?? "",
-            element: focusAtPress?.element,
-            owner: focusAtPress?.owner
-        )
+        // Captured when the offer went up, not read again here and not again
+        // when Replace is pressed. See `offeredCorrection` and `Correction`.
+        let target = offered.target
+        offeredCorrection = nil
 
         Log.write("offer: taken; editing the last transcript")
         previewPanel.onApply = { [weak self] text in self?.replace(target, with: text) }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -703,6 +703,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     // next one would pick it up.
                     guard let self, self.pressRun == run, let before else { return }
                     self.screenAtPress = (run, before)
+
+                    // A short dictation can be transcribed and pasted before
+                    // this copy finishes, and then the offer went up without a
+                    // pane to compare against. This is the only other moment
+                    // the search can start, so it starts here — for this press
+                    // alone, and only while this press still owns the offer.
+                    guard self.offerIsUp, self.offerPressRun == run, let element
+                    else { return }
+                    self.findWhereTheWordsLanded(comparedWith: before, in: element, for: run)
                 }
             }
         }
@@ -1881,7 +1890,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // remembered anchor is still a guess, and this is what replaces it with
         // the answer.
         if let screen = screenAtPress, screen.run == press.run, let element = press.element {
-            findWhereTheWordsLanded(comparedWith: screen.text, in: element, for: press)
+            findWhereTheWordsLanded(comparedWith: screen.text, in: element, for: press.run)
         }
     }
 
@@ -1903,7 +1912,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// started while this one is still looking cannot redirect it — and the
     /// offer it moves has to still be the one that press raised.
     private func findWhereTheWordsLanded(
-        comparedWith before: String, in element: AXUIElement, for press: Press
+        comparedWith before: String, in element: AXUIElement, for run: Int
     ) {
         let deadline = Date().addingTimeInterval(0.5)
         // Off the main thread, because the thing being read can be enormous:
@@ -1919,7 +1928,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 // offer may have expired, or another dictation may have raised
                 // its own — and then the pill this would move is not the one
                 // these words are under.
-                guard let self, self.offerIsUp, self.offerPressRun == press.run
+                guard let self, self.offerIsUp, self.offerPressRun == run
                 else { return }
                 switch outcome {
                 case .found(let found):

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -107,17 +107,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         /// What was focused when the key went down. The same element `focus`
         /// carries, held here as well so the offer needs nothing but the press.
         let element: AXUIElement?
-        /// The pane's text before a word was said, for an app that gave no
-        /// caret. Nil everywhere else — see `screenAtPress`.
-        let pane: String?
     }
 
     /// The focused element's text as it was at the press, for an app that gave
     /// no caret. What changed in it afterwards is where the words went.
     ///
     /// Nil whenever there was a caret to aim at, so the search below only ever
-    /// runs for the apps that need it. Read out of here once, into the `Press`
-    /// of the dictation that took it, and never again.
+    /// runs for the apps that need it.
+    ///
+    /// Stamped with the press that took it, and read by that press alone. Not
+    /// frozen onto the `Press` the way the element is: the copy runs on a
+    /// background queue and a short dictation can be transcribed before it
+    /// lands, so frozen early it would be frozen empty. The run is unique to
+    /// one press, so matching on it is the same guarantee, made later.
     private var screenAtPress: (run: Int, text: String)?
 
     /// Bumped by every press that starts a dictation. It is what a `Press`
@@ -1075,10 +1077,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // And the press itself, frozen the same way and for the same reason.
         // `pressRun` is still this dictation's here: a press that ends a
         // recording does not bump it — see `handleHotKeyPress`.
-        let press = Press(
-            run: pressRun, element: focus?.element,
-            pane: screenAtPress.flatMap { $0.run == pressRun ? $0.text : nil }
-        )
+        let press = Press(run: pressRun, element: focus?.element)
         Task { [weak self] in
             do {
                 // "Transcribing…" is the truth until the decoder is done, and
@@ -1877,11 +1876,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         offerPressRun = press.run
         pill.offer(key, for: Self.offerSeconds)
 
-        // Carried on the press, and set only when that press found no caret. A
+        // Taken at the press, and only when that press found no caret. Matched
+        // by run, so it is this dictation's own pane and nobody else's. A
         // remembered anchor is still a guess, and this is what replaces it with
         // the answer.
-        if let pane = press.pane, let element = press.element {
-            findWhereTheWordsLanded(comparedWith: pane, in: element, for: press)
+        if let screen = screenAtPress, screen.run == press.run, let element = press.element {
+            findWhereTheWordsLanded(comparedWith: screen.text, in: element, for: press)
         }
     }
 

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -724,8 +724,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 DispatchQueue.main.async {
                     // Kept for the press it was taken for, however many
                     // presses have started since: each of those has its own,
-                    // and this one is still going to be transcribed.
-                    guard let self, let before else { return }
+                    // and this one is still going to be transcribed. Unless it
+                    // is not — cancelled with Escape while this copy was still
+                    // running — in which case its run has been retired and
+                    // there is nothing left to compare a pane against.
+                    guard let self, let before, self.pressesInFlight.contains(run)
+                    else { return }
                     let now = Date()
                     self.screenAtPress[run] = (before, now)
                     self.screenAtPress = self.screenAtPress.filter { run, pane in
@@ -941,6 +945,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // opposite of useful when the reason you cancelled it was that
             // something sounded wrong.
             _ = recorder.stop(config: config)
+            // No words are coming, so this press's dictation is over here. The
+            // recorder is stopped directly rather than through
+            // `stopRecording`, so nothing else would retire it — and the pane
+            // it took is the largest thing the app holds. A snapshot still
+            // being copied lands on a run that has already gone and is dropped.
+            dictationEnded(pressRun)
             tickTimer?.invalidate(); tickTimer = nil
             pushToTalkPoll?.invalidate(); pushToTalkPoll = nil
             releaseTail?.invalidate(); releaseTail = nil

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -148,6 +148,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// most a prompt stage.
     private static let paneLifetime: TimeInterval = 300
 
+    /// The presses whose dictation was thrown away rather than delivered.
+    ///
+    /// "Not in flight" is two different things, and only one of them should
+    /// cost a press its pane. A dictation that finished and pasted is retired
+    /// and still wants its pane: the offer is on screen and the words are what
+    /// the pane is about. One that was cancelled wants nothing ever again.
+    /// Guarding the snapshot store on the first meaning threw the offer's own
+    /// baseline away; not guarding it at all kept a cancelled press's pane for
+    /// the length of the sweep. This is the difference, written down.
+    ///
+    /// Bounded by construction: only a press that dispatched a snapshot is ever
+    /// put here, and that snapshot's own callback takes it out again.
+    private var cancelledPresses: Set<Int> = []
+
     /// The presses that took a pane and whose dictation has not ended yet.
     ///
     /// The age above is a backstop and this is what stops it hitting a live
@@ -743,7 +757,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     // against — which is the whole thing this exists to do.
                     // A pane nobody comes back for is a lifetime, not a leak,
                     // and the sweep below is what bounds it.
-                    guard let self, let before else { return }
+                    //
+                    // Cancelled is the one exception, and the only one: that
+                    // press is never going to write a word, so its pane is
+                    // dropped here rather than waiting out the sweep. Taken out
+                    // of the set as it is read, which is what keeps the set
+                    // from growing. See `cancelledPresses`.
+                    guard let self else { return }
+                    guard self.cancelledPresses.remove(run) == nil else { return }
+                    guard let before else { return }
                     let now = Date()
                     self.screenAtPress[run] = (before, now)
                     self.screenAtPress = self.screenAtPress.filter { run, pane in
@@ -753,9 +775,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
                     // A short dictation can be transcribed and written while
                     // this copy is still running, so the offer can already be
-                    // up. Then this is the one other moment the search can
+                    // up and this press already retired. Retired is not
+                    // cancelled: this is the one other moment the search can
                     // start, and it starts here — for this press alone, and
-                    // only while this press still owns the offer.
+                    // only while the offer on screen is still the one it
+                    // raised, which is a run-owned thing now and not a slot a
+                    // later dictation can move. See `offeredCorrection`.
                     //
                     // Whether this snapshot is a *before* is left to the diff.
                     // Nothing here can know: the paste is a posted ⌘V and the
@@ -880,7 +905,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     // by the time someone presses the hotkey, and a refusal
                     // here should not offer to cancel an install that finished
                     // days ago.
-                    self.dictationEnded(self.pressRun)
+                    self.dictationCancelled(self.pressRun)
                     self.permissions.show(.revisiting)
                 }
             }
@@ -901,7 +926,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // failure people describe as "the app stopped working", and a
             // notice that fades in four seconds is gone by the time they look.
             captureProblem(error.localizedDescription)
-            dictationEnded(pressRun)
+            dictationCancelled(pressRun)
             return
         }
 
@@ -964,7 +989,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // `stopRecording`, so nothing else would retire it — and the pane
             // it took is the largest thing the app holds. A snapshot still
             // being copied lands on a run that has already gone and is dropped.
-            dictationEnded(pressRun)
+            dictationCancelled(pressRun)
             tickTimer?.invalidate(); tickTimer = nil
             pushToTalkPoll?.invalidate(); pushToTalkPoll = nil
             releaseTail?.invalidate(); releaseTail = nil
@@ -1069,7 +1094,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // coming, so this press's dictation ends here. Everything that does
         // reach a transcript ends on one of `transcribe`'s own paths.
         if recording == nil || !config.transcription.enabled {
-            dictationEnded(pressRun)
+            dictationCancelled(pressRun)
         }
 
         if let reason {
@@ -1205,7 +1230,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     self.runsInFlight -= 1
                     guard !self.wasCancelled(run) else {
                         Log.write("escape: dropped the transcript of a cancelled run")
-                        self.dictationEnded(press.run)
+                        self.dictationCancelled(press.run)
                         self.stopWatchingForEscapeIfIdle()
                         self.updateUI()
                         return
@@ -1221,8 +1246,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     if self.transcriptionRun == run { self.endProgress() }
                     self.runsInFlight -= 1
                     self.stopWatchingForEscapeIfIdle()
-                    // Cancelled or failed, this dictation is over either way.
-                    self.dictationEnded(press.run)
+                    // Cancelled or failed, nothing is going to be written.
+                    self.dictationCancelled(press.run)
                     guard !self.wasCancelled(run) else { return }
                     Log.write("transcription failed: \(error.localizedDescription)")
                     self.presentAlert(title: "Transcription failed", message: error.localizedDescription)
@@ -1991,6 +2016,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func dictationEnded(_ run: Int) {
         screenAtPress.removeValue(forKey: run)
         pressesInFlight.remove(run)
+        cancelledPresses.remove(run)
+    }
+
+    /// Over, and with nothing written. The pane goes as it does for any other
+    /// ending, and the press is marked so a snapshot still being copied is
+    /// dropped when it lands instead of sitting out the sweep.
+    private func dictationCancelled(_ run: Int) {
+        dictationEnded(run)
+        cancelledPresses.insert(run)
     }
 
     /// For an app with no caret: keep asking what changed until the words show
@@ -2090,7 +2124,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Under the minimum, so the recorder deletes the clip and gives back
         // nothing. Nothing to transcribe, nothing to deliver.
         _ = recorder.stop(config: config)
-        dictationEnded(pressRun)
+        dictationCancelled(pressRun)
         tickTimer?.invalidate(); tickTimer = nil
         pushToTalkPoll?.invalidate(); pushToTalkPoll = nil
         releaseTail?.invalidate(); releaseTail = nil

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1892,11 +1892,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
               !text.isEmpty else { return }
 
         // Two dictations can finish out of order — a long prompt stage on the
-        // first, none on the second. The newer one's offer is the one under the
-        // words you are looking at, so an older one arriving after it does not
-        // take the pill back off it.
-        if offerIsUp, let owner = offerPressRun, owner > press.run {
-            Log.write("offer: a newer dictation already has the pill")
+        // first, none on the second. The newer one's offer is the one about the
+        // words you are looking at, so an older one arriving after it never
+        // gets the pill: not while that offer is up, and not after it has
+        // expired either, because reappearing to talk about older text is the
+        // same mistake made a few seconds later. `offerPressRun` is cleared by
+        // the next press, which is what ends the ordering.
+        if let owner = offerPressRun, owner > press.run {
+            Log.write("offer: a newer dictation has already had the pill")
             return
         }
 

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -118,12 +118,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Kept per press, and read by that press alone. Not frozen onto the
     /// `Press` the way the element is: the copy runs on a background queue and
     /// a short dictation can be transcribed before it lands, so frozen early it
-    /// would be frozen empty. And not one slot, because two dictations are
-    /// ordinarily in flight and the older one still needs the pane it started
-    /// with. Bounded to the press in hand and the one before it — a value here
-    /// has been seen at 395,489 characters — and each is taken out when it is
-    /// used.
+    /// would be frozen empty. And not one slot, because dictations overlap and
+    /// an older one still needs the pane it started with.
+    ///
+    /// A press's pane lives until its dictation is delivered, and
+    /// `insertDictation` takes it out — used or not. The cap is only for the
+    /// dictations that never get that far, cancelled with Escape or heard as a
+    /// command: a value here has been seen at 395,489 characters, so the
+    /// newest few are kept and the rest dropped.
     private var screenAtPress: [Int: String] = [:]
+
+    /// How many panes to keep. Past what anyone can have in flight at once —
+    /// each one is a hotkey press whose transcript has not landed yet.
+    private static let panesKept = 4
 
     /// Bumped by every press that starts a dictation. It is what a `Press`
     /// carries, and what a snapshot that took a moment to copy is stamped with
@@ -612,9 +619,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if !recorder.isRecording {
             anchorAtPress = nil
             pressRun += 1
-            // The press before this one may still be waiting on a transcript,
-            // so its pane stays; anything older cannot be.
-            screenAtPress = screenAtPress.filter { pressRun - $0.key <= 1 }
             readTheAnchor()
         }
 
@@ -705,13 +709,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             DispatchQueue.global(qos: .utility).async { [weak self] in
                 let before = CaretAnchor.snapshot(of: element)
                 DispatchQueue.main.async {
-                    // Kept for the press it was taken for, whether or not a
-                    // newer press has started since: that press takes its own
-                    // and this one is still going to be transcribed. Two
-                    // presses back, nothing is waiting on it any more.
-                    guard let self, let before, self.pressRun - run <= 1
-                    else { return }
+                    // Kept for the press it was taken for, however many
+                    // presses have started since: each of those has its own,
+                    // and this one is still going to be transcribed.
+                    guard let self, let before else { return }
                     self.screenAtPress[run] = before
+                    for stale in self.screenAtPress.keys.sorted().dropLast(Self.panesKept) {
+                        self.screenAtPress.removeValue(forKey: stale)
+                    }
 
                     // A short dictation can be transcribed and written while
                     // this copy is still running, so the offer can already be
@@ -2738,6 +2743,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Log.write("Accessibility not granted; left transcript on the clipboard")
             setLabel("Copied — grant Accessibility to auto-paste", clearAfter: 4)
         }
+        // Delivered, so nothing wants this dictation's pane any more. Already
+        // gone on the path that made the offer. The clipboard paths above
+        // return before this and leave theirs to the cap, which is what the
+        // cap is for.
+        screenAtPress.removeValue(forKey: press.run)
         updateUI()
     }
 

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -130,9 +130,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// on the chance that a transcript from five minutes ago is still coming.
     private var screenAtPress: [Int: (text: String, at: Date)] = [:]
 
-    /// How long a pane is worth keeping. Nothing waits this long: the whole
-    /// chain is a decoder and at most a prompt stage.
+    /// How long a pane is worth keeping, for a press that is no longer in
+    /// flight. Nothing waits this long: the whole chain is a decoder and at
+    /// most a prompt stage.
     private static let paneLifetime: TimeInterval = 300
+
+    /// The presses that took a pane and whose dictation has not ended yet.
+    ///
+    /// The age above is a backstop and this is what stops it hitting a live
+    /// dictation: a prompt stage can outlast any number written here, and its
+    /// pane is the one thing that cannot be fetched again. Every way a
+    /// dictation ends goes through `dictationEnded(_:)`, which is what keeps
+    /// this from growing.
+    private var pressesInFlight: Set<Int> = []
 
     /// Bumped by every press that starts a dictation. It is what a `Press`
     /// carries, and what a snapshot that took a moment to copy is stamped with
@@ -708,6 +718,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // anything needs it.
             let element = focusAtPress?.element
             let run = pressRun
+            pressesInFlight.insert(run)
             DispatchQueue.global(qos: .utility).async { [weak self] in
                 let before = CaretAnchor.snapshot(of: element)
                 DispatchQueue.main.async {
@@ -717,8 +728,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     guard let self, let before else { return }
                     let now = Date()
                     self.screenAtPress[run] = (before, now)
-                    self.screenAtPress = self.screenAtPress.filter {
-                        now.timeIntervalSince($0.value.at) < Self.paneLifetime
+                    self.screenAtPress = self.screenAtPress.filter { run, pane in
+                        self.pressesInFlight.contains(run)
+                            || now.timeIntervalSince(pane.at) < Self.paneLifetime
                     }
 
                     // A short dictation can be transcribed and written while
@@ -850,6 +862,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     // by the time someone presses the hotkey, and a refusal
                     // here should not offer to cancel an install that finished
                     // days ago.
+                    self.dictationEnded(self.pressRun)
                     self.permissions.show(.revisiting)
                 }
             }
@@ -870,6 +883,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // failure people describe as "the app stopped working", and a
             // notice that fades in four seconds is gone by the time they look.
             captureProblem(error.localizedDescription)
+            dictationEnded(pressRun)
             return
         }
 
@@ -1027,6 +1041,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
+        // A clip too short to keep, or transcription switched off: no words are
+        // coming, so this press's dictation ends here. Everything that does
+        // reach a transcript ends on one of `transcribe`'s own paths.
+        if recording == nil || !config.transcription.enabled {
+            dictationEnded(pressRun)
+        }
+
         if let reason {
             // A notice, not an alert, for the reason already written above
             // `startRecording`'s catch: `runModal` holds the main run loop, the
@@ -1160,6 +1181,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     self.runsInFlight -= 1
                     guard !self.wasCancelled(run) else {
                         Log.write("escape: dropped the transcript of a cancelled run")
+                        self.dictationEnded(press.run)
                         self.stopWatchingForEscapeIfIdle()
                         self.updateUI()
                         return
@@ -1175,6 +1197,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     if self.transcriptionRun == run { self.endProgress() }
                     self.runsInFlight -= 1
                     self.stopWatchingForEscapeIfIdle()
+                    // Cancelled or failed, this dictation is over either way.
+                    self.dictationEnded(press.run)
                     guard !self.wasCancelled(run) else { return }
                     Log.write("transcription failed: \(error.localizedDescription)")
                     self.presentAlert(title: "Transcription failed", message: error.localizedDescription)
@@ -1933,6 +1957,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    /// This press's dictation is over, however it ended. Drops the pane it
+    /// started with — nothing can want it again — and lets the sweep above
+    /// reach anything that is somehow left.
+    private func dictationEnded(_ run: Int) {
+        screenAtPress.removeValue(forKey: run)
+        pressesInFlight.remove(run)
+    }
+
     /// For an app with no caret: keep asking what changed until the words show
     /// up, then move the pill there.
     ///
@@ -2029,6 +2061,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Under the minimum, so the recorder deletes the clip and gives back
         // nothing. Nothing to transcribe, nothing to deliver.
         _ = recorder.stop(config: config)
+        dictationEnded(pressRun)
         tickTimer?.invalidate(); tickTimer = nil
         pushToTalkPoll?.invalidate(); pushToTalkPoll = nil
         releaseTail?.invalidate(); releaseTail = nil
@@ -2288,14 +2321,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // so there is nothing to compare a pane against.
         if let command = commandAfterWakePhrase(trimmed) {
             Log.write("command heard: \"\(command)\"")
-            screenAtPress.removeValue(forKey: press.run)
+            dictationEnded(press.run)
             handleVoiceCommand(command)
             return
         }
 
         guard !trimmed.isEmpty else {
             Log.write("transcription produced no text")
-            screenAtPress.removeValue(forKey: press.run)
+            dictationEnded(press.run)
             updateUI()
             return
         }
@@ -2681,7 +2714,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // However this ends, this dictation is over and nothing wants the pane
         // it started with. The path that makes the offer takes it before this
         // runs; every other path here is a clipboard, and those make no offer.
-        defer { screenAtPress.removeValue(forKey: press.run) }
+        defer { dictationEnded(press.run) }
         // Confirmed the same field, or nothing to confirm against. Anything
         // else copies.
         //
@@ -2755,7 +2788,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Log.write("Accessibility not granted; left transcript on the clipboard")
             setLabel("Copied — grant Accessibility to auto-paste", clearAfter: 4)
         }
-        screenAtPress.removeValue(forKey: press.run)
         updateUI()
     }
 

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -723,13 +723,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 let before = CaretAnchor.snapshot(of: element)
                 DispatchQueue.main.async {
                     // Kept for the press it was taken for, however many
-                    // presses have started since: each of those has its own,
-                    // and this one is still going to be transcribed. Unless it
-                    // is not — cancelled with Escape while this copy was still
-                    // running — in which case its run has been retired and
-                    // there is nothing left to compare a pane against.
-                    guard let self, let before, self.pressesInFlight.contains(run)
-                    else { return }
+                    // presses have started since and whether or not that press
+                    // has already been retired: a short dictation can be
+                    // written before this copy finishes, and refusing the pane
+                    // then would leave the offer with nothing to compare
+                    // against — which is the whole thing this exists to do.
+                    // A pane nobody comes back for is a lifetime, not a leak,
+                    // and the sweep below is what bounds it.
+                    guard let self, let before else { return }
                     let now = Date()
                     self.screenAtPress[run] = (before, now)
                     self.screenAtPress = self.screenAtPress.filter { run, pane in

--- a/Sources/ParrotFlow/CaretAnchor.swift
+++ b/Sources/ParrotFlow/CaretAnchor.swift
@@ -34,8 +34,18 @@ import ApplicationServices
 ///
 /// Three of five, and the two that do not answer cannot be made to: Ghostty has
 /// no caret to report and VS Code builds no accessibility tree unless it
-/// detects a screen reader. Where this returns nothing the pill opens where it
-/// always has, which is the whole of the fallback.
+/// detects a screen reader.
+///
+/// ## The apps that give no caret
+///
+/// For those, `read(at:)` misses and the answer is found the other way round.
+/// `snapshot(of:)` takes the pane's text at the press, `landed(after:at:)`
+/// compares it with the pane after the words arrive, and the difference between
+/// the two is where they went. That runs after the insertion, so it moves a
+/// pill that is already on screen rather than deciding where one opens.
+///
+/// It is a diff and not a search, and that is what makes it work at all. See
+/// `landed(after:at:)`.
 enum CaretAnchor {
 
     /// Which rung answered. Logged, because "the pill opened in the wrong
@@ -46,6 +56,12 @@ enum CaretAnchor {
         /// The focused control's own rectangle — only taken when the control is
         /// small enough that its box and its caret mean the same thing.
         case field
+        /// Worked out afterwards, from what changed on screen. For the apps
+        /// that have no caret to give — see `landed(after:at:)`.
+        case landed
+        /// Where the last dictation into this same element ended up. A guess,
+        /// and the only thing available at the press for an app with no caret.
+        case remembered
     }
 
     struct Found {
@@ -79,6 +95,14 @@ enum CaretAnchor {
     /// has answered by now; this cap is for the app that is not.
     private static let timeout: Float = 0.08
 
+    /// For the reads that happen after the dictation instead of inside the
+    /// key-down handler.
+    ///
+    /// Longer because nothing is waiting on them and the value being copied is
+    /// large: Outlook's message pane measured 395,489 characters, and every
+    /// look copies all of them out of a busy process.
+    private static let unhurriedTimeout: Float = 0.5
+
     /// Where the caret is, for the element focus was on when the key went down.
     static func read(at element: AXUIElement?) -> Outcome {
         guard Permissions.accessibility == .granted else {
@@ -109,6 +133,129 @@ enum CaretAnchor {
             return .found(Found(rect: box, text: box, source: .field))
         }
         return .missed(pane == nil ? "no geometry" : "no caret, and the pane is too big to stand in for one")
+    }
+
+    /// How many characters the element holds.
+    ///
+    /// One number rather than the text, so it is cheap enough to ask inside the
+    /// key-down handler. The value itself has been seen at 395,489 characters
+    /// and copying that would delay the recording.
+    ///
+    /// This is what tells a remembered anchor from a stale one. It changes the
+    /// moment anything is printed into the pane, which is exactly when last
+    /// time's row stops belonging to last time's words.
+    static func characterCount(of element: AXUIElement?) -> Int? {
+        guard let element else { return nil }
+        AXUIElementSetMessagingTimeout(element, timeout)
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            element, kAXNumberOfCharactersAttribute as CFString, &value
+        ) == .success, let count = value as? Int else { return nil }
+        return count
+    }
+
+    // MARK: - Apps with no caret, found afterwards
+
+    /// The pane's text as it was before a word of this was said.
+    ///
+    /// Only worth taking for an app that would not give a caret, and only ever
+    /// off the main thread: see `unhurriedTimeout` for the size of the thing
+    /// being copied.
+    static func snapshot(of element: AXUIElement?) -> String? {
+        guard let element else { return nil }
+        AXUIElementSetMessagingTimeout(element, unhurriedTimeout)
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            element, kAXValueAttribute as CFString, &value
+        ) == .success, let text = value as? String, !text.isEmpty
+        else { return nil }
+        return text
+    }
+
+    /// Where the words landed, by comparing the pane with how it was.
+    ///
+    /// A diff and not a search, and that is the difference between this working
+    /// and not. The first version looked for the transcript in the field. That
+    /// fails whenever what was written is not what was transcribed, and a
+    /// pipeline stage rewriting the sentence between the two is normal. It also
+    /// fails when the text is there but not as one string: a value is what is
+    /// *rendered*, so a wrapped sentence has a newline through the middle of it
+    /// and a terminal drawing an input box pads it with spaces. Nothing has to
+    /// match a diff. What changed is where the words are.
+    ///
+    /// Bounded at both ends, because a terminal is not a text field. A spinner
+    /// or a clock ticking above would poison a common prefix on its own, so
+    /// take the common suffix too and the change sits between two fixed points.
+    /// A change spanning more than half the pane is a repaint rather than an
+    /// insertion, and is refused.
+    ///
+    /// Runs after the insertion, so it is off the main thread and unhurried.
+    static func landed(after before: String, at element: AXUIElement?) -> Outcome {
+        guard let element else { return .missed("the element is gone") }
+        // For every read below, the snapshot included.
+        AXUIElementSetMessagingTimeout(element, unhurriedTimeout)
+
+        guard let now = snapshot(of: element) else { return .missed("no text to compare") }
+        guard now != before else { return .missed("the screen has not changed yet") }
+
+        // UTF-16, because that is the unit an accessibility range counts in.
+        // The indices found here are handed straight back to the app.
+        let old = Array(before.utf16), new = Array(now.utf16)
+        var head = 0
+        while head < old.count, head < new.count, old[head] == new[head] { head += 1 }
+        var tail = 0
+        while tail < old.count - head, tail < new.count - head,
+              old[old.count - 1 - tail] == new[new.count - 1 - tail] { tail += 1 }
+
+        let length = new.count - head - tail
+        guard length > 0 else { return .missed("the screen changed, but nothing was added") }
+        guard length < new.count / 2 else { return .missed("the whole pane repainted") }
+
+        let pane = frame(of: element).map(flipped)
+
+        // There is an index now, so ask the app where it is. An app can keep no
+        // caret and still measure text perfectly well — Outlook does — and the
+        // two failings are unrelated: one is about tracking a cursor, the other
+        // about measuring text. Asked with a range of our own, the app that
+        // would not say where the caret was says exactly where the words are.
+        if let rect = bounds(of: CFRange(location: head, length: length), in: element) {
+            let text = flipped(rect)
+            return .found(Found(rect: across(text, pane), text: text, source: .landed))
+        }
+
+        // No bounds, so work out the row instead. A terminal is a fixed grid:
+        // ask which line the last character is on for the row count, and the
+        // pane's height over that is the pitch. Measured on Ghostty at 53 rows
+        // of 17.3pt, a real line height rather than a fit.
+        guard let pane else { return .missed("no geometry") }
+        guard let row = line(of: head, in: element),
+              let rows = line(of: new.count - 1, in: element).map({ $0 + 1 }), rows > 0
+        else { return .missed("no bounds, and it will not say which line an index is on") }
+
+        // The grid gives a row and no column — see `across` for why the column
+        // would be thrown away anyway. So the row is the whole width of the
+        // pane, and it is both rectangles: there is no narrower one to pick the
+        // display from, and a row of a pane straddling two monitors goes to
+        // whichever shows more of it.
+        //
+        // Built in flipped coordinates, where `maxY` is the pane's top edge, so
+        // rows count downward from there.
+        let pitch = pane.height / CGFloat(rows)
+        let rect = NSRect(
+            x: pane.minX, y: pane.maxY - CGFloat(row + 1) * pitch,
+            width: pane.width, height: pitch
+        )
+        return .found(Found(rect: rect, text: rect, source: .landed))
+    }
+
+    /// Which row of the grid an index sits on. Nil when the app will not say.
+    private static func line(of index: Int, in element: AXUIElement) -> Int? {
+        var out: CFTypeRef?
+        guard AXUIElementCopyParameterizedAttributeValue(
+            element, kAXLineForIndexParameterizedAttribute as CFString,
+            NSNumber(value: index), &out
+        ) == .success, let value = out as? NSNumber else { return nil }
+        return value.intValue >= 0 ? value.intValue : nil
     }
 
     // MARK: - The questions

--- a/Sources/ParrotFlow/CaretAnchor.swift
+++ b/Sources/ParrotFlow/CaretAnchor.swift
@@ -223,14 +223,28 @@ enum CaretAnchor {
             return .found(Found(rect: across(text, pane), text: text, source: .landed))
         }
 
-        // No bounds, so work out the row instead. A terminal is a fixed grid:
-        // ask which line the last character is on for the row count, and the
-        // pane's height over that is the pitch. Measured on Ghostty at 53 rows
-        // of 17.3pt, a real line height rather than a fit.
+        // No bounds, so work out the row instead. A terminal is a fixed grid,
+        // so the pane's height over the number of rows it shows is the pitch,
+        // and the row is all that is left to find.
         guard let pane else { return .missed("no geometry") }
         guard let row = line(of: head, in: element),
-              let rows = line(of: new.count - 1, in: element).map({ $0 + 1 }), rows > 0
+              let grid = visibleGrid(of: element, holding: new.count)
         else { return .missed("no bounds, and it will not say which line an index is on") }
+
+        // Every row the pane shows, not every row that has text on it. A pitch
+        // is a line height and it has a range: 17.3pt was measured on Ghostty,
+        // and an answer far outside that came from counting the wrong rows.
+        // Refused rather than used, which is the rule everywhere else here —
+        // the pill stays where it opened, and nowhere in particular beats
+        // somewhere wrong.
+        let pitch = pane.height / CGFloat(grid.rows)
+        guard (6.0...40.0).contains(pitch), (grid.first..<grid.first + grid.rows).contains(row)
+        else {
+            return .missed(String(
+                format: "the grid says row %d of %d at %.0fpt, which is not a line of text",
+                row, grid.rows, pitch
+            ))
+        }
 
         // The grid gives a row and no column — see `across` for why the column
         // would be thrown away anyway. So the row is the whole width of the
@@ -240,12 +254,36 @@ enum CaretAnchor {
         //
         // Built in flipped coordinates, where `maxY` is the pane's top edge, so
         // rows count downward from there.
-        let pitch = pane.height / CGFloat(rows)
         let rect = NSRect(
-            x: pane.minX, y: pane.maxY - CGFloat(row + 1) * pitch,
+            x: pane.minX, y: pane.maxY - CGFloat(row - grid.first + 1) * pitch,
             width: pane.width, height: pitch
         )
         return .found(Found(rect: rect, text: rect, source: .landed))
+    }
+
+    /// The rows the pane is showing: the first one, and how many.
+    ///
+    /// `AXVisibleCharacterRange` is what is on screen, so the lines it spans
+    /// are the rows on screen. Asked first because it is the only answer that
+    /// is about the viewport rather than about the text — and it also gives the
+    /// row the top of the pane is showing, which a row index has to be counted
+    /// from when the value carries scrollback above it.
+    ///
+    /// Without it, the value's own last line is all there is to go on. That is
+    /// only the viewport if the app reports its blank rows too: Ghostty does,
+    /// and 53 rows over a 917pt pane is 17.3pt, a real line height rather than
+    /// a fit. An app that stopped at the last written line would report too few
+    /// rows and the pitch would come out too large — which is why the caller
+    /// checks the pitch instead of trusting it.
+    private static func visibleGrid(of element: AXUIElement, holding count: Int) -> (first: Int, rows: Int)? {
+        if let visible = range(kAXVisibleCharacterRangeAttribute, of: element), visible.length > 0,
+           let first = line(of: visible.location, in: element),
+           let last = line(of: visible.location + visible.length - 1, in: element),
+           last >= first {
+            return (first, last - first + 1)
+        }
+        guard count > 0, let last = line(of: count - 1, in: element) else { return nil }
+        return (0, last + 1)
     }
 
     /// Which row of the grid an index sits on. Nil when the app will not say.
@@ -287,9 +325,14 @@ enum CaretAnchor {
     }
 
     private static func selectedRange(of element: AXUIElement) -> CFRange? {
+        range(kAXSelectedTextRangeAttribute, of: element)
+    }
+
+    /// Any attribute whose value is a range.
+    private static func range(_ attribute: String, of element: AXUIElement) -> CFRange? {
         var value: CFTypeRef?
         guard AXUIElementCopyAttributeValue(
-            element, kAXSelectedTextRangeAttribute as CFString, &value
+            element, attribute as CFString, &value
         ) == .success, let wrapped = value, CFGetTypeID(wrapped) == AXValueGetTypeID()
         else { return nil }
         var range = CFRange()

--- a/Sources/ParrotFlow/CaretAnchor.swift
+++ b/Sources/ParrotFlow/CaretAnchor.swift
@@ -135,23 +135,39 @@ enum CaretAnchor {
         return .missed(pane == nil ? "no geometry" : "no caret, and the pane is too big to stand in for one")
     }
 
-    /// How many characters the element holds.
+    /// A fingerprint of what the pane is showing, read at the press.
     ///
-    /// One number rather than the text, so it is cheap enough to ask inside the
-    /// key-down handler. The value itself has been seen at 395,489 characters
-    /// and copying that would delay the recording.
+    /// This is what tells a remembered anchor from a stale one, and it has to
+    /// be the text because the cheap number is about something else.
+    /// `AXNumberOfCharacters` was tried and is wrong here: measured on Ghostty
+    /// it answers 49,842 and does not move while eight lines of output are
+    /// printed, with `AXValue` at 2,082 over the same two reads. The count is
+    /// the scrollback and the value is the screen, and only a resize changes
+    /// the first. Compared against, it can never fail — so in the one app the
+    /// `remembered` rung exists for, the guard was not a guard.
     ///
-    /// This is what tells a remembered anchor from a stale one. It changes the
-    /// moment anything is printed into the pane, which is exactly when last
-    /// time's row stops belonging to last time's words.
-    static func characterCount(of element: AXUIElement?) -> Int? {
+    /// Hashed rather than kept, because this is a staleness check and the
+    /// question is only "the same as last time". It is compared within one run
+    /// of the app, which is the only place a `hashValue` means anything.
+    ///
+    /// Reading the value at key-down is the thing that handler is told never to
+    /// do, and it is allowed here for two reasons: it is capped at the same
+    /// 80ms as everything else `read(at:)` asks, and it is only asked when
+    /// there is a landing for this exact element to check — which is the rung
+    /// below a caret, so the apps with one never pay for it.
+    ///
+    /// Not answering inside the cap means refusing the anchor, and that is
+    /// right rather than merely safe. A pane too big to read in 80ms is
+    /// Outlook's, and Outlook's pane scrolls too: a remembered rectangle there
+    /// is worth no more than one in a terminal.
+    static func paneDigest(of element: AXUIElement?) -> Int? {
         guard let element else { return nil }
         AXUIElementSetMessagingTimeout(element, timeout)
         var value: CFTypeRef?
         guard AXUIElementCopyAttributeValue(
-            element, kAXNumberOfCharactersAttribute as CFString, &value
-        ) == .success, let count = value as? Int else { return nil }
-        return count
+            element, kAXValueAttribute as CFString, &value
+        ) == .success, let text = value as? String, !text.isEmpty else { return nil }
+        return text.hashValue
     }
 
     // MARK: - Apps with no caret, found afterwards

--- a/Sources/ParrotFlow/CaretAnchor.swift
+++ b/Sources/ParrotFlow/CaretAnchor.swift
@@ -95,6 +95,26 @@ enum CaretAnchor {
     /// has answered by now; this cap is for the app that is not.
     private static let timeout: Float = 0.08
 
+    /// How many lines of the value may sit below where the change starts.
+    ///
+    /// This is what an insertion looks like from outside: it happens at the
+    /// end of the buffer, because that is where a prompt is. What is under the
+    /// caret while you type is the rest of the input area and whatever the
+    /// program draws beneath it — Claude Code's input box grows to about six
+    /// lines as you type into it, with a border under that and a mode line and
+    /// a status line under that, which is nine. Twelve leaves room for a
+    /// program that draws one more.
+    ///
+    /// It is nothing beside the thing being excluded. A scroll changes the
+    /// first line of the value and every line after it, and a full repaint the
+    /// same, so both cover hundreds of lines rather than twelve.
+    ///
+    /// The same number answers both questions the diff asks — how many lines
+    /// the change covers, and how many written lines are below it — because
+    /// both are asking the same thing about the same object: how big an input
+    /// area and the furniture around it can be.
+    private static let promptLines = 12
+
     /// For the reads that happen after the dictation instead of inside the
     /// key-down handler.
     ///
@@ -202,8 +222,13 @@ enum CaretAnchor {
     /// Bounded at both ends, because a terminal is not a text field. A spinner
     /// or a clock ticking above would poison a common prefix on its own, so
     /// take the common suffix too and the change sits between two fixed points.
-    /// A change spanning more than half the pane is a repaint rather than an
-    /// insertion, and is refused.
+    ///
+    /// That gives one contiguous span, and the span is taken only when it is
+    /// certainly an insertion: it has to start within `promptLines` of the end
+    /// of the value. Anything else is refused, and refused means the pill stays
+    /// at the bottom of the screen — which is the rule the whole rung answers
+    /// to. If it moves it has to move to the right place, and it must never
+    /// come to rest over the words being edited.
     ///
     /// Runs after the insertion, so it is off the main thread and unhurried.
     static func landed(after before: String, at element: AXUIElement?) -> Outcome {
@@ -225,7 +250,45 @@ enum CaretAnchor {
 
         let length = new.count - head - tail
         guard length > 0 else { return .missed("the screen changed, but nothing was added") }
-        guard length < new.count / 2 else { return .missed("the whole pane repainted") }
+
+        // Two questions about the span, and it has to answer both. See
+        // `promptLines` for the number, which is the same in each because both
+        // are asking how big an input area and its furniture can be.
+        //
+        // The rule this replaces was that a span covering more than half the
+        // value is a repaint. It refused the case it exists for: paste two
+        // words into Claude Code's input box and the box, the mode line and
+        // the status line all redraw, so the span runs from the box down to the
+        // bottom of the pane — and in a small pane that is more than half of
+        // it. Measured, the log said "the whole pane repainted", and it said it
+        // more often the taller the input box had grown, which is a bigger
+        // redraw and not a different kind of one. Size was the wrong question.
+        //
+        // How many lines it covers. An insertion is a line or a few, even when
+        // a program redraws its whole input area around it. A scroll changes
+        // every line there is, and so does a repaint, and neither is somewhere
+        // to put the pill.
+        let changed = new[head..<(new.count - tail)]
+        var spanned = 1
+        for unit in changed where unit == 0x0A { spanned += 1 }
+        guard spanned <= promptLines else {
+            return .missed("the change covers \(spanned) lines, which is a repaint and not an insertion")
+        }
+
+        // And whether it is at the end of what has been written. This is what
+        // stops the pill going to a clock or a spinner that ticked while the
+        // app had not redrawn yet: that is a small contiguous change too, and
+        // the only thing that tells it apart from a dictation is where it is.
+        //
+        // Blank lines do not count towards the distance. They are what a
+        // terminal pads its viewport with — a prompt in a pane with no history
+        // sits above a screenful of them, which is where the 53 rows in
+        // `visibleGrid` came from — so counting them would put every fresh pane
+        // a screen away from its own end.
+        let below = contentLines(in: new[(new.count - tail)...])
+        guard below <= promptLines else {
+            return .missed("the change ends \(below) lines above the last written one, so it is not at a prompt")
+        }
 
         let pane = frame(of: element).map(flipped)
 
@@ -301,6 +364,15 @@ enum CaretAnchor {
     /// where it opened. The arithmetic itself is sound where the viewport is
     /// known: 53 rows over a 917pt pane is 17.3pt, a real line height rather
     /// than a fit.
+    ///
+    /// That 53 came from a pane with no history in it, which is the thing to
+    /// know about the attribute. Once a Ghostty pane has scrolled, its value
+    /// carries the scrollback and `AXVisibleCharacterRange` answers `0` and
+    /// the whole length — so it is not imprecise about the viewport, it is
+    /// untrue about it, and untrue in exactly the panes that have scrolled.
+    /// Measured, the refusal reads "the grid says row 1364 of 1365 at 1pt",
+    /// which is the plausibility check below doing its job. It stays refusing:
+    /// there is no viewport in that answer to be had.
     private static func visibleGrid(of element: AXUIElement) -> (first: Int, rows: Int)? {
         guard let visible = range(kAXVisibleCharacterRangeAttribute, of: element),
               visible.length > 0,
@@ -309,6 +381,24 @@ enum CaretAnchor {
               last >= first
         else { return nil }
         return (first, last - first + 1)
+    }
+
+    /// How many lines of a slice have anything on them.
+    ///
+    /// Spaces and tabs are nothing: a terminal pads with both, and a row of
+    /// them is a blank row however it was drawn.
+    private static func contentLines(in units: ArraySlice<UInt16>) -> Int {
+        var lines = 0
+        var occupied = false
+        for unit in units {
+            if unit == 0x0A {
+                if occupied { lines += 1 }
+                occupied = false
+            } else if unit != 0x20, unit != 0x09 {
+                occupied = true
+            }
+        }
+        return occupied ? lines + 1 : lines
     }
 
     /// Which row of the grid an index sits on. Nil when the app will not say.

--- a/Sources/ParrotFlow/CaretAnchor.swift
+++ b/Sources/ParrotFlow/CaretAnchor.swift
@@ -297,6 +297,14 @@ enum CaretAnchor {
         // two failings are unrelated: one is about tracking a cursor, the other
         // about measuring text. Asked with a range of our own, the app that
         // would not say where the caret was says exactly where the words are.
+        //
+        // A span over several lines comes back as one rectangle covering all of
+        // them, and that is what is wanted. `flipped` puts its Cocoa `minY` at
+        // the bottom of the span, `across` keeps that edge, and `beside` opens
+        // the pill below `minY` — so the pill clears the whole insertion and
+        // not just the line it started on. Nothing to do here; it is written
+        // down because the arithmetic is invisible and the grid below had to be
+        // fixed for exactly this.
         if let rect = bounds(of: CFRange(location: head, length: length), in: element) {
             let text = flipped(rect)
             return .found(Found(rect: across(text, pane), text: text, source: .landed))
@@ -306,7 +314,14 @@ enum CaretAnchor {
         // so the pane's height over the number of rows it shows is the pitch,
         // and the row is all that is left to find.
         guard let pane else { return .missed("no geometry") }
-        guard let row = line(of: head, in: element),
+
+        // The row the change *ends* on, not the one it starts on. A dictation
+        // long enough to wrap covers two or three rows, and anchored to the
+        // first the pill came to rest on top of the rest of it — which is the
+        // one thing this rung must never do. Below the last row is below all of
+        // them, and it is also where the caret has ended up, so it is the right
+        // answer for its own reasons and not only for that bug.
+        guard let row = line(of: head + length - 1, in: element),
               let grid = visibleGrid(of: element)
         else { return .missed("no bounds, and it will not say how the grid is laid out") }
 

--- a/Sources/ParrotFlow/CaretAnchor.swift
+++ b/Sources/ParrotFlow/CaretAnchor.swift
@@ -228,7 +228,7 @@ enum CaretAnchor {
         // and the row is all that is left to find.
         guard let pane else { return .missed("no geometry") }
         guard let row = line(of: head, in: element),
-              let grid = visibleGrid(of: element, showing: now)
+              let grid = visibleGrid(of: element)
         else { return .missed("no bounds, and it will not say how the grid is laid out") }
 
         // Checked, not trusted. A pitch is a line height and it has a range —
@@ -273,26 +273,26 @@ enum CaretAnchor {
     /// pane is showing, which a row index has to be counted from when the value
     /// carries scrollback above it.
     ///
-    /// Without that attribute the value's own last line is all there is. It is
-    /// the bottom row only when the app pads the rows nothing was written to,
-    /// and whether it does is visible in the value: a padded value ends on a
-    /// blank row, a trimmed one ends on the row somebody last wrote to. Ghostty
-    /// pads, which is where 53 rows over a 917pt pane — 17.3pt, a real line
-    /// height rather than a fit — came from. Ends on text, and the count is the
-    /// text's rather than the screen's: refused, and the pill stays where it
-    /// opened.
-    private static func visibleGrid(of element: AXUIElement, showing value: String) -> (first: Int, rows: Int)? {
-        if let visible = range(kAXVisibleCharacterRangeAttribute, of: element), visible.length > 0,
-           let first = line(of: visible.location, in: element),
-           let last = line(of: visible.location + visible.length - 1, in: element),
-           last >= first {
-            return (first, last - first + 1)
-        }
-
-        let lastLine = value.lastIndex(of: "\n").map { value[value.index(after: $0)...] }
-        guard let lastLine, lastLine.allSatisfy(\.isWhitespace) else { return nil }
-        guard let last = line(of: value.utf16.count - 1, in: element) else { return nil }
-        return (0, last + 1)
+    /// Without that attribute, nothing. Counting the lines the value holds was
+    /// tried and does not work: that is how many rows have text on them, which
+    /// is the viewport only if the app pads the rows nothing was written to,
+    /// and the value gives no reliable way to tell whether it did. Get it wrong
+    /// and the pitch is wrong by the ratio between the two — 40 lines of a
+    /// 53-row screen is 22.9pt against a real 17.3pt, close enough to pass any
+    /// check on the number and still a quarter of the way down the screen.
+    ///
+    /// So the grid needs the viewport or it gets nothing, and the pill stays
+    /// where it opened. The arithmetic itself is sound where the viewport is
+    /// known: 53 rows over a 917pt pane is 17.3pt, a real line height rather
+    /// than a fit.
+    private static func visibleGrid(of element: AXUIElement) -> (first: Int, rows: Int)? {
+        guard let visible = range(kAXVisibleCharacterRangeAttribute, of: element),
+              visible.length > 0,
+              let first = line(of: visible.location, in: element),
+              let last = line(of: visible.location + visible.length - 1, in: element),
+              last >= first
+        else { return nil }
+        return (first, last - first + 1)
     }
 
     /// Which row of the grid an index sits on. Nil when the app will not say.

--- a/Sources/ParrotFlow/CaretAnchor.swift
+++ b/Sources/ParrotFlow/CaretAnchor.swift
@@ -228,15 +228,14 @@ enum CaretAnchor {
         // and the row is all that is left to find.
         guard let pane else { return .missed("no geometry") }
         guard let row = line(of: head, in: element),
-              let grid = visibleGrid(of: element, holding: new.count)
-        else { return .missed("no bounds, and it will not say which line an index is on") }
+              let grid = visibleGrid(of: element, showing: now)
+        else { return .missed("no bounds, and it will not say how the grid is laid out") }
 
-        // Every row the pane shows, not every row that has text on it. A pitch
-        // is a line height and it has a range: 17.3pt was measured on Ghostty,
-        // and an answer far outside that came from counting the wrong rows.
-        // Refused rather than used, which is the rule everywhere else here —
-        // the pill stays where it opened, and nowhere in particular beats
-        // somewhere wrong.
+        // Checked, not trusted. A pitch is a line height and it has a range —
+        // 17.3pt was measured on Ghostty — and the row has to be one the pane
+        // is showing. Either failing means the grid was read wrong, and a grid
+        // read wrong is refused rather than used: the pill stays where it
+        // opened, and nowhere in particular beats somewhere wrong.
         let pitch = pane.height / CGFloat(grid.rows)
         guard (6.0...40.0).contains(pitch), (grid.first..<grid.first + grid.rows).contains(row)
         else {
@@ -263,26 +262,36 @@ enum CaretAnchor {
 
     /// The rows the pane is showing: the first one, and how many.
     ///
-    /// `AXVisibleCharacterRange` is what is on screen, so the lines it spans
-    /// are the rows on screen. Asked first because it is the only answer that
-    /// is about the viewport rather than about the text — and it also gives the
-    /// row the top of the pane is showing, which a row index has to be counted
-    /// from when the value carries scrollback above it.
+    /// The rows on *screen*, which is not the same question as how many rows
+    /// have text on them. Get that wrong and the pitch is wrong by the ratio
+    /// between the two, and the pill goes to a row that is plausible and not
+    /// the right one.
     ///
-    /// Without it, the value's own last line is all there is to go on. That is
-    /// only the viewport if the app reports its blank rows too: Ghostty does,
-    /// and 53 rows over a 917pt pane is 17.3pt, a real line height rather than
-    /// a fit. An app that stopped at the last written line would report too few
-    /// rows and the pitch would come out too large — which is why the caller
-    /// checks the pitch instead of trusting it.
-    private static func visibleGrid(of element: AXUIElement, holding count: Int) -> (first: Int, rows: Int)? {
+    /// `AXVisibleCharacterRange` is the range on screen, so the lines it spans
+    /// are the rows on screen. Asked first because it is the only answer that
+    /// is about the viewport at all — and it also gives the row the top of the
+    /// pane is showing, which a row index has to be counted from when the value
+    /// carries scrollback above it.
+    ///
+    /// Without that attribute the value's own last line is all there is. It is
+    /// the bottom row only when the app pads the rows nothing was written to,
+    /// and whether it does is visible in the value: a padded value ends on a
+    /// blank row, a trimmed one ends on the row somebody last wrote to. Ghostty
+    /// pads, which is where 53 rows over a 917pt pane — 17.3pt, a real line
+    /// height rather than a fit — came from. Ends on text, and the count is the
+    /// text's rather than the screen's: refused, and the pill stays where it
+    /// opened.
+    private static func visibleGrid(of element: AXUIElement, showing value: String) -> (first: Int, rows: Int)? {
         if let visible = range(kAXVisibleCharacterRangeAttribute, of: element), visible.length > 0,
            let first = line(of: visible.location, in: element),
            let last = line(of: visible.location + visible.length - 1, in: element),
            last >= first {
             return (first, last - first + 1)
         }
-        guard count > 0, let last = line(of: count - 1, in: element) else { return nil }
+
+        let lastLine = value.lastIndex(of: "\n").map { value[value.index(after: $0)...] }
+        guard let lastLine, lastLine.allSatisfy(\.isWhitespace) else { return nil }
+        guard let last = line(of: value.utf16.count - 1, in: element) else { return nil }
         return (0, last + 1)
     }
 

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -126,16 +126,20 @@ final class PillHUD {
 
     /// Point the pill at where the words are going, for this dictation.
     ///
-    /// Set once, at the press, and read by every state until the pill goes
-    /// away: the recording, the transcribing, and the offer all appear in the
-    /// same place, so nothing moves while you are watching it. Nil puts it back
-    /// at the bottom of the screen, which is where it opened before any of
-    /// this and is the whole of the fallback.
+    /// Set at the press and read by every state until the pill goes away: the
+    /// recording, the transcribing, and the offer all appear in the same place,
+    /// so nothing moves while you are watching it. Nil puts it back at the
+    /// bottom of the screen, which is where it opened before any of this.
     ///
-    /// Not re-read later, deliberately. Scroll the window or move focus while
-    /// you are talking and the anchor is stale — but you moved, and a pill that
-    /// stayed where the dictation started is easier to explain than one that
-    /// jumps halfway through.
+    /// Set a second time only for an app that gave no caret to aim at. There
+    /// the words are found after they land, so the pill is already up and this
+    /// moves it. One move to somewhere right beats staying somewhere wrong.
+    ///
+    /// Never re-read on its own, deliberately. Scroll the window or move focus
+    /// while you are talking and the anchor is stale — but you moved, and a
+    /// pill that stayed where the dictation started is easier to explain than
+    /// one that jumps halfway through. The caller aims it again only when it
+    /// has a better answer than the one it opened with.
     func aim(at anchor: CaretAnchor.Found?) {
         near = anchor
         guard let anchor else { return }
@@ -144,6 +148,12 @@ final class PillHUD {
             anchor.source.rawValue,
             anchor.rect.minX, anchor.rect.minY, anchor.rect.width, anchor.rect.height
         ))
+        // Already up: move it there, with the animation it uses for everything
+        // else. An app with no caret has no anchor at the press, so the only
+        // one it will ever get arrives after the words land — which is after
+        // the pill is on screen. Without this the answer would be found and
+        // never used.
+        if let panel, panel.isVisible { morph(to: panel.frame.size) }
     }
 
     // MARK: - Coming and going

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -275,6 +275,17 @@ real one.
 that shows the mic is hot. Both on by default; the pill is the only thing on
 screen that says recording is happening, so turning it off is a real choice.
 
+**Where the pill appears.** Next to the place your words are about to go, so you
+can see where they are headed before you have said any of them. Where the app
+will not say where that is, it sits at the bottom of the screen instead. That is
+where it always used to be.
+
+Terminals split two ways, and it is worth knowing which one you are in. A pane
+running a full-screen program shows only what fits on the screen. Claude Code,
+vim and less all work this way, and the pill follows your words there. A pane
+sitting at an ordinary shell prompt keeps everything you have run in it, and the
+pill goes to the bottom of the screen.
+
 `correct_offer` is what the pill does after the words land. It stays where it
 is for three seconds and reads `Wrong?  <your hotkey>  to fix it`. Tap that key
 — press and let go, faster than a dictation — and the whole sentence opens in

--- a/docs/proposals/hud-placement-and-offer.md
+++ b/docs/proposals/hud-placement-and-offer.md
@@ -386,6 +386,28 @@ gates quiet sound whatever is printed on the case.
 - The launch panel from the design pass is not built at all, and its lettering
   was never chosen — Serif (New York, `design: .serif`), Rounded, or Wide caps.
 - `--panels` sheet has not been reviewed since the pill changed shape.
+- **A pane read after the paste is not a baseline, and nothing here can tell.**
+  The `landed` rung takes the pane at the press on a background queue. A short
+  dictation can be transcribed and written before that copy finishes, and then
+  the baseline already holds the words: every retry compares equal strings, the
+  diff reports the screen unchanged, and the pill never aims. It is not fixed
+  here because the moment cannot be observed. `TextInserter` posts a ⌘V and the
+  target app reads the pasteboard when it gets round to it, so no instant in
+  this process means "the words are on screen" — a clock stands in for it badly
+  in both directions, and rejecting on one throws away the baselines that were
+  in time. A real fix is the insertion reporting when the target *took* the
+  text, which belongs ahead of this work rather than inside it. The cost
+  meanwhile is the documented fallback: the pill stays where it opened, which
+  is where it opened before any of this. It is not a wrong position.
+- **`lastTranscript` and `focusAtPress` are one slot each.** Dictations overlap,
+  so a later one moves them under an earlier one. The offer reads neither now —
+  it carries the transcript and the press it was raised for. Every other path
+  that reads them is untouched and has the same shape of race.
+- **None of this has been seen running.** Ghostty and Outlook need a person in
+  front of them; the numbers in this section are the spike's. Whether Ghostty
+  answers `AXVisibleCharacterRange` is unknown, and the grid rung needs it —
+  without it that rung refuses and Ghostty falls back to `remembered`, or to
+  the bottom of the screen.
 
 ## 7. The PRs
 

--- a/docs/proposals/hud-placement-and-offer.md
+++ b/docs/proposals/hud-placement-and-offer.md
@@ -17,7 +17,9 @@ Design mockup: <https://claude.ai/code/artifact/4b31fdb8-192f-40df-9e42-64efcb93
 
 The pill used to appear 96pt off the bottom of the screen, always. It now opens
 next to the place the dictation is about to go, and stays there for the whole of
-it — recording, transcribing, and the offer, one position.
+it — recording, transcribing, and the offer, one position. The exception is an
+app that gives no caret: there the words are found after they land, so the pill
+opens where it can and moves once.
 
 ### Read it at the press, not at the end
 
@@ -122,18 +124,42 @@ being edited.
 Then ask the app for the bounds of *that* range. An app can keep no caret and
 still measure text perfectly well — Outlook does — and the two failings are
 unrelated. Only where there are no bounds fall back to the terminal grid:
-`AXLineForIndex` on the last character gives the row count, and the height over
-it gives the pitch. Measured on Ghostty at 53 rows of 17.3pt, a real line height
-rather than a fit.
+`AXLineForIndex` over the range `AXVisibleCharacterRange` reports gives the rows
+on screen, and the pane's height over that is the pitch. Measured on Ghostty at
+53 rows of 17.3pt, a real line height rather than a fit.
+
+The viewport must come from that attribute and from nothing else. Counting the
+lines in the value was tried and is wrong: that is how many rows have text on
+them, which is the screen only if the app pads the blank ones, and the value
+gives no way to tell whether it did. And the attribute is only worth having
+where it is true. In a Ghostty pane with scrollback it answers `0` and the whole
+buffer length — so it is not imprecise about the viewport, it is untrue about
+it, and untrue in exactly the panes that have scrolled. The 53 rows came from a
+pane with no history. Where the pitch that falls out is not a plausible line
+height the rung refuses, which is the observed `the grid says row 1364 of 1365
+at 1pt`.
 
 **A remembered anchor goes stale, and looks confident while it is.** A terminal
 scrolls between dictations, so last time's row belongs to something else — often
 the input box you are about to type into, which is where the pill was seen
-sitting. Two things invalidate it: the pane's character count must match (one
-cheap attribute, and it changes the moment anything is printed) and the landing
-must be under a minute old. Refused, the pill opens at the bottom of the screen
-and `landed` moves it a moment later — starting nowhere in particular beats
-starting somewhere wrong.
+sitting. Two things invalidate it: the pane must still be showing what it showed
+when the words landed, and the landing must be under a minute old. Refused, the
+pill opens at the bottom of the screen and `landed` moves it a moment later —
+starting nowhere in particular beats starting somewhere wrong.
+
+That first condition was `AXNumberOfCharacters` to begin with, on the grounds
+that it is one cheap attribute and it moves whenever anything is printed into
+the pane. It does not move. Measured
+on Ghostty it answers 49,842 and does not move while eight lines of output
+print, with `AXValue` at 2,082 across the same two reads: the count is the
+scrollback, the value is the screen, and only a resize changes the first.
+Compared against, the guard could never fail — in the one app this rung exists
+for. It is a digest of the visible text instead, read at the press under the
+same 80ms cap the other rungs use. That is a read the key-down handler is
+otherwise forbidden, and it is allowed only because it is capped and only asked
+when there is a landing for this exact element to check. A read that does not
+finish in the cap refuses, which is right rather than merely safe: a pane too
+big to read in 80ms is Outlook's, and Outlook's pane scrolls too.
 
 **Poll, do not retry once.** Every 80ms for half a second, off the main thread —
 Outlook's message pane reported 395,489 characters, copied out of another process
@@ -152,6 +178,22 @@ Two routes were considered and rejected: patching Ghostty upstream (means runnin
 a private build until it lands) and shipping an Input Method Kit component (works
 everywhere, but the user must select ParrotFlow as their input source and all
 their typing routes through us). Ghostty gets rung 3 and 4 instead.
+
+**Which of the two you get depends on what the pane is running.** The mechanism
+is worth naming, because it is not about any one program.
+
+A full-screen program draws on the *alternate screen*, and that screen has no
+scrollback. The value is then the viewport and nothing else. The row count is
+true, the pitch comes out at a real line height, and rung 4 answers.
+
+An ordinary shell prompt keeps its history in the same value, and
+`AXVisibleCharacterRange` claims all of it is on screen. Rung 4 refuses, and
+what is left is rung 3 or the bottom of the screen.
+
+That is the whole difference between two panes of one window. It is also why 53
+rows and 1,365 rows came from the same application. Claude Code is the example,
+not the cause: vim, less and anything else on the alternate screen behave the
+same way.
 
 ---
 

--- a/docs/proposals/hud-placement-and-offer.md
+++ b/docs/proposals/hud-placement-and-offer.md
@@ -101,9 +101,23 @@ compare after. Nothing has to match, so it survives a pipeline stage rewriting
 the sentence, a wrap putting a newline through the middle of it, and a terminal
 padding it with spaces — all three broke the search. Bound the diff at **both**
 ends: a spinner or clock ticking above would poison a common prefix on its own,
-so take the common suffix too and the change sits between two fixed points. A
-change spanning more than half the screen is a repaint, not an insertion, and is
-refused.
+so take the common suffix too and the change sits between two fixed points.
+
+That leaves one contiguous span, and it is taken only when it is certainly an
+insertion: it covers at most twelve lines, and at most twelve *written* lines
+sit below it. Both halves are needed, and each refuses one thing. Without the
+first, a scroll qualifies — it ends at the end of the buffer too. Without the
+second, a clock ticking near the top qualifies — it is small and contiguous
+too, and where it is is the only thing that tells it apart from a dictation.
+Blank lines do not count towards the second: a terminal pads its viewport with
+them, and a prompt in a pane with no history sits above a screenful. Twelve is
+what fits under the caret while you type — an input box grown to about six
+lines, a border, a mode line and a status line — against the hundreds a scroll
+or a repaint covers.
+
+Anything else is refused, and refused is the bottom of the screen. If the pill
+moves it moves to the right place, and it never comes to rest over the words
+being edited.
 
 Then ask the app for the bounds of *that* range. An app can keep no caret and
 still measure text perfectly well — Outlook does — and the two failings are


### PR DESCRIPTION
PR 3 of the HUD stack. Base is `feat/pill-opens-at-the-caret` (#106), which is not merged — the diff here is only this PR's work.

Implements section 1 of `docs/proposals/hud-placement-and-offer.md`, rungs 3 and 4 of the ladder.

## The problem

#106 gives the pill a position in apps that report a caret: iTerm2, Terminal.app, Notes, ordinary fields. Two do not.

- Ghostty reports `AXSelectedTextRange` as `0` whatever the caret is doing.
- Outlook reports `0+0` for a 395,489-character body.

For those the pill opens at the bottom of the screen. This works out where the words went *after* they land, and guesses at the press from where the last one landed.

## What is added

**`landed` (rung 4).** Snapshot the pane's text at the press, compare it after.

- **A diff, not a search.** The first version looked for the transcript in the field. That fails when a pipeline stage rewrote the sentence between transcription and insertion, when a wrap put a newline through the middle of it, and when a terminal padded it with spaces. Nothing has to match a diff. What changed is where the words are.
- **Bounded at both ends.** A spinner or a clock ticking above would poison a common prefix on its own, so the common suffix is taken too and the change sits between two fixed points. A change spanning more than half the pane is a repaint, not an insertion, and is refused.
- **Then ask for the bounds of that range.** An app can keep no caret and still measure text perfectly well — Outlook does — and the two failings are unrelated. Only where there are no bounds does it fall back to the terminal grid.
- **The grid needs the viewport.** `AXVisibleCharacterRange` gives the rows on screen and the row the top of the pane is showing; the pane's height over that count is the pitch, and 53 rows over a 917pt pane is 17.3pt, a real line height rather than a fit. Counting the lines the value holds was tried instead and does not work: that counts rows with text on them, which is the screen only if the app pads the blank ones, and 40 lines of a 53-row screen gives 22.9pt — close enough to pass any check on the number and still a quarter of the way down the screen. No viewport, no grid; the pill stays where it opened.
- **Polled, not retried once.** Every 80ms for half a second, off the main thread — every look copies the whole pane out of a busy process. Nothing waits for it: the pill is already on screen and moves if and when there is somewhere better to be, so a miss is not a delay.

**`remembered` (rung 3).** Where the last dictation into this same element ended up, used at the press.

A remembered anchor goes stale and looks confident while it is. A terminal scrolls between dictations, so last time's row belongs to something else — often the input box you are about to type into, which is where the pill was seen sitting. Two things invalidate it: the pane's character count must match (one cheap attribute, changes the moment anything is printed) and the landing must be under a minute old. It is only recorded when the pane will report a character count at all, since that count is the only thing that can tell the guess it has gone stale.

**`aim(at:)` morphs a pill that is already up.** #106 left this out on purpose because the anchor always arrived before the pill. Now it can arrive after, and this is what moves it.

## One dictation's press state stays its own

Push-to-talk does not wait for the previous transcript, so two dictations are ordinarily in flight. A `Press` — run and element — is frozen when the recording starts and carried down the delivery chain beside `destination` and `focus`, which exist for exactly this reason. Three rules follow from it:

- The pane snapshot is stamped with the press that took it and read by that press alone.
- A snapshot read *after* the words were written is not a baseline. The write time is recorded per press and such a snapshot is dropped; diffed against the pane it would find nothing, forever.
- Offer ownership only moves forward. Two dictations can finish out of order — a long prompt stage on the first, none on the second — and the older one does not take the pill off the newer one's offer.

## Files

- `Sources/ParrotFlow/CaretAnchor.swift` — `.landed` and `.remembered`, `characterCount(of:)`, `snapshot(of:)`, `landed(after:at:)`, `line(of:in:)`, `visibleGrid(of:)` and the grid arithmetic.
- `Sources/ParrotFlow/PillHUD.swift` — the morph branch in `aim(at:)`.
- `Sources/ParrotFlow/AppDelegate.swift` — `Press`, `screenAtPress`, `lastLanding`, `readTheAnchor()`, `findWhereTheWordsLanded(comparedWith:in:for:)`, and the `remembered` fallback at the press.

## Kept from the base, not from the spike

The reference spike's `CaretAnchor.Found` carries one rectangle. This stack's carries two: `text` (the caret's own rectangle, which decides *which display*) and `rect` (where the pill goes). Both are populated on every new path, so the multi-monitor fixes in `4a1493b` and `bba16c6` still hold. In the grid fallback there is a row and no column, so the row is both rectangles — a row of a pane straddling two monitors goes to whichever shows more of it.

## Checked

- `swift build -c release` clean, and the warning list is byte-identical to the base branch's.
- `swiftlint lint` — no new violations, exit 0.
- Every deterministic script in `.github/workflows/checks.yml`: numbers 97/97, replacements 23/23, pipeline 71/71, wake 24/24, split 14/14, dotted 54/54, dates 26/26, transform folders 12/12, eval 25/25, audio recovery 11/11, possessive 35/35, default config, vocabulary config 61/61, seeded transform, pinned certificate, no voice 5/5.
- Not run: `check-inplace.sh` and `check-span.sh`. They replace `/Applications/ParrotFlowDev.app` and take over the keyboard, and the machine is in use for dictation.

## Not verified

The behaviour itself needs Ghostty and Outlook in front of a person. The numbers quoted here come from the spike's measurements and were not re-measured on this branch. In particular, whether Ghostty answers `AXVisibleCharacterRange` is unknown; without it the grid rung refuses and Ghostty falls back to `remembered` or to the bottom of the screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
