### PR TITLE
docs: rebuild setup.md around seven steps, one hand-over, and the vocabulary

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -27,19 +27,20 @@ Say which download you are on. A silent 10 GB download looks like a hang.
 
 | What | Size | When | Needed for |
 | --- | --- | --- | --- |
-| The app | 3 MB | Step 3 | everything |
-| Parakeet, the speech model | 1.2 GB | Step 5, automatic | dictation |
-| Gemma, the language model | 10 GB | Step 9, optional | voice commands |
+| The app | 3 MB | Step 2 | everything |
+| Parakeet, the speech model | 1.2 GB | Step 3, automatic | dictation |
+| Gemma, the language model | 10 GB | Step 7, optional | voice commands |
 
-Dictation works after Step 5. Everything after is extra.
+Dictation works after Step 3. Everything after is extra.
 
 **Already installed** (`ls -d /Applications/ParrotFlow.app`)? This is an
-upgrade. Run Step 3 anyway — it replaces the app in place — then go to Step 7,
-read `~/.config/parrotflow/config.yaml`, and ask only about what is missing.
+upgrade. Run Step 2 anyway — it replaces the app in place — then go to Step 4,
+read `~/.config/parrotflow/config.yaml`, and Step 5, read
+`~/.config/parrotflow/vocabulary.yaml`, and ask only about what is missing.
 
 ---
 
-## Step 1 — Say what is about to happen
+## Step 1 — Explain, then check the Mac
 
 They should be able to stop you here.
 
@@ -54,22 +55,20 @@ They should be able to stop you here.
 If they ask what the 10 GB is for: only spoken commands. Dictation does not need
 it.
 
-## Step 2 — Check the Mac
-
 ```sh
 sw_vers -productVersion                # need 14 or higher
 uname -m                               # need arm64
-sysctl -n hw.memsize                   # bytes of RAM — write this down, Step 9 needs it
+sysctl -n hw.memsize                   # bytes of RAM — write this down, Step 7 needs it
 df -g / | tail -1 | awk '{print $4}'   # GB free — need 15 or more
 ```
 
-**Remember the RAM number.** It decides a setting in Step 9.
+**Remember the RAM number.** It decides a setting in Step 7.
 
 Stop if macOS is older than 14, or if the Mac is Intel — speech recognition runs
 on the Neural Engine and Intel Macs have none. Under 15 GB free: say so and ask
 whether to continue. Dictation needs 1.5 GB; the 10 GB model is optional.
 
-## Step 3 — Install the app
+## Step 2 — Install, and get both permissions
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/znat/parrotflow/main/scripts/install.sh | sh
@@ -85,9 +84,7 @@ Download fails → check `https://github.com/znat/parrotflow/releases` for a
 release. `/Applications` not writable → rerun with
 `PARROTFLOW_DEST=~/Applications`.
 
-## Step 4 — Microphone permission
-
-The app asks at first launch; the window may already be open.
+**Microphone.** The app asks at first launch; the window may already be open.
 
 > macOS is asking if ParrotFlow can use your microphone. Please say yes.
 
@@ -101,27 +98,8 @@ Want `✓ microphone  Granted`. Anything else: **System Settings → Privacy &
 Security → Microphone**, then check again. This also prints the config the app
 is using. Read it; you will come back to it.
 
-## Step 5 — Prove transcription works, and download Parakeet
-
-Needs no microphone.
-
-```sh
-say -o /tmp/pf-check.wav --data-format=LEI16@16000 --channels=1 "Testing one two three"
-/Applications/ParrotFlow.app/Contents/MacOS/ParrotFlow --transcribe /tmp/pf-check.wav
-```
-
-`say` writes exactly the 16 kHz mono WAV the model expects. The first run
-downloads that model — tell them first:
-
-> Downloading the speech model now. It is called Parakeet, about 1.2 GB, and it
-> runs on your Mac. A few minutes.
-
-`Testing 123.` is a correct result; what matters is that text came back. If this
-fails, stop and fix it — nothing after this step can work.
-
-## Step 6 — Accessibility permission, or the clipboard instead
-
-A real choice. Ask before opening any settings window.
+**Accessibility, or the clipboard instead.** A real choice. Ask before opening
+any settings window.
 
 > **Type the text for me** — ParrotFlow types straight into the app you are
 > using. Needs the Accessibility permission.
@@ -136,7 +114,7 @@ The cost is the missing permission, not the setting — reading a selection is
 exactly what Accessibility controls:
 
 > Two things will not work: fixing a word by voice, and the voice commands in
-> Step 10. Both have to read the text you selected. Dictation is not affected,
+> Step 7. Both have to read the text you selected. Dictation is not affected,
 > and you can turn the permission on later without reinstalling anything.
 
 Typing — the default — open the window:
@@ -159,7 +137,25 @@ grep "launched —" ~/Library/Logs/ParrotFlow.log | tail -1
 Want `accessibility=Granted`. `NotGranted` means the switch is off or they
 ticked a different app.
 
-## Step 7 — The questions that shape the config
+## Step 3 — Prove transcription works with no voice
+
+Needs no microphone.
+
+```sh
+say -o /tmp/pf-check.wav --data-format=LEI16@16000 --channels=1 "Testing one two three"
+/Applications/ParrotFlow.app/Contents/MacOS/ParrotFlow --transcribe /tmp/pf-check.wav
+```
+
+`say` writes exactly the 16 kHz mono WAV the model expects. The first run
+downloads that model — tell them first:
+
+> Downloading the speech model now. It is called Parakeet, about 1.2 GB, and it
+> runs on your Mac. A few minutes.
+
+`Testing 123.` is a correct result; what matters is that text came back. If this
+fails, stop and fix it — nothing after this step can work.
+
+## Step 4 — The questions that shape the config
 
 Ask together, edit `~/.config/parrotflow/config.yaml` after each answer. The app
 reloads on save.
@@ -213,12 +209,56 @@ want it: `transcription: numbers: true`.
 Check every edit with `--check-config`. It prints each rule and reports a
 pattern it cannot compile.
 
-## Step 8 — Let them try it
+## Step 5 — Build the vocabulary
+
+Dictation gets names, jargon and internal acronyms wrong more than anything
+else, and a colleague's name is dictated constantly. Build a `vocabulary.yaml`
+now, from what this person actually says.
+
+> I want to gather the names and terms you say a lot — colleagues, projects,
+> tools — so dictation gets them right from the start. I will look at your
+> code, and I will hand you something to paste into Slack. Nothing leaves your
+> Mac; I will say more about that before I ask for anything.
+
+Follow `.claude/skills/vocabulary-corpus/SKILL.md` for the whole of this step.
+It mines the codebase, gives you the Slack prompt to hand over, and — this is
+the part that matters — screens every candidate against rejection criteria
+earned from measurement, so a name that would overwrite an ordinary word never
+reaches the file. Follow it in full rather than shortcutting the rejections.
+
+**There is no audio calibration in this procedure.** Do not have them read
+sentences aloud, and do not reach for `.claude/skills/calibrate`. It exists,
+but it answers a question this setup does not ask. `vocabulary.acoustic`
+defaults to `false` (`Sources/ParrotFlow/Config.swift`), so a term is matched
+only by the written rule the skill produces, never by sound — no ~98 MB model
+to pull, no clip to record, no threshold to tune. The one thing calibration
+used to catch — a term that overwrites an ordinary word it sounds like — is
+exactly what the skill's step 3 rejection criteria catch before anything is
+written.
+
+When the vocabulary is written, confirm it parsed:
+
+```sh
+/Applications/ParrotFlow.app/Contents/MacOS/ParrotFlow --check-config
+```
+
+It now prints a `vocabulary:` block — how many terms, how many carry a rule,
+and, since this Mac has `acoustic: false`, a line saying plainly that matching
+is by rule only. A term with neither a rule nor a rendering says so too; that
+means it does nothing yet, which is worth mentioning rather than leaving
+silent.
+
+## Step 6 — Let them try it
 
 You cannot do this one.
 
 > Your turn. Open any text box, hold the **right Option key**, say a sentence,
-> let go. About a second later the text appears at your cursor.
+> let go.
+
+A small pill appears next to where the words are about to land while they
+talk. A beat after they let go, the text lands there and the pill turns into a
+row of chips — **Correct** first, plus anything else set to appear there — and
+fades out on its own after nine seconds.
 
 ```sh
 grep -E "transcribed|speech gate|hotkey" ~/Library/Logs/ParrotFlow.log | tail -5
@@ -227,16 +267,20 @@ grep -E "transcribed|speech gate|hotkey" ~/Library/Logs/ParrotFlow.log | tail -5
 - Nothing in the log → the key never fired. Check `--check-config` for a
   registration failure; ask if another app owns that key.
 - `speech gate: no speech detected` → wrong input device, or they let go early.
-- `transcribed: …` but no text → Accessibility. Back to Step 6.
+- `transcribed: …` but no text → Accessibility. Back to Step 2.
 
-## Step 9 — Voice commands (the 10 GB part)
+## Step 7 — The optional model half
 
-> Optional, and last. It downloads a 10 GB model called Gemma, which understands
-> the commands you say out loud. Everything else already works without it, and
-> the download runs in the background. Do you want it?
+One decision covers everything in this step: do they want the 10 GB part.
 
-No → set `llm: enabled: false`, tell them they can still fix words by hand from
-the menu bar, skip to Step 12.
+> Optional, and last. It downloads a 10 GB model called Gemma, which
+> understands the commands you say out loud. Everything else already works
+> without it, and the download runs in the background. Do you want it?
+
+**No** → set `llm: enabled: false`, tell them they can still fix words by hand
+from the menu bar, and go to **Hand over**.
+
+**Yes** → keep going.
 
 **Ollama runs the model.** These answer whether it is installed and running:
 
@@ -263,7 +307,7 @@ Ollama app.
 all. Homebrew: `brew upgrade ollama`. The Ollama app: they must update it
 themselves, you cannot.
 
-**Now use the RAM number from Step 2.** The model needs 9.6 GB while loaded:
+**Now use the RAM number from Step 1.** The model needs 9.6 GB while loaded:
 
 | RAM | `llm.keep_loaded` | Why |
 | --- | --- | --- |
@@ -291,9 +335,8 @@ Check later with `tail -2 /tmp/parrotflow-pull.log` and `ollama list | grep
 gemma4`. An error about the model or manifest means Ollama is too old, whatever
 its version string said.
 
-## Step 10 — Teach them what they can say
-
-Do this while the download runs. It is the part people miss.
+**Teach them what they can say.** Do this while the download runs. It is the
+part people miss.
 
 Everything starts with the wake phrase `hey parrot`: hold the same key, say the
 phrase, then say what you want. Those words are never typed into the document.
@@ -325,14 +368,15 @@ each tuned because it beats `free_form` at that one job:
 > Three are tuned for one job each. Everything else goes to the general one. You
 > do not have to remember which is which.
 
+`grammar` is also already on the pill from Step 6 — the **G** chip, right after
+any dictation, no wake phrase needed. `bullets` and `terse` only run when asked
+out loud.
+
 A transform of their own goes in `transforms:` and needs a `description` — that
 is what the router matches spoken words against, and `--check-config` reports an
 entry without one as an error.
 
-## Step 11 — Slack handles, if they use Slack
-
-Skip unless they use Slack, and skip if they said no in Step 9 — this needs the
-model.
+**Slack handles, if they use Slack.** Skip this unless they use Slack.
 
 The config ships a `slack_mentions` transform that turns names into handles when
 you ask for it out loud. It carries three example names, and the list is the
@@ -375,7 +419,7 @@ text. Ask them to paste a handle into a message **without sending** and say
 whether it turns blue. If it stays plain, it looks like a mention and notifies
 nobody — tell them that rather than leaving them to find out.
 
-## Step 12 — Hand over
+## Hand over
 
 > Done. Three things:
 >
@@ -387,8 +431,9 @@ nobody — tell them that rather than leaving them to find out.
 > **Change text** — select it, hold the key, say what you want. You always see
 > the result first.
 >
-> Settings are in `~/.config/parrotflow/config.yaml` and reload on save. The
-> menu bar icon has *Correct a Word…*, *Settings* — *Edit Config…* and *View
+> Settings are in `~/.config/parrotflow/config.yaml`, and the names it has
+> learnt are in `vocabulary.yaml` beside it. Both reload on save. The menu bar
+> icon has *Correct a Word…*, *Settings* — *Edit Config…* and *View
 > Transforms* — and *Permissions…*.
 
 ---
@@ -435,7 +480,7 @@ speech model.
 
 **A command never returns.** The app ignores an unknown flag and starts as a
 menu bar app, which never exits — the installed app is older than this file.
-Ctrl-C, rerun Step 3, retry.
+Ctrl-C, rerun Step 2, retry.
 
 **Do not** suggest turning off Gatekeeper, `xattr -dr com.apple.quarantine`, or
 `sudo`. Nothing here needs them. If something looks like it does, something else

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -80,7 +80,8 @@ Installs to `/Applications` and starts it.
 
 Download fails → check `https://github.com/znat/parrotflow/releases` for a
 release. `/Applications` not writable → rerun with
-`PARROTFLOW_DEST=~/Applications`.
+`PARROTFLOW_DEST=~/Applications`, and use that path instead of `/Applications`
+in every command below.
 
 **Microphone.** The app asks at first launch; the window may already be open.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -64,9 +64,8 @@ df -g / | tail -1 | awk '{print $4}'   # GB free — need 15 or more
 
 **Remember the RAM number.** It decides a setting in Step 7.
 
-Stop if macOS is older than 14, or if the Mac is Intel — speech recognition runs
-on the Neural Engine and Intel Macs have none. Under 15 GB free: say so and ask
-whether to continue. Dictation needs 1.5 GB; the 10 GB model is optional.
+Stop if macOS is older than 14, or if the Mac is Intel. Under 15 GB free: say
+so and ask whether to continue.
 
 ## Step 2 — Install, and get both permissions
 
@@ -74,8 +73,7 @@ whether to continue. Dictation needs 1.5 GB; the 10 GB model is optional.
 curl -fsSL https://raw.githubusercontent.com/znat/parrotflow/main/scripts/install.sh | sh
 ```
 
-Checks 3 MB against its published checksum, installs to `/Applications`, starts
-it.
+Installs to `/Applications` and starts it.
 
 > The app is installed. There is a microphone icon in your menu bar now, top
 > right. Can you see it?
@@ -109,9 +107,7 @@ any settings window.
 >
 > Typing is what most people want. Which do you prefer?
 
-Clipboard → set `transcription: insert_mode: clipboard`, and say what it costs.
-The cost is the missing permission, not the setting — reading a selection is
-exactly what Accessibility controls:
+Clipboard → set `transcription: insert_mode: clipboard`, then say:
 
 > Two things will not work: fixing a word by voice, and the voice commands in
 > Step 7. Both have to read the text you selected. Dictation is not affected,
@@ -146,8 +142,7 @@ say -o /tmp/pf-check.wav --data-format=LEI16@16000 --channels=1 "Testing one two
 /Applications/ParrotFlow.app/Contents/MacOS/ParrotFlow --transcribe /tmp/pf-check.wav
 ```
 
-`say` writes exactly the 16 kHz mono WAV the model expects. The first run
-downloads that model — tell them first:
+The first run downloads that model — tell them first:
 
 > Downloading the speech model now. It is called Parakeet, about 1.2 GB, and it
 > runs on your Mac. A few minutes.
@@ -160,11 +155,9 @@ fails, stop and fix it — nothing after this step can work.
 Ask together, edit `~/.config/parrotflow/config.yaml` after each answer. The app
 reloads on save.
 
-**1. Languages.** Dictation understands many languages with no setting. This
-list only tells ParrotFlow which language a transcript was in, so it can pick
-the right correction rules. **Only `en` and `fr` work today** — if they name
-another, say dictation works in it but the correction rules are not written yet,
-and leave this on English.
+**1. Languages.** **Only `en` and `fr` work today** — if they name another, say
+dictation works in it but the correction rules are not written yet, and leave
+this on English.
 
 ```yaml
 transcription:
@@ -211,9 +204,8 @@ pattern it cannot compile.
 
 ## Step 5 — Build the vocabulary
 
-Dictation gets names, jargon and internal acronyms wrong more than anything
-else, and a colleague's name is dictated constantly. Build a `vocabulary.yaml`
-now, from what this person actually says.
+Build a `vocabulary.yaml` from the names, jargon and acronyms this person
+actually says.
 
 > I want to gather the names and terms you say a lot — colleagues, projects,
 > tools — so dictation gets them right from the start. I will look at your
@@ -221,20 +213,13 @@ now, from what this person actually says.
 > Mac; I will say more about that before I ask for anything.
 
 Follow `.claude/skills/vocabulary-corpus/SKILL.md` for the whole of this step.
-It mines the codebase, gives you the Slack prompt to hand over, and — this is
-the part that matters — screens every candidate against rejection criteria
-earned from measurement, so a name that would overwrite an ordinary word never
-reaches the file. Follow it in full rather than shortcutting the rejections.
+Do not shortcut its rejection criteria — they are what stops a name from
+overwriting an ordinary word.
 
-**There is no audio calibration in this procedure.** Do not have them read
-sentences aloud, and do not reach for `.claude/skills/calibrate`. It exists,
-but it answers a question this setup does not ask. `vocabulary.acoustic`
-defaults to `false` (`Sources/ParrotFlow/Config.swift`), so a term is matched
-only by the written rule the skill produces, never by sound — no ~98 MB model
-to pull, no clip to record, no threshold to tune. The one thing calibration
-used to catch — a term that overwrites an ordinary word it sounds like — is
-exactly what the skill's step 3 rejection criteria catch before anything is
-written.
+**No audio calibration in this procedure.** Do not have them read sentences
+aloud, and do not use `.claude/skills/calibrate`. `vocabulary.acoustic`
+defaults to `false`, so terms match by rule only, not by sound. No model to
+download, no clip to record, no threshold to tune.
 
 When the vocabulary is written, confirm it parsed:
 
@@ -242,11 +227,9 @@ When the vocabulary is written, confirm it parsed:
 /Applications/ParrotFlow.app/Contents/MacOS/ParrotFlow --check-config
 ```
 
-It now prints a `vocabulary:` block — how many terms, how many carry a rule,
-and, since this Mac has `acoustic: false`, a line saying plainly that matching
-is by rule only. A term with neither a rule nor a rendering says so too; that
-means it does nothing yet, which is worth mentioning rather than leaving
-silent.
+It prints a `vocabulary:` block: term count, and whether matching is by rule
+only. A term with no rule and no rendering does nothing — say so if one shows
+up.
 
 ## Step 6 — Let them try it
 
@@ -255,10 +238,8 @@ You cannot do this one.
 > Your turn. Open any text box, hold the **right Option key**, say a sentence,
 > let go.
 
-A small pill appears next to where the words are about to land while they
-talk. A beat after they let go, the text lands there and the pill turns into a
-row of chips — **Correct** first, plus anything else set to appear there — and
-fades out on its own after nine seconds.
+A pill appears near where the words will land while they talk. The text lands
+there, then the pill turns into chips — **Correct** first — for nine seconds.
 
 ```sh
 grep -E "transcribed|speech gate|hotkey" ~/Library/Logs/ParrotFlow.log | tail -5
@@ -335,13 +316,12 @@ Check later with `tail -2 /tmp/parrotflow-pull.log` and `ollama list | grep
 gemma4`. An error about the model or manifest means Ollama is too old, whatever
 its version string said.
 
-**Teach them what they can say.** Do this while the download runs. It is the
-part people miss.
+**Teach them what they can say.** Do this while the download runs.
 
 Everything starts with the wake phrase `hey parrot`: hold the same key, say the
 phrase, then say what you want. Those words are never typed into the document.
 Print the real list first — the `capabilities` lines from `--check-config` —
-rather than describing what this file assumes.
+rather than reading from this file.
 
 > Say a name it gets wrong, and spell it:
 >
@@ -361,9 +341,9 @@ rather than describing what this file assumes.
 > Escape cancels. Select nothing and it works on the last thing you dictated.
 
 The last example matches no prompt at all — `free_form` sends the whole
-instruction to the model. **This is why the list is not a menu. Do not read them
-commands to memorise.** A new install ships `bullets`, `terse` and `grammar`,
-each tuned because it beats `free_form` at that one job:
+instruction to the model. **Do not read the examples as a menu to memorise.**
+A new install ships `bullets`, `terse` and `grammar` as tuned transforms;
+everything else goes to `free_form`:
 
 > Three are tuned for one job each. Everything else goes to the general one. You
 > do not have to remember which is which.
@@ -372,15 +352,13 @@ each tuned because it beats `free_form` at that one job:
 any dictation, no wake phrase needed. `bullets` and `terse` only run when asked
 out loud.
 
-A transform of their own goes in `transforms:` and needs a `description` — that
-is what the router matches spoken words against, and `--check-config` reports an
-entry without one as an error.
+A transform of their own goes in `transforms:` and needs a `description` —
+`--check-config` reports one without it as an error.
 
 **Slack handles, if they use Slack.** Skip this unless they use Slack.
 
-The config ships a `slack_mentions` transform that turns names into handles when
-you ask for it out loud. It carries three example names, and the list is the
-whole point of it.
+The config ships a `slack_mentions` transform with three example names to
+replace.
 
 > Do you use Slack? I can teach it your colleagues' handles — then "hey parrot,
 > use Slack mentions" turns "tell Marie the deadline moved" into "tell
@@ -392,7 +370,7 @@ whole point of it.
 
 They can also just name the handful of people they message most. Either way the
 source is them: **never invent or guess a handle.** A wrong one pings the wrong
-colleague and the person dictating will not notice.
+person and nobody notices.
 
 Put what they paste into the list inside that transform's prompt, one per line,
 keeping the shape and dropping the examples:
@@ -413,11 +391,9 @@ Then `--check-config`, and say what it does and does not do:
 > And it never sends anything: you get text in your Slack box, and the last look
 > is yours.
 
-Check one thing with them, because it decides whether this is worth having:
-ParrotFlow inserts by paste, and Slack's composer does not always re-read pasted
-text. Ask them to paste a handle into a message **without sending** and say
-whether it turns blue. If it stays plain, it looks like a mention and notifies
-nobody — tell them that rather than leaving them to find out.
+Check one thing with them: ask them to paste a handle into a message **without
+sending** and say whether it turns blue. If it stays plain, it looks like a
+mention but notifies nobody — tell them that.
 
 ## Hand over
 
@@ -448,10 +424,8 @@ speech was found and what was transcribed.
 failures show in `--check-config`. For a single modifier key, check it reaches
 the app at all with `--watch-modifiers`.
 
-**Permissions look granted but the app disagrees.** Almost always a signature
-problem: macOS ties grants to the app's signature, and a replaced build loses
-them while System Settings still shows the tick. Toggling does not fix it — the
-dead record is reused.
+**Permissions look granted but the app disagrees.** Toggling the switch does
+not fix it — it reuses the same dead record.
 
 ```sh
 tccutil reset Accessibility com.parrotflow.app


### PR DESCRIPTION
## Summary

- Merges the old 12 steps into 7 plus a hand-over, per the agreed grouping: install + microphone + accessibility-or-clipboard become one step instead of three trips (two of them to System Settings), and the Ollama/Gemma/commands/Slack steps become one step behind a single "do you want the 10 GB part" decision instead of three re-asks of it.
- Adds a new step 5, "Build the vocabulary" — the vocabulary feature shipped 2026-08-06 and was not mentioned in setup.md at all, even though `--check-config` already reports on it. The step points at `.claude/skills/vocabulary-corpus/SKILL.md` rather than duplicating it.
- Explicitly rules out audio calibration for this procedure: `vocabulary.acoustic` defaults to `false` (`Sources/ParrotFlow/Config.swift`), so terms match by written rule only, not by sound. No `.claude/skills/calibrate` reference, no clips, no reading sentences aloud.
- Fixes drift found while reading the rest of the file against the current source: the pill/HUD that appears near the cursor during and after a dictation was never mentioned; the old step 8 told the agent the text "appears at your cursor" with nothing about the pill or its Correct/G chips.

## Not included

Left out on purpose: unmerged PR #118 (VS Code / Codex accessibility work — `AXManualAccessibility`, Chromium trees). That is a separate change and not part of this doc's scope.

## Test plan

- [x] Re-read every command kept or added against `docs/cli.md` and the source in `Sources/ParrotFlow/` (install script, `--check-config`, `--transcribe`, `--numbers`, log grep patterns, `tccutil`, Ollama commands).
- [x] Verified `vocabulary.acoustic` defaults to `false` in `Config.swift`, and that `--check-config`'s `notices()` only reports the `vocabulary:` block once `vocabulary.yaml` has terms.
- [x] Verified the pill/offer behavior (nine-second fade, Correct first, `grammar`'s `offer: true`/`key: g` in the shipped default config) against `docs/configuration.md`, `docs/pipelines.md`, and `Config.defaultYAML`.
- [x] Confirmed corrections now write to `vocabulary.yaml` (`AppDelegate.learn` → `ConfigWriter.addVocabularyPronunciation`), matching PR #119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)