### PR TITLE
feat: the surfaces go near-black, and the plumage comes down a step

### DIFF
--- a/Sources/ParrotFlow/CorrectionPanel.swift
+++ b/Sources/ParrotFlow/CorrectionPanel.swift
@@ -300,7 +300,10 @@ struct CorrectionView: View {
         }
         .padding(Parrot.panelPadding)
         .frame(width: CorrectionMetrics.width)
-        .parrotSurface(RoundedRectangle(cornerRadius: Parrot.panelRadius, style: .continuous))
+        .parrotSurface(
+            RoundedRectangle(cornerRadius: Parrot.panelRadius, style: .continuous),
+            solid: true
+        )
         .onAppear {
             focused = model.visibleTokens.first(where: { $0.isManual })?.id
                 ?? model.visibleTokens.first?.id

--- a/Sources/ParrotFlow/ParrotStyle.swift
+++ b/Sources/ParrotFlow/ParrotStyle.swift
@@ -78,6 +78,12 @@ extension View {
     /// of what is underneath — enough that the surface reads as sitting *over*
     /// something rather than cut out of the screen. Below about 90% the text
     /// starts fighting the backdrop, which is the thing glass never solved.
+    ///
+    /// Every surface passes `solid` now, so `glass` and `scrim` are on no call
+    /// site. Kept rather than deleted because one surface in the design — the
+    /// launch panel — is not drawn yet, and the reasons written on this path
+    /// would go with it. See "Not done" in
+    /// `docs/proposals/hud-placement-and-offer.md`.
     func parrotSurface<S: InsettableShape>(
         _ shape: S, alive: Bool = false, glass: Bool = false, solid: Bool = false,
         scrim: Double? = nil

--- a/Sources/ParrotFlow/ParrotStyle.swift
+++ b/Sources/ParrotFlow/ParrotStyle.swift
@@ -16,13 +16,18 @@ enum Parrot {
     // walks this wheel in this order, so the surfaces share a direction of
     // travel and not just a set of colours.
     //
-    // Saturated on purpose. Muted versions of these read as the system's own
-    // red/yellow/green/blue — the colours of a traffic light and of every other
-    // Mac alert — and the point of them is that this app is a parrot.
-    static let scarlet = Color(red: 1.00, green: 0.16, blue: 0.15)
-    static let amber = Color(red: 1.00, green: 0.75, blue: 0.00)
-    static let leaf = Color(red: 0.00, green: 0.85, blue: 0.42)
-    static let sky = Color(red: 0.00, green: 0.60, blue: 1.00)
+    // Still well clear of the system's own red/yellow/green/blue — the colours
+    // of a traffic light and of every other Mac alert. The point of them is
+    // that this app is a parrot.
+    //
+    // One step down in chroma from the values these started at. On glass the
+    // hues sat over a lit, shifting ground and needed the saturation to hold.
+    // The surfaces are near-black now, so the hues carry much further and the
+    // old values read as neon.
+    static let scarlet = Color(red: 0.761, green: 0.373, blue: 0.349)  // #c25f59
+    static let amber = Color(red: 0.761, green: 0.604, blue: 0.361)  // #c29a5c
+    static let leaf = Color(red: 0.373, green: 0.639, blue: 0.514)  // #5fa383
+    static let sky = Color(red: 0.353, green: 0.537, blue: 0.710)  // #5a89b5
 
     /// Closes on scarlet so an angular gradient has no seam.
     static let wheel: [Color] = [scarlet, amber, leaf, sky, scarlet]
@@ -43,13 +48,13 @@ enum Parrot {
 
 extension View {
 
-    /// Dark glass and the plumage rim: the family look.
+    /// A dark ground and the plumage rim: the family look.
     ///
     /// The colour lives on the edge and nowhere else. A surface washed in a
     /// feather is a surface you have to read text off, and these appear over
-    /// documents, terminals and dark editors without knowing which — dark glass
-    /// is the one background that stays legible over all of them, and the rim
-    /// carries the identity without asking anything of the text.
+    /// documents, terminals and dark editors without knowing which — a dark
+    /// ground is the one background that stays legible over all of them, and
+    /// the rim carries the identity without asking anything of the text.
     ///
     /// `alive` is for work of unknown length. The rim turns and brightens, which
     /// is the only motion any of these surfaces make — it means the app is busy,
@@ -64,16 +69,29 @@ extension View {
     /// `scrim` is how much of the desktop it keeps out, and only means anything
     /// under glass. Default is thin, for the pill, which is glanced at. Pass
     /// more for anything holding a sentence you have to read and select.
+    ///
+    /// `solid` is the near-black ground, and it is the opposite bet from
+    /// `glass`. Glass gives a surface thickness by letting the desktop through;
+    /// this holds the desktop out, so a sentence is read off a known ground
+    /// rather than off whatever happened to be behind the window. 95% rather
+    /// than 100% because the last 5% is not transparency so much as a hairline
+    /// of what is underneath — enough that the surface reads as sitting *over*
+    /// something rather than cut out of the screen. Below about 90% the text
+    /// starts fighting the backdrop, which is the thing glass never solved.
     func parrotSurface<S: InsettableShape>(
-        _ shape: S, alive: Bool = false, glass: Bool = false, scrim: Double? = nil
+        _ shape: S, alive: Bool = false, glass: Bool = false, solid: Bool = false,
+        scrim: Double? = nil
     ) -> some View {
         background {
+            if solid {
+                shape.fill(Color(red: 0.035, green: 0.035, blue: 0.043).opacity(0.95))
+            }
             // No `.regularMaterial` under glass. That blurs what is inside the
             // window, and on a panel with a clear background there is nothing
             // inside it to blur — it comes out flat grey, and a scrim over flat
             // grey is a black-to-grey gradient rather than glass. The material
             // for those surfaces sits behind the whole window; see `ParrotGlass`.
-            if !glass {
+            if !glass, !solid {
                 shape.fill(.regularMaterial)
             }
             // The material alone takes the shade of whatever is behind it, which
@@ -93,9 +111,9 @@ extension View {
             // Nothing at all where the system has real Liquid Glass: it does
             // its own tinting, through `tintColor` on the view behind, and a
             // scrim painted on top of it is paint over glass.
-            if !glass {
+            if !glass, !solid {
                 shape.fill(Color.black.opacity(0.34))
-            } else if !ParrotGlass.isPlatform {
+            } else if glass, !ParrotGlass.isPlatform {
                 shape.fill(Color.black.opacity(scrim ?? 0.08))
             }
 

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -318,6 +318,11 @@ final class PillHUD {
         // Real glass under the capsule. See `ParrotGlass` for why AppKit has to
         // do this and SwiftUI cannot — and why it is masked rather than left to
         // fill the window, which here would frost the margin the glow lives in.
+        //
+        // Still here under a near-black capsule, because the capsule is 95%
+        // opaque and this is what the last 5% shows. A blurred hint of the
+        // desktop is what makes the surface read as sitting over something; the
+        // desktop itself, unblurred, would read as the surface being thin.
         let container = ParrotGlass.container(
             hosting, radius: PillMetrics.height / 2, inset: PillMetrics.bleed,
             // Barely tinted. The pill is glanced at over whatever you are
@@ -604,12 +609,12 @@ struct PillView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .parrotSurface(Capsule(), alive: isWorking, glass: true)
+        .parrotSurface(Capsule(), alive: isWorking, solid: true)
         // Under the capsule, so it is the capsule's shape and not the glow's.
         .shadow(color: .black.opacity(0.22), radius: 7, y: 2)
         // Behind everything above it. `.background` applied last sits furthest
         // back, which is where the bloom has to be — over the fill it would be
-        // a coloured film on the glass rather than light coming off the edge.
+        // a coloured film on the surface rather than light coming off the edge.
         .background { PlumageBloom(shape: Capsule(), alive: isWorking) }
         // The transparent margin the bloom spills into. See `PillMetrics.bleed`.
         .padding(PillMetrics.bleed)
@@ -793,9 +798,10 @@ struct Meter: View {
     }
 
     private func height(for index: Int) -> CGFloat {
-        // Gentle arc so the meter reads as a waveform rather than a bar chart.
-        let mid = CGFloat(bars - 1) / 2
-        let distance = abs(CGFloat(index) - mid) / mid
-        return 6 + (1 - distance) * 10
+        // A triangle, not a diamond. The arc rose to the middle and fell away
+        // again, which reads as a shape with a peak — something that has
+        // already happened. Rising the whole way reads as something still
+        // opening, which is what a microphone that is still listening is.
+        6 + CGFloat(index) / CGFloat(bars - 1) * 13
     }
 }

--- a/Sources/ParrotFlow/PreviewPanel.swift
+++ b/Sources/ParrotFlow/PreviewPanel.swift
@@ -356,11 +356,7 @@ struct PreviewView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .parrotSurface(
             RoundedRectangle(cornerRadius: Parrot.panelRadius, style: .continuous),
-            glass: true,
-            // Heavier than the pill's. This one holds a sentence you read word
-            // by word and select inside; the pill holds four words you glance
-            // at. Same glass, less of the desktop coming through it.
-            scrim: 0.30
+            solid: true
         )
         .background {
             PlumageBloom(

--- a/docs/proposals/hud-placement-and-offer.md
+++ b/docs/proposals/hud-placement-and-offer.md
@@ -204,9 +204,8 @@ same way.
   out of the screen. Below about 90% the text starts fighting the backdrop,
   which is the thing glass never solved.
 - **The plumage loses a step of chroma** against near-black. The mockup's values
-  are `#c25f59 / #c29a5c / #5fa383 / #5a89b5`. **Not yet done in the app** —
-  `ParrotStyle` still carries the saturated set, which reads as neon on the new
-  ground.
+  are `#c25f59 / #c29a5c / #5fa383 / #5a89b5`, and `ParrotStyle` now carries
+  them. The saturated set it carried before reads as neon on the new ground.
 - **The meter is a triangle, not a diamond.** Rising to the middle and falling
   away reads as a shape with a peak — something that already happened. Rising
   the whole way reads as still opening, which is what a live microphone is.

--- a/docs/proposals/hud-placement-and-offer.md
+++ b/docs/proposals/hud-placement-and-offer.md
@@ -434,9 +434,11 @@ gates quiet sound whatever is printed on the case.
 
 ## 6. Not done
 
-- The plumage is still the saturated set; only the pill went near-black. The
-  correction and preview panels are still glass, so the surfaces have drifted
-  apart — which is the one thing `ParrotStyle` exists to prevent.
+- `parrotSurface(glass:)` is now unreachable. All three surfaces pass `solid:`,
+  so nothing asks for the sheen, the light scrim or the rim's top weighting. It
+  is left in rather than deleted: the launch panel below is unbuilt and unstyled,
+  and deleting a path takes the reasons written on it with it. Delete it once
+  the last surface in the design is drawn.
 - The correction panel's Save writes nothing.
 - The launch panel from the design pass is not built at all, and its lettering
   was never chosen — Serif (New York, `design: .serif`), Rounded, or Wide caps.


### PR DESCRIPTION
Section 2 of `docs/proposals/hud-placement-and-offer.md`. Stacked on
#107 (`feat/pill-finds-the-words`) — review the diff against that branch.

## What changes

The pill, the correction panel and the preview panel were dark glass.
They are now near-black at 95%.

`parrotSurface` gets a `solid:` option. It fills the shape with
`#09090B` at 95% and skips the material, the scrim and the glass sheen.
The 5% is not transparency so much as a hairline of what is underneath:
the surface reads as sitting *over* something rather than cut out of the
screen. Below about 90% the text starts fighting the backdrop, which is
the thing glass never solved.

The `ParrotGlass` backdrop behind the pill and the preview window stays.
At 95% opaque it is what the last 5% shows. A blurred hint of the desktop
is what reads as depth; the desktop itself, unblurred, would read as the
surface being thin.

The plumage comes down a step of chroma with it:

| | before | after |
|---|---|---|
| scarlet | `#FF2926` | `#c25f59` |
| amber | `#FFBF00` | `#c29a5c` |
| leaf | `#00D96B` | `#5fa383` |
| sky | `#0099FF` | `#5a89b5` |

On glass the hues sat over a lit, shifting ground and needed the
saturation to hold. Against near-black they carry much further, and the
old values read as neon. The wheel's order does not change, so every
gradient in the app still walks it in the same direction.

The meter is a triangle, not a diamond. Rising to the middle and falling
away again reads as a shape with a peak — something that has already
happened. Rising the whole way reads as something still opening, which is
what a microphone that is still listening is.

## Why all three surfaces in one PR

Drift between them is the one thing `ParrotStyle` exists to prevent. The
pill, the notice and the two dialogs grew one at a time, each borrowing
roughly what the last one did. A PR that made only the pill near-black
would ship that drift on purpose.

`CorrectionPanel` and `PreviewPanel` take the one-line surface change
only. Their bodies are untouched.

## The glass path

With all three surfaces on `solid:`, nothing passes `glass:` or `scrim:`
any more. Both are left in rather than deleted, and both the function's
comment and the proposal's "Not done" say so. One surface in the design
— the launch panel — is not drawn yet, and deleting a path takes the
reasons written on it with it. It goes when the last surface is drawn.

## Verifying

**This one is looked at, not asserted on.** `--panel-sheet` draws every
surface into one PNG, and it needs a window server — it will not run on
the CI runner or headless. A human should run it on a screen and check
the three surfaces side by side:

```sh
make app
.build/ParrotFlowDev.app/Contents/MacOS/ParrotFlow --panel-sheet /tmp/sheet.png
```

What ran here:

- `swift build -c release` — clean. The 20 `AppDelegate` Sendable
  warnings are pre-existing; the four files touched add none.
- `swiftlint lint` — no findings in any file touched.
- Every deterministic script in `.github/workflows/checks.yml`, all
  green: numbers 97/97, replacements 23/23, pipeline 71/71, wake 24/24,
  split 14/14, dotted 54/54, dates 26/26, transform-folders 12/12,
  eval 25/25, audio-recovery 11/11, possessive 35/35, default-config,
  vocabulary-config 61/61, seeded-transform, pinned-certificate,
  no-voice 5/5.

`check-inplace.sh` and `check-span.sh` were not run: they replace
`/Applications/ParrotFlowDev.app` and take over the keyboard, and that
app is in use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
