### PR TITLE
fix: give config.yaml live-reload 10s before it interrupts you

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -8,6 +8,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var vocabularyWatcher: FileWatcher?
     private var transformWatchers: [FileWatcher] = []
 
+    /// Set while a live-reload failure is waiting out its grace period —
+    /// see `loadConfig(announceErrors:)`.
+    private var configReloadNotice: DispatchWorkItem?
+
+    /// How long a bad config.yaml is given to be fixed before the failure is
+    /// shown. Round number, long enough to finish an edit and save again.
+    static let configReloadGraceSeconds: TimeInterval = 10
+
     private let hotKeys = HotKeyManager()
     private let recorder = Recorder()
     private let pill = PillHUD()
@@ -423,18 +431,34 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             config = try ConfigStore.load()
         } catch {
             if announceErrors {
-                presentAlert(
-                    title: "Could not read config.yaml",
-                    message: "\(error.localizedDescription)\n\nFalling back to the previous settings."
-                )
+                Log.write("config: could not reload — \(error.localizedDescription)")
+                armConfigReloadNotice()
             }
             return
         }
+        configReloadNotice?.cancel()
+        configReloadNotice = nil
         applyConfig()
         // After the load, not with the other watchers: a transform can be
         // renamed, removed or pointed at a different file, so which files are
         // worth watching is only known once the config has been read.
         watchTransformFiles()
+    }
+
+    /// Holds a live-reload failure for `configReloadGraceSeconds` before saying
+    /// anything, and re-arms rather than stacks on every write in that window.
+    ///
+    /// An editor can leave config.yaml briefly invalid mid-save — several
+    /// syscalls, or an atomic replace caught between the delete and the
+    /// rewrite. The grace period gives the next save a chance to be the real
+    /// one before the user is interrupted over a file they are still editing.
+    private func armConfigReloadNotice() {
+        configReloadNotice?.cancel()
+        let notice = DispatchWorkItem { [weak self] in
+            self?.flash("Could not reload config.yaml — using the previous settings", tone: .failure)
+        }
+        configReloadNotice = notice
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.configReloadGraceSeconds, execute: notice)
     }
 
     /// Says a config problem once, at the moment it appears.


### PR DESCRIPTION
## Summary
- A live-reload parse failure used to call `presentAlert` right away — an app-modal `NSAlert` that steals focus from whatever window (usually the editor) the user is actually in. Editors often write `config.yaml` in several syscalls, or do an atomic save-then-replace, so the very first reload after a save is often briefly invalid on its way to being valid. The dialog fired on that transient state, not on a real problem.
- `loadConfig(announceErrors:)` now starts (or extends) a 10s grace window on a live-reload failure instead of alerting immediately. If a later reload in that window succeeds, the pending notice is cancelled silently — no dialog, no pill. If the window elapses and the config is still unreadable, it notifies via `flash(_:tone: .failure)` — the non-modal pill/menu-bar notice this codebase already uses for every other background/async failure (capture problems, transcription/transform errors). `presentAlert` stays reserved for direct synchronous responses to a button the user just clicked (update install, correction-panel save).
- Multiple writes in the window (an editor can fire several per autosave) coalesce into one pending `DispatchWorkItem`, replaced rather than stacked — same pattern as `armTheOfferDeadline`. Each failed reload attempt is still logged via `Log.write`, which this path had none of before.
- The startup path (`announceErrors: false`) is untouched — it was already silent on a bad config and stays that way. The running config's fallback behavior is untouched too: it always stays on the last valid version; only when and how the user is told about a failure changed.

## Test plan
- [x] `swift build` — clean, no new warnings or errors (confirmed against a stash of the change: same warning count before/after)
- [x] Manually traced both outcomes, since there's no existing test harness for `FileWatcher`/live-reload/this error path (confirmed by search — this PR doesn't invent one):
  - Transient bad save: reload fails → grace timer arms → next reload succeeds → timer is cancelled in the success path before `applyConfig()` runs → nothing shown, nothing logged as an error.
  - Genuinely broken config: reload fails → grace timer arms → further failing reloads within the window re-arm (cancel + reschedule) the same single timer rather than stacking → timer fires once, after 10s → exactly one `flash(..., tone: .failure)`.
- [ ] No automated coverage — flagging the gap rather than implying it's covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)