### PR TITLE
fix: close the launch-time gap in llm.keep_loaded warm-up

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1390,6 +1390,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard config.llm.enabled, config.llm.keepLoaded else { return }
 
         let llm = llmConfig()
+        let system = Router.prompt(
+            for: Catalogue(transforms: config.transforms), freeForm: config.freeForm
+        )
         Task.detached(priority: .background) {
             let started = Date()
             let loaded = await LocalLLM.warmUp(config: llm)
@@ -1399,6 +1402,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     ? String(format: "llm: %@ loaded and pinned in %.1fs", llm.model, elapsed)
                     : "llm: could not preload \(llm.model) — is Ollama running?"
             )
+            guard loaded else { return }
+
+            // A pinned model can be resident and still cold — see
+            // `LocalLLM.keepWarm` — so this closes the gap before
+            // `startKeepWarm`'s first 15s tick instead of waiting for it.
+            let warmed = await LocalLLM.keepWarm(system: system, config: llm)
+            Log.write(warmed ? "llm: warmed with one generate call" : "llm: warm-up generate ping failed")
         }
     }
 


### PR DESCRIPTION
## Summary
- `warmUp()` at launch sends Ollama a load-only call (no prompt). It moves the model into memory, but a pinned model can still be resident and cold: `LocalLLM.keepWarm`'s own doc comment measured this — 3.59s of a 4.01s router call was prompt eval of five tokens because 718ms/token is weights being fetched back on first touch, not inference.
- The thing that actually keeps the model warm is `keepWarmTick`'s 15s timer, which runs a real 1-token generate call through `LocalLLM.keepWarm` whenever the model has been idle 60s. `LocalLLM.lastCallAt` starts at `.distantPast`, so the earliest that generate ping can fire is the first tick after launch, up to 15-20s in.
- Any real LLM call (vocabulary judge, router, a transform) landing in that window still pays the full cold-start cost, even with `keep_loaded: true` — contrary to what its doc comment promises ("Pin the model in RAM at launch").
- Fix: once `warmUp()` succeeds inside `warmUpLLM()`, chain one `LocalLLM.keepWarm` call immediately, reusing the same router system prompt `keepWarmTick` uses so it also warms Ollama's prompt cache. No new HTTP-call code — this reuses `LocalLLM.keepWarm` as-is.
- Still gated behind `config.llm.enabled && config.llm.keepLoaded`, still off the main thread (`Task.detached`), still silent on failure via `Log.write` — a failed ping just falls back to today's behavior, no user-facing error.
- `keep_alive: -1` in `complete` and the 15s timer's ongoing tick behavior are untouched. In the normal case the chained ping stamps `lastCallAt` well before the timer's first tick, so that tick's own 60s-idle guard just no-ops — no duplicate call, no change needed there.

## Test plan
- [x] `swift build` — clean, no new warnings (diffed the full warning list before/after by stashing the change: same 42 warnings, only line numbers shifted by the 10 added lines).
- [x] Manually traced both branches, since there's no test harness for this path — it's wall-clock behavior against a real Ollama server, and this PR doesn't invent one:
  - `warmUp()` succeeds → `keepWarm` fires right after, off the main thread, logs `llm: warmed with one generate call` or the failure variant.
  - `warmUp()` fails (Ollama not running) → `guard loaded else { return }` skips the generate ping, app continues exactly as before, no crash, no block.
- [ ] No automated coverage for the timing behavior itself — flagging the gap rather than implying it's covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)