### PR TITLE
fix: a microphone that changes takes neither the hotkey nor the app with it

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,9 +10,15 @@ let package = Package(
         .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.15.5"),
     ],
     targets: [
+        // Three lines of Objective-C, for the one thing Swift cannot do:
+        // catch an NSException. See Sources/ObjCExceptions/include.
+        .target(
+            name: "ObjCExceptions",
+            path: "Sources/ObjCExceptions"
+        ),
         .executableTarget(
             name: "ParrotFlow",
-            dependencies: ["Yams", "FluidAudio"],
+            dependencies: ["Yams", "FluidAudio", "ObjCExceptions"],
             path: "Sources/ParrotFlow"
         )
     ]

--- a/Sources/ObjCExceptions/ObjCExceptions.m
+++ b/Sources/ObjCExceptions/ObjCExceptions.m
@@ -1,0 +1,10 @@
+#import "ObjCExceptions.h"
+
+NSException *_Nullable PFRunCatchingObjCExceptions(void (NS_NOESCAPE ^block)(void)) {
+    @try {
+        block();
+        return nil;
+    } @catch (NSException *exception) {
+        return exception;
+    }
+}

--- a/Sources/ObjCExceptions/include/ObjCExceptions.h
+++ b/Sources/ObjCExceptions/include/ObjCExceptions.h
@@ -1,0 +1,24 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Runs `block` and hands back the Objective-C exception it raised, or nil.
+///
+/// Swift has no `catch` for an `NSException`. One thrown inside a Swift frame
+/// unwinds straight through it and out of whatever run loop callback the frame
+/// was called from, so `do`/`catch` around the call never runs and nothing is
+/// logged. AppKit catches it at the top of the loop and the app carries on
+/// looking healthy, having silently dropped the work.
+///
+/// AVFoundation raises them for programmer errors, and one of those errors is
+/// reachable from a microphone that changes: `installTapOnBus:` raises when the
+/// format it is handed no longer matches the hardware format of the node. See
+/// #123.
+///
+/// Catching one is not a way to keep going as if nothing happened — whatever
+/// raised it is in whatever state it was in. It is a way to find out, so the
+/// caller can throw the object away and say so.
+NSException *_Nullable PFRunCatchingObjCExceptions(void (NS_NOESCAPE ^block)(void))
+    NS_SWIFT_NAME(runCatchingObjCExceptions(_:));
+
+NS_ASSUME_NONNULL_END

--- a/Sources/ParrotFlow/AudioRecoveryCommand.swift
+++ b/Sources/ParrotFlow/AudioRecoveryCommand.swift
@@ -1,6 +1,7 @@
 import AVFoundation
 import CoreAudio
 import Foundation
+import ObjCExceptions
 import Yams
 
 /// `--audio-recovery` — drives a device change past the recorder and checks it
@@ -55,6 +56,14 @@ enum AudioRecoveryCommand {
         }
 
         print("")
+        print("The engine and its own input")
+        var graph = 0
+        graph += checkAGraphThatDisagreesWithItselfIsRebuilt() ? 0 : 1
+        graph += checkAnExceptionComesBackAsAValue() ? 0 : 1
+        graph += checkAReplacedEngineIsNotReleasedOnTheSpot() ? 0 : 1
+        failures += graph
+
+        print("")
         thisMachine()
 
         print("")
@@ -66,7 +75,7 @@ enum AudioRecoveryCommand {
         capture += checkOneLostBufferIsForgiven(config: config) ? 0 : 1
         failures += capture
 
-        let total = cases.count + 4
+        let total = cases.count + 7
         print("")
         print("  \(total - failures)/\(total)")
         return failures == 0 ? 0 : 1
@@ -91,14 +100,119 @@ enum AudioRecoveryCommand {
         // released segfaults. No engine is started, so the microphone
         // indicator stays off — the same promise `Recorder.warmUp` makes.
         let engine = AVAudioEngine()
-        let engineFormat = engine.inputNode.outputFormat(forBus: 0)
+        let formats = Recorder.EngineFormats(
+            tap: engine.inputNode.outputFormat(forBus: 0),
+            hardware: engine.inputNode.inputFormat(forBus: 0)
+        )
         print("  device   \(Recorder.inputDeviceName ?? "unnamed") — \(binding.described)")
-        print("  engine   \(Int(engineFormat.sampleRate)) Hz, \(engineFormat.channelCount) ch")
-        print(
-            "  agree    "
-            + (engineFormat.sampleRate == binding.sampleRate
-               ? "yes"
-               : "NO — a press would rebuild the engine before recording")
+        print("  engine   \(formats.described)")
+        // Both comparisons, in the words the log would use. The engine against
+        // itself is the one that decides whether a tap can be installed at all.
+        if let problem = Recorder.formatProblem(formats, against: binding) {
+            print("  agree    NO — \(problem)")
+            print("           a press would rebuild the engine before recording")
+        } else {
+            print("  agree    yes")
+        }
+    }
+
+    // MARK: - The graph
+
+    /// The engine's own two formats disagree, and nothing about the device
+    /// does. #123: this is what an AirPods link settling looks like from
+    /// inside, and comparing only the binding drops it.
+    ///
+    /// Dropping it is not a missed rebuild, it is a crash. The press after it
+    /// installs a tap at the format the node has left, and `installTap` answers
+    /// that by raising an exception through the hotkey handler.
+    private static func checkAGraphThatDisagreesWithItselfIsRebuilt() -> Bool {
+        let name = "a graph that disagrees with itself is rebuilt"
+        let binding = Recorder.InputBinding(device: 2, sampleRate: 24000, channels: 1)
+        guard let tap = format(24000), let hardware = format(16000) else {
+            return say(false, name, "could not build the formats")
+        }
+
+        let recorder = Recorder()
+        recorder.currentInput = { binding }
+        recorder.warmUp()
+
+        // Moved after the binding is settled, so the device is provably not
+        // what fires this: `currentInput` answers the same thing throughout.
+        let before = recorder.rebuilds
+        recorder.engineFormats = { _ in
+            Recorder.EngineFormats(tap: tap, hardware: hardware)
+        }
+        recorder.simulateConfigurationChange()
+        settle(untilTrue: { recorder.rebuilds > before }, seconds: 2)
+
+        guard recorder.rebuilds > before else {
+            return say(false, name, "the device had not moved, so the change was dropped")
+        }
+        return say(true, name, "rebuilt")
+    }
+
+    /// An NSException raised inside a Swift frame comes back as a value.
+    ///
+    /// The one thing the shim in `Sources/ObjCExceptions` exists for. Without
+    /// it, this raise would unwind out of the run loop callback that called it
+    /// — past every `catch`, past every log line — and AppKit would swallow it
+    /// at the top of the loop.
+    private static func checkAnExceptionComesBackAsAValue() -> Bool {
+        let name = "an exception comes back as a value"
+        let raised = runCatchingObjCExceptions {
+            NSException(
+                name: .invalidArgumentException,
+                reason: "required condition is false: format.sampleRate == inputHWFormat.sampleRate",
+                userInfo: nil
+            ).raise()
+        }
+        guard let raised else {
+            return say(false, name, "nothing came back, so the exception was not caught")
+        }
+        guard runCatchingObjCExceptions({}) == nil else {
+            return say(false, name, "a block that raised nothing came back with something")
+        }
+        return say(true, name, "\(raised.name.rawValue)")
+    }
+
+    /// The engine a rebuild replaced is held, not released where it stood.
+    ///
+    /// Releasing it there is a crash, not a leak: `dealloc` blocks for seconds
+    /// tearing down a Bluetooth audio unit, and AVFoundation delivers property
+    /// changes to the object throughout. One landed on 2026-08-12 at 18:22:43.
+    ///
+    /// Both halves are checked. Held is the fix; let go afterwards is what
+    /// makes it a delay rather than an engine kept forever, holding a device
+    /// open that nothing is recording through.
+    private static func checkAReplacedEngineIsNotReleasedOnTheSpot() -> Bool {
+        let name = "a replaced engine is held, then let go"
+        let recorder = Recorder()
+        recorder.currentInput = { Recorder.InputBinding(device: 1, sampleRate: 48000, channels: 1) }
+        recorder.warmUp()
+
+        recorder.currentInput = { Recorder.InputBinding(device: 2, sampleRate: 24000, channels: 1) }
+        recorder.simulateConfigurationChange()
+        settle(untilTrue: { recorder.rebuilds > 0 }, seconds: 2)
+
+        guard recorder.rebuilds > 0 else {
+            return say(false, name, "nothing was replaced, so there was nothing to hold")
+        }
+        guard recorder.enginesInRetirement == 1 else {
+            return say(false, name, "the engine was let go where it was replaced")
+        }
+
+        // Longer than the recorder holds one. Nothing waits on this in the app;
+        // it is waited on here so "held" cannot pass by being "kept".
+        settle(untilTrue: { recorder.enginesInRetirement == 0 }, seconds: 15)
+        guard recorder.enginesInRetirement == 0 else {
+            return say(false, name, "it was still being held after 15s")
+        }
+        return say(true, name, "held, then let go")
+    }
+
+    private static func format(_ rate: Double) -> AVAudioFormat? {
+        AVAudioFormat(
+            commonFormat: .pcmFormatFloat32, sampleRate: rate, channels: 1, interleaved: false
         )
     }
 

--- a/Sources/ParrotFlow/Recorder.swift
+++ b/Sources/ParrotFlow/Recorder.swift
@@ -1,6 +1,7 @@
 import AVFoundation
 import CoreAudio
 import Foundation
+import ObjCExceptions
 
 /// Captures the default input device and writes 16 kHz mono PCM WAV files —
 /// the format Parakeet expects, so the transcription step can read them as-is.
@@ -91,11 +92,34 @@ final class Recorder {
         }
     }
 
+    /// The two formats an engine holds for its own input node.
+    ///
+    /// `tap` is what a tap has to be installed with. `hardware` is what
+    /// `installTap` checks it against — the assertion is literally
+    /// `format.sampleRate == inputHWFormat.sampleRate`. They are the same
+    /// number until the device moves under a graph that has not been rebuilt
+    /// since, and then they are one number each.
+    ///
+    /// Both come off the same node, so this is the engine talking about itself.
+    /// It is a different question from `InputBinding`, which is CoreAudio
+    /// talking about the device, and the difference is #123: the device and the
+    /// engine agreed at 24000 Hz while the node's two halves did not, so every
+    /// check passed and the tap still asserted.
+    struct EngineFormats {
+        let tap: AVAudioFormat
+        let hardware: AVAudioFormat
+
+        var described: String {
+            "tap at \(Int(tap.sampleRate)) Hz, input at \(Int(hardware.sampleRate)) Hz"
+        }
+    }
+
     enum RecorderError: LocalizedError {
         case noInputDevice
         case unsupportedFormat
         case converterUnavailable
         case inputStillConnecting
+        case inputMovedWhileStarting
 
         var errorDescription: String? {
             switch self {
@@ -107,6 +131,8 @@ final class Recorder {
                 return "Could not convert the microphone's format to 16 kHz mono."
             case .inputStillConnecting:
                 return "The microphone is still connecting — press again in a moment."
+            case .inputMovedWhileStarting:
+                return "The microphone changed as the recording started — press again."
             }
         }
     }
@@ -149,6 +175,16 @@ final class Recorder {
     /// message you can act on, not an app that stops answering the hotkey.
     private static let rebuildWaitSeconds: Double = 1.5
 
+    /// How long a replaced engine is kept alive before it is let go. See
+    /// `retire`.
+    ///
+    /// Long enough to be past the change that caused the rebuild: the AirPods
+    /// link that crashed the app was still posting property changes seven
+    /// seconds after it became the input, and the rebuild itself takes a
+    /// tenth of that. Nothing waits on this, so the cost of being generous is
+    /// one engine object held a few seconds longer.
+    private static let retirementSeconds: Double = 10
+
     private(set) var isRecording = false
     private(set) var startedAt: Date?
 
@@ -161,6 +197,16 @@ final class Recorder {
         return rebuildCount
     }
     private var rebuildCount = 0
+
+    /// How many replaced engines are being held rather than released. Read by
+    /// `--audio-recovery`, from a different thread than the one that counts
+    /// them. Zero at rest.
+    var enginesInRetirement: Int {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return retiredCount
+    }
+    private var retiredCount = 0
 
     /// 0...1, already smoothed — drive a meter with it. Called on the main queue.
     var onLevel: ((Float) -> Void)?
@@ -179,6 +225,18 @@ final class Recorder {
     /// input under the recorder without moving the machine's audio settings.
     /// Nothing in the app replaces it.
     var currentInput: () -> InputBinding? = InputBinding.system
+
+    /// What the engine says about its own input node, both halves of it.
+    ///
+    /// A property for the same reason as `currentInput`: it is the only way to
+    /// put a graph that disagrees with itself in front of the check without a
+    /// microphone that does it on cue. Nothing in the app replaces it.
+    var engineFormats: (AVAudioEngine) -> EngineFormats = { engine in
+        EngineFormats(
+            tap: engine.inputNode.outputFormat(forBus: 0),
+            hardware: engine.inputNode.inputFormat(forBus: 0)
+        )
+    }
 
     /// Recreated when the audio device changes — an engine holds on to the
     /// device it was prepared against. Guarded by `stateLock`.
@@ -205,6 +263,8 @@ final class Recorder {
     /// delivered, no recording started, and not one line was written. The app
     /// looked dead, and quitting it was the only way out.
     private let engineQueue = DispatchQueue(label: "com.parrotflow.recorder.engine")
+    /// Lets go of the engines the rebuilds replaced. See `retire`.
+    private let retirementQueue = DispatchQueue(label: "com.parrotflow.recorder.retirement")
     /// Empty unless a rebuild is under way. `start` waits on it, briefly.
     private let rebuildGroup = DispatchGroup()
 
@@ -272,9 +332,9 @@ final class Recorder {
         try waitForRebuild()
 
         var engine = currentEngine()
-        var inputFormat = engine.inputNode.outputFormat(forBus: 0)
+        var formats = engineFormats(engine)
 
-        if let problem = Self.formatProblem(inputFormat, against: currentInput()),
+        if let problem = Self.formatProblem(formats, against: currentInput()),
            problem != acceptedFormatMismatch {
             // A second chance rather than an error, for both shapes of the
             // problem. An empty format means the engine is pointing at nothing;
@@ -286,30 +346,67 @@ final class Recorder {
             rebuildEngine(because: problem)
             try waitForRebuild()
             engine = currentEngine()
-            inputFormat = engine.inputNode.outputFormat(forBus: 0)
+            formats = engineFormats(engine)
 
-            let remaining = Self.formatProblem(inputFormat, against: currentInput())
-            // Remembered whether it cleared or not. A device whose engine and
-            // stream never agree would otherwise buy a rebuild on every single
-            // press, which is a second bug wearing the first one's clothes.
-            acceptedFormatMismatch = remaining
-            if let remaining {
-                // Fail open. A recording that may be wrong beats refusing to
-                // record — but said out loud, because the whole point of #95 is
-                // that this used to be the silent path.
+            let remaining = Self.formatProblem(formats, against: currentInput())
+            if let remaining, Self.graphProblem(formats) == nil {
+                // Fail open. The engine agrees with itself and disagrees with
+                // the device: the tap will install, and whether it hears
+                // anything is what the counters in `process` are for. A
+                // recording that may be wrong beats refusing to record — but
+                // said out loud, because the whole point of #95 is that this
+                // used to be the silent path.
+                //
+                // Remembered, because a device whose engine and stream never
+                // agree would otherwise buy a rebuild on every single press,
+                // which is a second bug wearing the first one's clothes.
+                acceptedFormatMismatch = remaining
                 Log.write("after the rebuild, \(remaining) — recording anyway")
                 report("The microphone is not answering as expected.")
+            } else {
+                // Either it cleared, or the engine still disagrees with itself.
+                // That second one is never remembered: it is not a device to be
+                // lived with, it is a graph a rebuild has always fixed, and the
+                // press after this one has to be allowed to try again.
+                acceptedFormatMismatch = nil
             }
         }
-        guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
+        guard formats.tap.sampleRate > 0, formats.tap.channelCount > 0 else {
             throw RecorderError.noInputDevice
         }
         let inputNode = engine.inputNode
 
-        let url = try openCapture(inputFormat: inputFormat, config: config)
+        let url = try openCapture(inputFormat: formats.tap, config: config)
 
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
-            self?.process(buffer: buffer)
+        // The last look, at the one number `installTap` is about to assert on.
+        // The hardware format can move between the check above and this line —
+        // that is a few milliseconds, and settling a Bluetooth link lands
+        // inside them. Re-read rather than trusted, because being wrong here
+        // does not return an error.
+        if let problem = Self.graphProblem(engineFormats(engine)) {
+            Log.write("\(problem) — not installing the tap")
+            teardown()
+            try? FileManager.default.removeItem(at: url)
+            rebuildEngine(because: problem)
+            throw RecorderError.inputMovedWhileStarting
+        }
+
+        // Wrapped, because `installTap` reports this by raising an
+        // NSException, which unwinds through the hotkey handler and out of the
+        // run loop: no error, no log line, no recording, and an app that still
+        // answers its menu. That is #123, and it is what made "the microphone
+        // changed" look like "the app died". The engine is thrown away rather
+        // than reused — whatever raised it is in whatever state it was in.
+        if let raised = runCatchingObjCExceptions({
+            inputNode.installTap(onBus: 0, bufferSize: 4096, format: formats.tap) { [weak self] buffer, _ in
+                self?.process(buffer: buffer)
+            }
+        }) {
+            Log.write("installing the tap raised \(raised.name.rawValue): \(raised.reason ?? "no reason given")")
+            teardown()
+            try? FileManager.default.removeItem(at: url)
+            rebuildEngine(because: "installing the tap raised an exception")
+            throw RecorderError.inputMovedWhileStarting
         }
 
         do {
@@ -680,33 +777,84 @@ final class Recorder {
 
         stateLock.lock()
         let bound = self.bound
+        let engine = self.engine
+        let rebuilding = self.rebuilding
         stateLock.unlock()
 
         let current = currentInput()
-        guard current != bound else { return }
-        rebuildEngine(because: "input moved: \(Self.describe(bound)) → \(Self.describe(current))")
+        guard current == bound else {
+            rebuildEngine(because: "input moved: \(Self.describe(bound)) → \(Self.describe(current))")
+            return
+        }
+
+        // Nothing below this line asks anything of an engine that is already
+        // being replaced. `adopt` is stopping that one on another thread, and
+        // reading a format off it at the same moment is a race against a
+        // teardown for an answer that is about to be thrown away.
+        guard !rebuilding else { return }
+
+        // The device is where it was, and the engine can still have moved. It
+        // is the engine that posts this notification, and it posts it about
+        // itself: AirPods settle their link, the node's hardware format changes
+        // underneath a graph that was built against the old one, and CoreAudio
+        // reports the same device at the same rate throughout. Comparing only
+        // the binding drops that, and the next press installs a tap that
+        // asserts. See #123.
+        //
+        // Our own `prepare()` posts this notification too, and that echo still
+        // costs nothing: an engine that agrees with itself has no problem to
+        // find here.
+        guard let problem = Self.graphProblem(engineFormats(engine)) else { return }
+        rebuildEngine(because: problem)
     }
 
     private static func describe(_ binding: InputBinding?) -> String {
         binding?.described ?? "no input device"
     }
 
-    /// Why this format cannot be recorded through, or nil if it can.
+    /// Why this engine cannot have a tap installed on it, or nil if it can.
     ///
-    /// The second test is the one #95 needed. A format that disagrees with the
-    /// device is not a broken format — it passes every guard, builds a
-    /// converter, installs a tap — it is a format that used to be true.
-    private static func formatProblem(
-        _ format: AVAudioFormat, against input: InputBinding?
-    ) -> String? {
-        if format.sampleRate <= 0 || format.channelCount == 0 {
+    /// Asked of the engine alone, so it holds wherever the device is: a graph
+    /// whose two halves disagree is unusable against every device, including
+    /// the one it is pointing at. `installTap` makes the same comparison and
+    /// answers it by raising an exception, so this has to be asked first.
+    ///
+    /// This is #123. The engine was at 24000 Hz, the device was at 24000 Hz,
+    /// every check agreed — and the node's own hardware format had moved when
+    /// the AirPods link settled, 700 ms before the key was pressed.
+    ///
+    /// Not private: `--audio-recovery` prints the sentence it would write.
+    static func graphProblem(_ formats: EngineFormats) -> String? {
+        if formats.tap.sampleRate <= 0 || formats.tap.channelCount == 0 {
             return "the input format came back empty"
         }
+        guard formats.tap.sampleRate != formats.hardware.sampleRate else { return nil }
+        return String(
+            format: "the engine's tap is at %.0f Hz and its own input is at %.0f Hz",
+            formats.tap.sampleRate, formats.hardware.sampleRate
+        )
+    }
+
+    /// Why this format cannot be recorded through, or nil if it can.
+    ///
+    /// Two questions, asked in the order they cost. The graph has to hold
+    /// before the device is worth asking about — and it is the half nothing
+    /// asked until #123.
+    ///
+    /// The device test is the one #95 needed. A format that disagrees with the
+    /// device is not a broken format — it passes every guard, builds a
+    /// converter, installs a tap — it is a format that used to be true.
+    ///
+    /// Not private: `--audio-recovery` prints the sentence it would write.
+    static func formatProblem(
+        _ formats: EngineFormats, against input: InputBinding?
+    ) -> String? {
+        if let problem = graphProblem(formats) { return problem }
         guard let input, input.sampleRate > 0 else { return nil }
-        guard format.sampleRate != input.sampleRate else { return nil }
+        guard formats.tap.sampleRate != input.sampleRate else { return nil }
         return String(
             format: "the engine is at %.0f Hz and the device is at %.0f Hz",
-            format.sampleRate, input.sampleRate
+            formats.tap.sampleRate, input.sampleRate
         )
     }
 
@@ -786,11 +934,48 @@ final class Recorder {
         )
         observeConfigurationChanges(on: fresh)
         old.stop()
+        retire(old)
 
         Log.write(String(
             format: "capture engine rebuilt in %.1fs — mic=%@, %@",
             took, Self.inputDeviceName ?? "none", Self.describe(binding)
         ))
+    }
+
+    /// Holds a replaced engine for a while, then lets it go.
+    ///
+    /// Releasing one on the spot is what crashed the app on 2026-08-12 at
+    /// 18:22:43, seven seconds after AirPods became the input: `adopt` on the
+    /// engine queue was inside `-[AVAudioEngine dealloc]`, blocked in
+    /// `invalidateAudioUnit` while a Bluetooth audio unit tore itself down, and
+    /// the AVAudioIOUnit queue delivered a property change to the same object.
+    /// The callback messaged an engine that was halfway gone — EXC_BAD_ACCESS,
+    /// with the two threads named in the report.
+    ///
+    /// The window is not small. A device change is exactly when AVFoundation
+    /// has property changes in flight, and tearing down that unit is measured
+    /// in seconds, not milliseconds. So a replaced engine is stopped, set
+    /// aside, and released once the device that was changing has stopped
+    /// changing.
+    ///
+    /// On its own queue, because the release blocks for as long as the teardown
+    /// does, and blocking `engineQueue` would make the next rebuild wait behind
+    /// a dead engine — which the press after it would see as a microphone that
+    /// is still connecting.
+    private func retire(_ old: AVAudioEngine) {
+        stateLock.lock()
+        retiredCount += 1
+        stateLock.unlock()
+
+        retirementQueue.asyncAfter(deadline: .now() + Self.retirementSeconds) { [weak self] in
+            // `old` is captured on purpose: this block is the only thing
+            // holding it, and the release is the block ending.
+            withExtendedLifetime(old) {}
+            guard let self else { return }
+            self.stateLock.lock()
+            self.retiredCount -= 1
+            self.stateLock.unlock()
+        }
     }
 
     // MARK: - Device

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -256,14 +256,24 @@ dead — it shows whether the key is reaching the app at all, and whether left
 and right are distinguishable on your keyboard.
 
 `--audio-recovery` is for the other kind of dead: the microphone changed —
-AirPods connected, a headset came out — and dictation has been recording
-silence ever since. It moves the input binding inside the process instead of
-switching your real input device, so it is safe to run while somebody is
-dictating and it never opens the microphone. That is also its limit: it proves
-the recorder replaces its engine and that the capture path writes a real signal
-afterwards, and it proves nothing about what the hardware then sends. The cases
-are in `tests/audio-recovery-cases.yaml`; `scripts/check-audio-recovery.sh` runs
-it against a scratch config.
+AirPods connected, a headset came out — and since then dictation records
+silence, or the hotkey starts nothing at all. It moves the input binding inside
+the process instead of switching your real input device, so it is safe to run
+while somebody is dictating and it never opens the microphone. That is also its
+limit: it proves the recorder replaces its engine and that the capture path
+writes a real signal afterwards, and it proves nothing about what the hardware
+then sends. The cases are in `tests/audio-recovery-cases.yaml`;
+`scripts/check-audio-recovery.sh` runs it against a scratch config.
+
+It asks two questions, and the second one is easy to miss. `Device changes` is
+CoreAudio against the engine: has the input moved. `The engine and its own
+input` is the engine against itself — the two formats it holds for its input
+node, which is the pair `installTap` compares. A microphone can move only that
+pair, and it is the more expensive way to be wrong: a stale binding costs a
+silent clip, while a graph that disagrees with itself makes `installTap` raise
+an exception through the hotkey handler, and the app then answers its menu and
+records nothing until it is restarted. The `This machine` block prints both
+comparisons for whatever is plugged in right now.
 
 You can make a test clip without a microphone at all — `say` writes exactly the
 format the model wants:


### PR DESCRIPTION
Closes #123.

Switch the input to AirPods and the next press did nothing, and went on doing
nothing until the app was restarted.

## The press that did nothing

`installTap` raises an Objective-C exception when the format it is handed is
not the node's hardware format. Swift cannot catch one, so the `catch` in
`startRecording` never ran, nothing reached the log, and AppKit swallowed it at
the top of the run loop — an app that answers its menu and never records. The
clip from the press is still on disk at 0.000000 sec, which is `openCapture`
having made the file one line before the throw.

Every check compared the engine to the CoreAudio device, and both said
24000 Hz. The pair `installTap` asserts on is the two formats the input node
holds for *itself*, and those had moved when the AirPods link settled, 700 ms
before the key went down. The evidence, from two presses on 2026-08-12, is in
the issue.

So the engine is now asked about itself:

- `graphProblem` compares the node's tap format to its own hardware format.
  `formatProblem` asks that first, before the device question it already asked
- a configuration change whose binding has not moved is no longer dropped. The
  engine posting it is itself the news that the graph moved
- the same question again immediately before the tap goes on, because the
  hardware format can move inside the milliseconds `openCapture` takes
- and the install is wrapped in three lines of Objective-C, so an exception
  from anywhere else in AVFoundation becomes a Swift error: logged, said on
  screen, clip deleted, engine thrown away

## The crash under it

Fixing that exposed a segfault on the next switch. `adopt` released the
replaced engine where it stood, and a device change is exactly when
AVFoundation has property changes in flight: `dealloc` blocked for seconds
tearing down a Bluetooth audio unit while the `AVAudioIOUnit` queue messaged
the same object. Both threads are named in the report.

A replaced engine is now stopped, set aside, and released ten seconds later on
its own queue. Ten because the callback that crashed it arrived seven seconds
after the rebuild. Its own queue because the release blocks for as long as the
teardown does, and blocking the engine queue would make the next rebuild look
like a microphone that never connects.

## What was measured

`--audio-recovery` goes from 11 to 14 and grows a section:

```
The engine and its own input
  ✓ a graph that disagrees with itself is rebuilt  rebuilt
  ✓ an exception comes back as a value             NSInvalidArgumentException
  ✓ a replaced engine is held, then let go         held, then let go
```

The first was falsified against the old code before it was kept: with the
notification still being dropped it reads `the device had not moved, so the
change was dropped`, 12/13. `This machine` now prints both comparisons for
whatever is plugged in.

## What it does not prove

The retirement window makes the crash very unlikely, not impossible. It is a
race in AVFoundation's ownership of its own callbacks, and ten seconds past a
settled device is a wide margin rather than a proof. If it fires again the
report will name the same two threads, and the answer is a different engine
lifecycle, not a bigger number.

Nothing here opens a microphone, so the hardware half is still a claim to check
by hand: switch to AirPods, dictate, switch back, dictate.
