### PR TITLE
feat: make text and audio logging configurable, audio off by default

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1023,12 +1023,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard recording || transcribing else { return }
 
         if recording {
-            // The clip on disk is left alone. It cost nothing to write, the
-            // recordings folder is where you go to find out what the app heard,
-            // and deleting the evidence of the thing you just cancelled is the
-            // opposite of useful when the reason you cancelled it was that
-            // something sounded wrong.
-            _ = recorder.stop(config: config)
+            // The clip on disk is left alone, unless `logging.audio` says
+            // recordings do not accumulate at all. Kept, it cost nothing to
+            // write, the recordings folder is where you go to find out what
+            // the app heard, and deleting the evidence of the thing you just
+            // cancelled is the opposite of useful when the reason you
+            // cancelled it was that something sounded wrong.
+            if let clip = recorder.stop(config: config) {
+                Recorder.discardIfNotKept(clip, config: config)
+            }
             // No words are coming, so this press's dictation is over here. The
             // recorder is stopped directly rather than through
             // `stopRecording`, so nothing else would retire it — and the pane
@@ -1132,6 +1135,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Log.write(String(format: "wrote %@ (%.2fs)", recording.url.lastPathComponent, recording.duration))
             if config.transcription.enabled {
                 transcribe(recording)
+            } else {
+                // Nothing is going to read the file — `transcribe` is what
+                // would otherwise discard it once it is done.
+                Recorder.discardIfNotKept(recording, config: config)
             }
         }
 
@@ -1235,6 +1242,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             run: pressRun, element: focus?.element, owner: focus?.owner, mic: micAtPress
         )
         Task { [weak self] in
+            // Whatever happens below — decoded, cancelled, or thrown — nothing
+            // needs the clip on disk once this dictation is over.
+            defer { Recorder.discardIfNotKept(recording, config: config) }
             do {
                 // "Transcribing…" is the truth until the decoder is done, and
                 // a lie for the second a prompt or a script spends after it.

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -47,6 +47,8 @@ enum CheckConfigCommand {
         print("  · speech gate       \(config.audio.speechGate ? "on" : "off")")
         print("  · feedback          sound=\(config.feedback.sound) overlay=\(config.feedback.overlay)"
               + " correct_offer=\(config.feedback.correctOffer)")
+        print("  · logging           text=\(config.logging.text ? "on" : "off")"
+              + " audio=\(config.logging.audio ? "on" : "off")")
 
         // Transcription — printed so a mis-decoded config is visible rather
         // than silently falling back to "no vocabulary".

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -27,6 +27,7 @@ struct Config: Decodable, Equatable {
     var transcription: Transcription = Transcription()
     var llm: LLM = LLM()
     var updates: UpdatePolicy = UpdatePolicy()
+    var logging: Logging = Logging()
     /// Everything nameable: `transforms:`, plus anything still written under
     /// the older `prompts:`.
     var transforms: [Transform] = []
@@ -67,7 +68,7 @@ struct Config: Decodable, Equatable {
 
 
     enum CodingKeys: String, CodingKey {
-        case hotkey, audio, feedback, transcription, llm, transforms, prompts, updates
+        case hotkey, audio, feedback, transcription, llm, transforms, prompts, updates, logging
         case freeForm = "free_form"
     }
 
@@ -1633,6 +1634,35 @@ struct Config: Decodable, Equatable {
         }
     }
 
+    /// What gets written to disk about a dictation, apart from the transcript
+    /// itself.
+    ///
+    /// Two switches because the two artifacts have nothing in common but
+    /// where they end up. The text log is prose, rotates itself, and is how
+    /// every problem in this app gets diagnosed — it stays on. A clip is a
+    /// recording of your voice, keeps growing forever, and nothing downstream
+    /// needs it once the words have landed — it stays off until you ask for
+    /// it, for calibration or for `--transcribe`.
+    struct Logging: Codable, Equatable {
+        /// The line-by-line log at `~/Library/Logs/ParrotFlow.log` — see
+        /// `Log`. On by default.
+        var text: Bool = true
+        /// Keep each dictation's recording on disk, in `audio.output_dir`.
+        /// Off by default: nothing written, nothing left behind.
+        var audio: Bool = false
+
+        enum CodingKeys: String, CodingKey { case text, audio }
+
+        init() {}
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            self.init()
+            if let v = try c.decodeIfPresent(Bool.self, forKey: .text) { text = v }
+            if let v = try c.decodeIfPresent(Bool.self, forKey: .audio) { audio = v }
+        }
+    }
+
     init() {}
 
     /// Hand-rolled so a partial config.yaml is valid: anything you leave out
@@ -1650,6 +1680,7 @@ struct Config: Decodable, Equatable {
         if let updates = try c.decodeIfPresent(UpdatePolicy.self, forKey: .updates) {
             self.updates = updates
         }
+        if let logging = try c.decodeIfPresent(Logging.self, forKey: .logging) { self.logging = logging }
         // `transforms:` first, then anything still under `prompts:`. Both are
         // read: `prompts:` is what every config written before this existed
         // says, and a rename that silently empties the section is the one
@@ -2889,6 +2920,7 @@ if __name__ == "__main__":
     static func load() throws -> Config {
         try createIfMissing()
         let text = try String(contentsOf: fileURL, encoding: .utf8)
+        let config: Config
         // An empty config.yaml is a supported state — it means "defaults for
         // everything" — and it must not take the vocabulary down with it. The
         // two files are independent, and one of them being blank says nothing
@@ -2896,15 +2928,21 @@ if __name__ == "__main__":
         if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             var bare = Config()
             bare.vocabulary = loadVocabulary()
-            return bare
+            config = bare
+        } else {
+            // A relative `command:` is relative to the file that declared it,
+            // so a config carries its scripts beside it and a `--pipeline`
+            // fixture carries its own.
+            var decoded = try YAMLDecoder().decode(
+                Config.self, from: text, userInfo: [.configDirectory: directory]
+            )
+            decoded.vocabulary = loadVocabulary()
+            config = decoded
         }
-        // A relative `command:` is relative to the file that declared it, so a
-        // config carries its scripts beside it and a `--pipeline` fixture
-        // carries its own.
-        var config = try YAMLDecoder().decode(
-            Config.self, from: text, userInfo: [.configDirectory: directory]
-        )
-        config.vocabulary = loadVocabulary()
+        // Every caller reads the config through here — the app at launch and
+        // on every save, and each CLI command once — so this is the one place
+        // that has to set it.
+        Log.textEnabled = config.logging.text
         return config
     }
 
@@ -2966,6 +3004,17 @@ if __name__ == "__main__":
       # Click a chip to run it. Tapping the dictation hotkey — press and let go
       # — opens the correction panel too. Holding it starts the next dictation.
       correct_offer: true
+
+    logging:
+      # The line-by-line log at ~/Library/Logs/\(AppVariant.logFileName) — how
+      # every problem in this app gets diagnosed. Leave it on.
+      text: true
+
+      # Write each dictation's recording to disk, in audio.output_dir. Off by
+      # default: a recording of your voice should not pile up there unless you
+      # asked for it. Turn it on for --transcribe, calibration, or to hear what
+      # the app heard.
+      audio: false
 
     transcription:
       # paste     -> typed into the app you're in (needs Accessibility)

--- a/Sources/ParrotFlow/EditTestCommand.swift
+++ b/Sources/ParrotFlow/EditTestCommand.swift
@@ -28,7 +28,10 @@ enum EditTestCommand {
 
     private static func report(_ line: String) {
         print(line)
-        Log.write("edit-test: \(line)")
+        // Forced, same reason as `PeekCommand.report`: scripts/check-inplace.sh
+        // and check-span.sh read this back out of the log file, which is the
+        // only transport that survives LaunchServices throwing stdout away.
+        Log.write("edit-test: \(line)", force: true)
     }
 
     /// Everything both modes need before either is allowed to write.

--- a/Sources/ParrotFlow/Log.swift
+++ b/Sources/ParrotFlow/Log.swift
@@ -11,6 +11,11 @@ enum Log {
         .homeDirectoryForCurrentUser
         .appendingPathComponent("Library/Logs/\(AppVariant.logFileName)")
 
+    /// `config.logging.text`. True until a config has actually loaded, so
+    /// nothing written before then — including a config that fails to parse
+    /// — is lost. Set from `ConfigStore.load()`.
+    static var textEnabled = true
+
     private static let queue = DispatchQueue(label: "com.parrotflow.log")
 
     private static let timestampFormatter: DateFormatter = {
@@ -29,10 +34,16 @@ enum Log {
         queue.sync {}
     }
 
-    static func write(_ message: String) {
+    /// - Parameter force: writes to the file even with `textEnabled` off. For
+    ///   the handful of commands whose only transport this is — `--peek` and
+    ///   `--edit-test`/`--span-test` are read out of this file by a harness
+    ///   because LaunchServices throws their stdout away. Everything else
+    ///   respects the setting.
+    static func write(_ message: String, force: Bool = false) {
         let line = "\(timestampFormatter.string(from: Date()))  \(message)\n"
         NSLog("[ParrotFlow] %@", message)
 
+        guard force || textEnabled else { return }
         queue.async {
             guard let data = line.data(using: .utf8) else { return }
             let fm = FileManager.default

--- a/Sources/ParrotFlow/PeekCommand.swift
+++ b/Sources/ParrotFlow/PeekCommand.swift
@@ -25,7 +25,10 @@ enum PeekCommand {
     /// LaunchServices throws stdout away. A harness reads the log.
     private static func report(_ line: String) {
         print(line)
-        Log.write("peek: \(line)")
+        // Forced: this is the only transport that survives LaunchServices
+        // throwing stdout away, whatever `logging.text` says — see the doc
+        // comment above.
+        Log.write("peek: \(line)", force: true)
     }
 
     /// `expecting` is the harness's precondition, not a convenience.

--- a/Sources/ParrotFlow/Recorder.swift
+++ b/Sources/ParrotFlow/Recorder.swift
@@ -941,7 +941,16 @@ final class Recorder {
 
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd'T'HH-mm-ss"
-        let name = "parrotflow-\(formatter.string(from: Date())).wav"
+        // The timestamp alone is only second-precision, and push-to-talk does
+        // not wait for the previous dictation's transcription before starting
+        // the next recording — two presses inside the same second would name
+        // the same file. That used to mean the second recording's write
+        // silently clobbered whatever the first was still being read from; now
+        // that a clip can be deleted once its own dictation is done with it,
+        // an earlier clip's cleanup could delete a later recording still using
+        // the same name. The suffix makes every capture its own file.
+        let suffix = UUID().uuidString.prefix(8)
+        let name = "parrotflow-\(formatter.string(from: Date()))-\(suffix).wav"
         return dir.appendingPathComponent(name)
     }
 

--- a/Sources/ParrotFlow/Recorder.swift
+++ b/Sources/ParrotFlow/Recorder.swift
@@ -481,11 +481,17 @@ final class Recorder {
         // failure this file is about, delivered as text instead of as nothing.
         // So it is not handed on.
         //
-        // The file stays where it is. It is the evidence of what went wrong,
-        // and deleting it is the opposite of useful — the same reason
-        // `cancelDictation` leaves a cancelled clip alone.
+        // The file stays where it is, unless `logging.audio` says recordings
+        // do not accumulate at all — that setting is about not keeping your
+        // voice on disk, and a partial clip is still your voice. Kept, it is
+        // evidence of what went wrong, and deleting it is the opposite of
+        // useful — the same reason `cancelDictation` leaves a cancelled clip
+        // alone.
         if lost > Self.droppedAudioTolerance {
             Log.write("\(url.lastPathComponent) is short and will not be transcribed")
+            if !config.logging.audio {
+                try? FileManager.default.removeItem(at: url)
+            }
             report("Part of that recording was lost. Say it again.")
             return nil
         }
@@ -937,5 +943,19 @@ final class Recorder {
         formatter.dateFormat = "yyyy-MM-dd'T'HH-mm-ss"
         let name = "parrotflow-\(formatter.string(from: Date())).wav"
         return dir.appendingPathComponent(name)
+    }
+
+    /// Removes a clip once nothing needs the file on disk any more, unless
+    /// `logging.audio` says to keep it.
+    ///
+    /// Not folded into `stop()`: the caller still needs the file to exist right
+    /// after `stop()` returns, to hand it to the transcriber. This runs once
+    /// that is done — after transcription finishes, or straight away when
+    /// nothing was ever going to transcribe it. `--record`, `--audio-recovery`
+    /// and the rest of the terminal commands manage their own clips directly
+    /// and never call this — a deliberate `--record` keeps what it wrote.
+    static func discardIfNotKept(_ recording: Recording, config: Config) {
+        guard !config.logging.audio else { return }
+        try? FileManager.default.removeItem(at: recording.url)
     }
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -100,6 +100,17 @@ llm:
 updates:
   after_days: 7
 
+# What gets written to disk about a dictation, apart from the transcript.
+logging:
+  # The line-by-line log at ~/Library/Logs/ParrotFlow.log — how every problem
+  # in this app gets diagnosed. Leave it on.
+  text: true
+  # Write each dictation's recording to disk, in audio.output_dir. Off by
+  # default: a recording of your voice should not pile up there unless you
+  # asked for it. Turn it on for --transcribe, calibration, or to hear what
+  # the app heard.
+  audio: false
+
 # What the activation phrase can reach, and what a pipeline can name. The
 # description is what the router matches your words against, so write it the
 # way you would say it; the whole instruction reaches the body, which is why

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,10 @@ feedback:
   sound: true
   overlay: true
   correct_offer: true
+
+logging:
+  text: true    # ~/Library/Logs/ParrotFlow.log
+  audio: false  # keep each dictation's recording on disk
 ```
 
 ## Where things live
@@ -52,17 +56,17 @@ feedback:
 |---|---|
 | Config | `~/.config/parrotflow/config.yaml` |
 | Transforms | `~/.config/parrotflow/transforms/<name>/` — one folder each |
-| Recordings | `~/Recordings/ParrotFlow` |
+| Recordings | `~/Recordings/ParrotFlow` — empty unless `logging.audio: true` |
 | Trace | `~/Recordings/ParrotFlow/trace.jsonl` |
-| Log | `~/Library/Logs/ParrotFlow.log` |
+| Log | `~/Library/Logs/ParrotFlow.log` — off with `logging.text: false` |
 | The example transform | `~/.config/parrotflow/transforms/code_identifiers/`, written on first launch and never overwritten |
 
 The menu bar item shows the current state and offers *Correct a Word…*, *Open
-Recordings Folder* — the wavs and `trace.jsonl` — *Settings*, which holds *Edit
-Config…* (`config.yaml`) and *Open Config Folder* — everything you own, so
-`vocabulary.yaml`, `transforms/` and `voice/` too — and
-*Permissions…*. Both open in VS Code if it is installed, and in whatever the
-system would otherwise use if it is not.
+Recordings Folder* — the wavs, if `logging.audio` is on, and `trace.jsonl` —
+*Settings*, which holds *Edit Config…* (`config.yaml`) and *Open Config
+Folder* — everything you own, so `vocabulary.yaml`, `transforms/` and `voice/`
+too — and *Permissions…*. Both open in VS Code if it is installed, and in
+whatever the system would otherwise use if it is not. See [`logging`](#logging).
 
 ### A folder per transform
 
@@ -167,9 +171,11 @@ It works with the hotkey still held, which is the point of it: in push-to-talk
 the key is down for the whole sentence, and letting go is what commits the
 recording. Say the wrong thing and you can stop before it lands.
 
-A recording that is cancelled is still written to your recordings folder — it is
-where you go to hear what the app heard, and the moment you most want that is
-the moment you cancelled. It is simply never transcribed.
+With `logging.audio: true`, a recording that is cancelled is still kept in your
+recordings folder — it is where you go to hear what the app heard, and the
+moment you most want that is the moment you cancelled. It is simply never
+transcribed. With `logging.audio` at its default of `false`, the clip is
+discarded like any other.
 
 Cancelling during transcription cannot make the decoder stop sooner. The model
 call is not interruptible. What it guarantees is that nothing is written when it
@@ -355,6 +361,43 @@ capital G — so only bare letters are exposed, and only until the offer goes.
 `esc` ends it, and so does starting the next dictation.
 
 Off by setting it to `false`. Then no key is taken at any time.
+
+## `logging`
+
+What gets written to disk about a dictation, apart from the transcript itself.
+Two separate switches, because the two artifacts have nothing in common but
+where they end up.
+
+`text` controls the line-by-line log at `~/Library/Logs/ParrotFlow.log` — see
+[Where things live](#where-things-live). On by default: it is how every
+problem in this app gets diagnosed, from a hotkey that will not register to a
+pipeline stage that silently did nothing. Turn it off and the app still works
+exactly the same; it just stops narrating itself to that file.
+
+`--peek` and `--edit-test`/`--span-test` write to the log whatever this says.
+Both are meant to be run as `open -na ParrotFlowDev --args --peek`, the only
+way to carry the app's own Accessibility grant from a terminal, and
+LaunchServices throws away the stdout of a process launched that way — the log
+is the one transport that survives, and the harnesses built on these commands
+read it back out.
+
+`audio` controls whether each dictation's recording is kept on disk, in
+`audio.output_dir`. **Off by default** — a recording of your voice should not
+accumulate there unless you asked for it. This is a change from earlier
+versions, which always kept every clip.
+
+Turn it on to get the old behaviour back: every recording, including a
+cancelled one (see [Escape stops a dictation](#escape-stops-a-dictation)) and
+one whose ending was lost to a device change, stays in your recordings folder.
+Turn it on before you want to build up a history of clips to work from — for
+calibration, or to re-run against a change with `--transcribe`.
+
+With it off, a clip exists on disk only for as long as the app needs it to
+transcribe your words, and is removed the moment that is done. With
+`transcription: { enabled: false }` nothing transcribes it at all, so nothing
+is kept either. Commands you run yourself from the terminal — `--record`,
+`--transcribe <file>`, `--spot` — are unaffected either way: they write and
+keep the file you asked them to, because you asked for it by running them.
 
 ## See also
 


### PR DESCRIPTION
## Summary

- Adds `logging.text` (default `true`) and `logging.audio` (default `false`) to `config.yaml`.
- Text logging gates `Log.write`'s file output — `~/Library/Logs/ParrotFlow.log` / `ParrotFlow-Dev.log`. NSLog (the unified system log) is untouched; the setting only controls the file, matching how the task described it.
- Audio logging gates whether a dictation's `.wav` clip survives on disk once nothing needs it any more. Capture still writes the file during recording — transcription reads it from disk — but it is now discarded: right after transcription finishes, immediately when transcription is disabled, and for a clip kept "for diagnosis" when too much audio was lost to a device change. This is a default-off behaviour change: existing users who never set `logging:` will stop accumulating clips.
- `--check-config` reports both settings, next to `feedback`.
- `config.example.yaml` and `docs/configuration.md` are updated to match. `README.md` and `docs/setup.md` are untouched, as requested.

## Decisions on the CLI commands that write to the log

- `--peek` and `--edit-test`/`--span-test` always write to the log regardless of `logging.text`. `--peek`'s own doc comment says the log is its only transport — it's meant to be launched via `open -na ParrotFlowDev --args --peek` to carry the app's Accessibility grant, and LaunchServices throws away that process's stdout. `--edit-test`/`--span-test` are launched the same way for the same reason, and `scripts/check-inplace.sh`/`check-span.sh` read their output back out of the log file (confirmed by grepping those scripts). Both commands now pass `force: true` to `Log.write`.
- Every other CLI command (`--record`, `--transcribe`, `--boost-eval`, `--spot`, etc.) just runs from an ordinary terminal, so its own `print()` output is available regardless of the log setting; their `Log.write` calls are left to respect `logging.text` like the rest of the app.
- Deliberate audio-writing commands (`--record`, `--transcribe <file>`, `--spot`, `--audio-recovery`) are unaffected by `logging.audio` — a person running them is asking for the file, and they manage their own clips directly rather than going through the app's live-dictation cleanup path.

## Test plan

- [x] `swift build` and `swift build -c release` both succeed.
- [x] `scripts/check-audio-recovery.sh` — 11/11 (its scratch config has no `logging:` key, so it now defaults to `audio: false`; verified this doesn't change any of its assertions, since it manages its own clip files directly).
- [x] `scripts/check-default-config.sh` — passes; `logging:` now matches between `Config.defaultYAML` and `config.example.yaml`.
- [x] Verified with a scratch `PARROTFLOW_CONFIG_DIR`: a config with no `logging:` key reports `text=on audio=off`; a config with only `logging: { audio: true }` reports `text=on audio=on` (partial override keeps the other default).
- [x] Ran the rest of the fast `scripts/check-*.sh` suite locally — all green (one `check-replacements.sh` run showed a known-flaky NSSpellChecker timeout, reproduced as green on rerun, and is unrelated to this change).
- [x] `swiftlint lint` — no new violations introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)