### PR TITLE
feat: the offer names commands, and you can click them

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2081,17 +2081,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         //
         // The correction panel rather than the preview panel — the offer names
         // one thing and that is the surface that does it. Over the sentence
-        // frozen when the offer went up, so a dictation that finished in the
-        // meantime cannot move what is being corrected. Saving is the panel's
-        // own, unchanged: the same `saveCorrections` the spoken command uses.
-        guard let text = offered?.target.original ?? lastTranscript else { return }
+        // frozen when the offer went up, and back into the field frozen with
+        // it: the panel can be open for a while, and `focusAtPress` by then can
+        // belong to a dictation that finished in the meantime. Teaching a rule
+        // is the panel's own and is unchanged.
+        guard let target = offered?.target else { return }
         Log.write("offer: taken; opening the correction panel")
+        // Nothing here is a selection, and the offer's own target is what says
+        // where the words go. Cleared so no later save can read one left behind
+        // by an earlier flow.
         pendingSelection = nil
         correctionPanel.onSave = { [weak self] rules, correctedText in
-            self?.saveCorrections(rules, correctedText: correctedText)
+            self?.saveOfferedCorrection(rules, correctedText: correctedText, into: target)
         }
-        correctionPanel.onCancel = { [weak self] in self?.pendingSelection = nil }
-        correctionPanel.show(selection: text)
+        correctionPanel.onCancel = { Log.write("offer: correction dismissed") }
+        correctionPanel.show(selection: target.original)
     }
 
     /// This press's dictation is over, however it ended. Drops the pane it
@@ -2268,10 +2272,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// a word is what "Hey parrot, correct" and the correction panel are for,
     /// and quietly writing a rule out of every fixed sentence would fill
     /// config.yaml with pairs that will never recur.
-    private func replace(_ target: Correction, with edited: String) {
+    ///
+    /// Returns whether the field has the sentence. False means it is on the
+    /// clipboard instead and that has already been said on screen, so a caller
+    /// with more to report should stop rather than talk over it. Nothing to
+    /// change counts as true: the field already says what was asked for.
+    @discardableResult
+    private func replace(_ target: Correction, with edited: String) -> Bool {
         let corrected = edited.trimmingCharacters(in: .whitespacesAndNewlines)
         let original = target.original.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !original.isEmpty, !corrected.isEmpty, corrected != original else { return }
+        guard !original.isEmpty, !corrected.isEmpty, corrected != original else { return true }
 
         if let owner = target.owner, !owner.isActive {
             owner.activate()
@@ -2297,7 +2307,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         lastTranscript = corrected
                     }
                     applied("Correction")
-                    return
+                    return true
                 case .failed, .notAttempted:
                     break
                 }
@@ -2312,6 +2322,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(corrected, forType: .string)
         flash("Correction copied — this app won't let me edit it", tone: .caution)
+        return false
     }
 
     private func beginCorrection() {
@@ -2334,10 +2345,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         correctionPanel.show(selection: selection?.text ?? "")
     }
 
-    private func saveCorrections(
-        _ rules: [(heard: String, corrected: String)],
-        correctedText: String
-    ) {
+    /// Write out what the panel taught, one rule at a time.
+    ///
+    /// False means one could not be written and the user has already been shown
+    /// why. Nothing after it should run: a correction that half-saved and then
+    /// went on to rewrite the field would leave the two disagreeing.
+    private func learn(_ rules: [(heard: String, corrected: String)]) -> Bool {
         for rule in rules {
             do {
                 try ConfigWriter.addReplacement(heard: rule.heard, corrected: rule.corrected)
@@ -2345,9 +2358,49 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 Trace.correction(heard: rule.heard, corrected: rule.corrected, via: "command")
             } catch {
                 presentAlert(title: "Could not save the rule", message: error.localizedDescription)
-                pendingSelection = nil
-                return
+                return false
             }
+        }
+        return true
+    }
+
+    /// Save what the panel taught, then write the sentence back into the field
+    /// the offer was about.
+    ///
+    /// Separate from `saveCorrections` for one reason: the destination. That
+    /// one has to work out where the words go, and falls back to `focusAtPress`
+    /// and then to the clipboard. This one already knows — the offer froze the
+    /// element and its app when it went up. The panel can be open for as long
+    /// as it takes to think about a spelling, and push-to-talk does not wait
+    /// for the previous transcript, so anything read at this moment can belong
+    /// to a newer dictation. `replace` carries the same care the tapped offer
+    /// takes: focus handed back first, a refusal to write unless the field is
+    /// still the one that was dictated into, and the clipboard when it cannot.
+    private func saveOfferedCorrection(
+        _ rules: [(heard: String, corrected: String)],
+        correctedText: String,
+        into target: Correction
+    ) {
+        guard learn(rules) else { return }
+        // On the clipboard, and `replace` has said so. A rule notice on top of
+        // that would bury the one thing you need to act on.
+        guard replace(target, with: correctedText) else { return }
+        switch rules.count {
+        // Nothing taught, so `replace` has already said the only thing there
+        // is to say.
+        case 0: break
+        case 1: flash("Saved  \(rules[0].heard) → \(rules[0].corrected)", tone: .done)
+        default: flash("Saved \(rules.count) rules", tone: .done)
+        }
+    }
+
+    private func saveCorrections(
+        _ rules: [(heard: String, corrected: String)],
+        correctedText: String
+    ) {
+        guard learn(rules) else {
+            pendingSelection = nil
+            return
         }
 
         // Put the corrected phrase back where it came from, whether or not any

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -272,6 +272,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// something in the way.
     private static let offerSeconds: TimeInterval = 3
 
+    /// What the offer offers: Correct, then every transform that asked for a
+    /// place on it with `offer: true`.
+    ///
+    /// Correct is first and is not a transform. It is the one command that is
+    /// about the words rather than about rewriting them, it needs no model, and
+    /// it cannot fail.
+    ///
+    /// Read fresh each time rather than stored, so a config reloaded between
+    /// two dictations changes what the next offer says.
+    private var offerCommands: [OfferedCommand] {
+        [OfferedCommand(title: "Correct", key: "C")]
+            + config.transforms.filter(\.offer).map {
+                OfferedCommand(title: $0.name, key: $0.offerKey)
+            }
+    }
+
     /// The last substitution made in somebody else's window, and enough to put
     /// it back.
     ///
@@ -1972,16 +1988,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// had nothing on it at all: the pill simply vanished and the dictation was
     /// over, which is a fine thing to feel and a wasted second of screen.
     ///
-    /// The key is read from the binding that is actually registered rather than
-    /// written down here, so a config that moved the hotkey moves what this
-    /// advertises. A modifier-only binding has a name too. If registration
-    /// failed there is no key to offer and nothing is shown.
+    /// The commands are read from the config, so what is on the pill is what
+    /// that machine can actually do. It no longer waits on the hotkey being
+    /// registered: it used to print that key's name, and now it prints its own
+    /// letters and is worked with the mouse.
+    ///
     /// `press` is the dictation this offer is about, carried down from its own
     /// key-down — see `insertDictation`. Nothing below reads press-time state
     /// off `self`, so an offer can never be moved by another dictation's press.
     private func showCorrectOffer(for press: Press) {
         guard config.feedback.correctOffer else { return }
-        guard let key = hotKeys.binding?.displayName else { return }
         guard let text = lastTranscript?.trimmingCharacters(in: .whitespacesAndNewlines),
               !text.isEmpty else { return }
 
@@ -2002,7 +2018,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         offeredCorrection = (press.run, Correction(
             original: text, element: press.element, owner: press.owner
         ))
-        pill.offer(key, for: Self.offerSeconds)
+        let commands = offerCommands
+        pill.offer(commands, for: Self.offerSeconds)
+        // The list is captured, not read again in the closure: a config
+        // reloaded while the offer is up would otherwise renumber the chips
+        // under the pointer, and the click would run whatever took the slot.
+        pill.model.onPick = { [weak self] index in
+            guard let self, self.offerIsUp, commands.indices.contains(index) else { return }
+            // Index 0 is Correct, which is not a transform and cannot be one:
+            // a config free to name a transform "Correct" must not be able to
+            // take that slot over.
+            self.runOfferedCommand(index == 0 ? nil : commands[index].title)
+        }
+        // The highlight is the pointer's mark and does not outlive it. Leaving
+        // the pill gives it up, so a chip is never lit for a command that is
+        // not about to happen. Cleared here rather than in the view because
+        // this closure is where the rest of the leaving behaviour will hang.
+        pill.model.onHover = { [weak self] inside in
+            guard !inside else { return }
+            self?.pill.model.selected = nil
+        }
 
         // Taken at the press, and only when that press found no caret. Matched
         // by run, so it is this dictation's own pane and nobody else's. A
@@ -2012,6 +2047,51 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
            let element = press.element {
             findWhereTheWordsLanded(comparedWith: pane, in: element, for: press.run)
         }
+    }
+
+    /// Run the command a chip was clicked on, and take the offer down.
+    ///
+    /// `transform` is the name on the chip, or nil for Correct. The pill goes
+    /// first, before anything opens: whatever the command puts on screen
+    /// belongs over the words, which is where the pill is sitting.
+    private func runOfferedCommand(_ transform: String?) {
+        let offered = offeredCorrection
+        offerUntil = nil
+        offeredCorrection = nil
+        pill.hide()
+
+        // Looked up again rather than carried on the chip, so a transform
+        // deleted from a config reloaded while the offer was up is not run
+        // from a chip that outlived it.
+        if let name = transform {
+            guard let found = config.transforms.first(where: { $0.name == name }) else {
+                Log.write("offer: \"\(name)\" is no longer in the config")
+                return
+            }
+            Log.write("offer: taken; running \"\(name)\"")
+            // No instruction: the chip is the whole of what was asked for.
+            // This still shows the transform's preview, because that is what
+            // `confirm:` asks for today.
+            runTransform(found, instruction: "")
+            return
+        }
+
+        // Correct, which is not a transform: it is about the words rather than
+        // about rewriting them.
+        //
+        // The correction panel rather than the preview panel — the offer names
+        // one thing and that is the surface that does it. Over the sentence
+        // frozen when the offer went up, so a dictation that finished in the
+        // meantime cannot move what is being corrected. Saving is the panel's
+        // own, unchanged: the same `saveCorrections` the spoken command uses.
+        guard let text = offered?.target.original ?? lastTranscript else { return }
+        Log.write("offer: taken; opening the correction panel")
+        pendingSelection = nil
+        correctionPanel.onSave = { [weak self] rules, correctedText in
+            self?.saveCorrections(rules, correctedText: correctedText)
+        }
+        correctionPanel.onCancel = { [weak self] in self?.pendingSelection = nil }
+        correctionPanel.show(selection: text)
     }
 
     /// This press's dictation is over, however it ended. Drops the pane it

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -217,6 +217,19 @@ enum CheckConfigCommand {
             }
         }
 
+        // And `offer:` is the other part nothing else can show you. The pill is
+        // up for a few seconds after a dictation, so a chip that failed to
+        // appear — or a `key:` that was dropped for being two characters — is
+        // read as the offer simply being short.
+        let offered = config.transforms.filter(\.offer)
+        if !offered.isEmpty {
+            print("  · offer             \(offered.count) transform(s) on the pill, after Correct")
+            for transform in offered {
+                print("      \(transform.name)"
+                    + (transform.offerKey.isEmpty ? " — no key, click only" : " — \(transform.offerKey)"))
+            }
+        }
+
         for prompt in config.prompts where prompt.description.isEmpty {
             print("  ✗ prompt \"\(prompt.name)\" has no description; the router cannot pick it")
             ok = false

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -551,10 +551,15 @@ struct Config: Decodable, Equatable {
         var unreadable: String?
         /// `tests: { path: heldout.yaml }` — the set `--eval` scores by default.
         var tests: String?
+        /// `offer: true` — put this on the pill after a dictation.
+        var offer = false
+        /// `key: f` — the letter shown on its chip.
+        var offerKey = ""
 
         enum CodingKeys: String, CodingKey {
             case name, description, display, confirm, prompt, content, replace, command
-            case tests, returns
+            case tests, returns, offer
+            case offerKey = "key"
             case timeout = "timeout_seconds"
         }
 
@@ -618,6 +623,12 @@ struct Config: Decodable, Equatable {
             } else {
                 unreadable = "`tests:` is neither a filename nor `{ path: <filename> }`"
             }
+
+            offer = try c.decodeIfPresent(Bool.self, forKey: .offer) ?? false
+            // One letter, upper case. The chip draws it as a keycap and a
+            // keycap holds one character; a key is printed in capitals whatever
+            // the config wrote it as.
+            offerKey = String(try trimmed(.offerKey).prefix(1)).uppercased()
 
             // A body written either way. The mapping is tried first and only
             // succeeds on `{ path: <string> }`, so nothing that decoded before
@@ -768,6 +779,7 @@ struct Config: Decodable, Equatable {
                 display: entry.display,
                 folder: entry.folder, timeout: entry.timeout,
                 confirm: entry.confirm, returnsJSON: entry.returnsJSON,
+                offer: entry.offer, offerKey: entry.offerKey,
                 body: body, source: entry.source,
                 tests: entry.tests
             ))
@@ -840,6 +852,17 @@ struct Config: Decodable, Equatable {
         /// the transcript, `sed` is still a transform, and nothing anybody has
         /// already written has to change.
         var returnsJSON: Bool = false
+        /// Whether this gets a chip on the pill after a dictation, next to
+        /// Correct.
+        ///
+        /// Off by default. The offer is on screen for a few seconds and every
+        /// entry costs the others room, so a transform joins it only by asking
+        /// — it holds what you reach for without thinking, not every transform
+        /// a config happens to define.
+        var offer: Bool = false
+        /// The letter shown on that chip. Empty when the config named none; the
+        /// chip is still there and still clickable.
+        var offerKey: String = ""
         var body: Body
         /// Where the body was read from, when it was read from a file at all —
         /// `prompt: { path: slack.md }`. Nil for an inline body, and nil for a
@@ -2939,9 +2962,9 @@ if __name__ == "__main__":
     feedback:
       sound: true     # a click when recording starts and stops
       overlay: true   # the floating pill while you speak
-      # After the words land the pill offers to correct them for 3s. Tap the
-      # dictation hotkey — press and let go — to open the correction panel over
-      # what was just written. Holding it still starts the next dictation.
+      # After the words land the pill names what can be done to them, for 3s.
+      # Click a chip to run it. Tapping the dictation hotkey — press and let go
+      # — opens the correction panel too. Holding it starts the next dictation.
       correct_offer: true
 
     transcription:
@@ -3076,6 +3099,13 @@ if __name__ == "__main__":
       - name: grammar
         description: fix grammar and punctuation mistakes, not formatting or numbers
         display: Fixing grammar
+        # `offer: true` puts it on the pill after a dictation, next to Correct;
+        # `key:` is the letter drawn on its chip. Worth it for this one: fixing
+        # what you just said is the thing you reach for without thinking. Leave
+        # both off for anything you would only ever ask for out loud — the offer
+        # is on screen briefly and every entry costs the others room.
+        offer: true
+        key: g
         prompt: |
           Correct grammar, spelling and punctuation. Make the smallest change
           that makes the text correct — and make it. Every error is fixed.

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -10,6 +10,14 @@ import SwiftUI
 /// is slow enough that the surfaces drifted apart from each other unnoticed.
 enum PanelsCommand {
 
+    /// What the offer is drawn with here: Correct and one offered transform,
+    /// which is what the shipped config puts on the pill. A row of chips is the
+    /// shape worth looking at, not one chip on its own.
+    private static let offerChips = [
+        OfferedCommand(title: "Correct", key: "C"),
+        OfferedCommand(title: "grammar", key: "G")
+    ]
+
     /// Draws every surface into one PNG, light beside dark.
     ///
     /// The panels are the one part of the app with no test: they are looked at,
@@ -35,7 +43,7 @@ enum PanelsCommand {
         let notice = pill(.notice("Grammar applied", .done))
         let caution = pill(.notice("Grammar copied — this app won't let me edit it", .caution))
         let thinking = pill(.working("Thinking…"))
-        let offer = pill(.offer("Right ⌘"))
+        let offer = pill(.offer(offerChips))
 
         let overlay = pill(.recording, icon: sampleIcon(), level: 0.75)
 
@@ -236,7 +244,16 @@ enum PanelsCommand {
             pill.working("Thinking…")
         case "offer":
             // No duration: it is here to be looked at, not timed out.
-            pill.set(.offer("Right ⌘"))
+            pill.set(.offer(offerChips))
+            // The one state that takes the mouse, so the one worth being able
+            // to hover. Nothing runs — this is the surface, not the app — but
+            // the highlight has to come and go the way it does there.
+            pill.model.onHover = { inside in
+                if !inside { pill.model.selected = nil }
+            }
+            pill.model.onPick = { index in
+                print("offer: chip \(index) — \(offerChips[index].title)")
+            }
         case "vocabulary":
             correction.show(selection: "Tasmin and Mick")
         case "rule":
@@ -280,7 +297,7 @@ enum PanelsCommand {
                 (2.6, { pill.working("Transcribing…") }),
                 (4.0, { pill.working("Grammar…") }),
                 (5.4, { pill.notice("Grammar applied", tone: .done, duration: nil) }),
-                (7.4, { pill.offer("Right ⌘", for: 3) }),
+                (7.4, { pill.offer(offerChips, for: 3) }),
                 (11.4, { pill.recording(icon: nil) }),
                 (14.0, { pill.working("Transcribing…") }),
                 (15.4, { pill.notice("Nowhere to type — the transcription is on your clipboard",

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -47,8 +47,22 @@ enum PillState: Equatable {
     case working(String)
     /// A sentence, for a few seconds.
     case notice(String, NoticeTone)
-    /// What you can do about what just happened, and the key that does it.
-    case offer(String)
+    /// What you can do about what just happened. One entry per command; which
+    /// one the pointer is on lives in the model, not here, so moving the
+    /// highlight is not a state change and does not crossfade the whole pill.
+    case offer([OfferedCommand])
+}
+
+/// A command on the offer, and the letter that runs it.
+///
+/// The letter is drawn as a key rather than as an icon. An icon says what a
+/// command is about; a key says you can press it, which is the more useful
+/// thing on a surface that is up for a few seconds.
+struct OfferedCommand: Equatable {
+    let title: String
+    /// Empty when the config named none. The chip is still there and still
+    /// clickable.
+    let key: String
 }
 
 final class PillModel: ObservableObject {
@@ -63,6 +77,21 @@ final class PillModel: ObservableObject {
     /// words are going, and a window with no caret in it is not somewhere they
     /// can go. See `Destination`.
     @Published var appIcon: NSImage?
+
+    /// Which command the pointer is on, if any.
+    ///
+    /// Nil when it is on none, which is how the offer arrives. This is only
+    /// ever the pointer's mark and it does not outlive the pointer — leaving
+    /// the pill clears it. Nothing runs without a click, so a chip lit before
+    /// you have touched anything is saying something about a command that is
+    /// not about to happen.
+    @Published var selected: Int?
+
+    /// Clicking a command, and the pointer coming and going. Closures rather
+    /// than published state: they are messages out of the view, and nothing
+    /// about them should redraw it.
+    var onPick: ((Int) -> Void)?
+    var onHover: ((Bool) -> Void)?
 }
 
 /// The one floating surface a dictation ever puts on screen.
@@ -120,8 +149,12 @@ final class PillHUD {
     }
 
     /// What you can do about the text that just landed, and for how long.
-    func offer(_ label: String, for duration: TimeInterval) {
-        set(.offer(label), for: duration)
+    ///
+    /// The highlight is cleared first. It belonged to the last offer's pointer,
+    /// and the pointer is not on this one yet.
+    func offer(_ commands: [OfferedCommand], for duration: TimeInterval) {
+        model.selected = nil
+        set(.offer(commands), for: duration)
     }
 
     /// Point the pill at where the words are going, for this dictation.
@@ -181,6 +214,17 @@ final class PillHUD {
         // `PillHUD.motion`.
         withAnimation(.easeInOut(duration: Self.motion)) {
             model.state = state
+        }
+
+        // The pill ignores the mouse in every state but this one. It sits over
+        // whatever you are working in, so a surface that swallowed clicks for
+        // the length of a dictation would be a hole in your screen — but the
+        // offer is made of buttons, and a button you cannot click is a picture
+        // of a button.
+        if case .offer = state {
+            panel.ignoresMouseEvents = false
+        } else {
+            panel.ignoresMouseEvents = true
         }
 
         let size = PillMetrics.panelSize(for: state, hasIcon: model.appIcon != nil)
@@ -520,7 +564,7 @@ enum PillMetrics {
         case .recording: return recording(hasIcon: hasIcon)
         case .working(let message): return text(message)
         case .notice(let message, _): return text(message)
-        case .offer(let label): return offer(label)
+        case .offer(let commands): return offer(commands)
         }
     }
 
@@ -538,26 +582,39 @@ enum PillMetrics {
         min(600, max(300, CGFloat(message.count) * 8 + 86))
     }
 
-    /// The offer is a short question wrapped around a keycap, and it has no
-    /// minimum.
+    /// A row of chips, and no minimum.
     ///
     /// Unlike a message, which is a sentence you have to be able to read to the
     /// end, this is a shape you learn after seeing it twice. Held to the 300pt
     /// floor it would be a mostly empty pill, and an offer that looks like a
     /// notice reads as something having gone wrong.
     ///
-    /// "Wrong?" and "to fix it" either side, with 8pt between the three.
+    /// Much narrower than it was. It used to ask a whole question — "Wrong?
+    /// Right ⌘ to fix it" — because it appeared at the bottom of the screen
+    /// with no connection to the words it was about. Under the words, that
+    /// sentence is answering a question nobody has to be asked any more.
     ///
-    /// Generous rather than tight. The three parts are laid out by SwiftUI and
-    /// measured here, and the two numbers only ever agree approximately — a
-    /// capsule a few points too wide has a little air at the end, one a few
-    /// points too narrow truncates the sentence it exists to ask.
-    static func offer(_ label: String) -> CGFloat {
-        padding * 2 + 58 + 8 + keycap(label) + 8 + 56
+    /// Generous rather than tight: the chips are laid out by SwiftUI and
+    /// measured here, and the two numbers only ever agree approximately. The
+    /// title is `.fixedSize()`, so a capsule a few points too narrow lets a
+    /// chip hang over the end rather than shortening it.
+    static func offer(_ commands: [OfferedCommand]) -> CGFloat {
+        // A chip is its keycap, its words and 10pt of padding either side; then
+        // 4pt between one chip and the next.
+        let chips = commands.reduce(CGFloat(0)) { total, command in
+            total + 20 + (command.key.isEmpty ? 0 : keycap) + title(command.title)
+        }
+        return padding * 2 + chips + CGFloat(max(commands.count - 1, 0)) * 4
     }
 
-    static func keycap(_ label: String) -> CGFloat {
-        max(30, CGFloat(label.count) * 7.5 + 16)
+    /// The keycap on a chip: one character at 11pt bold, 5pt either side, and
+    /// the 7pt between it and the words.
+    static let keycap: CGFloat = 26
+
+    /// A chip's words at 13pt rounded. Per character, which is what everything
+    /// else on this surface measures text with.
+    static func title(_ words: String) -> CGFloat {
+        CGFloat(words.count) * 7.5
     }
 }
 
@@ -603,12 +660,16 @@ struct PillView: View {
             case .notice(let message, let tone):
                 MessageContent(message: message, tone: tone)
                     .transition(.opacity)
-            case .offer(let label):
-                OfferContent(label: label)
+            case .offer(let commands):
+                OfferContent(commands: commands)
                     .transition(.opacity)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // The whole surface, not each chip: moving from one chip to the next
+        // must not read as leaving the pill. What leaving costs is decided by
+        // whoever raised the offer — see `PillModel.onHover`.
+        .onHover { inside in model.onHover?(inside) }
         .parrotSurface(Capsule(), alive: isWorking, solid: true)
         // Under the capsule, so it is the capsule's shape and not the glow's.
         .shadow(color: .black.opacity(0.22), radius: 7, y: 2)
@@ -684,52 +745,86 @@ private struct MessageContent: View {
     }
 }
 
-/// The key you can press, and what it does.
+/// What can be done to the words that just landed, one chip per command.
 ///
-/// A keycap rather than a dot, because this is the one state that is not news
-/// about something that already happened — it is a thing you can still do, and
-/// the difference has to be visible before the words are read. The key is drawn
-/// from the binding that is actually registered, so a config that moved the
-/// hotkey moves what this advertises. Offering a key that does nothing is worse
-/// than offering nothing.
+/// Chips rather than a sentence, because the pill now sits under those words:
+/// they are the subject, so this only has to name what can be done to them.
+/// The old wording — "Wrong? Right ⌘ to fix it" — was a whole question because
+/// it appeared at the bottom of the screen with no connection to anything.
+///
+/// Each chip carries a letter. This is the one pill state that is not news
+/// about something that already happened — it is a thing you can still do — and
+/// that difference has to be visible before the words are read.
 private struct OfferContent: View {
-    let label: String
+    @EnvironmentObject private var model: PillModel
+    let commands: [OfferedCommand]
+
+    /// The lit chip's lettering: leaf lightened almost to white, so the words
+    /// stay readable over a fill of the same colour.
+    private static let litText = Color(red: 0.89, green: 0.96, blue: 0.93)
 
     var body: some View {
-        HStack(spacing: 8) {
-            // The question first. "Correct" alone named the action without
-            // saying what it was for, which reads as an instruction to correct
-            // something rather than an offer to fix what just landed — and the
-            // answer to it is usually no, so it has to be askable at a glance.
-            Text("Wrong?")
-                .font(.system(size: 13, weight: .medium, design: .rounded))
-                .lineLimit(1)
-
-            Text(label)
-                .font(.system(size: 12, weight: .semibold, design: .rounded))
-                // A key's name is one line whatever it is. Without this the
-                // capsule's width wins the argument and "Right ⌘" wraps to two.
-                .lineLimit(1)
-                .fixedSize()
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
-                .background {
-                    RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .fill(Color.white.opacity(0.12))
-                        .overlay {
-                            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                .strokeBorder(Color.white.opacity(0.22), lineWidth: 0.5)
-                        }
-                }
-
-            Text("to fix it")
-                .font(.system(size: 13, weight: .medium, design: .rounded))
-                .lineLimit(1)
+        HStack(spacing: 4) {
+            ForEach(Array(commands.enumerated()), id: \.offset) { index, command in
+                // A tap gesture rather than a `Button`. The pill is a
+                // `nonactivatingPanel` and is never the key window, and SwiftUI
+                // draws controls in an inactive window at reduced emphasis — so
+                // a lit chip came up washed out until the pointer landed on it,
+                // which read as nothing being lit at all. `contentShape` is what
+                // makes the whole capsule the target and not just the glyphs.
+                chip(command, lit: model.selected == index)
+                    .contentShape(Capsule())
+                    .onTapGesture { model.onPick?(index) }
+                    // Light what the pointer is over, so the letter on the chip
+                    // and the pointer say the same thing about the same command.
+                    .onHover { over in if over { model.selected = index } }
+            }
 
             Spacer(minLength: 0)
         }
         .padding(.horizontal, PillMetrics.padding)
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// Lit carries the same leaf as a changed word and as the confirm button:
+    /// they are the same claim — this is the one that will happen — so the eye
+    /// learns the colour once.
+    private func chip(_ command: OfferedCommand, lit: Bool) -> some View {
+        HStack(spacing: 7) {
+            if !command.key.isEmpty {
+                Text(command.key)
+                    .font(.system(size: 11, weight: .bold, design: .rounded))
+                    // A floor rather than a width: every letter draws in the
+                    // same box, so the chips do not step in and out by a point
+                    // as the pointer moves along them.
+                    .frame(minWidth: 9)
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 2)
+                    .background {
+                        RoundedRectangle(cornerRadius: 4, style: .continuous)
+                            .fill(Color.white.opacity(lit ? 0.2 : 0.12))
+                    }
+            }
+            Text(command.title)
+                .font(.system(size: 13, weight: .medium, design: .rounded))
+                // One line whatever the capsule thinks. The width is measured
+                // in `PillMetrics.offer`, and without this the capsule would
+                // win the argument and wrap a name to two lines.
+                .lineLimit(1)
+                .fixedSize()
+        }
+        .foregroundStyle(lit ? Self.litText : .secondary)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background {
+            Capsule()
+                .fill(lit ? Parrot.leaf.opacity(0.28) : Color.white.opacity(0.05))
+                .overlay {
+                    Capsule().strokeBorder(
+                        lit ? Parrot.leaf.opacity(0.62) : .clear, lineWidth: 1
+                    )
+                }
+        }
     }
 }
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -137,6 +137,13 @@ transforms:
   - name: grammar
     description: fix grammar and punctuation mistakes, not formatting or numbers
     display: Fixing grammar
+    # `offer: true` puts it on the pill after a dictation, next to Correct;
+    # `key:` is the letter drawn on its chip. Worth it for this one: fixing what
+    # you just said is the thing you reach for without thinking. Leave both off
+    # for anything you would only ever ask for out loud — the offer is on screen
+    # briefly and every entry costs the others room.
+    offer: true
+    key: g
     prompt: |
       Correct grammar, spelling and punctuation. Make the smallest change
       that makes the text correct — and make it. Every error is fixed.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -308,6 +308,10 @@ $PF --panel-sheet s.png   # draw every surface into one PNG, light beside dark
 `vocabulary`, `rule`, `dictation`, `preview` or `sequence`. `--panel-sheet` draws all of
 them at once, which is where drift between them shows up.
 
+`offer` is the one state that takes the mouse — hover a chip to light it, click
+one to print which was chosen. Every other state lets clicks through, so the
+pill is never a hole in your screen while you are dictating.
+
 `sequence` is the one that cannot be checked from a still. The pill is a single
 panel that changes width and crossfades its contents rather than being replaced
 — hot mic, decoding, applied, the offer, gone — and whether that morphs or

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -287,19 +287,26 @@ sitting at an ordinary shell prompt keeps everything you have run in it, and the
 pill goes to the bottom of the screen.
 
 `correct_offer` is what the pill does after the words land. It stays where it
-is for three seconds and reads `Wrong?  <your hotkey>  to fix it`. Tap that key
-— press and let go, faster than a dictation — and the whole sentence opens in
-an editable box. Fix it, press Replace, and it goes back over what was written.
-Hold the key as usual and you start the next dictation, exactly as before.
+is for three seconds and names what can be done to them, one chip per command:
+`Correct` first, then every transform with `offer: true` — see
+[pipelines.md](pipelines.md#offer-and-key-or-getting-on-the-pill). Click a chip
+to run it. `Correct` opens the per-word panel over what was just dictated;
+a transform runs as it always does.
+
+Tapping the dictation hotkey — press and let go, faster than a dictation —
+still opens the whole sentence in an editable box. Fix it, press Replace, and
+it goes back over what was written. Hold the key as usual and you start the
+next dictation, exactly as before.
 
 The threshold is `audio.min_duration_seconds`, which is already the app's line
 between a press and a dictation: below it the recording is deleted, so a tap
 has never done anything. Nothing that used to be a dictation becomes a tap.
 
-This is the sentence, not the vocabulary. Nothing is written to `replacements:`
-— fixing one sentence is not the same as teaching a word, and most of a
-misheard sentence is words that will never come up again. To teach a word, say
-"Hey parrot, correct" or use the menu bar, which open the per-word panel.
+The editable box is the sentence, not the vocabulary. Nothing is written to
+`replacements:` from it — fixing one sentence is not the same as teaching a
+word, and most of a misheard sentence is words that will never come up again.
+Teaching a word is what the per-word panel is for, which `Correct` and "Hey
+parrot, correct" both open.
 
 Off by setting it to `false`.
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -239,6 +239,41 @@ it runs. Long instructions are cut at a word boundary. Reading it mid-wait is
 also how you catch the router having heard you wrong, a second before the
 preview would have told you.
 
+### `offer:` and `key:`, or: getting on the pill
+
+After a dictation the pill names what can be done to the words that just
+landed. `Correct` is always first — it is not a transform, it needs no model,
+and it cannot fail. After it comes every transform that asked for a place:
+
+```yaml
+  - name: grammar
+    description: fix grammar and punctuation mistakes
+    display: Fixing grammar
+    offer: true       # put a chip on the pill
+    key: g            # the letter drawn on it
+    prompt: |
+      Correct grammar, spelling and punctuation. Return only the text.
+```
+
+Click a chip to run it. A transform runs as it always does, so it still shows
+its preview when `confirm:` is on.
+
+**Both are off by default.** The offer is on screen for a few seconds and every
+entry costs the others room, so a transform joins it only by asking. Put a
+chip on what you reach for without thinking. Leave it off anything you would
+only ever ask for out loud — that is what the wake phrase is for.
+
+`key:` is one letter, drawn as a keycap and shown in capitals whatever you
+write. More than one character is cut to the first. A transform with `offer:
+true` and no `key:` still gets a chip, without a keycap on it.
+
+`--check-config` prints what is on the pill and the letter each chip carries.
+A chip that is missing, or a `key:` that was cut, is otherwise invisible: the
+pill is up for three seconds and a short offer looks like a normal one.
+
+Only the shipped `grammar` asks for a place. Everything else in
+config.example.yaml is left off.
+
 ### `command:`, or: the app stops needing new primitives
 
 The transcript arrives on **stdin** and comes back on **stdout**. That is the


### PR DESCRIPTION
PR 5 of the HUD placement and offer stack. Base is `feat/near-black-surfaces`
(#108), which is not merged — the stack is reviewed unmerged, so this diff is
this PR's work only.

Spec: `docs/proposals/hud-placement-and-offer.md`, section 3. That section
describes the finished offer, which spans PRs 5 to 9. This is the first slice:
a working, clickable offer with **no system-wide event tap in it**.

## What changes

The pill said *"Wrong? Right ⌘ to fix it"*. That was a whole sentence because
the pill used to appear at the bottom of the screen with no connection to the
words it was about. PRs 2 and 3 put it under those words, so the words are the
subject now and the pill only has to name what can be done to them.

One chip per command, each carrying the letter that will run it:

```
[ C Correct ] [ G grammar ]
```

The list is `["Correct"] + transforms where offer: true`. Correct is first and
is not a transform: it is the one command about the words rather than about
rewriting them, it needs no model, and it cannot fail.

## The two new config keys

```yaml
  - name: grammar
    description: fix grammar and punctuation mistakes
    offer: true       # a chip on the pill
    key: g            # the letter drawn on it
```

Both default off. The offer is on screen for a few seconds and every entry
costs the others room, so a transform joins it only by asking. The shipped
`grammar` asks; nothing else in the default config or in
`config.example.yaml` does.

`key:` is cut to one character and upper-cased. `--check-config` now prints
what is on the pill and the letter each chip carries — a chip that failed to
appear, or a `key:` that was cut, is otherwise invisible in three seconds of
pill.

Documented in `docs/pipelines.md` beside `display:`, and the `correct_offer`
paragraph in `docs/configuration.md` is brought up to date.

## Four decisions, not taste

- **A letter, not an icon.** An icon says what a command is *about*; a key says
  you can press it, which is the more useful thing on a surface up for a few
  seconds.
- **Nothing is preselected.** `selected` starts nil. It is only ever the
  pointer's mark and it does not outlive the pointer — leaving the pill clears
  it. Nothing runs without a click, so a chip lit before you have touched
  anything is saying something about a command that is not about to happen.
- **The chips are not `Button`s.** The pill is a `nonactivatingPanel` and is
  never the key window, and SwiftUI draws controls in an inactive window at
  reduced emphasis — a lit chip came up washed out until the pointer landed on
  it, which read as nothing being lit at all. Tap gesture, explicit
  `contentShape`.
- **The pill takes the mouse only in the offer state.** `ignoresMouseEvents` is
  set per state in `set(_:for:)`. The pill sits over whatever you are working
  in, so a surface that swallowed clicks for the length of a dictation would be
  a hole in your screen — but the offer is made of buttons, and a button you
  cannot click is a picture of a button.

## What a click does

**Correct** opens the correction panel over the transcript frozen when the
offer went up — not the preview panel, which is what the base does today. The
offer names one thing and that is the surface that does it.

The sentence goes back into the field frozen with it, through
`replace(_:with:)` — the routine the tapped offer already uses. The panel can
be open for as long as it takes to think about a spelling, and push-to-talk
does not wait for the previous transcript, so anything read at save time can
belong to a newer dictation. Teaching a rule is the panel's own and is
unchanged: `learn(_:)` is split out of `saveCorrections` and shared, and
`saveCorrections` itself behaves exactly as it did. Rebuilding the panel is
PR 11.

**A transform** calls the existing `runTransform(_:instruction:)` with an empty
instruction, so it still shows its preview — that is what `confirm:` asks for
today. Making an offered command rewrite in place without a preview is PR 9.

Correct is identified by its index, not by its title, so a config free to name
a transform "Correct" cannot take that slot over.

## Explicitly not here

| Not in this PR | Owner |
|---|---|
| `OfferKeys`, the event tap, the letters actually working | PR 6 |
| decay, fade, hover holding the clock | PR 7 |
| when the offer is raised | PR 8 |
| an offered command rewriting in place, no preview | PR 9 |
| the correction panel rebuilt around spans | PR 11 |

`takeTheOfferIfTapped` — the hotkey tap — is untouched and still opens the
preview panel. PR 6 is the one PR that swallows keys from every app on the
machine, and it should be reviewed as exactly that and nothing else.

One deliberate deletion: `showCorrectOffer` no longer requires
`hotKeys.binding?.displayName`. That guard existed only because the pill
printed the hotkey's name, and it does not print it any more.

## Checks

- `swift build -c release` clean. 20 compiler warnings before, 20 after — all
  the pre-existing `AppDelegate` Sendable ones, none new.
- `swiftlint` reports nothing new in the changed files.
- Every deterministic script from `.github/workflows/checks.yml` run locally
  and green, including `check-default-config.sh` (28 keys, 9 transforms) and
  `check-vocabulary-config.sh` (61/61). `check-inplace.sh` and `check-span.sh`
  were **not** run: they replace `/Applications/ParrotFlowDev.app` and take over
  the keyboard.
- `--check-config` against both the shipped default and `config.example.yaml`
  reports `offer  1 transform(s) on the pill, after Correct / grammar — G`.

## Please render the sheet

`--panel-sheet` is updated for the new `.offer` shape, and `--panels offer` now
wires hover and click so the state can be worked with a pointer. A human should
look at it:

```sh
make app && .build/ParrotFlowDev.app/Contents/MacOS/ParrotFlow --panel-sheet /tmp/sheet.png
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
