### PR TITLE
fix: check Input Monitoring before taking the offer's keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ install: stop app
 	  && open "/Applications/$$APP_NAME.app" \
 	  && echo "==> Installed and launched /Applications/$$APP_NAME.app"
 
-## Quit, remove, and forget its Microphone/Accessibility grants — the three
-## things a test cycle needs undone together, so a stale grant or a leftover
-## copy never survives into the next install. config.yaml and vocabulary.yaml
-## are left alone: that is tuning, not install state.
+## Quit, remove, and forget its permission grants — the things a test cycle
+## needs undone together, so a stale grant or a leftover copy never survives
+## into the next install. config.yaml and vocabulary.yaml are left alone: that
+## is tuning, not install state.
 ##
 ## Uses VARIANT like everything else here, which defaults to dev — the one
 ## you are working on, running the whole time you are testing the other one.
@@ -98,6 +98,7 @@ try-install: release
 reset-permissions:
 	@$(V) tccutil reset Microphone "$$BUNDLE_ID" || true
 	@$(V) tccutil reset Accessibility "$$BUNDLE_ID" || true
+	@$(V) tccutil reset ListenEvent "$$BUNDLE_ID" || true
 	@$(V) echo "==> Permissions reset for $$BUNDLE_ID"
 
 ## Tail this variant's log

--- a/Sources/ParrotFlow/OfferKeys.swift
+++ b/Sources/ParrotFlow/OfferKeys.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Carbon.HIToolbox
+import IOKit.hid
 
 /// Takes the offer's letters and Escape while the offer is on screen, and gives
 /// them back the moment it is not.
@@ -27,7 +28,12 @@ import Carbon.HIToolbox
 /// `c` in the sentence it is about to correct.
 ///
 /// A `CGEvent` tap is the only way to consume a key without holding focus. It
-/// needs Accessibility, which the app already requires.
+/// needs Accessibility, which the app already requires, and Input Monitoring,
+/// which nothing else in the app does — Accessibility alone lets the tap
+/// create without error, and then macOS delivers it nothing: no denial, no
+/// disabled-by-timeout event, just silence indistinguishable from a user who
+/// never presses the chip's letter. `start` asks for it below and refuses to
+/// stand up a tap that would only ever look like it is working.
 ///
 /// ## What keeps it safe
 ///
@@ -86,6 +92,28 @@ final class OfferKeys {
             Log.write("offer keys: accessibility is not granted; the keys are not taken")
             return
         }
+        // Unlike Accessibility, a missing grant here does not stop the tap
+        // from being created — it just leaves it empty. Checked first so that
+        // never happens: `.unknown` means the request below has never been
+        // made, so this is also what puts the app in System Settings for the
+        // user to grant it in the first place.
+        let listenAccess = IOHIDCheckAccess(kIOHIDRequestTypeListenEvent)
+        guard listenAccess == kIOHIDAccessTypeGranted else {
+            if listenAccess == kIOHIDAccessTypeUnknown {
+                IOHIDRequestAccess(kIOHIDRequestTypeListenEvent)
+            }
+            Log.write("offer keys: input monitoring is not granted; the keys are not taken")
+            return
+        }
+        // Secure Event Input — what a terminal turns on so no other process,
+        // permissions or not, can see what you type into it — blocks a tap
+        // the same way a missing grant does: created, enabled, and given
+        // nothing. Logged here rather than guarded on: it can flip on after
+        // the tap is already up, so refusing to start one here would not
+        // even cover every case, and the honest answer is in the log either
+        // way instead of a guess.
+        Log.write("offer keys: secure input is \(IsSecureEventInputEnabled() ? "on" : "off")")
+
         handler = onKey
         expiry = until
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ Start from the question you have.
 | | |
 |---|---|
 | [setup.md](setup.md) | The guided install, written to be handed to an agent. Permissions, Ollama, model sizing, and a check that transcription works. |
-| [permissions.md](permissions.md) | Microphone and Accessibility: what needs which, and what a rebuild does to the grants. |
+| [permissions.md](permissions.md) | Microphone, Accessibility, and Input Monitoring: what needs which, and what a rebuild does to the grants. |
 | [configuration.md](configuration.md) | Every setting in `config.yaml`, what it does, and what happens when it is wrong. |
 
 ## Using it

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -7,9 +7,18 @@ spoken corrections, because reading your selection is exactly what that
 permission governs. `insert_mode: clipboard` works without it: the transcript
 is copied and you press ⌘V.
 
-Nothing else is asked for. Gating a pipeline stage by app reads the frontmost
-app from `NSWorkspace` rather than off the focused element, so it costs no
-permission that gating by text does not.
+**Input Monitoring** — required for the offer's own hotkeys (`C` for Correct,
+and any `key:` on a transform with `offer: true`). The offer's chips sit in a
+window that never takes focus, so catching their letters before they land in
+whatever you were typing into needs a system-wide key tap — and macOS gates
+that with Input Monitoring, separately from Accessibility. Without it the
+chips still draw and still take the mouse; only the keyboard shortcut is
+silently gone; the letter types instead. Requested the first time the offer
+goes up.
+
+Gating a pipeline stage by app reads the frontmost app from `NSWorkspace`
+rather than off the focused element, so it costs no permission that gating by
+text does not.
 
 ## Checking them
 
@@ -34,8 +43,9 @@ pins the binary's `cdhash`, which changes on every single build.
 So the grant you gave to yesterday's build does not apply to today's. Worse,
 the entry stays in System Settings pointing at a binary that no longer exists,
 so it *looks* granted. Un-ticking and re-ticking that entry doesn't help —
-it reuses the same dead record. Accessibility enforces this strictly;
-Microphone is more forgiving but still breaks when the bundle is replaced.
+it reuses the same dead record. Accessibility and Input Monitoring enforce
+this strictly; Microphone is more forgiving but still breaks when the bundle
+is replaced.
 
 The symptom is unmistakable: System Settings shows the app ticked, and the app
 insists the permission isn't granted.


### PR DESCRIPTION
## Summary
- `OfferKeys` only ever checked `AXIsProcessTrusted()` before standing up its `CGEvent` tap. macOS also gates a system-wide keystroke tap with Input Monitoring, separately from Accessibility — and a missing grant there doesn't fail tap creation, it just leaves the tap running and silently fed nothing.
- Symptom: the offer's chips drew fine and took the mouse fine, but a chip's own letter (`C` for Correct, or any custom `key:`) just typed into whatever you were dictating into instead of running the command.
- `start()` now checks `IOHIDCheckAccess` and calls `IOHIDRequestAccess` the first time, so the app shows up in System Settings to grant. It also logs Secure Event Input's state on the way in, since a stuck Secure Keyboard Entry flag (commonly left on by a terminal app) blocks the same tap the same silent way and is otherwise indistinguishable from a missing grant.
- `docs/permissions.md` documents Input Monitoring as a third required permission.

## Test plan
- [x] `swift build` — clean
- [x] Rebuilt and reinstalled the dev app (`make install`), confirmed via log that the tap now logs `secure input is on/off` on every offer
- [x] Verified end-to-end: HUD hotkeys (`C`, custom `F`) now run their command instead of typing the letter, once Input Monitoring is granted and Secure Input is off

🤖 Generated with [Claude Code](https://claude.com/claude-code)