### PR TITLE
feat: the offer takes its own keys

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -243,26 +243,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// When the offer to correct the last dictation stops being on screen.
     ///
     /// Held here as well as in the pill because the pill only knows how to draw
-    /// it. Whether a press is a tap on the offer or the start of a dictation is
-    /// decided against this, and that decision is made in the hotkey handler
-    /// before anything is drawn at all.
+    /// it. It is also the deadline the key tap is given, so the keys can never
+    /// be held for longer than the offer is worth.
     private var offerUntil: Date?
-    /// Whether the offer was still up when this press went down.
+    /// The keyboard, for as long as the offer is up. See `OfferKeys`.
+    private let offerKeys = OfferKeys()
+    /// The chips the offer on screen is showing, and so the letters it claims.
     ///
-    /// Captured at the press rather than read at the release, because the three
-    /// seconds can run out in between — and a press that began as a tap on the
-    /// offer should stay one, or the gesture would depend on how fast you let
-    /// go of a key you have already pressed.
-    private var pressTookTheOffer = false
-    /// Whether an ordinary key went down while the hotkey was held.
+    /// Held rather than read from the config when the keys are armed, because
+    /// the keys can be armed after the chips were drawn — see
+    /// `watchTheOfferKeys`. A config reloaded in between must not leave a
+    /// letter claimed for a chip that is not on screen.
+    private var offerOnScreen: [OfferedCommand]?
+    /// Gives the keys back when the offer simply runs out.
     ///
-    /// A bare-modifier hotkey — `hotkey: right_command` — is also half of every
-    /// shortcut that uses that modifier. Right ⌘ V is a press and a release
-    /// well under the tap threshold, and without this it would open the
-    /// correction panel instead of pasting. Set by the same keyboard monitors
-    /// Escape already installs, so it costs nothing extra and is only watched
-    /// while there is a recording to watch.
-    private var keyDownDuringPress = false
+    /// The pill takes itself off screen after `offerSeconds` and tells nobody,
+    /// so an offer that nobody answers ends with no call back into here. This
+    /// is that call. Without it the tap's own expiry would be the only thing
+    /// left to end it, and that is the backstop, not the way out.
+    private var offerKeysExpiry: DispatchWorkItem?
 
     /// How long the offer stays up.
     ///
@@ -698,10 +697,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         // Before the recording starts, because starting it is what takes the
-        // offer off the screen.
-        pressTookTheOffer = offerIsUp
-        offerUntil = nil
-        keyDownDuringPress = false
+        // offer off the screen. A new dictation is one of the ways the offer
+        // ends, so it is one of the ways the keys go back.
+        endTheOffer()
 
         switch config.hotkey.mode {
         case .toggle:
@@ -826,12 +824,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // the character key is still down and a flicked-back modifier means
         // the chord never really broke.
         pushToTalkPoll?.invalidate(); pushToTalkPoll = nil
-        // Checked here rather than in `stopRecording`, which is the wrong side
-        // of the release tail: the mic stays open for `release_tail_seconds`
-        // after the key comes up, so by the time the recorder is stopped every
-        // press has lasted at least that long and no tap would ever be short
-        // enough to see.
-        if takeTheOfferIfTapped() { return }
         stopRecordingAfterTail()
     }
 
@@ -904,10 +896,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             startRecording()
             return
         }
-        // The second press of a toggle is the end of the gesture, which is
-        // where push-to-talk checks too. Same rule, measured between two
-        // presses instead of between a press and a release.
-        if takeTheOfferIfTapped() { return }
         stopRecording()
     }
 
@@ -1051,10 +1039,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // what a `hotkey:` of "escape" would resolve through.
         guard let escape = KeyCodes.code(for: "escape") else { return }
         let cancel: (NSEvent) -> Void = { [weak self] event in
-            // Any key at all, before the Escape test: a key going down during
-            // a press is what tells a chord apart from a tap. See
-            // `takeTheOfferIfTapped`.
-            self?.keyDownDuringPress = true
             guard event.keyCode == UInt16(escape) else { return }
             DispatchQueue.main.async { self?.cancelDictation() }
         }
@@ -1079,6 +1063,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func stopWatchingForEscapeIfIdle() {
         guard !recorder.isRecording, runsInFlight <= 0 else { return }
         stopWatchingForEscape()
+        // The same moment, read the other way round: Escape has nothing left to
+        // cancel, so an offer that was raised while a dictation was still
+        // running can have its keys now. See `watchTheOfferKeys`.
+        if offerIsUp, !offerKeys.isRunning { watchTheOfferKeys() }
     }
 
     private func stopWatchingForEscape() {
@@ -2039,6 +2027,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.pill.model.selected = nil
         }
 
+        offerOnScreen = commands
+        watchTheOfferKeys()
+
         // Taken at the press, and only when that press found no caret. Matched
         // by run, so it is this dictation's own pane and nobody else's. A
         // remembered anchor is still a guess, and this is what replaces it with
@@ -2049,15 +2040,98 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// Run the command a chip was clicked on, and take the offer down.
+    /// Take the offer's letters and Escape for as long as the offer is up.
+    ///
+    /// Consumed rather than only heard — see `OfferKeys` for why that needs a
+    /// system-wide tap, and for the fences on it. The keys go back the moment
+    /// the offer does, by every path that ends it and by the timer below.
+    ///
+    /// The commands are `offerOnScreen` — the same list the chips were drawn
+    /// from and the same list `onPick` closed over. Read fresh from the config
+    /// here it could disagree with both: a config reloaded while the offer is
+    /// up would leave a letter claimed for a chip that is not on screen.
+    ///
+    /// Called when the offer is raised, and again from
+    /// `stopWatchingForEscapeIfIdle` for the offer that could not have the keys
+    /// the first time.
+    private func watchTheOfferKeys() {
+        // Whatever the last call left running goes first, deadline included.
+        offerKeysExpiry?.cancel()
+        offerKeysExpiry = nil
+        offerKeys.stop()
+
+        guard let until = offerUntil, let commands = offerOnScreen else { return }
+
+        // The offer can also end by nobody answering it. The pill takes itself
+        // down and says nothing, so this is what hands the keyboard back.
+        // Armed before the tap is, so the offer is cleaned up at its deadline
+        // even on the path below that installs no tap at all.
+        let expire = DispatchWorkItem { [weak self] in self?.endTheOffer() }
+        offerKeysExpiry = expire
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + until.timeIntervalSinceNow, execute: expire
+        )
+
+        // Not while another dictation is running. Push-to-talk does not wait
+        // for the previous transcript, so an offer can go up while a newer
+        // press is still recording or decoding — and Escape belongs to that
+        // press, to cancel it. A tap consumes before any monitor is reached, so
+        // arming here would take Escape away from the dictation and spend it
+        // dismissing the offer. The chips stay clickable meanwhile, and
+        // `stopWatchingForEscapeIfIdle` calls back here the moment that
+        // dictation is over — so an offer still on screen then gets its keys
+        // for whatever is left of its three seconds.
+        guard !recorder.isRecording, runsInFlight <= 0 else {
+            Log.write("offer keys: a dictation is still running; the keys wait for it")
+            return
+        }
+        let letters = Set(commands.map(\.key).filter { !$0.isEmpty })
+        offerKeys.start(until: until, letters: letters) { [weak self] key in
+            guard let self, self.offerIsUp else { return }
+            switch key {
+            case .letter(let typed):
+                guard let index = commands.firstIndex(where: { $0.key == typed }) else { return }
+                // The highlight moves first, so what runs is what the pill was
+                // showing when it ran.
+                self.pill.model.selected = index
+                // The same door the pointer uses. A key and a click must not be
+                // two ways of running a command, or only one of them gets the
+                // guards the other one has.
+                self.pill.model.onPick?(index)
+            case .dismiss:
+                Log.write("offer: dismissed")
+                self.endTheOffer()
+                self.pill.hide()
+            }
+        }
+    }
+
+    /// The offer is over, however it ended: nothing left to run, and the keys
+    /// go back.
+    ///
+    /// Called by every ending — a letter, a click, Escape, Return, the offer
+    /// running out, and a new dictation starting. Safe to call when there is no
+    /// offer, which is most of the time. A caller that still needs the words
+    /// the offer was about reads `offeredCorrection` before calling this.
+    private func endTheOffer() {
+        offerUntil = nil
+        offeredCorrection = nil
+        offerOnScreen = nil
+        offerKeysExpiry?.cancel()
+        offerKeysExpiry = nil
+        offerKeys.stop()
+    }
+
+    /// Run the command a chip was clicked on or lettered, and take the offer
+    /// down.
     ///
     /// `transform` is the name on the chip, or nil for Correct. The pill goes
     /// first, before anything opens: whatever the command puts on screen
     /// belongs over the words, which is where the pill is sitting.
     private func runOfferedCommand(_ transform: String?) {
+        // Read before the offer is ended, which is what clears it.
         let offered = offeredCorrection
-        offerUntil = nil
-        offeredCorrection = nil
+        endTheOffer()
         pill.hide()
 
         // Looked up again rather than carried on the chip, so a transform
@@ -2179,65 +2253,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
         queue.asyncAfter(deadline: .now() + 0.04) { look() }
-    }
-
-    /// A press on the dictation key that was too short to be a dictation, made
-    /// while the offer was up: open the correction panel instead.
-    ///
-    /// The dictation key rather than a key of its own because there is no key
-    /// of its own to have. Carbon needs a modifier, an `NSEvent` monitor cannot
-    /// swallow what it sees — so a bare ⌫ would open the panel *and* delete a
-    /// character out of the sentence it is about to correct — and a new combo
-    /// is one more thing to configure and collide with. The key already in your
-    /// hand is the one you can offer without asking for anything.
-    ///
-    /// The threshold is `audio.min_duration_seconds`, not a number of its own.
-    /// That is already the app's definition of a press too short to be speech:
-    /// under it the recorder deletes the clip and returns nothing, so a tap has
-    /// always cost nothing and done nothing. This gives it something to do
-    /// without taking anything away — a press that would have been a dictation
-    /// still is one.
-    ///
-    /// A chord is not a tap. With a bare-modifier hotkey the key is also half
-    /// of every shortcut that uses it, so `keyDownDuringPress` throws out any
-    /// press that had another key inside it — Right ⌘ V is a press and a
-    /// release well under the threshold, and it means paste. Seeing that key
-    /// in somebody else's window needs Accessibility, which is the grant the
-    /// app already asks for; without it the chord is invisible and a shortcut
-    /// during the offer opens the panel.
-    ///
-    /// Returns whether the offer was taken, so the caller can stop.
-    private func takeTheOfferIfTapped() -> Bool {
-        guard pressTookTheOffer, recorder.isRecording, !keyDownDuringPress,
-              let started = recorder.startedAt,
-              Date().timeIntervalSince(started) < config.audio.minDurationSeconds,
-              let offered = offeredCorrection, offered.run == offerPressRun
-        else { return false }
-
-        pressTookTheOffer = false
-        offerUntil = nil
-
-        // Under the minimum, so the recorder deletes the clip and gives back
-        // nothing. Nothing to transcribe, nothing to deliver.
-        _ = recorder.stop(config: config)
-        dictationCancelled(pressRun)
-        tickTimer?.invalidate(); tickTimer = nil
-        pushToTalkPoll?.invalidate(); pushToTalkPoll = nil
-        releaseTail?.invalidate(); releaseTail = nil
-        stopWatchingForEscapeIfIdle()
-        pill.hide()
-
-        // Captured when the offer went up, not read again here and not again
-        // when Replace is pressed. See `offeredCorrection` and `Correction`.
-        let target = offered.target
-        offeredCorrection = nil
-
-        Log.write("offer: taken; editing the last transcript")
-        previewPanel.onApply = { [weak self] text in self?.replace(target, with: text) }
-        previewPanel.onCancel = { Log.write("offer: dismissed; the text stands as dictated") }
-        previewPanel.show(transcript: target.original)
-        updateUI()
-        return true
     }
 
     /// What an offer is about: the sentence, and the field it was written into.

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -224,9 +224,23 @@ enum CheckConfigCommand {
         let offered = config.transforms.filter(\.offer)
         if !offered.isEmpty {
             print("  · offer             \(offered.count) transform(s) on the pill, after Correct")
+            // Correct's letter is not a transform's to lose, and the first chip
+            // with a letter is the one that key runs. So a second chip asking
+            // for the same letter is drawn with a keycap that never fires, and
+            // that is invisible on a pill that is up for three seconds.
+            var taken: Set<String> = ["C"]
             for transform in offered {
-                print("      \(transform.name)"
-                    + (transform.offerKey.isEmpty ? " — no key, click only" : " — \(transform.offerKey)"))
+                let key = transform.offerKey
+                let note: String
+                if key.isEmpty {
+                    note = " — no key, click only"
+                } else if taken.contains(key) {
+                    note = " — \(key), already taken; this chip is click only"
+                } else {
+                    note = " — \(key)"
+                    taken.insert(key)
+                }
+                print("      \(transform.name)\(note)")
             }
         }
 

--- a/Sources/ParrotFlow/OfferKeys.swift
+++ b/Sources/ParrotFlow/OfferKeys.swift
@@ -1,0 +1,181 @@
+import AppKit
+import Carbon.HIToolbox
+
+/// Takes the offer's letters and Escape while the offer is on screen, and gives
+/// them back the moment it is not.
+///
+/// ## Why this is a tap and not a monitor
+///
+/// The pill is a `nonactivatingPanel` and never takes keyboard focus — that is
+/// deliberate, because it appears while you are typing into somebody else's
+/// window. `NSEvent.addGlobalMonitorForEvents` can hear a key in that state but
+/// cannot swallow one, so a letter on a chip would also be typed into your
+/// document: press `C` to correct and you get the correction panel and a stray
+/// `c` in the sentence it is about to correct.
+///
+/// A `CGEvent` tap is the only way to consume a key without holding focus. It
+/// needs Accessibility, which the app already requires.
+///
+/// ## What keeps it safe
+///
+/// Swallowing keys system-wide is a thing to be nervous about, so it is fenced
+/// three ways. It only exists while the offer is up — created on the way in and
+/// destroyed on the way out. It only ever consumes Escape and the letters the
+/// offer has claimed, and it passes everything else through untouched. And it
+/// carries its own expiry: if the object that owns it somehow never calls
+/// `stop`, the next key past the deadline tears the tap down and goes through.
+/// The failure mode is a key that works, not a keyboard that stops.
+final class OfferKeys {
+
+    enum Key: Equatable {
+        /// Escape, or Return. Both end the offer; only Escape is consumed.
+        case dismiss
+        /// Run the command this letter belongs to.
+        case letter(String)
+    }
+
+    private var tap: CFMachPort?
+    private var source: CFRunLoopSource?
+    private var handler: ((Key) -> Void)?
+    private var expiry = Date.distantPast
+    /// The letters the offer has claimed, uppercased. Empty is allowed — then
+    /// only Escape and Return are watched.
+    private var letters: Set<String> = []
+
+    var isRunning: Bool { tap != nil }
+
+    /// Begin taking the keys, until `until` at the latest.
+    ///
+    /// `letters` must already be uppercased, which is the shape `Config` stores
+    /// a `key:` in: the comparison below uppercases what was typed, so a
+    /// lowercase entry here would claim a letter and then never match it.
+    func start(until: Date, letters: Set<String>, onKey: @escaping (Key) -> Void) {
+        stop()
+        self.letters = letters
+        guard AXIsProcessTrusted() else {
+            Log.write("offer keys: accessibility is not granted; the keys are not taken")
+            return
+        }
+        handler = onKey
+        expiry = until
+
+        // The two "the system switched your tap off" events are subscribed to
+        // as well as the keys. They arrive through the tap itself, so a tap
+        // that does not ask for them cannot be told it is dead.
+        let mask = (1 << CGEventType.keyDown.rawValue)
+            | (1 << CGEventType.tapDisabledByTimeout.rawValue)
+            | (1 << CGEventType.tapDisabledByUserInput.rawValue)
+
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: CGEventMask(mask),
+            callback: { _, type, event, refcon in
+                guard let refcon else { return Unmanaged.passUnretained(event) }
+                let keys = Unmanaged<OfferKeys>.fromOpaque(refcon).takeUnretainedValue()
+                return keys.handle(type, event)
+            },
+            // Unretained, and safe because the tap is torn down in `stop`,
+            // which `deinit` also calls: the callback cannot outlive the object
+            // it points at.
+            userInfo: Unmanaged.passUnretained(self).toOpaque()
+        ) else {
+            Log.write("offer keys: could not create the tap; the keys are not taken")
+            handler = nil
+            return
+        }
+
+        // On the main run loop, so `handle` runs on the main thread and can
+        // touch the same state `start` and `stop` do.
+        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        CGEvent.tapEnable(tap: tap, enable: true)
+        self.tap = tap
+        self.source = source
+        Log.write("offer keys: taking \(letters.sorted().joined()) and escape")
+    }
+
+    /// Give the keyboard back. Safe to call when nothing is running, and safe
+    /// to call twice — every path that ends the offer calls it.
+    func stop() {
+        if let tap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+            CFMachPortInvalidate(tap)
+        }
+        if let source {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+        }
+        tap = nil
+        source = nil
+        handler = nil
+        letters = []
+        expiry = .distantPast
+    }
+
+    deinit { stop() }
+
+    private func handle(
+        _ type: CGEventType, _ event: CGEvent
+    ) -> Unmanaged<CGEvent>? {
+        // The system switches a tap off if it ever takes too long, and says so
+        // through the tap itself. Left unhandled, the tap is silently dead and
+        // the offer's keys stop working with nothing in the log.
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            Log.write("offer keys: the tap was switched off; re-enabling it")
+            if let tap { CGEvent.tapEnable(tap: tap, enable: true) }
+            return Unmanaged.passUnretained(event)
+        }
+        guard type == .keyDown else { return Unmanaged.passUnretained(event) }
+
+        // The backstop. Nothing should reach here after the offer has gone, and
+        // if it does the key goes through and the tap goes away.
+        guard Date() < expiry else {
+            DispatchQueue.main.async { [weak self] in self?.stop() }
+            return Unmanaged.passUnretained(event)
+        }
+
+        // A modified key is somebody else's shortcut — ⌘C copies, ⇧F types a
+        // capital F, ⌃C interrupts. Only the bare key belongs to the offer, and
+        // checking first means a letter with a modifier on it is never even
+        // considered.
+        let claimed: CGEventFlags = [.maskCommand, .maskAlternate, .maskControl, .maskShift]
+        guard event.flags.isDisjoint(with: claimed) else {
+            return Unmanaged.passUnretained(event)
+        }
+
+        // Letters and Escape are taken. Return is only watched.
+        //
+        // The arrows and space were here and are gone. Selecting with one key
+        // and confirming with another is a menu, and this is two buttons: the
+        // letter on each says how to press it, and the mouse says the same
+        // thing again. Every key taken from the system has to earn it, and a
+        // selection nobody needed did not.
+        let key: Key
+        var take = true
+        switch Int(event.getIntegerValueField(.keyboardEventKeycode)) {
+        case kVK_Escape:
+            key = .dismiss
+        case kVK_Return, kVK_ANSI_KeypadEnter:
+            // Return means you are sending what was dictated, which is the end
+            // of the whole errand — so the offer goes at once rather than
+            // sitting over your shoulder while you read the reply. Passed
+            // through, never taken: this is the key the dictation was for.
+            key = .dismiss
+            take = false
+        default:
+            guard !letters.isEmpty,
+                  let typed = NSEvent(cgEvent: event)?.charactersIgnoringModifiers?.uppercased(),
+                  letters.contains(typed)
+            else { return Unmanaged.passUnretained(event) }
+            key = .letter(typed)
+        }
+
+        // Handed to the next turn of the main loop rather than run here. What
+        // the handler does opens panels and calls models, and a tap that takes
+        // too long inside its own callback is the tap macOS switches off.
+        let handler = self.handler
+        DispatchQueue.main.async { handler?(key) }
+        return take ? nil : Unmanaged.passUnretained(event)
+    }
+}

--- a/Sources/ParrotFlow/PreviewPanel.swift
+++ b/Sources/ParrotFlow/PreviewPanel.swift
@@ -22,7 +22,13 @@ final class PreviewPanel {
     var onCancel: (() -> Void)?
 
     /// The whole dictation, editable, so a misheard sentence can be fixed
-    /// where it landed. Opened by the offer the pill makes after a dictation.
+    /// where it landed.
+    ///
+    /// Nothing in the app opens it this way today. A tap of the dictation key
+    /// during the offer used to, and that cost the key its one job — pressing
+    /// it while the offer was up opened a panel instead of starting the
+    /// dictation you had just asked for. Kept for `--panels-sheet`, which is
+    /// where the surfaces are compared side by side.
     func show(transcript: String) {
         model.loadTranscript(transcript)
         present()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -289,26 +289,27 @@ pill goes to the bottom of the screen.
 `correct_offer` is what the pill does after the words land. It stays where it
 is for three seconds and names what can be done to them, one chip per command:
 `Correct` first, then every transform with `offer: true` — see
-[pipelines.md](pipelines.md#offer-and-key-or-getting-on-the-pill). Click a chip
-to run it. `Correct` opens the per-word panel over what was just dictated;
-a transform runs as it always does.
+[pipelines.md](pipelines.md#offer-and-key-or-getting-on-the-pill). `Correct`
+opens the per-word panel over what was just dictated; a transform runs as it
+always does.
 
-Tapping the dictation hotkey — press and let go, faster than a dictation —
-still opens the whole sentence in an editable box. Fix it, press Replace, and
-it goes back over what was written. Hold the key as usual and you start the
-next dictation, exactly as before.
+| | Does |
+|---|---|
+| a chip's letter — `C`, `G` | Runs that command |
+| a click on a chip | Runs that command |
+| `esc` | Dismisses |
+| `↩` | Dismisses, and reaches the app underneath untouched |
+| the dictation hotkey | Starts the next dictation, exactly as before |
 
-The threshold is `audio.min_duration_seconds`, which is already the app's line
-between a press and a dictation: below it the recording is deleted, so a tap
-has never done anything. Nothing that used to be a dictation becomes a tap.
+**The letters are taken from every app for those three seconds.** The pill
+never holds keyboard focus, so it swallows the letters system-wide or it does
+not get them at all. Finish a dictation and immediately type a word starting
+with `C` or `G` and the first keystroke runs a command instead of typing.
+A letter with a modifier on it is never taken — `⌘C` copies and `⇧G` types a
+capital G — so only bare letters are exposed, and only until the offer goes.
+`esc` ends it, and so does starting the next dictation.
 
-The editable box is the sentence, not the vocabulary. Nothing is written to
-`replacements:` from it — fixing one sentence is not the same as teaching a
-word, and most of a misheard sentence is words that will never come up again.
-Teaching a word is what the per-word panel is for, which `Correct` and "Hey
-parrot, correct" both open.
-
-Off by setting it to `false`.
+Off by setting it to `false`. Then no key is taken at any time.
 
 ## See also
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -255,8 +255,8 @@ and it cannot fail. After it comes every transform that asked for a place:
       Correct grammar, spelling and punctuation. Return only the text.
 ```
 
-Click a chip to run it. A transform runs as it always does, so it still shows
-its preview when `confirm:` is on.
+Press the letter on a chip, or click it. A transform runs as it always does, so
+it still shows its preview when `confirm:` is on.
 
 **Both are off by default.** The offer is on screen for a few seconds and every
 entry costs the others room, so a transform joins it only by asking. Put a
@@ -265,7 +265,13 @@ only ever ask for out loud — that is what the wake phrase is for.
 
 `key:` is one letter, drawn as a keycap and shown in capitals whatever you
 write. More than one character is cut to the first. A transform with `offer:
-true` and no `key:` still gets a chip, without a keycap on it.
+true` and no `key:` still gets a chip, without a keycap on it — clickable, and
+on no key.
+
+The letter is taken from whatever app you are typing into, for the three
+seconds the offer is up. Pick one you are unlikely to start a word with right
+after dictating. `C` is already `Correct`'s; a second chip asking for it is
+drawn but never reached, because the first chip with that letter wins.
 
 `--check-config` prints what is on the pill and the letter each chip carries.
 A chip that is missing, or a `key:` that was cut, is otherwise invisible: the


### PR DESCRIPTION
PR 7 of the HUD stack. Base is `feat/the-offer-names-commands` (#109).
Spec: `docs/proposals/hud-placement-and-offer.md`, section 3, "Taking a key
without holding focus".

PR 6 drew a letter on each chip and made the chips clickable. The letters did
nothing. They work now.

**This is the one PR in the stack that takes keys from every app on the
machine. That is what it should be reviewed as.**

| | Does |
|---|---|
| a chip's letter — `C`, `G` | Runs that command |
| `esc` | Dismisses. Consumed |
| `↩` | Dismisses, and is passed through untouched |
| the dictation hotkey | Starts the next dictation, exactly as before |

## Why a tap

The pill is a `nonactivatingPanel` and never takes keyboard focus. That is
deliberate: it appears while you are typing into somebody else's window.
`NSEvent.addGlobalMonitorForEvents` can hear a key in that state but cannot
swallow one, so a bare `C` would open the correction panel *and* type a `c`
into the sentence it is about to correct. A `CGEvent` tap is the only way to
consume a key without focus. It needs Accessibility, which the app already
requires.

`↩` is watched, not taken. Return is the key you press to send what you just
dictated. Taking it would mean accepting the offer cost you the thing the
dictation was for. Pressing it means the errand is over, so the offer goes at
once rather than sitting over your shoulder while you read the reply.

## The three fences

1. **It exists only while the offer is up.** Created when the offer is raised,
   destroyed by every path that ends it: a letter, a click, Escape, Return, a
   new dictation starting, and the offer running out. That last one had no call
   back into the app — the pill takes itself down after three seconds and tells
   nobody — so `offerKeysExpiry` is what hands the keyboard back. Without it
   the tap's own expiry would be the only thing left, and that is the backstop,
   not the way out.
2. **It consumes Escape and the claimed letters, and passes everything else
   through.** A modified key goes through too: `⌘C` copies, `⇧F` types a
   capital F. The modifiers are checked before anything else, so a modified
   letter is never even considered.
3. **It carries its own expiry.** If it is ever not torn down, the first key
   past the deadline kills the tap and goes through. It also handles
   `tapDisabledByTimeout` and `tapDisabledByUserInput` — macOS switches a tap
   off if it is ever slow, and unhandled that leaves it silently dead with
   nothing in the log.

The failure mode has to be a key that works, not a keyboard that stops.

**Not armed while another dictation is running.** Push-to-talk does not wait
for the previous transcript, so an offer can go up while a newer press is still
recording or decoding — and Escape belongs to that press, to cancel it. A tap
consumes before any monitor is reached, so arming there would spend the
dictation's Escape on dismissing the offer.

The chips stay clickable meanwhile, and `stopWatchingForEscapeIfIdle` — which
already runs at exactly the moment Escape has nothing left to cancel — arms the
keys then, for whatever is left of the offer's three seconds. That is why the
chips are held in `offerOnScreen`: the keys can be armed later than the chips
were drawn, so the letters have to be the ones on screen rather than whatever
the config says by then. The expiry work item is armed before that guard, so an
offer whose keys never arrive is still cleaned up at its deadline.

The handler is also handed to the next turn of the main loop rather than run
inside the tap callback. What it does opens panels and calls models, and a tap
that takes too long inside its own callback is the tap macOS switches off.

## The cost, out loud

**For as long as the offer is up — three seconds — a bare `C` or `G` is
swallowed.** Finish dictating, immediately type a word starting with one of
those, and the first keystroke runs a command instead of typing.

Modified keys are safe. Bare ones are not. `esc` ends it, and so does starting
the next dictation. `feedback.correct_offer: false` means no key is ever taken.

If it proves annoying the fix is to dismiss the offer on the first keystroke
that is not one of its own, which cuts the exposure to a single keypress. Not
built here.

## The hotkey is freed

`takeTheOfferIfTapped` is deleted. A tap of the dictation key used to accept
the offer, which cost that key its one job: pressing it while the offer was up
opened a panel instead of starting the dictation you had just asked for. The
hotkey is the hotkey, whatever else is on screen. `pressTookTheOffer` and
`keyDownDuringPress` were its only state and go with it.

`PreviewPanel.show(transcript:)` was its surface. It is still reached by
`--panels-sheet`, so it stays, with a comment saying nothing in the app opens
it any more.

## One command path, not two

A letter runs its command through `PillHUD.onPick` — the same closure a click
runs through, over the same captured command list. A key and a click must not
be two ways of running a command, or only one of them gets the guards the other
one has. The highlight moves to the chip first, so what runs is what the pill
was showing when it ran.

The letters are taken from the same captured list, not read fresh: a config
reloaded while the offer is up would otherwise leave a letter claimed for a
chip that is not on screen.

## Also here

`--check-config` now says when a `key:` is already taken. The first chip with a
letter is the one that key runs, so a second chip asking for `C` is drawn with
a keycap that never fires — invisible on a pill that is up for three seconds.

```
· offer             1 transform(s) on the pill, after Correct
    grammar — C, already taken; this chip is click only
```

`docs/configuration.md` and `docs/pipelines.md` say what the keys do and what
they cost.

## What was verified

- `swift build -c release`: **no new warnings.** 20 pre-existing `AppDelegate`
  Sendable warnings before and after; `OfferKeys.swift` adds none.
- SwiftLint: **32 before, 32 after.**
- All 16 deterministic `scripts/check-*.sh` from `.github/workflows/checks.yml`
  pass.
- `--check-config` against a fresh default config, with and without a colliding
  `key:`.

## Review round 1

Greptile scored 4/5 with one P1: with the overlap guard as first written, an
offer raised during another dictation never got its keys, even after that
dictation finished. Correct, and fixed by the re-arm above. Nothing else was
raised.

## What was not verified

**Nothing that needs a keyboard.** The machine this was written on is being
dictated into with the dev build, so the tap was never installed live. Unproven
by hand, all of it by code reading only:

- that a letter runs its command and the keystroke does not also reach the app,
- that `⌘C` and `⇧F` still reach the app while the offer is up,
- that `↩` both dismisses the offer and reaches the app,
- that the tap is gone the moment the offer is,
- the `tapDisabledByTimeout` path, which needs a tap slow enough for macOS to
  switch off.

`scripts/check-inplace.sh` and `scripts/check-span.sh` were deliberately not
run: they replace `/Applications/ParrotFlowDev.app` and take the keyboard.

## Not in this PR

- No decay or fade, and no `hovering` — PR 8.
- No change to when the offer is raised — PR 9.
- No in-place rewrite for offered transforms — PR 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
