### PR TITLE
feat: surface update alert automatically, check hourly, and drop Correct a Word from menu

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -610,9 +610,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         self.flash("Could not check for updates: \(error.localizedDescription)")
                         self.updateUI()
                     }
-                    return
+                } else {
+                    // A failed poll leaves everything as it was — a known
+                    // update stays known, and a version already alerted for
+                    // is not asked about again just because this fetch
+                    // failed. The next successful poll picks up from here.
+                    await MainActor.run { [weak self] in
+                        guard let self,
+                            self.updateSchedulingGeneration == schedulingGenerationAtStart
+                        else { return }
+                        Log.write("updates: check failed — \(error.localizedDescription)")
+                    }
                 }
-                latest = nil
+                return
             }
             await MainActor.run { [weak self] in
                 guard let self else { return }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -71,6 +71,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// background check that began during that manual check, and answers
     /// after it, can tell its answer is now stale and skip overwriting it.
     private var manualCheckGeneration = 0
+    /// Bumped by `startUpdateChecks`, so a check already in flight when
+    /// config.yaml reloads — and so working from a stale `afterDays` — is
+    /// discarded on arrival rather than reviving state the reload just
+    /// changed.
+    private var updateSchedulingGeneration = 0
 
     private lazy var transcriber = Transcriber { [weak self] status in
         DispatchQueue.main.async { self?.handleTranscriberStatus(status) }
@@ -540,6 +545,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// thing off — and a setting that only takes effect after a restart is one
     /// that will be reported as not working.
     private func startUpdateChecks() {
+        // Discards any check already in flight: it captured the old
+        // afterDays and would otherwise revive state this reload just
+        // changed. Clearing updateCheckInFlight here, rather than waiting
+        // for that stale check's own completion, keeps the menu correct
+        // right away even if the completion never discards cleanly.
+        updateSchedulingGeneration += 1
+        updateCheckInFlight = false
+
         updatesTimer?.invalidate()
         updatesTimer = nil
 
@@ -573,6 +586,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         let generationAtStart = manualCheckGeneration
+        let schedulingGenerationAtStart = updateSchedulingGeneration
         if manual {
             updateCheckInFlight = true
             updateUI()
@@ -585,7 +599,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             } catch {
                 if manual {
                     await MainActor.run { [weak self] in
-                        guard let self else { return }
+                        guard let self,
+                            self.updateSchedulingGeneration == schedulingGenerationAtStart
+                        else { return }
                         self.updateCheckInFlight = false
                         self.manualCheckGeneration += 1
                         Log.write("updates: check failed — \(error.localizedDescription)")
@@ -597,7 +613,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 latest = nil
             }
             await MainActor.run { [weak self] in
-                guard let self else { return }
+                guard let self,
+                    self.updateSchedulingGeneration == schedulingGenerationAtStart
+                else { return }
                 // A manual answer always applies. A background one only does
                 // if a manual check has not started, or finished, meanwhile.
                 if !manual {

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -67,6 +67,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// True between a manual "Check for Updates" click and its answer, so the
     /// menu item can say so and a second click cannot start a second request.
     private var updateCheckInFlight = false
+    /// Bumped by every `checkForUpdate`, so a background check that answers
+    /// after a manual one has started cannot clobber the manual result — or
+    /// the reverse. Only the most recently started check's completion counts.
+    private var updateCheckGeneration = 0
 
     private lazy var transcriber = Transcriber { [weak self] status in
         DispatchQueue.main.async { self?.handleTranscriberStatus(status) }
@@ -573,6 +577,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             updateUI()
         }
 
+        updateCheckGeneration += 1
+        let generation = updateCheckGeneration
+
         Task<Void, Never> {
             var latest: Updates.Release?
             do {
@@ -580,7 +587,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             } catch {
                 if manual {
                     await MainActor.run { [weak self] in
-                        guard let self else { return }
+                        guard let self, generation == self.updateCheckGeneration else { return }
                         self.updateCheckInFlight = false
                         Log.write("updates: check failed — \(error.localizedDescription)")
                         self.flash("Could not check for updates: \(error.localizedDescription)")
@@ -591,7 +598,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 latest = nil
             }
             await MainActor.run { [weak self] in
-                guard let self else { return }
+                guard let self, generation == self.updateCheckGeneration else { return }
                 self.updateCheckInFlight = false
                 let decision = Updates.decide(
                     current: Updates.current, latest: latest, afterDays: afterDays

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -76,6 +76,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// discarded on arrival rather than reviving state the reload just
     /// changed.
     private var updateSchedulingGeneration = 0
+    /// Bumped by every manual check, so an older manual request's completion
+    /// — canceled, failed, or just slow — cannot overwrite the feedback for
+    /// a newer manual request the user is actually waiting on.
+    private var manualRequestID = 0
 
     private lazy var transcriber = Transcriber { [weak self] status in
         DispatchQueue.main.async { self?.handleTranscriberStatus(status) }
@@ -587,9 +591,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let generationAtStart = manualCheckGeneration
         let schedulingGenerationAtStart = updateSchedulingGeneration
+        let myRequestID: Int
         if manual {
             updateCheckInFlight = true
+            manualRequestID += 1
+            myRequestID = manualRequestID
             updateUI()
+        } else {
+            myRequestID = 0
         }
 
         Task<Void, Never> {
@@ -599,7 +608,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             } catch {
                 if manual {
                     await MainActor.run { [weak self] in
-                        guard let self else { return }
+                        // A newer manual request has since started — its own
+                        // completion owns the feedback now, not this one.
+                        guard let self, myRequestID == self.manualRequestID else { return }
                         guard self.updateSchedulingGeneration == schedulingGenerationAtStart else {
                             self.flash("Update check canceled — settings changed")
                             return
@@ -626,6 +637,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
             await MainActor.run { [weak self] in
                 guard let self else { return }
+                // A newer manual request has since started — its own
+                // completion owns the feedback now, not this one.
+                if manual, myRequestID != self.manualRequestID { return }
                 guard self.updateSchedulingGeneration == schedulingGenerationAtStart else {
                     if manual { self.flash("Update check canceled — settings changed") }
                     return

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -67,10 +67,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// True between a manual "Check for Updates" click and its answer, so the
     /// menu item can say so and a second click cannot start a second request.
     private var updateCheckInFlight = false
-    /// Bumped by every `checkForUpdate`, so a background check that answers
-    /// after a manual one has started cannot clobber the manual result — or
-    /// the reverse. Only the most recently started check's completion counts.
-    private var updateCheckGeneration = 0
+    /// Bumped by every manual check, so a background check that started
+    /// before it — and answers after — knows a manual answer has since
+    /// landed and does not overwrite it.
+    private var manualCheckGeneration = 0
 
     private lazy var transcriber = Transcriber { [weak self] status in
         DispatchQueue.main.async { self?.handleTranscriberStatus(status) }
@@ -572,13 +572,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
+        let generationAtStart = manualCheckGeneration
         if manual {
             updateCheckInFlight = true
+            manualCheckGeneration += 1
             updateUI()
         }
-
-        updateCheckGeneration += 1
-        let generation = updateCheckGeneration
 
         Task<Void, Never> {
             var latest: Updates.Release?
@@ -587,7 +586,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             } catch {
                 if manual {
                     await MainActor.run { [weak self] in
-                        guard let self, generation == self.updateCheckGeneration else { return }
+                        guard let self else { return }
                         self.updateCheckInFlight = false
                         Log.write("updates: check failed — \(error.localizedDescription)")
                         self.flash("Could not check for updates: \(error.localizedDescription)")
@@ -598,7 +597,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 latest = nil
             }
             await MainActor.run { [weak self] in
-                guard let self, generation == self.updateCheckGeneration else { return }
+                guard let self else { return }
+                // A manual answer always applies. A background one only does
+                // if a manual check has not started, or finished, meanwhile.
+                if !manual {
+                    guard !self.updateCheckInFlight,
+                        self.manualCheckGeneration == generationAtStart
+                    else { return }
+                }
                 self.updateCheckInFlight = false
                 let decision = Updates.decide(
                     current: Updates.current, latest: latest, afterDays: afterDays

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -674,6 +674,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     }
                 case .waiting(let release, let daysToGo):
                     self.updateAvailable = nil
+                    // A longer after_days can drop an already-alerted release
+                    // back into waiting. Forget the alert so it can fire
+                    // again once the release re-qualifies.
+                    if self.alertedUpdate == release.version { self.alertedUpdate = nil }
                     Log.write("updates: holding \(release.version) for \(daysToGo) more day(s)")
                     if manual {
                         self.flash(

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -61,6 +61,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// So the notice fires when a version first becomes available, and not
     /// again every day for as long as the user leaves it alone.
     private var announcedUpdate: String?
+    /// So the modal is offered once per version while idle, and not again on
+    /// every hourly check while the user is busy or has not answered it yet.
+    private var alertedUpdate: String?
+    /// True between a manual "Check for Updates" click and its answer, so the
+    /// menu item can say so and a second click cannot start a second request.
+    private var updateCheckInFlight = false
 
     private lazy var transcriber = Transcriber { [weak self] status in
         DispatchQueue.main.async { self?.handleTranscriberStatus(status) }
@@ -524,7 +530,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Updates
 
-    /// Once shortly after launch, then daily.
+    /// Once shortly after launch, then hourly.
     ///
     /// Restarted on every config load, since `after_days` can turn the whole
     /// thing off — and a setting that only takes effect after a restart is one
@@ -543,21 +549,50 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         DispatchQueue.main.asyncAfter(deadline: .now() + 20) { [weak self] in
             self?.checkForUpdate()
         }
-        let timer = Timer(timeInterval: 86_400, repeats: true) { [weak self] _ in
+        let timer = Timer(timeInterval: 3_600, repeats: true) { [weak self] _ in
             self?.checkForUpdate()
         }
         RunLoop.main.add(timer, forMode: .common)
         updatesTimer = timer
     }
 
-    private func checkForUpdate() {
+    /// - Parameter manual: True for a menu click, false for the timer.
+    ///   A manual check reports its result even when there is nothing new —
+    ///   a click with no visible answer reads as broken — and shows the
+    ///   update alert straight away rather than waiting for the app to go
+    ///   idle, since the user just asked for it.
+    private func checkForUpdate(manual: Bool = false) {
         let afterDays = config.updates.afterDays
-        guard afterDays >= 0 else { return }
+        guard afterDays >= 0 else {
+            if manual { flash("Update checks are disabled") }
+            return
+        }
+
+        if manual {
+            updateCheckInFlight = true
+            updateUI()
+        }
 
         Task<Void, Never> {
-            let latest = try? await Updates.latest()
+            var latest: Updates.Release?
+            do {
+                latest = try await Updates.latest()
+            } catch {
+                if manual {
+                    await MainActor.run { [weak self] in
+                        guard let self else { return }
+                        self.updateCheckInFlight = false
+                        Log.write("updates: check failed — \(error.localizedDescription)")
+                        self.flash("Could not check for updates: \(error.localizedDescription)")
+                        self.updateUI()
+                    }
+                    return
+                }
+                latest = nil
+            }
             await MainActor.run { [weak self] in
                 guard let self else { return }
+                self.updateCheckInFlight = false
                 let decision = Updates.decide(
                     current: Updates.current, latest: latest, afterDays: afterDays
                 )
@@ -569,10 +604,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         Log.write("updates: \(release.version) is available")
                         self.flash("ParrotFlow \(release.version) is available")
                     }
-                case .waiting(let release, let days):
+                    // The modal steals focus, so a background check waits for
+                    // a moment with nothing running. A manual check was asked
+                    // for, so it shows right away.
+                    let idle = !self.recorder.isRecording && self.runsInFlight <= 0
+                    if self.alertedUpdate != release.version, manual || idle {
+                        self.alertedUpdate = release.version
+                        self.showUpdate()
+                    }
+                case .waiting(let release, let daysToGo):
                     self.updateAvailable = nil
-                    Log.write("updates: holding \(release.version) for \(days) more day(s)")
-                default:
+                    Log.write("updates: holding \(release.version) for \(daysToGo) more day(s)")
+                    if manual {
+                        self.flash(
+                            "ParrotFlow \(release.version) is out, offered in "
+                                + "\(daysToGo) day\(daysToGo == 1 ? "" : "s")"
+                        )
+                    }
+                case .upToDate:
+                    self.updateAvailable = nil
+                    if manual { self.flash("ParrotFlow is up to date") }
+                case .skipped(let release):
+                    self.updateAvailable = nil
+                    if manual { self.flash("You skipped \(release.version)") }
+                case .snoozed(let release, _):
+                    self.updateAvailable = nil
+                    if manual { self.flash("ParrotFlow \(release.version) is snoozed for now") }
+                case .disabled:
                     self.updateAvailable = nil
                 }
                 self.updateUI()
@@ -612,6 +670,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             }
         }
+    }
+
+    @objc private func checkForUpdateNow() {
+        checkForUpdate(manual: true)
     }
 
     /// The release notes, and the three answers to them.
@@ -3784,9 +3846,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             ? "⚠︎ 1 setting in config.yaml does nothing"
             : "⚠︎ \(configProblems.count) settings in config.yaml do nothing"
 
-        updateItem.isHidden = updateAvailable == nil
-        if let release = updateAvailable {
+        if updateCheckInFlight {
+            updateItem.isHidden = false
+            updateItem.title = "Checking for Updates…"
+            updateItem.isEnabled = false
+        } else if let release = updateAvailable {
+            updateItem.isHidden = false
             updateItem.title = "↑ ParrotFlow \(release.version) is available"
+            updateItem.action = #selector(showUpdate)
+            updateItem.isEnabled = true
+        } else if config.updates.afterDays >= 0 {
+            updateItem.isHidden = false
+            updateItem.title = "Check for Updates"
+            updateItem.action = #selector(checkForUpdateNow)
+            updateItem.isEnabled = true
+        } else {
+            updateItem.isHidden = true
         }
     }
 

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -67,9 +67,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// True between a manual "Check for Updates" click and its answer, so the
     /// menu item can say so and a second click cannot start a second request.
     private var updateCheckInFlight = false
-    /// Bumped by every manual check, so a background check that started
-    /// before it — and answers after — knows a manual answer has since
-    /// landed and does not overwrite it.
+    /// Bumped when a manual check finishes, not when it starts — so a
+    /// background check that began during that manual check, and answers
+    /// after it, can tell its answer is now stale and skip overwriting it.
     private var manualCheckGeneration = 0
 
     private lazy var transcriber = Transcriber { [weak self] status in
@@ -575,7 +575,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let generationAtStart = manualCheckGeneration
         if manual {
             updateCheckInFlight = true
-            manualCheckGeneration += 1
             updateUI()
         }
 
@@ -588,6 +587,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     await MainActor.run { [weak self] in
                         guard let self else { return }
                         self.updateCheckInFlight = false
+                        self.manualCheckGeneration += 1
                         Log.write("updates: check failed — \(error.localizedDescription)")
                         self.flash("Could not check for updates: \(error.localizedDescription)")
                         self.updateUI()
@@ -606,6 +606,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     else { return }
                 }
                 self.updateCheckInFlight = false
+                if manual { self.manualCheckGeneration += 1 }
                 let decision = Updates.decide(
                     current: Updates.current, latest: latest, afterDays: afterDays
                 )

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3717,14 +3717,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         menu.addItem(.separator())
 
-        let correctItem = NSMenuItem(
-            title: "Correct a Word…",
-            action: #selector(correctWord),
-            keyEquivalent: ""
-        )
-        correctItem.target = self
-        menu.addItem(correctItem)
-
         let revealItem = NSMenuItem(
             title: "Open Recordings Folder",
             action: #selector(openRecordingsFolder),
@@ -3893,10 +3885,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     // MARK: - Menu actions
-
-    @objc private func correctWord() {
-        beginCorrection()
-    }
 
     /// `--preview-panel` shows the correction panel with sample text, so its
     /// layout can be iterated on without dictating into it every time.

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -599,9 +599,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             } catch {
                 if manual {
                     await MainActor.run { [weak self] in
-                        guard let self,
-                            self.updateSchedulingGeneration == schedulingGenerationAtStart
-                        else { return }
+                        guard let self else { return }
+                        guard self.updateSchedulingGeneration == schedulingGenerationAtStart else {
+                            self.flash("Update check canceled — settings changed")
+                            return
+                        }
                         self.updateCheckInFlight = false
                         self.manualCheckGeneration += 1
                         Log.write("updates: check failed — \(error.localizedDescription)")
@@ -613,9 +615,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 latest = nil
             }
             await MainActor.run { [weak self] in
-                guard let self,
-                    self.updateSchedulingGeneration == schedulingGenerationAtStart
-                else { return }
+                guard let self else { return }
+                guard self.updateSchedulingGeneration == schedulingGenerationAtStart else {
+                    if manual { self.flash("Update check canceled — settings changed") }
+                    return
+                }
                 // A manual answer always applies. A background one only does
                 // if a manual check has not started, or finished, meanwhile.
                 if !manual {

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -263,9 +263,9 @@ enum CheckConfigCommand {
         case ..<0:
             print("  · updates           never checked")
         case 0:
-            print("  · updates           checked daily, offered as soon as published")
+            print("  · updates           checked hourly, offered as soon as published")
         case let days:
-            print("  · updates           checked daily, offered after \(days) day\(days == 1 ? "" : "s")")
+            print("  · updates           checked hourly, offered after \(days) day\(days == 1 ? "" : "s")")
         }
 
         // Environment

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1040,7 +1040,7 @@ struct Config: Decodable, Equatable {
     /// A local Ollama model, used to interpret spoken commands.
     /// How long a release has to have existed before this Mac will take it.
     ///
-    /// Not a polling interval — the check itself is daily. This is a waiting
+    /// Not a polling interval — the check itself is hourly. This is a waiting
     /// period, and it is the only defence a one-person project has against its
     /// own release pipeline being taken: a bad release that is noticed and
     /// pulled inside the window is one nobody's app ever offered. See

--- a/Sources/ParrotFlow/UpdateCheckCommand.swift
+++ b/Sources/ParrotFlow/UpdateCheckCommand.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Asks the same question the app asks daily, and shows its working.
+/// Asks the same question the app asks hourly, and shows its working.
 ///
 ///     ParrotFlow --update-check
 ///     ParrotFlow --update-check --after-days 0

--- a/Sources/ParrotFlow/Updates.swift
+++ b/Sources/ParrotFlow/Updates.swift
@@ -136,7 +136,7 @@ enum Updates {
     // MARK: - Asking GitHub
 
     /// One call, no authentication. Unauthenticated GitHub allows 60 an hour
-    /// per address, and this runs once a day.
+    /// per address, and this runs once an hour — comfortably under the cap.
     static func latest(timeout: TimeInterval = 10) async throws -> Release {
         guard let url = URL(string: "https://api.github.com/repos/\(repo)/releases/latest") else {
             throw Failure.malformed("bad URL")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,12 +61,12 @@ logging:
 | Log | `~/Library/Logs/ParrotFlow.log` — off with `logging.text: false` |
 | The example transform | `~/.config/parrotflow/transforms/code_identifiers/`, written on first launch and never overwritten |
 
-The menu bar item shows the current state and offers *Correct a Word…*, *Open
-Recordings Folder* — the wavs, if `logging.audio` is on, and `trace.jsonl` —
-*Settings*, which holds *Edit Config…* (`config.yaml`) and *Open Config
-Folder* — everything you own, so `vocabulary.yaml`, `transforms/` and `voice/`
-too — and *Permissions…*. Both open in VS Code if it is installed, and in
-whatever the system would otherwise use if it is not. See [`logging`](#logging).
+The menu bar item shows the current state and offers *Open Recordings
+Folder* — the wavs, if `logging.audio` is on, and `trace.jsonl` — *Settings*,
+which holds *Edit Config…* (`config.yaml`) and *Open Config Folder* —
+everything you own, so `vocabulary.yaml`, `transforms/` and `voice/` too —
+and *Permissions…*. Both open in VS Code if it is installed, and in whatever
+the system would otherwise use if it is not. See [`logging`](#logging).
 
 ### A folder per transform
 

--- a/docs/corrections.md
+++ b/docs/corrections.md
@@ -122,7 +122,6 @@ sentence is French. Score a model or a prompt against them with
 
 ## Without speaking
 
-*Correct a Word…* in the menu opens the same panel,
 `--learn <heard> <corrected>` adds a rule from the terminal, and
 `--command "<what you'd say>"` shows how a phrase would be routed. See
 [cli.md](cli.md).

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -362,8 +362,8 @@ mention but notifies nobody — tell them that.
 >
 > Settings are in `~/.config/parrotflow/config.yaml`, and the names it has
 > learnt are in `vocabulary.yaml` beside it. Both reload on save. The menu bar
-> icon has *Correct a Word…*, *Settings* — *Edit Config…* and *View
-> Transforms* — and *Permissions…*.
+> icon has *Settings* — *Edit Config…* and *View Transforms* — and
+> *Permissions…*.
 
 ---
 


### PR DESCRIPTION
## Summary

- Poll GitHub for a new release every hour instead of once a day, still far under the 60/hour unauthenticated rate limit. `updates.after_days` is unchanged — it's a separate waiting period after a release publishes, not the polling rate.
- Pop the update `NSAlert` on its own once the app is idle, instead of only showing it when the user notices and clicks the menu-bar item. Gated on not being mid-recording or mid-transcription (`!recorder.isRecording && runsInFlight <= 0`) so it can never interrupt a dictation. If the app stays busy through every hourly check, the popup keeps retrying and the menu-bar item remains the manual fallback the whole time.
- Add a "Check for Updates" menu item so a check can be triggered on demand, instead of only waiting for the timer. It replaces the existing "available" item when there's nothing new, shows "Checking for Updates…" while in flight, and reports its result in every case (up to date, still waiting, skipped, snoozed, or a fetch failure) since a click with no visible response reads as broken. A manual check also shows the alert immediately rather than waiting for idle, since the user asked for it directly.
- Remove "Correct a Word…" from the menu (and its now-dead wrapper), and update the three docs pages that listed it as a way to reach the correction panel. `beginCorrection()` itself is untouched — it's still reached from the hotkey and offer paths.

## Test plan

- [x] `swift build` — clean, no errors
- [ ] Manual: click "Check for Updates" with no update available, confirm the flash and title revert
- [ ] Manual: click "Check for Updates" while offline, confirm the failure flash
- [ ] Manual: confirm the alert auto-pops once idle after a release is found, and not mid-dictation

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>