### PR TITLE
feat: teaching a name writes vocabulary.yaml, not config.yaml

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -167,6 +167,13 @@ jobs:
       - name: What vocabulary.yaml adds up to
         run: scripts/check-vocabulary-config.sh
 
+      # `--learn` used to write into config.yaml's `transcription.replacements`.
+      # It writes into vocabulary.yaml now, the same file the correction panel
+      # and the voice spelling command write, and the splice has to handle
+      # every shape that file has been written by hand.
+      - name: --learn writes a pronunciation
+        run: scripts/check-learn.sh
+
       # The same trap, one directory over: the transform folder a first launch
       # is seeded with against the copy in examples/ that people read and
       # score. It has always been able to drift and has never been checked

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2729,8 +2729,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func learn(_ rules: [(heard: String, corrected: String)]) -> Bool {
         for rule in rules {
             do {
-                try ConfigWriter.addReplacement(heard: rule.heard, corrected: rule.corrected)
-                Log.write("learned replacement: \(rule.heard) -> \(rule.corrected)")
+                try ConfigWriter.addVocabularyPronunciation(
+                    term: rule.corrected, heard: rule.heard
+                )
+                Log.write("learned pronunciation: \(rule.heard) -> \(rule.corrected)")
                 Trace.correction(heard: rule.heard, corrected: rule.corrected, via: "command")
             } catch {
                 presentAlert(title: "Could not save the rule", message: error.localizedDescription)
@@ -3193,8 +3195,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             guard let self else { return }
             for rule in rules {
                 do {
-                    try ConfigWriter.addReplacement(heard: rule.heard, corrected: rule.corrected)
-                    Log.write("learned replacement: \(rule.heard) -> \(rule.corrected)")
+                    try ConfigWriter.addVocabularyPronunciation(
+                        term: rule.corrected, heard: rule.heard
+                    )
+                    Log.write("learned pronunciation: \(rule.heard) -> \(rule.corrected)")
                     Trace.correction(
                         heard: rule.heard, corrected: rule.corrected, via: "panel"
                     )

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -3011,13 +3011,15 @@ if __name__ == "__main__":
             app: /term|ghostty|warp|kitty|alacritty|hyper|code|cursor|zed|xcode|jetbrains|idea|pycharm|webstorm/
             when: /\\b(?:function|method|variable|class|constant|type|struct|interface|enum|fonction|méthode|classe|constante)\\b/
 
-      # The spelling you want, and the ways it comes out wrong. Whole words,
-      # case-insensitive. A source in /slashes/ is a regular expression, and
-      # then the target is a template where $1 writes back what it captured. An
-      # empty target deletes, which is how filler words go.
+      # Patterns and deletions. Whole words, case-insensitive. A source in
+      # /slashes/ is a regular expression, and then the target is a template
+      # where $1 writes back what it captured. An empty target deletes, which
+      # is how filler words go. A name the recogniser mangles does not belong
+      # here — say "hey parrot" and fix it in the panel, and it is learnt in
+      # vocabulary.yaml instead.
       #
-      #   Supabase: [super base, superbees]
       #   "": ['/[,]?\\s*\\b(?:u+m+|u+h+|erm+|hmm+)\\b[,]?/']
+      #   '$1.$2': ['/\\b(\\w+) dot (\\w+)\\b/']    # "user dot name" -> user.name
       replacements: {}
 
 

--- a/Sources/ParrotFlow/ConfigWriter.swift
+++ b/Sources/ParrotFlow/ConfigWriter.swift
@@ -83,7 +83,7 @@ enum ConfigWriter {
         if value.hasPrefix("[") {
             let end = closingFlow(in: lines, from: start, deeperThan: 2)
             let sources = lines[start...end].joined(separator: " ")
-            if sources.contains(heard) { return yaml }
+            if flowListContains(heard, in: sources) { return yaml }
             guard let close = lines[end].lastIndex(of: "]") else { return yaml }
             let before = String(lines[end][lines[end].startIndex..<close])
             let separator = before.trimmingCharacters(in: .whitespaces).hasSuffix("[") ? "" : ", "
@@ -91,11 +91,30 @@ enum ConfigWriter {
             return lines.joined(separator: "\n")
         }
 
-        // A block already — `floor:`, `pronunciations:`, or both — or a bare
-        // (`Term:`) or legacy-floor (`Term: 0.85`) term with neither yet.
+        // A single-line flow mapping: `Claude: {floor: off, heard: [cloud]}`.
+        // Broken into one key per line rather than parsed and rewritten, so
+        // whatever it already says — `heard:`, `floor:`, both — survives
+        // untouched and the new rendering only ever adds a `pronunciations:`
+        // block beside it.
+        if value.hasPrefix("{"), value.hasSuffix("}") {
+            let pairs = splitFlowMapping(String(value.dropFirst().dropLast()))
+            if pairs.contains(where: { $0.key == "heard" && flowListContains(heard, in: $0.value) }) {
+                return yaml
+            }
+            let expanded = ["  \(quoted(term)):"]
+                + pairs.map { "    \($0.key): \($0.value)" }
+                + ["    pronunciations:"] + entry
+            lines.replaceSubrange(start...start, with: expanded)
+            return lines.joined(separator: "\n")
+        }
+
+        // A block already — `floor:`, `heard:`, `pronunciations:`, any mix —
+        // or a bare (`Term:`) or legacy-floor (`Term: 0.85`) term with none
+        // of them yet.
         let bodyIndent = 4
         var blockEnd = start
         var pronunciationsLine: Int?
+        var heardRange: ClosedRange<Int>?
         cursor = start + 1
         while cursor < lines.count {
             let line = lines[cursor]
@@ -105,8 +124,22 @@ enum ConfigWriter {
             if indentation(of: line).count == bodyIndent, trimmed.hasPrefix("pronunciations:") {
                 pronunciationsLine = cursor
             }
+            // The old key, possibly wrapped over two lines — cutting only the
+            // first would strand the tail as invalid YAML, so its whole span
+            // is tracked rather than just the one line it starts on.
+            if indentation(of: line).count == bodyIndent, trimmed.hasPrefix("heard:") {
+                let end = closingFlow(in: lines, from: cursor, deeperThan: bodyIndent)
+                heardRange = cursor...end
+                blockEnd = end
+                cursor = end + 1
+                continue
+            }
             blockEnd = cursor
             cursor += 1
+        }
+
+        if let heardRange, flowListContains(heard, in: lines[heardRange].joined(separator: " ")) {
+            return yaml
         }
 
         if let pronunciationsStart = pronunciationsLine {
@@ -287,6 +320,44 @@ enum ConfigWriter {
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .filter { !$0.isEmpty }
         return inside.count
+    }
+
+    /// Whether `item` is one of a flow sequence's entries, exactly — not
+    /// merely a substring of a longer one. "Press" is not "Pressy", and a
+    /// bare `contains` over the raw text said it was, so a rendering that
+    /// happened to be a prefix of one already there was silently dropped.
+    private static func flowListContains(_ item: String, in text: String) -> Bool {
+        guard let open = text.firstIndex(of: "["), let close = text.lastIndex(of: "]"),
+              open < close else { return false }
+        return text[text.index(after: open)..<close]
+            .split(separator: ",")
+            .map { unquoted($0.trimmingCharacters(in: .whitespaces)) }
+            .contains { $0.caseInsensitiveCompare(item) == .orderedSame }
+    }
+
+    /// A one-line flow mapping's entries, split on its own top-level commas —
+    /// `{floor: off, heard: [cloud, cloude]}` has a comma inside `heard:`'s
+    /// list that is not one of the mapping's own separators.
+    private static func splitFlowMapping(_ inner: String) -> [(key: String, value: String)] {
+        var depth = 0
+        var pieces: [String] = [""]
+        for character in inner {
+            if character == "[" || character == "{" { depth += 1 }
+            if character == "]" || character == "}" { depth -= 1 }
+            if character == ",", depth == 0 {
+                pieces.append("")
+            } else {
+                pieces[pieces.count - 1].append(character)
+            }
+        }
+        return pieces.compactMap { piece in
+            let trimmed = piece.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty, let colon = trimmed.firstIndex(of: ":") else { return nil }
+            let key = unquoted(String(trimmed[trimmed.startIndex..<colon]))
+            let value = String(trimmed[trimmed.index(after: colon)...])
+                .trimmingCharacters(in: .whitespaces)
+            return (key, value)
+        }
     }
 
     // MARK: - Helpers

--- a/Sources/ParrotFlow/ConfigWriter.swift
+++ b/Sources/ParrotFlow/ConfigWriter.swift
@@ -1,111 +1,155 @@
 import Foundation
 
-/// Adds a replacement rule to config.yaml without disturbing anything else.
+/// Writes what a correction taught into `vocabulary.yaml`, without disturbing
+/// anything else in it.
 ///
 /// Deliberately text-level rather than decode-edit-encode: round-tripping
 /// through Yams would strip every comment in the file, and the comments are
-/// most of what makes that config readable. So we find the `replacements:`
-/// block and splice one line into it.
+/// most of what makes that config readable. So we find the `terms:` block and
+/// splice a pronunciation into it.
 enum ConfigWriter {
 
-    enum WriteError: LocalizedError {
-        case noTranscriptionSection
+    // MARK: - Learning a pronunciation
 
-        var errorDescription: String? {
-            switch self {
-            case .noTranscriptionSection:
-                return "config.yaml has no `transcription:` section to add the rule to."
-            }
-        }
-    }
-
-    /// Records that `heard` should be written as `corrected`.
-    static func addReplacement(heard: String, corrected: String) throws {
-        let url = ConfigStore.fileURL
-        let original = try String(contentsOf: url, encoding: .utf8)
-        let updated = try insert(heard: heard, corrected: corrected, into: original)
+    /// Records that `term` is sometimes heard as `heard`.
+    ///
+    /// Where the correction panel, `--learn` and the voice spelling command
+    /// write — see `Config.Vocabulary`. `config.yaml`'s `transcription.
+    /// replacements` stays for patterns and deletions; a name the recogniser
+    /// mangled is a pronunciation, not a pattern, and belongs beside the
+    /// pronunciations the acoustic pass already found on its own.
+    static func addVocabularyPronunciation(term: String, heard: String) throws {
+        let url = ConfigStore.vocabularyURL
+        let original = (try? String(contentsOf: url, encoding: .utf8)) ?? "terms: {}\n"
+        let updated = try insertVocabulary(term: term, heard: heard, into: original)
         try updated.write(to: url, atomically: true, encoding: .utf8)
     }
 
-    /// Splices the mishearing into the list under its target spelling, adding
-    /// the target if it is new.
+    /// Splices the rendering into the term's `pronunciations:`, adding the
+    /// term if it is new.
     ///
-    /// Text-level rather than decode-edit-encode: round-tripping through Yams
-    /// would strip every comment in the file, and the comments are most of what
-    /// makes that config readable.
-    static func insert(heard: String, corrected: String, into yaml: String) throws -> String {
+    /// `from: correction` is what tells this rendering apart from one
+    /// `scripts/mine-pronunciations.py` found on its own — see
+    /// `Config.Vocabulary.Pronunciation.Source`.
+    static func insertVocabulary(term: String, heard: String, into yaml: String) throws -> String {
         var lines = yaml.components(separatedBy: "\n")
+        let entry = ["      - heard: \(quoted(heard))", "        from: correction"]
 
-        guard let transcriptionIndex = lines.firstIndex(where: {
-            $0.hasPrefix("transcription:")
-        }) else {
-            throw WriteError.noTranscriptionSection
+        guard let termsIndex = lines.firstIndex(where: { $0.hasPrefix("terms:") }) else {
+            var out = lines
+            if let last = out.last, !last.isEmpty { out.append("") }
+            out.append("terms:")
+            out.append(contentsOf: newTerm(term, entry: entry))
+            return out.joined(separator: "\n")
         }
 
-        // Find `replacements:` inside the transcription block, which ends at
-        // the first non-indented, non-blank line.
-        var replacementsIndex: Int?
-        var index = transcriptionIndex + 1
-        while index < lines.count {
-            let line = lines[index]
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            if !line.hasPrefix(" ") && !trimmed.isEmpty { break }
-            if trimmed.hasPrefix("replacements:") { replacementsIndex = index; break }
-            index += 1
-        }
-
-        guard let start = replacementsIndex else {
-            let insertAt = endOfBlock(in: lines, from: transcriptionIndex)
-            lines.insert(contentsOf: [
-                "  replacements:",
-                "    \(quoted(corrected)): [\(quoted(heard))]",
-            ], at: insertAt)
+        // `terms: {}` has to become a block mapping first.
+        if lines[termsIndex].trimmingCharacters(in: .whitespaces).hasSuffix("{}") {
+            lines[termsIndex] = "terms:"
+            lines.insert(contentsOf: newTerm(term, entry: entry), at: termsIndex + 1)
             return lines.joined(separator: "\n")
         }
 
-        let keyIndent = indentation(of: lines[start])
-        let entryIndent = keyIndent + "  "
-
-        // `replacements: {}` has to become a block mapping first.
-        if lines[start].trimmingCharacters(in: .whitespaces).hasSuffix("{}") {
-            lines[start] = "\(keyIndent)replacements:"
-            lines.insert("\(entryIndent)\(quoted(corrected)): [\(quoted(heard))]", at: start + 1)
-            return lines.joined(separator: "\n")
-        }
-
-        // Look for the target, and append to its list if it is already there.
-        var lastEntry = start
-        var cursor = start + 1
+        // Find the term's own line, directly under `terms:`.
+        var start: Int?
+        var cursor = termsIndex + 1
         while cursor < lines.count {
             let line = lines[cursor]
             let trimmed = line.trimmingCharacters(in: .whitespaces)
             if trimmed.isEmpty { cursor += 1; continue }
-            guard indentation(of: line).count > keyIndent.count else { break }
-
-            if !trimmed.hasPrefix("#"), let colon = trimmed.firstIndex(of: ":") {
-                let existing = unquoted(String(trimmed[trimmed.startIndex..<colon]))
-                if existing.caseInsensitiveCompare(corrected) == .orderedSame {
-                    let sources = String(trimmed[trimmed.index(after: colon)...])
-                        .trimmingCharacters(in: .whitespaces)
-                    // Already listed: nothing to add.
-                    if sources.contains(heard) { return yaml }
-                    if let close = line.lastIndex(of: "]") {
-                        let separator = sources == "[]" ? "" : ", "
-                        lines[cursor] = String(line[line.startIndex..<close])
-                            + separator + quoted(heard) + "]"
-                        return lines.joined(separator: "\n")
-                    }
-                }
-                lastEntry = cursor
+            guard line.hasPrefix(" ") else { break }
+            if indentation(of: line).count == 2, !trimmed.hasPrefix("#"),
+               let colon = trimmed.firstIndex(of: ":"),
+               unquoted(String(trimmed[trimmed.startIndex..<colon]))
+                   .caseInsensitiveCompare(term) == .orderedSame {
+                start = cursor
+                break
             }
             cursor += 1
         }
 
-        lines.insert(
-            "\(entryIndent)\(quoted(corrected)): [\(quoted(heard))]",
-            at: lastEntry + 1
-        )
+        guard let start else {
+            // A new term: append at the end of `terms:`.
+            let insertAt = endOfBlock(in: lines, from: termsIndex)
+            lines.insert(contentsOf: newTerm(term, entry: entry), at: insertAt)
+            return lines.joined(separator: "\n")
+        }
+
+        let head = lines[start]
+        guard let colon = head.firstIndex(of: ":") else { return yaml }
+        let value = String(head[head.index(after: colon)...]).trimmingCharacters(in: .whitespaces)
+
+        // Shorthand list: `Term: [a, b]`, possibly wrapped over two lines.
+        if value.hasPrefix("[") {
+            let end = closingFlow(in: lines, from: start, deeperThan: 2)
+            let sources = lines[start...end].joined(separator: " ")
+            if sources.contains(heard) { return yaml }
+            guard let close = lines[end].lastIndex(of: "]") else { return yaml }
+            let before = String(lines[end][lines[end].startIndex..<close])
+            let separator = before.trimmingCharacters(in: .whitespaces).hasSuffix("[") ? "" : ", "
+            lines[end] = before + separator + quoted(heard) + "]"
+            return lines.joined(separator: "\n")
+        }
+
+        // A block already — `floor:`, `pronunciations:`, or both — or a bare
+        // (`Term:`) or legacy-floor (`Term: 0.85`) term with neither yet.
+        let bodyIndent = 4
+        var blockEnd = start
+        var pronunciationsLine: Int?
+        cursor = start + 1
+        while cursor < lines.count {
+            let line = lines[cursor]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty { cursor += 1; continue }
+            guard indentation(of: line).count >= bodyIndent else { break }
+            if indentation(of: line).count == bodyIndent, trimmed.hasPrefix("pronunciations:") {
+                pronunciationsLine = cursor
+            }
+            blockEnd = cursor
+            cursor += 1
+        }
+
+        if let pronunciationsStart = pronunciationsLine {
+            var listEnd = pronunciationsStart
+            var scan = pronunciationsStart + 1
+            while scan < lines.count {
+                let line = lines[scan]
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                if trimmed.isEmpty { scan += 1; continue }
+                guard indentation(of: line).count > bodyIndent else { break }
+                let bare = trimmed.hasPrefix("- ") ? String(trimmed.dropFirst(2)) : trimmed
+                let existing = bare.hasPrefix("heard:")
+                    ? unquoted(String(bare.dropFirst("heard:".count)).trimmingCharacters(in: .whitespaces))
+                    : unquoted(bare)
+                if existing.caseInsensitiveCompare(heard) == .orderedSame { return yaml }
+                listEnd = scan
+                scan += 1
+            }
+            lines.insert(contentsOf: entry, at: listEnd + 1)
+            return lines.joined(separator: "\n")
+        }
+
+        if blockEnd > start {
+            // A block with `floor:` but no `pronunciations:` yet.
+            lines.insert(contentsOf: ["    pronunciations:"] + entry, at: blockEnd + 1)
+            return lines.joined(separator: "\n")
+        }
+
+        // Bare, or carrying a legacy floor number that has to move under its
+        // own key before anything can nest below it.
+        if value.isEmpty {
+            lines.insert(contentsOf: ["    pronunciations:"] + entry, at: start + 1)
+        } else {
+            lines[start] = "  \(quoted(term)):"
+            lines.insert(
+                contentsOf: ["    floor: \(value)", "    pronunciations:"] + entry, at: start + 1
+            )
+        }
         return lines.joined(separator: "\n")
+    }
+
+    private static func newTerm(_ term: String, entry: [String]) -> [String] {
+        ["  \(quoted(term)):", "    pronunciations:"] + entry
     }
 
     // MARK: - Forgetting a term's pronunciations
@@ -116,9 +160,9 @@ enum ConfigWriter {
     /// spellings and the audio that piled up behind a name — and a person who
     /// wanted the name gone would delete the name.
     ///
-    /// Text-level, for the same reason `insert` is: this file carries a long
-    /// header explaining what its numbers mean, and a round trip through Yams
-    /// would throw all of it away.
+    /// Text-level, for the same reason `insertVocabulary` is: this file
+    /// carries a long header explaining what its numbers mean, and a round
+    /// trip through Yams would throw all of it away.
     static func forgetPronunciations(of term: String) throws -> Int {
         let url = ConfigStore.vocabularyURL
         guard let original = try? String(contentsOf: url, encoding: .utf8) else { return 0 }

--- a/Sources/ParrotFlow/LearnCommand.swift
+++ b/Sources/ParrotFlow/LearnCommand.swift
@@ -1,13 +1,14 @@
 import Foundation
 
-/// `--learn <heard> <corrected>` — adds a replacement rule from the terminal.
+/// `--learn <heard> <corrected>` — adds a vocabulary pronunciation from the
+/// terminal.
 ///
 /// The same code path the correction panel uses, minus the UI. Useful on its
 /// own, and it makes the config-rewriting logic testable without a GUI.
 enum LearnCommand {
     static func run(heard: String, corrected: String) -> Int32 {
         do {
-            try ConfigWriter.addReplacement(heard: heard, corrected: corrected)
+            try ConfigWriter.addVocabularyPronunciation(term: corrected, heard: heard)
             Trace.correction(heard: heard, corrected: corrected, via: "learn")
             print("✓ \(heard) → \(corrected)")
             return 0

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -80,8 +80,7 @@ transcription:
   # belong here.
   replacements:
     "": ['/[,]?\s*\b(?:mm[-‑]?hmm|uh[-‑]?huh|mhm|u+m+|u+h+|erm+|hmm+|mm+)\b[,]?/']
-    Tasmeen: [Tasmid, Tasmin, Tasmine]
-    Supabase: [super base, superbees]
+    '$1.$2': ['/\b(\w+) dot (\w+)\b/']    # "user dot name" -> user.name
 
 # The local Ollama model behind spoken commands. Without it dictation still
 # works and every `prompt:` transform below stops.

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -67,17 +67,17 @@ For a name that comes out wrong, nothing needs writing — say
 $PF --learn "super base" Supabase
 ```
 
-For a pattern, add it to `transcription.replacements` and check it:
+For a pattern or a deletion, add it to `transcription.replacements` and check
+it:
 
 ```yaml
 replacements:
-  Supabase: [super base, superbees]
   "": ['/\b(?:u+m+|erm+)\b/']          # empty target deletes
   '$1 ticket': ['/\bticket number (\d+)\b/']
 ```
 
 ```sh
-$PF --replace "we deployed to super base and um it worked"
+$PF --replace "ticket number 42 and um it worked"
 scripts/check-replacements.sh
 ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -211,8 +211,8 @@ instruction that would have been spoken. `--command` runs the whole
 wake-phrase path: is this a command at all, is it a correction, which words in
 the previous transcript does it target.
 
-`--learn` writes a replacement rule from the terminal, the same one the
-correction panel would have written.
+`--learn` adds a pronunciation to `vocabulary.yaml` from the terminal, the
+same one the correction panel would have written.
 
 ## Forgetting what a name sounds like
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -214,14 +214,15 @@ end of what was still there.
 
 ## `transcription.replacements`
 
-The spelling you want, and the ways it comes out wrong. Whole words,
-case-insensitive.
+Patterns and deletions, hand-written. Whole words, case-insensitive. A name
+the recogniser mangles does not go here — say "hey parrot" and fix it in the
+panel, and it lands in `vocabulary.yaml` instead — but a pattern with no fixed
+spelling, or a deletion, has nowhere else to live.
 
 ```yaml
 replacements:
-  Tasmeen: [Tasmid, Tasmin, Tasmine]
-  Supabase: [super base, superbees]
   "": ['/[,]?\s*\b(?:u+m+|u+h+|erm+|hmm+)\b[,]?/']
+  '$1.$2': ['/\b(\w+) dot (\w+)\b/']
 ```
 
 A source in `/slashes/` is a regular expression, and with one the target is a
@@ -229,12 +230,8 @@ template, so `$1` writes back what the pattern captured. An **empty target
 deletes** rather than substitutes, which is how filler words go, punctuation
 and spacing included.
 
-Grouped by the spelling you want rather than one line per mistake, because the
-same name comes out wrong a dozen ways and they all mean one thing.
-
-The table runs as the `replacements` stage; the `fuzzy` stage runs the same
-table against renderings you never taught it. Both are pipeline stages, so
-whether they run at all is [pipelines.md](pipelines.md).
+The table runs as the `replacements` stage — a pipeline stage, so whether it
+runs at all is [pipelines.md](pipelines.md).
 
 ## `llm`
 

--- a/docs/corrections.md
+++ b/docs/corrections.md
@@ -178,9 +178,9 @@ everything about the instruction fails.
 
 ## See also
 
-- [configuration.md](configuration.md#transcriptionreplacements) — the rule
-  table a correction writes into
-- [pipelines.md](pipelines.md) — the `fuzzy` stage, which catches renderings you
-  never taught
+- [transcription.md](transcription.md#2-a-vocabulary--for-words-the-recogniser-gets-wrong) —
+  the vocabulary a correction writes into
+- [transcription.md](transcription.md#per-term) — `vocabulary.acoustic`, which
+  catches renderings you never taught, by sound
 - [authoring.md](authoring.md) — changing the prompts behind any of this, with
   the case sets that say whether you made it better

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -428,7 +428,7 @@ dropped as soon as focus moves. Copy the text first, then say the command.
 http://localhost:11434/api/version` and `ollama list | grep gemma4`.
 
 **A name is still wrong after teaching it.**
-`grep -A5 replacements ~/.config/parrotflow/config.yaml`.
+`grep -A5 <name> ~/.config/parrotflow/vocabulary.yaml`.
 
 **Dictation is slow the first time.** The first clip after launch loads the
 speech model.

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -18,10 +18,11 @@ takes text prompts.
 So "transcribe this as bullet points" or "the speaker is French" cannot be
 passed to the model. Two things cover what you'd actually want from a prompt:
 
-### 1. A replacements map — for names and jargon
+### 1. A replacements map — for patterns and deletions
 
-Rare names are fixed by literal, word-boundary, case-insensitive substitution
-on the finished transcript, taught through the correction panel.
+Literal, word-boundary, case-insensitive substitution on the finished
+transcript, written by hand in `config.yaml`. A name the recogniser mangles
+does not belong here — that is what the vocabulary below is for.
 
 A source wrapped in slashes is a regular expression instead, and an empty
 target deletes rather than substitutes. That combination is what handles
@@ -404,9 +405,10 @@ a resumable transfer, and a working app (record-only) until it lands.
 
 ## Voice corrections
 
-Saying "hey parrot, <name> spells T A S M E E N" adds a replacement rule. A
-local model picks which words in the previous transcript were meant; the
-spelling comes from the letters by regex, never from the model.
+Saying "hey parrot, <name> spells T A S M E E N" adds a pronunciation to
+`vocabulary.yaml`. A local model picks which words in the previous transcript
+were meant; the spelling comes from the letters by regex, never from the
+model.
 
 That split is deliberate and measured. Given the whole job the model returns
 the right span but mangles the letters it is copying — "S I O B H A N" came

--- a/scripts/check-learn.sh
+++ b/scripts/check-learn.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Checks that `--learn` writes into vocabulary.yaml, not config.yaml.
+#
+#   scripts/check-learn.sh
+#
+# The correction panel and the "hey parrot, <name> spells ..." voice command
+# call the same code this does. A name is a pronunciation, not a pattern, so
+# it belongs beside the pronunciations the acoustic pass finds on its own —
+# `config.yaml`'s `transcription.replacements` stays for patterns and
+# deletions, which `--learn` never touches.
+#
+# `vocabulary.yaml` has been written by hand five different ways over time —
+# a bare term, a legacy `floor:` number, a shorthand list, and a block with or
+# without `pronunciations:` already in it — and every one of those has to
+# still be valid YAML with the new rendering spliced in, not just the shape a
+# fresh install starts with.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/release/ParrotFlow"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+
+WORK="$(mktemp -d -t parrotflow-learn)"
+trap 'rm -rf "$WORK"' EXIT
+printf 'transcription:\n  languages: [en]\n' > "$WORK/config.yaml"
+
+pass=0; total=0; failed=""
+
+wants() {
+  total=$((total + 1))
+  if printf '%s' "$2" | grep -qF -- "$3"; then
+    pass=$((pass + 1))
+    printf '  ✓ %s\n' "$1"
+  else
+    failed="$failed
+      $1"
+    printf '  ✗ %s\n      want  %s\n      got   %s\n' "$1" "$3" "$2"
+  fi
+}
+
+rejects() {
+  total=$((total + 1))
+  if printf '%s' "$2" | grep -qF -- "$3"; then
+    failed="$failed
+      $1"
+    printf '  ✗ %s\n      unwanted  %s\n      got       %s\n' "$1" "$3" "$2"
+  else
+    pass=$((pass + 1))
+    printf '  ✓ %s\n' "$1"
+  fi
+}
+
+learn() {
+  PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --learn "$1" "$2" >/dev/null 2>&1
+}
+vocab() { cat "$WORK/vocabulary.yaml"; }
+config() { cat "$WORK/config.yaml"; }
+
+# --- a fresh install: `terms: {}` becomes a block ---------------------------
+printf 'terms: {}\n' > "$WORK/vocabulary.yaml"
+learn "super base" Supabase
+wants "a new term is added"          "$(vocab)" "Supabase:"
+wants "with its rendering"           "$(vocab)" "heard: super base"
+wants "and its provenance"           "$(vocab)" "from: correction"
+rejects "config.yaml is untouched"   "$(config)" "replacements"
+
+# --- a second rendering of the same term appends, does not duplicate -------
+learn superbees Supabase
+wants "a second rendering is added"  "$(vocab)" "heard: superbees"
+n="$(grep -c 'heard: super base' "$WORK/vocabulary.yaml")"
+total=$((total + 1))
+if [ "$n" = "1" ]; then
+  pass=$((pass + 1)); printf '  ✓ the first rendering is still there once\n'
+else
+  failed="$failed
+      the first rendering is still there once"
+  printf '  ✗ the first rendering is still there once\n      got %s\n' "$n"
+fi
+
+# --- learning the same rendering again is a no-op ---------------------------
+before="$(vocab)"
+learn superbees Supabase
+total=$((total + 1))
+if [ "$(vocab)" = "$before" ]; then
+  pass=$((pass + 1)); printf '  ✓ a repeated rendering changes nothing\n'
+else
+  failed="$failed
+      a repeated rendering changes nothing"
+  printf '  ✗ a repeated rendering changes nothing\n'
+fi
+
+# --- an existing shorthand list gets appended to, not replaced --------------
+printf 'terms:\n  Redcrawl: [Redcroll, red crawl]\n' > "$WORK/vocabulary.yaml"
+learn "Red Croll" Redcrawl
+wants "the old renderings survive"   "$(vocab)" "Redcroll, red crawl, Red Croll"
+
+# --- a bare term (nothing known yet) grows a pronunciations block ----------
+printf 'terms:\n  Tasmeen:\n' > "$WORK/vocabulary.yaml"
+learn Tasmid Tasmeen
+wants "a bare term gets pronunciations" "$(vocab)" "pronunciations:"
+wants "with the new rendering"          "$(vocab)" "heard: Tasmid"
+
+# --- a legacy floor number moves under its own key, not overwritten --------
+printf 'terms:\n  Mirza: 0.85\n' > "$WORK/vocabulary.yaml"
+learn Mirsa Mirza
+wants "the floor number is kept"        "$(vocab)" "floor: 0.85"
+wants "with a pronunciations block added" "$(vocab)" "heard: Mirsa"
+
+# --- a block with `floor:` but no `pronunciations:` yet ---------------------
+printf 'terms:\n  Vercel:\n    floor: off\n' > "$WORK/vocabulary.yaml"
+learn Versailles Vercel
+wants "floor: off is kept"              "$(vocab)" "floor: off"
+wants "pronunciations are added beside it" "$(vocab)" "heard: Versailles"
+
+# --- a term found case-insensitively, and one with punctuation -------------
+printf 'terms:\n  gpt-4o: [gpt four o]\n' > "$WORK/vocabulary.yaml"
+learn "gpt 4 oh" "GPT-4o"
+n="$(grep -c '^  gpt-4o' "$WORK/vocabulary.yaml")"
+total=$((total + 1))
+if [ "$n" = "1" ]; then
+  pass=$((pass + 1)); printf '  ✓ a case-insensitive match reuses the existing term\n'
+else
+  failed="$failed
+      a case-insensitive match reuses the existing term"
+  printf '  ✗ a case-insensitive match reuses the existing term\n      got %s\n' "$n"
+fi
+
+# --- the result always parses -----------------------------------------------
+got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --check-config 2>&1)"
+rejects "the last file written still parses" "$got" "could not be read"
+
+printf '\n  %d/%d\n' "$pass" "$total"
+if [ -n "$failed" ]; then
+  printf '  failed:%s\n' "$failed"
+  exit 1
+fi

--- a/scripts/check-learn.sh
+++ b/scripts/check-learn.sh
@@ -93,6 +93,63 @@ printf 'terms:\n  Redcrawl: [Redcroll, red crawl]\n' > "$WORK/vocabulary.yaml"
 learn "Red Croll" Redcrawl
 wants "the old renderings survive"   "$(vocab)" "Redcroll, red crawl, Red Croll"
 
+# --- a rendering that is a substring of an existing one is not a duplicate --
+# Greptile found this one: "Press" is not "Pressy", and a bare `contains`
+# over the joined list text said it was, so the write was silently skipped.
+printf 'terms:\n  Praisy: [Prissy, Pressy]\n' > "$WORK/vocabulary.yaml"
+learn Press Praisy
+wants "the shorter rendering is still added" "$(vocab)" "Prissy, Pressy, Press"
+before="$(vocab)"
+learn Pressy Praisy
+total=$((total + 1))
+if [ "$(vocab)" = "$before" ]; then
+  pass=$((pass + 1)); printf '  ✓ the exact rendering it is a substring of still no-ops\n'
+else
+  failed="$failed
+      the exact rendering it is a substring of still no-ops"
+  printf '  ✗ the exact rendering it is a substring of still no-ops\n'
+fi
+
+# --- a single-line flow mapping keeps its `heard:` list -------------------
+# Greptile found this one too: the writer did not recognise `{...}` on the
+# term's own line, fell through to the legacy-floor branch, and shoved the
+# whole mapping under a `floor:` key — which the decoder cannot read back as
+# pronunciations, so the old renderings were reachable only by their raw
+# text, not as terms the sound search or the exact pass would ever find.
+printf 'terms:\n  Claude: {floor: off, heard: [cloud]}\n' > "$WORK/vocabulary.yaml"
+learn cloude Claude
+wants "floor: off survives the rewrite"   "$(vocab)" "floor: off"
+wants "the old heard: list survives"      "$(vocab)" "heard: [cloud]"
+wants "the new rendering is added beside it" "$(vocab)" "heard: cloude"
+got="$(PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --check-config 2>&1)"
+wants "and both renderings are read back" "$got" "1 terms in vocabulary.yaml, 0 matched by sound, 2 by rule"
+before="$(vocab)"
+learn cloud Claude
+total=$((total + 1))
+if [ "$(vocab)" = "$before" ]; then
+  pass=$((pass + 1)); printf '  ✓ a duplicate inside the old heard: list still no-ops\n'
+else
+  failed="$failed
+      a duplicate inside the old heard: list still no-ops"
+  printf '  ✗ a duplicate inside the old heard: list still no-ops\n'
+fi
+
+# --- a block-style (not flow-mapping) `heard:` list is also recognised -----
+printf 'terms:\n  Praisy:\n    heard: [Prissy, Pressy]\n' > "$WORK/vocabulary.yaml"
+before="$(vocab)"
+learn Pressy Praisy
+total=$((total + 1))
+if [ "$(vocab)" = "$before" ]; then
+  pass=$((pass + 1)); printf '  ✓ a duplicate inside a block heard: list no-ops\n'
+else
+  failed="$failed
+      a duplicate inside a block heard: list no-ops"
+  printf '  ✗ a duplicate inside a block heard: list no-ops\n'
+fi
+learn Prezi Praisy
+wants "a new rendering still gets a pronunciations block" "$(vocab)" "heard: Prezi"
+wants "beside the old heard: list, not instead of it"     "$(vocab)" "heard: [Prissy, Pressy]"
+
 # --- a bare term (nothing known yet) grows a pronunciations block ----------
 printf 'terms:\n  Tasmeen:\n' > "$WORK/vocabulary.yaml"
 learn Tasmid Tasmeen


### PR DESCRIPTION
## Summary

The correction panel, "hey parrot, `<name>` spells ...", and `--learn` all
wrote a taught name into `config.yaml`'s `transcription.replacements`. That
table is hand-written and meant for patterns and deletions (filler words,
the dotted-path template) — a name the recogniser mangled is a
pronunciation, and `vocabulary.yaml` is already where the app records those
from the acoustic pass. The docs already described this split; the write
path hadn't caught up.

- `ConfigWriter.addVocabularyPronunciation` replaces `addReplacement`,
  splicing into `vocabulary.yaml`'s `terms:` instead of `config.yaml`'s
  `replacements:`. Handles every shape that file has been written by hand:
  a bare term, a legacy `floor:` number, a shorthand list, a block with or
  without `pronunciations:` already in it, and duplicate renderings (no-op).
- `transcription.replacements` itself is untouched: still exists, still
  runs as a pipeline stage, still takes patterns and deletions by hand.
- `config.example.yaml` and the app's own default config no longer show
  names as `replacements:` examples — that was never where they belonged.
- Docs updated to match (`cli.md`, `setup.md`, `corrections.md`,
  `transcription.md`, `authoring.md`, `configuration.md`).

## Known gap, not fixed here

The `fuzzy` pipeline stage reads its targets from `transcription.rules`
only, not from `vocabularyRules`. So a name learnt from now on gets
exact-match coverage (the `replacements` stage's exact pass already unions
`vocabularyRules`) but not `fuzzy`'s edit-distance matching for spellings
never taught. `vocabulary.acoustic` covers that gap by sound when it's on.
Wiring `fuzzy` to vocabulary targets too is a separate change.

## Test plan

- [x] `swift build -c release`
- [x] `scripts/check-replacements.sh` — 23/23 (transcription.replacements
      pipeline, unaffected)
- [x] `scripts/check-vocabulary-config.sh` — 61/61 (unaffected)
- [x] `scripts/check-default-config.sh` — passes (default install matches
      `config.example.yaml`)
- [x] `scripts/check-learn.sh` (new) — 16/16, covering every vocabulary.yaml
      shape `--learn` can splice into
- [x] Manual: `--learn` against scratch config dirs, `--check-config` reads
      the result back cleanly for each shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)