### PR TITLE
feat: the offer follows every dictation, and a command rewrites in place

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1984,13 +1984,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         return offerUntil > Date()
     }
 
-    /// Say what can be done about the words that just landed, and for how long.
+    /// Say what can be done about the words just dictated, and for how long.
     ///
-    /// Only after a paste that worked. Every other ending already has something
-    /// to say — "on your clipboard", "grant Accessibility" — and those are more
-    /// useful than an offer, so they keep the pill. This is the one ending that
-    /// had nothing on it at all: the pill simply vanished and the dictation was
-    /// over, which is a fine thing to feel and a wasted second of screen.
+    /// After every ending, not only a paste that worked. A word the recogniser
+    /// got wrong is worth teaching whether or not the sentence reached a text
+    /// field, and the offer cannot wait: it is about the words you are looking
+    /// at now. The messages the clipboard endings used to put on the pill —
+    /// "on your clipboard", "grant Accessibility" — are worth keeping and worth
+    /// less than the offer, so they moved to the menu bar, where messages that
+    /// are not urgent live. See `insertDictation`.
+    ///
+    /// `landing` is where those words actually went. It is frozen into the
+    /// correction, and it is what keeps a correction out of a field the
+    /// dictation never wrote into.
     ///
     /// The commands are read from the config, so what is on the pill is what
     /// that machine can actually do. It no longer waits on the hotkey being
@@ -2000,7 +2006,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `press` is the dictation this offer is about, carried down from its own
     /// key-down — see `insertDictation`. Nothing below reads press-time state
     /// off `self`, so an offer can never be moved by another dictation's press.
-    private func showCorrectOffer(for press: Press) {
+    private func showCorrectOffer(for press: Press, landing: Correction.Landing) {
         guard config.feedback.correctOffer else { return }
         guard let text = lastTranscript?.trimmingCharacters(in: .whitespacesAndNewlines),
               !text.isEmpty else { return }
@@ -2022,7 +2028,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         offerPressRun = press.run
         // This dictation's own words and its own field, frozen with the offer.
         offeredCorrection = (press.run, Correction(
-            original: text, element: press.element, owner: press.owner
+            original: text, element: press.element, owner: press.owner, landing: landing
         ))
         let commands = offerCommands
         pill.offer(commands, for: Self.offerSeconds)
@@ -2053,8 +2059,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // by run, so it is this dictation's own pane and nobody else's. A
         // remembered anchor is still a guess, and this is what replaces it with
         // the answer.
-        if let pane = screenAtPress.removeValue(forKey: press.run)?.text,
-           let element = press.element {
+        //
+        // Dropped on every ending, not only the one that uses it. A pane
+        // belongs to one run and no later dictation can want it, so it is
+        // retired here as `dictationEnded` would retire it — leaving it for the
+        // sweep would be keeping a copy of somebody's screen for no reason.
+        let pane = screenAtPress.removeValue(forKey: press.run)?.text
+        // Nothing landed in a field on the clipboard endings, so the diff has
+        // nothing to find. Whatever it did find would be something else moving
+        // on screen.
+        if landing == .field, let pane, let element = press.element {
             findWhereTheWordsLanded(comparedWith: pane, in: element, for: press.run)
         }
     }
@@ -2214,6 +2228,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         endTheOffer()
         pill.hide()
 
+        // The sentence and where it went, frozen when the offer went up. Both
+        // commands need it, and neither has anything to work on without it.
+        guard let target = offered?.target else { return }
+
         // Looked up again rather than carried on the chip, so a transform
         // deleted from a config reloaded while the offer was up is not run
         // from a chip that outlived it.
@@ -2223,10 +2241,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 return
             }
             Log.write("offer: taken; running \"\(name)\"")
-            // No instruction: the chip is the whole of what was asked for.
-            // This still shows the transform's preview, because that is what
-            // `confirm:` asks for today.
-            runTransform(found, instruction: "")
+            runOfferedTransform(found, over: target)
             return
         }
 
@@ -2239,7 +2254,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // it: the panel can be open for a while, and `focusAtPress` by then can
         // belong to a dictation that finished in the meantime. Teaching a rule
         // is the panel's own and is unchanged.
-        guard let target = offered?.target else { return }
         Log.write("offer: taken; opening the correction panel")
         // Nothing here is a selection, and the offer's own target is what says
         // where the words go. Cleared so no later save can read one left behind
@@ -2250,6 +2264,87 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         correctionPanel.onCancel = { Log.write("offer: correction dismissed") }
         correctionPanel.show(selection: target.original)
+    }
+
+    /// Run a transform over the sentence the offer is about, and put the result
+    /// where that sentence went.
+    ///
+    /// Not `runTransform`, which is the selection path: that one looks for text
+    /// to work on in whatever is frontmost, and falls back to `lastTranscript`.
+    /// Both readings are wrong here. The offer already knows what it is about —
+    /// it froze the sentence and its landing when it went up — and a dictation
+    /// that ended on the clipboard left nothing in front to find, so the
+    /// selection path would rewrite text nobody dictated.
+    ///
+    /// No preview panel, whatever the transform's `confirm:` says. `runInline`
+    /// makes the same argument and for the same reason.
+    ///
+    /// The target is `target`, captured when the chip was pressed rather than
+    /// read when the model answers. A grammar pass takes seconds and focus can
+    /// move in them; the sentence this rewrites has to be the one that was on
+    /// screen when the key went down.
+    private func runOfferedTransform(
+        _ transform: Config.Transform, over target: Correction
+    ) {
+        let before = target.original.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !before.isEmpty else { return }
+
+        Log.write("offer: \(transform.name) over \"\(before.prefix(80))\"")
+        beginProgress(transform.progressLabel)
+
+        // On the main actor for the whole of it, so the answer is handled where
+        // every other caller hands it back with `MainActor.run`. `perform` is
+        // not isolated and does its waiting off here.
+        Task { @MainActor [weak self] in
+            do {
+                // No instruction: the chip is the whole of what was asked for.
+                guard let result = try await self?.perform(
+                    transform, instruction: "", on: before
+                ) else { return }
+                self?.finishOfferedTransform(
+                    transform, over: target, before: before, after: result
+                )
+            } catch {
+                // Fail open: the words are untouched, wherever they are. Losing
+                // a rewrite costs a second attempt; losing the sentence costs
+                // the sentence.
+                Log.write("offer: \(transform.name) failed: \(error.localizedDescription)")
+                self?.endProgress()
+                self?.setLabel(error.localizedDescription, clearAfter: 7)
+            }
+        }
+    }
+
+    /// The model has answered. Write it back, or say why there is nothing to
+    /// write.
+    ///
+    /// Every refusal here leaves the sentence exactly as it is — in the field or
+    /// on the clipboard — and says so in the menu bar. The pill is not used: it
+    /// sits over the words, and a notice there would cover the thing the message
+    /// is about.
+    private func finishOfferedTransform(
+        _ transform: Config.Transform, over target: Correction, before: String, after: String
+    ) {
+        endProgress()
+
+        let cleaned = after.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleaned.isEmpty else {
+            Log.write("offer: \(transform.name) returned nothing")
+            setLabel("\(transform.name) returned nothing", clearAfter: 7)
+            return
+        }
+        // Saying so beats replacing text with itself and calling it done, which
+        // looks identical to the prompt having silently failed.
+        guard cleaned != before else {
+            Log.write("offer: \(transform.name) changed nothing")
+            setLabel("\(transform.name): nothing to change", clearAfter: 7)
+            return
+        }
+
+        Log.write("offer: \(transform.name) rewrote the dictation")
+        Log.write("    before: \(before)")
+        Log.write("    after:  \(cleaned)")
+        replace(target, with: cleaned, describedAs: transform.name)
     }
 
     /// This press's dictation is over, however it ended. Drops the pane it
@@ -2348,14 +2443,34 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let original: String
         let element: AXUIElement?
         let owner: NSRunningApplication?
+        /// Where the words went, so the correction can follow them.
+        let landing: Landing
+
+        /// The two places a dictation can end up.
+        ///
+        /// The offer is raised after every ending, and only one of them wrote
+        /// anything into a field. The rest left the sentence on the clipboard,
+        /// and `element` there is either nil or a field the words never
+        /// reached — so this is what stops a correction being written into it.
+        enum Landing {
+            /// Pasted into `element`, which was confirmed focused at the paste.
+            case field
+            /// Left on the clipboard. Nothing was written into any field.
+            case clipboard
+        }
     }
 
-    /// Put the edited sentence back over the one that was written.
+    /// Put the rewritten sentence where the dictation went.
     ///
-    /// The same ladder a transform without a selection climbs: hand focus back
-    /// first — showing the panel activated us, so ⌘V here would land in our own
-    /// window — then replace what we typed rather than pasting after it, which
-    /// is what leaves both versions side by side.
+    /// One mechanism, two destinations, and `target.landing` decides. Both
+    /// commands on the offer end here: `what` is the name to put on screen —
+    /// "Correction", or the transform's own name.
+    ///
+    /// **Into the field**, when that is where the words landed. The same ladder
+    /// a transform without a selection climbs: hand focus back first — showing
+    /// the panel activated us, so ⌘V here would land in our own window — then
+    /// replace what we typed rather than pasting after it, which is what leaves
+    /// both versions side by side.
     ///
     /// It refuses to write unless the field is the one that was dictated into.
     /// `insertDictation` makes the same check for the same reason: the words
@@ -2363,21 +2478,43 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// than one place. Not knowing is not the same as knowing it is fine, so a
     /// lookup that fails counts as moved and the text goes to the clipboard.
     ///
+    /// **Onto the clipboard**, when that is where the dictation went. Nothing
+    /// was written into any field then, so there is nothing to rewrite — and
+    /// `target.element` is either nil or a field these words never reached.
+    /// Writing into it is exactly the "a sentence in somebody else's window"
+    /// failure the focus check exists to prevent. What comes next after a
+    /// clipboard ending is ⌘V, so the rewrite has to be what that pastes.
+    ///
     /// No rules are saved. This is the sentence, not the vocabulary: teaching
     /// a word is what "Hey parrot, correct" and the correction panel are for,
     /// and quietly writing a rule out of every fixed sentence would fill
     /// config.yaml with pairs that will never recur.
     ///
-    /// Returns whether the field has the sentence. False means it is on the
-    /// clipboard instead and that has already been said on screen, so a caller
-    /// with more to report should stop rather than talk over it. Nothing to
-    /// change counts as true: the field already says what was asked for.
+    /// Returns false when the sentence is on the clipboard — said on screen
+    /// either way, and a caller with more to report should stop rather than
+    /// talk over the one thing there is to act on. True means the field has it,
+    /// or there was nothing to change.
     @discardableResult
-    private func replace(_ target: Correction, with edited: String) -> Bool {
+    private func replace(
+        _ target: Correction, with edited: String, describedAs what: String
+    ) -> Bool {
         let corrected = edited.trimmingCharacters(in: .whitespacesAndNewlines)
         let original = target.original.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !original.isEmpty, !corrected.isEmpty, corrected != original else { return true }
 
+        if target.landing == .clipboard {
+            Log.write("offer: the dictation went to the clipboard; \(what) went there too")
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(corrected, forType: .string)
+            noteRewritten(original, as: corrected)
+            flash("\(what) copied — ⌘V to paste", tone: .done)
+            return false
+        }
+
+        // Only for a landing in a field. Nothing is posted at the app on the
+        // clipboard path, and after a dictation that ended because focus moved,
+        // pulling the app the user has left back in front would be the second
+        // surprise in a row.
         if let owner = target.owner, !owner.isActive {
             owner.activate()
             // Let it come forward before the keystroke is posted.
@@ -2393,15 +2530,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 // lands on the wrong line.
                 switch applyInPlace(
                     [Edit(find: original, replace: corrected, fuzzy: false)],
-                    dictated: original, in: now, describedAs: "correction"
+                    dictated: original, in: now, describedAs: what
                 ) {
                 case .replaced:
-                    // Only if this is still the sentence the app thinks it
-                    // wrote last. A newer dictation has its own.
-                    if lastTranscript?.trimmingCharacters(in: .whitespacesAndNewlines) == original {
-                        lastTranscript = corrected
-                    }
-                    applied("Correction")
+                    noteRewritten(original, as: corrected)
+                    applied(what)
                     return true
                 case .failed, .notAttempted:
                     break
@@ -2413,11 +2546,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
-        Log.write("offer: left the correction on the clipboard")
+        Log.write("offer: left \(what) on the clipboard")
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(corrected, forType: .string)
-        flash("Correction copied — this app won't let me edit it", tone: .caution)
+        flash("\(what) copied — this app won't let me edit it", tone: .caution)
         return false
+    }
+
+    /// The last dictation now reads differently, so a command that works on it
+    /// works on the new text rather than on the sentence it replaced.
+    ///
+    /// Only if this is still the sentence the app thinks it wrote last. A newer
+    /// dictation has its own, and it is one slot.
+    private func noteRewritten(_ original: String, as corrected: String) {
+        guard lastTranscript?.trimmingCharacters(in: .whitespacesAndNewlines) == original
+        else { return }
+        lastTranscript = corrected
     }
 
     private func beginCorrection() {
@@ -2465,12 +2609,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Separate from `saveCorrections` for one reason: the destination. That
     /// one has to work out where the words go, and falls back to `focusAtPress`
     /// and then to the clipboard. This one already knows — the offer froze the
-    /// element and its app when it went up. The panel can be open for as long
-    /// as it takes to think about a spelling, and push-to-talk does not wait
-    /// for the previous transcript, so anything read at this moment can belong
-    /// to a newer dictation. `replace` carries the same care the tapped offer
-    /// takes: focus handed back first, a refusal to write unless the field is
-    /// still the one that was dictated into, and the clipboard when it cannot.
+    /// element, its app and the landing when it went up. The panel can be open
+    /// for as long as it takes to think about a spelling, and push-to-talk does
+    /// not wait for the previous transcript, so anything read at this moment can
+    /// belong to a newer dictation. `replace` carries the same care the tapped
+    /// offer takes: focus handed back first, a refusal to write unless the field
+    /// is still the one that was dictated into, and the clipboard when the
+    /// dictation itself went there.
     private func saveOfferedCorrection(
         _ rules: [(heard: String, corrected: String)],
         correctedText: String,
@@ -2479,7 +2624,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard learn(rules) else { return }
         // On the clipboard, and `replace` has said so. A rule notice on top of
         // that would bury the one thing you need to act on.
-        guard replace(target, with: correctedText) else { return }
+        guard replace(target, with: correctedText, describedAs: "Correction") else { return }
         switch rules.count {
         // Nothing taught, so `replace` has already said the only thing there
         // is to say.
@@ -3013,8 +3158,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     ) {
         let element = press.element
         // However this ends, this dictation is over and nothing wants the pane
-        // it started with. The path that makes the offer takes it before this
-        // runs; every other path here is a clipboard, and those make no offer.
+        // it started with. Every path here makes the offer now, and the offer
+        // takes the pane before this runs — so this is the backstop for the
+        // three ways `showCorrectOffer` returns without getting that far: the
+        // offer switched off in the config, an empty transcript, and a newer
+        // dictation that already had the pill.
         defer { dictationEnded(press.run) }
         // Confirmed the same field, or nothing to confirm against. Anything
         // else copies.
@@ -3039,7 +3187,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 Log.write(now == nil
                     ? "could not read what is focused; copied instead of pasting"
                     : "focus moved since the press; copied instead of pasting")
-                flash("Focus moved — the transcription is on your clipboard", tone: .caution)
+                // The menu bar, not the pill. The pill is about to carry the
+                // offer, and a notice on it would be the offer's own surface
+                // saying something else.
+                setLabel("Focus moved — the transcription is on your clipboard", clearAfter: 4)
+                showCorrectOffer(for: press, landing: .clipboard)
                 updateUI()
                 return
             }
@@ -3068,7 +3220,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             TextInserter.insert(text, mode: .clipboard)
             if config.feedback.sound { NSSound(named: "Glass")?.play() }
             Log.write("nothing to type into (\(reason.described)); copied instead")
-            flash("Nowhere to type — the transcription is on your clipboard", tone: .done)
+            // In the menu bar, for the same reason as above: the pill is the
+            // offer's.
+            setLabel("Nowhere to type — the transcription is on your clipboard", clearAfter: 4)
+            showCorrectOffer(for: press, landing: .clipboard)
             updateUI()
             return
         }
@@ -3078,16 +3233,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             if config.feedback.sound { NSSound(named: "Glass")?.play() }
             // The words are in the field and you are looking at them. This is
             // the only second in which correcting one is free.
-            showCorrectOffer(for: press)
+            showCorrectOffer(for: press, landing: .field)
         case .copied:
             // Deliberate clipboard mode — confirm it landed.
             if config.feedback.sound { NSSound(named: "Glass")?.play() }
             setLabel("Copied — ⌘V to paste", clearAfter: 4)
+            showCorrectOffer(for: press, landing: .clipboard)
         case .clipboardOnly:
             if config.feedback.sound { NSSound(named: "Glass")?.play() }
             // Don't nag on every dictation — the text is safe on the clipboard.
             Log.write("Accessibility not granted; left transcript on the clipboard")
             setLabel("Copied — grant Accessibility to auto-paste", clearAfter: 4)
+            showCorrectOffer(for: press, landing: .clipboard)
         }
         updateUI()
     }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2575,6 +2575,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 // there, so there is nothing to settle for — and settling for
                 // the nearest thing over a whole sentence is how a rewrite
                 // lands on the wrong line.
+                //
+                // The sentence is found by its text, and the last copy of it
+                // wins — `Surface.range(of:)`. That is the right answer for
+                // what this is: the offer is about the newest dictation, and
+                // the newest dictation is the last thing written. Say the same
+                // short sentence twice and the second one is the one corrected.
+                //
+                // It cannot tell that copy from one *you* typed after it, and
+                // nothing here can. Where the paste landed is not knowable:
+                // `TextInserter` posts ⌘V and the app takes the pasteboard when
+                // it gets round to it, so no range comes back. Refusing when
+                // there is more than one copy would be worse than being wrong
+                // rarely — a terminal echoes what you send it, so a second copy
+                // appears there for reasons that have nothing to do with you.
                 switch applyInPlace(
                     [Edit(find: original, replace: corrected, fuzzy: false)],
                     dictated: original, in: now, describedAs: what

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2544,15 +2544,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // rather than this dictation's. Writing over it would take
             // something away that this app never put there, and losing a
             // rewrite costs a second attempt.
-            guard NSPasteboard.general.changeCount == change else {
+            guard copyOverOurOwn(corrected, unlessChangedFrom: change) else {
                 Log.write("offer: the clipboard has been used since the dictation;"
                     + " \(what) was not written over it")
                 flash("Clipboard has changed — \(what) not copied", tone: .caution)
                 return false
             }
             Log.write("offer: the dictation went to the clipboard; \(what) went there too")
-            NSPasteboard.general.clearContents()
-            NSPasteboard.general.setString(corrected, forType: .string)
             noteRewritten(original, as: corrected)
             flash("\(what) copied — ⌘V to paste", tone: .done)
             return false
@@ -2612,7 +2610,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // The sentence is untouched in the field either way, so a refusal here
         // costs the rewrite and nothing else. What it protects is what you
         // copied while the model was thinking.
-        guard NSPasteboard.general.changeCount == clipboardWhenChosen else {
+        guard copyOverOurOwn(corrected, unlessChangedFrom: clipboardWhenChosen) else {
             Log.write("offer: the field refused \(what) and the clipboard has been used"
                 + " since; left both alone")
             flash("\(what) not applied — the clipboard has changed", tone: .caution)
@@ -2620,10 +2618,31 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         Log.write("offer: left \(what) on the clipboard")
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(corrected, forType: .string)
         flash("\(what) copied — this app won't let me edit it", tone: .caution)
         return false
+    }
+
+    /// Put text on the clipboard, unless somebody else has been there since.
+    ///
+    /// `change` is `NSPasteboard.changeCount` from the moment this app last knew
+    /// what was on the clipboard. Anything copied since moves it, and then the
+    /// clipboard is somebody's work rather than ours to overwrite.
+    ///
+    /// The look and the write sit next to each other with nothing between them
+    /// — no logging, no message — because there is nothing stronger to have.
+    /// `NSPasteboard` offers no compare-and-write: `declareTypes(owner:)` names
+    /// an owner for callbacks and stops no other process from writing. Any check
+    /// is a look followed by a write, and the gap can only be made small. It is
+    /// two calls here, and the messages are left to the caller so they cannot
+    /// get in between.
+    ///
+    /// Returns false when it did not write.
+    private func copyOverOurOwn(_ text: String, unlessChangedFrom change: Int) -> Bool {
+        let pasteboard = NSPasteboard.general
+        guard pasteboard.changeCount == change else { return false }
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+        return true
     }
 
     /// The last dictation now reads differently, so a command that works on it

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2068,7 +2068,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Nothing landed in a field on the clipboard endings, so the diff has
         // nothing to find. Whatever it did find would be something else moving
         // on screen.
-        if landing == .field, let pane, let element = press.element {
+        if case .field = landing, let pane, let element = press.element {
             findWhereTheWordsLanded(comparedWith: pane, in: element, for: press.run)
         }
     }
@@ -2455,8 +2455,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         enum Landing {
             /// Pasted into `element`, which was confirmed focused at the paste.
             case field
-            /// Left on the clipboard. Nothing was written into any field.
-            case clipboard
+            /// Left on the clipboard, with `NSPasteboard.changeCount` as it was
+            /// straight after. Anything copied since — by the user or by
+            /// anything else on the machine — moves that count, and then the
+            /// clipboard is not this dictation's any more. See `replace`.
+            case clipboard(change: Int)
+
+            /// The clipboard as it is right now.
+            ///
+            /// Called immediately after the words were put there, so the count
+            /// it takes is the one our own write produced. Read any later and
+            /// it would be agreeing with whatever had happened in between.
+            static func clipboardNow() -> Landing {
+                .clipboard(change: NSPasteboard.general.changeCount)
+            }
         }
     }
 
@@ -2502,7 +2514,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let original = target.original.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !original.isEmpty, !corrected.isEmpty, corrected != original else { return true }
 
-        if target.landing == .clipboard {
+        if case .clipboard(let change) = target.landing {
+            // Only over our own words. A correction panel can be open for as
+            // long as it takes to think about a spelling, and a transform takes
+            // seconds — copy anything in that time and the clipboard is yours
+            // rather than this dictation's. Writing over it would take
+            // something away that this app never put there, and losing a
+            // rewrite costs a second attempt.
+            guard NSPasteboard.general.changeCount == change else {
+                Log.write("offer: the clipboard has been used since the dictation;"
+                    + " \(what) was not written over it")
+                flash("Clipboard has changed — \(what) not copied", tone: .caution)
+                return false
+            }
             Log.write("offer: the dictation went to the clipboard; \(what) went there too")
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(corrected, forType: .string)
@@ -3191,7 +3215,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 // offer, and a notice on it would be the offer's own surface
                 // saying something else.
                 setLabel("Focus moved — the transcription is on your clipboard", clearAfter: 4)
-                showCorrectOffer(for: press, landing: .clipboard)
+                showCorrectOffer(for: press, landing: .clipboardNow())
                 updateUI()
                 return
             }
@@ -3223,7 +3247,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // In the menu bar, for the same reason as above: the pill is the
             // offer's.
             setLabel("Nowhere to type — the transcription is on your clipboard", clearAfter: 4)
-            showCorrectOffer(for: press, landing: .clipboard)
+            showCorrectOffer(for: press, landing: .clipboardNow())
             updateUI()
             return
         }
@@ -3238,13 +3262,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // Deliberate clipboard mode — confirm it landed.
             if config.feedback.sound { NSSound(named: "Glass")?.play() }
             setLabel("Copied — ⌘V to paste", clearAfter: 4)
-            showCorrectOffer(for: press, landing: .clipboard)
+            showCorrectOffer(for: press, landing: .clipboardNow())
         case .clipboardOnly:
             if config.feedback.sound { NSSound(named: "Glass")?.play() }
             // Don't nag on every dictation — the text is safe on the clipboard.
             Log.write("Accessibility not granted; left transcript on the clipboard")
             setLabel("Copied — grant Accessibility to auto-paste", clearAfter: 4)
-            showCorrectOffer(for: press, landing: .clipboard)
+            showCorrectOffer(for: press, landing: .clipboardNow())
         }
         updateUI()
     }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2232,6 +2232,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // commands need it, and neither has anything to work on without it.
         guard let target = offered?.target else { return }
 
+        // The clipboard as it is at the moment you choose. Everything below
+        // takes time — a model call, or a panel left open while you think —
+        // and the write-backs that copy check this before they do. What you
+        // copied while the model was thinking is not this app's to drop.
+        let clipboardWhenChosen = NSPasteboard.general.changeCount
+
         // Looked up again rather than carried on the chip, so a transform
         // deleted from a config reloaded while the offer was up is not run
         // from a chip that outlived it.
@@ -2241,7 +2247,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 return
             }
             Log.write("offer: taken; running \"\(name)\"")
-            runOfferedTransform(found, over: target)
+            runOfferedTransform(found, over: target, clipboardWhenChosen: clipboardWhenChosen)
             return
         }
 
@@ -2260,7 +2266,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // by an earlier flow.
         pendingSelection = nil
         correctionPanel.onSave = { [weak self] rules, correctedText in
-            self?.saveOfferedCorrection(rules, correctedText: correctedText, into: target)
+            self?.saveOfferedCorrection(
+                rules, correctedText: correctedText, into: target,
+                clipboardWhenChosen: clipboardWhenChosen
+            )
         }
         correctionPanel.onCancel = { Log.write("offer: correction dismissed") }
         correctionPanel.show(selection: target.original)
@@ -2284,7 +2293,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// move in them; the sentence this rewrites has to be the one that was on
     /// screen when the key went down.
     private func runOfferedTransform(
-        _ transform: Config.Transform, over target: Correction
+        _ transform: Config.Transform, over target: Correction, clipboardWhenChosen: Int
     ) {
         let before = target.original.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !before.isEmpty else { return }
@@ -2302,7 +2311,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     transform, instruction: "", on: before
                 ) else { return }
                 self?.finishOfferedTransform(
-                    transform, over: target, before: before, after: result
+                    transform, over: target, before: before, after: result,
+                    clipboardWhenChosen: clipboardWhenChosen
                 )
             } catch {
                 // Fail open: the words are untouched, wherever they are. Losing
@@ -2323,7 +2333,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// sits over the words, and a notice there would cover the thing the message
     /// is about.
     private func finishOfferedTransform(
-        _ transform: Config.Transform, over target: Correction, before: String, after: String
+        _ transform: Config.Transform, over target: Correction, before: String, after: String,
+        clipboardWhenChosen: Int
     ) {
         endProgress()
 
@@ -2344,7 +2355,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Log.write("offer: \(transform.name) rewrote the dictation")
         Log.write("    before: \(before)")
         Log.write("    after:  \(cleaned)")
-        replace(target, with: cleaned, describedAs: transform.name)
+        replace(
+            target, with: cleaned, describedAs: transform.name,
+            clipboardWhenChosen: clipboardWhenChosen
+        )
     }
 
     /// This press's dictation is over, however it ended. Drops the pane it
@@ -2502,13 +2516,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// and quietly writing a rule out of every fixed sentence would fill
     /// config.yaml with pairs that will never recur.
     ///
+    /// **Never over a clipboard that has moved on.** Both write-backs that copy
+    /// check first, and both leave it alone when something else has been copied
+    /// since. `clipboardWhenChosen` is `NSPasteboard.changeCount` as it was when
+    /// the command was taken, which is the start of the wait that makes this
+    /// possible — a model call, or a panel open while somebody thinks about a
+    /// spelling. A rewrite that is refused costs a second attempt; a clipboard
+    /// this app never filled and then emptied costs whatever was in it.
+    ///
     /// Returns false when the sentence is on the clipboard — said on screen
     /// either way, and a caller with more to report should stop rather than
     /// talk over the one thing there is to act on. True means the field has it,
     /// or there was nothing to change.
     @discardableResult
     private func replace(
-        _ target: Correction, with edited: String, describedAs what: String
+        _ target: Correction, with edited: String, describedAs what: String,
+        clipboardWhenChosen: Int
     ) -> Bool {
         let corrected = edited.trimmingCharacters(in: .whitespacesAndNewlines)
         let original = target.original.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -2568,6 +2591,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     ? "offer: could not read what is focused; copied instead of rewriting"
                     : "offer: focus moved since the dictation; copied instead of rewriting")
             }
+        }
+
+        // The field would not take it, so the clipboard is the last place left
+        // — and only if it is still the one you had when you chose the command.
+        // The sentence is untouched in the field either way, so a refusal here
+        // costs the rewrite and nothing else. What it protects is what you
+        // copied while the model was thinking.
+        guard NSPasteboard.general.changeCount == clipboardWhenChosen else {
+            Log.write("offer: the field refused \(what) and the clipboard has been used"
+                + " since; left both alone")
+            flash("\(what) not applied — the clipboard has changed", tone: .caution)
+            return false
         }
 
         Log.write("offer: left \(what) on the clipboard")
@@ -2643,12 +2678,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func saveOfferedCorrection(
         _ rules: [(heard: String, corrected: String)],
         correctedText: String,
-        into target: Correction
+        into target: Correction,
+        clipboardWhenChosen: Int
     ) {
         guard learn(rules) else { return }
-        // On the clipboard, and `replace` has said so. A rule notice on top of
-        // that would bury the one thing you need to act on.
-        guard replace(target, with: correctedText, describedAs: "Correction") else { return }
+        // On the clipboard, or not written at all, and `replace` has said which.
+        // A rule notice on top of that would bury the one thing you need to act
+        // on.
+        guard replace(
+            target, with: correctedText, describedAs: "Correction",
+            clipboardWhenChosen: clipboardWhenChosen
+        ) else { return }
         switch rules.count {
         // Nothing taught, so `replace` has already said the only thing there
         // is to say.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -301,6 +301,10 @@ what a command produces goes back to the clipboard. So the ⌘V you were about t
 press pastes the corrected version. The notices those endings used to put on the
 pill are in the menu bar now, under the parrot.
 
+Only over the dictation itself. Copy something else while the panel is open, or
+while a transform is running, and the clipboard is yours rather than the
+dictation's — the result is not written over it, and the menu bar says so.
+
 | | Does |
 |---|---|
 | a chip's letter — `C`, `G` | Runs that command |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -286,12 +286,20 @@ vim and less all work this way, and the pill follows your words there. A pane
 sitting at an ordinary shell prompt keeps everything you have run in it, and the
 pill goes to the bottom of the screen.
 
-`correct_offer` is what the pill does after the words land. It stays where it
-is and names what can be done to them, one chip per command:
+`correct_offer` is what the pill does after a dictation. It stays where it
+is and names what can be done to the words, one chip per command:
 `Correct` first, then every transform with `offer: true` — see
 [pipelines.md](pipelines.md#offer-and-key-or-getting-on-the-pill). `Correct`
-opens the per-word panel over what was just dictated; a transform runs as it
-always does.
+opens the per-word panel over what was just dictated; a transform rewrites it
+straight away, with no preview.
+
+**After every dictation, not only one that landed in a field.** A word the
+recogniser got wrong is worth fixing whether or not the sentence reached a text
+field. A dictation that ended on the clipboard — focus moved, nowhere to type,
+`insert_mode: clipboard`, or no Accessibility grant — gets the same offer, and
+what a command produces goes back to the clipboard. So the ⌘V you were about to
+press pastes the corrected version. The notices those endings used to put on the
+pill are in the menu bar now, under the parrot.
 
 | | Does |
 |---|---|

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -241,9 +241,10 @@ preview would have told you.
 
 ### `offer:` and `key:`, or: getting on the pill
 
-After a dictation the pill names what can be done to the words that just
-landed. `Correct` is always first — it is not a transform, it needs no model,
-and it cannot fail. After it comes every transform that asked for a place:
+After a dictation the pill names what can be done to the words — wherever they
+went, a field or the clipboard. `Correct` is always first — it is not a
+transform, it needs no model, and it cannot fail. After it comes every transform
+that asked for a place:
 
 ```yaml
   - name: grammar
@@ -255,8 +256,15 @@ and it cannot fail. After it comes every transform that asked for a place:
       Correct grammar, spelling and punctuation. Return only the text.
 ```
 
-Press the letter on a chip, or click it. A transform runs as it always does, so
-it still shows its preview when `confirm:` is on.
+Press the letter on a chip, or click it. A transform taken from the pill runs
+over the sentence that was just dictated and writes the result straight back —
+into the field it went into, or onto the clipboard if that is where it went.
+
+**No preview, whatever `confirm:` says.** That setting guards text you selected
+and are about to have overwritten. Nothing is overwritten here: the words came
+from the dictation you just made, they are on screen above the pill, and you
+picked the command with a key. If the transform fails or changes nothing, the
+words are left exactly as they are and the menu bar says why.
 
 **Both are off by default.** The offer is on screen for a few seconds and every
 entry costs the others room, so a transform joins it only by asking. Put a
@@ -268,7 +276,7 @@ write. More than one character is cut to the first. A transform with `offer:
 true` and no `key:` still gets a chip, without a keycap on it — clickable, and
 on no key.
 
-The letter is taken from whatever app you are typing into, for the three
+The letter is taken from whatever app you are typing into, for the nine
 seconds the offer is up. Pick one you are unlikely to start a word with right
 after dictating. `C` is already `Correct`'s; a second chip asking for it is
 drawn but never reached, because the first chip with that letter wins.

--- a/docs/proposals/hud-placement-and-offer.md
+++ b/docs/proposals/hud-placement-and-offer.md
@@ -468,10 +468,14 @@ gates quiet sound whatever is printed on the case.
 
 ## 7. The PRs
 
-Fourteen, in this order. The rule for the boundaries: **each one is safe to
+Thirteen, in this order. The rule for the boundaries: **each one is safe to
 merge alone and can be judged on its own**. Where that meant splitting something
 that was written together, it is split — the spike is one commit and does not
 have to stay that shape.
+
+There were fourteen. 9 and 10 were one question — when a command is taken from
+the offer, where does the result go — and splitting it would have shipped a
+transform chip that rewrote whatever was in front of it. They landed together.
 
 Two run first because they are independent of everything else and one of them is
 a live bug. Two more are independent enough to reorder if something is urgent:
@@ -516,8 +520,7 @@ would be shipping that drift on purpose.
 | 6 | `feat: the offer names what can be done` | Chips, `offer:` and `key:` in config, no sentence, no preselection, clicks, `ignoresMouseEvents` per state | — |
 | 7 | `feat: the offer takes its own keys` | `OfferKeys` and the tap, letters, `esc` consumed, `↩` watched, the hotkey freed | 6 |
 | 8 | `feat: the offer fades rather than vanishing` | Linear decay, nine seconds, held by the pointer, cut by a decision, the generation guard | 6, 7 |
-| 9 | `feat: the offer follows every dictation` | All four endings; the clipboard messages move to the menu bar | 6 |
-| 10 | `feat: a command from the offer rewrites in place` | `runOfferedTransform`, no preview whatever `confirm:` says | 6 |
+| 9 | `feat: the offer follows every dictation, and a command rewrites in place` | All four endings; the clipboard messages move to the menu bar; `runOfferedTransform`, no preview whatever `confirm:` says | 6 |
 
 **Why 6 before 7.** #6 is clickable on its own, so it is a working feature
 without a system-wide event tap in it. #7 is the one PR that swallows keys from
@@ -540,5 +543,6 @@ else.
   side and invisible a week apart, which is what that sheet is for.
 - **7** — that a modified key still reaches the app, and that the tap is gone
   the moment the offer is.
-- **9, 10** — a dictation down each of the four endings.
+- **9** — a dictation down each of the four endings, and a transform taken from
+  the offer after one that landed and one that did not.
 - **13** — the file on disk, and a second dictation proving the rule fires.


### PR DESCRIPTION
`insertDictation` ends five ways. Only one of them raised the offer:

| Ending | Was | Now |
|---|---|---|
| focus moved since the press | clipboard, notice on the pill | clipboard, notice in the menu bar, **offer** |
| nowhere to type | clipboard, notice on the pill | clipboard, notice in the menu bar, **offer** |
| `.pasted` | field, offer | unchanged |
| `.copied` (`insert_mode: clipboard`) | clipboard, menu bar | **offer** as well |
| `.clipboardOnly` (no Accessibility) | clipboard, menu bar | **offer** as well |

A word the recogniser got wrong is worth teaching whether or not the sentence
reached a text field, and the offer cannot wait — it is about the words you are
looking at now. The clipboard notices are worth keeping and worth less than the
offer, so the two `flash` calls become `setLabel`: the pill is the offer's, and
the menu bar is where a message that is not urgent lives. The `Log.write` lines
are untouched.

This PR also folds in spec PR #10, `a command from the offer rewrites in
place`. Both halves answer one question — when a command is taken from the
offer, where does the result go — and the answer is one mechanism.

## Where a command writes back

This is the claim worth checking, so here it is plainly. `Correction` carries a
`landing`, frozen when the offer goes up, and it decides:

- **Into the field** — after `.pasted`, and only then. The app is brought
  forward, the focused element is compared against the one that was dictated
  into, and the sentence is substituted in place. That path is unchanged apart
  from the label it logs.
- **Onto the clipboard** — after the other four. The corrected or rewritten
  sentence replaces the clipboard, so the ⌘V you were about to press pastes it.

Nothing writes into `press.element` on the four clipboard endings. That element
is nil on the "nowhere to type" path, and on the other three it is a field these
words never reached — writing into it is exactly the "a sentence in somebody
else's window" failure the focus check exists to prevent. The app is not
activated on those paths either: after a dictation that ended *because* focus
moved, pulling the app you just left back in front is the second surprise in a
row.

Two smaller consequences on the clipboard endings. The landed-diff is skipped —
nothing landed, so it would only report something else moving on screen — and
the pane snapshot is retired anyway rather than left for the sweep.

## A transform from the offer

A chip used to call `runTransform(found, instruction: "")`. That is the
*selection* path: it takes `selectionAtPress`, or reads the selection in
whatever is frontmost, and falls back to `lastTranscript`. After a clipboard
ending there is no selection belonging to this dictation, so it could rewrite
unrelated text in an unrelated window — on the "focus moved" path, in another
window by definition.

`runOfferedTransform` replaces it. It runs over the sentence the offer froze and
hands the result to the same write-back Correct uses, so the landing decides
where it goes. No preview, whatever `confirm:` says: nothing is being
overwritten, the words are on screen above the pill, and you chose the command
with a key. `runInline` already makes that argument.

It fails open. A transform that errors, returns nothing, or changes nothing
leaves the words exactly as they are — in the field or on the clipboard — and
says why in the menu bar rather than on the pill, which sits over the words the
message is about.

## Comments that became false

Three, rewritten rather than deleted: `showCorrectOffer`'s "Only after a paste
that worked" paragraph, the `defer { dictationEnded(press.run) }` note that said
every other path makes no offer, and `runOfferedCommand`'s note that a transform
still shows its preview. `docs/configuration.md` and `docs/pipelines.md` said
both of those things too.

## Checked

- `swift build` — 20 warnings, the same 20 `origin/main` has. None new.
- `swiftlint lint` — one pre-existing warning in this file (`CFEqual(now!, …)`),
  none new.
- `scripts/check-default-config.sh`, `check-pipeline.sh` (71/71),
  `check-no-voice.sh` (5/5), `check-transform-folders.sh` (12/12).
- Not run: `check-inplace.sh` and `check-span.sh` replace the installed dev app
  and take the keyboard, and this machine is being dictated into.
- Not run on a live mic. The spec asks for a dictation down each of the four
  endings; that needs the person at the keyboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## After review

Two write-backs were tightened in review, both about the clipboard:

- A clipboard landing carries `NSPasteboard.changeCount` from the moment the
  words were put there. Copy anything before the command finishes and the
  rewrite is not written over it (e4575e0).
- The last-resort copy — the field refused the rewrite — checks the same thing
  from the moment the command was taken (dada54b). The sentence is untouched in
  the field there, so a refusal costs only the rewrite.
- The read and the pasteboard write sit next to each other with nothing between
  them (9ecd384). `NSPasteboard` has no compare-and-write, so the gap can only
  be made small, and that is said on the function.

Three findings are rebutted in the thread rather than fixed: the fallback copy
using the command-time count (the fallback exists so a correction is never
lost), the last identical occurrence winning a rewrite (`Surface.range(of:)`'s
documented rule, and ⌘V reports no range back), and check-then-write not being
atomic (no such primitive exists). Each reason is written into the code as well
as into the thread.
