### PR TITLE
feat: a Bluetooth microphone says so, once

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -68,6 +68,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var labelToken = 0
     private let correctionPanel = CorrectionPanel()
     private let previewPanel = PreviewPanel()
+    /// Says once per microphone that this one will cost you words.
+    private let micNotice = MicNotice()
     private var pendingSelection: SelectionReader.Selection?
     /// Captured the moment the hotkey goes down — see SelectionReader.snapshot.
     private var selectionAtPress: SelectionReader.Selection?
@@ -2007,6 +2009,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// key-down — see `insertDictation`. Nothing below reads press-time state
     /// off `self`, so an offer can never be moved by another dictation's press.
     private func showCorrectOffer(for press: Press, landing: Correction.Landing) {
+        // Beside the offer, not on it: its own window, so advice about the
+        // microphone never costs you the chance to fix the sentence. Here
+        // because this is the end of a dictation and every ending comes
+        // through — a Bluetooth mic is worth saying something about the moment
+        // you have watched a transcript come back short, and worth nothing at
+        // launch, when you were not dictating.
+        //
+        // Above the guards below, which are all about the offer rather than
+        // about the microphone: `correct_offer: false` is a choice about
+        // commands on the pill, an empty transcript is the symptom itself, and
+        // a dictation that lost the pill to a newer one still used the same
+        // microphone. It is said once per microphone, so none of them can make
+        // it say it twice either.
+        micNotice.showIfNeeded()
+
         guard config.feedback.correctOffer else { return }
         guard let text = lastTranscript?.trimmingCharacters(in: .whitespacesAndNewlines),
               !text.isEmpty else { return }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -82,12 +82,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// without Accessibility — an app condition has no business needing a
     /// permission that gating a stage by app does not otherwise require.
     private var appAtPress: Pipeline.App?
-    /// Which microphone the engine opened for this recording, and whether it
-    /// is on Bluetooth. Read when recording starts and frozen onto the `Press`
-    /// when the clip is handed to the decoder, so the microphone notice names
-    /// the device that recorded the words rather than whatever is default a
-    /// second later. One slot is enough: only one recording runs at a time,
-    /// and it is taken the moment that recording stops.
+    /// Which microphone the engine is recording through, and whether it is on
+    /// Bluetooth. Read when recording starts and frozen onto the `Press` when
+    /// the clip is handed to the decoder, so the microphone notice names the
+    /// device that recorded the words rather than whatever is default a second
+    /// later. One slot is enough: only one recording runs at a time, and it is
+    /// taken the moment that recording stops.
     private var micAtPress: (name: String, isBluetooth: Bool)?
     /// That same app's icon, for the pill. Held apart from `appAtPress` because
     /// `Pipeline.App` is what the pipeline matches on and has no business
@@ -955,10 +955,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         do {
             try recorder.start(config: config)
-            // Asked here, where the engine has just opened the device, and not
-            // when the transcript comes back. One lookup, so the name and the
-            // transport are the same device's — see `Recorder.inputDevice`.
-            micAtPress = Recorder.inputDevice
+            // The engine's own device, asked here rather than when the
+            // transcript comes back. Not the system default: that is a
+            // different question the moment a headset connects, and the notice
+            // is about the microphone these words went through. See
+            // `Recorder.boundDevice`.
+            micAtPress = recorder.boundDevice
         } catch {
             // A notice, not an alert. `runModal` holds the main run loop, and
             // the hotkey is delivered on it: one failed press behind a modal

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -956,9 +956,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         do {
             try recorder.start(config: config)
             // Asked here, where the engine has just opened the device, and not
-            // when the transcript comes back. Two reads of a CoreAudio
-            // property, next to the call that opened the microphone.
-            micAtPress = Recorder.inputDeviceName.map { ($0, Recorder.inputIsBluetooth) }
+            // when the transcript comes back. One lookup, so the name and the
+            // transport are the same device's — see `Recorder.inputDevice`.
+            micAtPress = Recorder.inputDevice
         } catch {
             // A notice, not an alert. `runModal` holds the main run loop, and
             // the hotkey is delivered on it: one failed press behind a modal

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -82,6 +82,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// without Accessibility — an app condition has no business needing a
     /// permission that gating a stage by app does not otherwise require.
     private var appAtPress: Pipeline.App?
+    /// Which microphone the engine opened for this recording, and whether it
+    /// is on Bluetooth. Read when recording starts and frozen onto the `Press`
+    /// when the clip is handed to the decoder, so the microphone notice names
+    /// the device that recorded the words rather than whatever is default a
+    /// second later. One slot is enough: only one recording runs at a time,
+    /// and it is taken the moment that recording stops.
+    private var micAtPress: (name: String, isBluetooth: Bool)?
     /// That same app's icon, for the pill. Held apart from `appAtPress` because
     /// `Pipeline.App` is what the pipeline matches on and has no business
     /// carrying an image around.
@@ -112,6 +119,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         /// And the app it belonged to, for the same reason: an offer taken
         /// later has to write back into the window that was dictated into.
         let owner: NSRunningApplication?
+        /// The microphone this dictation was recorded on, and whether it was on
+        /// Bluetooth. Frozen for the same reason as everything above it: the
+        /// default input can change while the decoder runs — a headset
+        /// disconnects, somebody picks another device in System Settings — and
+        /// the notice is about the microphone that recorded these words. See
+        /// `micAtPress`.
+        let mic: String?
+        let micIsBluetooth: Bool
     }
 
     /// The words the offer on screen is about, and the field they went into.
@@ -940,6 +955,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         do {
             try recorder.start(config: config)
+            // Asked here, where the engine has just opened the device, and not
+            // when the transcript comes back. Two reads of a CoreAudio
+            // property, next to the call that opened the microphone.
+            micAtPress = Recorder.inputDeviceName.map { ($0, Recorder.inputIsBluetooth) }
         } catch {
             // A notice, not an alert. `runModal` holds the main run loop, and
             // the hotkey is delivered on it: one failed press behind a modal
@@ -1209,7 +1228,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // And the press itself, frozen the same way and for the same reason.
         // `pressRun` is still this dictation's here: a press that ends a
         // recording does not bump it — see `handleHotKeyPress`.
-        let press = Press(run: pressRun, element: focus?.element, owner: focus?.owner)
+        // And the microphone that recorded it, read when the engine opened the
+        // device. Taken here rather than read at the end for the same reason as
+        // the rest: the default input can change while the decoder runs.
+        let press = Press(
+            run: pressRun, element: focus?.element, owner: focus?.owner,
+            mic: micAtPress?.name, micIsBluetooth: micAtPress?.isBluetooth ?? false
+        )
         Task { [weak self] in
             do {
                 // "Transcribing…" is the truth until the decoder is done, and
@@ -2019,10 +2044,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Above the guards below, which are all about the offer rather than
         // about the microphone: `correct_offer: false` is a choice about
         // commands on the pill, an empty transcript is the symptom itself, and
-        // a dictation that lost the pill to a newer one still used the same
-        // microphone. It is said once per microphone, so none of them can make
-        // it say it twice either.
-        micNotice.showIfNeeded()
+        // a dictation that lost the pill to a newer one was still recorded on
+        // the same microphone. `MicNotice` decides for itself whether there is
+        // anything to say, so none of them can make it say it twice either.
+        //
+        // The microphone comes off the press, not off CoreAudio. This runs when
+        // the decoder is done, and by then the default input can be another
+        // device — see `micAtPress`.
+        micNotice.showIfNeeded(mic: press.mic, isBluetooth: press.micIsBluetooth)
 
         guard config.feedback.correctOffer else { return }
         guard let text = lastTranscript?.trimmingCharacters(in: .whitespacesAndNewlines),

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -82,13 +82,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// without Accessibility — an app condition has no business needing a
     /// permission that gating a stage by app does not otherwise require.
     private var appAtPress: Pipeline.App?
-    /// Which microphone the engine is recording through, and whether it is on
-    /// Bluetooth. Read when recording starts and frozen onto the `Press` when
-    /// the clip is handed to the decoder, so the microphone notice names the
-    /// device that recorded the words rather than whatever is default a second
-    /// later. One slot is enough: only one recording runs at a time, and it is
-    /// taken the moment that recording stops.
-    private var micAtPress: (name: String, isBluetooth: Bool)?
+    /// Which microphone the engine is recording through. Read when recording
+    /// starts and frozen onto the `Press` when the clip is handed to the
+    /// decoder, so the microphone notice names the device that recorded the
+    /// words rather than whatever is default a second later. One slot is
+    /// enough: only one recording runs at a time, and it is taken the moment
+    /// that recording stops.
+    private var micAtPress: Recorder.InputDevice?
     /// That same app's icon, for the pill. Held apart from `appAtPress` because
     /// `Pipeline.App` is what the pipeline matches on and has no business
     /// carrying an image around.
@@ -119,14 +119,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         /// And the app it belonged to, for the same reason: an offer taken
         /// later has to write back into the window that was dictated into.
         let owner: NSRunningApplication?
-        /// The microphone this dictation was recorded on, and whether it was on
-        /// Bluetooth. Frozen for the same reason as everything above it: the
-        /// default input can change while the decoder runs — a headset
-        /// disconnects, somebody picks another device in System Settings — and
-        /// the notice is about the microphone that recorded these words. See
-        /// `micAtPress`.
-        let mic: String?
-        let micIsBluetooth: Bool
+        /// The microphone this dictation was recorded on. Frozen for the same
+        /// reason as everything above it: the default input can change while
+        /// the decoder runs — a headset disconnects, somebody picks another
+        /// device in System Settings — and the notice is about the microphone
+        /// that recorded these words. See `micAtPress`.
+        let mic: Recorder.InputDevice?
     }
 
     /// The words the offer on screen is about, and the field they went into.
@@ -1234,8 +1232,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // device. Taken here rather than read at the end for the same reason as
         // the rest: the default input can change while the decoder runs.
         let press = Press(
-            run: pressRun, element: focus?.element, owner: focus?.owner,
-            mic: micAtPress?.name, micIsBluetooth: micAtPress?.isBluetooth ?? false
+            run: pressRun, element: focus?.element, owner: focus?.owner, mic: micAtPress
         )
         Task { [weak self] in
             do {
@@ -2053,7 +2050,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // The microphone comes off the press, not off CoreAudio. This runs when
         // the decoder is done, and by then the default input can be another
         // device — see `micAtPress`.
-        micNotice.showIfNeeded(mic: press.mic, isBluetooth: press.micIsBluetooth)
+        micNotice.showIfNeeded(press.mic)
 
         guard config.feedback.correctOffer else { return }
         guard let text = lastTranscript?.trimmingCharacters(in: .whitespacesAndNewlines),

--- a/Sources/ParrotFlow/MicNotice.swift
+++ b/Sources/ParrotFlow/MicNotice.swift
@@ -42,8 +42,8 @@ final class MicNotice {
     /// when the recording starts — see `micAtPress` in `AppDelegate` — because
     /// the default input can change while the decoder runs, and this is about
     /// the microphone that recorded these words. The transport comes from
-    /// CoreAudio; see `Recorder.inputIsBluetooth` for why it is the transport
-    /// and not the name.
+    /// CoreAudio; see `Recorder.isBluetooth` for why it is the transport and
+    /// not the name.
     func showIfNeeded(mic: String?, isBluetooth: Bool) {
         guard let mic else { return }
         guard lastMic != mic else { return }

--- a/Sources/ParrotFlow/MicNotice.swift
+++ b/Sources/ParrotFlow/MicNotice.swift
@@ -20,24 +20,45 @@ final class MicNotice {
     private var panel: NSPanel?
     private let model = MicNoticeModel()
 
-    /// The microphones already spoken about, so each is mentioned once for as
-    /// long as the app is running. Changing to another and back says it again,
-    /// which is right: that is a decision being revisited.
-    private var told: Set<String> = []
+    /// The microphone the last dictation was recorded on, whether or not
+    /// anything was said about it.
+    ///
+    /// One slot rather than a list of the ones already mentioned, and that is
+    /// the difference between "once ever" and what this is meant to be.
+    /// Changing microphone forgets the one you left, so coming back to it says
+    /// it again — that is a decision being revisited. A list cannot do that: it
+    /// remembers every microphone the app has ever seen and never says anything
+    /// twice.
+    ///
+    /// It only ever sees the microphone a dictation was on. Switching away and
+    /// back with no dictation in between is not a change this can see, and
+    /// nothing is said.
+    private var lastMic: String?
 
-    /// After a dictation, if this microphone is on Bluetooth and has not been
-    /// mentioned yet. The transport is asked of CoreAudio — see
-    /// `Recorder.inputIsBluetooth` for why it is the transport and not the name.
-    func showIfNeeded() {
-        guard Recorder.inputIsBluetooth, let mic = Recorder.inputDeviceName else { return }
-        guard !told.contains(mic) else { return }
-        told.insert(mic)
+    /// After a dictation, if it was recorded on Bluetooth and that microphone
+    /// is not the one the last dictation used.
+    ///
+    /// The microphone is passed in rather than asked for here. It is frozen
+    /// when the recording starts — see `micAtPress` in `AppDelegate` — because
+    /// the default input can change while the decoder runs, and this is about
+    /// the microphone that recorded these words. The transport comes from
+    /// CoreAudio; see `Recorder.inputIsBluetooth` for why it is the transport
+    /// and not the name.
+    func showIfNeeded(mic: String?, isBluetooth: Bool) {
+        guard let mic else { return }
+        guard lastMic != mic else { return }
+        // Set for a wired microphone too. This is which microphone was last
+        // decided about, not which one was last complained about, and a
+        // dictation on the built-in mic is what makes going back to the
+        // headset a new decision.
+        lastMic = mic
+        guard isBluetooth else { return }
 
         Log.write("mic: \(mic) is on Bluetooth; said so once")
         show(mic: mic)
     }
 
-    /// Put it on screen for a named microphone, transport and `told` aside.
+    /// Put it on screen for a named microphone, transport and `lastMic` aside.
     ///
     /// Split out so `--panels microphone` raises the surface the app raises,
     /// rather than a copy of it that can drift.

--- a/Sources/ParrotFlow/MicNotice.swift
+++ b/Sources/ParrotFlow/MicNotice.swift
@@ -1,0 +1,219 @@
+import AppKit
+import SwiftUI
+
+/// Says once, per microphone, that this microphone will cost you words.
+///
+/// A dialog rather than a line on the pill, and once rather than always, because
+/// it is not a status — it is a thing to read, decide about, and not be told
+/// again. On the pill it was either in the way of the offer or riding along
+/// under the meter saying the same sentence into every dictation.
+///
+/// Collapsed to a sentence and a fix. The three reasons underneath are true and
+/// worth having, and they are not what you need at the moment they appear —
+/// what you need then is whether to go and change the microphone.
+///
+/// It never takes focus. It arrives just after a dictation, which is exactly
+/// when you are typing again, and a dialog that stole the keyboard to give
+/// advice would be a worse citizen than the microphone it is complaining about.
+final class MicNotice {
+
+    private var panel: NSPanel?
+    private let model = MicNoticeModel()
+
+    /// The microphones already spoken about, so each is mentioned once for as
+    /// long as the app is running. Changing to another and back says it again,
+    /// which is right: that is a decision being revisited.
+    private var told: Set<String> = []
+
+    /// After a dictation, if this microphone is on Bluetooth and has not been
+    /// mentioned yet. The transport is asked of CoreAudio — see
+    /// `Recorder.inputIsBluetooth` for why it is the transport and not the name.
+    func showIfNeeded() {
+        guard Recorder.inputIsBluetooth, let mic = Recorder.inputDeviceName else { return }
+        guard !told.contains(mic) else { return }
+        told.insert(mic)
+
+        Log.write("mic: \(mic) is on Bluetooth; said so once")
+        show(mic: mic)
+    }
+
+    /// Put it on screen for a named microphone, transport and `told` aside.
+    ///
+    /// Split out so `--panels microphone` raises the surface the app raises,
+    /// rather than a copy of it that can drift.
+    func show(mic: String) {
+        model.mic = mic
+        // Collapsed again on every appearance: the disclosure is a decision
+        // about the notice in front of you, not a preference to carry forward.
+        model.expanded = false
+        model.onClose = { [weak self] in self?.dismiss() }
+
+        if panel == nil { build() }
+        resize()
+        reposition()
+        // With the rise the other panels get, and without their key window:
+        // this arrives on its own while you are typing into somebody else's
+        // field. See `riseIntoView`.
+        panel?.riseIntoView(makeKey: false)
+    }
+
+    /// Straight out, where the arrival is animated. The other surfaces fade
+    /// because they leave on a timer; this one leaves because you pressed the
+    /// button on it, and a decision you made yourself should not have to play
+    /// out. See `PillHUD.fadeOut`.
+    private func dismiss() {
+        panel?.orderOut(nil)
+    }
+
+    private func build() {
+        let hosting = NSHostingView(rootView: MicNoticeView().environmentObject(model))
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: MicNoticeMetrics.width,
+                                height: MicNoticeMetrics.height(expanded: false)),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.contentView = hosting
+        panel.isFloatingPanel = true
+        panel.level = .floating
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.hasShadow = true
+        panel.hidesOnDeactivate = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.adoptParrotAppearance()
+        self.panel = panel
+
+        // Resize with the disclosure, so opening it does not clip the reasons.
+        model.onResize = { [weak self] in self?.resize() }
+    }
+
+    private func resize() {
+        guard let panel else { return }
+        let height = MicNoticeMetrics.height(expanded: model.expanded)
+        // The origin is kept, so the disclosure grows the panel upwards. It
+        // sits on the bottom edge of the screen and has nowhere else to grow.
+        let origin = panel.frame.origin
+        panel.setFrame(
+            NSRect(x: origin.x, y: origin.y, width: MicNoticeMetrics.width, height: height),
+            display: true, animate: panel.isVisible
+        )
+        panel.contentView?.frame = NSRect(
+            x: 0, y: 0, width: MicNoticeMetrics.width, height: height
+        )
+    }
+
+    /// Bottom right, out of the way of both the words and the pill.
+    private func reposition() {
+        guard let panel else { return }
+        let mouse = NSEvent.mouseLocation
+        let screen = NSScreen.screens.first { NSMouseInRect(mouse, $0.frame, false) } ?? NSScreen.main
+        guard let frame = screen?.visibleFrame else { return }
+        panel.setFrameOrigin(NSPoint(
+            x: frame.maxX - panel.frame.width - 24,
+            y: frame.minY + 24
+        ))
+    }
+}
+
+enum MicNoticeMetrics {
+    static let width: CGFloat = 380
+    /// Two heights rather than a measured fit. The sentence is one device name
+    /// long and the reasons are fixed text, so there is nothing here to
+    /// measure that is not known when it is written — and both are on the
+    /// `--panels-sheet`, where a name that outgrew the box would show.
+    static func height(expanded: Bool) -> CGFloat { expanded ? 258 : 118 }
+}
+
+final class MicNoticeModel: ObservableObject {
+    @Published var mic = "This microphone"
+    @Published var expanded = false {
+        didSet { onResize?() }
+    }
+    var onClose: (() -> Void)?
+    var onResize: (() -> Void)?
+}
+
+struct MicNoticeView: View {
+    @EnvironmentObject private var model: MicNoticeModel
+
+    private static let reasons = [
+        ("Narrow band", "Bluetooth carries less of your voice than a wired mic does."),
+        ("Aggressive gating", "Noise reduction takes quiet pauses and soft consonants for background noise, and mutes them."),
+        ("Latency", "Wireless delay makes the recogniser misalign or drop words in fast speech."),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 9) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 12))
+                    .foregroundStyle(Parrot.amber)
+                    .padding(.top, 1)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("\(model.mic) will cost you words")
+                        .font(.system(size: 13, weight: .semibold, design: .rounded))
+                        .fixedSize(horizontal: false, vertical: true)
+                    Text("Switch to the built-in mic for dictation.")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 0)
+            }
+
+            if model.expanded {
+                VStack(alignment: .leading, spacing: 7) {
+                    ForEach(Self.reasons, id: \.0) { reason in
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(reason.0)
+                                .font(.system(size: 11, weight: .semibold, design: .rounded))
+                                .foregroundStyle(Parrot.amber.opacity(0.9))
+                            Text(reason.1)
+                                .font(.system(size: 11.5))
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                }
+                .padding(.leading, 21)
+            }
+
+            HStack(spacing: 8) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.16)) { model.expanded.toggle() }
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 9, weight: .bold))
+                            .rotationEffect(.degrees(model.expanded ? 90 : 0))
+                        Text(model.expanded ? "Less" : "Why")
+                    }
+                    .font(.system(size: 12, weight: .medium, design: .rounded))
+                    .foregroundStyle(.secondary)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+
+                Spacer(minLength: 0)
+
+                Button("Got it") { model.onClose?() }
+                    .font(.system(size: 12, weight: .medium, design: .rounded))
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.primary)
+                    .padding(.horizontal, 11)
+                    .padding(.vertical, 4)
+                    .background {
+                        Capsule().fill(Color.white.opacity(0.12))
+                    }
+            }
+        }
+        .padding(Parrot.panelPadding)
+        .frame(width: MicNoticeMetrics.width, alignment: .leading)
+        .parrotSurface(
+            RoundedRectangle(cornerRadius: Parrot.panelRadius, style: .continuous),
+            solid: true
+        )
+    }
+}

--- a/Sources/ParrotFlow/MicNotice.swift
+++ b/Sources/ParrotFlow/MicNotice.swift
@@ -57,10 +57,10 @@ final class MicNotice {
         panel?.riseIntoView(makeKey: false)
     }
 
-    /// Straight out, where the arrival is animated. The other surfaces fade
-    /// because they leave on a timer; this one leaves because you pressed the
-    /// button on it, and a decision you made yourself should not have to play
-    /// out. See `PillHUD.fadeOut`.
+    /// Out at once, where the arrival is animated. The pill fades because it
+    /// leaves on a timer; this leaves because you pressed the button on it, and
+    /// a decision you made yourself should not have to play out. The correction
+    /// and preview panels go the same way for the same reason.
     private func dismiss() {
         panel?.orderOut(nil)
     }
@@ -121,8 +121,8 @@ enum MicNoticeMetrics {
     static let width: CGFloat = 380
     /// Two heights rather than a measured fit. The sentence is one device name
     /// long and the reasons are fixed text, so there is nothing here to
-    /// measure that is not known when it is written — and both are on the
-    /// `--panels-sheet`, where a name that outgrew the box would show.
+    /// measure that is not known when it is written — and both states are on
+    /// `--panel-sheet`, where a name that outgrew the box would show.
     static func height(expanded: Bool) -> CGFloat { expanded ? 258 : 118 }
 }
 

--- a/Sources/ParrotFlow/MicNotice.swift
+++ b/Sources/ParrotFlow/MicNotice.swift
@@ -20,7 +20,7 @@ final class MicNotice {
     private var panel: NSPanel?
     private let model = MicNoticeModel()
 
-    /// The microphone the last dictation was recorded on, whether or not
+    /// The device the last dictation was recorded on, by UID, whether or not
     /// anything was said about it.
     ///
     /// One slot rather than a list of the ones already mentioned, and that is
@@ -30,35 +30,40 @@ final class MicNotice {
     /// remembers every microphone the app has ever seen and never says anything
     /// twice.
     ///
+    /// The UID and not the name, because the name is not an identity: two
+    /// microphones can answer to "Headset Microphone", and one of them going
+    /// quiet on you is the whole subject of this file.
+    ///
     /// It only ever sees the microphone a dictation was on. Switching away and
     /// back with no dictation in between is not a change this can see, and
     /// nothing is said.
-    private var lastMic: String?
+    private var lastDevice: String?
 
     /// After a dictation, if it was recorded on Bluetooth and that microphone
     /// is not the one the last dictation used.
     ///
-    /// The microphone is passed in rather than asked for here. It is frozen
-    /// when the recording starts — see `micAtPress` in `AppDelegate` — because
-    /// the default input can change while the decoder runs, and this is about
-    /// the microphone that recorded these words. The transport comes from
+    /// The device is passed in rather than asked for here. It is frozen when
+    /// the recording starts — see `micAtPress` in `AppDelegate` — because the
+    /// default input can change while the decoder runs, and this is about the
+    /// microphone that recorded these words. The transport comes from
     /// CoreAudio; see `Recorder.isBluetooth` for why it is the transport and
     /// not the name.
-    func showIfNeeded(mic: String?, isBluetooth: Bool) {
-        guard let mic else { return }
-        guard lastMic != mic else { return }
+    func showIfNeeded(_ device: Recorder.InputDevice?) {
+        guard let device else { return }
+        guard lastDevice != device.uid else { return }
         // Set for a wired microphone too. This is which microphone was last
         // decided about, not which one was last complained about, and a
         // dictation on the built-in mic is what makes going back to the
         // headset a new decision.
-        lastMic = mic
-        guard isBluetooth else { return }
+        lastDevice = device.uid
+        guard device.isBluetooth else { return }
 
-        Log.write("mic: \(mic) is on Bluetooth; said so once")
-        show(mic: mic)
+        Log.write("mic: \(device.name) is on Bluetooth; said so once")
+        show(mic: device.name)
     }
 
-    /// Put it on screen for a named microphone, transport and `lastMic` aside.
+    /// Put it on screen for a named microphone, transport and `lastDevice`
+    /// aside.
     ///
     /// Split out so `--panels microphone` raises the surface the app raises,
     /// rather than a copy of it that can drift.

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -18,6 +18,10 @@ enum PanelsCommand {
         OfferedCommand(title: "grammar", key: "G")
     ]
 
+    /// A Bluetooth headset with a long name, because the notice puts the name
+    /// in its first sentence and a short one would not say whether it fits.
+    private static let sampleMicName = "Tasmin's AirPods Pro Max"
+
     /// Draws every surface into one PNG, light beside dark.
     ///
     /// The panels are the one part of the app with no test: they are looked at,
@@ -63,6 +67,16 @@ enum PanelsCommand {
         rule.loadRules([(heard: "Tasmin", corrected: "Tasmeen"),
                         (heard: "Mick", corrected: "Mik")])
 
+        // Both states of the microphone notice, because the disclosure is the
+        // shape of it: collapsed is what you read, open is the argument. A
+        // device name long enough to outgrow the box shows here and nowhere
+        // else — see `MicNoticeMetrics`.
+        let micNotice = MicNoticeModel()
+        micNotice.mic = sampleMicName
+        let micNoticeOpen = MicNoticeModel()
+        micNoticeOpen.mic = sampleMicName
+        micNoticeOpen.expanded = true
+
         let preview = PreviewModel()
         preview.load(
             prompt: "Grammar",
@@ -107,6 +121,15 @@ enum PanelsCommand {
             // comparison that matters: it has to not look like one.
             (AnyView(PillView().environmentObject(offer)),
              pillSize(offer), .dark, true),
+            // Not a pill state at all, and the only surface here that is
+            // about the hardware rather than about the words. Next to the pill
+            // because that is what it appears beside.
+            (AnyView(MicNoticeView().environmentObject(micNotice)),
+             NSSize(width: MicNoticeMetrics.width,
+                    height: MicNoticeMetrics.height(expanded: false)), .dark, true),
+            (AnyView(MicNoticeView().environmentObject(micNoticeOpen)),
+             NSSize(width: MicNoticeMetrics.width,
+                    height: MicNoticeMetrics.height(expanded: true)), .dark, true),
             (AnyView(CorrectionView().environmentObject(correction)),
              NSSize(width: CorrectionMetrics.width, height: CorrectionMetrics.height(forRows: 2)), .dark, false),
             (AnyView(CorrectionView().environmentObject(rule)),
@@ -231,6 +254,7 @@ enum PanelsCommand {
         let pill = PillHUD()
         let correction = CorrectionPanel()
         let preview = PreviewPanel()
+        let micNotice = MicNotice()
         var ticker: Timer?
 
         switch surface {
@@ -277,6 +301,12 @@ enum PanelsCommand {
                 before: "i think we should of asked them first, their going to be annoyed",
                 after: "I think we should have asked them first — they're going to be annoyed."
             )
+        // The one surface that has to be clicked to be seen whole: it opens
+        // where it opens in the app, and the disclosure and "Got it" both work
+        // here. `show(mic:)` rather than `showIfNeeded`, so it appears on a
+        // machine whose microphone is wired.
+        case "microphone":
+            micNotice.show(mic: sampleMicName)
         case "pill":
             pill.recording(icon: sampleIcon())
             // A meter frozen at zero says nothing about how the meter looks.
@@ -316,7 +346,7 @@ enum PanelsCommand {
                 }
             }
         default:
-            print("usage: ParrotFlow --panels <notice|caution|failure|thinking|offer|vocabulary|rule|dictation|preview|pill|sequence> [seconds]")
+            print("usage: ParrotFlow --panels <notice|caution|failure|thinking|offer|vocabulary|rule|dictation|preview|microphone|pill|sequence> [seconds]")
             return 2
         }
 

--- a/Sources/ParrotFlow/Recorder.swift
+++ b/Sources/ParrotFlow/Recorder.swift
@@ -828,17 +828,25 @@ final class Recorder {
         return name(of: deviceID)
     }
 
-    /// The default input, named and with its transport, from one lookup.
+    /// The device this recorder is bound to, named and with its transport.
+    ///
+    /// Asked of the engine's own binding, not of the system default. `bound` is
+    /// the device the running engine was prepared against, which is the one the
+    /// words are being recorded through; the default can move the moment after
+    /// `start` returns, and asking again would name a microphone that heard
+    /// nothing. Nil before the first engine is built.
     ///
     /// One device ID, asked twice, rather than two properties that each ask
-    /// which device is default. The default input can change between two such
-    /// reads — a headset connects, and macOS makes it the input — and the pair
-    /// then describes two devices: a wired microphone reported as Bluetooth,
-    /// or the other way round. The callers of the single properties print a
-    /// name and nothing else; this is the one that decides with both.
-    static var inputDevice: (name: String, isBluetooth: Bool)? {
-        guard let deviceID = defaultInputDeviceID, let name = name(of: deviceID) else { return nil }
-        return (name, isBluetooth(deviceID))
+    /// which device is default. Between two such reads the answer can change —
+    /// a headset connects, and macOS makes it the input — and the pair would
+    /// then describe two devices: a wired microphone reported as Bluetooth, or
+    /// the other way round.
+    var boundDevice: (name: String, isBluetooth: Bool)? {
+        stateLock.lock()
+        let deviceID = bound?.device
+        stateLock.unlock()
+        guard let deviceID, let name = Self.name(of: deviceID) else { return nil }
+        return (name, Self.isBluetooth(deviceID))
     }
 
     private static func name(of deviceID: AudioDeviceID) -> String? {

--- a/Sources/ParrotFlow/Recorder.swift
+++ b/Sources/ParrotFlow/Recorder.swift
@@ -859,11 +859,14 @@ final class Recorder {
         let deviceID = bound?.device
         stateLock.unlock()
         guard let deviceID, let name = Self.name(of: deviceID) else { return nil }
-        // The name stands in where a device will not give a UID. Two devices
-        // sharing a name is rarer than one refusing to identify itself, and
-        // this string is only ever compared with another read of itself.
+        // The device ID stands in where a device will not give a UID — never
+        // the name, which is what a UID is here to be better than. Two devices
+        // attached at once always have different IDs, so the fallback still
+        // tells them apart; what it cannot do is survive a reconnection, since
+        // macOS hands the ID back out. That costs a notice said a second time
+        // for the same headset, which is the safe direction to be wrong in.
         return InputDevice(
-            uid: Self.uid(of: deviceID) ?? name,
+            uid: Self.uid(of: deviceID) ?? "device-id:\(deviceID)",
             name: name,
             isBluetooth: Self.isBluetooth(deviceID)
         )

--- a/Sources/ParrotFlow/Recorder.swift
+++ b/Sources/ParrotFlow/Recorder.swift
@@ -828,7 +828,20 @@ final class Recorder {
         return name(of: deviceID)
     }
 
-    /// The device this recorder is bound to, named and with its transport.
+    /// A microphone: what to call it, and what to decide about it with.
+    struct InputDevice {
+        /// CoreAudio's UID for the device. What tells two microphones apart,
+        /// including two that answer to the same name — a headset and a webcam
+        /// both called "Headset Microphone" are one string and two devices.
+        /// Stable across unplugging and reconnecting, which `AudioDeviceID` is
+        /// not.
+        let uid: String
+        /// What System Settings calls it, and what the notice says out loud.
+        let name: String
+        let isBluetooth: Bool
+    }
+
+    /// The device this recorder is bound to.
     ///
     /// Asked of the engine's own binding, not of the system default. `bound` is
     /// the device the running engine was prepared against, which is the one the
@@ -836,17 +849,40 @@ final class Recorder {
     /// `start` returns, and asking again would name a microphone that heard
     /// nothing. Nil before the first engine is built.
     ///
-    /// One device ID, asked twice, rather than two properties that each ask
+    /// One device ID, asked three times, rather than properties that each ask
     /// which device is default. Between two such reads the answer can change —
-    /// a headset connects, and macOS makes it the input — and the pair would
+    /// a headset connects, and macOS makes it the input — and the answer would
     /// then describe two devices: a wired microphone reported as Bluetooth, or
     /// the other way round.
-    var boundDevice: (name: String, isBluetooth: Bool)? {
+    var boundDevice: InputDevice? {
         stateLock.lock()
         let deviceID = bound?.device
         stateLock.unlock()
         guard let deviceID, let name = Self.name(of: deviceID) else { return nil }
-        return (name, Self.isBluetooth(deviceID))
+        // The name stands in where a device will not give a UID. Two devices
+        // sharing a name is rarer than one refusing to identify itself, and
+        // this string is only ever compared with another read of itself.
+        return InputDevice(
+            uid: Self.uid(of: deviceID) ?? name,
+            name: name,
+            isBluetooth: Self.isBluetooth(deviceID)
+        )
+    }
+
+    /// The device's own identifier, the one that outlives a reconnection.
+    private static func uid(of deviceID: AudioDeviceID) -> String? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyDeviceUID,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var uid: CFString?
+        var size = UInt32(MemoryLayout<CFString?>.size)
+        let status = withUnsafeMutablePointer(to: &uid) {
+            AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, $0)
+        }
+        guard status == noErr, let uid = uid as String?, !uid.isEmpty else { return nil }
+        return uid
     }
 
     private static func name(of deviceID: AudioDeviceID) -> String? {

--- a/Sources/ParrotFlow/Recorder.swift
+++ b/Sources/ParrotFlow/Recorder.swift
@@ -825,7 +825,23 @@ final class Recorder {
     /// Settings and by plugging something in, neither of which this app sees.
     static var inputDeviceName: String? {
         guard let deviceID = defaultInputDeviceID else { return nil }
+        return name(of: deviceID)
+    }
 
+    /// The default input, named and with its transport, from one lookup.
+    ///
+    /// One device ID, asked twice, rather than two properties that each ask
+    /// which device is default. The default input can change between two such
+    /// reads — a headset connects, and macOS makes it the input — and the pair
+    /// then describes two devices: a wired microphone reported as Bluetooth,
+    /// or the other way round. The callers of the single properties print a
+    /// name and nothing else; this is the one that decides with both.
+    static var inputDevice: (name: String, isBluetooth: Bool)? {
+        guard let deviceID = defaultInputDeviceID, let name = name(of: deviceID) else { return nil }
+        return (name, isBluetooth(deviceID))
+    }
+
+    private static func name(of deviceID: AudioDeviceID) -> String? {
         var nameAddress = AudioObjectPropertyAddress(
             mSelector: kAudioObjectPropertyName,
             mScope: kAudioObjectPropertyScopeGlobal,
@@ -840,7 +856,7 @@ final class Recorder {
         return name.isEmpty ? nil : name
     }
 
-    /// Whether the microphone is on the other end of a Bluetooth link.
+    /// Whether this device is on the other end of a Bluetooth link.
     ///
     /// Asked of CoreAudio, not of the name. A list of brands is a list that is
     /// wrong the day somebody buys a headset nobody thought of, and it was
@@ -848,9 +864,7 @@ final class Recorder {
     /// words is the transport. A Bluetooth microphone runs over a voice profile
     /// that narrows the band and gates quiet sound, and it does that whatever
     /// is printed on the case.
-    static var inputIsBluetooth: Bool {
-        guard let deviceID = defaultInputDeviceID else { return false }
-
+    private static func isBluetooth(_ deviceID: AudioDeviceID) -> Bool {
         var address = AudioObjectPropertyAddress(
             mSelector: kAudioDevicePropertyTransportType,
             mScope: kAudioObjectPropertyScopeGlobal,

--- a/Sources/ParrotFlow/Recorder.swift
+++ b/Sources/ParrotFlow/Recorder.swift
@@ -840,6 +840,32 @@ final class Recorder {
         return name.isEmpty ? nil : name
     }
 
+    /// Whether the microphone is on the other end of a Bluetooth link.
+    ///
+    /// Asked of CoreAudio, not of the name. A list of brands is a list that is
+    /// wrong the day somebody buys a headset nobody thought of, and it was
+    /// answering the wrong question anyway: what costs you the ends of your
+    /// words is the transport. A Bluetooth microphone runs over a voice profile
+    /// that narrows the band and gates quiet sound, and it does that whatever
+    /// is printed on the case.
+    static var inputIsBluetooth: Bool {
+        guard let deviceID = defaultInputDeviceID else { return false }
+
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyTransportType,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var transport: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        let status = AudioObjectGetPropertyData(
+            deviceID, &address, 0, nil, &size, &transport
+        )
+        guard status == noErr else { return false }
+        return transport == kAudioDeviceTransportTypeBluetooth
+            || transport == kAudioDeviceTransportTypeBluetoothLE
+    }
+
     // MARK: - Files
 
     private func makeOutputURL(config: Config) throws -> URL {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -305,8 +305,13 @@ $PF --panel-sheet s.png   # draw every surface into one PNG, light beside dark
 ```
 
 `--panels` takes `pill`, `notice`, `caution`, `failure`, `thinking`, `offer`,
-`vocabulary`, `rule`, `dictation`, `preview` or `sequence`. `--panel-sheet` draws all of
+`vocabulary`, `rule`, `dictation`, `preview`, `microphone` or `sequence`.
+`--panel-sheet` draws all of
 them at once, which is where drift between them shows up.
+
+`microphone` is the Bluetooth notice, with a made-up device name. It is the one
+surface with something to click besides the offer: *Why* opens the reasons and
+resizes the panel, *Got it* dismisses it. The sheet draws it both ways.
 
 `offer` is the one state that takes the mouse — hover a chip to light it, click
 one to print which was chosen. Every other state lets clicks through, so the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -284,10 +284,15 @@ with nothing on screen to say why.
 
 So a notice appears in the bottom right after a dictation, saying which
 microphone it is and to use the built-in one instead. *Why* opens the three
-reasons; *Got it* dismisses it. It is said once per microphone for as long as
-the app runs — not at launch, when you are not dictating and it would be advice
-about nothing, and not every time, which is nagging. Change the input device
-and change back and it is said again: that is a decision being revisited.
+reasons; *Got it* dismisses it. It is said once for as long as you stay on that
+microphone — not at launch, when you are not dictating and it would be advice
+about nothing, and not every time, which is nagging. Dictate on another
+microphone and come back to this one and it is said again: that is a decision
+being revisited.
+
+The microphone it names is the one that recorded the words, read when the
+recording starts. Change the input device while a transcript is still coming
+back and the notice still talks about the microphone you actually used.
 
 The transport is what is asked about, not the name. A list of brands is wrong
 the day somebody buys a headset nobody thought of, and the transport is the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -269,6 +269,30 @@ Skips clips with no speech in them, so a key pressed by accident costs nothing.
 Gated on speech being *present*, not on how much — a one-word dictation is a
 real one.
 
+## The microphone
+
+Whatever the system input device is, picked in System Settings. There is
+nothing to set here: the app follows that choice, the menu bar names the device
+in use, and `--check-config` prints it.
+
+**A Bluetooth microphone costs you words, and the app says so once.** AirPods
+and most headsets record over a Bluetooth voice profile. That profile carries
+less of your voice than a wired mic does, its noise reduction mutes quiet
+pauses and soft consonants, and the wireless delay makes the recogniser drop
+words in fast speech. What you see is a transcript missing its trailing words,
+with nothing on screen to say why.
+
+So a notice appears in the bottom right after a dictation, saying which
+microphone it is and to use the built-in one instead. *Why* opens the three
+reasons; *Got it* dismisses it. It is said once per microphone for as long as
+the app runs — not at launch, when you are not dictating and it would be advice
+about nothing, and not every time, which is nagging. Change the input device
+and change back and it is said again: that is a decision being revisited.
+
+The transport is what is asked about, not the name. A list of brands is wrong
+the day somebody buys a headset nobody thought of, and the transport is the
+thing that costs you the words.
+
 ## `feedback`
 
 `sound` is the chime when a transcript lands. `overlay` is the floating pill


### PR DESCRIPTION
Section 5 and PR 11 of `docs/proposals/hud-placement-and-offer.md`. Stacked on
#113 — the diff below is against `feat/the-offer-follows-every-dictation`.

## What it does

AirPods and most headsets record over a Bluetooth voice profile. It narrows the
band, gates quiet sound and adds delay, so the ends of your words go missing and
nothing on screen says why. The app now says it — once, for as long as you stay
on that microphone, just after a dictation.

| | |
|---|---|
| `Recorder.InputDevice` | UID, name and transport of the device the engine is bound to |
| `MicNotice` | The panel, bottom right, and the one slot behind it |
| `Press.mic` | The microphone frozen when the recording starts |
| `showCorrectOffer` | One line, at the end of every dictation |
| `--panels microphone`, `--panel-sheet` | The surface on its own, and both its states |

## Three shapes this is not

Each was built and thrown away. The file's doc comment keeps the reasons.

**Not a line on the pill.** It was either in the way of the offer or riding
under the volume meter, saying the same sentence into every dictation.

**Not a warning every time.** This is not a status. It is a thing to read,
decide about, and not be told again.

**Not the three reasons up front.** They are true and worth having, and they are
not what you need at the moment it appears — what you need then is whether to go
and change the microphone. So they sit under a *Why*.

## Once, and what "once" is measured against

`lastDevice` is one slot: the microphone the last dictation was recorded on, by
UID. Not a list of the ones already mentioned — that is the difference between "once ever"
and what this is meant to be. Changing microphone forgets the one you left, so
dictating on another and coming back is a decision being revisited, and it is
said again.

The slot is set for a wired microphone too. It holds which microphone was last
decided about, not which one was last complained about, and a dictation on the
built-in mic is what makes going back to the headset a change.

It only sees the microphone a dictation was on. Switching away and back with
nothing dictated in between is not a change it can see.

## The microphone that recorded the words

Read in `startRecording`, right after `recorder.start` opens the device, and
frozen onto the `Press` beside the element and the app. Transcription is async:
read at the end instead, a headset that disconnected in that second takes the
notice with it, and one that connected gets named for a dictation it never
heard. That struct exists so nothing about a dictation is read off `self` after
the fact.

Taken from the engine's own binding, not from the system default. `bound` is
the device the running engine was prepared against; the default can move the
line after `start` returns, and a headset that connects in that gap would get
named for a dictation it never heard. `Recorder.boundDevice` reads that field
once and asks that one device ID for its UID, its name and its transport — two
lookups of "what is default now" can straddle a change and describe two
devices.

The UID is what decides, and the name is only what it says out loud. Two
microphones can answer to "Headset Microphone", and with the name as the key the
wired one silences the notice for the Bluetooth one. Where a device gives no
UID, its CoreAudio device ID stands in — unique among the devices attached at
once, and not stable across a reconnection, which costs a notice repeated rather
than a notice missed.

## The transport, not the name

A list of brand names is wrong the day somebody buys a headset nobody thought
of, and it was the wrong question anyway. What costs you the ends of your words
is the transport: a Bluetooth voice profile narrows the band and gates quiet
sound whatever is printed on the case.

## Where it is raised

`showCorrectOffer(for:landing:)`, which all five endings of `insertDictation`
reach — pasted, copied, no Accessibility, focus moved, nowhere to type. On
every dictation, not only the ones that paste cleanly.

It sits **above** that function's guards, and that is the one place this differs
from the spike. Those guards are about the offer, not about the microphone:
`correct_offer: false` is a choice about chips on the pill, an empty transcript
is the symptom itself, and a dictation that lost the pill to a newer one was
still recorded on the same microphone.

It never takes focus. It arrives when you are already typing again, and a dialog
that stole the keyboard to give advice would be a worse citizen than the
microphone it is complaining about.

## What it looks like

Both states are on `--panel-sheet`, with a device name long enough to say
whether it fits.

`--panels microphone` puts the real panel on screen with a made-up name —
`show(mic:)` rather than `showIfNeeded`, so it appears on a machine whose
microphone is wired. *Why* and *Got it* both work there.

## Checks

- `swift build`: **20 warnings before, 20 after** — the same 20, all
  pre-existing Swift 6 concurrency warnings in `AppDelegate.swift`, moved by a
  line or two.
- `swiftlint lint`: **32 warnings before, 32 after**, identical set, 0 errors.
- `scripts/check-audio-recovery.sh` 11/11, `check-default-config.sh` ✓,
  `check-no-voice.sh` 5/5. The rest of the check scripts score prompts and
  patterns this PR does not touch. `check-inplace.sh` and `check-span.sh` were
  not run: they replace the installed app and take the keyboard.
- `--panel-sheet` and `--panels microphone` both render.

## Docs

`docs/configuration.md` gains **The microphone** — where the input device comes
from, what Bluetooth costs, and what "once" means. `docs/cli.md` gains the new
`--panels` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
