### PR TITLE
feat: the final permissions screen invites you to dictate, live

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,9 +66,10 @@ release machinery and gets no warning. `make hooks` refuses it locally — see
 
 ## What not to change without being asked
 
-- `Config.defaultYAML` and `config.example.yaml` are what a new install gets,
-  and several check scripts read the real file rather than a fixture. Changing
-  a default changes what everyone gets on first launch.
+- `config.example.yaml` is what a new install gets — `Config.defaultYAML`
+  reads it directly, substituting only the few lines that differ per variant
+  — and several check scripts read the real file rather than a fixture.
+  Changing a default changes what everyone gets on first launch.
 - The stop lists in the `dotted` pattern and in `examples/transforms/code_identifiers/code_identifiers.py`
   are judgements about how people speak, tuned against scored sets. They are
   meant to be edited by the person whose speech they describe — not silently

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,9 @@ export VARIANT ?= dev
 
 V := . scripts/variant.sh &&
 
-.PHONY: app run install uninstall stop clean reset-permissions logs \
-        dev-certificate release release-certificate try-install which hooks
+.PHONY: app run install uninstall uninstall-dev uninstall-release stop clean \
+        reset-permissions logs dev-certificate release release-certificate \
+        try-install which hooks
 
 ## Build the app bundle into .build/
 app:
@@ -42,9 +43,21 @@ install: stop app
 ## things a test cycle needs undone together, so a stale grant or a leftover
 ## copy never survives into the next install. config.yaml and vocabulary.yaml
 ## are left alone: that is tuning, not install state.
+##
+## Uses VARIANT like everything else here, which defaults to dev — the one
+## you are working on, running the whole time you are testing the other one.
+## `make uninstall` typed without thinking wipes that one. uninstall-dev and
+## uninstall-release below name the variant instead of trusting the default.
 uninstall: stop reset-permissions
 	@$(V) rm -rf "/Applications/$$APP_NAME.app" \
 	  && echo "==> $$DISPLAY_NAME fully uninstalled — config left in ~/$$CONFIG_DIR"
+
+## The unambiguous forms — ignore whatever VARIANT is set to.
+uninstall-dev:
+	@$(MAKE) --no-print-directory uninstall VARIANT=dev
+
+uninstall-release:
+	@$(MAKE) --no-print-directory uninstall VARIANT=release
 
 ## Quit this variant. The other one keeps running.
 stop:

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,13 @@ install: stop app
 	  && open "/Applications/$$APP_NAME.app" \
 	  && echo "==> Installed and launched /Applications/$$APP_NAME.app"
 
-uninstall: stop
-	@$(V) rm -rf "/Applications/$$APP_NAME.app"
+## Quit, remove, and forget its Microphone/Accessibility grants — the three
+## things a test cycle needs undone together, so a stale grant or a leftover
+## copy never survives into the next install. config.yaml and vocabulary.yaml
+## are left alone: that is tuning, not install state.
+uninstall: stop reset-permissions
+	@$(V) rm -rf "/Applications/$$APP_NAME.app" \
+	  && echo "==> $$DISPLAY_NAME fully uninstalled — config left in ~/$$CONFIG_DIR"
 
 ## Quit this variant. The other one keeps running.
 stop:

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3590,15 +3590,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         case .downloading(let what):
             setLabel("Downloading \(what)")
             transcriberLabelToken = labelToken
+            // `what` reads like "speech model 43%" — the number, if this is
+            // the one download that carries one, is the only part worth a
+            // second field for; the rest is already the sentence above.
+            let percent = what.split(separator: " ").last.flatMap { token -> Int? in
+                token.hasSuffix("%") ? Int(token.dropLast()) : nil
+            }
+            permissions.model.speechModel = .preparing(percent: percent)
         case .loading:
             setLabel("Loading speech model…")
             transcriberLabelToken = labelToken
+            permissions.model.speechModel = .preparing(percent: nil)
         case .failed(let message):
             setLabel("Model error: \(message)")
             transcriberLabelToken = labelToken
+            // Not surfaced as "preparing" forever: the permissions window
+            // isn't the place a transcription failure gets diagnosed, and a
+            // stuck "downloading" badge there would outlive the one place
+            // that does explain it — this label, and the log.
+            permissions.model.speechModel = .ready
         case .ready, .idle:
             if transcriberLabelToken == labelToken { setLabel(nil) }
             transcriberLabelToken = nil
+            permissions.model.speechModel = .ready
         }
     }
 
@@ -3744,6 +3758,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let shortcut = hotKeys.binding?.displayName
             ?? KeyCodes.displayString(key: config.hotkey.key, modifiers: config.hotkey.modifiers)
+        permissions.model.hotkeyDisplay = shortcut
 
         if let transcriptionLabel {
             statusInfoItem.title = transcriptionLabel

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -356,7 +356,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         watchActivation()
 
-        recorder.warmUp()
+        // Touching the engine's inputNode is what warmUp does, and it is also
+        // what makes AVFoundation put up the native microphone dialog on its
+        // own — before the window below has had a chance to explain why.
+        // Skipped here when the answer isn't in yet; the first recording
+        // after permission is granted pays the warm-up cost instead.
+        if Permissions.microphone == .granted {
+            recorder.warmUp()
+        }
         recorder.onLevel = { [weak self] level in
             self?.pill.model.level = level
         }

--- a/Sources/ParrotFlow/AppVariant.swift
+++ b/Sources/ParrotFlow/AppVariant.swift
@@ -41,11 +41,11 @@ enum AppVariant {
         isDev ? "~/Recordings/ParrotFlow Dev" : "~/Recordings/ParrotFlow"
     }
 
-    /// Right ⌘ for dev, so both builds can run at once and you choose which one
-    /// hears you by which key you hold. Both are bare modifiers, which is what
-    /// push-to-talk wants.
+    /// Right ⌥ for dev, Right ⌘ for release, so both builds can run at once
+    /// and you choose which one hears you by which key you hold. Both are
+    /// bare modifiers, which is what push-to-talk wants.
     static var defaultHotkey: String {
-        isDev ? "right_command" : "right_option"
+        isDev ? "right_option" : "right_command"
     }
 
     /// The parrot this build sits in the menu bar with when nothing is happening.

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1065,7 +1065,7 @@ struct Config: Decodable, Equatable {
 
     struct LLM: Codable, Equatable {
         var enabled: Bool = true
-        var model: String = "gemma4:e4b"
+        var model: String = "gemma4:e4b-mlx"
         var endpoint: String = "http://localhost:11434"
         var timeoutSeconds: Double = 20
         /// Load the model at launch and pin it in Ollama's memory. Trades a few

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -2166,404 +2166,52 @@ enum ConfigStore {
         }
     }
 
-    /// Computed rather than a constant because the dev build seeds a different
-    /// hotkey and recordings directory — see `AppVariant`.
+    /// `config.example.yaml` — the one copy of the default config's content,
+    /// same reasoning as `exampleTransformsDirectory` above: seeded from the
+    /// real file instead of a second, hand-synced copy in the binary. It was
+    /// a string here for a while, and it drifted — config.example.yaml
+    /// gained the vocabulary judge stage and app-scoped transforms that this
+    /// string never did, silently, because nothing compared the two beyond a
+    /// key-name check that could not see into a pipeline's steps.
+    static var configTemplateURL: URL {
+        if !Permissions.isRunningFromBuildDirectory,
+           let bundled = Bundle.main.resourceURL?.appendingPathComponent("config.example.yaml"),
+           FileManager.default.fileExists(atPath: bundled.path) {
+            return bundled
+        }
+        return URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // Config.swift -> Sources/ParrotFlow/
+            .deletingLastPathComponent()  // -> Sources/
+            .deletingLastPathComponent()  // -> repo root
+            .appendingPathComponent("config.example.yaml")
+    }
+
+    /// What a new install's config.yaml is written with.
+    ///
+    /// config.example.yaml itself, with the four lines that differ per
+    /// variant swapped in. The release build needs no substitution at all —
+    /// the file already reads as its own defaults — which is the point: a
+    /// release config.yaml and config.example.yaml can now be compared for
+    /// equality instead of trusted to have been kept in sync by hand.
     static var defaultYAML: String {
-        """
-    # \(AppVariant.displayName) configuration
-    # Edit and save — changes are picked up automatically. Delete any line to
-    # get its default back. `--check-config` says what the file adds up to.
-
-    hotkey:
-      # A bare modifier — right_option, left_option, right_command,
-      # left_command, right_control, left_control, right_shift, left_shift, fn
-      # — or a character key (a-z, 0-9, f1-f20, space, return, arrows,
-      # punctuation), which needs `modifiers` below.
-      key: \(AppVariant.defaultHotkey)
-
-      # Any of: command, control, option, shift.
-      modifiers: []
-
-      # push_to_talk records while the key is held; toggle taps on and off.
-      # A bare modifier wants push_to_talk, or typing an accented character
-      # with it would start recording.
-      mode: push_to_talk
-
-      # Keep the mic open this long after you let go, so the last syllable is
-      # not cut off. push_to_talk only. 0 turns it off.
-      release_tail_seconds: 0.3
-
-    audio:
-      # Where the recordings and trace.jsonl go.
-      output_dir: \(AppVariant.defaultOutputDir)
-
-      # Skip clips with no speech in them, so a stray keypress does not decode
-      # room tone into a sentence.
-      speech_gate: true
-
-    feedback:
-      sound: true     # a click when recording starts and stops
-      overlay: true   # the floating pill while you speak
-      # After the words land the pill names what can be done to them, for 3s.
-      # Click a chip to run it. Tapping the dictation hotkey — press and let go
-      # — opens the correction panel too. Holding it starts the next dictation.
-      correct_offer: true
-
-    logging:
-      # The line-by-line log at ~/Library/Logs/\(AppVariant.logFileName) — how
-      # every problem in this app gets diagnosed. Leave it on.
-      text: true
-
-      # Write each dictation's recording to disk, in audio.output_dir. Off by
-      # default: a recording of your voice should not pile up there unless you
-      # asked for it. Turn it on for --transcribe, calibration, or to hear what
-      # the app heard.
-      audio: false
-
-    transcription:
-      # paste     -> typed into the app you're in (needs Accessibility)
-      # clipboard -> copied, you press Cmd-V
-      insert_mode: paste
-
-      # Say one of these and what follows is an instruction: "hey parrot, make
-      # that a bullet list". One of them mid-sentence turns the rest into an
-      # instruction about the words before it. An empty list turns this off.
-      activation_phrases: [hey parrot, by the way parrot]
-
-      # Terminals only: they cannot be edited in place, so the input line is
-      # cleared and retyped corrected. Everywhere else ignores this.
-      rewrite_line: true
-
-      # Languages you dictate in, most spoken first. Supported: en, fr.
-      # One entry means no detection runs. Name only what you actually speak.
-      languages: [en]
-
-      # What a finished transcript runs through, in order. A stage runs only if
-      # it is listed here.
-      #
-      #   replacements  the table below
-      #   fuzzy         the same table against words the spell checker does not
-      #                 know. Needs replacements before it
-      #   numbers       "two hundred forty-three" -> 243, ordinals, decimals
-      #
-      # A transform can be a stage too, and any stage takes a condition — on the
-      # text with `when:` / `unless:`, or on the app with `app:`. A key per
-      # language wins over `default`. See docs/pipelines.md.
-      pipelines:
-        default:
-          - replacements
-          - fuzzy
-          - numbers
-          # "is that true question mark" -> is that true? A spoken mark
-          # replaces the decoder's own punctuation rather than sitting beside
-          # it. English only.
-          - transform: punctuation
-          # A word or phrase said twice by accident, taken out.
-          - transform: repetitions
-          # "read user dot name" -> read user.name, where you write code-ish text.
-          - transform: dotted
-            app: /term|ghostty|warp|kitty|alacritty|hyper|slack|discord/
-          # "a python function called max retries" -> ...called max_retries. The
-          # script is written to transforms/code_identifiers/ on first launch, with
-          # its own case set beside it, and both are yours to edit.
-          - transform: code_identifiers
-            app: /term|ghostty|warp|kitty|alacritty|hyper|code|cursor|zed|xcode|jetbrains|idea|pycharm|webstorm/
-            when: /\\b(?:function|method|variable|class|constant|type|struct|interface|enum|fonction|méthode|classe|constante)\\b/
-
-      # Patterns and deletions. Whole words, case-insensitive. A source in
-      # /slashes/ is a regular expression, and then the target is a template
-      # where $1 writes back what it captured. An empty target deletes, which
-      # is how filler words go. A name the recogniser mangles does not belong
-      # here — say "hey parrot" and fix it in the panel, and it is learnt in
-      # vocabulary.yaml instead.
-      #
-      #   "": ['/[,]?\\s*\\b(?:u+m+|u+h+|erm+|hmm+)\\b[,]?/']
-      #   '$1.$2': ['/\\b(\\w+) dot (\\w+)\\b/']    # "user dot name" -> user.name
-      replacements: {}
-
-
-
-    # The local Ollama model behind spoken commands. Without it dictation still
-    # works and every `prompt:` transform below stops.
-    llm:
-      enabled: true
-      model: gemma4:e4b
-      endpoint: http://localhost:11434
-      # Pin the model in RAM. Ollama otherwise drops it after five minutes and
-      # the next command waits 7-10s for the reload.
-      keep_loaded: true
-
-    # Checking whether a newer ParrotFlow exists.
-    #
-    # One call a day to GitHub's release API — no account, nothing about you, and
-    # nothing about what you dictate. It is the only request this app makes on its
-    # own; the speech model is fetched once on first use, and the language model
-    # never leaves your Mac.
-    #
-    # The number is a waiting period, not how often it looks:
-    #
-    #   -1   never ask at all
-    #    0   offer a release the day it is published
-    #    7   only offer a release that has existed for a week
-    #
-    # The wait is the point. A release that turns out to be bad — a pipeline taken,
-    # a key stolen — is one that gets noticed and pulled, and a week of distance
-    # means your Mac never saw it. What proves an archive is ours is the pinned
-    # signing certificate in scripts/install.sh; this is the other half, and buys
-    # the time someone needs to notice in the first place.
-    updates:
-      # Checking whether a newer ParrotFlow exists: one call a day to GitHub's
-      # release API, nothing about you or what you dictate.
-      #
-      #   -1  never ask     0  offer it the day it is published
-      #    7  only offer a release that has existed for a week
-      #
-      # The wait is the point: a bad release is one that gets noticed and
-      # pulled, and a week of distance means your Mac never saw it.
-      after_days: 7
-
-    # What the activation phrase can reach, and what a pipeline can name.
-    #
-    #     "hey parrot, make that a bullet list"
-    #
-    # A description is not a comment — it is what the router matches your words
-    # against, so write it the way you would say it.
-    #
-    # One of three bodies. `prompt:` asks the local model and costs about a
-    # second; `replace:` is a substitution table and costs nothing; `command:`
-    # runs a program of yours — transcript on stdin, rewrite on stdout — and
-    # costs a process start. A `command:` is the one thing in this file that
-    # runs code, and --check-config names every one out loud.
-    #
-    # A transform owns transforms/<name>/ beside this file: its script or its
-    # prompt, and the case set `--eval <name>` scores it against. A long body
-    # can live there instead of here — `prompt: { path: slack.md }`.
-    #
-    # `display:` is what the menu bar says while it runs. Results are shown
-    # before they replace your selection; `confirm: false` skips that.
-    # See docs/pipelines.md.
-    transforms:
-      - name: bullets
-        description: turn text into a short bullet list
-        display: Making bullets
-        prompt: |
-          Rewrite the text as concise bullets, one idea each.
-          Keep the speaker's wording. Return only the bullets.
-
-      - name: terse
-        description: shorten text without losing anything it says
-        display: Cutting it down
-        prompt: |
-          Cut this down. No filler, same facts, same voice.
-          Return only the shortened text.
-
-      - name: grammar
-        description: fix grammar and punctuation mistakes, not formatting or numbers
-        display: Fixing grammar
-        # `offer: true` puts it on the pill after a dictation, next to Correct;
-        # `key:` is the letter drawn on its chip. Worth it for this one: fixing
-        # what you just said is the thing you reach for without thinking. Leave
-        # both off for anything you would only ever ask for out loud — the offer
-        # is on screen briefly and every entry costs the others room.
-        offer: true
-        key: g
-        prompt: |
-          Correct grammar, spelling and punctuation. Make the smallest change
-          that makes the text correct — and make it. Every error is fixed.
-          Nothing else is touched.
-
-          Fix: subject-verb agreement, verb forms, confused homophones
-          (its/it's, their/they're, weather/whether), missing or wrong
-          punctuation, a missing capital at the start of a sentence, and a
-          missing full stop at the end.
-
-          Never reword, reorder, shorten, expand, or improve. Never add or
-          remove words except where grammar requires it. Never add quotation
-          marks, emphasis, or punctuation the sentence does not need. Keep the
-          speaker's own vocabulary, register and phrasing, including informal,
-          blunt or repetitive wording. A sentence that is already correct comes
-          back exactly as it was.
-
-          A phrase before the main clause takes a comma after it. A trailing
-          please or thanks does not.
-
-          Return only the text.
-
-      # Scoped to one kind of window each by the pipeline above. `grammar` mends
-      # a sentence; these two also lay one out, which is the part no substitution
-      # can express. Both are told twice not to write anything: a model handed a
-      # dictated email will gladly return a better one in its own voice.
-      - name: email
-        description: lay dictated text out as an email
-        display: Laying out the email
-        prompt: |
-          Lay the text out as an email, in the language it was dictated in.
-          Fix the writing; do not write it.
-
-          Correct grammar, spelling and punctuation, and drop the hesitations
-          — um, uh, euh, well, you know, I mean. Every other word survives:
-          the wording, the order and the tone are the speaker's.
-
-          If the text opens with a greeting, it goes on its own line, with a
-          comma after it and a blank line under it. If it does not, the email
-          starts with the first sentence. Never add a greeting nobody spoke.
-
-          Break the body into paragraphs where the subject changes, a blank
-          line between them. Add no headings and no emphasis.
-
-          Three or more things listed in a row never stay inline. Whatever
-          joined them — commas, "and", nothing at all — the words introducing
-          them take a colon and each thing goes on a line of its own behind a
-          dash. No number has to be said for this: "here is what I need from
-          you", "the steps are", "we should" all open a list as surely as
-          "there are three things" does. Two things are a sentence and stay
-          one.
-
-          The email ends on the last thing the speaker said. If that last
-          thing is a name, it is a signature: a blank line, then the name on
-          its own line, and a closing word said just before it — thanks,
-          merci — on the line above. If it is anything else — a question, a
-          goodbye, a sentence — that is the last line, and there is nothing
-          under it. The only name that can appear is one that was spoken; an
-          unspoken one has no stand-in, in brackets or otherwise.
-
-          A short reply is not an email with parts. One or two sentences and
-          no hello in front of them come back as one or two sentences,
-          corrected, with no line put anywhere.
-
-          Return only the email.
-
-      # 3/3. "Add nothing" rather than "no greeting, no sign-off": the second
-      # wording read as an instruction to remove one, and "hey uh quick one the
-      # build is red" came back as "The build is red". The slang line is there
-      # because "gonna" was being corrected to "going to", which is the
-      # speaker's voice going out with the hesitations.
-      - name: slack
-        description: tidy dictated text into a chat message
-        display: Tidying for chat
-        prompt: |
-          Tidy the text into a chat message, in the language it was dictated
-          in. Fix the writing; do not write it.
-
-          Correct grammar, spelling and punctuation, and drop the hesitations
-          — um, uh, euh, well, you know, I mean. Every other word survives.
-          Slang and contractions are the speaker's voice rather than
-          mistakes: gonna stays gonna, ouais stays ouais.
-
-          Add nothing: no greeting, no sign-off, no heading, no bullet, no
-          bold, no backtick. Slack's composer renders none of that when text
-          arrives by paste, so it would land in the message as characters.
-          Remove nothing either: a spoken "hey" is part of the message.
-
-          One paragraph, unless the text plainly holds two.
-
-          Return only the message.
-
-      # Said out loud — "hey parrot, use Slack mentions" — and deliberately in
-      # no pipeline. A message that names someone is not a message that pings
-      # them, and nothing in a transcript tells the two apart. So this is the
-      # one you ask for.
-      #
-      # `confirm` covers one of the two ways of asking. With text selected the
-      # result is shown first; mid-sentence there is no preview whatever
-      # `confirm` says. Either way what lands is text in your composer, and
-      # ParrotFlow sends nothing.
-      #
-      # It was two `replace:` tables for a while — a table cannot invent a
-      # handle, where this prompt's first draft answered "Sofia already looked
-      # at it" with "@priya already looked at it". They came back out because a
-      # table has to be triggered from inside the sentence, and "mention" is a
-      # word English already uses: "I should mention here that the deadline
-      # changed" became "I should @here that the deadline changed". A pipeline
-      # stage has no preview, so a false positive there is a message already
-      # sent. Asking out loud fires when you ask and never otherwise. The whole
-      # excursion is written up in config.example.yaml.
-      #
-      # Put your own people in the list.
-      - name: slack_mentions
-        description: turn people's names into Slack mentions
-        display: Adding mentions
-        prompt: |
-          Return the text word for word, with one kind of change and no
-          other: a name that appears in this list becomes its handle.
-
-            Marie   -> @marie.dupont
-            Thomas  -> @tleroy
-            Priya   -> @priya
-
-          Every occurrence, including where the message is about that person
-          rather than to them.
-
-          A name that is not in the list is left exactly as it was. Sofia
-          stays Sofia. Never give a name a handle that belongs to someone
-          else, and never invent one.
-
-          Two group mentions are a judgement rather than a lookup. "everyone
-          here", "whoever is around" -> @here, which pings the people who are
-          online. "the whole channel", "everyone", "all of them" -> @channel,
-          which pings the ones who are away too. Only where the text means
-          the people: "the file is here" is a place, and stays.
-
-          A mention replaces the words that name the person or the group, and
-          not one word more: "heads up to the whole channel" comes back as
-          "heads up to @channel".
-
-          Nothing is ever deleted. Every other word, the order and the
-          punctuation come back as they went in.
-
-          Return only the text.
-
-      # The two tables the pipeline above names. Same pattern, different output —
-      # that is the whole reason a table has a name.
-      #
-      # The pattern reads "a word, then dot or point, then a word", then refuses
-      # it when either side is a word code does not use there — without that,
-      # "voilà le point sur les tests" loses its middle. Score it with
-      # scripts/check-dotted.sh, which reads the pattern out of this file.
-      #
-      # Hyphen and underscore reuse the same lists — same risk shape. `dash`
-      # is left out: an ordinary word nobody has measured a guard for, unlike
-      # `dot`/`point`. `tiret` excludes "tiret bas" so the two rules never
-      # claim the same words.
-      - name: dotted
-        description: spoken dot, hyphen and underscore paths as code
-        replace:
-          '$1.': ['/\\b(?!(?:le|la|les|l|un|une|des|du|de|d|ce|cet|cette|ces|mon|ma|mes|ton|ta|tes|son|sa|ses|notre|nos|votre|vos|leur|leurs|au|aux|à|quel|quelle|chaque|autre|même|premier|première|deuxième|dernier|dernière|seul|seule|bon|bonne|mauvais|certain|tel|telle|quelque|the|a|an)\\b)(\\w+) (?:dot|point) (?!(?:de|du|des|d|le|la|les|l|un|une|sur|dans|en|et|ou|que|qui|où|à|au|aux|pour|par|avec|sans|est|sont|était|sera|me|te|se|ne|n|c|il|elle|je|tu|nous|vous|ils|elles|ce|plus|moins|très|mais|donc|car|si|comme|final|finale|barre|virgule|commun|commune|faible|faibles|fort|forts|mort|culminant|névralgique|chaud|sensible|positif|négatif|clé|focal|nommé|com|net|org|matrix|product|notation|plot)\\b)(?=\\w)/']
-          '$1-': ['/\\b(?!(?:le|la|les|l|un|une|des|du|de|d|ce|cet|cette|ces|mon|ma|mes|ton|ta|tes|son|sa|ses|notre|nos|votre|vos|leur|leurs|au|aux|à|quel|quelle|chaque|autre|même|premier|première|deuxième|dernier|dernière|seul|seule|bon|bonne|mauvais|certain|tel|telle|quelque|the|a|an)\\b)(\\w+) (?:hyphen|tiret(?! bas)) (?!(?:de|du|des|d|le|la|les|l|un|une|sur|dans|en|et|ou|que|qui|où|à|au|aux|pour|par|avec|sans|est|sont|était|sera|me|te|se|ne|n|c|il|elle|je|tu|nous|vous|ils|elles|ce|plus|moins|très|mais|donc|car|si|comme|final|finale|barre|virgule|commun|commune|faible|faibles|fort|forts|mort|culminant|névralgique|chaud|sensible|positif|négatif|clé|focal|nommé|com|net|org|matrix|product|notation|plot)\\b)(?=\\w)/']
-          '$1_': ['/\\b(?!(?:le|la|les|l|un|une|des|du|de|d|ce|cet|cette|ces|mon|ma|mes|ton|ta|tes|son|sa|ses|notre|nos|votre|vos|leur|leurs|au|aux|à|quel|quelle|chaque|autre|même|premier|première|deuxième|dernier|dernière|seul|seule|bon|bonne|mauvais|certain|tel|telle|quelque|the|a|an)\\b)(\\w+) (?:underscore|souligné|tiret bas) (?!(?:de|du|des|d|le|la|les|l|un|une|sur|dans|en|et|ou|que|qui|où|à|au|aux|pour|par|avec|sans|est|sont|était|sera|me|te|se|ne|n|c|il|elle|je|tu|nous|vous|ils|elles|ce|plus|moins|très|mais|donc|car|si|comme|final|finale|barre|virgule|commun|commune|faible|faibles|fort|forts|mort|culminant|névralgique|chaud|sensible|positif|négatif|clé|focal|nommé|com|net|org|matrix|product|notation|plot)\\b)(?=\\w)/']
-
-      - name: backticks
-        description: wrap dotted paths in backticks, for chat
-        replace:
-          '`$1`': ['/\\b([A-Za-z_]\\w*(?:\\.[A-Za-z_]\\w*)+)/']
-
-      # A program rather than a table, because casing words is not something a
-      # substitution can express. Written to transforms/code_identifiers/ on
-      # first launch and yours to edit — the stop lists in it decide where a name
-      # ends, which is a judgement about how you speak.
-      - name: code_identifiers
-        description: spoken names as identifiers
-        display: Formatting identifiers
-        command: code_identifiers.py
-
-      # Written to transforms/punctuation/ on first launch. Rules only, no
-      # model — see the script for the guard list this leans on.
-      - name: punctuation
-        description: spoken marks as punctuation
-        command: punctuation.py
-
-      # Written to transforms/repetitions/ on first launch. Cheap enough not
-      # to gate: 0.04s, mostly the python3 start, and it deletes nothing when
-      # it finds nothing.
-      - name: repetitions
-        description: delete a word or phrase said twice by accident
-        command: repetitions.py
-
-    # Do what was asked even when no transform above matches:
-    # "hey parrot, sort that list alphabetically". A remark that was never an
-    # instruction is still refused, and you see every result first.
-    free_form: true
-    """
+        guard let text = try? String(contentsOf: configTemplateURL, encoding: .utf8) else {
+            Log.write("config: could not read \(configTemplateURL.path); writing nothing")
+            return ""
+        }
+        guard AppVariant.isDev else { return text }
+        return text
+            .replacingOccurrences(
+                of: "# ParrotFlow configuration",
+                with: "# \(AppVariant.displayName) configuration")
+            .replacingOccurrences(
+                of: "  key: right_command",
+                with: "  key: \(AppVariant.defaultHotkey)")
+            .replacingOccurrences(
+                of: "  output_dir: ~/Recordings/ParrotFlow",
+                with: "  output_dir: \(AppVariant.defaultOutputDir)")
+            .replacingOccurrences(
+                of: "~/Library/Logs/ParrotFlow.log",
+                with: "~/Library/Logs/\(AppVariant.logFileName)")
     }
 }
 

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -138,6 +138,15 @@ enum PanelsCommand {
                 .environmentObject(PermissionsModel.showing(
                     .accessibility, asked: true, context: .revisiting))),
              NSSize(width: PermissionMetrics.width, height: PermissionMetrics.height), .dark, false),
+            // The screen after both are granted, in the two shapes it comes
+            // in: the speech model already there, and still on its way — the
+            // only two states DonePane's invitation sentence ever chooses
+            // between.
+            (AnyView(PermissionsView().environmentObject(PermissionsModel.done())),
+             NSSize(width: PermissionMetrics.width, height: PermissionMetrics.height), .dark, false),
+            (AnyView(PermissionsView()
+                .environmentObject(PermissionsModel.done(speechModel: .preparing(percent: 43)))),
+             NSSize(width: PermissionMetrics.width, height: PermissionMetrics.height), .dark, false),
             (AnyView(PillView().environmentObject(notice)),
              pillSize(notice), .dark, true),
             (AnyView(PillView().environmentObject(thinking)),

--- a/Sources/ParrotFlow/Permissions.swift
+++ b/Sources/ParrotFlow/Permissions.swift
@@ -148,10 +148,6 @@ enum Permissions {
         }
     }
 
-    static func openAccessibilitySettings() {
-        open("x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
-    }
-
     private static func open(_ urlString: String) {
         guard let url = URL(string: urlString) else { return }
         NSWorkspace.shared.open(url)

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -80,6 +80,22 @@ final class PermissionsModel: ObservableObject {
     @Published var micStatus: Permissions.Status = .notDetermined
     @Published var axStatus: Permissions.Status = .notGranted
     @Published var axBlocker: String?
+    /// Pushed from AppDelegate.handleTranscriberStatus, not polled — nothing
+    /// in this file can ask the transcriber actor anything, and this window
+    /// is not the one place that needs to know. Defaults to `.ready` rather
+    /// than an "unknown" third case: a launch that never touches the
+    /// transcriber (transcription disabled) should not sit on a
+    /// "downloading" message forever for a download that will never start.
+    @Published var speechModel: SpeechModelProgress = .ready
+    /// Pushed from AppDelegate.updateUI, where the same string is already
+    /// computed for the menu bar — one source, so a rebound hotkey shows up
+    /// here without this file knowing config exists.
+    @Published var hotkeyDisplay: String = "your hotkey"
+
+    enum SpeechModelProgress: Equatable {
+        case ready
+        case preparing(percent: Int?)
+    }
 
     /// What is left to ask for, fixed when the window opens.
     ///
@@ -137,6 +153,22 @@ final class PermissionsModel: ObservableObject {
         model.steps = PermissionStep.allCases
         model.index = PermissionStep.allCases.firstIndex(of: step) ?? 0
         model.asked = asked
+        return model
+    }
+
+    /// Past every step, for `--panel-sheet` — `showing(_:)` always parks on
+    /// one, and DonePane is only ever reached by walking off the end of
+    /// `steps`, which nothing outside this file can set directly.
+    static func done(
+        speechModel: SpeechModelProgress = .ready, hotkeyDisplay: String = "Right ⌥"
+    ) -> PermissionsModel {
+        let model = PermissionsModel()
+        model.micStatus = .granted
+        model.axStatus = .granted
+        model.steps = PermissionStep.allCases
+        model.index = PermissionStep.allCases.count
+        model.speechModel = speechModel
+        model.hotkeyDisplay = hotkeyDisplay
         return model
     }
 
@@ -345,7 +377,9 @@ struct PermissionsView: View {
                 )
             } else {
                 DonePane(
-                    micStatus: model.micStatus, axStatus: model.axStatus, onClose: onClose
+                    micStatus: model.micStatus, axStatus: model.axStatus,
+                    speechModel: model.speechModel, hotkeyDisplay: model.hotkeyDisplay,
+                    onClose: onClose
                 )
             }
         }
@@ -386,7 +420,7 @@ private struct Instrument: View {
                     .frame(width: PillMetrics.recording(hasIcon: false) + PillMetrics.bleed * 2,
                            height: PillMetrics.height + PillMetrics.bleed * 2)
             case .accessibility:
-                Landing()
+                SettingsRowMock()
             }
         }
         .frame(height: 88)
@@ -401,42 +435,75 @@ private struct Instrument: View {
     }()
 }
 
-/// The four feathers, then a field with the words already in it and the caret
-/// after them. `PlumageMark` is documented as the pill once it has heard you,
-/// which makes it exactly the right mark to show arriving somewhere.
-private struct Landing: View {
+/// What Accessibility actually asks for is a row in System Settings, not
+/// anything this app draws — so the picture is that row, not a metaphor for
+/// it. The switch animates on a loop rather than sitting lit: someone reading
+/// this has not ticked it yet, and a switch already on would show the answer
+/// instead of the question. `allowsHitTesting(false)` on the mock switch is
+/// not a precaution — nothing here is wired to anything, ever.
+private struct SettingsRowMock: View {
+    @State private var isOn = false
+
     var body: some View {
-        HStack(spacing: 12) {
-            // Scaled up rather than redrawn: it is the app's mark at label size
-            // everywhere else, and this is the one place it is the subject of
-            // the picture rather than a label on one.
-            PlumageMark()
-                .scaleEffect(1.5)
-                .frame(width: 18)
-
-            Image(systemName: "arrow.right")
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(.secondary)
-
-            HStack(spacing: 2) {
-                Text("hold the hotkey and talk")
-                    .font(.system(size: 13, design: .rounded))
-                    .foregroundStyle(.primary)
-                RoundedRectangle(cornerRadius: 1)
-                    .fill(Parrot.action)
-                    .frame(width: 2, height: 16)
-            }
-            .padding(.horizontal, 11)
-            .padding(.vertical, 9)
-            .background(
-                Color.primary.opacity(0.07),
-                in: RoundedRectangle(cornerRadius: Parrot.fieldRadius, style: .continuous)
-            )
-            .overlay {
-                RoundedRectangle(cornerRadius: Parrot.fieldRadius, style: .continuous)
-                    .strokeBorder(Parrot.action.opacity(0.55), lineWidth: 1.5)
+        HStack(spacing: 10) {
+            appIcon
+            Text(AppVariant.displayName)
+                .font(.system(size: 13))
+                .foregroundStyle(.primary)
+            Spacer(minLength: 12)
+            MockToggle(isOn: isOn)
+        }
+        .padding(.horizontal, 16)
+        .frame(maxWidth: 260)
+        .onAppear {
+            withAnimation(.easeInOut(duration: 0.7).repeatForever(autoreverses: true).delay(0.5)) {
+                isOn = true
             }
         }
+    }
+
+    /// The real app icon, the same file System Settings itself reads. Loaded
+    /// by path rather than `NSImage(named:)`: a loose `AppIcon.icns` with no
+    /// asset-catalog entry doesn't reliably resolve by name, and silently
+    /// drawing the wrong mark is worse than a fallback that says so by being
+    /// visibly different. `PlumageMark` falls back only if that ever fails —
+    /// running the bare binary outside any bundle, mainly.
+    @ViewBuilder
+    private var appIcon: some View {
+        if let url = Bundle.main.url(forResource: "AppIcon", withExtension: "icns"),
+           let icon = NSImage(contentsOf: url) {
+            Image(nsImage: icon)
+                .resizable()
+                .interpolation(.high)
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 24, height: 24)
+                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        } else {
+            PlumageMark(size: 20)
+                .frame(width: 24, height: 24)
+        }
+    }
+}
+
+/// Shaped and sized after the real macOS toggle in Privacy & Security, not
+/// approximated from memory — capsule track, round knob inset by 2pt, knob
+/// on the side the value is on. Never a real `Toggle`: a control that can be
+/// clicked invites clicking it, and clicking this one would do nothing.
+private struct MockToggle: View {
+    let isOn: Bool
+
+    var body: some View {
+        Capsule()
+            .fill(isOn ? Parrot.action : Color.primary.opacity(0.18))
+            .frame(width: 34, height: 20)
+            .overlay(alignment: isOn ? .trailing : .leading) {
+                Circle()
+                    .fill(.white)
+                    .frame(width: 16, height: 16)
+                    .padding(2)
+                    .shadow(color: .black.opacity(0.25), radius: 1, y: 0.5)
+            }
+            .allowsHitTesting(false)
     }
 }
 
@@ -553,31 +620,24 @@ private struct StepPane: View {
 private struct DonePane: View {
     let micStatus: Permissions.Status
     let axStatus: Permissions.Status
+    let speechModel: PermissionsModel.SpeechModelProgress
+    let hotkeyDisplay: String
     let onClose: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Spacer(minLength: 20)
 
-            Text(everything ? "Ready" : "Something was switched off")
+            Text(title)
                 .font(.system(size: 19, weight: .semibold, design: .rounded))
                 .padding(.bottom, 7)
 
-            // Reachable two ways now: a permission revoked in System Settings
-            // while this window is open, or a skip from the menu bar. Either
-            // way what is true is that something is missing, which it says
-            // rather than pretending the app is fine.
-            Text(everything
-                ? "Hold your hotkey, say something, let go."
-                : "ParrotFlow needs both. Reopen this window from the menu bar when you want to "
-                    + "finish, or check what is missing below.")
-                .font(.system(size: 12))
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+            invitation
                 .padding(.bottom, 18)
 
-            StatusLine(title: "Microphone", status: micStatus)
-            StatusLine(title: "Accessibility", status: axStatus)
+            StatusLine(title: "Microphone", text: micStatus.label, color: micStatus.badgeColor)
+            StatusLine(title: "Accessibility", text: axStatus.label, color: axStatus.badgeColor)
+            StatusLine(title: "Speech model", text: speechModel.label, color: speechModel.badgeColor)
 
             Spacer(minLength: 16)
 
@@ -589,16 +649,96 @@ private struct DonePane: View {
     }
 
     private var everything: Bool { micStatus == .granted && axStatus == .granted }
+
+    /// "Ready" oversold it while the model was still on its way in — someone
+    /// reads that word, holds the hotkey, and dictates into a download that
+    /// has not finished. Only true once both permissions and the model are
+    /// all the way there.
+    private var title: String {
+        guard everything else { return "Something was switched off" }
+        if case .preparing = speechModel { return "Almost ready" }
+        return "Ready"
+    }
+
+    /// Both permissions granted is the gate for reaching this screen at all
+    /// (see `PermissionsModel.begin`'s step filter) — what is still open past
+    /// that is only ever the speech model, and only ever a matter of time,
+    /// not a decision to make. So the two states get their own sentence
+    /// rather than a status line read in silence: one says dictate now, the
+    /// other says what to wait for and then dictate.
+    ///
+    /// The hotkey is a key someone presses, not a word in a sentence — plain
+    /// prose let it blend into "Hold Right Option and start dictating." and
+    /// read past. Its own line, in the same bordered mark this window
+    /// already uses for a key combination, is what makes it the one thing to
+    /// notice here.
+    @ViewBuilder
+    private var invitation: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            switch speechModel {
+            case .ready:
+                EmptyView()
+            case .preparing:
+                Text("The speech model is still downloading.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+            }
+
+            if everything {
+                HStack(spacing: 6) {
+                    Text(holdVerb)
+                    HotkeyBadge(text: hotkeyDisplay)
+                    Text("and start dictating.")
+                }
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+            } else {
+                Text("ParrotFlow needs both. Reopen this window from the menu bar when you want to "
+                    + "finish, or check what is missing below.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var holdVerb: String {
+        if case .preparing = speechModel { return "Once it's done, hold" }
+        return "Hold"
+    }
+}
+
+/// The same bordered field this window already draws for a key combination
+/// — one mark for "this is a key you press," not two.
+private struct HotkeyBadge: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 12, weight: .medium, design: .rounded))
+            .foregroundStyle(.primary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(
+                Color.primary.opacity(0.07),
+                in: RoundedRectangle(cornerRadius: Parrot.fieldRadius, style: .continuous)
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: Parrot.fieldRadius, style: .continuous)
+                    .strokeBorder(Parrot.action.opacity(0.55), lineWidth: 1.5)
+            }
+    }
 }
 
 private struct StatusLine: View {
     let title: String
-    let status: Permissions.Status
+    let text: String
+    let color: Color
 
     var body: some View {
         HStack(spacing: 8) {
             Text(title).font(.system(size: 12))
-            StatusBadge(status: status)
+            StatusBadge(text: text, color: color)
             Spacer()
         }
         .padding(.vertical, 3)
@@ -606,22 +746,43 @@ private struct StatusLine: View {
 }
 
 private struct StatusBadge: View {
-    let status: Permissions.Status
+    let text: String
+    let color: Color
 
     var body: some View {
-        Text(status.label)
+        Text(text)
             .font(.system(size: 10, weight: .semibold))
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
             .background(color.opacity(0.18), in: Capsule())
             .foregroundStyle(color)
     }
+}
 
-    private var color: Color {
-        switch status {
+private extension Permissions.Status {
+    var badgeColor: Color {
+        switch self {
         case .granted: return Parrot.leaf
         case .denied: return Parrot.scarlet
         case .notDetermined, .notGranted: return Parrot.amber
+        }
+    }
+}
+
+private extension PermissionsModel.SpeechModelProgress {
+    var label: String {
+        switch self {
+        case .ready: return "Ready"
+        case .preparing(let percent):
+            guard let percent else { return "Downloading" }
+            return "Downloading \(percent)%"
+        }
+    }
+
+    var badgeColor: Color {
+        switch self {
+        case .ready: return Parrot.leaf
+        case .preparing: return Parrot.amber
         }
     }
 }

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -33,18 +33,16 @@ enum PermissionStep: CaseIterable {
         }
     }
 
-    /// What it is for, and why this app is the one asking. Two sentences at
-    /// most: this is read once, standing between someone and the thing they
+    /// Says only why this permission, not what the app is or how it works —
+    /// one sentence, read once, standing between someone and the thing they
     /// just installed.
     var reason: String {
         switch self {
         case .microphone:
-            return "Hold the hotkey and ParrotFlow records. The recording becomes "
-                + "text on this Mac, and never leaves it."
+            return "ParrotFlow needs microphone access to turn what you say into text."
         case .accessibility:
-            return "This is what puts the text into the app you are already in, and "
-                + "reads the words you select so you can fix them out loud. Both "
-                + "halves of ParrotFlow need it."
+            return "ParrotFlow needs Accessibility access to type that text into "
+                + "the app you're using."
         }
     }
 
@@ -168,6 +166,22 @@ final class PermissionsWindowController {
     private var window: NSWindow?
     private var timer: Timer?
     private var accessibilityObserver: NSObjectProtocol?
+    /// The step a fronting attempt is under way for, and how many ticks it
+    /// gets to actually land. A step is only worth fighting for the moment it
+    /// first appears — activation is asynchronous and the first attempt does
+    /// not always take (see poll below), so this allows a few retries rather
+    /// than marking it "done" the instant one attempt is fired and never
+    /// checking whether it actually worked.
+    private var fronting: (index: Int, attemptsLeft: Int)?
+    /// The step that has already been in front at least once. Checked before
+    /// `fronting` is ever armed, and for good — granting Accessibility means
+    /// clicking into System Settings, not this window, and the first
+    /// successful appearance is the only one this window is owed. Without
+    /// this, clicking into Settings to tick the box put the window out of
+    /// key focus again, `fronting`'s budget hadn't run out yet, and the next
+    /// tick re-fronted it on top of the very checkbox someone was reaching
+    /// for.
+    private var succeededIndex: Int?
 
     init() {
         accessibilityObserver = Permissions.observeAccessibilityChanges { [weak self] in
@@ -191,6 +205,8 @@ final class PermissionsWindowController {
         NSApp.activate(ignoringOtherApps: true)
         window?.makeKeyAndOrderFront(nil)
         window?.center()
+        fronting = nil
+        succeededIndex = model.index
 
         timer?.invalidate()
         timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
@@ -201,6 +217,34 @@ final class PermissionsWindowController {
     private func poll() {
         model.refresh()
         model.advancePastGranted()
+        guard model.current != nil else { fronting = nil; return }
+
+        // Once this step has been in front at all, it is done — regardless
+        // of what has focus now, or whether `fronting`'s own budget has any
+        // attempts left. See `succeededIndex`'s doc comment.
+        if window?.isKeyWindow == true { succeededIndex = model.index }
+        guard succeededIndex != model.index else { return }
+
+        // A new step gets a few ticks' worth of attempts to land its one
+        // successful appearance — activation is asynchronous and does not
+        // always take on the first try.
+        if fronting?.index != model.index {
+            fronting = (model.index, attemptsLeft: 3)
+        }
+        guard var attempt = fronting, attempt.attemptsLeft > 0 else { return }
+        attempt.attemptsLeft -= 1
+        fronting = attempt
+        let target = attempt.index
+
+        NSApp.activate(ignoringOtherApps: true)
+        // NSApp.activate only lands on the next turn of the run loop — see
+        // the same trap in CorrectionPanel.present(). Calling
+        // makeKeyAndOrderFront synchronously right after it here did nothing,
+        // because activation had not actually happened yet.
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.fronting?.index == target else { return }
+            self.window?.makeKeyAndOrderFront(nil)
+        }
     }
 
     private func build() {
@@ -247,12 +291,14 @@ final class PermissionsWindowController {
         case .microphone:
             Permissions.requestMicrophone { [weak self] _ in self?.poll() }
         case .accessibility:
-            // Request before opening Settings, always. It is
-            // AXIsProcessTrustedWithOptions that registers this binary with
-            // TCC — open the pane first and the app may not be in the list to
-            // tick, which reads as the instructions being wrong.
+            // AXIsProcessTrustedWithOptions with the prompt option is what
+            // registers this binary with TCC — skip it and the app may not
+            // be in the list to tick, which reads as the instructions being
+            // wrong. It also puts up its own system alert with an "Open
+            // System Settings" button, so a second, explicit open() here
+            // used to land on top of that alert as a doubled prompt. The
+            // alert's own button is the one way through now.
             Permissions.requestAccessibility()
-            Permissions.openAccessibilitySettings()
         }
     }
 }
@@ -428,8 +474,8 @@ private struct StepPane: View {
                 .padding(.bottom, 7)
 
             Text(step.reason)
-                .font(.system(size: 12))
-                .foregroundStyle(.secondary)
+                .font(.system(size: 14))
+                .foregroundStyle(.primary)
                 .fixedSize(horizontal: false, vertical: true)
                 .lineSpacing(2)
 
@@ -458,10 +504,18 @@ private struct StepPane: View {
             Spacer(minLength: 16)
 
             HStack(spacing: 10) {
-                Button(step.declineTitle(in: context), action: onDecline)
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.tertiary)
-                    .font(.system(size: 12))
+                // Not offered during setup: both permissions are required, and a
+                // way out here would be a way to finish installing without
+                // either — the exact state that fails later, silently, at the
+                // moment someone holds the key and nothing is written.
+                // Revisiting still gets it, and the window's own close button
+                // besides — this screen only ever asks to skip, never to quit.
+                if context != .installing {
+                    Button(step.declineTitle(in: context), action: onDecline)
+                        .buttonStyle(.plain)
+                        .foregroundStyle(.tertiary)
+                        .font(.system(size: 12))
+                }
 
                 Spacer()
 

--- a/Sources/ParrotFlow/WarmModelsCommand.swift
+++ b/Sources/ParrotFlow/WarmModelsCommand.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// `--warm-models` — downloads Parakeet (and the voice detector, if the
+/// config asks for one) without waiting for a first dictation.
+///
+/// `Transcriber.prepare` already does this lazily, on the first real
+/// transcription. This command calls the same method and nothing else, so
+/// `install.sh` — or anyone else scripting a setup — can trigger the
+/// download on its own schedule instead of the user's first attempt to
+/// dictate.
+enum WarmModelsCommand {
+
+    static func run() -> Int32 {
+        guard #available(macOS 14, *) else {
+            print("✗ transcription needs macOS 14 or later")
+            return 1
+        }
+
+        let config: Config
+        do {
+            config = try ConfigStore.load()
+        } catch {
+            print("✗ config: \(CheckConfigCommand.describe(error))")
+            return 1
+        }
+
+        var exitCode: Int32 = 0
+        let done = DispatchSemaphore(value: 0)
+
+        Task {
+            let transcriber = Transcriber { status in
+                if case .downloading(let what) = status {
+                    print("\r  downloading \(what)…", terminator: "")
+                    fflush(stdout)
+                }
+            }
+            do {
+                try await transcriber.prepare(config: config)
+                print("\r\u{1B}[K✓ models ready")
+            } catch {
+                print("\r\u{1B}[K✗ \(error.localizedDescription)")
+                exitCode = 1
+            }
+            done.signal()
+        }
+
+        done.wait()
+        return exitCode
+    }
+}

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -5,6 +5,7 @@ import AppKit
 //   ParrotFlow.app/Contents/MacOS/ParrotFlow --check-config
 //   ParrotFlow.app/Contents/MacOS/ParrotFlow --record 3
 //   ParrotFlow.app/Contents/MacOS/ParrotFlow --transcribe clip.wav
+//   ParrotFlow.app/Contents/MacOS/ParrotFlow --warm-models
 //
 let arguments = CommandLine.arguments
 
@@ -88,6 +89,10 @@ if let index = arguments.firstIndex(of: "--transcribe") {
         path: arguments[index + 1],
         withVocabulary: !arguments.contains("--no-vocab")
     ))
+}
+
+if arguments.contains("--warm-models") {
+    exit(WarmModelsCommand.run())
 }
 
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,7 +1,65 @@
+# ParrotFlow configuration
+# Edit and save — changes are picked up automatically. Delete any line to
+# get its default back. `--check-config` says what the file adds up to.
+
+hotkey:
+  # A bare modifier — right_option, left_option, right_command,
+  # left_command, right_control, left_control, right_shift, left_shift, fn
+  # — or a character key (a-z, 0-9, f1-f20, space, return, arrows,
+  # punctuation), which needs `modifiers` below.
+  key: right_command
+
+  # Any of: command, control, option, shift.
+  modifiers: []
+
+  # push_to_talk records while the key is held; toggle taps on and off.
+  # A bare modifier wants push_to_talk, or typing an accented character
+  # with it would start recording.
+  mode: push_to_talk
+
+  # Keep the mic open this long after you let go, so the last syllable is
+  # not cut off. push_to_talk only. 0 turns it off.
+  release_tail_seconds: 0.3
+
+audio:
+  # Where the recordings and trace.jsonl go.
+  output_dir: ~/Recordings/ParrotFlow
+
+  # Skip clips with no speech in them, so a stray keypress does not decode
+  # room tone into a sentence.
+  speech_gate: true
+
+feedback:
+  sound: true     # a click when recording starts and stops
+  overlay: true   # the floating pill while you speak
+  # After the words land the pill names what can be done to them, for 3s.
+  # Click a chip to run it. Tapping the dictation hotkey — press and let go
+  # — opens the correction panel too. Holding it starts the next dictation.
+  correct_offer: true
+
+logging:
+  # The line-by-line log at ~/Library/Logs/ParrotFlow.log — how
+  # every problem in this app gets diagnosed. Leave it on.
+  text: true
+
+  # Write each dictation's recording to disk, in audio.output_dir. Off by
+  # default: a recording of your voice should not pile up there unless you
+  # asked for it. Turn it on for --transcribe, calibration, or to hear what
+  # the app heard.
+  audio: false
+
 transcription:
+  # paste     -> typed into the app you're in (needs Accessibility)
+  # clipboard -> copied, you press Cmd-V
+  insert_mode: paste
+
   # Say one of these, and what follows is an instruction, not dictation:
   # "hey parrot, make that a bullet list". An empty list turns this off.
   activation_phrases: [hey parrot, by the way parrot]
+
+  # Terminals only: they cannot be edited in place, so the input line is
+  # cleared and retyped corrected. Everywhere else ignores this.
+  rewrite_line: true
 
   # Languages you dictate in, most spoken first. Supported: en, fr. One entry
   # turns off language detection.

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -113,7 +113,7 @@ permissions and a ~1 GB download before it does anything.
 curl -fsSL .../install.sh | sh          (~3 MB, checksum verified)
         │
         ▼
-Launch — no Dock icon, a 🎙 appears in the menu bar
+Launch — no Dock icon, a 🦜 appears in the menu bar
         │
         ▼
   ├─ Microphone       [Grant]   ← system prompt, required

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -41,11 +41,13 @@ printf 'APPL????' > "$APP/Contents/PkgInfo"
 cp "$ROOT/Resources/AppIcon.icns" "$APP/Contents/Resources/"
 cp "$ROOT"/Resources/MenuBarParrot*.png "$APP/Contents/Resources/"
 
-# The one shipped transform is seeded from here — copied, not baked into the
-# binary as a string, so there is one copy of it and not two drifting apart.
-# See Config.exampleTransformsDirectory.
+# The shipped transforms and the default config.yaml are seeded from here —
+# copied, not baked into the binary as strings, so there is one copy of each
+# and not two drifting apart. See Config.exampleTransformsDirectory and
+# Config.configTemplateURL.
 cp -R "$ROOT/examples" "$APP/Contents/Resources/examples"
 find "$APP/Contents/Resources/examples" -name __pycache__ -type d -exec rm -rf {} +
+cp "$ROOT/config.example.yaml" "$APP/Contents/Resources/config.example.yaml"
 
 # Resources/Info.plist carries the released identity; the dev bundle is that
 # file with three keys rewritten. One template rather than two files means a key

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -72,9 +72,23 @@ echo "==> Build stamp: $STAMP"
 
 # Ad-hoc ("-") by default. Set CODESIGN_IDENTITY to a self-signed identity to
 # keep the microphone permission across rebuilds — see README.
-# Prefer a stable self-signed identity when one exists — see dev-certificate.sh.
-if [ -z "${CODESIGN_IDENTITY:-}" ] && security find-identity -v -p codesigning 2>/dev/null | grep -q "ParrotFlow Dev"; then
-    CODESIGN_IDENTITY="ParrotFlow Dev"
+#
+# The identity has to match the variant. TCC keys a grant to the certificate,
+# not only the bundle id: signing com.parrotflow.app (release) with the Dev
+# certificate makes a locally built copy a different identity than the one
+# distributed, and permission grants stop lining up between them — this was
+# picking "ParrotFlow Dev" whenever it existed, for either variant, which is
+# exactly that bug. Prefer the matching identity, fall back to the other
+# rather than ad-hoc — see dev-certificate.sh.
+if [ -z "${CODESIGN_IDENTITY:-}" ]; then
+    PREFERRED="ParrotFlow Dev"
+    [ "$VARIANT" = "release" ] && PREFERRED="ParrotFlow Release"
+    for candidate in "$PREFERRED" "ParrotFlow Release" "ParrotFlow Dev"; do
+        if security find-identity -v -p codesigning 2>/dev/null | grep -q "$candidate"; then
+            CODESIGN_IDENTITY="$candidate"
+            break
+        fi
+    done
 fi
 IDENTITY="${CODESIGN_IDENTITY:--}"
 echo "==> Signing with identity: $IDENTITY"

--- a/scripts/check-default-config.sh
+++ b/scripts/check-default-config.sh
@@ -1,21 +1,27 @@
 #!/usr/bin/env bash
-# Checks that what a new install is written with teaches everything
-# config.example.yaml documents.
+# Checks that config.example.yaml — what a new install is written with, and
+# what anyone reads to find out what exists — is one file, not two drifting
+# copies of the same shape.
 #
-# There are two copies of the config's shape — `Config.defaultYAML`, which is
-# written on first launch, and config.example.yaml, which is what anyone reads
-# to find out what exists. They drift, and the drift is silent both ways: a key
-# missing from the template is a feature nobody discovers, and a key missing
-# from the example is one nobody can look up.
+# It used to be two: `Config.defaultYAML`, a hand-synced Swift string written
+# on first launch, and config.example.yaml, read by everyone else. They
+# drifted, silently, more than once — `languages` went missing from the
+# string while the example kept it; then the vocabulary judge stage and the
+# app-scoped transforms landed in the example and never reached the string,
+# so a new install ran a pipeline with no judge in it and nothing said so. A
+# key-name comparison between the two caught the first kind of drift and was
+# structurally blind to the second: a missing pipeline *step* is not a
+# missing *key*.
 #
-# It has already bitten twice. `languages` was absent from the template, so a
-# new install shipped a pipeline whose comment promised numbers in French while
-# listing only English. Then `prompts` was absent, so "hey parrot, make that a
-# list" did nothing on a fresh machine and nothing said why.
+# `Config.defaultYAML` now reads config.example.yaml itself and substitutes
+# four lines that differ per variant — see Config.configTemplateURL. There is
+# one file, so there is nothing left to drift. What is left to check:
 #
-# Only the template is required to be complete. The example deliberately starts
-# at `transcription:` and says nothing about hotkeys or audio, so keys the
-# template has and the example lacks are reported and not failed.
+#   1. config.example.yaml still parses as YAML.
+#   2. Every pipeline step still names something real — a `stage:` this app
+#      knows, or a `transform:` this file defines.
+#   3. Config.defaultYAML has not grown back into a second copy — the
+#      regression this check exists to catch.
 set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
@@ -23,78 +29,71 @@ python3 - "$ROOT" <<'PY'
 import re, sys, pathlib, yaml
 
 root = pathlib.Path(sys.argv[1])
-src = (root / "Sources/ParrotFlow/Config.swift").read_text()
-start = src.index('static var defaultYAML: String {')
-open_quote = src.index('"""', start) + 3
-close_quote = src.index('"""', open_quote)
-# The template is a Swift literal: interpolations stand in for per-variant
-# values, and an escaped backslash is one backslash by the time YAML sees it.
-raw = re.sub(r'\\\((.*?)\)', 'placeholder', src[open_quote:close_quote]).replace("\\\\", "\\")
+ok = True
 
+example_path = root / "config.example.yaml"
 try:
-    template = yaml.safe_load(raw)
+    example = yaml.safe_load(example_path.read_text())
 except yaml.YAMLError as error:
-    print("  ✗ Config.defaultYAML is not valid YAML — a new install would fail to parse")
+    print(f"  ✗ config.example.yaml is not valid YAML")
     print(f"      {error}")
     sys.exit(1)
 
-example = yaml.safe_load((root / "config.example.yaml").read_text())
-
-def keys(node, prefix=""):
-    found = []
-    for key, value in (node or {}).items():
-        found.append(prefix + key)
-        # `replacements` and `pipelines` hold user data, not schema; their keys
-        # are names and languages, and comparing those would be nonsense.
-        if isinstance(value, dict) and key not in ("replacements", "pipelines"):
-            found += keys(value, prefix + key + ".")
-    return found
-
-missing = sorted(set(keys(example)) - set(keys(template)))
-extra = sorted(set(keys(template)) - set(keys(example)))
-
-ok = True
-for key in missing:
-    print(f"  ✗ {key} is in config.example.yaml but not in the file a new install gets")
-    ok = False
-# The example starts at `transcription:` by design, so the hotkey, audio and
-# feedback sections are permanently "extra". Counted rather than listed: twelve
-# lines of expected noise on every run is how a check stops being read.
-if extra:
-    print(f"  · {len(extra)} keys are written on install and not documented in the example"
-          f" ({', '.join(sorted({k.split('.')[0] for k in extra}))})")
-
-# Transforms are a list, so the key check above says nothing about which ones.
-# `prompts:` is read too: it is the older name for the same section, still
-# accepted, and a config written before the rename must not read as empty here.
+# Every transform this file defines, by name.
 def names(doc):
     entries = (doc.get("transforms") or []) + (doc.get("prompts") or [])
     return {e.get("name") for e in entries}
-for name in sorted(names(example) - names(template)):
-    print(f"  ✗ transform \"{name}\" is documented but not written on install")
-    ok = False
 
-# A pipeline step naming a transform the file does not define is a config the
-# app refuses on first launch. It happened: `dotted-chat` was renamed to
-# `backticks` and the steps were not brought along, and nothing here noticed
-# because the key check and the name check both looked only at what exists,
-# never at whether the two halves agree.
+defined = names(example)
+
+# The stage kinds this app understands without a name — everything else in a
+# pipeline step must be one of these, or a `transform:` naming a defined one.
+BUILTIN_STAGES = {"replacements", "fuzzy", "numbers", "vocabulary"}
+
 def steps(doc):
-    named = []
+    found = []
     for entries in ((doc.get("transcription") or {}).get("pipelines") or {}).values():
         for entry in entries or []:
-            if isinstance(entry, dict) and entry.get("transform"):
-                named.append(entry["transform"])
-    return named
+            if isinstance(entry, str):
+                found.append(("stage", entry))
+            elif isinstance(entry, dict):
+                if entry.get("transform"):
+                    found.append(("transform", entry["transform"]))
+                elif entry.get("stage"):
+                    found.append(("stage", entry["stage"]))
+    return found
 
-for doc, where in ((template, "a new install"), (example, "config.example.yaml")):
-    for step in sorted(set(steps(doc)) - {n for n in names(doc) if n}):
-        print(f"  ✗ {where} runs `transform: {step}`, which it never defines")
+for kind, step in steps(example):
+    if kind == "transform" and step not in defined:
+        print(f"  ✗ pipeline runs `transform: {step}`, which config.example.yaml never defines")
+        ok = False
+    elif kind == "stage" and step not in BUILTIN_STAGES:
+        print(f"  ✗ pipeline runs `stage: {step}`, which is not a stage this app knows"
+              f" ({', '.join(sorted(BUILTIN_STAGES))})")
         ok = False
 
+# The regression this whole check exists to catch: defaultYAML growing back
+# into a second, hand-synced copy of the config's shape. It should be a few
+# lines that read the file and swap in the variant-specific ones — not
+# something that itself defines `transforms:`, `pipelines:`, or `llm:`.
+config_swift = (root / "Sources/ParrotFlow/Config.swift").read_text()
+start = config_swift.index("static var defaultYAML: String {")
+end = config_swift.index("\n}", start) if "\n}" in config_swift[start:] else len(config_swift)
+body = config_swift[start:start + 2000] if end == len(config_swift) else config_swift[start:end]
+
+if "configTemplateURL" not in body:
+    print("  ✗ Config.defaultYAML no longer reads configTemplateURL — has it gone back to"
+          " being a literal string? That is the two-copies problem this check exists to catch.")
+    ok = False
+if re.search(r"\btransforms:\s*$", body, re.MULTILINE) or "pipelines:" in body:
+    print("  ✗ Config.defaultYAML appears to embed config content directly (`transforms:` or"
+          " `pipelines:` found in its body) — that is the two-copies problem this check exists"
+          " to catch")
+    ok = False
+
 if ok:
-    print(f"  ✓ a new install gets every key config.example.yaml documents"
-          f"  ({len(keys(template))} keys, {len(names(template))} transforms,"
-          f" {len(steps(template))} transform step(s))")
+    print(f"  ✓ config.example.yaml is the one copy, parses, and its pipeline"
+          f" names only real stages and transforms"
+          f"  ({len(defined)} transforms, {len(steps(example))} pipeline step(s))")
 sys.exit(0 if ok else 1)
 PY

--- a/scripts/check-dotted.sh
+++ b/scripts/check-dotted.sh
@@ -4,7 +4,8 @@
 #   scripts/check-dotted.sh
 #
 # The pattern is not written in the case file or in a fixture. It is read out of
-# `Config.defaultYAML`, so this scores the rule a new install actually gets — a
+# config.example.yaml — the file a new install is actually seeded with, see
+# Config.defaultYAML — so this scores the rule a new install actually gets. A
 # committed copy would be free to drift from the thing that ships, and this is
 # the one rewrite that fires on ordinary language rather than on a name someone
 # taught it.
@@ -28,17 +29,10 @@ DECIMAL="$(mktemp -t parrotflow-decimal).yaml"
 trap 'rm -f "$FIXTURE" "$CHAT" "$DECIMAL"' EXIT
 
 python3 - "$ROOT" "$FIXTURE" "$CHAT" "$DECIMAL" <<'PY'
-import re, sys, pathlib, yaml
+import sys, pathlib, yaml
 
 root, out, chat, decimal = (pathlib.Path(a) for a in sys.argv[1:5])
-src = (root / "Sources/ParrotFlow/Config.swift").read_text()
-start = src.index("static var defaultYAML: String {")
-open_quote = src.index('"""', start) + 3
-close_quote = src.index('"""', open_quote)
-# A Swift literal: interpolations stand in for per-variant values, and an
-# escaped backslash is one backslash by the time YAML sees it.
-raw = re.sub(r"\\\((.*?)\)", "placeholder", src[open_quote:close_quote]).replace("\\\\", "\\")
-doc = yaml.safe_load(raw)
+doc = yaml.safe_load((root / "config.example.yaml").read_text())
 
 transforms = [t for t in doc.get("transforms") or [] if "replace" in t]
 if not any(t["name"] == "dotted" for t in transforms):

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -256,9 +256,21 @@ if command -v ollama >/dev/null 2>&1 && ! INSTALLED="$(ollama list 2>/dev/null)"
     if [ "$SETUP_VOICE" != "0" ]; then
         say "Starting Ollama"
         brew services start ollama || die "could not start Ollama"
-        # Freshly started, not freshly listening — give it a moment before the
-        # model check below asks it anything.
-        sleep 2
+        # Bounded poll, not a fixed sleep: freshly started is not freshly
+        # listening, and a guessed delay that is too short makes the model
+        # check below fail silently — it sees Ollama still not answering and
+        # skips the pull with no explanation. Up to 15s, checked every second.
+        i=0
+        until ollama list >/dev/null 2>&1; do
+            i=$((i + 1))
+            if [ "$i" -ge 15 ]; then
+                printf '    Ollama started but is not answering yet. Run this installer\n'
+                printf '    again once it has, or pull the model yourself:\n\n'
+                printf '      ollama pull %s\n\n' "$MODEL"
+                break
+            fi
+            sleep 1
+        done
     else
         printf '      brew services start ollama\n\n'
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -174,12 +174,13 @@ open "$DEST/$APP_NAME.app" || die "installed, but could not launch it"
 
 cat <<'EOF'
 
-    ParrotFlow is running — look for 🎙 in your menu bar.
+    ParrotFlow is running — look for 🦜 in your menu bar.
 
     Next:
-      1. Say yes to the microphone prompt.
-      2. Click the 🎙 icon, choose Permissions…, and grant Accessibility —
-         without it, dictation transcribes but can't type it in for you.
+      1. Say yes to the microphone prompt — wait until it's granted.
+      2. Click the 🦜 icon, choose Permissions…, grant Accessibility, and
+         wait until that's granted too — without it, dictation transcribes
+         but can't type the result in for you.
       3. Hold Right Option, say something, let go.
 
 EOF
@@ -223,6 +224,11 @@ fi
 # tests the same value instead of re-reading the environment.
 SETUP_VOICE="${PARROTFLOW_SETUP_VOICE:-1}"
 
+# Set by any branch below that finds something to do, so the end of this
+# section can say plainly that nothing was needed — silence reads as "did
+# this even run", not as "already done".
+NEEDED_SETUP=""
+
 # What Ollama backs: not only spoken commands, but also the check that a
 # vocabulary term applied in the right context. Dictation and the deterministic
 # match still work without Ollama; that match then ships unchecked instead of
@@ -234,6 +240,7 @@ SETUP_VOICE="${PARROTFLOW_SETUP_VOICE:-1}"
 # started it and stopped there, never looking at whether the model it needs
 # was actually present.
 if ! command -v ollama >/dev/null 2>&1; then
+    NEEDED_SETUP=1
     printf '    Ollama is not on this Mac. It runs the language model behind two\n'
     printf '    things: spoken commands, and the check that a vocabulary match fits\n'
     printf '    its sentence before it is kept. Without it, dictation still works,\n'
@@ -251,6 +258,7 @@ if ! command -v ollama >/dev/null 2>&1; then
 fi
 
 if command -v ollama >/dev/null 2>&1 && ! INSTALLED="$(ollama list 2>/dev/null)"; then
+    NEEDED_SETUP=1
     printf '    Ollama is installed but not answering, so spoken commands and the\n'
     printf '    vocabulary context check will not work. Start it:\n\n'
     if [ "$SETUP_VOICE" != "0" ]; then
@@ -279,6 +287,7 @@ fi
 if command -v ollama >/dev/null 2>&1 \
     && INSTALLED="$(ollama list 2>/dev/null)" \
     && ! printf '%s\n' "$INSTALLED" | grep -qF "$MODEL"; then
+    NEEDED_SETUP=1
     printf '    The %s model is not downloaded yet. Spoken commands and the\n' "$MODEL"
     printf '    vocabulary context check need it:\n\n'
     # Only the default's size is known here. A model named in someone's own
@@ -289,12 +298,18 @@ if command -v ollama >/dev/null 2>&1 \
     if [ "$SETUP_VOICE" != "0" ]; then
         printf '    ParrotFlow is already running and dictation already works — this\n'
         printf '    download only unlocks spoken commands and the vocabulary check.\n\n'
-        say "Pulling $MODEL"
+        say "Downloading $MODEL — this runs in the background, and dictation"
+        printf '    keeps working the whole time.\n\n'
         ollama pull "$MODEL" || die "could not pull $MODEL"
     else
         printf '      ollama pull %s\n\n' "$MODEL"
         printf '    Dictation works the whole time it downloads.\n\n'
     fi
+fi
+
+if [ -z "$NEEDED_SETUP" ]; then
+    printf '    Ollama and the %s model are already set up — spoken\n' "$MODEL"
+    printf '    commands and the vocabulary check are ready now.\n\n'
 fi
 
 cat <<'EOF'

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -27,6 +27,7 @@
 #
 #   PARROTFLOW_VERSION=0.2.0   install a specific version instead of the latest
 #   PARROTFLOW_DEST=~/Applications   install somewhere other than /Applications
+#   PARROTFLOW_SETUP_VOICE=0   skip installing Ollama and pulling the Gemma model
 set -eu
 
 REPO="znat/parrotflow"
@@ -183,9 +184,15 @@ EOF
 
 # --- What is still missing ---------------------------------------------------
 #
-# Reported, never installed. Nothing here can prompt, and starting a 10 GB
-# download because someone ran an install command is not a decision to take on
-# their behalf.
+# The speech model is reported, never installed: the app already downloads it
+# on first use, with a progress figure and without blocking recording, which
+# this script cannot match. See docs/distribution.md.
+#
+# Ollama and the Gemma model are installed here by default. This is not the
+# grammar checker or a nice extra: the vocabulary judge that keeps a matched
+# name from landing in the wrong sentence runs on this model, so a Mac without
+# it gets rule matches with nothing reviewing them. PARROTFLOW_SETUP_VOICE=0
+# skips it, for a script or a machine that wants the app alone.
 #
 # Every check below asks the filesystem or another program, never the app we
 # just installed. That is the rule, and the reason is the URLs: this script is
@@ -203,31 +210,62 @@ fi
 
 # Their config wins if it names a different model; this file is the user's, so
 # reading it costs nothing and does not depend on the app's version.
-MODEL="gemma4:e4b"
+MODEL="gemma4:e4b-mlx"
 CONFIG="$HOME/.config/parrotflow/config.yaml"
 if [ -f "$CONFIG" ]; then
     NAMED="$(sed -n 's/^[[:space:]]*model:[[:space:]]*\([^[:space:]#]*\).*/\1/p' "$CONFIG" | head -1)"
     [ -n "$NAMED" ] && MODEL="$NAMED"
 fi
 
+# Set unless the caller opted out. Read once, here, so every branch below
+# tests the same value instead of re-reading the environment.
+SETUP_VOICE="${PARROTFLOW_SETUP_VOICE:-1}"
+
+# What Ollama backs: not only spoken commands, but also the check that a
+# vocabulary term applied in the right context. Dictation and the deterministic
+# match still work without Ollama; that match then ships unchecked instead of
+# reviewed, so a name can land in the wrong place with nothing to catch it.
 if ! command -v ollama >/dev/null 2>&1; then
-    printf '    Voice commands — "hey parrot, fix the grammar", teaching it how a\n'
-    printf '    name is spelled — need Ollama, which runs a language model on this\n'
-    printf '    Mac. Optional: dictation works without it.\n\n'
-    printf '      brew install ollama && brew services start ollama\n'
-    printf '      ollama pull %s\n\n' "$MODEL"
+    printf '    Ollama is not on this Mac. It runs the language model behind two\n'
+    printf '    things: spoken commands, and the check that a vocabulary match fits\n'
+    printf '    its sentence before it is kept. Without it, dictation still works,\n'
+    printf '    and vocabulary still matches — the match just ships unreviewed.\n\n'
+    if [ "$SETUP_VOICE" != "0" ]; then
+        printf '    ParrotFlow is already running and dictation already works — this\n'
+        printf '    download only unlocks spoken commands and the vocabulary check.\n\n'
+        say "Installing Ollama"
+        brew install ollama && brew services start ollama \
+            || die "could not install or start Ollama"
+        say "Pulling $MODEL"
+        ollama pull "$MODEL" || die "could not pull $MODEL"
+    else
+        printf '      brew install ollama && brew services start ollama\n'
+        printf '      ollama pull %s\n\n' "$MODEL"
+    fi
 elif ! INSTALLED="$(ollama list 2>/dev/null)"; then
-    printf '    Ollama is installed but not answering, so voice commands will not\n'
-    printf '    work. Start it:\n\n'
-    printf '      brew services start ollama\n\n'
+    printf '    Ollama is installed but not answering, so spoken commands and the\n'
+    printf '    vocabulary context check will not work. Start it:\n\n'
+    if [ "$SETUP_VOICE" != "0" ]; then
+        say "Starting Ollama"
+        brew services start ollama || die "could not start Ollama"
+    else
+        printf '      brew services start ollama\n\n'
+    fi
 elif ! printf '%s\n' "$INSTALLED" | grep -qF "$MODEL"; then
-    printf '    Voice commands need the %s model, which is not downloaded yet:\n\n' "$MODEL"
-    printf '      ollama pull %s\n\n' "$MODEL"
+    printf '    The %s model is not downloaded yet. Spoken commands and the\n' "$MODEL"
+    printf '    vocabulary context check need it:\n\n'
     # Only the default's size is known here. A model named in someone's own
     # config could be any size, and a wrong number is worse than none.
-    if [ "$MODEL" = "gemma4:e4b" ]; then
-        printf '    About 9.6 GB. Dictation works the whole time it downloads.\n\n'
+    if [ "$MODEL" = "gemma4:e4b-mlx" ]; then
+        printf '    About 8.8 GB.\n\n'
+    fi
+    if [ "$SETUP_VOICE" != "0" ]; then
+        printf '    ParrotFlow is already running and dictation already works — this\n'
+        printf '    download only unlocks spoken commands and the vocabulary check.\n\n'
+        say "Pulling $MODEL"
+        ollama pull "$MODEL" || die "could not pull $MODEL"
     else
+        printf '      ollama pull %s\n\n' "$MODEL"
         printf '    Dictation works the whole time it downloads.\n\n'
     fi
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -227,6 +227,12 @@ SETUP_VOICE="${PARROTFLOW_SETUP_VOICE:-1}"
 # vocabulary term applied in the right context. Dictation and the deterministic
 # match still work without Ollama; that match then ships unchecked instead of
 # reviewed, so a name can land in the wrong place with nothing to catch it.
+#
+# Three checks in sequence, not mutually exclusive branches: installing Ollama
+# still leaves the model to pull, and starting a stopped Ollama still leaves
+# the model to check. A stopped service used to be a dead end — the script
+# started it and stopped there, never looking at whether the model it needs
+# was actually present.
 if ! command -v ollama >/dev/null 2>&1; then
     printf '    Ollama is not on this Mac. It runs the language model behind two\n'
     printf '    things: spoken commands, and the check that a vocabulary match fits\n'
@@ -238,22 +244,29 @@ if ! command -v ollama >/dev/null 2>&1; then
         say "Installing Ollama"
         brew install ollama && brew services start ollama \
             || die "could not install or start Ollama"
-        say "Pulling $MODEL"
-        ollama pull "$MODEL" || die "could not pull $MODEL"
     else
         printf '      brew install ollama && brew services start ollama\n'
         printf '      ollama pull %s\n\n' "$MODEL"
     fi
-elif ! INSTALLED="$(ollama list 2>/dev/null)"; then
+fi
+
+if command -v ollama >/dev/null 2>&1 && ! INSTALLED="$(ollama list 2>/dev/null)"; then
     printf '    Ollama is installed but not answering, so spoken commands and the\n'
     printf '    vocabulary context check will not work. Start it:\n\n'
     if [ "$SETUP_VOICE" != "0" ]; then
         say "Starting Ollama"
         brew services start ollama || die "could not start Ollama"
+        # Freshly started, not freshly listening — give it a moment before the
+        # model check below asks it anything.
+        sleep 2
     else
         printf '      brew services start ollama\n\n'
     fi
-elif ! printf '%s\n' "$INSTALLED" | grep -qF "$MODEL"; then
+fi
+
+if command -v ollama >/dev/null 2>&1 \
+    && INSTALLED="$(ollama list 2>/dev/null)" \
+    && ! printf '%s\n' "$INSTALLED" | grep -qF "$MODEL"; then
     printf '    The %s model is not downloaded yet. Spoken commands and the\n' "$MODEL"
     printf '    vocabulary context check need it:\n\n'
     # Only the default's size is known here. A model named in someone's own

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -178,7 +178,9 @@ cat <<'EOF'
 
     Next:
       1. Say yes to the microphone prompt.
-      2. Hold Right Option, say something, let go.
+      2. Click the 🎙 icon, choose Permissions…, and grant Accessibility —
+         without it, dictation transcribes but can't type it in for you.
+      3. Hold Right Option, say something, let go.
 
 EOF
 


### PR DESCRIPTION
## Summary
Follow-up to #133 (merged) — this commit landed just after that PR's squash-merge, so it never made it into main. Same content, opened as its own PR.

- The "Ready" screen now includes a third status line, "Speech model", fed live from the transcriber's real download/ready state.
- Two states: "Ready" once the model is actually ready, "Almost ready" while it's still downloading (with a live percent) — so nobody dictates into a download that hasn't finished.
- The hotkey is drawn as its own bordered mark instead of sitting as plain text in a sentence.
- Replaced the accessibility step's illustration with a native SwiftUI reproduction of the real System Settings row (icon, name, animated toggle) — reproducing what you'll actually see, not a metaphor for it.

## Test plan
- [x] `swift build` succeeds, no new warnings
- [x] Verified live: rebuilt and reinstalled to `/Applications`, both states (ready / still downloading) rendered correctly via `--panel-sheet`
- [x] Confirmed the diff against origin/main is exactly this commit's content (the other 9 commits on the old branch were already merged via #133 before this one was made)