### PR TITLE
docs: show the curl install command in the README, not the agent tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,13 +129,9 @@ More examples, their own test cases, in
 
 ParrotFlow requires Apple silicon and macOS 14 or later.
 
-> [!TIP]
-> Paste this in Claude Code or any coding agent to set up ParrotFlow.
->
-> ```text
-> Set up ParrotFlow on my Mac by following
-> https://raw.githubusercontent.com/znat/parrotflow/main/docs/setup.md
-> ```
+```sh
+curl -fsSL https://raw.githubusercontent.com/znat/parrotflow/main/scripts/install.sh | sh
+```
 
 Setup will install the Parakeet speech model (1.2 GB,
 needed for dictation), and [Ollama](https://ollama.com/download) with a


### PR DESCRIPTION
## Summary
- Replaces the "paste this into a coding agent" TIP block in the README's Install section with the direct `curl -fsSL .../install.sh | sh` command.
- `docs/setup.md` and the agent-driven flow are untouched — this only changes what a human reading the README on GitHub sees first.

## Test plan
- [ ] README renders correctly on GitHub