### PR TITLE
feat: the correction panel is the sentence you said, edited in place

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -147,6 +147,13 @@ jobs:
       - name: A possessive across a substitution
         run: scripts/check-possessive.sh
 
+      # The model behind the correction panel: the whitespace of the selection
+      # it opened on, and where the caret lands. Both are invisible in the
+      # panel, and both were wrong. Compiles the one file on its own, so it
+      # needs no window.
+      - name: The correction panel's spans
+        run: scripts/check-spans.sh
+
       # Not a validation set: it checks that the file a new install is written
       # with still teaches everything config.example.yaml documents. That has
       # drifted twice, both times silently.

--- a/Sources/ParrotFlow/CorrectionPanel.swift
+++ b/Sources/ParrotFlow/CorrectionPanel.swift
@@ -414,12 +414,14 @@ struct CorrectionView: View {
 
             // Leaf, the colour of a changed word's bar. The same promise: this
             // is the thing that is going to happen.
-            ActionButton(title: confirmTitle, styled: confirmLabel, key: "↩",
+            ActionButton(title: confirmTitle, styled: confirmLabel, key: "⌘↩",
                          filled: false, glass: Parrot.leaf,
                          enabled: model.hasChanges) { model.onSubmit?() }
-                // Plain Return, because Return already submits from inside a
-                // word — there is nowhere in this panel it would insert a line.
-                .keyboardShortcut(.return, modifiers: [])
+                // ⌘↩ is the one the button advertises, because it works from
+                // anywhere on the panel. Plain Return goes on saving too — it
+                // is handled inside the word field, where there is nowhere in
+                // this panel a newline could go instead.
+                .keyboardShortcut(.return, modifiers: .command)
         }
         .padding(.top, 4)
     }
@@ -501,12 +503,17 @@ struct CorrectionView: View {
         confirmParts.map(\.text).joined()
     }
 
-    /// The same sentence with the words themselves lit. They are the thing to
-    /// check before pressing it, so they are the part that is not dimmed.
+    /// The same sentence with the words themselves lit — in amber, the colour
+    /// they are in the sentence above.
+    ///
+    /// That is the whole reason for the colour: the orange words on the button
+    /// are the orange words in the sentence, so nothing has to say which words
+    /// are about to be taught. White read as one more bold word in a green
+    /// label and said nothing.
     private var confirmLabel: Text {
         confirmParts.reduce(Text("")) { label, part in
             label + (part.lit
-                ? Text(part.text).bold().foregroundStyle(Color.white)
+                ? Text(part.text).bold().foregroundStyle(Parrot.amber)
                 : Text(part.text).foregroundStyle(ActionButton.glassText))
         }
     }
@@ -527,10 +534,18 @@ private struct SpanView: View {
             // Set at the size of the word below it. Small, it read as a
             // footnote about the word; the same size, the two lines read as one
             // sentence rewritten over another.
+            //
+            // Amber, like the word below it: the two of them are one change,
+            // and the change is the thing on this panel worth looking at. It
+            // was tertiary grey — the dimmest thing on the panel, which is the
+            // wrong end for the one line you are being asked to check. Under
+            // full strength, so the word that will be written wins; the line
+            // through it dimmer again, so it reads as a line through a word and
+            // not as a second word.
             Text(span.showsHeard ? span.heardShown : " ")
                 .font(.system(size: CorrectionMetrics.wordSize, design: .rounded))
-                .foregroundStyle(.tertiary)
-                .strikethrough(span.showsHeard, color: .white.opacity(0.22))
+                .foregroundStyle(Parrot.amber.opacity(0.75))
+                .strikethrough(span.showsHeard, color: Parrot.amber.opacity(0.4))
                 .lineLimit(1)
                 .fixedSize()
 
@@ -562,6 +577,10 @@ private struct SpanView: View {
         return Color.white.opacity(0.13)
     }
 
+    /// Drawn, never typed. A comma is not a `WordField`: there is nothing to
+    /// teach about one, so it takes no focus, no tab stop and no caret, and a
+    /// click on it does nothing. It belongs to the word it follows and is
+    /// spaced that way — tight against the word, and the gap after it.
     private func punctuation(_ text: String) -> some View {
         Text(text)
             .font(.system(size: CorrectionMetrics.wordSize))

--- a/Sources/ParrotFlow/CorrectionPanel.swift
+++ b/Sources/ParrotFlow/CorrectionPanel.swift
@@ -1,48 +1,44 @@
 import AppKit
 import SwiftUI
 
-/// The teach-a-word panel: one row per selected word, each mapping what
-/// ParrotFlow wrote to what it should have written.
+/// Teach me the words I got wrong.
 ///
-/// Selecting a phrase gives you a row per word rather than one row for the
-/// whole string, because rules are per-word — "Tasmin and Mick" should teach
-/// two rules, not one rule for a phrase that will never recur verbatim. Rows
-/// left blank are skipped, so the words you did not come to fix cost nothing.
+/// The sentence you just dictated, editable in place. What was heard sits above
+/// the word it became, struck through; the bar under each word carries its
+/// state; and a rule is keyed on a **span** rather than on a word — see
+/// `Span` for why that is the whole point.
 ///
-/// Visually a sibling of the recording pill and the notice: same material,
-/// same plumage rim, same footer as the preview panel. The words are set in
-/// monospace — they are literal strings being mapped to other literal strings,
-/// and each row is a line that lands in config.yaml.
+/// Four gestures, and every one of them is a gesture a text field already has:
+/// type over a word, `space` to split one into two, `⌫` at the start to join a
+/// word to the one before, and clear a word to remove it. `⌘Z` undoes. There is
+/// deliberately nothing of its own to learn — an earlier pass had "click a
+/// struck word to release it", and needing a sentence to explain it was the
+/// argument against it.
+///
+/// Visually a sibling of the pill: near-black at 95%, the same plumage rim.
 final class CorrectionPanel {
 
     private var panel: KeyPanel?
-    private let model = CorrectionModel()
+    private let model = SpansModel()
 
     /// (rules to save, the full corrected text to put back).
     var onSave: (([(heard: String, corrected: String)], String) -> Void)?
     var onCancel: (() -> Void)?
 
     func show(selection: String) {
-        model.load(selection: selection)
-        model.onSubmit = { [weak self] in self?.commit() }
-        model.onCancel = { [weak self] in self?.dismiss(cancelled: true) }
-
-        if panel == nil { build() }
-        resize()
-        reposition()
-
-        NSApp.activate(ignoringOtherApps: true)
-        panel?.riseIntoView(makeKey: true)
+        model.load(sentence: selection)
+        present()
     }
 
-    /// Opens with the rules already filled in — the model proposed them, the
-    /// user confirms them. One keystroke, and nothing is written on a guess.
-    ///
-    /// More than one row when the utterance carried more than one correction:
-    /// "Tasmeen spells T A S M E E N and Mick spells M I K" is two rules, and
-    /// splitting them across two panels would mean saying it twice.
+    /// Opens with the rules already filled in — the model proposed them, you
+    /// confirm them. Written as a sentence of its own, because the panel now
+    /// edits a sentence rather than a table of pairs.
     func show(rules: [(heard: String, corrected: String)]) {
-        model.loadRules(rules)
+        model.load(rules: rules)
+        present()
+    }
+
+    private func present() {
         model.onSubmit = { [weak self] in self?.commit() }
         model.onCancel = { [weak self] in self?.dismiss(cancelled: true) }
 
@@ -55,15 +51,11 @@ final class CorrectionPanel {
 
     private func commit() {
         let rules = model.rules()
-        let corrected = model.correctedText()
+        let corrected = model.sentence()
         dismiss(cancelled: false)
         onSave?(rules, corrected)
     }
 
-    /// Escape reaches here twice — once through the button that advertises it,
-    /// once through the panel's own `cancelOperation` for when nothing inside
-    /// holds focus. Whichever arrives first closes the panel; the other finds
-    /// it already gone.
     private func dismiss(cancelled: Bool) {
         guard panel?.isVisible == true else { return }
         panel?.orderOut(nil)
@@ -88,13 +80,13 @@ final class CorrectionPanel {
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         panel.adoptParrotAppearance()
         panel.onCancel = { [weak self] in self?.dismiss(cancelled: true) }
+        panel.onUndo = { [weak self] in self?.model.undo() }
         self.panel = panel
     }
 
-    /// Grows with the number of words, up to a scrolling cap.
     private func resize() {
         guard let panel else { return }
-        let height = CorrectionMetrics.height(forRows: model.visibleTokens.count)
+        let height = CorrectionMetrics.height(forWords: model.spans.count)
         panel.setContentSize(NSSize(width: CorrectionMetrics.width, height: height))
         panel.contentView?.frame = NSRect(
             x: 0, y: 0, width: CorrectionMetrics.width, height: height
@@ -106,7 +98,6 @@ final class CorrectionPanel {
         let mouse = NSEvent.mouseLocation
         let screen = NSScreen.screens.first { NSMouseInRect(mouse, $0.frame, false) } ?? NSScreen.main
         guard let frame = screen?.visibleFrame else { return }
-
         let size = panel.frame.size
         panel.setFrameOrigin(NSPoint(
             x: frame.midX - size.width / 2,
@@ -116,14 +107,44 @@ final class CorrectionPanel {
 }
 
 enum CorrectionMetrics {
-    static let width: CGFloat = 500
-    static let rowHeight: CGFloat = 38
-    static let maxRows = 7
-    /// Title, column labels, and the footer the preview panel also carries.
-    private static let chrome: CGFloat = 126
 
-    static func height(forRows rows: Int) -> CGFloat {
-        chrome + rowHeight * CGFloat(max(1, min(rows, maxRows)))
+    /// The size the sentence is set in, and the size the struck line above it
+    /// is set in too. They are the same sentence said twice — one of them set
+    /// small read as a footnote about the other.
+    static let wordSize: CGFloat = 21
+    /// The struck line, the word, and the bar under it. Both lines of text are
+    /// 21pt now, so this is close to twice what the first pass reserved.
+    static let spanHeight: CGFloat = 62
+    /// Air between one line of the sentence and the next.
+    static let lineGap: CGFloat = 16
+    static let lineHeight: CGFloat = spanHeight + lineGap
+
+    static let width: CGFloat = 700
+    /// Header, the hint row, the footer, and the panel's own padding. Measured
+    /// off the built view rather than added up by hand: the sentence gets
+    /// whatever is left over, so guessing this low squeezes it and the words
+    /// disappear under the fold with nothing to say they have.
+    private static let chrome: CGFloat = 159
+    /// Past this the sentence scrolls rather than the panel growing. Three
+    /// lines is about thirty words — a long sentence, and already a panel a
+    /// third of the way down the screen. A whole paragraph of dictation would
+    /// otherwise open a panel taller than the screen it floats over.
+    static let maxLines = 3
+    /// What one word costs across the line, spacing included. Measured off the
+    /// panel at 21pt: ordinary dictation fits twelve or thirteen words to a
+    /// line at this width, and this is a little under that. Being wrong is
+    /// cheap either way — too few lines and the sentence scrolls, too many and
+    /// there is air under it.
+    private static let wordWidth: CGFloat = 56
+
+    private static func lines(forWords words: Int) -> Int {
+        let perLine = max(1, Int((width - Parrot.panelPadding * 2) / wordWidth))
+        return max(1, min(maxLines, (words + perLine - 1) / perLine))
+    }
+
+    static func height(forWords words: Int) -> CGFloat {
+        // The gap belongs between lines, so the last one does not pay for it.
+        chrome + lineHeight * CGFloat(lines(forWords: words)) - lineGap
     }
 }
 
@@ -131,169 +152,63 @@ enum CorrectionMetrics {
 /// to take a keystroke.
 private final class KeyPanel: NSPanel {
     var onCancel: (() -> Void)?
+    var onUndo: (() -> Void)?
 
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { true }
 
-    /// SwiftUI's `onExitCommand` only fires when something inside holds focus.
-    /// Handling it on the panel means Escape always closes, even if the view
-    /// somehow renders with nothing focusable.
-    override func cancelOperation(_ sender: Any?) {
-        onCancel?()
-    }
-}
+    override func cancelOperation(_ sender: Any?) { onCancel?() }
 
-// MARK: - Model
-
-/// One selected word, plus the punctuation and spacing around it so the
-/// phrase can be put back together exactly as it was found.
-struct CorrectionToken: Identifiable {
-    let id = UUID()
-    /// Punctuation before the word — an opening quote or bracket.
-    var prefix: String = ""
-    /// The bare word. This is what becomes a rule.
-    var word: String
-    /// Trailing punctuation and whitespace.
-    var suffix: String = ""
-    var replacement: String = ""
-    var isRemoved: Bool = false
-    /// Typed by hand rather than taken from a selection, so the word itself is
-    /// editable and it contributes nothing to reassembly.
-    var isManual: Bool = false
-
-    var resolved: String {
-        guard !isManual else { return "" }
-        let body = isRemoved || replacement.isEmpty ? word : replacement
-        return prefix + body + suffix
-    }
-}
-
-final class CorrectionModel: ObservableObject {
-    @Published var tokens: [CorrectionToken] = []
-    var onSubmit: (() -> Void)?
-    var onCancel: (() -> Void)?
-
-    var visibleTokens: [CorrectionToken] {
-        tokens.filter { !$0.isRemoved && (!$0.word.isEmpty || $0.isManual) }
-    }
-
-    var pendingRuleCount: Int { rules().count }
-
-    func load(selection: String) {
-        tokens = Self.tokenize(selection).filter { !$0.word.isEmpty || !$0.prefix.isEmpty }
-        // Nothing selected (or nothing readable): give a row you can type both
-        // halves into, rather than a panel with no fields at all.
-        if !tokens.contains(where: { !$0.word.isEmpty }) {
-            tokens.append(CorrectionToken(word: "", isManual: true))
+    /// ⌘Z here rather than on the field, because the undo is the panel's: it
+    /// puts back a whole arrangement of spans, and the field a keystroke landed
+    /// in may not exist afterwards.
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if event.modifierFlags.contains(.command),
+           event.charactersIgnoringModifiers?.lowercased() == "z" {
+            onUndo?()
+            return true
         }
-    }
-
-    func loadRules(_ rules: [(heard: String, corrected: String)]) {
-        tokens = rules.map {
-            CorrectionToken(word: $0.heard, replacement: $0.corrected, isManual: true)
-        }
-    }
-
-    func remove(_ id: UUID) {
-        guard let index = tokens.firstIndex(where: { $0.id == id }) else { return }
-        tokens[index].isRemoved = true
-        tokens[index].replacement = ""
-        objectWillChange.send()
-    }
-
-    /// Only rows that were actually changed become rules.
-    func rules() -> [(heard: String, corrected: String)] {
-        tokens.compactMap { token in
-            guard !token.isRemoved else { return nil }
-            let corrected = token.replacement.trimmingCharacters(in: .whitespacesAndNewlines)
-            let heard = token.word.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !corrected.isEmpty, !heard.isEmpty, corrected != heard else { return nil }
-            return (heard, corrected)
-        }
-    }
-
-    /// The whole selection with corrections applied, ready to go back into the
-    /// field it came from.
-    func correctedText() -> String {
-        tokens.map(\.resolved).joined()
-    }
-
-    /// Splits on whitespace, keeping punctuation attached to its word so
-    /// "Mick." teaches a rule for "Mick" but comes back with its full stop.
-    static func tokenize(_ text: String) -> [CorrectionToken] {
-        let punctuation = CharacterSet.punctuationCharacters
-            .union(.symbols)
-            .subtracting(CharacterSet(charactersIn: "'-"))
-
-        var tokens: [CorrectionToken] = []
-        var index = text.startIndex
-
-        while index < text.endIndex {
-            // Whitespace belongs to the previous token's suffix.
-            while index < text.endIndex, text[index].isWhitespace {
-                if tokens.isEmpty {
-                    tokens.append(CorrectionToken(word: ""))
-                }
-                tokens[tokens.count - 1].suffix.append(text[index])
-                index = text.index(after: index)
-            }
-            guard index < text.endIndex else { break }
-
-            var token = CorrectionToken(word: "")
-            while index < text.endIndex,
-                  let scalar = text[index].unicodeScalars.first,
-                  punctuation.contains(scalar), !text[index].isWhitespace {
-                token.prefix.append(text[index])
-                index = text.index(after: index)
-            }
-            while index < text.endIndex, !text[index].isWhitespace {
-                if let scalar = text[index].unicodeScalars.first, punctuation.contains(scalar) {
-                    break
-                }
-                token.word.append(text[index])
-                index = text.index(after: index)
-            }
-            while index < text.endIndex, !text[index].isWhitespace {
-                guard let scalar = text[index].unicodeScalars.first,
-                      punctuation.contains(scalar) else { break }
-                token.suffix.append(text[index])
-                index = text.index(after: index)
-            }
-
-            if token.word.isEmpty && token.prefix.isEmpty && token.suffix.isEmpty { break }
-            tokens.append(token)
-        }
-
-        return tokens.filter { !($0.word.isEmpty && $0.prefix.isEmpty) }
+        return super.performKeyEquivalent(with: event)
     }
 }
 
 // MARK: - View
 
 struct CorrectionView: View {
-    @EnvironmentObject private var model: CorrectionModel
-    @FocusState private var focused: UUID?
+    @EnvironmentObject private var model: SpansModel
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            PanelHeader(title: "Vocabulary", note: "teach a word")
-            columns
+        VStack(alignment: .leading, spacing: 14) {
+            PanelHeader(title: "Vocabulary", note: "teach me the words I got wrong")
 
-            ScrollView {
-                VStack(spacing: 0) {
-                    ForEach($model.tokens) { $token in
-                        if !token.isRemoved, !token.word.isEmpty || token.isManual {
-                            row($token)
-                        }
+            // Scrolls past the cap rather than growing without end. A minute of
+            // dictation is a paragraph, and a panel the height of the screen is
+            // not a thing you can read a sentence off.
+            ScrollView(.vertical) {
+                SentenceFlow(spacing: 7, lineSpacing: CorrectionMetrics.lineGap) {
+                    ForEach(model.spans) { span in
+                        SpanView(span: span)
                     }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .frame(maxHeight: CorrectionMetrics.rowHeight * CGFloat(CorrectionMetrics.maxRows))
+            .frame(maxHeight: CorrectionMetrics.lineHeight
+                * CGFloat(CorrectionMetrics.maxLines) - CorrectionMetrics.lineGap)
+            .padding(.top, 8)
+
+            // Laid out whether it shows or not. It arrives on the first edit,
+            // the panel is sized once when it opens, and a row appearing under
+            // the sentence would push the buttons off the bottom.
+            hint.opacity(model.hasEdited ? 1 : 0)
 
             PanelActions(
                 status: summary,
                 cancelTitle: "Cancel",
-                confirmTitle: "Save",
+                confirmTitle: confirmTitle,
+                // The hint row above holds its space whether it shows or not,
+                // so the standing 24pt over the buttons would sit on top of a
+                // band of nothing.
+                compact: true,
                 onCancel: { model.onCancel?() },
                 onConfirm: { model.onSubmit?() }
             )
@@ -304,80 +219,133 @@ struct CorrectionView: View {
             RoundedRectangle(cornerRadius: Parrot.panelRadius, style: .continuous),
             solid: true
         )
-        .onAppear {
-            focused = model.visibleTokens.first(where: { $0.isManual })?.id
-                ?? model.visibleTokens.first?.id
-        }
         .onExitCommand { model.onCancel?() }
     }
 
-    private var columns: some View {
-        HStack(spacing: 12) {
-            Text("HEARD AS")
-                .frame(width: 150, alignment: .leading)
-            Text("SHOULD BE")
-            Spacer()
+    /// Only the two you could not guess. Clearing a field to empty is what
+    /// clearing a field does everywhere, and ⌘Z is on the button below.
+    private var hint: some View {
+        HStack(spacing: 14) {
+            key("space", "splits a word in two")
+            key("⌫", "at the start joins it to the word before")
         }
-        .font(.system(size: 9, weight: .semibold, design: .rounded))
-        .kerning(0.9)
-        .foregroundStyle(.quaternary)
-        .padding(.bottom, 6)
+        .font(.system(size: 12, design: .rounded))
+        .foregroundStyle(.tertiary)
     }
 
-    private func row(_ token: Binding<CorrectionToken>) -> some View {
-        HStack(spacing: 12) {
-            Group {
-                if token.wrappedValue.isManual {
-                    TextField("wrong word", text: token.word)
-                        .textFieldStyle(.plain)
-                        .focused($focused, equals: token.wrappedValue.id)
-                        .onSubmit { model.onSubmit?() }
-                        .parrotField(focused: focused == token.wrappedValue.id)
-                } else {
-                    Text(token.wrappedValue.word)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
+    private func key(_ cap: String, _ said: String) -> some View {
+        HStack(spacing: 5) {
+            Text(cap)
+                .font(.system(size: 11.5, weight: .semibold, design: .rounded))
+                .padding(.horizontal, 5)
+                .padding(.vertical, 1.5)
+                .background {
+                    RoundedRectangle(cornerRadius: 4, style: .continuous)
+                        .fill(Color.white.opacity(0.1))
                 }
-            }
-            .font(.system(size: 14, weight: .medium, design: .monospaced))
-            .foregroundStyle(.secondary)
-            .frame(width: 150, alignment: .leading)
-
-            Image(systemName: "arrow.right")
-                .font(.system(size: 10, weight: .semibold))
-                .foregroundStyle(
-                    token.wrappedValue.replacement.isEmpty
-                        ? AnyShapeStyle(.quaternary)
-                        : AnyShapeStyle(Parrot.leaf)
-                )
-
-            TextField("leave blank to skip", text: token.replacement)
-                .textFieldStyle(.plain)
-                .font(.system(size: 14, weight: .medium, design: .monospaced))
-                .focused($focused, equals: token.wrappedValue.id)
-                .onSubmit { model.onSubmit?() }
-                .parrotField(focused: focused == token.wrappedValue.id)
-
-            Button {
-                model.remove(token.wrappedValue.id)
-            } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: 9, weight: .bold))
-                    .foregroundStyle(.tertiary)
-                    .frame(width: 18, height: 18)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .help("Leave this word alone")
+            Text(said)
         }
-        .frame(height: CorrectionMetrics.rowHeight)
     }
 
     private var summary: String {
-        switch model.pendingRuleCount {
-        case 0: return "Fill in a word to save a rule"
-        case 1: return "1 rule to save"
-        case let count: return "\(count) rules to save"
+        switch model.rules().count {
+        case 0: return "Change a word to teach one"
+        case 1: return "1 word → vocabulary"
+        case let count: return "\(count) words → vocabulary"
         }
+    }
+
+    /// The button names the words it is about to teach.
+    ///
+    /// The corrected forms, not what was heard: those are the terms that get
+    /// written to the vocabulary, and reading them off the button before
+    /// pressing it is the whole check. Past three the names would run the
+    /// button into the status line, so it counts them instead. With nothing
+    /// changed there is nothing to name, and the status line to the left
+    /// already says what to do about that.
+    private var confirmTitle: String {
+        let words = model.rules().map(\.corrected)
+        switch words.count {
+        case 0: return "Save"
+        case 1...3: return "Add \(words.joined(separator: ", ")) to the vocabulary"
+        default: return "Add \(words.count) words to the vocabulary"
+        }
+    }
+}
+
+/// One span: what was heard above, what it became below, and the bar that says
+/// which is which.
+private struct SpanView: View {
+    @EnvironmentObject private var model: SpansModel
+    let span: Span
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            // Absolutely nothing moves when this appears — it is laid out in
+            // the space the flow already reserved above every word, so a word
+            // changing never shifts the line it is in.
+            //
+            // Set at the size of the word below it. Small, it read as a
+            // footnote about the word; the same size, the two lines read as one
+            // sentence rewritten over another.
+            Text(span.isChanged || span.heard.count > 1 ? span.heardShown : " ")
+                .font(.system(size: CorrectionMetrics.wordSize, design: .rounded))
+                .foregroundStyle(.tertiary)
+                .strikethrough(span.isChanged || span.heard.count > 1, color: .white.opacity(0.22))
+                .lineLimit(1)
+                .fixedSize()
+
+            HStack(alignment: .firstTextBaseline, spacing: 0) {
+                if !span.pre.isEmpty { punctuation(span.pre) }
+                ForEach(Array(span.value.enumerated()), id: \.offset) { at, word in
+                    if at > 0 { punctuation(" ") }
+                    field(word, at: at)
+                }
+                if !span.post.isEmpty { punctuation(span.post) }
+            }
+
+            // The whole state display. Faint is untouched, sky is where you
+            // are, leaf is what will change — and it runs unbroken under a
+            // multi-word span, which is how "these are one thing you said" is
+            // said without adding anything.
+            RoundedRectangle(cornerRadius: 1)
+                .fill(bar)
+                .frame(height: 1.5)
+        }
+        .fixedSize()
+    }
+
+    private var isHere: Bool { model.focus?.span == span.id }
+
+    private var bar: Color {
+        if span.isChanged { return Parrot.leaf }
+        if isHere { return Parrot.sky }
+        return Color.white.opacity(0.13)
+    }
+
+    private func punctuation(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: CorrectionMetrics.wordSize))
+            .foregroundStyle(.secondary)
+    }
+
+    private func field(_ word: String, at: Int) -> some View {
+        WordField(
+            text: word,
+            isChanged: span.isChanged,
+            focused: model.focus?.span == span.id && model.focus?.word == at,
+            caret: model.focus?.at,
+            onChange: { model.typed($0, span: span.id, word: at) },
+            onJoinBack: { model.joinBack(span: span.id, word: at) },
+            onEdge: { forward in
+                model.step(from: span.id, word: at, forward: forward, keepingEdge: true)
+            },
+            onTab: { forward in
+                model.step(from: span.id, word: at, forward: forward, keepingEdge: false)
+            },
+            onSubmit: { model.onSubmit?() },
+            onCancel: { model.onCancel?() }
+        )
+        .onTapGesture { model.focus = SpanCaret(span: span.id, word: at, at: nil) }
     }
 }

--- a/Sources/ParrotFlow/CorrectionPanel.swift
+++ b/Sources/ParrotFlow/CorrectionPanel.swift
@@ -48,10 +48,22 @@ final class CorrectionPanel {
         reposition()
         NSApp.activate(ignoringOtherApps: true)
         panel?.riseIntoView(makeKey: true)
-        // Again, now that there is a window to be first responder in. Setting
-        // it before the panel exists gets the bar under the first word right
-        // and the caret nowhere.
-        model.focusFirst()
+
+        // Focus again on the next turn of the runloop, and not before. Two
+        // things have to be true before a field can show a caret, and neither
+        // is true on this turn: there has to be a window to be first responder
+        // in, and that window has to be key — a field made first responder in a
+        // window that is not key draws no insertion point. `NSApp.activate`
+        // only lands on the next turn, so the key status is asked for again
+        // there rather than trusted here.
+        //
+        // The focus itself is unchanged from the one `load` set, so it takes
+        // `focusTick` to make it a change SwiftUI redraws for.
+        DispatchQueue.main.async { [weak self] in
+            guard let self, let panel = self.panel else { return }
+            if !panel.isKeyWindow { panel.makeKeyAndOrderFront(nil) }
+            self.model.focusFirst()
+        }
     }
 
     private func commit() {
@@ -562,6 +574,7 @@ private struct SpanView: View {
             isChanged: span.isChanged,
             focused: model.focus?.span == span.id && model.focus?.word == at,
             caret: model.focus?.at,
+            tick: model.focusTick,
             onChange: { model.typed($0, span: span.id, word: at) },
             onJoinBack: { model.joinBack(span: span.id, word: at) },
             onEdge: { forward in

--- a/Sources/ParrotFlow/CorrectionPanel.swift
+++ b/Sources/ParrotFlow/CorrectionPanel.swift
@@ -605,6 +605,10 @@ private struct SpanView: View {
             onSubmit: { model.onSubmit?() },
             onCancel: { model.onCancel?() }
         )
+        // `focus` directly, not `moveCaret`: this records where the caret now
+        // is, it does not ask for it to move. AppKit put it where you clicked
+        // before this ran, and the tick stays where it was so no field treats
+        // the click as a request. The `at` is never read for that reason.
         .onTapGesture { model.focus = SpanCaret(span: span.id, word: at, at: nil) }
     }
 }

--- a/Sources/ParrotFlow/CorrectionPanel.swift
+++ b/Sources/ParrotFlow/CorrectionPanel.swift
@@ -41,15 +41,28 @@ final class CorrectionPanel {
     private func present() {
         model.onSubmit = { [weak self] in self?.commit() }
         model.onCancel = { [weak self] in self?.dismiss(cancelled: true) }
+        model.width = CorrectionMetrics.width(fitting: model.spans, room: Self.room())
 
         if panel == nil { build() }
         resize()
         reposition()
         NSApp.activate(ignoringOtherApps: true)
         panel?.riseIntoView(makeKey: true)
+        // Again, now that there is a window to be first responder in. Setting
+        // it before the panel exists gets the bar under the first word right
+        // and the caret nowhere.
+        model.focusFirst()
     }
 
     private func commit() {
+        // Twice is possible: Return reaches the confirm button and, when that
+        // button is off, the word field's own newline handler. Once the panel
+        // is down there is nothing left to save.
+        guard panel?.isVisible == true else { return }
+        // Nothing to do is nothing to do, whichever key asked. The button says
+        // so by being off; this is the same answer for the field's Return.
+        guard model.hasChanges else { return }
+
         let rules = model.rules()
         let corrected = model.sentence()
         dismiss(cancelled: false)
@@ -65,7 +78,7 @@ final class CorrectionPanel {
     private func build() {
         let hosting = NSHostingView(rootView: CorrectionView().environmentObject(model))
         let panel = KeyPanel(
-            contentRect: NSRect(x: 0, y: 0, width: CorrectionMetrics.width, height: 200),
+            contentRect: NSRect(x: 0, y: 0, width: model.width, height: 200),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
@@ -81,28 +94,52 @@ final class CorrectionPanel {
         panel.adoptParrotAppearance()
         panel.onCancel = { [weak self] in self?.dismiss(cancelled: true) }
         panel.onUndo = { [weak self] in self?.model.undo() }
+        // Grow and shrink with the help disclosure, so opening it does not
+        // clip the explanation.
+        model.onResize = { [weak self] in self?.resize() }
         self.panel = panel
     }
 
     private func resize() {
         guard let panel else { return }
-        let height = CorrectionMetrics.height(forWords: model.spans.count)
-        panel.setContentSize(NSSize(width: CorrectionMetrics.width, height: height))
-        panel.contentView?.frame = NSRect(
-            x: 0, y: 0, width: CorrectionMetrics.width, height: height
+        let size = NSSize(
+            width: model.width,
+            height: CorrectionMetrics.height(model.spans, width: model.width, help: model.help)
         )
+        // Grows about its middle. The panel opens in the centre of the screen,
+        // and a disclosure that walked it upwards would move the sentence you
+        // are reading.
+        let old = panel.frame
+        let origin = panel.isVisible
+            ? NSPoint(x: old.midX - size.width / 2, y: old.midY - size.height / 2)
+            : old.origin
+        panel.setFrame(
+            NSRect(origin: origin, size: size), display: true, animate: panel.isVisible
+        )
+        panel.contentView?.frame = NSRect(origin: .zero, size: size)
     }
 
     private func reposition() {
         guard let panel else { return }
-        let mouse = NSEvent.mouseLocation
-        let screen = NSScreen.screens.first { NSMouseInRect(mouse, $0.frame, false) } ?? NSScreen.main
-        guard let frame = screen?.visibleFrame else { return }
+        guard let frame = Self.screen()?.visibleFrame else { return }
         let size = panel.frame.size
         panel.setFrameOrigin(NSPoint(
             x: frame.midX - size.width / 2,
             y: frame.midY - size.height / 2
         ))
+    }
+
+    /// The screen the panel will open on: the one the pointer is on, which is
+    /// the one you are working on.
+    private static func screen() -> NSScreen? {
+        let mouse = NSEvent.mouseLocation
+        return NSScreen.screens.first { NSMouseInRect(mouse, $0.frame, false) } ?? NSScreen.main
+    }
+
+    /// How wide the panel is allowed to get before it has to wrap.
+    private static func room() -> CGFloat {
+        let visible = screen()?.visibleFrame.width ?? CorrectionMetrics.minWidth
+        return visible - CorrectionMetrics.screenMargin * 2
     }
 }
 
@@ -119,32 +156,97 @@ enum CorrectionMetrics {
     static let lineGap: CGFloat = 16
     static let lineHeight: CGFloat = spanHeight + lineGap
 
-    static let width: CGFloat = 700
-    /// Header, the hint row, the footer, and the panel's own padding. Measured
-    /// off the built view rather than added up by hand: the sentence gets
-    /// whatever is left over, so guessing this low squeezes it and the words
-    /// disappear under the fold with nothing to say they have.
-    private static let chrome: CGFloat = 159
-    /// Past this the sentence scrolls rather than the panel growing. Three
-    /// lines is about thirty words — a long sentence, and already a panel a
-    /// third of the way down the screen. A whole paragraph of dictation would
-    /// otherwise open a panel taller than the screen it floats over.
-    static let maxLines = 3
-    /// What one word costs across the line, spacing included. Measured off the
-    /// panel at 21pt: ordinary dictation fits twelve or thirteen words to a
-    /// line at this width, and this is a little under that. Being wrong is
-    /// cheap either way — too few lines and the sentence scrolls, too many and
-    /// there is air under it.
-    private static let wordWidth: CGFloat = 56
+    /// The gap between two spans on a line. `SentenceFlow` is given the same
+    /// number, so the wrap counted here is the wrap you get.
+    static let spanGap: CGFloat = 7
 
-    private static func lines(forWords words: Int) -> Int {
-        let perLine = max(1, Int((width - Parrot.panelPadding * 2) / wordWidth))
-        return max(1, min(maxLines, (words + perLine - 1) / perLine))
+    /// Narrow enough not to be a slab behind four words, wide enough for the
+    /// footer: the confirm button naming three words is 310pt of label before
+    /// the key cap, and the status line and Cancel are beside it.
+    static let minWidth: CGFloat = 640
+    /// Air left either side of the panel on the screen it opens on.
+    static let screenMargin: CGFloat = 80
+    /// The head, the instruction, the hint row, the disclosure, the footer, and
+    /// the panel's own padding. Measured off the built view rather than added up by hand: the
+    /// sentence gets whatever is left over, so guessing this low squeezes it
+    /// and the words disappear under the fold with nothing to say they have.
+    private static let chrome: CGFloat = 210
+    /// The explanation, open. Measured the same way.
+    private static let helpHeight: CGFloat = 125
+    /// The explanation keeps a readable measure whatever the panel does — a
+    /// paragraph 1200pt wide is one your eye loses its place in — so its height
+    /// is one number rather than a function of the width. About 60 characters.
+    static let helpWidth: CGFloat = 380
+    /// Set on a leading of 1.6, which is loose for a paragraph you are meant to
+    /// read once. SwiftUI counts the extra, not the whole line.
+    static let helpLineSpacing: CGFloat = {
+        let font = NSFont.systemFont(ofSize: 12.5)
+        return 12.5 * 1.6 - NSLayoutManager().defaultLineHeight(for: font)
+    }()
+    /// Past this the sentence scrolls rather than the panel growing. Three
+    /// lines is a long sentence, and already a panel a third of the way down
+    /// the screen. A whole paragraph of dictation would otherwise open a panel
+    /// taller than the screen it floats over.
+    static let maxLines = 3
+
+    /// 21pt in the rounded face the struck line is set in. The words below it
+    /// are `WordField.font`, which is not rounded and not the same width.
+    static let heardFont: NSFont = {
+        let plain = NSFont.systemFont(ofSize: wordSize)
+        guard let rounded = plain.fontDescriptor.withDesign(.rounded) else { return plain }
+        return NSFont(descriptor: rounded, size: wordSize) ?? plain
+    }()
+
+    /// The width that puts the sentence on one line, within what the screen
+    /// allows. Past that it wraps, which is what the line count is for.
+    static func width(fitting spans: [Span], room: CGFloat) -> CGFloat {
+        let wanted = contentWidth(spans) + Parrot.panelPadding * 2
+        return min(max(minWidth, wanted), max(minWidth, room))
     }
 
-    static func height(forWords words: Int) -> CGFloat {
+    /// The whole sentence on one line.
+    static func contentWidth(_ spans: [Span]) -> CGFloat {
+        guard !spans.isEmpty else { return 0 }
+        return spans.reduce(0) { $0 + spanWidth($1) + spanGap } - spanGap
+    }
+
+    /// What one span occupies: the wider of the words and the struck line above
+    /// them. A name the decoder split takes its width from what was heard.
+    static func spanWidth(_ span: Span) -> CGFloat {
+        var written = span.value.reduce(0) { $0 + WordField.width(of: $1) }
+        written += CGFloat(max(0, span.value.count - 1)) * text(" ", in: WordField.font)
+        written += text(span.pre, in: WordField.font) + text(span.post, in: WordField.font)
+        let heard = span.showsHeard ? text(span.heardShown, in: heardFont) : 0
+        return max(written, heard)
+    }
+
+    private static func text(_ string: String, in font: NSFont) -> CGFloat {
+        guard !string.isEmpty else { return 0 }
+        return ceil((string as NSString).size(withAttributes: [.font: font]).width)
+    }
+
+    /// The same greedy wrap `SentenceFlow` does, counted ahead of time. The
+    /// panel is sized before it is drawn, and an estimate off by one line is
+    /// either a scrollbar on a sentence that fits or a band of nothing.
+    static func lines(_ spans: [Span], width: CGFloat) -> Int {
+        let available = width - Parrot.panelPadding * 2
+        var lines = 1
+        var x: CGFloat = 0
+        for span in spans {
+            let span = spanWidth(span)
+            if x > 0, x + span > available {
+                lines += 1
+                x = 0
+            }
+            x += span + spanGap
+        }
+        return lines
+    }
+
+    static func height(_ spans: [Span], width: CGFloat, help: Bool) -> CGFloat {
+        let shown = max(1, min(maxLines, lines(spans, width: width)))
         // The gap belongs between lines, so the last one does not pay for it.
-        chrome + lineHeight * CGFloat(lines(forWords: words)) - lineGap
+        return chrome + lineHeight * CGFloat(shown) - lineGap + (help ? helpHeight : 0)
     }
 }
 
@@ -176,16 +278,27 @@ private final class KeyPanel: NSPanel {
 
 struct CorrectionView: View {
     @EnvironmentObject private var model: SpansModel
+    @State private var hovering = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
-            PanelHeader(title: "Vocabulary", note: "teach me the words I got wrong")
+            head
+
+            // The one thing the panel wants from you, right above the words it
+            // is about, and larger than the title. The title says which panel
+            // this is; this says what to do with it.
+            Text("Fix what I misheard.")
+                .font(.system(size: 16.5))
+                .foregroundStyle(.primary)
+                .padding(.top, 2)
 
             // Scrolls past the cap rather than growing without end. A minute of
             // dictation is a paragraph, and a panel the height of the screen is
             // not a thing you can read a sentence off.
             ScrollView(.vertical) {
-                SentenceFlow(spacing: 7, lineSpacing: CorrectionMetrics.lineGap) {
+                SentenceFlow(
+                    spacing: CorrectionMetrics.spanGap, lineSpacing: CorrectionMetrics.lineGap
+                ) {
                     ForEach(model.spans) { span in
                         SpanView(span: span)
                     }
@@ -201,20 +314,12 @@ struct CorrectionView: View {
             // the sentence would push the buttons off the bottom.
             hint.opacity(model.hasEdited ? 1 : 0)
 
-            PanelActions(
-                status: summary,
-                cancelTitle: "Cancel",
-                confirmTitle: confirmTitle,
-                // The hint row above holds its space whether it shows or not,
-                // so the standing 24pt over the buttons would sit on top of a
-                // band of nothing.
-                compact: true,
-                onCancel: { model.onCancel?() },
-                onConfirm: { model.onSubmit?() }
-            )
+            help
+
+            footer
         }
         .padding(Parrot.panelPadding)
-        .frame(width: CorrectionMetrics.width)
+        .frame(width: model.width)
         .parrotSurface(
             RoundedRectangle(cornerRadius: Parrot.panelRadius, style: .continuous),
             solid: true
@@ -247,28 +352,150 @@ struct CorrectionView: View {
         }
     }
 
-    private var summary: String {
-        switch model.rules().count {
-        case 0: return "Change a word to teach one"
-        case 1: return "1 word → vocabulary"
-        case let count: return "\(count) words → vocabulary"
+    /// The name of the window, and nothing asked of you.
+    ///
+    /// The mark runs the plumage the other way from `PlumageMark` — shortest
+    /// bar sky, tallest scarlet — because this panel is read left to right off
+    /// a word, not off a pill.
+    private var head: some View {
+        HStack(spacing: 8) {
+            HStack(alignment: .bottom, spacing: 1.5) {
+                ForEach(Self.bars, id: \.height) { bar in
+                    Capsule()
+                        .fill(bar.colour)
+                        .frame(width: 2.5, height: bar.height)
+                }
+            }
+            .frame(height: 11, alignment: .bottom)
+
+            Text("Vocabulary".uppercased())
+                .font(.system(size: 11, weight: .semibold, design: .rounded))
+                .kerning(11 * 0.085)
+                .foregroundStyle(Parrot.sky)
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    private static let bars: [(height: CGFloat, colour: Color)] = [
+        (5, Parrot.sky), (7, Parrot.leaf), (9, Parrot.amber), (11, Parrot.scarlet)
+    ]
+
+    /// Three buttons, right to left in the order you are least likely to want
+    /// them. No status line: there was one saying "change a word to teach one",
+    /// which is the instruction a second time, in grey, in the far corner from
+    /// the words it is about.
+    private var footer: some View {
+        HStack(spacing: 8) {
+            Spacer(minLength: 12)
+
+            // The cap advertises ⌘Z; the panel is what handles it. The undo
+            // puts back a whole arrangement of spans and the field a keystroke
+            // landed in may not exist afterwards, so it cannot live on a field.
+            ActionButton(title: "Undo", key: "⌘Z", filled: false,
+                         enabled: model.canUndo, quiet: true) { model.undo() }
+
+            ActionButton(title: "Discard", key: "", filled: false, quiet: true) {
+                model.onCancel?()
+            }
+            .keyboardShortcut(.cancelAction)
+
+            // Leaf, the colour of a changed word's bar. The same promise: this
+            // is the thing that is going to happen.
+            ActionButton(title: confirmTitle, styled: confirmLabel, key: "↩",
+                         filled: false, glass: Parrot.leaf,
+                         enabled: model.hasChanges) { model.onSubmit?() }
+                // Plain Return, because Return already submits from inside a
+                // word — there is nowhere in this panel it would insert a line.
+                .keyboardShortcut(.return, modifiers: [])
+        }
+        .padding(.top, 4)
+    }
+
+    /// The one question the panel cannot answer by being looked at: which words
+    /// are worth correcting.
+    ///
+    /// Shut by default and shut again on every appearance. It answers something
+    /// you ask once — by the tenth correction, two paragraphs about what
+    /// dictation is are in the way of a two-second job.
+    private var help: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.16)) { model.help.toggle() }
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "arrowtriangle.right.fill")
+                        .font(.system(size: 7))
+                        .rotationEffect(.degrees(model.help ? 90 : 0))
+                    Text("Not sure what to correct?")
+                }
+                .font(.system(size: 11.5, design: .rounded))
+                .foregroundStyle(hovering ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary))
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .onHover { hovering = $0 }
+
+            if model.help { explanation }
+        }
+    }
+
+    private var explanation: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Text("Dictation gets ordinary words right. The ones it misses are yours: product names, people, the jargon you work in. Correct one here and ParrotFlow keeps it, so the next dictation hears it right.")
+            Text("Leave a word alone if you simply said it badly. There is nothing to learn from that one — say it again.")
+        }
+        .font(.system(size: 12.5))
+        .lineSpacing(CorrectionMetrics.helpLineSpacing)
+        .foregroundStyle(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(width: CorrectionMetrics.helpWidth, alignment: .leading)
+        .padding(.leading, 11)
+        // A rule rather than an indent on its own: the paragraphs are an aside
+        // about the sentence above them, and the line says so without a heading
+        // to say it. An overlay, not a column beside them — in an HStack the
+        // shape takes the height of the first paragraph and stops.
+        .overlay(alignment: .leading) {
+            RoundedRectangle(cornerRadius: 1)
+                .fill(Color.white.opacity(0.10))
+                .frame(width: 1.5)
         }
     }
 
     /// The button names the words it is about to teach.
     ///
     /// The corrected forms, not what was heard: those are the terms that get
-    /// written to the vocabulary, and reading them off the button before
-    /// pressing it is the whole check. Past three the names would run the
-    /// button into the status line, so it counts them instead. With nothing
-    /// changed there is nothing to name, and the status line to the left
-    /// already says what to do about that.
-    private var confirmTitle: String {
+    /// written, and reading them off the button before pressing it is the whole
+    /// check. Past three the names would run the button off the panel, so it
+    /// counts them instead. With none the sentence stays and the words drop out
+    /// of it, so the button does not change shape while you type.
+    private var confirmParts: [(text: String, lit: Bool)] {
         let words = model.rules().map(\.corrected)
-        switch words.count {
-        case 0: return "Save"
-        case 1...3: return "Add \(words.joined(separator: ", ")) to the vocabulary"
-        default: return "Add \(words.count) words to the vocabulary"
+        var parts: [(String, Bool)] = [("Add", false)]
+        if words.count > 3 {
+            parts.append((" \(words.count) words", false))
+        } else {
+            for (index, word) in words.enumerated() {
+                // English, not a list: "A and B", "A, B and C".
+                parts.append((index == 0 ? " " : (index == words.count - 1 ? " and " : ", "), false))
+                parts.append((word, true))
+            }
+        }
+        parts.append((" to the vocabulary", false))
+        return parts.map { (text: $0.0, lit: $0.1) }
+    }
+
+    private var confirmTitle: String {
+        confirmParts.map(\.text).joined()
+    }
+
+    /// The same sentence with the words themselves lit. They are the thing to
+    /// check before pressing it, so they are the part that is not dimmed.
+    private var confirmLabel: Text {
+        confirmParts.reduce(Text("")) { label, part in
+            label + (part.lit
+                ? Text(part.text).bold().foregroundStyle(Color.white)
+                : Text(part.text).foregroundStyle(ActionButton.glassText))
         }
     }
 }
@@ -288,10 +515,10 @@ private struct SpanView: View {
             // Set at the size of the word below it. Small, it read as a
             // footnote about the word; the same size, the two lines read as one
             // sentence rewritten over another.
-            Text(span.isChanged || span.heard.count > 1 ? span.heardShown : " ")
+            Text(span.showsHeard ? span.heardShown : " ")
                 .font(.system(size: CorrectionMetrics.wordSize, design: .rounded))
                 .foregroundStyle(.tertiary)
-                .strikethrough(span.isChanged || span.heard.count > 1, color: .white.opacity(0.22))
+                .strikethrough(span.showsHeard, color: .white.opacity(0.22))
                 .lineLimit(1)
                 .fixedSize()
 

--- a/Sources/ParrotFlow/CorrectionSpans.swift
+++ b/Sources/ParrotFlow/CorrectionSpans.swift
@@ -61,6 +61,15 @@ final class SpansModel: ObservableObject {
     @Published var spans: [Span] = []
     /// Which word has the caret, and where to put it after a rebuild.
     @Published var focus: SpanCaret?
+    /// Bumped every time the focus is asked for, even when it lands on the word
+    /// that already has it.
+    ///
+    /// `WordField` is driven by the value of `focus`, and an identical value is
+    /// not a change: SwiftUI does not redraw, so `makeFirstResponder` never
+    /// runs. That is exactly the opening focus — set once at load, asked for
+    /// again once the panel has a window — so the counter is what makes the
+    /// second ask a real one.
+    @Published private(set) var focusTick = 0
     /// Held back until the first edit — before you have touched anything the
     /// panel has one job, and a row of keys under it is a manual for a thing
     /// you have not started doing.
@@ -151,15 +160,21 @@ final class SpansModel: ObservableObject {
 
     // MARK: - What comes out
 
-    /// The caret starts in the first word. Without it the sentence reads as a
-    /// label: the panel was tested and the one thing said about it was that it
-    /// did not look editable.
+    /// The caret starts before the first letter of the first word. Without it
+    /// the sentence reads as a label: the panel was tested and the one thing
+    /// said about it was that it did not look editable.
+    ///
+    /// `at: 0` rather than the end, which is what nil means everywhere else.
+    /// Nil is right when you have arrived at a word to change it; here nothing
+    /// has been chosen yet, and the caret sits at the start of the sentence the
+    /// way it would in any other field you had just opened.
     ///
     /// Called again once the panel is on screen. A field can only be made first
     /// responder through its window, and when the sentence loads there is no
-    /// window yet.
+    /// window yet. See `focusTick` for what makes the second call count.
     func focusFirst() {
-        focus = spans.first.map { SpanCaret(span: $0.id, word: 0, at: nil) }
+        focus = spans.first.map { SpanCaret(span: $0.id, word: 0, at: 0) }
+        focusTick += 1
     }
 
     /// Anything to press the button for. Either a rule to teach, or a sentence

--- a/Sources/ParrotFlow/CorrectionSpans.swift
+++ b/Sources/ParrotFlow/CorrectionSpans.swift
@@ -345,6 +345,14 @@ final class SpansModel: ObservableObject {
         let gone = spans.remove(at: index)
         var into = spans[index - 1]
         let last = into.value.count - 1
+        // The punctuation that closed the word being joined to comes across
+        // first. `sentence()` prints the last heard word's `post` and no other,
+        // so once the two heard lists merge that mark has nowhere left to be
+        // printed from: "hello, world" joined came back "helloworld", a comma
+        // deleted by a keystroke aimed at the space.
+        into.value[last] += into.post
+        // Counted after it, so the caret lands where the space was rather than
+        // in front of a mark that was already there.
         let seam = into.value[last].utf16.count
         into.heard += gone.heard
         // The punctuation that opened the swallowed span comes across too.

--- a/Sources/ParrotFlow/CorrectionSpans.swift
+++ b/Sources/ParrotFlow/CorrectionSpans.swift
@@ -23,13 +23,26 @@ struct HeardWord: Equatable {
 
 struct Span: Identifiable, Equatable {
     let id: UUID
+    /// The whitespace that came before this span in the text the panel opened
+    /// on. Kept exactly, not normalised to one space: the panel opens on a
+    /// selection as often as on a fresh dictation, and a tab, a double space or
+    /// a line break in it is text nobody asked us to rewrite. The first span's
+    /// lead is whatever the selection started with.
+    ///
+    /// Never drawn: `SentenceFlow` spaces the words itself. This is only what
+    /// `sentence()` puts back.
+    var lead: String = ""
     /// Punctuation before the first word — an opening quote or bracket.
     var pre: String = ""
     var heard: [HeardWord]
     var value: [String]
 
-    init(id: UUID = UUID(), pre: String = "", heard: [HeardWord], value: [String]) {
+    init(
+        id: UUID = UUID(), lead: String = "", pre: String = "",
+        heard: [HeardWord], value: [String]
+    ) {
         self.id = id
+        self.lead = lead
         self.pre = pre
         self.heard = heard
         self.value = value
@@ -52,6 +65,13 @@ struct Span: Identifiable, Equatable {
 struct SpanCaret: Equatable {
     let span: UUID
     let word: Int
+    /// How far into the word, counted in **UTF-16 code units**. That is the one
+    /// coordinate system in this file, and it is that one because AppKit's
+    /// `NSRange` selection offsets are in it too, so `WordField` can use the
+    /// number as it stands. `String.count` counts grapheme clusters instead:
+    /// "😀" is 1 there and 2 here, "👩‍💻" is 1 there and 5 here, and a caret asked
+    /// for the end of such a word would land short of it.
+    ///
     /// Nil means the end of the word.
     let at: Int?
 }
@@ -93,6 +113,9 @@ final class SpansModel: ObservableObject {
     /// word was deleted". Neither teaches a rule; only one of them is a change
     /// worth a button.
     private var original = ""
+    /// The whitespace after the last word of the selection. On the model rather
+    /// than on a span: nothing can delete it, so nothing has to carry it.
+    private var trailing = ""
 
     private static let wordCharacters = CharacterSet.alphanumerics
         .union(CharacterSet(charactersIn: "'’-"))
@@ -100,7 +123,9 @@ final class SpansModel: ObservableObject {
     // MARK: - Loading
 
     func load(sentence: String) {
-        spans = Self.read(sentence)
+        let read = Self.read(sentence)
+        spans = read.spans
+        trailing = read.trailing
         // Nothing readable: one empty span, so the panel opens with somewhere
         // to type rather than with no fields at all.
         if spans.isEmpty { spans = [Span(heard: [HeardWord(word: "")], value: [""])] }
@@ -123,6 +148,11 @@ final class SpansModel: ObservableObject {
             guard !heard.isEmpty, !value.isEmpty else { return nil }
             return Span(heard: heard, value: value)
         }
+        // No source text here, so there are no separators to carry: one space
+        // between rules, which is what the panel assumed for everything before
+        // the leads existed.
+        for index in spans.indices.dropFirst() { spans[index].lead = " " }
+        trailing = ""
         if spans.isEmpty { spans = [Span(heard: [HeardWord(word: "")], value: [""])] }
         reset()
     }
@@ -136,22 +166,52 @@ final class SpansModel: ObservableObject {
         focusFirst()
     }
 
-    static func read(_ sentence: String) -> [Span] {
-        sentence.split(whereSeparator: \.isWhitespace).map { token in
-            let text = String(token)
-            var start = text.startIndex
-            var end = text.endIndex
-            while start < end, !isWord(text[start]) { start = text.index(after: start) }
-            while end > start, !isWord(text[text.index(before: end)]) {
-                end = text.index(before: end)
+    /// The sentence cut into spans, with the whitespace between them kept.
+    ///
+    /// Split-and-rejoin would be shorter and would normalise every separator to
+    /// one space. The panel opens on selections, so that would rewrite a tab, a
+    /// double space or a line break the user never touched, anywhere in the
+    /// selection, because one word beside it was corrected. Each span carries
+    /// the whitespace to its left; what is left over at the end is `trailing`.
+    static func read(_ sentence: String) -> (spans: [Span], trailing: String) {
+        var spans: [Span] = []
+        var lead = ""
+        var token = ""
+        for character in sentence {
+            if character.isWhitespace {
+                if !token.isEmpty {
+                    spans.append(span(token, lead: lead))
+                    lead = ""
+                    token = ""
+                }
+                lead.append(character)
+            } else {
+                token.append(character)
             }
-            let word = String(text[start..<end])
-            return Span(
-                pre: String(text[text.startIndex..<start]),
-                heard: [HeardWord(word: word, post: String(text[end...]))],
-                value: [word]
-            )
         }
+        if !token.isEmpty {
+            spans.append(span(token, lead: lead))
+            lead = ""
+        }
+        return (spans, lead)
+    }
+
+    /// One whitespace-free token, split into the punctuation around it and the
+    /// word inside.
+    private static func span(_ text: String, lead: String) -> Span {
+        var start = text.startIndex
+        var end = text.endIndex
+        while start < end, !isWord(text[start]) { start = text.index(after: start) }
+        while end > start, !isWord(text[text.index(before: end)]) {
+            end = text.index(before: end)
+        }
+        let word = String(text[start..<end])
+        return Span(
+            lead: lead,
+            pre: String(text[text.startIndex..<start]),
+            heard: [HeardWord(word: word, post: String(text[end...]))],
+            value: [word]
+        )
     }
 
     private static func isWord(_ character: Character) -> Bool {
@@ -193,10 +253,12 @@ final class SpansModel: ObservableObject {
     }
 
     /// The sentence as it now reads, ready to go back where it came from.
+    ///
+    /// Concatenated, not joined with a space. Every span carries the whitespace
+    /// that came before it, so the selection comes back spaced the way it went
+    /// in — tabs, double spaces and line breaks included.
     func sentence() -> String {
-        spans.map { $0.pre + $0.valueText + $0.post }
-            .filter { !$0.isEmpty }
-            .joined(separator: " ")
+        spans.reduce("") { $0 + $1.lead + $1.pre + $1.valueText + $1.post } + trailing
     }
 
     // MARK: - Editing
@@ -245,7 +307,13 @@ final class SpansModel: ObservableObject {
             return
         }
         guard spans.count > 1 else { return }
-        spans.remove(at: index)
+        // The whitespace before a word belongs to that word, so it goes with
+        // it: drop "bar" from "foo\nbar baz" and the line break goes too, and
+        // the space before "baz" is the one that survives. The first span is
+        // the exception — its lead is where the selection starts, not a gap
+        // between two words — so it is handed to whatever takes its place.
+        let gone = spans.remove(at: index)
+        if index == 0 { spans[0].lead = gone.lead }
         let back = max(0, index - 1)
         focus = SpanCaret(
             span: spans[back].id, word: spans[back].value.count - 1, at: nil
@@ -263,19 +331,25 @@ final class SpansModel: ObservableObject {
 
         if word > 0 {
             let taken = spans[index].value.remove(at: word)
-            let seam = spans[index].value[word - 1].count
+            // UTF-16, the unit `SpanCaret.at` is counted in.
+            let seam = spans[index].value[word - 1].utf16.count
             spans[index].value[word - 1] += taken
             focus = SpanCaret(span: id, word: word - 1, at: seam)
             return
         }
         guard index > 0 else { past.removeLast(); return }
 
+        // The lead goes with the seam: the two words become one word, and one
+        // word has no whitespace in the middle of it.
         let gone = spans.remove(at: index)
         var into = spans[index - 1]
         let last = into.value.count - 1
-        let seam = into.value[last].count
+        let seam = into.value[last].utf16.count
         into.heard += gone.heard
-        into.value[last] += gone.value.first ?? ""
+        // The punctuation that opened the swallowed span comes across too.
+        // Without it "blue" and "(red" join to "bluered" — a bracket deleted by
+        // a keystroke aimed at a space.
+        into.value[last] += gone.pre + (gone.value.first ?? "")
         into.value += gone.value.dropFirst()
         spans[index - 1] = into
         focus = SpanCaret(span: into.id, word: last, at: seam)
@@ -320,16 +394,18 @@ final class SpansModel: ObservableObject {
         typingAt = nil
     }
 
-    private func rememberTyping(in where_: String) {
+    /// `field` names one word of one span, so typing on is coalesced and typing
+    /// somewhere else is not.
+    private func rememberTyping(in field: String) {
         let now = Date()
-        if let typingAt, typingAt.word == where_,
+        if let typingAt, typingAt.word == field,
            now.timeIntervalSince(typingAt.when) < 0.7 {
-            self.typingAt = (where_, now)
+            self.typingAt = (field, now)
             return
         }
         past.append(spans)
         if past.count > 60 { past.removeFirst() }
-        typingAt = (where_, now)
+        typingAt = (field, now)
     }
 
     var canUndo: Bool { !past.isEmpty }

--- a/Sources/ParrotFlow/CorrectionSpans.swift
+++ b/Sources/ParrotFlow/CorrectionSpans.swift
@@ -40,6 +40,9 @@ struct Span: Identifiable, Equatable {
     var valueText: String { value.joined(separator: " ").trimmingCharacters(in: .whitespaces) }
     var post: String { heard.last?.post ?? "" }
     var isChanged: Bool { valueText != heardText }
+    /// Whether the struck line above the word has anything to say — the word
+    /// changed, or more than one heard word became it.
+    var showsHeard: Bool { isChanged || heard.count > 1 }
     /// More than one word on either side, so the underline has something to say
     /// by running under all of it.
     var isMulti: Bool { heard.count > 1 || value.count > 1 }
@@ -62,12 +65,25 @@ final class SpansModel: ObservableObject {
     /// panel has one job, and a row of keys under it is a manual for a thing
     /// you have not started doing.
     @Published var hasEdited = false
+    /// The long explanation, open or shut. Shut on every appearance: it is a
+    /// decision about the panel in front of you, not a preference to keep.
+    @Published var help = false {
+        didSet { onResize?() }
+    }
+    /// How wide the panel is. Fitted to the sentence when it loads, so a short
+    /// one is not given a line break it does not need.
+    @Published var width: CGFloat = CorrectionMetrics.minWidth
 
     var onSubmit: (() -> Void)?
     var onCancel: (() -> Void)?
+    var onResize: (() -> Void)?
 
     private var past: [[Span]] = []
     private var typingAt: (word: String, when: Date)?
+    /// The sentence as it arrived, to tell "nothing has happened" from "one
+    /// word was deleted". Neither teaches a rule; only one of them is a change
+    /// worth a button.
+    private var original = ""
 
     private static let wordCharacters = CharacterSet.alphanumerics
         .union(CharacterSet(charactersIn: "'’-"))
@@ -106,7 +122,9 @@ final class SpansModel: ObservableObject {
         past.removeAll()
         typingAt = nil
         hasEdited = false
-        focus = nil
+        help = false
+        original = sentence()
+        focusFirst()
     }
 
     static func read(_ sentence: String) -> [Span] {
@@ -132,6 +150,22 @@ final class SpansModel: ObservableObject {
     }
 
     // MARK: - What comes out
+
+    /// The caret starts in the first word. Without it the sentence reads as a
+    /// label: the panel was tested and the one thing said about it was that it
+    /// did not look editable.
+    ///
+    /// Called again once the panel is on screen. A field can only be made first
+    /// responder through its window, and when the sentence loads there is no
+    /// window yet.
+    func focusFirst() {
+        focus = spans.first.map { SpanCaret(span: $0.id, word: 0, at: nil) }
+    }
+
+    /// Anything to press the button for. Either a rule to teach, or a sentence
+    /// that now reads differently — clearing a word teaches nothing, but it is
+    /// still an edit, and dropping it into a dead button would lose it.
+    var hasChanges: Bool { !rules().isEmpty || sentence() != original }
 
     /// One rule per span that changed. Keyed on the span, which is the point.
     func rules() -> [(heard: String, corrected: String)] {

--- a/Sources/ParrotFlow/CorrectionSpans.swift
+++ b/Sources/ParrotFlow/CorrectionSpans.swift
@@ -36,6 +36,20 @@ struct Span: Identifiable, Equatable {
     var pre: String = ""
     var heard: [HeardWord]
     var value: [String]
+    /// This word holds punctuation that a join carried in, not punctuation
+    /// anybody typed. Set by `joinBack`, cleared as soon as you type the word
+    /// yourself, and it takes the span out of `rules()`.
+    ///
+    /// Provenance, not shape. Punctuation in a corrected word is often the
+    /// whole point — `.NET`, `O'Reilly`, `C++` are the terms people come to
+    /// this panel to teach — and no rule about which characters they are can
+    /// tell those from a comma that arrived because ⌫ ate the space in
+    /// "hello, world". Where the mark came from can.
+    ///
+    /// A flagged span still replaces. It teaches nothing, which is the right
+    /// way to fail: a rule not learned costs one more correction next time, and
+    /// a rule learned wrong fires forever, on sentences nobody meant to change.
+    var joinedMarks = false
 
     init(
         id: UUID = UUID(), lead: String = "", pre: String = "",
@@ -264,8 +278,13 @@ final class SpansModel: ObservableObject {
     var hasChanges: Bool { !rules().isEmpty || sentence() != original }
 
     /// One rule per span that changed. Keyed on the span, which is the point.
+    ///
+    /// Except a span whose punctuation a join carried in. That mark was never a
+    /// decision about a word, and a rule holding it would put it back into
+    /// every sentence that says those words again. See `Span.joinedMarks`.
     func rules() -> [(heard: String, corrected: String)] {
         spans.filter(\.isChanged).compactMap { span in
+            guard !span.joinedMarks else { return nil }
             let heard = span.heardText
             let corrected = span.valueText
             guard !heard.isEmpty, !corrected.isEmpty else { return nil }
@@ -300,6 +319,7 @@ final class SpansModel: ObservableObject {
                 return
             }
             spans[index].value.replaceSubrange(word...word, with: parts)
+            spans[index].joinedMarks = false
             moveCaret(to: SpanCaret(span: id, word: word + parts.count - 1, at: nil))
             return
         }
@@ -312,6 +332,11 @@ final class SpansModel: ObservableObject {
 
         rememberTyping(in: "\(id)-\(word)")
         spans[index].value[word] = text
+        // Typed is intentional. Whatever a join left in this word, you have now
+        // written the word yourself, so it is yours and it can be taught — even
+        // when what you wrote has punctuation in it, which for a name like
+        // "O'Reilly" is the reason you came to this panel.
+        spans[index].joinedMarks = false
         hasEdited = true
     }
 
@@ -370,7 +395,11 @@ final class SpansModel: ObservableObject {
         // so once the two heard lists merge that mark has nowhere left to be
         // printed from: "hello, world" joined came back "helloworld", a comma
         // deleted by a keystroke aimed at the space.
-        into.value[last] += into.post
+        //
+        // Read before the two heard lists merge, because after that `post` is
+        // the swallowed span's own mark and no longer this one's.
+        let swallowed = into.post
+        into.value[last] += swallowed
         // Counted after it, so the caret lands where the space was rather than
         // in front of a mark that was already there.
         let seam = into.value[last].utf16.count
@@ -380,6 +409,10 @@ final class SpansModel: ObservableObject {
         // a keystroke aimed at a space.
         into.value[last] += gone.pre + (gone.value.first ?? "")
         into.value += gone.value.dropFirst()
+        // Both marks are in the word now, and neither was typed. The word still
+        // goes back into the sentence — you joined it on purpose — but it
+        // teaches nothing until you write it yourself. See `Span.joinedMarks`.
+        if !(swallowed + gone.pre).isEmpty { into.joinedMarks = true }
         spans[index - 1] = into
         moveCaret(to: SpanCaret(span: into.id, word: last, at: seam))
     }

--- a/Sources/ParrotFlow/CorrectionSpans.swift
+++ b/Sources/ParrotFlow/CorrectionSpans.swift
@@ -89,6 +89,8 @@ final class SpansModel: ObservableObject {
     /// runs. That is exactly the opening focus — set once at load, asked for
     /// again once the panel has a window — so the counter is what makes the
     /// second ask a real one.
+    ///
+    /// It is also what re-arms a field you are coming back to. See `moveCaret`.
     @Published private(set) var focusTick = 0
     /// Held back until the first edit — before you have touched anything the
     /// panel has one job, and a row of keys under it is a manual for a thing
@@ -234,7 +236,25 @@ final class SpansModel: ObservableObject {
     /// responder through its window, and when the sentence loads there is no
     /// window yet. See `focusTick` for what makes the second call count.
     func focusFirst() {
-        focus = spans.first.map { SpanCaret(span: $0.id, word: 0, at: 0) }
+        moveCaret(to: spans.first.map { SpanCaret(span: $0.id, word: 0, at: 0) })
+    }
+
+    /// Put the caret somewhere, and renew the request so the field it names
+    /// answers it.
+    ///
+    /// The renewal is the point. `WordField` clears its own `placeCaret` once a
+    /// request has been answered, and arms it again only when the tick changes.
+    /// So a field you have already visited has cleared it, and coming back —
+    /// with an arrow, a tab, a join — would make it first responder and stop
+    /// there. Making a text field first responder selects the whole of it, so
+    /// the word would sit highlighted with the asked-for caret never placed,
+    /// and the next character typed would replace the word.
+    ///
+    /// Every keyboard move goes through here. A click does not: AppKit has
+    /// already put the caret where the pointer was, and re-placing it would
+    /// drag it to the end of the word you clicked into.
+    private func moveCaret(to caret: SpanCaret?) {
+        focus = caret
         focusTick += 1
     }
 
@@ -280,7 +300,7 @@ final class SpansModel: ObservableObject {
                 return
             }
             spans[index].value.replaceSubrange(word...word, with: parts)
-            focus = SpanCaret(span: id, word: word + parts.count - 1, at: nil)
+            moveCaret(to: SpanCaret(span: id, word: word + parts.count - 1, at: nil))
             return
         }
 
@@ -304,7 +324,7 @@ final class SpansModel: ObservableObject {
         hasEdited = true
         if spans[index].value.count > 1 {
             spans[index].value.remove(at: word)
-            focus = SpanCaret(span: id, word: max(0, word - 1), at: nil)
+            moveCaret(to: SpanCaret(span: id, word: max(0, word - 1), at: nil))
             return
         }
         guard spans.count > 1 else { return }
@@ -316,9 +336,9 @@ final class SpansModel: ObservableObject {
         let gone = spans.remove(at: index)
         if index == 0 { spans[0].lead = gone.lead }
         let back = max(0, index - 1)
-        focus = SpanCaret(
+        moveCaret(to: SpanCaret(
             span: spans[back].id, word: spans[back].value.count - 1, at: nil
-        )
+        ))
     }
 
     /// Backspace at the start of a word. Inside a span it glues two written
@@ -335,7 +355,7 @@ final class SpansModel: ObservableObject {
             // UTF-16, the unit `SpanCaret.at` is counted in.
             let seam = spans[index].value[word - 1].utf16.count
             spans[index].value[word - 1] += taken
-            focus = SpanCaret(span: id, word: word - 1, at: seam)
+            moveCaret(to: SpanCaret(span: id, word: word - 1, at: seam))
             return
         }
         guard index > 0 else { past.removeLast(); return }
@@ -361,7 +381,7 @@ final class SpansModel: ObservableObject {
         into.value[last] += gone.pre + (gone.value.first ?? "")
         into.value += gone.value.dropFirst()
         spans[index - 1] = into
-        focus = SpanCaret(span: into.id, word: last, at: seam)
+        moveCaret(to: SpanCaret(span: into.id, word: last, at: seam))
     }
 
     // MARK: - Moving about
@@ -373,12 +393,12 @@ final class SpansModel: ObservableObject {
     /// the way.
     func step(from id: UUID, word: Int, forward: Bool, keepingEdge: Bool) {
         guard let target = neighbour(of: id, word: word, forward: forward) else { return }
-        focus = SpanCaret(
+        moveCaret(to: SpanCaret(
             span: target.span, word: target.word,
             // Tab is a different job — arriving somewhere to change it — so it
             // lands on the last character whichever way it went.
             at: keepingEdge && forward ? nil : (keepingEdge ? 0 : nil)
-        )
+        ))
     }
 
     private func neighbour(

--- a/Sources/ParrotFlow/CorrectionSpans.swift
+++ b/Sources/ParrotFlow/CorrectionSpans.swift
@@ -1,0 +1,294 @@
+import AppKit
+import SwiftUI
+
+/// The sentence you just said, as spans, so a rule can be keyed on one.
+///
+/// A span owns two lists — the words that were **heard** and the words that
+/// **replace** them — and that is the whole idea. One heard word can become two
+/// and two can become one without either side losing track of the other, which
+/// is what a row-per-word panel could not express: `Redcrawl` decoded as "red
+/// crawl" has no row to live on, and typing the name into the first row taught
+/// the rule `red => Redcrawl`, which fires on the colour.
+///
+/// Everything below this panel already works in spans. The fuzzy pass scans
+/// two-word windows, `Vocabulary.widerSpans` offers the wider span for a name
+/// the decoder split, and `autoApplies` has a branch for exactly this shape.
+/// The panel was the last place still counting in words.
+struct HeardWord: Equatable {
+    var word: String
+    /// Punctuation that came after it. Kept per word so folding "his." into
+    /// "praise" does not cost the sentence its full stop.
+    var post: String = ""
+}
+
+struct Span: Identifiable, Equatable {
+    let id: UUID
+    /// Punctuation before the first word — an opening quote or bracket.
+    var pre: String = ""
+    var heard: [HeardWord]
+    var value: [String]
+
+    init(id: UUID = UUID(), pre: String = "", heard: [HeardWord], value: [String]) {
+        self.id = id
+        self.pre = pre
+        self.heard = heard
+        self.value = value
+    }
+
+    var heardText: String { heard.map(\.word).joined(separator: " ") }
+    var heardShown: String { heard.map { $0.word + $0.post }.joined(separator: " ") }
+    var valueText: String { value.joined(separator: " ").trimmingCharacters(in: .whitespaces) }
+    var post: String { heard.last?.post ?? "" }
+    var isChanged: Bool { valueText != heardText }
+    /// More than one word on either side, so the underline has something to say
+    /// by running under all of it.
+    var isMulti: Bool { heard.count > 1 || value.count > 1 }
+}
+
+/// Where the caret is, so a structural edit can put it back.
+struct SpanCaret: Equatable {
+    let span: UUID
+    let word: Int
+    /// Nil means the end of the word.
+    let at: Int?
+}
+
+final class SpansModel: ObservableObject {
+
+    @Published var spans: [Span] = []
+    /// Which word has the caret, and where to put it after a rebuild.
+    @Published var focus: SpanCaret?
+    /// Held back until the first edit — before you have touched anything the
+    /// panel has one job, and a row of keys under it is a manual for a thing
+    /// you have not started doing.
+    @Published var hasEdited = false
+
+    var onSubmit: (() -> Void)?
+    var onCancel: (() -> Void)?
+
+    private var past: [[Span]] = []
+    private var typingAt: (word: String, when: Date)?
+
+    private static let wordCharacters = CharacterSet.alphanumerics
+        .union(CharacterSet(charactersIn: "'’-"))
+
+    // MARK: - Loading
+
+    func load(sentence: String) {
+        spans = Self.read(sentence)
+        // Nothing readable: one empty span, so the panel opens with somewhere
+        // to type rather than with no fields at all.
+        if spans.isEmpty { spans = [Span(heard: [HeardWord(word: "")], value: [""])] }
+        reset()
+    }
+
+    /// Spans built from the rules themselves, one span per rule.
+    ///
+    /// Not `load(sentence:)` over the heard words joined up: that splits on
+    /// whitespace, so a rule that heard two words ("red crawl") becomes two
+    /// spans, and every rule after it lands on the wrong one. A rule is already
+    /// a span — heard words on one side, written words on the other — so it is
+    /// carried across as one.
+    func load(rules: [(heard: String, corrected: String)]) {
+        spans = rules.compactMap { rule in
+            let heard = rule.heard.split(whereSeparator: \.isWhitespace).map {
+                HeardWord(word: String($0))
+            }
+            let value = rule.corrected.split(whereSeparator: \.isWhitespace).map(String.init)
+            guard !heard.isEmpty, !value.isEmpty else { return nil }
+            return Span(heard: heard, value: value)
+        }
+        if spans.isEmpty { spans = [Span(heard: [HeardWord(word: "")], value: [""])] }
+        reset()
+    }
+
+    private func reset() {
+        past.removeAll()
+        typingAt = nil
+        hasEdited = false
+        focus = nil
+    }
+
+    static func read(_ sentence: String) -> [Span] {
+        sentence.split(whereSeparator: \.isWhitespace).map { token in
+            let text = String(token)
+            var start = text.startIndex
+            var end = text.endIndex
+            while start < end, !isWord(text[start]) { start = text.index(after: start) }
+            while end > start, !isWord(text[text.index(before: end)]) {
+                end = text.index(before: end)
+            }
+            let word = String(text[start..<end])
+            return Span(
+                pre: String(text[text.startIndex..<start]),
+                heard: [HeardWord(word: word, post: String(text[end...]))],
+                value: [word]
+            )
+        }
+    }
+
+    private static func isWord(_ character: Character) -> Bool {
+        character.unicodeScalars.allSatisfy { wordCharacters.contains($0) }
+    }
+
+    // MARK: - What comes out
+
+    /// One rule per span that changed. Keyed on the span, which is the point.
+    func rules() -> [(heard: String, corrected: String)] {
+        spans.filter(\.isChanged).compactMap { span in
+            let heard = span.heardText
+            let corrected = span.valueText
+            guard !heard.isEmpty, !corrected.isEmpty else { return nil }
+            return (heard, corrected)
+        }
+    }
+
+    /// The sentence as it now reads, ready to go back where it came from.
+    func sentence() -> String {
+        spans.map { $0.pre + $0.valueText + $0.post }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
+    // MARK: - Editing
+
+    /// A word was typed into. Coalesced, so a word typed letter by letter comes
+    /// back in one undo rather than eight.
+    func typed(_ text: String, span id: UUID, word: Int) {
+        guard let index = spans.firstIndex(where: { $0.id == id }),
+              spans[index].value.indices.contains(word) else { return }
+
+        // Whitespace anywhere — typed, or pasted — splits. Two written words,
+        // one heard span, and the underline runs under both to say so.
+        if text.contains(where: \.isWhitespace) {
+            let parts = text.split(whereSeparator: \.isWhitespace).map(String.init)
+            remember()
+            if parts.isEmpty {
+                removeWord(span: id, word: word)
+                return
+            }
+            spans[index].value.replaceSubrange(word...word, with: parts)
+            focus = SpanCaret(span: id, word: word + parts.count - 1, at: nil)
+            return
+        }
+
+        if text.isEmpty {
+            remember()
+            removeWord(span: id, word: word)
+            return
+        }
+
+        rememberTyping(in: "\(id)-\(word)")
+        spans[index].value[word] = text
+        hasEdited = true
+    }
+
+    /// A word cleared is a word you have decided not to write, and that is all
+    /// it is. Nothing nests under the word before it, and nothing is taught — a
+    /// rule mapping an ordinary word to nothing would fire on every dictation
+    /// you ever gave. Joining two words is a separate gesture with its own key.
+    private func removeWord(span id: UUID, word: Int) {
+        guard let index = spans.firstIndex(where: { $0.id == id }) else { return }
+        hasEdited = true
+        if spans[index].value.count > 1 {
+            spans[index].value.remove(at: word)
+            focus = SpanCaret(span: id, word: max(0, word - 1), at: nil)
+            return
+        }
+        guard spans.count > 1 else { return }
+        spans.remove(at: index)
+        let back = max(0, index - 1)
+        focus = SpanCaret(
+            span: spans[back].id, word: spans[back].value.count - 1, at: nil
+        )
+    }
+
+    /// Backspace at the start of a word. Inside a span it glues two written
+    /// words back together — the inverse of pressing space. At the head of a
+    /// span it swallows the span before, heard and written both, and the caret
+    /// sits at the seam.
+    func joinBack(span id: UUID, word: Int) {
+        guard let index = spans.firstIndex(where: { $0.id == id }) else { return }
+        remember()
+        hasEdited = true
+
+        if word > 0 {
+            let taken = spans[index].value.remove(at: word)
+            let seam = spans[index].value[word - 1].count
+            spans[index].value[word - 1] += taken
+            focus = SpanCaret(span: id, word: word - 1, at: seam)
+            return
+        }
+        guard index > 0 else { past.removeLast(); return }
+
+        let gone = spans.remove(at: index)
+        var into = spans[index - 1]
+        let last = into.value.count - 1
+        let seam = into.value[last].count
+        into.heard += gone.heard
+        into.value[last] += gone.value.first ?? ""
+        into.value += gone.value.dropFirst()
+        spans[index - 1] = into
+        focus = SpanCaret(span: into.id, word: last, at: seam)
+    }
+
+    // MARK: - Moving about
+
+    /// The arrows keep their edge. From before the first character, left goes
+    /// to before the first character of the word to the left; from after the
+    /// last, right goes to after the last. At an edge you are moving between
+    /// words rather than through them, and the caret should not change sides on
+    /// the way.
+    func step(from id: UUID, word: Int, forward: Bool, keepingEdge: Bool) {
+        guard let target = neighbour(of: id, word: word, forward: forward) else { return }
+        focus = SpanCaret(
+            span: target.span, word: target.word,
+            // Tab is a different job — arriving somewhere to change it — so it
+            // lands on the last character whichever way it went.
+            at: keepingEdge && forward ? nil : (keepingEdge ? 0 : nil)
+        )
+    }
+
+    private func neighbour(
+        of id: UUID, word: Int, forward: Bool
+    ) -> (span: UUID, word: Int)? {
+        guard let index = spans.firstIndex(where: { $0.id == id }) else { return nil }
+        if forward {
+            if word + 1 < spans[index].value.count { return (id, word + 1) }
+            guard index + 1 < spans.count else { return nil }
+            return (spans[index + 1].id, 0)
+        }
+        if word > 0 { return (id, word - 1) }
+        guard index > 0 else { return nil }
+        return (spans[index - 1].id, spans[index - 1].value.count - 1)
+    }
+
+    // MARK: - Undo
+
+    private func remember() {
+        past.append(spans)
+        if past.count > 60 { past.removeFirst() }
+        typingAt = nil
+    }
+
+    private func rememberTyping(in where_: String) {
+        let now = Date()
+        if let typingAt, typingAt.word == where_,
+           now.timeIntervalSince(typingAt.when) < 0.7 {
+            self.typingAt = (where_, now)
+            return
+        }
+        past.append(spans)
+        if past.count > 60 { past.removeFirst() }
+        typingAt = (where_, now)
+    }
+
+    var canUndo: Bool { !past.isEmpty }
+
+    func undo() {
+        guard let last = past.popLast() else { return }
+        spans = last
+        typingAt = nil
+        focus = nil
+    }
+}

--- a/Sources/ParrotFlow/CorrectionSpans.swift
+++ b/Sources/ParrotFlow/CorrectionSpans.swift
@@ -36,9 +36,9 @@ struct Span: Identifiable, Equatable {
     var pre: String = ""
     var heard: [HeardWord]
     var value: [String]
-    /// This word holds punctuation that a join carried in, not punctuation
-    /// anybody typed. Set by `joinBack`, cleared as soon as you type the word
-    /// yourself, and it takes the span out of `rules()`.
+    /// The marks a join carried into this word — punctuation nobody typed.
+    /// Filled by `joinBack`, emptied as you delete them, and while it holds
+    /// anything the span stays out of `rules()`.
     ///
     /// Provenance, not shape. Punctuation in a corrected word is often the
     /// whole point — `.NET`, `O'Reilly`, `C++` are the terms people come to
@@ -46,10 +46,15 @@ struct Span: Identifiable, Equatable {
     /// tell those from a comma that arrived because ⌫ ate the space in
     /// "hello, world". Where the mark came from can.
     ///
-    /// A flagged span still replaces. It teaches nothing, which is the right
-    /// way to fail: a rule not learned costs one more correction next time, and
-    /// a rule learned wrong fires forever, on sentences nobody meant to change.
-    var joinedMarks = false
+    /// The characters, not a flag, because typing is not consent. Capitalise
+    /// the H in "hello,world" and the comma is still a comma you never typed,
+    /// so the span goes on teaching nothing. Delete the comma and it teaches.
+    ///
+    /// A span holding marks still replaces. It teaches nothing, which is the
+    /// right way to fail: a rule not learned costs one more correction next
+    /// time, and a rule learned wrong fires forever, on sentences nobody meant
+    /// to change.
+    var joinedMarks: Set<Character> = []
 
     init(
         id: UUID = UUID(), lead: String = "", pre: String = "",
@@ -284,7 +289,7 @@ final class SpansModel: ObservableObject {
     /// every sentence that says those words again. See `Span.joinedMarks`.
     func rules() -> [(heard: String, corrected: String)] {
         spans.filter(\.isChanged).compactMap { span in
-            guard !span.joinedMarks else { return nil }
+            guard span.joinedMarks.isEmpty else { return nil }
             let heard = span.heardText
             let corrected = span.valueText
             guard !heard.isEmpty, !corrected.isEmpty else { return nil }
@@ -319,7 +324,7 @@ final class SpansModel: ObservableObject {
                 return
             }
             spans[index].value.replaceSubrange(word...word, with: parts)
-            spans[index].joinedMarks = false
+            pruneJoinedMarks(at: index)
             moveCaret(to: SpanCaret(span: id, word: word + parts.count - 1, at: nil))
             return
         }
@@ -332,12 +337,20 @@ final class SpansModel: ObservableObject {
 
         rememberTyping(in: "\(id)-\(word)")
         spans[index].value[word] = text
-        // Typed is intentional. Whatever a join left in this word, you have now
-        // written the word yourself, so it is yours and it can be taught — even
-        // when what you wrote has punctuation in it, which for a name like
-        // "O'Reilly" is the reason you came to this panel.
-        spans[index].joinedMarks = false
+        pruneJoinedMarks(at: index)
         hasEdited = true
+    }
+
+    /// Forget any carried mark the span no longer holds.
+    ///
+    /// A mark you deleted is a mark you decided about, so the span can teach
+    /// again. A mark still sitting there is one you typed around, not one you
+    /// chose — see `Span.joinedMarks`. Punctuation you typed yourself is never
+    /// in the set, so "O'Reilly" and ".NET" are taught whatever else happens.
+    private func pruneJoinedMarks(at index: Int) {
+        guard !spans[index].joinedMarks.isEmpty else { return }
+        let written = spans[index].valueText
+        spans[index].joinedMarks = spans[index].joinedMarks.filter(written.contains)
     }
 
     /// A word cleared is a word you have decided not to write, and that is all
@@ -349,6 +362,7 @@ final class SpansModel: ObservableObject {
         hasEdited = true
         if spans[index].value.count > 1 {
             spans[index].value.remove(at: word)
+            pruneJoinedMarks(at: index)
             moveCaret(to: SpanCaret(span: id, word: max(0, word - 1), at: nil))
             return
         }
@@ -412,7 +426,8 @@ final class SpansModel: ObservableObject {
         // Both marks are in the word now, and neither was typed. The word still
         // goes back into the sentence — you joined it on purpose — but it
         // teaches nothing until you write it yourself. See `Span.joinedMarks`.
-        if !(swallowed + gone.pre).isEmpty { into.joinedMarks = true }
+        into.joinedMarks.formUnion(swallowed)
+        into.joinedMarks.formUnion(gone.pre)
         spans[index - 1] = into
         moveCaret(to: SpanCaret(span: into.id, word: last, at: seam))
     }

--- a/Sources/ParrotFlow/CorrectionSpans.swift
+++ b/Sources/ParrotFlow/CorrectionSpans.swift
@@ -189,9 +189,10 @@ final class SpansModel: ObservableObject {
                 token.append(character)
             }
         }
-        if !token.isEmpty {
+        // A word at the end takes the whitespace before it, so nothing trails.
+        guard token.isEmpty else {
             spans.append(span(token, lead: lead))
-            lead = ""
+            return (spans, "")
         }
         return (spans, lead)
     }

--- a/Sources/ParrotFlow/CorrectionSpansView.swift
+++ b/Sources/ParrotFlow/CorrectionSpansView.swift
@@ -20,8 +20,10 @@ struct WordField: NSViewRepresentable {
     let text: String
     let isChanged: Bool
     let focused: Bool
-    /// Where to put the caret when focus arrives. Nil is the end, which is
-    /// where you want it when you have come to a word to change it.
+    /// Where to put the caret when focus arrives, in UTF-16 code units — see
+    /// `SpanCaret.at`, which is the only coordinate system the model counts in.
+    /// Nil is the end, which is where you want it when you have come to a word
+    /// to change it.
     let caret: Int?
     /// `SpansModel.focusTick`. It is here so a focus asked for twice with the
     /// same value still reaches `updateNSView` — see the model for why the
@@ -69,7 +71,13 @@ struct WordField: NSViewRepresentable {
         let editing = window.firstResponder === field.currentEditor()
         if !editing { window.makeFirstResponder(field) }
         if let editor = field.currentEditor() {
-            let at = caret.map { min($0, field.stringValue.count) } ?? field.stringValue.count
+            // `NSString.length`, not `String.count`. An NSRange counts UTF-16
+            // code units; `count` counts characters. They disagree on anything
+            // with an emoji or a combining accent in it — "😀" is 1 against 2,
+            // "👩‍💻" is 1 against 5 — so "the end of the word" clamped by `count`
+            // lands short of the end.
+            let length = (field.stringValue as NSString).length
+            let at = caret.map { min($0, length) } ?? length
             let wanted = NSRange(location: at, length: 0)
             // Cleared once the request has been answered, and the caret already
             // being there is an answer. Left set, it would fire on the next
@@ -126,7 +134,12 @@ struct WordField: NSViewRepresentable {
         ) -> Bool {
             let range = textView.selectedRange()
             let atStart = range.location == 0 && range.length == 0
-            let atEnd = range.location == textView.string.count && range.length == 0
+            // Same units on both sides: `selectedRange` is UTF-16, so the
+            // length it is compared against has to be. With `String.count` a
+            // word ending in an emoji never reads as "at the end", and the
+            // right arrow stops crossing to the next word.
+            let atEnd = range.location == (textView.string as NSString).length
+                && range.length == 0
 
             switch selector {
             case #selector(NSResponder.deleteBackward(_:)):

--- a/Sources/ParrotFlow/CorrectionSpansView.swift
+++ b/Sources/ParrotFlow/CorrectionSpansView.swift
@@ -58,7 +58,14 @@ struct WordField: NSViewRepresentable {
     func updateNSView(_ field: NSTextField, context: Wrapped) {
         context.coordinator.owner = self
         if field.stringValue != text { field.stringValue = text }
-        field.textColor = isChanged ? .white : NSColor.white.withAlphaComponent(0.82)
+        // Amber is the panel's colour for "this is the change": the corrected
+        // word here, the struck word above it, and the same words on the
+        // button. An unchanged word is dimmer than it was — still plainly text
+        // you can type into, but no longer competing with the one word you are
+        // being asked to check.
+        field.textColor = isChanged
+            ? NSColor(Parrot.amber)
+            : NSColor.white.withAlphaComponent(0.62)
 
         guard focused else { return }
         guard let window = field.window else { return }
@@ -91,13 +98,28 @@ struct WordField: NSViewRepresentable {
         }
     }
 
-    /// What one word occupies. Public because the panel has to know how wide
-    /// the sentence is before it opens — see `CorrectionMetrics.width` — and
-    /// two ways of measuring the same word would disagree by a pixel a word.
+    /// What one word occupies: its glyphs, and nothing more.
+    ///
+    /// Nothing more is the point. This used to return the glyphs plus 3pt, and
+    /// those 3pt were the daylight in front of every comma: the sentence is
+    /// drawn edge to edge, so slack inside a word's box is a gap between the
+    /// word and the punctuation that follows it. Measured off a render, the gap
+    /// before a comma went 5pt to 2pt when the 3pt came off, against 9.5pt after
+    /// it — which is a comma attached to the word it belongs to.
+    ///
+    /// The field's own inset needs no allowance here. `NSTextField` reports
+    /// `alignmentRectInsets` of 2pt either side, SwiftUI lays out the alignment
+    /// rect and hands the view a frame 2pt wider on each edge, so the glyphs
+    /// land exactly on the box. Those 2pt on the right are also where the caret
+    /// stands at the end of a word.
+    ///
+    /// Public because the panel has to know how wide the sentence is before it
+    /// opens — see `CorrectionMetrics.width` — and two ways of measuring the
+    /// same word would disagree by a pixel a word.
     static func width(of text: String) -> CGFloat {
         let width = (text as NSString).size(withAttributes: [.font: font]).width
         // A caret needs somewhere to stand in an empty word.
-        return max(ceil(width) + 3, 8)
+        return max(ceil(width), 8)
     }
 
     static var height: CGFloat { ceil(font.ascender - font.descender) + 2 }

--- a/Sources/ParrotFlow/CorrectionSpansView.swift
+++ b/Sources/ParrotFlow/CorrectionSpansView.swift
@@ -137,6 +137,9 @@ struct WordField: NSViewRepresentable {
         /// Set when the model asked for a caret position, cleared once it has
         /// been honoured — otherwise every redraw drags the caret back and you
         /// cannot move within a word.
+        ///
+        /// True to begin with, because the first tick a coordinator sees is the
+        /// one it was born holding, so nothing would arm the opening caret.
         var placeCaret = true
         /// The last tick honoured, so the next one is seen as new.
         var tick: Int
@@ -163,28 +166,30 @@ struct WordField: NSViewRepresentable {
             let atEnd = range.location == (textView.string as NSString).length
                 && range.length == 0
 
+            // None of these arm `placeCaret` here. This is the field the caret
+            // is leaving, and arming it does nothing for the field it is going
+            // to — that one is armed by the tick, which the model bumps on
+            // every move. Armed here it would only matter when the move does
+            // not happen: an arrow at the very end of the sentence has nowhere
+            // to go, and a field left armed drags the caret back on the redraw
+            // that follows your next keystroke.
             switch selector {
             case #selector(NSResponder.deleteBackward(_:)):
                 guard atStart else { return false }
-                placeCaret = true
                 owner.onJoinBack()
                 return true
             case #selector(NSResponder.moveLeft(_:)):
                 guard atStart else { return false }
-                placeCaret = true
                 owner.onEdge(false)
                 return true
             case #selector(NSResponder.moveRight(_:)):
                 guard atEnd else { return false }
-                placeCaret = true
                 owner.onEdge(true)
                 return true
             case #selector(NSResponder.insertTab(_:)):
-                placeCaret = true
                 owner.onTab(true)
                 return true
             case #selector(NSResponder.insertBacktab(_:)):
-                placeCaret = true
                 owner.onTab(false)
                 return true
             case #selector(NSResponder.insertNewline(_:)):

--- a/Sources/ParrotFlow/CorrectionSpansView.swift
+++ b/Sources/ParrotFlow/CorrectionSpansView.swift
@@ -68,13 +68,21 @@ struct WordField: NSViewRepresentable {
         }
     }
 
+    /// What one word occupies. Public because the panel has to know how wide
+    /// the sentence is before it opens — see `CorrectionMetrics.width` — and
+    /// two ways of measuring the same word would disagree by a pixel a word.
+    static func width(of text: String) -> CGFloat {
+        let width = (text as NSString).size(withAttributes: [.font: font]).width
+        // A caret needs somewhere to stand in an empty word.
+        return max(ceil(width) + 3, 8)
+    }
+
+    static var height: CGFloat { ceil(font.ascender - font.descender) + 2 }
+
     func sizeThatFits(
         _ proposal: ProposedViewSize, nsView: NSTextField, context: Wrapped
     ) -> CGSize? {
-        let width = (text as NSString)
-            .size(withAttributes: [.font: Self.font]).width
-        // A caret needs somewhere to stand in an empty word.
-        return CGSize(width: max(ceil(width) + 3, 8), height: ceil(Self.font.ascender - Self.font.descender) + 2)
+        CGSize(width: Self.width(of: text), height: Self.height)
     }
 
     func makeCoordinator() -> Coordinator { Coordinator(self) }

--- a/Sources/ParrotFlow/CorrectionSpansView.swift
+++ b/Sources/ParrotFlow/CorrectionSpansView.swift
@@ -23,6 +23,10 @@ struct WordField: NSViewRepresentable {
     /// Where to put the caret when focus arrives. Nil is the end, which is
     /// where you want it when you have come to a word to change it.
     let caret: Int?
+    /// `SpansModel.focusTick`. It is here so a focus asked for twice with the
+    /// same value still reaches `updateNSView` — see the model for why the
+    /// panel does that.
+    let tick: Int
 
     var onChange: (String) -> Void
     var onJoinBack: () -> Void
@@ -56,13 +60,24 @@ struct WordField: NSViewRepresentable {
 
         guard focused else { return }
         guard let window = field.window else { return }
+        // A new tick is the model asking for the caret again. It asks twice on
+        // opening, and the second ask is the one that can work.
+        if context.coordinator.tick != tick {
+            context.coordinator.tick = tick
+            context.coordinator.placeCaret = true
+        }
         let editing = window.firstResponder === field.currentEditor()
         if !editing { window.makeFirstResponder(field) }
         if let editor = field.currentEditor() {
             let at = caret.map { min($0, field.stringValue.count) } ?? field.stringValue.count
             let wanted = NSRange(location: at, length: 0)
-            if !editing || editor.selectedRange != wanted, context.coordinator.placeCaret {
-                editor.selectedRange = wanted
+            // Cleared once the request has been answered, and the caret already
+            // being there is an answer. Left set, it would fire on the next
+            // redraw instead — which is the redraw that follows your first
+            // keystroke, and it would drag the caret back to the front of the
+            // word you are typing in.
+            if context.coordinator.placeCaret {
+                if !editing || editor.selectedRange != wanted { editor.selectedRange = wanted }
                 context.coordinator.placeCaret = false
             }
         }
@@ -93,8 +108,13 @@ struct WordField: NSViewRepresentable {
         /// been honoured — otherwise every redraw drags the caret back and you
         /// cannot move within a word.
         var placeCaret = true
+        /// The last tick honoured, so the next one is seen as new.
+        var tick: Int
 
-        init(_ owner: WordField) { self.owner = owner }
+        init(_ owner: WordField) {
+            self.owner = owner
+            self.tick = owner.tick
+        }
 
         func controlTextDidChange(_ note: Notification) {
             guard let field = note.object as? NSTextField else { return }

--- a/Sources/ParrotFlow/CorrectionSpansView.swift
+++ b/Sources/ParrotFlow/CorrectionSpansView.swift
@@ -1,0 +1,186 @@
+import AppKit
+import SwiftUI
+
+/// One editable word.
+///
+/// AppKit rather than a SwiftUI `TextField`, and the reason is the caret. Half
+/// the gestures in this panel are about *where in the word* you are — space
+/// splits at the caret, backspace joins only from the start, the arrows cross
+/// only from an edge — and SwiftUI will not say. `NSTextField` hands over its
+/// field editor, which reports its selection exactly.
+struct WordField: NSViewRepresentable {
+
+    typealias NSViewType = NSTextField
+    // Spelled out, because the app has a `Context` of its own — the screen
+    // capture in Context.swift — and a bare `Context` here resolves to that,
+    // which fails conformance in a way the compiler describes as a
+    // "non-matching type".
+    typealias Wrapped = NSViewRepresentableContext<WordField>
+
+    let text: String
+    let isChanged: Bool
+    let focused: Bool
+    /// Where to put the caret when focus arrives. Nil is the end, which is
+    /// where you want it when you have come to a word to change it.
+    let caret: Int?
+
+    var onChange: (String) -> Void
+    var onJoinBack: () -> Void
+    /// Crossed an edge with an arrow. True for the right-hand edge.
+    var onEdge: (Bool) -> Void
+    var onTab: (Bool) -> Void
+    var onSubmit: () -> Void
+    var onCancel: () -> Void
+
+    static let font = NSFont.systemFont(ofSize: CorrectionMetrics.wordSize, weight: .regular)
+
+    func makeNSView(context: Wrapped) -> NSTextField {
+        let field = NSTextField(string: text)
+        field.delegate = context.coordinator
+        field.isBordered = false
+        field.drawsBackground = false
+        field.focusRingType = .none
+        field.font = Self.font
+        field.lineBreakMode = .byClipping
+        field.cell?.usesSingleLineMode = true
+        field.cell?.wraps = false
+        field.cell?.isScrollable = true
+        field.setContentHuggingPriority(.required, for: .horizontal)
+        return field
+    }
+
+    func updateNSView(_ field: NSTextField, context: Wrapped) {
+        context.coordinator.owner = self
+        if field.stringValue != text { field.stringValue = text }
+        field.textColor = isChanged ? .white : NSColor.white.withAlphaComponent(0.82)
+
+        guard focused else { return }
+        guard let window = field.window else { return }
+        let editing = window.firstResponder === field.currentEditor()
+        if !editing { window.makeFirstResponder(field) }
+        if let editor = field.currentEditor() {
+            let at = caret.map { min($0, field.stringValue.count) } ?? field.stringValue.count
+            let wanted = NSRange(location: at, length: 0)
+            if !editing || editor.selectedRange != wanted, context.coordinator.placeCaret {
+                editor.selectedRange = wanted
+                context.coordinator.placeCaret = false
+            }
+        }
+    }
+
+    func sizeThatFits(
+        _ proposal: ProposedViewSize, nsView: NSTextField, context: Wrapped
+    ) -> CGSize? {
+        let width = (text as NSString)
+            .size(withAttributes: [.font: Self.font]).width
+        // A caret needs somewhere to stand in an empty word.
+        return CGSize(width: max(ceil(width) + 3, 8), height: ceil(Self.font.ascender - Self.font.descender) + 2)
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    final class Coordinator: NSObject, NSTextFieldDelegate {
+        var owner: WordField
+        /// Set when the model asked for a caret position, cleared once it has
+        /// been honoured — otherwise every redraw drags the caret back and you
+        /// cannot move within a word.
+        var placeCaret = true
+
+        init(_ owner: WordField) { self.owner = owner }
+
+        func controlTextDidChange(_ note: Notification) {
+            guard let field = note.object as? NSTextField else { return }
+            owner.onChange(field.stringValue)
+        }
+
+        func control(
+            _ control: NSControl, textView: NSTextView, doCommandBy selector: Selector
+        ) -> Bool {
+            let range = textView.selectedRange()
+            let atStart = range.location == 0 && range.length == 0
+            let atEnd = range.location == textView.string.count && range.length == 0
+
+            switch selector {
+            case #selector(NSResponder.deleteBackward(_:)):
+                guard atStart else { return false }
+                placeCaret = true
+                owner.onJoinBack()
+                return true
+            case #selector(NSResponder.moveLeft(_:)):
+                guard atStart else { return false }
+                placeCaret = true
+                owner.onEdge(false)
+                return true
+            case #selector(NSResponder.moveRight(_:)):
+                guard atEnd else { return false }
+                placeCaret = true
+                owner.onEdge(true)
+                return true
+            case #selector(NSResponder.insertTab(_:)):
+                placeCaret = true
+                owner.onTab(true)
+                return true
+            case #selector(NSResponder.insertBacktab(_:)):
+                placeCaret = true
+                owner.onTab(false)
+                return true
+            case #selector(NSResponder.insertNewline(_:)):
+                owner.onSubmit()
+                return true
+            case #selector(NSResponder.cancelOperation(_:)):
+                owner.onCancel()
+                return true
+            default:
+                return false
+            }
+        }
+    }
+}
+
+/// Words laid out like a sentence, wrapping at the edge.
+///
+/// A plain `HStack` would push the panel wider than the screen for anything
+/// longer than a phrase, and a `LazyVGrid` gives every word the same column,
+/// which is not what a sentence looks like.
+struct SentenceFlow: Layout {
+    var spacing: CGFloat = 7
+    var lineSpacing: CGFloat = 20
+
+    func sizeThatFits(
+        proposal: ProposedViewSize, subviews: Subviews, cache: inout ()
+    ) -> CGSize {
+        let width = proposal.width ?? .infinity
+        var x: CGFloat = 0, y: CGFloat = 0, line: CGFloat = 0
+        for view in subviews {
+            let size = view.sizeThatFits(.unspecified)
+            if x > 0, x + size.width > width {
+                y += line + lineSpacing
+                x = 0
+                line = 0
+            }
+            x += size.width + spacing
+            line = max(line, size.height)
+        }
+        return CGSize(width: proposal.width ?? x, height: y + line)
+    }
+
+    func placeSubviews(
+        in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()
+    ) {
+        var x = bounds.minX, y = bounds.minY, line: CGFloat = 0
+        for view in subviews {
+            let size = view.sizeThatFits(.unspecified)
+            if x > bounds.minX, x + size.width > bounds.maxX {
+                y += line + lineSpacing
+                x = bounds.minX
+                line = 0
+            }
+            view.place(
+                at: CGPoint(x: x, y: y), anchor: .topLeading,
+                proposal: ProposedViewSize(size)
+            )
+            x += size.width + spacing
+            line = max(line, size.height)
+        }
+    }
+}

--- a/Sources/ParrotFlow/CorrectionSpansView.swift
+++ b/Sources/ParrotFlow/CorrectionSpansView.swift
@@ -67,7 +67,22 @@ struct WordField: NSViewRepresentable {
             ? NSColor(Parrot.amber)
             : NSColor.white.withAlphaComponent(0.62)
 
-        guard focused else { return }
+        // A field is armed only by a tick it sees while it has the focus. Every
+        // other field records the tick and stays disarmed.
+        //
+        // Recording it matters as much as arming it. A field that only looked
+        // at the tick while focused would go stale the moment the caret left,
+        // and the next *click* on it would arrive with a mismatch that reads
+        // exactly like a caret request — so the caret would jump to the end of
+        // the word you clicked into and your typing would land there. AppKit
+        // has already put the caret where the pointer was; a click has nothing
+        // to ask for. See `SpansModel.moveCaret`, which is the only thing that
+        // moves the tick.
+        guard focused else {
+            context.coordinator.tick = tick
+            context.coordinator.placeCaret = false
+            return
+        }
         guard let window = field.window else { return }
         // A new tick is the model asking for the caret again. It asks twice on
         // opening, and the second ask is the one that can work.

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -71,9 +71,16 @@ enum PanelsCommand {
         rule.spans[3].value = ["Vercel"]
         rule.spans.removeLast()
 
+        // The sentence with punctuation in it. A comma is drawn, not typed, and
+        // the gap around it is the thing to look at: it belongs after the
+        // comma, never between the comma and the word it follows.
+        let punctuated = SpansModel()
+        punctuated.load(sentence: "Trois, quatre, cinq.")
+        punctuated.spans[1].value = ["quatorze"]
+
         // A fixed room rather than this machine's screen, so the sheet is the
         // same picture wherever it is drawn.
-        for model in [correction, rule] {
+        for model in [correction, rule, punctuated] {
             model.width = CorrectionMetrics.width(fitting: model.spans, room: 1200)
         }
 
@@ -153,6 +160,8 @@ enum PanelsCommand {
              NSSize(width: correction.width, height: CorrectionMetrics.height(correction.spans, width: correction.width, help: false)), .dark, false),
             (AnyView(CorrectionView().environmentObject(rule)),
              NSSize(width: rule.width, height: CorrectionMetrics.height(rule.spans, width: rule.width, help: false)), .dark, false),
+            (AnyView(CorrectionView().environmentObject(punctuated)),
+             NSSize(width: punctuated.width, height: CorrectionMetrics.height(punctuated.spans, width: punctuated.width, help: false)), .dark, false),
             (AnyView(CorrectionView().environmentObject(helped)),
              NSSize(width: helped.width, height: CorrectionMetrics.height(helped.spans, width: helped.width, help: true)), .dark, false),
             // The dictation panel is deliberately not here. Its field is an
@@ -307,6 +316,11 @@ enum PanelsCommand {
             }
         case "vocabulary":
             correction.show(selection: "I work with Tasmin and Mick on Versal")
+        // The same panel over a sentence with punctuation in it. On its own
+        // because a comma is drawn rather than typed, and how it sits — against
+        // the word before it, with the gap after — is only settled by looking.
+        case "punctuation":
+            correction.show(selection: "Trois, quatre, cinq.")
         // One of the two rules heard two words, because that is the shape that
         // used to land on the wrong span — see `SpansModel.load(rules:)`.
         case "rule":
@@ -369,7 +383,9 @@ enum PanelsCommand {
                 }
             }
         default:
-            print("usage: ParrotFlow --panels <notice|caution|failure|thinking|offer|vocabulary|rule|dictation|preview|microphone|pill|sequence> [seconds]")
+            print("usage: ParrotFlow --panels <notice|caution|failure|thinking|offer"
+                + "|vocabulary|punctuation|rule|dictation|preview|microphone|pill"
+                + "|sequence> [seconds]")
             return 2
         }
 

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -59,13 +59,17 @@ enum PanelsCommand {
         // that is obvious side by side and invisible a week apart.
         let overlayBlind = pill(.recording, level: 0.75)
 
-        let correction = CorrectionModel()
-        correction.load(selection: "Tasmin and Mick")
-        correction.tokens[0].replacement = "Tasmeen"
+        // One span changed and one span with two heard words folded into it —
+        // the two shapes the panel exists for, side by side.
+        let correction = SpansModel()
+        correction.load(sentence: "I work with Tasmin and Mick")
+        correction.spans[3].value = ["Tasmeen"]
 
-        let rule = CorrectionModel()
-        rule.loadRules([(heard: "Tasmin", corrected: "Tasmeen"),
-                        (heard: "Mick", corrected: "Mik")])
+        let rule = SpansModel()
+        rule.load(sentence: "we deployed on Ver Sal")
+        rule.spans[3].heard += rule.spans[4].heard
+        rule.spans[3].value = ["Vercel"]
+        rule.spans.removeLast()
 
         // Both states of the microphone notice, because the disclosure is the
         // shape of it: collapsed is what you read, open is the argument. A
@@ -131,9 +135,9 @@ enum PanelsCommand {
              NSSize(width: MicNoticeMetrics.width,
                     height: MicNoticeMetrics.height(expanded: true)), .dark, true),
             (AnyView(CorrectionView().environmentObject(correction)),
-             NSSize(width: CorrectionMetrics.width, height: CorrectionMetrics.height(forRows: 2)), .dark, false),
+             NSSize(width: CorrectionMetrics.width, height: CorrectionMetrics.height(forWords: correction.spans.count)), .dark, false),
             (AnyView(CorrectionView().environmentObject(rule)),
-             NSSize(width: CorrectionMetrics.width, height: CorrectionMetrics.height(forRows: 1)), .dark, false),
+             NSSize(width: CorrectionMetrics.width, height: CorrectionMetrics.height(forWords: rule.spans.count)), .dark, false),
             // The dictation panel is deliberately not here. Its field is an
             // `NSTextField` and its background is real Liquid Glass, and this
             // sheet can draw neither — it came out as a white block inside an
@@ -285,9 +289,11 @@ enum PanelsCommand {
                 print("offer: chip \(index) — \(offerChips[index].title)")
             }
         case "vocabulary":
-            correction.show(selection: "Tasmin and Mick")
+            correction.show(selection: "I work with Tasmin and Mick on Versal")
+        // One of the two rules heard two words, because that is the shape that
+        // used to land on the wrong span — see `SpansModel.load(rules:)`.
         case "rule":
-            correction.show(rules: [(heard: "Tasmin", corrected: "Tasmeen"),
+            correction.show(rules: [(heard: "Ver Sal", corrected: "Vercel"),
                                     (heard: "Mick", corrected: "Mik")])
         // The panel the pill's offer opens: one line, editable, over what was
         // just dictated. A different shape from the transform preview below —

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -71,6 +71,21 @@ enum PanelsCommand {
         rule.spans[3].value = ["Vercel"]
         rule.spans.removeLast()
 
+        // A fixed room rather than this machine's screen, so the sheet is the
+        // same picture wherever it is drawn.
+        for model in [correction, rule] {
+            model.width = CorrectionMetrics.width(fitting: model.spans, room: 1200)
+        }
+
+        // The disclosure open, because it is the state that changes the size of
+        // the panel and the only one where the explanation can be read.
+        let helped = SpansModel()
+        helped.load(sentence: "I work with Tasmin and Mick")
+        helped.width = CorrectionMetrics.width(fitting: helped.spans, room: 1200)
+        helped.help = true
+        helped.spans[3].value = ["Tasmeen"]
+        helped.hasEdited = true
+
         // Both states of the microphone notice, because the disclosure is the
         // shape of it: collapsed is what you read, open is the argument. A
         // device name long enough to outgrow the box shows here and nowhere
@@ -135,9 +150,11 @@ enum PanelsCommand {
              NSSize(width: MicNoticeMetrics.width,
                     height: MicNoticeMetrics.height(expanded: true)), .dark, true),
             (AnyView(CorrectionView().environmentObject(correction)),
-             NSSize(width: CorrectionMetrics.width, height: CorrectionMetrics.height(forWords: correction.spans.count)), .dark, false),
+             NSSize(width: correction.width, height: CorrectionMetrics.height(correction.spans, width: correction.width, help: false)), .dark, false),
             (AnyView(CorrectionView().environmentObject(rule)),
-             NSSize(width: CorrectionMetrics.width, height: CorrectionMetrics.height(forWords: rule.spans.count)), .dark, false),
+             NSSize(width: rule.width, height: CorrectionMetrics.height(rule.spans, width: rule.width, help: false)), .dark, false),
+            (AnyView(CorrectionView().environmentObject(helped)),
+             NSSize(width: helped.width, height: CorrectionMetrics.height(helped.spans, width: helped.width, help: true)), .dark, false),
             // The dictation panel is deliberately not here. Its field is an
             // `NSTextField` and its background is real Liquid Glass, and this
             // sheet can draw neither — it came out as a white block inside an

--- a/Sources/ParrotFlow/ParrotStyle.swift
+++ b/Sources/ParrotFlow/ParrotStyle.swift
@@ -645,8 +645,19 @@ struct PanelActions: View {
 /// the shortcut is the answer to "how", not something to decode first.
 struct ActionButton: View {
     let title: String
+    /// Drawn instead of `title` when part of the label needs its own weight or
+    /// colour. The correction panel names the words it will teach and sets
+    /// those words brighter than the sentence around them.
+    var styled: Text?
     let key: String
     let filled: Bool
+    /// A translucent capsule in this colour, with a border of it and no glow,
+    /// instead of the standing filled gradient. For a button whose colour is
+    /// part of what it says.
+    var glass: Color?
+    /// Off: nothing to do, so nothing happens, and the keyboard shortcut on it
+    /// goes quiet too.
+    var enabled: Bool = true
     /// No capsule, no border — the label and its key and nothing else.
     ///
     /// For the button you are not expected to press. Two bordered buttons side
@@ -657,19 +668,31 @@ struct ActionButton: View {
 
     @State private var hovering = false
 
+    /// The text on a glass button. Not white — a green button wants a label
+    /// that has been near the green.
+    static let glassText = Color(red: 0.875, green: 0.941, blue: 0.906)  // #dff0e7
+
+    private var lit: Bool { hovering && enabled }
+
     var body: some View {
         Button(action: action) {
             HStack(spacing: 6) {
-                Text(title)
+                (styled ?? Text(title))
                     .font(.system(size: 12, weight: .semibold, design: .rounded))
-                    .foregroundStyle(filled ? AnyShapeStyle(.white) : AnyShapeStyle(.primary))
-                KeyCap(symbol: key, onFill: filled)
+                    .foregroundStyle(labelColour)
+                // Empty for a button whose key is not worth advertising — the
+                // correction panel's Discard, where escape is the way out of
+                // every panel in the app and does not need saying a third time.
+                if !key.isEmpty { KeyCap(symbol: key, onFill: filled) }
             }
             .padding(.horizontal, quiet ? 4 : 11)
             .padding(.vertical, 6)
             .background {
                 if quiet {
-                    Capsule().fill(Color.primary.opacity(hovering ? 0.08 : 0))
+                    Capsule().fill(Color.primary.opacity(lit ? 0.08 : 0))
+                } else if let glass {
+                    Capsule().fill(glass.opacity(lit ? 0.30 : 0.22))
+                    Capsule().strokeBorder(glass.opacity(0.5))
                 } else if filled {
                     Capsule().fill(
                         LinearGradient(
@@ -678,18 +701,25 @@ struct ActionButton: View {
                             endPoint: .bottom
                         )
                     )
-                    .shadow(color: Parrot.action.opacity(0.45), radius: hovering ? 10 : 6, y: 2)
+                    .shadow(color: Parrot.action.opacity(0.45), radius: lit ? 10 : 6, y: 2)
                 } else {
-                    Capsule().fill(Color.primary.opacity(hovering ? 0.10 : 0.06))
+                    Capsule().fill(Color.primary.opacity(lit ? 0.10 : 0.06))
                     Capsule().strokeBorder(.primary.opacity(0.10))
                 }
             }
-            .brightness(hovering && filled ? 0.05 : 0)
+            .brightness(lit && filled && glass == nil ? 0.05 : 0)
+            .opacity(enabled ? 1 : 0.4)
             .contentShape(Capsule())
         }
         .buttonStyle(.plain)
+        .disabled(!enabled)
         .onHover { hovering = $0 }
         .animation(.easeOut(duration: 0.12), value: hovering)
+    }
+
+    private var labelColour: AnyShapeStyle {
+        if glass != nil { return AnyShapeStyle(Self.glassText) }
+        return filled ? AnyShapeStyle(.white) : AnyShapeStyle(.primary)
     }
 }
 

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -402,7 +402,7 @@ if let index = arguments.firstIndex(of: "--panel-sheet") {
 
 if let index = arguments.firstIndex(of: "--panels") {
     guard arguments.indices.contains(index + 1) else {
-        print("usage: ParrotFlow --panels <notice|caution|failure|thinking|offer|vocabulary|rule|dictation|preview|pill|sequence> [seconds]")
+        print("usage: ParrotFlow --panels <notice|caution|failure|thinking|offer|vocabulary|punctuation|rule|dictation|preview|pill|sequence> [seconds]")
         exit(2)
     }
     let seconds = arguments.indices.contains(index + 2) ? Double(arguments[index + 2]) : nil

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -305,7 +305,8 @@ $PF --panel-sheet s.png   # draw every surface into one PNG, light beside dark
 ```
 
 `--panels` takes `pill`, `notice`, `caution`, `failure`, `thinking`, `offer`,
-`vocabulary`, `rule`, `dictation`, `preview`, `microphone` or `sequence`.
+`vocabulary`, `punctuation`, `rule`, `dictation`, `preview`, `microphone` or
+`sequence`.
 `--panel-sheet` draws all of
 them at once, which is where drift between them shows up.
 

--- a/docs/corrections.md
+++ b/docs/corrections.md
@@ -5,21 +5,28 @@ colleagues' names all day. A rule you teach once is written to your
 `config.yaml` and applied to every transcript afterwards.
 
 When a name comes out wrong, select it in whatever app you're in, hold the
-hotkey and say **"hey parrot"**. A panel opens showing what it heard and a
-field for what it should have written.
+hotkey and say **"hey parrot"**. A panel opens with the sentence in it,
+editable in place. What it heard sits above the word it became, struck through.
 
-    HEARD AS         SHOULD BE
-    Tasmin      →   [Tasmeen            ]  ×
-    and         →   [                   ]  ×
-    Mick        →   [Mik                ]  ×
-    return Save   esc Cancel              2 rules
+    VOCABULARY  teach me the words I got wrong
 
-You get a row per word, because rules are per-word — a phrase you selected
-once will never recur verbatim. Leave a row blank and it is skipped, so
-selecting a whole sentence to fix two names costs nothing. × drops a row you
-do not want to think about.
+                     Tasmin           Mick
+     I    work  with Tasmeen and      Mik
+     ──   ────  ──── ───────  ───     ───
+     space splits a word in two   ⌫ at the start joins it to the word before
 
-Saving writes each filled-in rule to `config.yaml` — comments and your other
+     2 words → vocabulary   Cancel esc   Add Tasmeen, Mik to the vocabulary ⌘↩
+
+Every gesture is one a text field already has: type over a word, space to
+split one word into two, ⌫ at the start of a word to join it to the word
+before, clear a word to drop it. ⌘Z undoes.
+
+A rule is keyed on what you edited, not on a word — so when the decoder splits
+a name in two ("red crawl" for Redcrawl), joining the two words teaches
+`red crawl => Redcrawl` and leaves the colour alone. The words you did not
+touch cost nothing.
+
+Saving writes one rule per changed word to `config.yaml` — comments and your other
 settings untouched — and puts the corrected phrase back where it came from,
 punctuation and spacing intact.
 
@@ -42,7 +49,8 @@ language:
     "hey parrot, Elastic search is one word"
     "hey parrot, Jean Luc avec un trait d'union"
 
-And one breath can carry two corrections, which open as two rows in the panel:
+And one breath can carry two corrections, which open as two changed words
+in the panel:
 
     "hey parrot, Tasmin spells T A S M E E N and Mick spells M I K"
     "hey parrot, Nathalie sans le h et Philipe avec deux p"
@@ -147,7 +155,7 @@ often before the transcript comes back. ParrotFlow snapshots the selection the
 moment the hotkey goes down, which covers most of it, and falls back to your
 clipboard when there is nothing to read. So if a terminal selection does not
 come through, copy it first — select, ⌘C, then say the phrase. The panel always
-opens either way, with a row you can type into.
+opens either way, with a word you can type into.
 
 ## An instruction inside a dictation
 

--- a/docs/corrections.md
+++ b/docs/corrections.md
@@ -8,18 +8,22 @@ When a name comes out wrong, select it in whatever app you're in, hold the
 hotkey and say **"hey parrot"**. A panel opens with the sentence in it,
 editable in place. What it heard sits above the word it became, struck through.
 
-    VOCABULARY  teach me the words I got wrong
+    VOCABULARY
+
+    Fix what I misheard.
 
                      Tasmin           Mick
      I    work  with Tasmeen and      Mik
      ──   ────  ──── ───────  ───     ───
      space splits a word in two   ⌫ at the start joins it to the word before
+     ▸ Not sure what to correct?
 
-     2 words → vocabulary   Cancel esc   Add Tasmeen, Mik to the vocabulary ⌘↩
+           Undo ⌘Z   Discard   Add Tasmeen and Mik to the vocabulary ↩
 
-Every gesture is one a text field already has: type over a word, space to
-split one word into two, ⌫ at the start of a word to join it to the word
-before, clear a word to drop it. ⌘Z undoes.
+The caret starts in the first word, so the sentence is a row of fields rather
+than a label. Every gesture is one a text field already has: type over a word,
+space to split one word into two, ⌫ at the start of a word to join it to the
+word before, clear a word to drop it. ⌘Z undoes, ↩ saves, escape discards.
 
 A rule is keyed on what you edited, not on a word — so when the decoder splits
 a name in two ("red crawl" for Redcrawl), joining the two words teaches

--- a/docs/corrections.md
+++ b/docs/corrections.md
@@ -18,12 +18,13 @@ editable in place. What it heard sits above the word it became, struck through.
      space splits a word in two   ⌫ at the start joins it to the word before
      ▸ Not sure what to correct?
 
-           Undo ⌘Z   Discard   Add Tasmeen and Mik to the vocabulary ↩
+           Undo ⌘Z   Discard   Add Tasmeen and Mik to the vocabulary ⌘↩
 
 The caret starts in the first word, so the sentence is a row of fields rather
 than a label. Every gesture is one a text field already has: type over a word,
 space to split one word into two, ⌫ at the start of a word to join it to the
-word before, clear a word to drop it. ⌘Z undoes, ↩ saves, escape discards.
+word before, clear a word to drop it. ⌘Z undoes, ⌘↩ saves, escape discards.
+Plain ↩ saves too, from inside a word.
 
 A rule is keyed on what you edited, not on a word — so when the decoder splits
 a name in two ("red crawl" for Redcrawl), joining the two words teaches

--- a/docs/proposals/hud-placement-and-offer.md
+++ b/docs/proposals/hud-placement-and-offer.md
@@ -532,7 +532,7 @@ else.
 | # | Title | Notes |
 |---|---|---|
 | 11 | `feat: a Bluetooth microphone says so, once` | `Recorder.inputIsBluetooth` and `MicNotice`. Independent — reorder freely. |
-| 12 | `feat: the correction panel works in spans` | `CorrectionSpans`, `CorrectionSpansView`, `CorrectionPanel`, the panels sheet. Save still writes nothing. The largest of these; expect it to want a second pass. |
+| 12 | `feat: the correction panel is the sentence you said, edited in place` | `CorrectionSpans`, `CorrectionSpansView`, `CorrectionPanel`, the panels sheet. **Landed.** It wanted the second pass it was expected to want: the head, the footer and the disclosure all came back changed after it was tried on a real dictation. Save still writes a replacement rule and nothing else — 13 is what closes that. |
 | 13 | `feat: teaching a word writes it down` | Save. A single term of five letters or more becomes a pronunciation in `vocabulary.yaml` — which `Config.vocabularyRules` turns into a rule as well — and anything else is a rule in `config.yaml`. Nothing in the app writes `vocabulary.yaml` today. |
 
 ### What each one has to show

--- a/scripts/check-spans.sh
+++ b/scripts/check-spans.sh
@@ -208,6 +208,46 @@ do {
     check("…of the first span", model.focus?.span == model.spans[0].id, true)
 }
 
+print("\n  --- every keyboard move is a new caret request ---")
+
+// `WordField` arms itself off `focusTick`, and disarms once it has answered.
+// A field you have already been in has disarmed, so a move back to it that did
+// not renew the tick would leave the whole word selected and the next character
+// typed would replace it.
+do {
+    let model = loaded("one two three")
+    var tick = model.focusTick
+    func moved(_ what: String) {
+        check(what, model.focusTick > tick, true)
+        tick = model.focusTick
+    }
+    model.step(from: model.spans[0].id, word: 0, forward: true, keepingEdge: true)
+    moved("an arrow across an edge")
+    model.step(from: model.spans[1].id, word: 0, forward: false, keepingEdge: true)
+    moved("…and the arrow back to a word already visited")
+    check("…which is the word it named", model.focus?.span == model.spans[0].id, true)
+    model.step(from: model.spans[0].id, word: 0, forward: true, keepingEdge: false)
+    moved("a tab")
+    type(model, "two more", span: 1)
+    moved("a word split in two")
+    joinBack(model, span: 1, word: 1)
+    moved("a join inside a span")
+    joinBack(model, span: 1)
+    moved("a join across spans")
+    type(model, "", span: 1)
+    moved("a word cleared")
+    model.focusFirst()
+    moved("the same word asked for twice")
+}
+do {
+    // Nowhere to go is not a move. The tick has to stay put, or the field you
+    // are in re-places the caret on the next redraw and typing drags it back.
+    let model = loaded("one two")
+    let tick = model.focusTick
+    model.step(from: model.spans[0].id, word: 0, forward: false, keepingEdge: true)
+    check("no neighbour, no new request", model.focusTick, tick)
+}
+
 print("\n  \(checks - failures)/\(checks)")
 exit(failures == 0 ? 0 : 1)
 SWIFT

--- a/scripts/check-spans.sh
+++ b/scripts/check-spans.sh
@@ -12,7 +12,9 @@
 #                      belongs to the user's text. Correcting one word must
 #                      not reformat the rest
 #   the punctuation    joining "blue" and "(red" with ⌫ has to keep the
-#                      bracket
+#                      bracket, and joining "hello," and "world" has to keep
+#                      the comma. ⌫ is aimed at the space, not at the marks
+#                      either side of it
 #   the caret offsets  `SpanCaret.at` counts UTF-16 code units, because that
 #                      is what AppKit's selection ranges count. A character
 #                      count agrees with it right up until a word holds an
@@ -146,6 +148,24 @@ do {
     let model = loaded("red crawl")
     joinBack(model, span: 1)
     check("nothing to carry", model.spans[0].value, ["redcrawl"])
+}
+do {
+    // The other side of the seam. ⌫ at the start of a word is aimed at the
+    // space before it, not at the comma before that.
+    let model = loaded("hello, world")
+    joinBack(model, span: 1)
+    check("hello, + world", model.spans[0].value, ["hello,world"])
+    check("…and the comma is still in the sentence", model.sentence(), "hello,world")
+    check("…with the caret after it", model.focus?.at ?? -1, 6)
+    check("…and the rule says nothing about it",
+          model.rules().map { "\($0.heard) => \($0.corrected)" },
+          ["hello world => hello,world"])
+}
+do {
+    // Both sides at once, and the sentence keeps every mark it arrived with.
+    let model = loaded("say \"hello,\" (world).")
+    joinBack(model, span: 2)
+    check("both sides of the seam", model.sentence(), "say \"hello,\"(world).")
 }
 
 print("\n  --- the caret is counted in UTF-16, the unit AppKit ranges use ---")

--- a/scripts/check-spans.sh
+++ b/scripts/check-spans.sh
@@ -72,6 +72,13 @@ func joinBack(_ model: SpansModel, span: Int, word: Int = 0) {
     model.joinBack(span: model.spans[span].id, word: word)
 }
 
+/// The marks a join left in a span, in an order that does not change between
+/// runs. A `Set` prints in hash order, which differs per process, and two of
+/// these checks passed and failed on alternate runs before they were sorted.
+func marks(_ model: SpansModel, _ span: Int) -> [Character] {
+    model.spans[span].joinedMarks.sorted()
+}
+
 print("\n  --- the whitespace of the selection survives an edit ---")
 
 for (name, sentence, want) in [
@@ -146,7 +153,7 @@ do {
     // never a decision about a word — see `Span.joinedMarks`.
     check("the rule it teaches", model.rules().map { "\($0.heard) => \($0.corrected)" },
           [String]())
-    check("…because the mark was not typed", model.spans[0].joinedMarks, true)
+    check("…because the mark was not typed", marks(model, 0), ["("] as [Character])
 }
 do {
     let model = loaded("red crawl")
@@ -235,7 +242,7 @@ do {
     check("a clean join still teaches",
           model.rules().map { "\($0.heard) => \($0.corrected)" },
           ["red crawl => Redcrawl"])
-    check("…and was never flagged", model.spans[0].joinedMarks, false)
+    check("…and carried nothing", marks(model, 0), [Character]())
 }
 do {
     // Typed punctuation is intentional, wherever it lands.
@@ -245,14 +252,49 @@ do {
           model.rules().map { "\($0.heard) => \($0.corrected)" }, ["dot => .NET"])
 }
 do {
-    // Typed over a flagged word: it is your word now, punctuation and all.
+    // Punctuation you typed is never in the set, so a join with nothing to
+    // carry leaves the name free to be taught with the apostrophe you added.
     let model = loaded("O Reilly")
     joinBack(model, span: 1)
     type(model, "O'Reilly", span: 0)
-    check("typing clears the flag", model.spans[0].joinedMarks, false)
+    check("nothing was carried", marks(model, 0), [Character]())
     check("…so the name is taught",
           model.rules().map { "\($0.heard) => \($0.corrected)" },
           ["O Reilly => O'Reilly"])
+}
+do {
+    // Typing is not consent. The comma is still a comma nobody typed, so a
+    // capital letter somewhere else in the word does not release it.
+    let model = loaded("hello, world")
+    joinBack(model, span: 1)
+    type(model, "Hello,world", span: 0)
+    check("an edit that leaves the mark", marks(model, 0), [","] as [Character])
+    check("…still teaches nothing", model.rules().count, 0)
+    check("…and still replaces", model.sentence(), "Hello,world")
+}
+do {
+    // Delete the mark and you have decided about it.
+    let model = loaded("hello, world")
+    joinBack(model, span: 1)
+    type(model, "Helloworld", span: 0)
+    check("the mark deleted", marks(model, 0), [Character]())
+    check("…so the word is taught",
+          model.rules().map { "\($0.heard) => \($0.corrected)" },
+          ["hello world => Helloworld"])
+}
+do {
+    // Two marks at one seam, dropped one at a time.
+    let model = loaded("say \"hello,\" (world).")
+    joinBack(model, span: 2)
+    check("both marks are held", marks(model, 1), ["\"", "(", ","] as [Character])
+    type(model, "hello,\"world", span: 1)
+    check("one dropped, two left", marks(model, 1), ["\"", ","] as [Character])
+    check("…and it teaches nothing yet", model.rules().count, 0)
+    type(model, "helloworld", span: 1)
+    check("all gone", marks(model, 1), [Character]())
+    check("…so it teaches",
+          model.rules().map { "\($0.heard) => \($0.corrected)" },
+          ["hello world => helloworld"])
 }
 do {
     // Undo carries the flag back with the spans, both ways round.
@@ -261,10 +303,10 @@ do {
     check("before the join it teaches",
           model.rules().map { "\($0.heard) => \($0.corrected)" }, ["hello => HELLO"])
     joinBack(model, span: 1)
-    check("the join flags it", model.spans[0].joinedMarks, true)
+    check("the join records the mark", marks(model, 0), [","] as [Character])
     check("…and it teaches nothing", model.rules().count, 0)
     model.undo()
-    check("undo puts the flag back down", model.spans[0].joinedMarks, false)
+    check("undo takes the mark back off", marks(model, 0), [Character]())
     check("…and the rule with it",
           model.rules().map { "\($0.heard) => \($0.corrected)" }, ["hello => HELLO"])
     check("…and the sentence", model.sentence(), "HELLO, world")

--- a/scripts/check-spans.sh
+++ b/scripts/check-spans.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# Checks the model behind the correction panel: the spans it reads a sentence
+# into, and the sentence it gives back.
+#
+#   scripts/check-spans.sh
+#
+# Three things are worth a script rather than a look at the panel, because all
+# three are invisible in it and all three were wrong once:
+#
+#   the whitespace     the panel opens on a selection as often as on a fresh
+#                      dictation. A tab, a double space or a line break in it
+#                      belongs to the user's text. Correcting one word must
+#                      not reformat the rest
+#   the punctuation    joining "blue" and "(red" with ⌫ has to keep the
+#                      bracket
+#   the caret offsets  `SpanCaret.at` counts UTF-16 code units, because that
+#                      is what AppKit's selection ranges count. A character
+#                      count agrees with it right up until a word holds an
+#                      emoji or a combining accent
+#
+# `CorrectionSpans.swift` is compiled on its own against the driver below —
+# there is no test target here, and the model needs no window, no microphone
+# and no model to answer. The one symbol it reaches out of its file for is
+# stubbed; if that list grows, this script says so by failing to compile.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SOURCE="$ROOT/Sources/ParrotFlow/CorrectionSpans.swift"
+
+WORK="$(mktemp -d -t parrotflow-spans)"
+trap 'rm -rf "$WORK"' EXIT
+
+cat > "$WORK/main.swift" <<'SWIFT'
+import AppKit
+
+// The only symbol CorrectionSpans.swift reads from another file.
+enum CorrectionMetrics { static let minWidth: CGFloat = 640 }
+
+var checks = 0, failures = 0
+
+func check(_ what: String, _ got: Any, _ want: Any) {
+    checks += 1
+    let got = show(got), want = show(want)
+    if got == want {
+        print("  ✓ \(what)  \(got)")
+    } else {
+        failures += 1
+        print("  ✗ \(what)\n      got   \(got)\n      want  \(want)")
+    }
+}
+
+/// Whitespace is the thing under test, so it has to be readable in the output.
+func show(_ value: Any) -> String {
+    String(describing: value)
+        .replacingOccurrences(of: "\t", with: "\\t")
+        .replacingOccurrences(of: "\n", with: "\\n")
+}
+
+func loaded(_ sentence: String) -> SpansModel {
+    let model = SpansModel()
+    model.load(sentence: sentence)
+    return model
+}
+
+/// One word typed into, the way the field's delegate reports it.
+func type(_ model: SpansModel, _ text: String, span: Int, word: Int = 0) {
+    model.typed(text, span: model.spans[span].id, word: word)
+}
+
+func joinBack(_ model: SpansModel, span: Int, word: Int = 0) {
+    model.joinBack(span: model.spans[span].id, word: word)
+}
+
+print("\n  --- the whitespace of the selection survives an edit ---")
+
+for (name, sentence, want) in [
+    ("a double space", "one  two", "one  TWO"),
+    ("a tab", "one\ttwo", "one\tTWO"),
+    ("a line break", "one\ntwo", "one\nTWO"),
+    ("whitespace at both ends", "  one \t two\n", "  one \t TWO\n"),
+] {
+    let model = loaded(sentence)
+    type(model, "TWO", span: 1)
+    check(name, model.sentence(), want)
+}
+
+for sentence in ["a\n\nb\tc   d", "\n\thello\t\n", "   ", ""] {
+    check("untouched: \(show(sentence))", loaded(sentence).sentence(), sentence)
+}
+
+do {
+    let model = loaded("Hello,   \"world\"!")
+    type(model, "World", span: 1)
+    check("punctuation stays with its word", model.sentence(), "Hello,   \"World\"!")
+}
+do {
+    // A word cleared takes the whitespace before it. That whitespace is where
+    // the word sat; the separator that survives belongs to the word that stays.
+    let model = loaded("foo\nbar baz")
+    type(model, "", span: 1)
+    check("a cleared word takes its own lead", model.sentence(), "foo baz")
+}
+do {
+    // Except the first, whose lead is where the selection starts.
+    let model = loaded("    foo bar")
+    type(model, "", span: 0)
+    check("the first word cleared leaves the indent", model.sentence(), "    bar")
+}
+do {
+    let model = loaded("foo bar\n")
+    type(model, "", span: 1)
+    check("the last word cleared leaves the newline", model.sentence(), "foo\n")
+}
+do {
+    let model = loaded("one\ttwosome")
+    type(model, "two some", span: 1)
+    check("a word split in two takes one space", model.sentence(), "one\ttwo some")
+}
+do {
+    let model = loaded("red \t crawl")
+    joinBack(model, span: 1)
+    check("a join takes the whitespace at the seam", model.sentence(), "redcrawl")
+}
+do {
+    let model = loaded("a  b  c")
+    joinBack(model, span: 1)
+    check("a join leaves the other separators", model.sentence(), "ab  c")
+}
+do {
+    let model = loaded("foo\nbar baz")
+    type(model, "", span: 1)
+    model.undo()
+    check("undo puts the whitespace back", model.sentence(), "foo\nbar baz")
+}
+
+print("\n  --- a join keeps the punctuation of what it swallowed ---")
+
+do {
+    let model = loaded("blue (red).")
+    joinBack(model, span: 1)
+    check("blue + (red", model.spans[0].value, ["blue(red"])
+    check("blue + (red, and the full stop", model.sentence(), "blue(red).")
+    check("the rule it teaches", model.rules().map { "\($0.heard) => \($0.corrected)" },
+          ["blue red => blue(red"])
+}
+do {
+    let model = loaded("red crawl")
+    joinBack(model, span: 1)
+    check("nothing to carry", model.spans[0].value, ["redcrawl"])
+}
+
+print("\n  --- the caret is counted in UTF-16, the unit AppKit ranges use ---")
+
+// "e" and a combining acute: one character, two UTF-16 code units.
+let accented = "caf\u{65}\u{301}"
+
+// The two counts have to differ, or the checks below say nothing.
+for (word, want) in [(accented, "4 5"), ("😀", "1 2"), ("👩‍💻", "1 5")] {
+    check("characters against code units", "\(word.count) \((word as NSString).length)", want)
+}
+
+// The seam a ⌫ join leaves the caret on is the end of the word before it —
+// exactly the number the two counts disagree about. Typed in rather than
+// dictated, because `read` treats an emoji as punctuation around a word, so the
+// only way one gets into a field is the keyboard.
+for word in [accented, "😀", "👩‍💻", "abc"] {
+    let model = loaded("x tail")
+    type(model, word, span: 0)
+    joinBack(model, span: 1)
+    check("the seam after \(word)", model.focus?.at ?? -1, (word as NSString).length)
+    check("…which is not its character count", model.focus?.at == word.count, word == "abc")
+    check("…and the words are one", model.spans[0].value, [word + "tail"])
+}
+do {
+    // The same seam inside one span: split a word, then join it back.
+    let model = loaded("x")
+    type(model, "\u{65}\u{301}😀 tail", span: 0)
+    check("split into two words", model.spans[0].value, ["\u{65}\u{301}😀", "tail"])
+    model.joinBack(span: model.spans[0].id, word: 1)
+    check("the seam inside a span", model.focus?.at ?? -1,
+          ("\u{65}\u{301}😀" as NSString).length)
+}
+do {
+    // The panel opens with the caret before the first letter, whatever the
+    // first word is made of.
+    let model = loaded("\(accented) tail")
+    check("the opening caret", model.focus?.at ?? -1, 0)
+    check("…in the first word", model.focus?.word ?? -1, 0)
+    check("…of the first span", model.focus?.span == model.spans[0].id, true)
+}
+
+print("\n  \(checks - failures)/\(checks)")
+exit(failures == 0 ? 0 : 1)
+SWIFT
+
+swiftc -O -o "$WORK/spans" "$WORK/main.swift" "$SOURCE" || {
+  echo "  the model no longer compiles on its own — see the note at the top"
+  exit 1
+}
+"$WORK/spans"

--- a/scripts/check-spans.sh
+++ b/scripts/check-spans.sh
@@ -141,8 +141,12 @@ do {
     joinBack(model, span: 1)
     check("blue + (red", model.spans[0].value, ["blue(red"])
     check("blue + (red, and the full stop", model.sentence(), "blue(red).")
+    // It used to teach `blue red => blue(red`, which put a bracket into every
+    // later sentence that said those two words. A mark a join carried in was
+    // never a decision about a word — see `Span.joinedMarks`.
     check("the rule it teaches", model.rules().map { "\($0.heard) => \($0.corrected)" },
-          ["blue red => blue(red"])
+          [String]())
+    check("…because the mark was not typed", model.spans[0].joinedMarks, true)
 }
 do {
     let model = loaded("red crawl")
@@ -157,9 +161,11 @@ do {
     check("hello, + world", model.spans[0].value, ["hello,world"])
     check("…and the comma is still in the sentence", model.sentence(), "hello,world")
     check("…with the caret after it", model.focus?.at ?? -1, 6)
+    // The comma is in the sentence and out of the rule. Both halves matter:
+    // the user joined those words on purpose, and the mark they did not type
+    // has no business in a correction that fires forever.
     check("…and the rule says nothing about it",
-          model.rules().map { "\($0.heard) => \($0.corrected)" },
-          ["hello world => hello,world"])
+          model.rules().map { "\($0.heard) => \($0.corrected)" }, [String]())
 }
 do {
     // Both sides at once, and the sentence keeps every mark it arrived with.
@@ -206,6 +212,69 @@ do {
     check("the opening caret", model.focus?.at ?? -1, 0)
     check("…in the first word", model.focus?.word ?? -1, 0)
     check("…of the first span", model.focus?.span == model.spans[0].id, true)
+}
+
+print("\n  --- a mark a join carried in teaches nothing, and still replaces ---")
+
+// Punctuation you typed is a decision about a word. Punctuation ⌫ dragged in
+// off the sentence is debris from an edit. The model tells them apart by where
+// the mark came from, not by which character it is — no shape rule can, because
+// ".NET" and "O'Reilly" are exactly the terms this panel exists to teach.
+do {
+    let model = loaded("hello, world")
+    joinBack(model, span: 1)
+    check("the sentence still joins", model.sentence(), "hello,world")
+    check("…and teaches nothing", model.rules().count, 0)
+}
+do {
+    // The case the span model was built for. No punctuation, so nothing to
+    // doubt: this one has to go on teaching.
+    let model = loaded("red crawl")
+    joinBack(model, span: 1)
+    type(model, "Redcrawl", span: 0)
+    check("a clean join still teaches",
+          model.rules().map { "\($0.heard) => \($0.corrected)" },
+          ["red crawl => Redcrawl"])
+    check("…and was never flagged", model.spans[0].joinedMarks, false)
+}
+do {
+    // Typed punctuation is intentional, wherever it lands.
+    let model = loaded("dot net")
+    type(model, ".NET", span: 0)
+    check("punctuation you typed teaches",
+          model.rules().map { "\($0.heard) => \($0.corrected)" }, ["dot => .NET"])
+}
+do {
+    // Typed over a flagged word: it is your word now, punctuation and all.
+    let model = loaded("O Reilly")
+    joinBack(model, span: 1)
+    type(model, "O'Reilly", span: 0)
+    check("typing clears the flag", model.spans[0].joinedMarks, false)
+    check("…so the name is taught",
+          model.rules().map { "\($0.heard) => \($0.corrected)" },
+          ["O Reilly => O'Reilly"])
+}
+do {
+    // Undo carries the flag back with the spans, both ways round.
+    let model = loaded("hello, world")
+    type(model, "HELLO", span: 0)
+    check("before the join it teaches",
+          model.rules().map { "\($0.heard) => \($0.corrected)" }, ["hello => HELLO"])
+    joinBack(model, span: 1)
+    check("the join flags it", model.spans[0].joinedMarks, true)
+    check("…and it teaches nothing", model.rules().count, 0)
+    model.undo()
+    check("undo puts the flag back down", model.spans[0].joinedMarks, false)
+    check("…and the rule with it",
+          model.rules().map { "\($0.heard) => \($0.corrected)" }, ["hello => HELLO"])
+    check("…and the sentence", model.sentence(), "HELLO, world")
+}
+do {
+    // A flagged span is still an edit, so the button is still live. Nothing to
+    // teach is not nothing to do.
+    let model = loaded("hello, world")
+    joinBack(model, span: 1)
+    check("nothing to teach is still something to save", model.hasChanges, true)
 }
 
 print("\n  --- every keyboard move is a new caret request ---")


### PR DESCRIPTION
PR 12 of the stack in [docs/proposals/hud-placement-and-offer.md](../blob/main/docs/proposals/hud-placement-and-offer.md) section 7.

## What the panel is now

It was a table: one row per word, "heard as" beside "should be", with text
fields. It is now the sentence you just dictated, laid out horizontally and
editable in place. What was heard sits above the word it became, struck
through at the same size. The bar under each word carries its state — faint
for untouched, sky for where you are, leaf for what will change.

    VOCABULARY

    Fix what I misheard.

                     Tasmin           Mick
     I    work  with Tasmeen and      Mik
     ──   ────  ──── ───────  ───     ───
     space splits a word in two   ⌫ at the start joins it to the word before
     ▸ Not sure what to correct?

           Undo ⌘Z   Discard   Add Tasmeen and Mik to the vocabulary ↩

The caret starts in the first word, so it reads as a row of fields rather
than a label. Every gesture is one a text field already has: type over a
word, `space` splits one word into two, `⌫` at the start joins it to the word
before, clearing a word drops it. `⌘Z` undoes the whole arrangement, `↩`
saves, escape discards. There is deliberately nothing of its own to learn.

The panel is as wide as the sentence needs, up to the screen less a margin,
so a short correction is not given a line break it does not need. Past three
lines it scrolls instead of growing.

## Why a rule is keyed on a span

A span owns two lists — the words that were **heard** and the words that
**replace** them. One heard word can become two, and two can become one,
without either side losing track of the other.

That is what a row-per-word panel could not express. `Redcrawl` decoded as
"red crawl" had no row to live on, and typing the name into the first row
taught `red => Redcrawl`, which then fired on the colour. Joining the two
words here teaches `red crawl => Redcrawl` and leaves the colour alone.

Everything below this panel already worked in spans: the fuzzy pass scans
two-word windows, `Vocabulary.widerSpans` offers the wider span for a name
the decoder split, and `autoApplies` has a branch for exactly this shape. The
panel was the last place still counting in words.

## What is not in it

**The button says "add to the vocabulary" and the code adds a replacement
rule.** `onSave` still goes to `learn()` → `ConfigWriter.addReplacement`,
which writes a rule to `config.yaml`. Nothing in the app writes
`vocabulary.yaml` today. The label is one PR ahead of the behaviour on
purpose; spec 13 closes the gap. Flagged so a reviewer does not have to find
it.

## Second pass

The panel was built, installed and tried on a real dictation, and the review
came back "it works, but it is not clear the text is editable". The second
commit is that round: the caret, the fitted width, a head that only names the
window, the instruction moved down to sit over the words, a footer of three
buttons with no status line, the confirm button in leaf naming the words it
will add, and a shut disclosure over which words are worth correcting at all.

`ActionButton` gained a glass style, a rich label and a disabled state.
`Parrot.action` and `PanelActions` are untouched — the preview panel and the
permissions window look exactly as they did.

## How it was checked

- `--panel-sheet` after every change; the correction panel is on it three
  times now, including with the disclosure open.
- The gesture set driven directly against `SpansModel` — split, join within a
  span, join across spans, clear, the arrow edges, tab, undo, punctuation
  surviving into the sentence, and the two-word-heard rule round trip.
- 20 pre-existing warnings in `AppDelegate.swift`, no new ones.

Not checked: anything needing a pointer or a keystroke on a real screen. This
machine has no Screen Recording permission for a screenshot, and the user was
dictating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
