### PR TITLE
feat: the offer goes when you click past it, or type past it

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -283,6 +283,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// It has a second job while the pointer is holding the offer open. See
     /// `offerDeadlinePassed`.
     private var offerKeysExpiry: DispatchWorkItem?
+    /// Watches for a click outside the offer, for as long as it is up. See
+    /// `watchForOfferOutsideClick`.
+    private var offerClickMonitors: [Any] = []
     /// True while the pointer is resting on the offer.
     ///
     /// The clock is stopped then, and `offerUntil` becomes a date that never
@@ -2136,6 +2139,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         offerOnScreen = commands
         watchTheOfferKeys()
+        watchForOfferOutsideClick()
 
         // Taken at the press, and only when that press found no caret. Matched
         // by run, so it is this dictation's own pane and nobody else's. A
@@ -2210,11 +2214,64 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 // guards the other one has.
                 self.pill.model.onPick?(index)
             case .dismiss:
-                Log.write("offer: dismissed")
-                self.endTheOffer()
-                self.pill.hide()
+                self.dismissOffer(reason: "the keyboard")
             }
         }
+    }
+
+    /// A click anywhere but on the offer ends it, the same way Escape or
+    /// Return does. Clicking outside the offer is already how you leave a menu
+    /// or close a popover on the Mac; this is one more surface answering to
+    /// the same habit rather than needing its own.
+    ///
+    /// Two monitors, the same pair `watchForEscape` uses and for the same
+    /// reason: the global one sees a click in whatever app you clicked into,
+    /// while it is in front; the local one sees a click on one of this app's
+    /// own windows before AppKit routes it anywhere. Neither consumes the
+    /// click — it still lands wherever it was headed, on the words you clicked
+    /// into or the panel you clicked in. A click on the pill itself is not
+    /// "outside" and does nothing here; the pill's own tap gesture is what
+    /// runs a chip.
+    ///
+    /// Installed with the offer and torn down by `endTheOffer`, so an idle app
+    /// is not watching the mouse at all — the same shape as `watchForEscape`.
+    private func watchForOfferOutsideClick() {
+        guard offerClickMonitors.isEmpty else { return }
+        let mask: NSEvent.EventTypeMask = [.leftMouseDown, .rightMouseDown, .otherMouseDown]
+        let dismissIfOutside: () -> Void = { [weak self] in
+            guard let self, self.offerIsUp, let frame = self.pill.frame,
+                  !frame.contains(NSEvent.mouseLocation)
+            else { return }
+            self.dismissOffer(reason: "a click outside it")
+        }
+        if let global = NSEvent.addGlobalMonitorForEvents(matching: mask, handler: { _ in
+            dismissIfOutside()
+        }) {
+            offerClickMonitors.append(global)
+        }
+        if let local = NSEvent.addLocalMonitorForEvents(matching: mask, handler: { event in
+            dismissIfOutside()
+            return event
+        }) {
+            offerClickMonitors.append(local)
+        }
+    }
+
+    private func stopWatchingForOfferOutsideClick() {
+        offerClickMonitors.forEach(NSEvent.removeMonitor)
+        offerClickMonitors.removeAll()
+    }
+
+    /// Take the offer down without running anything on it — Escape, Return, or
+    /// a click outside it. `reason` is only for the log.
+    ///
+    /// Not called by the deadline passing unanswered: the pill has already
+    /// faded itself out by then, on its own clock, and this would fade it a
+    /// second time. `offerDeadlinePassed` calls `endTheOffer` directly.
+    private func dismissOffer(reason: String) {
+        Log.write("offer: dismissed by \(reason)")
+        endTheOffer()
+        pill.hide()
     }
 
     /// Arm the call that ends the offer when nobody answers it.
@@ -2296,6 +2353,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         offerKeysExpiry?.cancel()
         offerKeysExpiry = nil
         offerKeys.stop()
+        stopWatchingForOfferOutsideClick()
     }
 
     /// Run the command a chip was clicked on or lettered, and take the offer

--- a/Sources/ParrotFlow/OfferKeys.swift
+++ b/Sources/ParrotFlow/OfferKeys.swift
@@ -4,6 +4,19 @@ import Carbon.HIToolbox
 /// Takes the offer's letters and Escape while the offer is on screen, and gives
 /// them back the moment it is not.
 ///
+/// ## Why any other key dismisses it
+///
+/// Only a chip's own letter runs its command — everything else you type ends
+/// the offer instead, the same as clicking anywhere but the pill does. Typing
+/// is the clearest sign there is that you have moved on to something else, and
+/// the offer has no business still claiming a letter over your shoulder once
+/// you have. This also bounds the one real risk left: the offer is up for nine
+/// seconds after every dictation, so a sentence that happens to start with a
+/// chip's own letter — `C` for Correct — still runs that command on its first
+/// keystroke. Every keystroke after that first one is safe, because the offer
+/// is already gone by then. Pick a chip's letter accordingly: one you are
+/// unlikely to start a word with right after dictating.
+///
 /// ## Why this is a tap and not a monitor
 ///
 /// The pill is a `nonactivatingPanel` and never takes keyboard focus — that is
@@ -28,7 +41,8 @@ import Carbon.HIToolbox
 final class OfferKeys {
 
     enum Key: Equatable {
-        /// Escape, or Return. Both end the offer; only Escape is consumed.
+        /// Escape, or any other key that is not a chip's own letter. All of
+        /// them end the offer; only Escape is consumed.
         case dismiss
         /// Run the command this letter belongs to.
         case letter(String)
@@ -131,6 +145,13 @@ final class OfferKeys {
 
     deinit { stop() }
 
+    /// A bare letter belongs to the offer; a letter with a modifier on it is
+    /// somebody else's shortcut — ⌘C copies, ⇧G types a capital G — so a chip
+    /// only answers to the plain key.
+    private static let anyModifier: CGEventFlags = [
+        .maskCommand, .maskAlternate, .maskControl, .maskShift,
+    ]
+
     private func handle(
         _ type: CGEventType, _ event: CGEvent
     ) -> Unmanaged<CGEvent>? {
@@ -151,40 +172,26 @@ final class OfferKeys {
             return Unmanaged.passUnretained(event)
         }
 
-        // A modified key is somebody else's shortcut — ⌘C copies, ⇧F types a
-        // capital F, ⌃C interrupts. Only the bare key belongs to the offer, and
-        // checking first means a letter with a modifier on it is never even
-        // considered.
-        let claimed: CGEventFlags = [.maskCommand, .maskAlternate, .maskControl, .maskShift]
-        guard event.flags.isDisjoint(with: claimed) else {
-            return Unmanaged.passUnretained(event)
-        }
-
-        // Letters and Escape are taken. Return is only watched.
-        //
-        // The arrows and space were here and are gone. Selecting with one key
-        // and confirming with another is a menu, and this is two buttons: the
-        // letter on each says how to press it, and the mouse says the same
-        // thing again. Every key taken from the system has to earn it, and a
-        // selection nobody needed did not.
+        // A bare letter the offer has claimed runs its command. Escape ends
+        // the offer and is swallowed, the one key taken from every app that is
+        // not a chip's own. Everything else — Return, a letter that is not on
+        // a chip, a modified key, an arrow, a function key — ends the offer
+        // too, but goes through untouched: it is the same "you have moved on"
+        // signal a click outside the pill sends, and only Escape and a
+        // matching letter were ever the offer's to keep.
         let key: Key
         var take = true
-        switch Int(event.getIntegerValueField(.keyboardEventKeycode)) {
-        case kVK_Escape:
+        let keycode = Int(event.getIntegerValueField(.keyboardEventKeycode))
+        if keycode == kVK_Escape, event.flags.isDisjoint(with: Self.anyModifier) {
             key = .dismiss
-        case kVK_Return, kVK_ANSI_KeypadEnter:
-            // Return means you are sending what was dictated, which is the end
-            // of the whole errand — so the offer goes at once rather than
-            // sitting over your shoulder while you read the reply. Passed
-            // through, never taken: this is the key the dictation was for.
+        } else if event.flags.isDisjoint(with: Self.anyModifier),
+                  !letters.isEmpty,
+                  let typed = NSEvent(cgEvent: event)?.charactersIgnoringModifiers?.uppercased(),
+                  letters.contains(typed) {
+            key = .letter(typed)
+        } else {
             key = .dismiss
             take = false
-        default:
-            guard !letters.isEmpty,
-                  let typed = NSEvent(cgEvent: event)?.charactersIgnoringModifiers?.uppercased(),
-                  letters.contains(typed)
-            else { return Unmanaged.passUnretained(event) }
-            key = .letter(typed)
         }
 
         // Handed to the next turn of the main loop rather than run here. What

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -274,6 +274,24 @@ final class PillHUD {
     /// appears without being asked for.
     static let offerAlpha: CGFloat = 0.92
 
+    /// The pill's own visible capsule right now — what a click has to land
+    /// inside of to count as a click on the pill rather than a click past it.
+    /// Nil while there is no pill up, so a caller cannot mistake the frame it
+    /// was last shown at for one it is still shown at.
+    ///
+    /// `panel.frame` inset by `bleed`, not `panel.frame` itself: the window is
+    /// bigger than the capsule on every side, for the glow to spill into — see
+    /// `PillMetrics.bleed`. That margin is fully transparent, and the pill
+    /// often sits right beside the words you are about to click into, so a
+    /// click meant to land past it can easily fall inside that invisible
+    /// window without landing anywhere near the capsule you can see. Counting
+    /// that as "on the pill" is why a click there used to look like it did
+    /// nothing.
+    var frame: NSRect? {
+        guard let panel, panel.isVisible else { return nil }
+        return panel.frame.insetBy(dx: PillMetrics.bleed, dy: PillMetrics.bleed)
+    }
+
     /// Whether the pointer is over the pill at this instant.
     ///
     /// Asked, rather than remembered from the last `hovering(_:)`. A hover that

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -342,23 +342,30 @@ dictation's — the result is not written over it, and the menu bar says so.
 |---|---|
 | a chip's letter — `C`, `G` | Runs that command |
 | a click on a chip | Runs that command |
+| a click anywhere else | Dismisses, and reaches whatever you clicked untouched |
+| any other key | Dismisses, and reaches whatever it was headed for untouched |
 | `esc` | Dismisses |
 | `↩` | Dismisses, and reaches the app underneath untouched |
 | the dictation hotkey | Starts the next dictation, exactly as before |
 
 It fades rather than vanishing. It arrives just below full strength and thins
-out over nine seconds, and then it is gone. The keys and the chips work the
-whole way down — the fading only says how long is left. Putting the pointer on
-the pill stops the clock, and taking it off starts the nine seconds again. Any
-of the endings above takes the pill at once.
+out over nine seconds, and then it is gone. The keys, the click, and the chips
+work the whole way down — the fading only says how long is left. Putting the
+pointer on the pill stops the clock, and taking it off starts the nine seconds
+again. Any of the endings above takes the pill at once.
 
 **The letters are taken from every app for those nine seconds.** The pill
-never holds keyboard focus, so it swallows the letters system-wide or it does
-not get them at all. Finish a dictation and immediately type a word starting
-with `C` or `G` and the first keystroke runs a command instead of typing.
-A letter with a modifier on it is never taken — `⌘C` copies and `⇧G` types a
-capital G — so only bare letters are exposed, and only until the offer goes.
-`esc` ends it, and so does starting the next dictation.
+never holds keyboard focus, so it swallows a chip's own letter system-wide or
+it does not get it at all. Only that bare letter runs a command — a letter
+with a modifier on it is somebody else's shortcut and is left alone, `⌘C`
+still copies and `⇧G` still types a capital G. Every other key you press ends
+the offer instead, the same as clicking anywhere but the pill does, and is
+passed straight through: it still lands wherever it was headed. So a dictation
+followed straight away by a sentence starting with `C` or `G` runs a command
+on that first keystroke — the offer is up, and that is still its letter — but
+every keystroke after it is safe, because the offer is already gone. Pick a
+chip's letter with that in mind: one you are unlikely to start a word with
+right after dictating.
 
 Off by setting it to `false`. Then no key is taken at any time.
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -278,8 +278,11 @@ on no key.
 
 The letter is taken from whatever app you are typing into, for the nine
 seconds the offer is up. Pick one you are unlikely to start a word with right
-after dictating. `C` is already `Correct`'s; a second chip asking for it is
-drawn but never reached, because the first chip with that letter wins.
+after dictating — the first keystroke of a word that starts with it still
+runs the command, though every keystroke after that is safe: typing anything
+else ends the offer, the same as clicking off the pill does. `C` is already
+`Correct`'s; a second chip asking for it is drawn but never reached, because
+the first chip with that letter wins.
 
 `--check-config` prints what is on the pill and the letter each chip carries.
 A chip that is missing, or a `key:` that was cut, is otherwise invisible: the


### PR DESCRIPTION
## Summary
- Clicking anywhere outside the offer pill now dismisses it, the same way Escape and Return already do — the click is not consumed, it still lands wherever it was headed.
- Typing any key that is not one of the offer's own chip letters also dismisses it, instead of sitting there for the rest of its nine seconds. Only a chip's own bare letter still runs its command; Escape is still the one key that gets swallowed.
- Fixed the click-outside check to exclude the pill's transparent bleed margin (52pt on every side of the visible capsule) — without this, a click that looked well clear of the pill often landed in that invisible window and did nothing, since the pill usually sits right next to the words you're about to click into.

A right-⌘-modifier scheme for the chip letters was tried first (to stop a chip's letter firing when it's really the first letter of the next sentence you type) and reverted — it fought the dictation hotkey and other apps that already bind right ⌘. The simpler rule bounds that same risk to one keystroke (the first one after the offer appears) rather than eliminating it, which is the tradeoff documented in `docs/configuration.md` and `docs/pipelines.md`.

## Test plan
- [x] `swift build` — clean, no new errors (pre-existing Swift-6-mode warnings only)
- [x] Installed the dev build (`make install`) and confirmed via `~/Library/Logs/ParrotFlow-Dev.log`:
  - a chip's own letter still runs its command (`offer: taken; running "Fix grammar"`)
  - a click outside the pill dismisses it (`offer: dismissed by a click outside it`)
  - a keystroke that is not a chip's letter dismisses it (`offer: dismissed by the keyboard`)
- [ ] Manual click-precision retest against the bleed-margin fix (fixed after the log-based testing above, not yet re-verified live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)