### PR TITLE
docs: the docs say the current state, not how it was decided

### DIFF
--- a/.claude/skills/ste/SKILL.md
+++ b/.claude/skills/ste/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: ste
+description: Switch the session to ASD-STE100 Simplified Technical English. All prose responses follow STE writing rules until the user says to stop.
+disable-model-invocation: true
+---
+
+# ASD-STE100 Simplified Technical English mode
+
+From now on in this session, write all prose in ASD-STE100 Simplified Technical English: explanations, summaries, findings, commit messages, and documentation. Do not change code, identifiers, commands, file paths, quoted text, or error messages. This mode stays active until the user tells you to stop.
+
+## Sentences and paragraphs
+
+- Keep instruction sentences to 20 words or fewer. Keep descriptive sentences to 25 words or fewer.
+- Write one instruction per sentence.
+- Keep paragraphs to 6 sentences or fewer, with one topic per paragraph.
+- Use vertical lists to present complex or sequential material.
+
+## Grammar
+
+- Use the active voice. Do not use the passive voice.
+- Use only the simple tenses: past, present, and future.
+- Do not use -ing verb forms (gerunds or present participles), except in technical names.
+- Do not use past participles as adjectives.
+- Start each instruction with an imperative verb ("Remove the file", not "The file should be removed").
+- Always use articles ("the", "a", "an") and demonstratives ("this", "these") before nouns. Do not omit them.
+- Do not put more than 3 nouns together in a cluster.
+- Use the present tense in descriptive text where possible.
+
+## Words
+
+- Use each word in only one meaning and as only one part of speech.
+- Use the same word for the same thing every time. Do not use synonyms for variety.
+- Prefer approved STE vocabulary. Examples:
+  - "use", not "utilize" or "employ"
+  - "start", not "initiate" or "commence"
+  - "do", not "perform" or "carry out"
+  - "show", not "demonstrate", "indicate", or "reveal"
+  - "make sure", not "ensure" or "verify"
+  - "correct", not "rectify"
+  - "enough", not "sufficient"
+  - "before", not "prior to"
+  - "help", not "assist" or "facilitate"
+- Keep technical names and technical verbs as they are (function names, product names, standard terms of the domain). A required technical term always wins over an STE vocabulary rule.
+
+## Warnings and instructions
+
+- Put a warning or caution before the instruction it applies to.
+- Start a warning or caution with a clear command.
+- Give the condition before the instruction ("If the test fails, read the log", not "Read the log if the test fails").

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,54 +6,46 @@ Start from the question you have.
 
 | | |
 |---|---|
-| [setup.md](setup.md) | The guided install, written to be handed to an agent. Permissions, Ollama, model sizing, and a check that transcription works before it hands over. |
-| [permissions.md](permissions.md) | Microphone and Accessibility: what needs which, and why a rebuilt app loses its grants. |
+| [setup.md](setup.md) | The guided install, written to be handed to an agent. Permissions, Ollama, model sizing, and a check that transcription works. |
+| [permissions.md](permissions.md) | Microphone and Accessibility: what needs which, and what a rebuild does to the grants. |
 | [configuration.md](configuration.md) | Every setting in `config.yaml`, what it does, and what happens when it is wrong. |
 
 ## Using it
 
 | | |
 |---|---|
-| [corrections.md](corrections.md) | Teaching it a name — by panel, by spelling it out, or by describing the change. |
-| [pipelines.md](pipelines.md) | The reference for what a transcript goes through: stages, transforms, conditions, per-app and per-language gating. |
-| [cli.md](cli.md) | Every terminal flag. How to test a config change without speaking into a microphone. |
+| [corrections.md](corrections.md) | Teach it a name — by panel, by spelling it out, or by description. |
+| [pipelines.md](pipelines.md) | What a transcript goes through: stages, transforms, conditions, per-app and per-language gates. |
+| [cli.md](cli.md) | Every terminal flag. Test a config change without a microphone. |
 
 ## Changing it
 
 | | |
 |---|---|
-| [authoring.md](authoring.md) | **Start here to write a prompt, a table or a script.** The procedure, with the measurement loop that says whether you improved it. |
-| [development.md](development.md) | Dev and released builds are separate apps. Building, the Makefile, and how a release is cut. |
-| [architecture.md](architecture.md) | What each file is for, where the time goes, and what the app deliberately does not do. |
-
-## Why it is built this way
-
-| | |
-|---|---|
-| [transcription.md](transcription.md) | Why Parakeet and not Whisper, why it cannot be prompted, and what covers that instead. |
-| [distribution.md](distribution.md) | Why this ships by curl rather than Homebrew, what notarization would change, and how updates work. |
+| [authoring.md](authoring.md) | **Start here to write a prompt, a table or a script.** The procedure, and the measurement loop that scores it. |
+| [development.md](development.md) | Dev and released builds are separate apps. Building, the Makefile, and how to cut a release. |
+| [architecture.md](architecture.md) | What each file is for, where the time goes, and what the app does not do. |
+| [transcription.md](transcription.md) | The speech model, its limits, and the stages that cover them. |
+| [distribution.md](distribution.md) | How the app ships, how it is signed, and how updates work. |
 
 ---
 
 ## If you are an agent
 
-Configuring this for someone, or changing a rewrite on their behalf:
+You configure this for someone, or you change a rewrite for them:
 
 1. **Read [authoring.md](authoring.md) first** if the task is a prompt, a
-   pipeline, a substitution or a script. It contains the decision that the rest
-   of the work hangs on — whether the job wants a model at all — and the loop
-   that proves the change was an improvement.
+   pipeline, a substitution or a script. It holds the first decision — whether
+   the job needs a model at all — and the loop that scores the change.
 2. **Validate with the binary, not by reading.** `--check-config` reports what
-   the app would actually use; `--pipeline <file.yaml> "<text>" --app <name>`
-   runs a stage against a sentence without a microphone. Both in
-   [cli.md](cli.md).
-3. **Never change a prompt or a pattern without scoring it.** Every rewrite has
-   a case set in `tests/` and a runner in `scripts/`. Record the number before
-   and after; a change that cannot be measured has not been shown to help.
-4. **Fail open.** A stage that errors must leave the transcript exactly as it
-   arrived. Check it by killing Ollama and running the pipeline again.
-5. **Say what a `command:` transform runs.** Config that executes code is worth
-   naming out loud to the person whose machine it will run on.
+   the app uses. `--pipeline <file.yaml> "<text>" --app <name>` runs a stage
+   against a sentence without a microphone. Both are in [cli.md](cli.md).
+3. **Score every change to a prompt or a pattern.** Each rewrite has a case set
+   in `tests/` and a runner in `scripts/`. Record the number before and after.
+4. **Fail open.** A stage that fails must leave the transcript as it arrived.
+   To check this, stop Ollama and run the pipeline again.
+5. **Say what a `command:` transform runs.** Config that executes code needs a
+   clear statement to the person who owns the machine.
 
-Installing rather than configuring: [setup.md](setup.md) is written for you,
-step by step, and expects to be followed in order.
+If you install rather than configure, read [setup.md](setup.md). It is written
+for you, and you must follow it in order.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -169,7 +169,7 @@ degrades to "not available" rather than failing.
 
 ## See also
 
-- [transcription.md](transcription.md) — why Parakeet rather than Whisper, why
-  it cannot be prompted, and what covers that instead
+- [transcription.md](transcription.md) — the speech model, its limits, and the
+  stages that cover them
 - [pipelines.md](pipelines.md) — the stage model in full
-- [distribution.md](distribution.md) — signing, updates, why this ships by curl
+- [distribution.md](distribution.md) — signing, updates, and the install

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -2,88 +2,10 @@
 
 How ParrotFlow gets onto someone else's Mac.
 
-Implemented: releases are automated, the app installs by `curl`, and a coding
-agent can drive the whole setup. Still open: notarization, and everything that
-unlocks — Homebrew, a double-clickable `.dmg`, a link that works for someone who
-was sent it.
-
-## The Mac App Store is a dead end for this app
-
-Worth settling first, because it constrains everything else.
-
-The App Store requires the App Sandbox, and
-[sandboxed apps cannot use the Accessibility APIs](https://developer.apple.com/forums/thread/707680)
-that let one app insert text into another. `AXIsProcessTrustedWithOptions` is
-not available under the sandbox. Since typing the transcript into whatever app
-you're in *is the product*, this isn't a feature to trade away.
-
-Global hotkeys would survive — a `CGEventTap` needs Input Monitoring, which
-sandboxed apps can request — but text insertion does not. Clipboard-manager
-style apps get
-[rejected under Guideline 2.4.5](https://developer.apple.com/forums/thread/820594)
-for related reasons.
-
-This is why every app in this category — Wispr Flow, VoiceInk, Handy, Raycast —
-ships outside the App Store. Direct download and Homebrew is the path.
-
-## Homebrew is closed to us until we notarize
-
-This was the plan, and it no longer works. Homebrew **removed
-`--no-quarantine`** in the 5.0 line, deliberately, on the grounds that it
-existed only to bypass a macOS security mechanism. Verified on 6.0.10: the flag
-isn't recognised, `brew install` just prints its usage. `HOMEBREW_CASK_OPTS`
-went with it.
-
-So a cask now always installs the app quarantined, Gatekeeper always assesses
-it, and an app signed with anything short of a Developer ID always fails that
-assessment. What Homebrew's maintainers tell users to do instead is run
-`xattr -rd com.apple.quarantine /Applications/Whatever.app` by hand.
-
-That is a bad sentence to put in the install instructions for *any* app. For
-this one — which then asks for the microphone and for permission to type into
-every window — it is disqualifying. "Turn off a security check, then let me
-listen to you" is not a trade a reasonable person should accept, and we should
-not be the ones asking.
-
-The official repo is further out than it was. [Acceptable Casks](https://docs.brew.sh/Acceptable-Casks)
-already required a cask work **"without requiring System Integrity Protection or
-Gatekeeper to be disabled"**, and homebrew-cask is dropping casks that fail its
-codesigning-and-notarization audit on **1 September 2026**.
-
-So Homebrew is not a first channel any more. It is a thing that unlocks after
-notarization, at the same moment everything else does.
-
-## Why curl works, and it isn't a trick
-
-The quarantine attribute is not applied by macOS. It is applied by the
-*downloading application*, via `LSFileQuarantineEnabled` — browsers set it, Mail
-sets it, Slack sets it. `curl` does not.
-
-Measured:
-
-```
-$ curl -o file.zip <url> && xattr -l file.zip
-com.apple.provenance                    ← no com.apple.quarantine
-
-$ xattr -l .build/ParrotFlow.app
-com.apple.provenance
-$ spctl --assess --type execute -vv .build/ParrotFlow.app
-rejected                                ← and yet it launches, every day
-```
-
-Gatekeeper only assesses quarantined files. No attribute, no assessment — which
-is why a locally built app runs without ceremony, and why a curl-fetched one
-does too. Same mechanism, and it is the mechanism every `curl | sh` developer
-tool has relied on for a decade.
-
-This is not us disabling a security feature. It is us not triggering one, which
-is a different thing: nothing is turned off, no state is changed, and a user who
-downloads the same zip in a browser still gets the full Gatekeeper treatment.
-
-The honest caveat: it works because Apple has not closed this path, and closing
-it would break most of the developer tooling ecosystem. Unlikely, not promised.
-Notarization is the only future-proof answer — curl is what lets us ship before
-we have it.
+Releases are automated. The app installs by `curl`, and a coding agent can
+drive the whole setup. The app is not notarized, so Homebrew, a
+double-clickable `.dmg`, and a link that opens for someone who was sent it do
+not work yet.
 
 ## Signing releases anyway
 
@@ -120,24 +42,6 @@ rotating it a one-line change rather than an archaeology exercise:
 openssl x509 -in ~/.parrotflow-release/cert.pem -outform DER | shasum -a 256
 codesign -d --extract-certificates=/tmp/c ParrotFlow.app && shasum -a 256 /tmp/c0
 ```
-
-## Gatekeeper without notarization is now genuinely bad
-
-This used to be a shrug — right-click, Open, done. Not since macOS 15:
-[Control-click no longer overrides Gatekeeper](https://developer.apple.com/news/?id=saqachfa).
-A user who downloads an unsigned build now has to open System Settings →
-Privacy & Security, scroll to a message about blocked software, click Open
-Anyway, and re-authenticate. Many will conclude the app is broken.
-
-There is a second, subtler cost, and we already ran into it: **ad-hoc signatures
-break permissions on every build**. TCC pins high-risk grants to the binary's
-cdhash, so a new build silently loses Microphone and Accessibility while System
-Settings still shows the app ticked. A Developer ID certificate makes the
-designated requirement key on the certificate instead, and the problem vanishes
-for users and for us.
-
-That's the real argument for the $99/year Apple Developer Program here — not
-polish, but that the permission model doesn't work properly without it.
 
 ## Signing and notarizing
 
@@ -312,23 +216,9 @@ sign with Developer ID instead, submit, staple, upload. The rest stays.
 | GitHub Releases hosting | Free |
 | Self-signed release certificate | Free |
 
-The $99 is still the only real decision, but what it buys has changed. It is no
-longer "polish plus a shorter install line" — Homebrew of any kind, a `.dmg`
-anyone can double-click, and a link that works when someone's colleague sends it
-to them are all on the far side of it. Curl covers the developer who is already
-in a terminal. It does not cover the person who was sent a link.
+The $99 buys notarization, and notarization is what Homebrew, a
+double-clickable `.dmg`, and a shareable link need. Curl covers a developer who
+is already in a terminal. It does not cover a person who was sent a link.
 
-What the self-signed certificate buys for free is the permissions problem:
-grants survive upgrades. That was the other half of the argument for $99, and it
-is now settled without it.
-
-## Sources
-
-- [Acceptable Casks](https://docs.brew.sh/Acceptable-Casks) · [Cask Cookbook](https://docs.brew.sh/Cask-Cookbook)
-- [Removing support for `--no-quarantine` for casks](https://github.com/Homebrew/brew/issues/20755) · [Prepare for deprecation](https://github.com/Homebrew/brew/pull/20929) · [discussion](https://github.com/orgs/Homebrew/discussions/6537)
-- [Updates to runtime protection in macOS Sequoia](https://developer.apple.com/news/?id=saqachfa)
-- [Safely open apps on your Mac](https://support.apple.com/en-us/102445)
-- [An Exhaustive Guide to Signing and Notarizing on macOS](https://armaan.cc/blog/signing-and-notarizing-macos)
-- [Accessibility permission in sandboxed app](https://developer.apple.com/forums/thread/707680)
-- [Guideline 2.4.5 rejection for CGEvent.post](https://developer.apple.com/forums/thread/820594)
-- [Notarization: the hardened runtime](https://eclecticlight.co/2021/01/07/notarization-the-hardened-runtime/)
+The self-signed certificate is free and keeps the permission grants across
+upgrades.

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -1,22 +1,13 @@
-# Transcription: picking a Parakeet runtime
+# Transcription
 
-Implemented in `Transcriber.swift`. Findings below are measured, not quoted.
+The speech model is Parakeet, run by FluidAudio on the Neural Engine.
+`Transcriber.swift` implements it.
 
-## Can Parakeet be prompted?
+## The model takes no instructions
 
-**No.** Parakeet has no text input, and this is architectural rather than a
-missing feature.
-
-Whisper's decoder is an autoregressive transformer over text, so you can prefix
-it with `initial_prompt` and the model conditions on those tokens. Parakeet TDT
-is a Token-and-Duration Transducer: a Conformer encoder feeding a small
-prediction network that only ever sees the tokens it has already emitted. There
-is no slot for an instruction. Of NVIDIA's ASR family only
-[Canary](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3/discussions/8)
-takes text prompts.
-
-So "transcribe this as bullet points" or "the speaker is French" cannot be
-passed to the model. Two things cover what you'd actually want from a prompt:
+Parakeet has no text input. You cannot tell it "the speaker is French" or
+"write this as bullet points". Two things do that work instead, both on the
+finished transcript.
 
 ### 1. A replacements map — for patterns and deletions
 
@@ -82,7 +73,7 @@ different owners: you write the config, the app writes the vocabulary — from
 corrections, from `--learn`, from the calibrate skill.
 
 ```yaml
-acoustic: true
+acoustic: false            # the default
 offer_below: 0.50
 decide_above: 3.0
 
@@ -105,10 +96,8 @@ terms:
 
 #### The two numbers
 
-What a spelling makes worth looking at and what the audio can veto are
-different questions. One threshold used to answer both and no value answered
-them both: strict enough to be safe it caught 2 of 20 misheard names, and loose
-enough to catch them "in general" became "in Redcrawl".
+What a spelling makes worth looking at, and what the audio can veto, are two
+different questions. Each has its own number.
 
 **`offer_below`** is how far a decoded word's spelling may sit from a term and
 still be put to the judge, from 0 to 1, where 1.0 is the term written out
@@ -289,27 +278,19 @@ flips:
 | the vocabulary rules switched off | 52/74 | 0/22 | 52/52 |
 
 The two bottom rows are the blind controls, and they are the point: a mechanism
-that does not beat its own blind version has not been shown to work. Held out
-from the clips the wording was chosen on it is 42/50, against the menu's 20/50.
-The measurement is recorded in PR #102 and the harness was not kept.
+that does not beat its own blind version has not been shown to work.
 
-An earlier round measured a spell-check gate with no model at 95% on
-`tests/judge-cases.yaml`, above the model. It cannot do the job alone. Its rule
-is "never replace a real word", so it cannot fix `cloud` -> `Claude` or
-`Versailles` -> `Vercel`. Those need the sentence.
+A spell-check gate cannot do this job alone. Its rule is "never replace a real
+word", so it cannot fix `cloud` -> `Claude` or `Versailles` -> `Vercel`. Those
+need the sentence.
 
 Every exchange is written to `trace.jsonl` under the stage's variables, so a
 verdict can be replayed rather than guessed at.
 
-The case set is 17% short sentences; real dictation here is 36%. The numbers
-above are therefore measured on inputs that favour a judge, since context is
-what it uses.
-
 A literal substitution cannot generalise to a mishearing you have not seen, so
-that half of the map grows one entry at a time. It also cannot corrupt a
-transcript that was already right, which turned out to matter more — and a
-pattern rule gives that property up in exchange for reach, which is the trade
-`app:` exists to bound.
+that half of the map grows one entry at a time. It also cannot corrupt a transcript that was already
+right. A pattern rule gives that property up for reach, and `app:` bounds the
+trade.
 
 ### 3. A local LLM pass — for everything else
 
@@ -321,87 +302,6 @@ dependency. An MLX model is the fallback for older systems.
 Keep it optional and off by default. It adds latency to every dictation and
 can rewrite text you meant literally. Filler words are not a job for it — a
 regex removes them for free.
-
-## Runtime options
-
-| Option | Language | Ships as | Verdict |
-| --- | --- | --- | --- |
-| [FluidAudio](https://github.com/FluidInference/FluidAudio) | Swift | SPM package, CoreML on ANE | **Recommended** |
-| [parakeet-coreml-swift](https://github.com/mweinbach/parakeet-coreml-swift) | Swift | SPM package, CoreML | Leaner, fewer features |
-| [parakeet-mlx](https://github.com/senstella/parakeet-mlx) | Python | pip + MLX | Needs a Python runtime |
-| [Apple SpeechAnalyzer](https://developer.apple.com/videos/play/wwdc2025/277/) | Swift | OS framework | No model to ship at all |
-
-**parakeet-mlx is out.** It would mean bundling a Python interpreter and its
-wheels into a Mac app, or making users manage a venv. That contradicts the
-whole "small, lightweight, one download" goal.
-
-**FluidAudio is the pick.** Apache 2.0, one SPM line, runs on the Neural Engine,
-~190× real-time on an M4 Pro, and it already solves the vocabulary problem —
-which is otherwise the hardest part of this project to do well.
-
-Its input format is "16 kHz mono Float32", which is exactly what `Recorder.swift`
-already writes. That was the point of fixing the audio format in v0.1.
-
-```swift
-let models = try await AsrModels.downloadAndLoad(version: .v3)
-let asrManager = AsrManager(config: .default)
-try await asrManager.configure(models: models)
-let result = try await asrManager.transcribe(samples, source: .system)
-```
-
-### Apple SpeechAnalyzer deserves a look
-
-macOS 26 added `SpeechAnalyzer` / `SpeechTranscriber` — on-device, streaming,
-with models the OS downloads and manages. Reportedly ~2× faster than Whisper
-Large V3 Turbo.
-
-It is genuinely tempting: **zero model bytes to ship**, no first-run download,
-no ~1 GB in the app's cache, and Apple maintains it. The costs are macOS 26+
-only, less control over the model, and no equivalent of FluidAudio's acoustic
-context biasing (the older `contextualStrings` is a weaker mechanism).
-
-Worth a spike before committing to Parakeet. If quality is comparable on your
-voice, it removes the single largest chunk of complexity in shipping this app.
-It's also a sensible fallback on machines where the Parakeet download fails.
-
-## Model size — the thing that shapes the install
-
-The HuggingFace repo for v3 CoreML totals **~3.0 GB**, but that's every variant
-in both `.mlpackage` and compiled `.mlmodelc` form. A working set is roughly:
-
-| File | Size |
-| --- | --- |
-| MelEncoder | 595 MB |
-| Encoder (fp) | 445 MB |
-| Encoder (int4 alternative) | 298 MB |
-| ParakeetDecoder | 37 MB |
-| JointDecision | 13 MB |
-
-So **~700 MB–1.1 GB** downloaded on first run, depending on the encoder variant.
-
-This must not go in the app bundle — it would make a ~1 GB download for
-something that is otherwise a few hundred KB, and it breaks the Homebrew route.
-Download on first launch into `~/Library/Caches`, with visible progress,
-a resumable transfer, and a working app (record-only) until it lands.
-
-## Proposed order
-
-1. Spike Apple `SpeechTranscriber` — cheapest possible path, decide on quality.
-2. Wire FluidAudio behind a `transcription.engine` config key, so both can coexist.
-3. Insert text into the frontmost app (needs Accessibility — see
-   [distribution.md](distribution.md)).
-4. Custom vocabulary from YAML.
-5. Optional LLM cleanup pass, off by default.
-
-## Sources
-
-- [FluidAudio](https://github.com/FluidInference/FluidAudio) · [Custom Vocabulary docs](https://github.com/FluidInference/FluidAudio/blob/main/Documentation/ASR/CustomVocabulary.md) · [Getting Started](https://github.com/FluidInference/FluidAudio/blob/main/Documentation/ASR/GettingStarted.md)
-- [parakeet-tdt-0.6b-v3-coreml](https://huggingface.co/FluidInference/parakeet-tdt-0.6b-v3-coreml)
-- [Can Parakeet be prompted? (NVIDIA discussion)](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3/discussions/8)
-- [NeMo word boosting](https://docs.nvidia.com/nemo-framework/user-guide/latest/nemotoolkit/asr/asr_customization/word_boosting.html)
-- [NeMo inverse text normalization](https://docs.nvidia.com/nemo-framework/user-guide/latest/nemotoolkit/nlp/text_normalization/wfst/wfst_text_normalization.html)
-- [WWDC25: SpeechAnalyzer](https://developer.apple.com/videos/play/wwdc2025/277/)
-- [parakeet-coreml-swift](https://github.com/mweinbach/parakeet-coreml-swift)
 
 ## Voice corrections
 


### PR DESCRIPTION
Two things.

## The `ste` skill

Adds `.claude/skills/ste/SKILL.md`. It switches a session to ASD-STE100 Simplified Technical English. It is user-invoked only (`disable-model-invocation: true`).

## The docs say what is true now

The docs carried decision records: options nobody took, plans whose steps are all shipped or abandoned, and measurements from experiments with no surviving harness. A reader cannot act on any of it.

**`transcription.md`** — 506 → 408 lines.

- Removed "Runtime options", "Model size", "Proposed order" and "Sources". The proposed order listed five steps that are all shipped or dropped.
- Removed the experiment numbers: the 42/50 judge result against a blind control, the 95% spell-check gate, and the "17% short sentences" caveat. The behaviour they describe stays; the measurements go.
- The `acoustic:` example showed `true`. The default is `false` (`Config.swift`), so the example taught the wrong thing. Fixed.
- Retitled from "picking a Parakeet runtime". "Can Parakeet be prompted?" becomes "The model takes no instructions" — the fact, without the Whisper comparison.

**`distribution.md`** — 334 → 224 lines. Removed the four sections that argue routes nobody took: the App Store, Homebrew, why curl is acceptable, and Gatekeeper. What the app signs, how it updates, how a release is cut and what it costs all stay.

**`docs/README.md`** — dropped the "Why it is built this way" group; both files move under "Changing it".

**`docs/architecture.md`** — its two "see also" lines described the files by their removed arguments.

## Checked

- `voice/observations.jsonl`, `voice/calibration.yaml` and `voice/samples/` are `VoiceStore.swift` on `main`, so they stay documented.
- `acoustic`, `offer_below` and `decide_above` all exist in `Config.swift`.
- Both anchors `corrections.md` links into still resolve.
- `swift build` clean; `check-default-config.sh` passes.

## Not in this PR

`setup.md`, `configuration.md` and `cli.md` have open PRs (#120, #121, #118) and would conflict.

`pipelines.md`, `authoring.md`, `corrections.md`, `development.md` and `permissions.md` still need the same pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)