### PR TITLE
feat: dictation reaches the apps that answer nothing

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -154,6 +154,12 @@ jobs:
       - name: The correction panel's spans
         run: scripts/check-spans.sh
 
+      # Which app gets which treatment. The one part of the destination path
+      # that runs without a screen or a real app in front, and a wrong entry is
+      # silent both ways — one already was, matching any app named "codex".
+      - name: What ParrotFlow makes of an app
+        run: scripts/check-profiles.sh
+
       # Not a validation set: it checks that the file a new install is written
       # with still teaches everything config.example.yaml documents. That has
       # drifted twice, both times silently.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,5 +17,14 @@ descriptions, issues, review comments, and documentation.
 This is about the prose, not the work. Be just as precise and just as thorough.
 Say the same things — say them in fewer, simpler words.
 
-Code comments in this repository follow the surrounding style, which explains
-*why* a thing is the way it is. Keep that habit, but keep the sentences short.
+## Code comments
+
+Strict minimum. Write a comment only for what you could not work out again by
+reading the code: a measured number, an error code, a constraint the API
+imposes, a thing that was tried and did not work.
+
+- No comment that restates the line under it.
+- No essays. One or two short sentences.
+- No design rationale that the code already shows.
+
+When in doubt, leave it out.

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -340,6 +340,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         loadConfig(announceErrors: false)
         watchConfig()
 
+        watchActivation()
+
         recorder.warmUp()
         recorder.onLevel = { [weak self] level in
             self?.pill.model.level = level
@@ -678,7 +680,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // reference we are holding, not another walk of the tree.
         destinationAtPress = Destination.at(app: front?.app, focus: focusAtPress?.element)
         appIconAtPress = destinationAtPress.acceptsText ? front?.icon : nil
-        Log.write("destination: \(destinationAtPress.described)")
+        // The app by name: `field (AXTextArea)` alone cannot be acted on.
+        let where_ = destinationAtPress.namesTheApp
+            ? "" : " in \(front?.app.described ?? "nothing")"
+        Log.write("destination: \(destinationAtPress.described)\(where_)")
         let elapsed = Date().timeIntervalSince(snapshotStart)
         if elapsed > 0.15 {
             Log.write(String(format: "selection snapshot was slow: %.2fs", elapsed))
@@ -754,6 +759,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `handleHotKeyPress`, and only for a press that starts a dictation.
     private func readTheAnchor() {
         guard destinationAtPress.acceptsText else { return }
+
+        // `focusAtPress` is not empty for a blind app — it holds whatever app
+        // was focused before — so every rung below would measure the wrong
+        // window. Measured on Codex: the pill anchored to a 712x44 box while
+        // accessibility reported nothing focused in the app in front.
+        if appAtPress.map({ AppProfile.of($0).anchor }) == .window {
+            if let pid = NSWorkspace.shared.frontmostApplication?.processIdentifier,
+               let found = CaretAnchor.window(of: pid) {
+                anchorAtPress = found
+                Log.write("pill: no caret — the app answers nothing; using its window")
+            } else {
+                Log.write("pill: no caret — the app answers nothing, and it has no window")
+            }
+            return
+        }
+
         switch CaretAnchor.read(at: focusAtPress?.element) {
         case .found(let found):
             anchorAtPress = found
@@ -2032,7 +2053,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `press` is the dictation this offer is about, carried down from its own
     /// key-down — see `insertDictation`. Nothing below reads press-time state
     /// off `self`, so an offer can never be moved by another dictation's press.
-    private func showCorrectOffer(for press: Press, landing: Correction.Landing) {
+    /// `headline` is only passed for an ending nobody chose.
+    private func showCorrectOffer(
+        for press: Press, landing: Correction.Landing, headline: String? = nil
+    ) {
         // Beside the offer, not on it: its own window, so advice about the
         // microphone never costs you the chance to fix the sentence. Here
         // because this is the end of a dictation and every ending comes
@@ -2076,7 +2100,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             original: text, element: press.element, owner: press.owner, landing: landing
         ))
         let commands = offerCommands
-        pill.offer(commands, for: Self.offerSeconds)
+        pill.offer(commands, headline: headline, for: Self.offerSeconds)
         // The list is captured, not read again in the closure: a config
         // reloaded while the offer is up would otherwise renumber the chips
         // under the pointer, and the click would run whatever took the slot.
@@ -2882,6 +2906,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// The token matters: these clears are fire-and-forget, so without it a
     /// timer armed for "Copied — ⌘V to paste" wipes whatever newer message has
     /// replaced it in the meantime.
+    /// Activation and not the press: the tree is not built by the time the
+    /// call returns. The app already in front at launch never sends one.
+    private func watchActivation() {
+        let centre = NSWorkspace.shared.notificationCenter
+        centre.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification, object: nil, queue: .main
+        ) { note in
+            ChromiumAccessibility.askIfNeeded(
+                note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
+            )
+        }
+        centre.addObserver(
+            forName: NSWorkspace.didTerminateApplicationNotification, object: nil, queue: .main
+        ) { note in
+            ChromiumAccessibility.forget(
+                note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
+            )
+        }
+        ChromiumAccessibility.askIfNeeded(NSWorkspace.shared.frontmostApplication)
+    }
+
     private func setLabel(_ message: String?, clearAfter: TimeInterval? = nil) {
         labelToken += 1
         let token = labelToken
@@ -3325,15 +3370,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let now = SelectionReader.focusedElement()
             if now == nil || !CFEqual(now!, element) {
                 TextInserter.insert(text, mode: .clipboard)
-                if config.feedback.sound { NSSound(named: "Glass")?.play() }
+                // Not the paste sound — see the nowhere-to-type ending below.
+                if config.feedback.sound { NSSound(named: "Tink")?.play() }
                 Log.write(now == nil
                     ? "could not read what is focused; copied instead of pasting"
                     : "focus moved since the press; copied instead of pasting")
-                // The menu bar, not the pill. The pill is about to carry the
-                // offer, and a notice on it would be the offer's own surface
-                // saying something else.
                 setLabel("Focus moved — the transcription is on your clipboard", clearAfter: 4)
-                showCorrectOffer(for: press, landing: .clipboardNow())
+                showCorrectOffer(
+                    for: press, landing: .clipboardNow(), headline: "Focus moved · ⌘V"
+                )
                 updateUI()
                 return
             }
@@ -3360,12 +3405,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if config.transcription.insertMode == .paste,
            case .nowhere(let reason) = destination, reason != .noAccessibility {
             TextInserter.insert(text, mode: .clipboard)
-            if config.feedback.sound { NSSound(named: "Glass")?.play() }
+            // Not Glass: a sound that cannot be told from success is no sound.
+            if config.feedback.sound { NSSound(named: "Tink")?.play() }
             Log.write("nothing to type into (\(reason.described)); copied instead")
-            // In the menu bar, for the same reason as above: the pill is the
-            // offer's.
             setLabel("Nowhere to type — the transcription is on your clipboard", clearAfter: 4)
-            showCorrectOffer(for: press, landing: .clipboardNow())
+            // And on the pill: the menu bar row is inside a menu you must open.
+            showCorrectOffer(
+                for: press, landing: .clipboardNow(), headline: "Nowhere to type · ⌘V"
+            )
             updateUI()
             return
         }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -681,9 +681,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         destinationAtPress = Destination.at(app: front?.app, focus: focusAtPress?.element)
         appIconAtPress = destinationAtPress.acceptsText ? front?.icon : nil
         // The app by name: `field (AXTextArea)` alone cannot be acted on.
-        let where_ = destinationAtPress.namesTheApp
+        let inWhichApp = destinationAtPress.namesTheApp
             ? "" : " in \(front?.app.described ?? "nothing")"
-        Log.write("destination: \(destinationAtPress.described)\(where_)")
+        Log.write("destination: \(destinationAtPress.described)\(inWhichApp)")
         let elapsed = Date().timeIntervalSince(snapshotStart)
         if elapsed > 0.15 {
             Log.write(String(format: "selection snapshot was slow: %.2fs", elapsed))
@@ -2901,11 +2901,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         setLabel(nil)
     }
 
-    /// Sets the menu bar title, optionally clearing it again after a delay.
-    ///
-    /// The token matters: these clears are fire-and-forget, so without it a
-    /// timer armed for "Copied — ⌘V to paste" wipes whatever newer message has
-    /// replaced it in the meantime.
     /// Activation and not the press: the tree is not built by the time the
     /// call returns. The app already in front at launch never sends one.
     private func watchActivation() {
@@ -2927,6 +2922,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         ChromiumAccessibility.askIfNeeded(NSWorkspace.shared.frontmostApplication)
     }
 
+    /// Sets the menu bar title, optionally clearing it again after a delay.
+    ///
+    /// The token matters: these clears are fire-and-forget, so without it a
+    /// timer armed for "Copied — ⌘V to paste" wipes whatever newer message has
+    /// replaced it in the meantime.
     private func setLabel(_ message: String?, clearAfter: TimeInterval? = nil) {
         labelToken += 1
         let token = labelToken

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -82,6 +82,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// without Accessibility — an app condition has no business needing a
     /// permission that gating a stage by app does not otherwise require.
     private var appAtPress: Pipeline.App?
+    /// The same app as a pid, for the window anchor. Kept from the press so the
+    /// pill is measured against the app the words are aimed at.
+    private var pidAtPress: pid_t?
     /// Which microphone the engine is recording through. Read when recording
     /// starts and frozen onto the `Press` when the clip is handed to the
     /// decoder, so the microphone notice names the device that recorded the
@@ -674,6 +677,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         focusAtPress = selectionAtPress ?? SelectionReader.focusSnapshot()
         let front = Self.appInFront()
         appAtPress = front?.app
+        pidAtPress = front?.pid
         // The icon is a promise that the words are going to land in that app,
         // so it is only made when they will. Off the element the snapshot above
         // already fetched — the answer costs two more attribute reads on a
@@ -765,8 +769,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // window. Measured on Codex: the pill anchored to a 712x44 box while
         // accessibility reported nothing focused in the app in front.
         if appAtPress.map({ AppProfile.of($0).anchor }) == .window {
-            if let pid = NSWorkspace.shared.frontmostApplication?.processIdentifier,
-               let found = CaretAnchor.window(of: pid) {
+            if let pid = pidAtPress, let found = CaretAnchor.window(of: pid) {
                 anchorAtPress = found
                 Log.write("pill: no caret — the app answers nothing; using its window")
             } else {
@@ -1204,7 +1207,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// the same answer the pipeline will be conditioned on. Reading NSWorkspace
     /// twice would let them disagree, and the one time they disagree is exactly
     /// the time the pill is worth having.
-    private static func appInFront() -> (app: Pipeline.App, icon: NSImage?)? {
+    private static func appInFront() -> (app: Pipeline.App, icon: NSImage?, pid: pid_t)? {
         guard let front = NSWorkspace.shared.frontmostApplication else { return nil }
         let app = Pipeline.App(
             name: front.localizedName ?? "", bundleID: front.bundleIdentifier ?? ""
@@ -1212,7 +1215,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Both empty is not an app you could write a condition against, and
         // saying so is what makes `app:` fail closed instead of matching "  ".
         guard !app.searchable.trimmingCharacters(in: .whitespaces).isEmpty else { return nil }
-        return (app, front.icon)
+        return (app, front.icon, front.processIdentifier)
     }
 
     private func transcribe(_ recording: Recorder.Recording) {

--- a/Sources/ParrotFlow/AppProfile.swift
+++ b/Sources/ParrotFlow/AppProfile.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// What an app affords, decided from its identity rather than by asking it.
+///
+/// One entry per app, instead of the same app appearing in a list in
+/// `Destination`, a branch in `CaretAnchor` and a special case in
+/// `AppDelegate`.
+struct AppProfile: Equatable {
+
+    enum Focus: String {
+        /// Ask what has focus and refuse anything that does not take text.
+        case examine
+        /// A terminal: its focused element is the screen, so an editable-field
+        /// test says no about a surface that is nothing but an input.
+        case screen
+        /// Answers nothing. The system hands back whatever app participated
+        /// last, so the answer is about somebody else's window.
+        case blind
+    }
+
+    enum Anchor: String {
+        case ladder
+        /// The bottom of the app's own window, read from the window server.
+        case window
+    }
+
+    var focus: Focus
+    var anchor: Anchor
+    /// Whether the visible text can be handed to the pipeline. See `Context`.
+    var readsPane: Bool
+
+    static let ordinary = AppProfile(focus: .examine, anchor: .ladder, readsPane: false)
+    static let terminal = AppProfile(focus: .screen, anchor: .ladder, readsPane: true)
+    static let blind = AppProfile(focus: .blind, anchor: .window, readsPane: false)
+
+    /// Bundle id and name both, because one terminal is several bundles and
+    /// Codex is one bundle called ChatGPT.
+    static func of(_ app: Pipeline.App) -> AppProfile {
+        let bundle = app.bundleID.lowercased()
+        let name = app.name.lowercased()
+        if terminalBundleIDs.contains(bundle) || terminalNames.contains(name) { return .terminal }
+        if blindBundleIDs.contains(bundle) || blindNames.contains(name) { return .blind }
+        return .ordinary
+    }
+
+    private static let terminalBundleIDs: Set<String> = [
+        "com.apple.terminal", "com.googlecode.iterm2", "com.mitchellh.ghostty",
+        "net.kovidgoyal.kitty", "com.github.wez.wezterm", "io.alacritty", "org.alacritty",
+        "dev.warp.warp-stable", "dev.warp.warp-preview", "co.zeit.hyper",
+        "com.raphaelamorim.rio", "org.tabby",
+    ]
+
+    private static let terminalNames: Set<String> = [
+        "terminal", "iterm", "iterm2", "ghostty", "kitty", "wezterm", "alacritty",
+        "warp", "hyper", "rio", "tabby",
+    ]
+
+    /// An app belongs here only once two things are measured: that
+    /// `ChromiumAccessibility` fails on it, and that a ⌘V into it lands. Codex
+    /// answers -25205 to `AXManualAccessibility` and -25208 to
+    /// `AXEnhancedUserInterface`.
+    private static let blindBundleIDs: Set<String> = ["com.openai.codex"]
+
+    private static let blindNames: Set<String> = ["codex"]
+}

--- a/Sources/ParrotFlow/AppProfile.swift
+++ b/Sources/ParrotFlow/AppProfile.swift
@@ -33,13 +33,15 @@ struct AppProfile: Equatable {
     static let terminal = AppProfile(focus: .screen, anchor: .ladder, readsPane: true)
     static let blind = AppProfile(focus: .blind, anchor: .window, readsPane: false)
 
-    /// Bundle id and name both, because one terminal is several bundles and
-    /// Codex is one bundle called ChatGPT.
+    /// Terminals by bundle id or name, because one terminal is several bundles
+    /// and anything built from source signs itself however the build did.
+    /// Blind apps by bundle id alone: the list is one measured build each, and
+    /// a name is something any app can claim.
     static func of(_ app: Pipeline.App) -> AppProfile {
         let bundle = app.bundleID.lowercased()
         let name = app.name.lowercased()
         if terminalBundleIDs.contains(bundle) || terminalNames.contains(name) { return .terminal }
-        if blindBundleIDs.contains(bundle) || blindNames.contains(name) { return .blind }
+        if blindBundleIDs.contains(bundle) { return .blind }
         return .ordinary
     }
 
@@ -58,8 +60,7 @@ struct AppProfile: Equatable {
     /// An app belongs here only once two things are measured: that
     /// `ChromiumAccessibility` fails on it, and that a ⌘V into it lands. Codex
     /// answers -25205 to `AXManualAccessibility` and -25208 to
-    /// `AXEnhancedUserInterface`.
+    /// `AXEnhancedUserInterface`. Its name is "ChatGPT", so the bundle id is
+    /// the only thing that identifies it.
     private static let blindBundleIDs: Set<String> = ["com.openai.codex"]
-
-    private static let blindNames: Set<String> = ["codex"]
 }

--- a/Sources/ParrotFlow/CaretAnchor.swift
+++ b/Sources/ParrotFlow/CaretAnchor.swift
@@ -62,6 +62,9 @@ enum CaretAnchor {
         /// Where the last dictation into this same element ended up. A guess,
         /// and the only thing available at the press for an app with no caret.
         case remembered
+        /// The bottom of the app's own window, for an app that answers
+        /// nothing. A guess: their composer sits at the bottom.
+        case window
     }
 
     struct Found {
@@ -153,6 +156,40 @@ enum CaretAnchor {
             return .found(Found(rect: box, text: box, source: .field))
         }
         return .missed(pane == nil ? "no geometry" : "no caret, and the pane is too big to stand in for one")
+    }
+
+    /// The bottom strip of an app's frontmost window, for apps that answer no
+    /// accessibility questions.
+    ///
+    /// Read from the window server, which cannot be refused by the app —
+    /// asking these apps for a window through AX fails as asking for a caret
+    /// does.
+    ///
+    /// Centred rather than full width because `beside` puts the pill at its
+    /// anchor's left edge, which would park it against the window frame.
+    static func window(of pid: pid_t) -> Found? {
+        let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+        guard let listed = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]]
+        else { return nil }
+
+        // Layer order, so the app's first entry is its frontmost window.
+        let mine = listed.first { entry in
+            (entry[kCGWindowOwnerPID as String] as? pid_t) == pid
+                && (entry[kCGWindowLayer as String] as? Int) == 0
+                && (entry[kCGWindowBounds as String] as? [String: CGFloat]).map {
+                    ($0["Width"] ?? 0) > 200 && ($0["Height"] ?? 0) > 200
+                } == true
+        }
+        guard let bounds = mine?[kCGWindowBounds as String] as? [String: CGFloat],
+              let x = bounds["X"], let y = bounds["Y"],
+              let width = bounds["Width"], let height = bounds["Height"]
+        else { return nil }
+
+        // `kCGWindowBounds` is top-left with y downward, like the AX API.
+        let strip = flipped(
+            CGRect(x: x + width / 4, y: y + height - 96, width: width / 2, height: 44)
+        )
+        return Found(rect: strip, text: strip, source: .window)
     }
 
     /// A fingerprint of what the pane is showing, read at the press.

--- a/Sources/ParrotFlow/ChromiumAccessibility.swift
+++ b/Sources/ParrotFlow/ChromiumAccessibility.swift
@@ -1,0 +1,49 @@
+import AppKit
+import ApplicationServices
+
+/// Asks Chromium apps to build the accessibility tree they keep switched off.
+///
+/// `AXManualAccessibility` is a Chromium convention, not an Apple API. Without
+/// it VS Code reports no focused element and no focused application, which
+/// reads as "nothing to type into" and sends the transcript to the clipboard.
+///
+/// The flag lives on the pid, so it dies with the process and a relaunched app
+/// must be asked again. Codex answers -25205 and cannot be unlocked this way;
+/// Slack and Notion expose a tree without being asked.
+enum ChromiumAccessibility {
+
+    /// Logged once per process. Deliberately does not gate the call: an app can
+    /// activate before its accessibility element exists, and a set keyed on
+    /// "asked" would remember that failure as a success and never retry.
+    private static var announced: Set<pid_t> = []
+
+    /// One delayed second attempt per process, for an app that activates before
+    /// it is ready. Bounded because native apps refuse this for ever.
+    private static var retried: Set<pid_t> = []
+
+    static func askIfNeeded(_ app: NSRunningApplication?) {
+        guard let app, Permissions.accessibility == .granted else { return }
+        let pid = app.processIdentifier
+
+        let element = AXUIElementCreateApplication(pid)
+        let result = AXUIElementSetAttributeValue(
+            element, "AXManualAccessibility" as CFString, kCFBooleanTrue
+        )
+
+        guard result == .success else {
+            if retried.insert(pid).inserted {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2) { askIfNeeded(app) }
+            }
+            return
+        }
+
+        guard announced.insert(pid).inserted else { return }
+        Log.write("accessibility: asked \(app.localizedName ?? "pid \(pid)") to build its tree")
+    }
+
+    static func forget(_ app: NSRunningApplication?) {
+        guard let app else { return }
+        announced.remove(app.processIdentifier)
+        retried.remove(app.processIdentifier)
+    }
+}

--- a/Sources/ParrotFlow/Context.swift
+++ b/Sources/ParrotFlow/Context.swift
@@ -179,7 +179,7 @@ enum Context {
     static func read(app: Pipeline.App?) -> Result<Capture, Declined> {
         guard Permissions.accessibility == .granted else { return .failure(.noPermission) }
         guard let app else { return .failure(.noApp) }
-        guard Destination.terminalName(of: app) != nil else { return .failure(.notATerminal) }
+        guard AppProfile.of(app).readsPane else { return .failure(.notATerminal) }
 
         let front = NSWorkspace.shared.frontmostApplication
         let frontID = front?.bundleIdentifier ?? ""
@@ -215,7 +215,7 @@ enum Context {
     ) -> Result<Capture, Declined> {
         guard Permissions.accessibility == .granted else { return .failure(.noPermission) }
         guard let app else { return .failure(.noApp) }
-        guard Destination.terminalName(of: app) != nil else { return .failure(.notATerminal) }
+        guard AppProfile.of(app).readsPane else { return .failure(.notATerminal) }
         guard !SelectionReader.isOurs(element) else { return .failure(.nothingFocused) }
         guard let value = SelectionReader.visibleText(of: element) else {
             return .failure(.unreadable)

--- a/Sources/ParrotFlow/Destination.swift
+++ b/Sources/ParrotFlow/Destination.swift
@@ -33,6 +33,13 @@ enum Destination: Equatable {
     /// named rather than examined.
     case terminal(name: String)
 
+    /// An app that takes a paste and answers no questions about itself.
+    ///
+    /// Kept apart from `terminal` because a terminal also has a readable pane
+    /// and these do not. Nothing is lost by not examining them: `TextInserter`
+    /// writes with ⌘V whatever the destination.
+    case named(name: String)
+
     /// Nothing focused that would take text. The transcript goes to the
     /// clipboard instead.
     ///
@@ -63,10 +70,20 @@ enum Destination: Equatable {
         return true
     }
 
+    /// True for the cases that already carry the app's name, so the log does
+    /// not print it twice.
+    var namesTheApp: Bool {
+        switch self {
+        case .terminal, .named: return true
+        case .field, .nowhere: return false
+        }
+    }
+
     var described: String {
         switch self {
         case .field(let role): return "field (\(role))"
         case .terminal(let name): return "terminal (\(name))"
+        case .named(let name): return "named (\(name))"
         case .nowhere(let reason): return "nowhere — \(reason.described)"
         }
     }
@@ -88,7 +105,15 @@ enum Destination: Equatable {
             return .nowhere(.noAccessibility)
         }
 
-        if let app, let name = terminalName(of: app) { return .terminal(name: name) }
+        // Before the examination: asking these apps what has focus returns
+        // something that is not about them.
+        if let app {
+            switch AppProfile.of(app).focus {
+            case .screen: return .terminal(name: app.described)
+            case .blind: return .named(name: app.described)
+            case .examine: break
+            }
+        }
 
         guard let focus else { return .nowhere(.nothingFocused) }
         let role = SelectionReader.role(of: focus) ?? "an unnamed element"
@@ -98,58 +123,4 @@ enum Destination: Equatable {
         return .field(role: role)
     }
 
-    /// The terminal in front, by name, or nil for anything else.
-    ///
-    /// A list rather than a test, because there is nothing to test: what makes a
-    /// terminal a terminal is on the far side of a pty, and everything the
-    /// accessibility API can see is a grid of characters — the same shape
-    /// whether it is showing a shell prompt or the output of `cat`.
-    ///
-    /// Both halves are checked because one terminal is several bundles. Warp
-    /// ships stable, preview and nightly under three identifiers, Alacritty has
-    /// been `io.` and `org.` in living memory, and anything built from source
-    /// signs itself however the build did — while the name in the menu bar
-    /// stays what you call it. A list that only knew identifiers would silently
-    /// stop recognising a terminal on the day its author renamed one.
-    ///
-    /// The exception is deliberately narrow either way: being wrong here costs
-    /// a paste into a window that ignores it, which is what happened before any
-    /// of this existed.
-    static func terminalName(of app: Pipeline.App) -> String? {
-        let bundle = app.bundleID.lowercased()
-        let name = app.name.lowercased()
-        if terminalBundleIDs.contains(bundle) || terminalNames.contains(name) {
-            return app.described
-        }
-        return nil
-    }
-
-    private static let terminalBundleIDs: Set<String> = [
-        "com.apple.terminal",
-        "com.googlecode.iterm2",
-        "com.mitchellh.ghostty",
-        "net.kovidgoyal.kitty",
-        "com.github.wez.wezterm",
-        "io.alacritty",
-        "org.alacritty",
-        "dev.warp.warp-stable",
-        "dev.warp.warp-preview",
-        "co.zeit.hyper",
-        "com.raphaelamorim.rio",
-        "org.tabby",
-    ]
-
-    private static let terminalNames: Set<String> = [
-        "terminal",
-        "iterm",
-        "iterm2",
-        "ghostty",
-        "kitty",
-        "wezterm",
-        "alacritty",
-        "warp",
-        "hyper",
-        "rio",
-        "tabby",
-    ]
 }

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -47,7 +47,9 @@ enum PanelsCommand {
         let notice = pill(.notice("Grammar applied", .done))
         let caution = pill(.notice("Grammar copied — this app won't let me edit it", .caution))
         let thinking = pill(.working("Thinking…"))
-        let offer = pill(.offer(offerChips))
+        let offer = pill(.offer(offerChips, nil))
+        // Beside the plain one: the two endings must not look the same.
+        let offerCopied = pill(.offer(offerChips, "Nowhere to type · ⌘V"))
 
         let overlay = pill(.recording, icon: sampleIcon(), level: 0.75)
 
@@ -147,6 +149,8 @@ enum PanelsCommand {
             // comparison that matters: it has to not look like one.
             (AnyView(PillView().environmentObject(offer)),
              pillSize(offer), .dark, true),
+            (AnyView(PillView().environmentObject(offerCopied)),
+             pillSize(offerCopied), .dark, true),
             // Not a pill state at all, and the only surface here that is
             // about the hardware rather than about the words. Next to the pill
             // because that is what it appears beside.

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -50,7 +50,10 @@ enum PillState: Equatable {
     /// What you can do about what just happened. One entry per command; which
     /// one the pointer is on lives in the model, not here, so moving the
     /// highlight is not a state change and does not crossfade the whole pill.
-    case offer([OfferedCommand])
+    ///
+    /// The headline is where the words went. Nil when they went into the field
+    /// you were looking at, set for the endings nobody asked for.
+    case offer([OfferedCommand], String?)
 }
 
 /// A command on the offer, and the letter that runs it.
@@ -184,10 +187,12 @@ final class PillHUD {
     /// long is left without a clock on screen, and stays usable to the last
     /// frame. The keys and the chips work the whole way down; the fading only
     /// says how long is left.
-    func offer(_ commands: [OfferedCommand], for duration: TimeInterval) {
+    func offer(
+        _ commands: [OfferedCommand], headline: String? = nil, for duration: TimeInterval
+    ) {
         model.selected = nil
         offerFor = duration
-        set(.offer(commands))
+        set(.offer(commands, headline))
         decay(over: duration)
     }
 
@@ -739,7 +744,7 @@ enum PillMetrics {
         case .recording: return recording(hasIcon: hasIcon)
         case .working(let message): return text(message)
         case .notice(let message, _): return text(message)
-        case .offer(let commands): return offer(commands)
+        case .offer(let commands, let headline): return offer(commands, headline: headline)
         }
     }
 
@@ -773,13 +778,17 @@ enum PillMetrics {
     /// measured here, and the two numbers only ever agree approximately. The
     /// title is `.fixedSize()`, so a capsule a few points too narrow lets a
     /// chip hang over the end rather than shortening it.
-    static func offer(_ commands: [OfferedCommand]) -> CGFloat {
+    ///
+    /// A headline widens it and is meant to: then the sentence is on the
+    /// clipboard and looking like a notice is the point.
+    static func offer(_ commands: [OfferedCommand], headline: String? = nil) -> CGFloat {
         // A chip is its keycap, its words and 10pt of padding either side; then
         // 4pt between one chip and the next.
         let chips = commands.reduce(CGFloat(0)) { total, command in
             total + 20 + (command.key.isEmpty ? 0 : keycap) + title(command.title)
         }
-        return padding * 2 + chips + CGFloat(max(commands.count - 1, 0)) * 4
+        let lead = headline.map { title($0) + gap } ?? 0
+        return padding * 2 + lead + chips + CGFloat(max(commands.count - 1, 0)) * 4
     }
 
     /// The keycap on a chip: one character at 11pt bold, 5pt either side, and
@@ -835,8 +844,8 @@ struct PillView: View {
             case .notice(let message, let tone):
                 MessageContent(message: message, tone: tone)
                     .transition(.opacity)
-            case .offer(let commands):
-                OfferContent(commands: commands)
+            case .offer(let commands, let headline):
+                OfferContent(commands: commands, headline: headline)
                     .transition(.opacity)
             }
         }
@@ -933,6 +942,7 @@ private struct MessageContent: View {
 private struct OfferContent: View {
     @EnvironmentObject private var model: PillModel
     let commands: [OfferedCommand]
+    let headline: String?
 
     /// The lit chip's lettering: leaf lightened almost to white, so the words
     /// stay readable over a fill of the same colour.
@@ -940,6 +950,15 @@ private struct OfferContent: View {
 
     var body: some View {
         HStack(spacing: 4) {
+            if let headline {
+                Text(headline)
+                    .font(.system(size: 13, weight: .medium, design: .rounded))
+                    .foregroundStyle(NoticeTone.caution.color)
+                    .lineLimit(1)
+                    .fixedSize()
+                    .padding(.trailing, PillMetrics.gap - 4)
+            }
+
             ForEach(Array(commands.enumerated()), id: \.offset) { index, command in
                 // A tap gesture rather than a `Button`. The pill is a
                 // `nonactivatingPanel` and is never the key window, and SwiftUI

--- a/Sources/ParrotFlow/ProfileCommand.swift
+++ b/Sources/ParrotFlow/ProfileCommand.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// `--profile <bundle-id> [name]` — what `AppProfile` makes of an app.
+///
+/// The routing every dictation turns on, printed for one app, so a case file
+/// can assert the table. Getting an entry wrong is silent in both directions: a
+/// missing one sends every dictation in that app to the clipboard, and a wrong
+/// one pastes without checking what has focus.
+enum ProfileCommand {
+
+    static func run(bundleID: String, name: String) -> Int32 {
+        let profile = AppProfile.of(Pipeline.App(name: name, bundleID: bundleID))
+        print("focus      \(profile.focus.rawValue)")
+        print("anchor     \(profile.anchor.rawValue)")
+        print("readsPane  \(profile.readsPane)")
+        return 0
+    }
+}

--- a/Sources/ParrotFlow/Surface.swift
+++ b/Sources/ParrotFlow/Surface.swift
@@ -132,9 +132,9 @@ struct Surface {
 
         let front = app ?? NSWorkspace.shared.frontmostApplication
         let isTerminal = front.map {
-            Destination.terminalName(of: Pipeline.App(
+            AppProfile.of(Pipeline.App(
                 name: $0.localizedName ?? "", bundleID: $0.bundleIdentifier ?? ""
-            )) != nil
+            )).focus == .screen
         } ?? false
 
         if isTerminal {

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -304,6 +304,16 @@ if let index = arguments.firstIndex(of: "--forget") {
     exit(ForgetCommand.run(term: arguments[index + 1]))
 }
 
+if let index = arguments.firstIndex(of: "--profile") {
+    guard arguments.indices.contains(index + 1), !arguments[index + 1].hasPrefix("--") else {
+        print("usage: ParrotFlow --profile <bundle-id> [name]")
+        exit(2)
+    }
+    let name = arguments.indices.contains(index + 2) && !arguments[index + 2].hasPrefix("--")
+        ? arguments[index + 2] : ""
+    exit(ProfileCommand.run(bundleID: arguments[index + 1], name: name))
+}
+
 if let index = arguments.firstIndex(of: "--peek") {
     let seconds = arguments.indices.contains(index + 1) ? Double(arguments[index + 1]) : nil
     let sentinel = arguments.firstIndex(of: "--find").flatMap { found in

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -273,6 +273,28 @@ say -o /tmp/t.wav --data-format=LEI16@16000 --channels=1 "testing one two three"
 $PF --transcribe /tmp/t.wav
 ```
 
+## What ParrotFlow makes of an app
+
+```sh
+$PF --profile com.openai.codex ChatGPT
+$PF --profile com.mitchellh.ghostty Ghostty
+```
+
+Prints the three things `AppProfile` decides from an app's identity: whether its
+focused element can be believed (`examine`, `screen` or `blind`), where the pill
+opens (`ladder` or `window`), and whether the visible pane can be read as
+context.
+
+The name is optional and matters only for terminals, which are matched on either
+half — one terminal ships under several bundle ids. Blind apps are matched on the
+bundle id alone.
+
+`scripts/check-profiles.sh` runs this over `tests/profile-cases.yaml`. It is the
+only part of the destination path that can be checked without a screen and a
+real app in front, so it runs in CI. It does not check what an app actually does
+— that Codex refuses `AXManualAccessibility`, that a ⌘V lands — only that the
+classification is what the case file says.
+
 ## Text insertion, which is the risky path
 
 ```sh
@@ -358,6 +380,7 @@ scripts/check-verdicts.sh          # what the name judge reads out of a reply
 scripts/check-judge-prompt.sh      # the judge's prompt is one its parser can read
 scripts/check-no-voice.sh          # nothing in git is one person's voice
 scripts/check-audio-recovery.sh    # a microphone that changes leaves a usable engine
+scripts/check-profiles.sh          # which app gets examined, named, or read for context
 
 PF_VIEWPORT=Ghostty scripts/check-inplace.sh   # the same set, in another terminal
 $PF --peek 3 --via-copy                        # what Select All + Copy hands back

--- a/scripts/check-profiles.sh
+++ b/scripts/check-profiles.sh
@@ -12,12 +12,11 @@
 # lands. Those need the apps and stay manual, like check-inplace.
 set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-BIN="${PARROTFLOW_BIN:-$ROOT/.build/debug/ParrotFlow}"
-
-if [ ! -x "$BIN" ]; then
-    echo "  ✗ no binary at $BIN — run: swift build"
-    exit 1
-fi
+# Release first, as the other check scripts do and as CI builds. Debug is the
+# fallback so this also runs after a plain `swift build`.
+BIN="$ROOT/.build/release/ParrotFlow"
+[ -x "$BIN" ] || BIN="$ROOT/.build/debug/ParrotFlow"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
 
 python3 - "$ROOT" "$BIN" <<'PY'
 import subprocess, sys, pathlib, yaml

--- a/scripts/check-profiles.sh
+++ b/scripts/check-profiles.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Checks that `AppProfile.of` classifies each app in tests/profile-cases.yaml
+# the way the case file says it should.
+#
+# This is the routing every dictation turns on, and it is the one part of the
+# destination path that can be checked without a screen, a microphone or a real
+# app in front: given a bundle id and a name, which focus rule, which pill
+# anchor, and whether the pane is readable.
+#
+# It cannot check the things underneath it — that Codex really does refuse
+# `AXManualAccessibility`, that VS Code really does take it, that a ⌘V really
+# lands. Those need the apps and stay manual, like check-inplace.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="${PARROTFLOW_BIN:-$ROOT/.build/debug/ParrotFlow}"
+
+if [ ! -x "$BIN" ]; then
+    echo "  ✗ no binary at $BIN — run: swift build"
+    exit 1
+fi
+
+python3 - "$ROOT" "$BIN" <<'PY'
+import subprocess, sys, pathlib, yaml
+
+root, binary = pathlib.Path(sys.argv[1]), sys.argv[2]
+cases = yaml.safe_load((root / "tests/profile-cases.yaml").read_text())
+
+ok = True
+for case in cases:
+    result = subprocess.run(
+        [binary, "--profile", case["bundle"], case.get("name", "")],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        print(f"  ✗ {case['what']}: exited {result.returncode}")
+        print(f"      {result.stderr.strip() or result.stdout.strip()}")
+        ok = False
+        continue
+
+    # `--profile` prints one "key  value" per line.
+    got = {}
+    for line in result.stdout.splitlines():
+        parts = line.split()
+        if len(parts) == 2:
+            got[parts[0]] = parts[1]
+
+    for field in ("focus", "anchor", "readsPane"):
+        want = str(case[field]).lower()
+        if got.get(field, "").lower() != want:
+            print(f"  ✗ {case['what']}")
+            print(f"      {case['bundle']} / \"{case.get('name', '')}\"")
+            print(f"      {field}: wanted {want}, got {got.get(field, 'nothing')}")
+            ok = False
+
+if ok:
+    print(f"  ✓ every app is classified as the case file says  ({len(cases)} cases)")
+sys.exit(0 if ok else 1)
+PY

--- a/tests/profile-cases.yaml
+++ b/tests/profile-cases.yaml
@@ -1,0 +1,78 @@
+# What `AppProfile.of` must make of an app: which focus rule, which pill anchor,
+# and whether the visible pane can be read as context.
+#
+# `bundle` and `name` are what `NSWorkspace` reports — the bundle identifier and
+# the localized name. Both are matched for terminals; only the bundle id is
+# matched for blind apps, because a name is something any app can claim.
+#
+# Add a row when you add an app. The wrong answer here is silent: `blind` on an
+# app that could have been examined pastes without checking what has focus, and
+# `ordinary` on an app that answers nothing sends every dictation to the
+# clipboard.
+
+- what: a terminal by bundle id
+  bundle: com.mitchellh.ghostty
+  name: Ghostty
+  focus: screen
+  anchor: ladder
+  readsPane: true
+
+- what: a terminal by name, built from source and signed however the build did
+  bundle: com.example.somebodys-build
+  name: Alacritty
+  focus: screen
+  anchor: ladder
+  readsPane: true
+
+- what: one terminal, several bundle ids
+  bundle: dev.warp.warp-preview
+  name: Warp
+  focus: screen
+  anchor: ladder
+  readsPane: true
+
+- what: Codex, which refuses both Chromium accessibility switches
+  bundle: com.openai.codex
+  name: ChatGPT
+  focus: blind
+  anchor: window
+  readsPane: false
+
+# The hole this file exists for. `blind` was matched on the name "codex" as well
+# as the bundle id, so any app calling itself Codex skipped the focus check
+# entirely. It never matched the real app either — Codex reports its name as
+# "ChatGPT", which is the row above.
+- what: an impostor calling itself Codex is still examined
+  bundle: com.example.whatever
+  name: Codex
+  focus: examine
+  anchor: ladder
+  readsPane: false
+
+- what: VS Code, which takes the unlock and can then be examined
+  bundle: com.microsoft.VSCode
+  name: Code
+  focus: examine
+  anchor: ladder
+  readsPane: false
+
+- what: Slack, which never needed anything
+  bundle: com.tinyspeck.slackmacgap
+  name: Slack
+  focus: examine
+  anchor: ladder
+  readsPane: false
+
+- what: an app nobody has classified
+  bundle: com.apple.finder
+  name: Finder
+  focus: examine
+  anchor: ladder
+  readsPane: false
+
+- what: matching ignores case
+  bundle: COM.MITCHELLH.GHOSTTY
+  name: GHOSTTY
+  focus: screen
+  anchor: ladder
+  readsPane: true


### PR DESCRIPTION
Three apps failed to take dictation, for three different reasons. All three are fixed, and the log now names the app on every `destination:` line — without that, none of these were diagnosable.

## VS Code — the tree was never built

Chromium builds its accessibility tree on request. Nothing was requesting it, so VS Code reported no focused element *and* no focused application, which reads as "nothing to type into" and sends the transcript to the clipboard.

`ChromiumAccessibility` sets `AXManualAccessibility` on each app as it comes to the front. Two properties matter:

- The flag lives on the **pid**, so it dies with the process. A relaunched editor must be asked again — this was verified by restarting VS Code and watching it break, then fixed.
- The cache must **not** gate the call. An app can activate a moment before its accessibility element exists; caching that failure as though it were a success means it is never retried. A failure buys one delayed retry, bounded per process.

Slack and Notion expose a tree unasked and are unaffected.

## Codex — cannot be unlocked at all

Measured: `-25205` (attributeUnsupported) to `AXManualAccessibility`, `-25208` (notImplemented) to `AXEnhancedUserInterface`. It takes a ⌘V and answers nothing else.

So it is **named rather than examined**, which is what terminals already were. `TextInserter` writes with ⌘V whatever the destination, so this decides only whether there is somewhere to write, never how.

Its pill was also opening in the wrong place — anchored to a 712x44 box belonging to whichever app had focus previously, because the system hands back the last participating app's element. The anchor now comes from `CGWindowListCopyWindowInfo`, which answers from outside the app and cannot be refused by it.

## The clipboard endings were silent

"Nowhere to type" and "focus moved" wrote to `statusInfoItem.title` — a row inside a menu you have to open — and played the same `Glass` sound as a success. Indistinguishable from the app having dropped the sentence, which is exactly how this was reported.

They now lead the offer pill and play `Tink`.

## AppProfile

Teaching the app about Codex meant editing three files. `AppProfile.of(app)` is now the single place that knows what an app affords — `focus`, `anchor`, `readsPane` — replacing two lists in `Destination`, two lookups in `Context` and one in `Surface`.

The anchor is now chosen by the app rather than by the write verdict, so where the pill opens and whether the words can be written are separate decisions.

## Testing

Verified by hand on this machine: VS Code across restarts, Codex in both its views, Slack and Ghostty unchanged. `--panel-sheet` draws the new offer state beside the plain one.

The refactor moved routing for terminals and ordinary apps, so those are the regression risk rather than Codex.

## Not done

Not split into per-concern commits — the `AppDelegate` changes interleave across all of them, and staging them apart would have been fiction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)