### PR TITLE
feat: the offer fades rather than vanishing

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -257,19 +257,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var offerOnScreen: [OfferedCommand]?
     /// Gives the keys back when the offer simply runs out.
     ///
-    /// The pill takes itself off screen after `offerSeconds` and tells nobody,
+    /// The pill fades itself off screen after `offerSeconds` and tells nobody,
     /// so an offer that nobody answers ends with no call back into here. This
     /// is that call. Without it the tap's own expiry would be the only thing
     /// left to end it, and that is the backstop, not the way out.
+    ///
+    /// It has a second job while the pointer is holding the offer open. See
+    /// `offerDeadlinePassed`.
     private var offerKeysExpiry: DispatchWorkItem?
+    /// True while the pointer is resting on the offer.
+    ///
+    /// The clock is stopped then, and `offerUntil` becomes a date that never
+    /// arrives — which is also why the deadline above is not armed with it:
+    /// `asyncAfter` at that distance is an overflow rather than a long wait.
+    /// See `holdTheOffer`.
+    private var offerHeld = false
 
     /// How long the offer stays up.
     ///
-    /// Long enough to read the key and act on it, short enough that it is gone
-    /// before you have started typing the next thing. It is on screen after
-    /// every dictation, so any longer and it stops being an offer and becomes
-    /// something in the way.
-    private static let offerSeconds: TimeInterval = 3
+    /// Long enough to read the sentence, decide it is wrong and reach for a
+    /// key, which three seconds was not. It can afford to be this long because
+    /// it does not sit there at full strength: it thins out the whole way — see
+    /// `PillHUD.offer` — and the pointer stops that clock and gives the nine
+    /// seconds back in full. A fade this generous would be clutter after every
+    /// dictation if reading it did not put it back.
+    ///
+    /// Not private: `--panels offer` previews the offer for as long as the app
+    /// gives it, and a preview with a number of its own is a preview of
+    /// something else.
+    static let offerSeconds: TimeInterval = 9
 
     /// What the offer offers: Correct, then every transform that asked for a
     /// place on it with `offer: true`.
@@ -2001,6 +2017,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         offerUntil = Date().addingTimeInterval(Self.offerSeconds)
+        // A new offer is never born held, whatever the last one ended as.
+        offerHeld = false
         offerPressRun = press.run
         // This dictation's own words and its own field, frozen with the offer.
         offeredCorrection = (press.run, Correction(
@@ -2021,10 +2039,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // The highlight is the pointer's mark and does not outlive it. Leaving
         // the pill gives it up, so a chip is never lit for a command that is
         // not about to happen. Cleared here rather than in the view because
-        // this closure is where the rest of the leaving behaviour will hang.
+        // this is where the rest of the leaving behaviour hangs.
         pill.model.onHover = { [weak self] inside in
-            guard !inside else { return }
-            self?.pill.model.selected = nil
+            guard let self else { return }
+            if !inside { self.pill.model.selected = nil }
+            self.holdTheOffer(inside)
         }
 
         offerOnScreen = commands
@@ -2066,11 +2085,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // down and says nothing, so this is what hands the keyboard back.
         // Armed before the tap is, so the offer is cleaned up at its deadline
         // even on the path below that installs no tap at all.
-        let expire = DispatchWorkItem { [weak self] in self?.endTheOffer() }
-        offerKeysExpiry = expire
-        DispatchQueue.main.asyncAfter(
-            deadline: .now() + until.timeIntervalSinceNow, execute: expire
-        )
+        armTheOfferDeadline()
 
         // Not while another dictation is running. Push-to-talk does not wait
         // for the previous transcript, so an offer can go up while a newer
@@ -2080,7 +2095,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // dismissing the offer. The chips stay clickable meanwhile, and
         // `stopWatchingForEscapeIfIdle` calls back here the moment that
         // dictation is over — so an offer still on screen then gets its keys
-        // for whatever is left of its three seconds.
+        // for whatever is left of its nine seconds.
         guard !recorder.isRecording, runsInFlight <= 0 else {
             Log.write("offer keys: a dictation is still running; the keys wait for it")
             return
@@ -2106,6 +2121,70 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    /// Arm the call that ends the offer when nobody answers it.
+    ///
+    /// One work item, replaced rather than added to, so the deadline can move
+    /// without the tap being torn down and built again.
+    private func armTheOfferDeadline() {
+        offerKeysExpiry?.cancel()
+        offerKeysExpiry = nil
+        guard let until = offerUntil else { return }
+        // Held, this is not a deadline but a look. The offer has no deadline
+        // while the pointer is on it, so what is armed instead is the question
+        // "is the pointer still there" — see `offerDeadlinePassed`.
+        let after = offerHeld ? Self.offerSeconds : max(0, until.timeIntervalSinceNow)
+        let expire = DispatchWorkItem { [weak self] in self?.offerDeadlinePassed() }
+        offerKeysExpiry = expire
+        DispatchQueue.main.asyncAfter(deadline: .now() + after, execute: expire)
+    }
+
+    /// Nobody answered the offer, or nobody has moved the pointer off it.
+    ///
+    /// Held, the pointer is asked for rather than waited on. `onHover` is the
+    /// only thing saying the pill is still under the pointer, and an exit that
+    /// never arrives — a Space change, Mission Control, a window ordered out —
+    /// would hold the offer open until the next dictation, with the letters it
+    /// takes from every app. So the hold is checked once every `offerSeconds`,
+    /// and a pointer that has gone without saying so is treated as one that
+    /// said so: the offer gets its nine seconds and runs out normally.
+    private func offerDeadlinePassed() {
+        guard offerHeld else { endTheOffer(); return }
+        if pill.pointerIsOver {
+            armTheOfferDeadline()
+            return
+        }
+        Log.write("offer: the pointer left without saying so; the clock starts again")
+        holdTheOffer(false)
+    }
+
+    /// The pointer stops the offer's clock, and gives it back in full when it
+    /// leaves.
+    ///
+    /// Stopped rather than reset. A surface that went on thinning while you
+    /// were reaching for it would be arguing about whether you had finished,
+    /// and a pointer can rest for longer than any number chosen here. So while
+    /// it is inside the offer has no deadline at all, and leaving starts a
+    /// whole new nine seconds.
+    ///
+    /// Three clocks have to move together, or the pill and the keys disagree:
+    /// the pill's own fade, this deadline, and the tap's expiry. The tap's is
+    /// a backstop against a tap that outlived its offer, and a pointer resting
+    /// on the pill is the opposite of that — the offer is on screen, by
+    /// definition. Every path that ends the offer still calls
+    /// `OfferKeys.stop`, so the tap does not depend on that expiry to go.
+    private func holdTheOffer(_ inside: Bool) {
+        // Nothing to hold once the offer is over. The pointer can leave a pill
+        // that a key has already dismissed, and that must not give it a
+        // deadline back.
+        guard offerUntil != nil else { return }
+        let until = inside ? Date.distantFuture : Date().addingTimeInterval(Self.offerSeconds)
+        offerHeld = inside
+        offerUntil = until
+        armTheOfferDeadline()
+        offerKeys.extend(until: until)
+        pill.hovering(inside)
+    }
+
     /// The offer is over, however it ended: nothing left to run, and the keys
     /// go back.
     ///
@@ -2115,6 +2194,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// the offer was about reads `offeredCorrection` before calling this.
     private func endTheOffer() {
         offerUntil = nil
+        offerHeld = false
         offeredCorrection = nil
         offerOnScreen = nil
         offerKeysExpiry?.cancel()

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -227,7 +227,7 @@ enum CheckConfigCommand {
             // Correct's letter is not a transform's to lose, and the first chip
             // with a letter is the one that key runs. So a second chip asking
             // for the same letter is drawn with a keycap that never fires, and
-            // that is invisible on a pill that is up for three seconds.
+            // that is invisible on a pill that fades out in nine seconds.
             var taken: Set<String> = ["C"]
             for transform in offered {
                 let key = transform.offerKey

--- a/Sources/ParrotFlow/OfferKeys.swift
+++ b/Sources/ParrotFlow/OfferKeys.swift
@@ -44,6 +44,22 @@ final class OfferKeys {
 
     var isRunning: Bool { tap != nil }
 
+    /// Move the deadline, after something said the offer is not over yet.
+    ///
+    /// The tap itself is left exactly as it is — the same letters, the same
+    /// handler. Only the backstop moves, and it has to move with the offer: a
+    /// tap still holding `C` for a pill the pointer is holding open, with an
+    /// expiry from before it was held, would give the letter back to the app
+    /// while the chip that claims it is still on screen.
+    ///
+    /// Does nothing when no tap is running. The offer can be up without one —
+    /// the keys wait for a dictation that is still going — and there is no
+    /// deadline to move until `start` gives it one.
+    func extend(until: Date) {
+        guard tap != nil else { return }
+        expiry = until
+    }
+
     /// Begin taking the keys, until `until` at the latest.
     ///
     /// `letters` must already be uppercased, which is the shape `Config` stores

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -243,13 +243,19 @@ enum PanelsCommand {
         case "thinking":
             pill.working("Thinking…")
         case "offer":
-            // No duration: it is here to be looked at, not timed out.
-            pill.set(.offer(offerChips))
+            // The real call rather than a bare `set`. The offer is the one
+            // state that arrives below full strength and thins out, so a
+            // preview holding it at full would be a picture of a pill that
+            // never appears. It gets the duration the app gives it.
+            pill.offer(offerChips, for: AppDelegate.offerSeconds)
             // The one state that takes the mouse, so the one worth being able
             // to hover. Nothing runs — this is the surface, not the app — but
-            // the highlight has to come and go the way it does there.
+            // the highlight and the hold behave the way they do there: park the
+            // pointer on the pill and it stops fading, which is also how you
+            // keep it on screen for as long as you want to look at it.
             pill.model.onHover = { inside in
                 if !inside { pill.model.selected = nil }
+                pill.hovering(inside)
             }
             pill.model.onPick = { index in
                 print("offer: chip \(index) — \(offerChips[index].title)")

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -111,6 +111,27 @@ final class PillHUD {
     /// Armed by a `set()` that carries a duration.
     private var pendingDismiss: DispatchWorkItem?
     private var isFading = false
+    /// Thinning out on a deadline, rather than holding and then going. Only the
+    /// offer does this — see `decay(over:)`.
+    private var isDecaying = false
+    /// How long the offer on screen was given, so the pointer can give it again.
+    private var offerFor: TimeInterval?
+    /// A decay the pointer has stopped, as against one still running.
+    ///
+    /// The two end differently. A stopped one sits at `offerAlpha`, which is a
+    /// real strength, so it can fade out the way every other state does. A
+    /// running one has already told AppKit to finish at zero, so a fade laid
+    /// over it has nothing left to move and it is cut instead.
+    private var decayIsHeld = false
+    /// Which decay is the live one.
+    ///
+    /// Replacing an animation makes the one it replaced call its completion
+    /// handler, straight away. A flag alone cannot tell those apart: the decay
+    /// that replaces it sets `isDecaying` back to true before the old handler
+    /// runs, so the old handler passes the guard and orders the panel out. That
+    /// was the pointer dismissing the offer it was there to hold open. The
+    /// handler checks this number as well, and a stale one does nothing.
+    private var decayRun = 0
 
     /// Where this dictation's words are going, set at the press by `aim(at:)`.
     /// Every state reads it while the pill is up, and `fadeOut` clears it, so
@@ -152,9 +173,113 @@ final class PillHUD {
     ///
     /// The highlight is cleared first. It belonged to the last offer's pointer,
     /// and the pointer is not on this one yet.
+    ///
+    /// This is the one state that leaves by going quiet rather than by
+    /// disappearing. Every other one holds full strength and then goes. This
+    /// one starts below full and thins the whole way out, for two reasons. It
+    /// is the only state nobody asked for — it arrives after a dictation you
+    /// had already finished — so it should announce itself less than a notice
+    /// does. And it is the only state with a deadline you might want to beat: a
+    /// hard cut gives you the time and then nothing, while a decay says how
+    /// long is left without a clock on screen, and stays usable to the last
+    /// frame. The keys and the chips work the whole way down; the fading only
+    /// says how long is left.
     func offer(_ commands: [OfferedCommand], for duration: TimeInterval) {
         model.selected = nil
-        set(.offer(commands), for: duration)
+        offerFor = duration
+        set(.offer(commands))
+        decay(over: duration)
+    }
+
+    /// From `Self.offerAlpha` to nothing, over `duration`, then gone.
+    ///
+    /// Linear on purpose. An eased fade spends most of its time near the ends
+    /// and crosses the middle quickly, which reads as the surface being yanked
+    /// away at the halfway mark. A straight ramp is the one shape that says
+    /// "this is running out" at a steady rate — a clock without a clock.
+    private func decay(over duration: TimeInterval) {
+        guard let panel else { return }
+        pendingDismiss?.cancel(); pendingDismiss = nil
+        isFading = false
+        isDecaying = true
+        decayIsHeld = false
+        decayRun += 1
+        let run = decayRun
+
+        // Land on the starting strength at once, cancelling whatever was
+        // animating alpha. Usually nothing — the offer follows a pill already
+        // on screen — but raised from cold, `set` starts a fade to full and the
+        // two would pull opposite ways.
+        if !panel.isVisible { panel.orderFrontRegardless() }
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0
+            panel.animator().alphaValue = Self.offerAlpha
+        }
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = duration
+            context.timingFunction = CAMediaTimingFunction(name: .linear)
+            panel.animator().alphaValue = 0
+        } completionHandler: { [weak self] in
+            // `decayRun` and not `isDecaying` alone: see the property.
+            guard let self, self.isDecaying, self.decayRun == run else { return }
+            self.isDecaying = false
+            // The aim belonged to the dictation that has just ended, the same
+            // as in `fadeOut`.
+            self.near = nil
+            panel.orderOut(nil)
+            // Back to full strength while off screen, or the next appearance
+            // starts from a panel that is already invisible and stays that way.
+            panel.alphaValue = 1
+        }
+    }
+
+    /// Hold the offer at full strength, or let it start running out again.
+    ///
+    /// The pointer resting on the pill is the least ambiguous statement there
+    /// is that you are still deciding, so the fade stops entirely rather than
+    /// resetting — and starts again from the beginning when the pointer leaves.
+    /// A surface that went on thinning while you were reaching for it would be
+    /// arguing with you about whether you had finished.
+    ///
+    /// This is also why the decay can be as long as it is. Nine seconds of
+    /// clutter would be too much to put on screen after every dictation if
+    /// reading it did not put it back.
+    func hovering(_ inside: Bool) {
+        // `isVisible` as well as the flag: a decay that finished a moment ago
+        // has taken the panel out, and nothing about the pointer should bring
+        // an offer that is over back onto the screen.
+        guard let panel, panel.isVisible, let offerFor, isDecaying || inside else { return }
+        if inside {
+            // Stop the running decay without letting its completion fire: the
+            // animation below replaces it, and a replaced animation calls its
+            // handler at once.
+            decayRun += 1
+            isDecaying = true
+            decayIsHeld = true
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0
+                panel.animator().alphaValue = Self.offerAlpha
+            }
+        } else {
+            decay(over: offerFor)
+        }
+    }
+
+    /// Where the offer starts. Below full, because it is the one surface that
+    /// appears without being asked for.
+    static let offerAlpha: CGFloat = 0.92
+
+    /// Whether the pointer is over the pill at this instant.
+    ///
+    /// Asked, rather than remembered from the last `hovering(_:)`. A hover that
+    /// arrives can be believed; a hover that never leaves cannot. A Space
+    /// change, Mission Control or a window ordered out from underneath the
+    /// pointer can all swallow the exit, and whoever is holding the offer open
+    /// on the strength of that hover would hold it — and the keys it takes —
+    /// until the next dictation.
+    var pointerIsOver: Bool {
+        guard let panel, panel.isVisible else { return false }
+        return panel.frame.contains(NSEvent.mouseLocation)
     }
 
     /// Point the pill at where the words are going, for this dictation.
@@ -204,9 +329,22 @@ final class PillHUD {
 
         // A fade that has not finished is a panel that is still on screen. Put
         // it back to full strength rather than morphing something half gone.
-        if isFading {
+        // The same for a decay, which is a fade with a longer clock on it: a
+        // pill part-way through running out that then has something to say
+        // would otherwise say it at whatever strength it had got down to.
+        if isFading || isDecaying {
             isFading = false
-            panel.alphaValue = 1
+            isDecaying = false
+            decayIsHeld = false
+            // The decay's handler is now a stale one. See `decayRun`.
+            decayRun += 1
+            // Zero-length rather than a plain assignment: that is what stops
+            // the animation underneath, which would otherwise go on pulling
+            // the alpha down under the state that has just replaced it.
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0
+                panel.animator().alphaValue = 1
+            }
         }
 
         // The words change with the frame, not after it: SwiftUI is told inside
@@ -225,6 +363,9 @@ final class PillHUD {
             panel.ignoresMouseEvents = false
         } else {
             panel.ignoresMouseEvents = true
+            // No offer, nothing for the pointer to hold: `hovering` reads this
+            // and must not act on a duration left behind by the last one.
+            offerFor = nil
         }
 
         let size = PillMetrics.panelSize(for: state, hasIcon: model.appIcon != nil)
@@ -295,6 +436,40 @@ final class PillHUD {
         pendingHide = nil
         pendingDismiss = nil
         guard let panel, panel.isVisible, !isFading else { return }
+
+        // A decision takes the offer at once rather than letting the rest of
+        // its decay play out. Escape, Return and running a command all arrive
+        // here, and a dismissal that took another few seconds to show would
+        // read as the key not working.
+        //
+        // A running decay is cut, because its alpha is already on its way to
+        // zero and a fade laid over that has nothing left to move. A decay the
+        // pointer is holding is not: it is stopped at `offerAlpha`, so it goes
+        // out the way every other state does. Clicking a chip is the common
+        // path and the pointer is on the pill by definition, so that is the
+        // one that must not blink out. The stale handler is seen off the same
+        // way as in `set`.
+        if isDecaying, !decayIsHeld {
+            isDecaying = false
+            decayRun += 1
+            near = nil
+            // A zero-length animation is how the running one is stopped, and
+            // it leaves the panel at full strength for the next appearance.
+            // Nothing is drawn at that strength: the panel goes out in the
+            // same turn.
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0
+                panel.animator().alphaValue = 1
+            }
+            panel.orderOut(nil)
+            return
+        }
+        // Nothing is decaying past this line. A held decay is standing at a
+        // real alpha, so it leaves as an ordinary fade — and either way the
+        // flags and the handler are seen off before that fade starts.
+        isDecaying = false
+        decayIsHeld = false
+        decayRun += 1
 
         isFading = true
         NSAnimationContext.runAnimationGroup { context in

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -312,6 +312,11 @@ them at once, which is where drift between them shows up.
 one to print which was chosen. Every other state lets clicks through, so the
 pill is never a hole in your screen while you are dictating.
 
+It is also the one state that fades. It arrives just below full strength and
+thins out over nine seconds, the same as in the app, so it leaves on its own.
+Put the pointer on it and the fading stops, which is both what the app does and
+how you keep it on screen for as long as you want to look at it.
+
 `sequence` is the one that cannot be checked from a still. The pill is a single
 panel that changes width and crossfades its contents rather than being replaced
 — hot mic, decoding, applied, the offer, gone — and whether that morphs or

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -287,7 +287,7 @@ sitting at an ordinary shell prompt keeps everything you have run in it, and the
 pill goes to the bottom of the screen.
 
 `correct_offer` is what the pill does after the words land. It stays where it
-is for three seconds and names what can be done to them, one chip per command:
+is and names what can be done to them, one chip per command:
 `Correct` first, then every transform with `offer: true` — see
 [pipelines.md](pipelines.md#offer-and-key-or-getting-on-the-pill). `Correct`
 opens the per-word panel over what was just dictated; a transform runs as it
@@ -301,7 +301,13 @@ always does.
 | `↩` | Dismisses, and reaches the app underneath untouched |
 | the dictation hotkey | Starts the next dictation, exactly as before |
 
-**The letters are taken from every app for those three seconds.** The pill
+It fades rather than vanishing. It arrives just below full strength and thins
+out over nine seconds, and then it is gone. The keys and the chips work the
+whole way down — the fading only says how long is left. Putting the pointer on
+the pill stops the clock, and taking it off starts the nine seconds again. Any
+of the endings above takes the pill at once.
+
+**The letters are taken from every app for those nine seconds.** The pill
 never holds keyboard focus, so it swallows the letters system-wide or it does
 not get them at all. Finish a dictation and immediately type a word starting
 with `C` or `G` and the first keystroke runs a command instead of typing.

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -275,7 +275,7 @@ drawn but never reached, because the first chip with that letter wins.
 
 `--check-config` prints what is on the pill and the letter each chip carries.
 A chip that is missing, or a `key:` that was cut, is otherwise invisible: the
-pill is up for three seconds and a short offer looks like a normal one.
+pill fades out over nine seconds and a short offer looks like a normal one.
 
 Only the shipped `grammar` asks for a place. Everything else in
 config.example.yaml is left off.


### PR DESCRIPTION
PR 7 of the HUD stack, on top of #110. Section 3 of
[docs/proposals/hud-placement-and-offer.md](docs/proposals/hud-placement-and-offer.md),
row 8 of its table.

The offer held full strength for three seconds and then disappeared. It now
starts just below full, thins out over nine seconds, holds while the pointer is
on it, and goes at once when you decide something.

## The decisions, and they are decisions

- **Below full to start.** 0.92. It is the one surface that appears without
  being asked for, so it should announce itself less than a notice does.
- **Linear, not eased.** An eased fade spends its time near the ends and
  crosses the middle fast, which reads as being yanked away halfway through. A
  straight ramp says "this is running out" at a steady rate — a clock without a
  clock.
- **Usable to the last frame.** The keys and the chips work the whole nine
  seconds. The fading only says how long is left.
- **Nine seconds, and it can afford to be**, because the pointer resets it.
  Three was not long enough to read the sentence, decide it is wrong and reach
  for a key. A fade this generous would be clutter after every dictation if
  using it did not put it back.
- **The pointer stops the clock, it does not reset it**, and it starts again
  from the beginning when the pointer leaves. A surface that went on thinning
  while you reached for it would be arguing about whether you had finished.
- **A decision cuts it at once.** Escape, Return or running a command takes the
  pill immediately rather than letting the fade play out. Dismissing is a
  decision, and a decision that took two more seconds to show would read as the
  key not working. A *running* decay is cut, because its alpha is already on
  its way to zero and a fade laid over that has nothing left to move. One the
  pointer is *holding* is stopped at 0.92, which is a real strength, so it
  leaves as an ordinary 0.18s fade — clicking a chip is the common path and the
  pointer is on the pill by definition, so that is the one that must not blink
  out.
- **Any new pill state cancels the decay and snaps back to full.** A decaying
  pill that then had something to say would otherwise say it at 20%.

## The generation number is not decoration

Restarting or cancelling a decay makes the animation it replaced fire its
completion handler immediately. A boolean cannot tell the two apart: the new
decay sets `isDecaying` back to true before the old handler runs, so the
superseded handler passes the guard and orders the panel out. That was a live
bug in the spike — the very thing meant to hold the offer open dismissed it.

`decayRun` is bumped by every path that replaces or cancels a decay, and the
completion handler does nothing unless it is still the live one. The naive
version looks correct, which is why the comment says what the number is for.

## Three clocks, moving together

The pill's own fade, the work item that ends the offer when nobody answers it,
and the tap's expiry. They have to agree, or the pill is on screen with keys
that no longer work, or the reverse.

`OfferKeys.extend(until:)` comes back for the third. The PR that added the tap
left it out as unused and said it belonged here; this is where the deadline
moves.

While the pointer is inside, the offer has no deadline at all. `offerUntil`
becomes a date that never arrives, which is why the work item is not armed with
it — `asyncAfter` at that distance is an overflow rather than a long wait.
Leaving arms a whole new nine seconds. The tap's expiry is a backstop against a
tap that outlived its offer, and a pointer resting on the pill is the opposite
of that. Every path that ends the offer still calls `OfferKeys.stop`.

**A hover that never leaves cannot be believed.** `onHover` is the only thing
saying the pill is still under the pointer, and a Space change, Mission Control
or a window ordered out from underneath it can all swallow the exit. That would
hold the offer open until the next dictation, with the letters it takes from
every app. So while it is held the work item is armed anyway, every
`offerSeconds`, and it asks `PillHUD.pointerIsOver` rather than trusting the
last event. A pointer that has gone without saying so is treated as one that
said so: the offer gets its nine seconds and runs out normally. The hold is
indefinite; the tap is not.

## The preview shows the real thing

`--panels offer` went through a bare `set(.offer(…))`, which held it at full
strength for as long as you left it. That was right when the offer had no
entrance of its own; it is wrong now, because a preview at alpha 1 is a picture
of a pill that never appears. It goes through `PillHUD.offer(_:for:)` instead,
and the hover closure calls `hovering(_:)` — so the preview fades like the real
one, and the pointer holds it open, which is how you keep it on screen to look
at. `AppDelegate.offerSeconds` stops being private for it: a preview with a
number of its own is a preview of something else.

## What was checked

- `swift build -c release` — 20 warnings, the same 20 pre-existing
  `AppDelegate` Sendable ones as on the base. No new ones.
- `swiftlint lint` — 32 warnings, the same 32 as on the base.
- Every deterministic script in `.github/workflows/checks.yml`, all green:
  numbers 97/97, replacements 23/23, pipeline 71/71, wake 24/24, split 14/14,
  dotted 54/54, dates 26/26, transform folders 12/12, eval 25/25, audio
  recovery 11/11, possessive 35/35, default config, vocabulary config, seeded
  transform 61/61, pinned certificate, no voice 5/5.
- `--check-config` still reads the config and prints the offer.

## What was not verified

**None of this has been seen running.** Every claim above is about pixels and a
pointer, and nothing in the check set has a screen or a mouse:

- That 0.92 reads as "below full" rather than as a rendering fault.
- That the linear ramp reads as a clock over nine seconds, and that nine is the
  right number rather than seven or twelve.
- That the pointer entering the pill holds it, and that leaving starts the nine
  seconds again — including that SwiftUI's `onHover` fires for both on a
  `nonactivatingPanel` that ignores the mouse in every other state.
- That a letter typed at second 8.5, when the pill is nearly transparent, still
  runs its command.
- That Escape, Return and a click all take the pill at once rather than leaving
  a ghost of it on screen — and that the cut on the running path and the fade
  on the held path both read as "gone" rather than as a glitch. The split rests
  on a claim about AppKit that was reasoned, not measured: that during
  `animator().alphaValue = 0` the property already reads zero.
- That a notice raised over a decaying offer comes up at full strength.
- That the generation guard holds in the app and not only in the reading of it.
- That an exit really can go missing, and that `pointerIsOver` answers
  correctly when it does. The screen coordinates it compares are the right ones
  on paper; nobody has watched it recover.

`scripts/check-inplace.sh` and `scripts/check-span.sh` were **not** run: they
replace `/Applications/ParrotFlowDev.app` and take the keyboard, and somebody
was dictating with that app.

## Not in this PR

When the offer is raised is PR 8. What a command does is PR 9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
