### PR TITLE
feat: a spelling lesson keeps the word it is teaching

### DIFF
--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -951,9 +951,12 @@ struct Pipeline: Equatable, Codable {
         _ step: Step, on text: String, config: Config, scope: Scope,
         findings: Vocabulary.Outcome?
     ) async -> StageResult {
-        func declined(_ why: String, _ vars: [String: Scope.Value] = [:]) -> StageResult {
+        func declined(
+            _ why: String, _ vars: [String: Scope.Value] = [:], fallback: String? = nil
+        ) -> StageResult {
             Log.write("pipeline: vocabulary — \(why)")
-            return StageResult(text: text, vars: vars.merging(["ok": .bool(false)]) { a, _ in a })
+            return StageResult(
+                text: fallback ?? text, vars: vars.merging(["ok": .bool(false)]) { a, _ in a })
         }
 
         let caps = step.caps ?? VocabularyJudge.Caps.standard
@@ -1040,8 +1043,7 @@ struct Pipeline: Equatable, Codable {
         // Nothing left for a model to answer. Returned before the `llm.enabled`
         // guard so the rule still fires on a machine with no Ollama.
         if taught.allSatisfy({ $0 }) {
-            let chosen = VocabularyJudge.applying(
-                taught.map { !$0 }, to: text, changes: changes)
+            let chosen = VocabularyJudge.reverting(taught, in: text, changes: changes)
             return StageResult(text: chosen, vars: [
                 "asked": .int(0), "slots": .int(slots.count),
                 "reverted": .string(lessons.joined(separator: "; ")),
@@ -1053,9 +1055,16 @@ struct Pipeline: Equatable, Codable {
         // thing about this stage a fixture can assert — the verdict comes from
         // a model and is not deterministic — and it was unreachable while this
         // guard ran first.
+        //
+        // A lesson mixed with an ordinary substitution still has a model to
+        // ask about the ordinary one, but not here: the model is off. The
+        // lesson is reverted anyway — that part never needed a model — and the
+        // ordinary change is left exactly as it arrived, same as every other
+        // decline in this stage.
         guard config.llm.enabled else {
             return declined("llm.enabled is false",
-                            ["asked": .int(0), "slots": .int(slots.count)])
+                            ["asked": .int(0), "slots": .int(slots.count)],
+                            fallback: VocabularyJudge.reverting(taught, in: text, changes: changes))
         }
 
         let built = VocabularyJudge.sentences(in: text, from: changes)
@@ -1081,7 +1090,8 @@ struct Pipeline: Equatable, Codable {
             )
         } catch {
             return declined("\(error.localizedDescription); kept as they are",
-                            ["asked": .int(changes.count), "slots": .int(slots.count)])
+                            ["asked": .int(changes.count), "slots": .int(slots.count)],
+                            fallback: VocabularyJudge.reverting(taught, in: text, changes: changes))
         }
 
         // A lesson mixed in with real questions is still shown to the model,

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -1019,14 +1019,20 @@ struct Pipeline: Equatable, Codable {
         guard !slots.isEmpty else {
             return StageResult(text: text, vars: ["asked": .int(0), "slots": .int(0)])
         }
+        // Computed ahead of the slot cap below, so a lesson still reverts even
+        // in a sentence with too many other places to send to a model.
+        let changes = VocabularyJudge.changes(in: text, from: slots)
+        let taught = VocabularyJudge.teaching(in: text, changes: changes)
+
         // Too many places to judge at once. Keeping what arrived is the safe
-        // answer, and it is logged rather than silent.
+        // answer, and it is logged rather than silent — except a spelling
+        // lesson, which was never going to a model anyway.
         guard slots.count <= caps.slots else {
             return declined("\(slots.count) slots > \(caps.slots); kept as they are",
-                            ["asked": .int(0), "slots": .int(slots.count)])
+                            ["asked": .int(0), "slots": .int(slots.count)],
+                            fallback: VocabularyJudge.reverting(taught, in: text, changes: changes))
         }
 
-        let changes = VocabularyJudge.changes(in: text, from: slots)
         guard !changes.isEmpty else {
             return StageResult(text: text, vars: ["asked": .int(0), "slots": .int(slots.count)])
         }
@@ -1034,7 +1040,6 @@ struct Pipeline: Equatable, Codable {
         // A spelling lesson is settled here and never asked about. Both models
         // measured answered all four of the archive's cases the wrong way, and
         // the prompt paragraph that described the pattern did not move them.
-        let taught = VocabularyJudge.teaching(in: text, changes: changes)
         let lessons = zip(changes, taught).filter { $0.1 }.map { "\($0.0.now) -> \($0.0.was)" }
         if !lessons.isEmpty {
             Log.write("vocabulary judge: spelling lesson, reverted without asking — "

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -1027,6 +1027,27 @@ struct Pipeline: Equatable, Codable {
         guard !changes.isEmpty else {
             return StageResult(text: text, vars: ["asked": .int(0), "slots": .int(slots.count)])
         }
+
+        // A spelling lesson is settled here and never asked about. Both models
+        // measured answered all four of the archive's cases the wrong way, and
+        // the prompt paragraph that described the pattern did not move them.
+        let taught = VocabularyJudge.teaching(in: text, changes: changes)
+        let lessons = zip(changes, taught).filter { $0.1 }.map { "\($0.0.now) -> \($0.0.was)" }
+        if !lessons.isEmpty {
+            Log.write("vocabulary judge: spelling lesson, reverted without asking — "
+                + lessons.joined(separator: "; "))
+        }
+        // Nothing left for a model to answer. Returned before the `llm.enabled`
+        // guard so the rule still fires on a machine with no Ollama.
+        if taught.allSatisfy({ $0 }) {
+            let chosen = VocabularyJudge.applying(
+                taught.map { !$0 }, to: text, changes: changes)
+            return StageResult(text: chosen, vars: [
+                "asked": .int(0), "slots": .int(slots.count),
+                "reverted": .string(lessons.joined(separator: "; ")),
+                "judged": .string(chosen),
+            ])
+        }
         // Checked here rather than at the top so that a pipeline with no model
         // still publishes what the stage found. `vocabulary.slots` is the one
         // thing about this stage a fixture can assert — the verdict comes from
@@ -1063,7 +1084,14 @@ struct Pipeline: Equatable, Codable {
                             ["asked": .int(changes.count), "slots": .int(slots.count)])
         }
 
+        // A lesson mixed in with real questions is still shown to the model,
+        // so the numbering `question` writes and `verdicts` reads stays one
+        // list. Its answer about that change is then discarded: the rule
+        // decides it, and the rule is 4/4 where the models are 0/4.
         let verdicts = VocabularyJudge.verdicts(reply, count: changes.count)
+            .enumerated().map { index, keep in
+                index < taught.count && taught[index] ? false : keep
+            }
         let chosen = VocabularyJudge.applying(verdicts, to: text, changes: changes)
         // What the judge undid, in the words it put back. Named `reverted`
         // rather than `kept_as_decoded`: on a menu a place that kept its

--- a/Sources/ParrotFlow/TeachingCommand.swift
+++ b/Sources/ParrotFlow/TeachingCommand.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Whether a substitution sits inside a spelling lesson.
+///
+///     ParrotFlow --teaching "Hey Barrot Versal Spells V E R C E L" Versal
+///     REVERT
+///     ParrotFlow --teaching "upload and Versal. Sending the file" Versal
+///     ASK
+///
+/// `VocabularyJudge.teaching` decides this with no model, no audio and no
+/// config behind it, and what it decides is whether a name is written over the
+/// word a correction is teaching. This is the entry point
+/// `scripts/check-spells-rule.sh` scores, so the set runs against the shipped
+/// function rather than against a copy of it.
+enum TeachingCommand {
+    static func run(text: String, word: String) -> Int32 {
+        guard let range = text.range(of: word) else {
+            print("not found: \(word)")
+            return 2
+        }
+        let change = VocabularyJudge.Change(
+            range: range, was: word, now: word, terms: []
+        )
+        let taught = VocabularyJudge.teaching(in: text, changes: [change])
+        print(taught[0] ? "REVERT" : "ASK")
+        return 0
+    }
+}

--- a/Sources/ParrotFlow/VocabularyJudge.swift
+++ b/Sources/ParrotFlow/VocabularyJudge.swift
@@ -97,10 +97,6 @@ enum VocabularyJudge {
         the original was the ordinary word and the name does not belong in that
         sentence.
 
-        Sometimes the user is teaching a correction rather than dictating — "urza
-        spells mirza", "Versal spells V E R C E L". The word before "spells" has to
-        survive. Keep those.
-
         The names in their vocabulary are: {terms}. Anything else in the sentence is an
         ordinary word, however much it looks like one of them.
 
@@ -906,6 +902,41 @@ enum VocabularyJudge {
                                 now: slot.options[1], terms: slot.terms))
         }
         return built
+    }
+
+    /// The changes a spelling lesson settles, so no model is asked about them.
+    ///
+    /// "urza spells mirza" teaches a mapping. The word before `spells` is the
+    /// source, and writing the term over it destroys the lesson — "Mirza spells
+    /// mirza" teaches nothing. `true` means revert it.
+    ///
+    /// Matched on the word after the span, not on the activation phrase. That
+    /// phrase is itself mangled in the archive — "Hey Barrot", "by the way
+    /// pirate" — so `spells` is the only reliable tell.
+    ///
+    /// **Measured on the four cases in `tests/judge-cases.yaml`**: the rule is
+    /// 4/4, and `gemma4:e4b-mlx` and `gemma3:4b` are both 0/4, each answering
+    /// KEEP to all of them. The sentence looks exactly like the one where a
+    /// name was misheard, so a model reading it has nothing to go on. Prose
+    /// telling it about the pattern was in `prompt` and did not fix them.
+    ///
+    /// The honest false positive is a sentence really about spelling — "Vercel
+    /// spells its name oddly" — which loses its substitution. Nothing in the
+    /// archive does that, and the cost is one name left as the decoder wrote
+    /// it, which is where every other failure in this stage lands.
+    static func teaching(in text: String, changes: [Change]) -> [Bool] {
+        changes.map { change in
+            var cursor = change.range.upperBound
+            while cursor < text.endIndex, text[cursor].isWhitespace {
+                cursor = text.index(after: cursor)
+            }
+            var next = ""
+            while cursor < text.endIndex, text[cursor].isLetter {
+                next.append(text[cursor])
+                cursor = text.index(after: cursor)
+            }
+            return next.compare("spells", options: .caseInsensitive) == .orderedSame
+        }
     }
 
     /// The sentence with every change taken, and the one with none of them.

--- a/Sources/ParrotFlow/VocabularyJudge.swift
+++ b/Sources/ParrotFlow/VocabularyJudge.swift
@@ -974,6 +974,24 @@ enum VocabularyJudge {
         return out + text[cursor...]
     }
 
+    /// Text with every taught span put back to what the decoder wrote, and
+    /// every other span left exactly as `text` already has it.
+    ///
+    /// Unlike `applying`, a change that is not being reverted is not
+    /// rewritten to `now` — the model may never have run, so there is no
+    /// verdict to write it from. This is what a spelling lesson mixed with an
+    /// ordinary substitution needs when the model is disabled or unreachable:
+    /// the lesson still gets undone, the ordinary change is left untouched.
+    static func reverting(_ taught: [Bool], in text: String, changes: [Change]) -> String {
+        var out = "", cursor = text.startIndex
+        for (index, change) in changes.enumerated() {
+            out += text[cursor..<change.range.lowerBound]
+            out += (index < taught.count && taught[index]) ? change.was : String(text[change.range])
+            cursor = change.range.upperBound
+        }
+        return out + text[cursor...]
+    }
+
     /// One verdict per change, read off the reply. `true` is KEEP.
     ///
     /// A number, then the word. Read loosely because a model that answers

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -196,6 +196,14 @@ if let index = arguments.firstIndex(of: "--verdicts") {
     exit(VerdictsCommand.run(count: count, reply: arguments[index + 2]))
 }
 
+if let index = arguments.firstIndex(of: "--teaching") {
+    guard arguments.indices.contains(index + 2) else {
+        print("usage: ParrotFlow --teaching \"<sentence>\" <word>")
+        exit(2)
+    }
+    exit(TeachingCommand.run(text: arguments[index + 1], word: arguments[index + 2]))
+}
+
 if let index = arguments.firstIndex(of: "--command") {
     guard arguments.indices.contains(index + 1) else {
         print("usage: ParrotFlow --command \"hey parrot, Tasmin spells T A S M E E N\""

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -80,6 +80,7 @@ $PF --normalize "<text>"
 $PF --dates "<instruction>" "<text>" [--locale FR] [--lang en,fr]
 $PF --inflected <term> <heard>
 $PF --verdicts <count> "<reply>"
+$PF --teaching "<sentence>" <word>
 ```
 
 `--inflected` asks what the vocabulary pass would write where a decoded word
@@ -94,6 +95,22 @@ question it answers is whether a possessive survives a substitution, and
 into somebody's sentence or takes one out, so it has its own set:
 `scripts/check-verdicts.sh` against `tests/verdict-cases.yaml`, malformed
 replies included.
+
+`--teaching` asks whether a substitution sits inside a spelling lesson —
+`--teaching "Hey Barrot Versal Spells V E R C E L" Versal` prints `REVERT`, and
+`ASK` for anything else. The word before `spells` is what a lesson is teaching,
+so writing the term over it destroys the correction: "Mirza spells mirza"
+teaches nothing. The judge reverts those without asking a model, because every
+model measured answered all four of the archive's cases the wrong way.
+
+Most lessons never reach it. "hey parrot, Tasmin spells T A S M E E N" is a
+[spoken instruction](#testing-a-spoken-instruction) and the vocabulary stage is
+skipped for it.
+The rule is for the ones where the wake phrase was itself mangled — "Hey
+Barrot", "by the way pirate" — so the command was never recognised and the
+sentence arrived as ordinary dictation. `scripts/check-spells-rule.sh` scores
+it against `tests/spells-cases.yaml` and sweeps all 59 of
+`tests/judge-cases.yaml` to check it fires nowhere else.
 
 `--pipeline` takes a YAML file holding a pipeline — its own, not your config —
 so a case file states the setup it assumes instead of inheriting this machine's.
@@ -389,6 +406,7 @@ scripts/check-vocabulary-config.sh # what vocabulary.yaml adds up to, old keys i
 scripts/check-possessive.sh        # whether a possessive survives a substitution
 scripts/check-verdicts.sh          # what the name judge reads out of a reply
 scripts/check-judge-prompt.sh      # the judge's prompt is one its parser can read
+scripts/check-spells-rule.sh       # a spelling lesson keeps the word it is teaching
 scripts/check-no-voice.sh          # nothing in git is one person's voice
 scripts/check-audio-recovery.sh    # a microphone that changes leaves a usable engine
 scripts/check-profiles.sh          # which app gets examined, named, or read for context

--- a/scripts/check-spells-rule.sh
+++ b/scripts/check-spells-rule.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Scores `VocabularyJudge.teaching` against tests/spells-cases.yaml.
+#
+#   scripts/check-spells-rule.sh
+#
+# The rule reverts a substitution sitting immediately before "spells", because
+# that word is the source of a spelling lesson and writing the term over it
+# destroys the correction the user is making.
+#
+# Two halves, and the second is the one that matters. Firing on the four real
+# lessons is easy. Not firing anywhere else is the whole risk: this rule runs
+# before the model and its answer cannot be argued with, so a false positive is
+# a name silently left as the decoder wrote it.
+#
+# So the sweep. Every case in tests/judge-cases.yaml is put to the rule, and it
+# has to fire on exactly the four lessons and nothing else. That set is 59
+# sentences of real dictation this rule was never tuned on, which is the only
+# evidence available that the pattern is as narrow as it looks.
+#
+# Nothing here calls a model. The rule is a pure function over text, and that
+# is the point of it — the four cases are the ones every model tried answered
+# the wrong way.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/release/ParrotFlow"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+
+CONFIG="$(mktemp -d -t parrotflow-spells)"
+trap 'rm -rf "$CONFIG"' EXIT
+export PARROTFLOW_CONFIG_DIR="$CONFIG"
+
+pass=0; total=0; missed=0; overfired=0
+
+echo "  tests/spells-cases.yaml"
+while IFS=$'\x1f' read -r name said heard expect; do
+  [ -z "$name" ] && continue
+  total=$((total + 1))
+  got="$("$BIN" --teaching "$said" "$heard" 2>/dev/null | tail -1)"
+
+  if [ "$got" = "$expect" ]; then
+    pass=$((pass + 1))
+    printf '    ✓ %-34s %s\n' "$name" "$got"
+    continue
+  fi
+  # Which direction, because they are not equally expensive. Failing to fire
+  # leaves the model to answer, which is the behaviour before this rule. Firing
+  # wrongly overrides a decision nothing can appeal.
+  if [ "$expect" = "REVERT" ]; then
+    missed=$((missed + 1)); why="did not fire; the model answers, as before"
+  else
+    overfired=$((overfired + 1)); why="fired on an ordinary sentence"
+  fi
+  printf '    ✗ %-34s got %s, want %s  (%s)\n' "$name" "$got" "$expect" "$why"
+done < <(python3 -c '
+import sys, yaml
+for case in yaml.safe_load(open(sys.argv[1]))["cases"]:
+    print("\x1f".join([case["name"], case["said"], case["heard"], case["expect"]]))
+' "$ROOT/tests/spells-cases.yaml")
+
+if [ "$total" -eq 0 ]; then
+  echo "    ✗ no cases read from tests/spells-cases.yaml"
+  exit 1
+fi
+
+# The sweep. `heard` is the decoder's word, so this asks the rule the same
+# question the stage asks it, on every substitution the archive proposed.
+echo
+echo "  sweep over tests/judge-cases.yaml"
+fired=0; swept=0; wrong=""
+while IFS=$'\x1f' read -r said heard; do
+  [ -z "$heard" ] && continue
+  swept=$((swept + 1))
+  got="$("$BIN" --teaching "$said" "$heard" 2>/dev/null | tail -1)"
+  [ "$got" != "REVERT" ] && continue
+  fired=$((fired + 1))
+  # A lesson has "spells" in it. Anything else the rule reverted is a case this
+  # script did not predict, and it is named rather than counted.
+  case "$(printf '%s' "$said" | tr '[:upper:]' '[:lower:]')" in
+    *" spells "*) ;;
+    *) wrong="$wrong\n      $heard — $said" ;;
+  esac
+done < <(python3 -c '
+import re, sys
+text = open(sys.argv[1]).read()
+for said, heard, _, _ in re.findall(
+        r"  - said: \"(.*?)\"\n    heard: \"(.*?)\"\n    term: \"(.*?)\"\n"
+        r"    expect: (\w+)", text, re.S):
+    print("\x1f".join([said, heard]))
+' "$ROOT/tests/judge-cases.yaml")
+
+printf '    fired on %d of %d substitutions\n' "$fired" "$swept"
+if [ "$swept" -eq 0 ]; then
+  echo "    ✗ no cases read from tests/judge-cases.yaml"
+  exit 1
+fi
+if [ -n "$wrong" ]; then
+  printf '    ✗ fired on a sentence with no spelling lesson in it:'
+  printf "$wrong\n"
+  overfired=$((overfired + 1))
+fi
+if [ "$fired" -ne 4 ]; then
+  printf '    ✗ expected 4, the lessons labelled in that file\n'
+  overfired=$((overfired + 1))
+fi
+
+echo
+printf '  %d/%d  (tests/spells-cases.yaml)\n' "$pass" "$total"
+[ "$overfired" -gt 0 ] && printf '    %d fired on an ordinary sentence  ← the expensive direction\n' "$overfired"
+[ "$missed" -gt 0 ] && printf '    %d did not fire\n' "$missed"
+[ "$pass" = "$total" ] && [ "$overfired" -eq 0 ]

--- a/tests/spells-cases.yaml
+++ b/tests/spells-cases.yaml
@@ -1,0 +1,73 @@
+# Spelling-lesson cases for `VocabularyJudge.teaching`.
+#
+# The rule reverts a substitution whose word sits immediately before "spells".
+# "urza spells mirza" teaches a mapping, and writing the term over the source
+# destroys it: "Mirza spells mirza" teaches nothing.
+#
+# expect: REVERT — the rule fires, and no model is asked
+# expect: ASK    — the rule does not fire, and the model decides as before
+#
+# The four real lessons are the ones harvested into tests/judge-cases.yaml.
+# Everything else here is a control, because a rule is only worth what it
+# leaves alone: `scripts/check-spells-rule.sh` also sweeps all 59 judge cases
+# and fails if the rule fires anywhere but on those four.
+
+cases:
+  # The four from the archive. The activation phrase is mangled in every one of
+  # them — "Hey Barrot", "by the way pirate" — which is why the match is on the
+  # word after the span and not on the phrase.
+  - name: versal spells, capital S
+    said: "Hey Barrot Versal Spells V E R C E L"
+    heard: "Versal"
+    expect: REVERT
+
+  - name: irza spells, mid sentence
+    said: "Uh, by the way, Irza spells Mirza mirza."
+    heard: "Irza"
+    expect: REVERT
+
+  - name: urza spells, no punctuation
+    said: "Uh by the way pirate urza spells mirza"
+    heard: "urza"
+    expect: REVERT
+
+  - name: pressy spells, letters after
+    said: "Hey Parrot, Pressy spells Pr. A I S Y"
+    heard: "Pressy"
+    expect: REVERT
+
+  # Controls. The same words, doing their ordinary job.
+  - name: versal not before spells
+    said: "there is a compression layer before between history and upload and Versal. Sending the file to its back end."
+    heard: "Versal"
+    expect: ASK
+
+  - name: praise is not a lesson
+    said: "The team deserves praise for how quickly they shipped a Ruxby."
+    heard: "praise"
+    expect: ASK
+
+  - name: bedrock is not a lesson
+    said: "I had Salmon with Salman and we argued about bedrock principles."
+    heard: "bedrock"
+    expect: ASK
+
+  # The word after the span is the test, so a term two words away is not one.
+  - name: spells further along the sentence
+    said: "Mirza said the dashboard spells every name wrong."
+    heard: "Mirza"
+    expect: ASK
+
+  # A lesson that ends the sentence has nothing after it.
+  - name: nothing follows the span
+    said: "Um not Peter, uh Frederick."
+    heard: "Frederick."
+    expect: ASK
+
+  # The honest false positive, recorded rather than hidden. A sentence really
+  # about spelling loses its substitution. Nothing in the archive does this,
+  # and the cost is one name left as the decoder wrote it.
+  - name: genuinely about spelling, and lost
+    said: "Versal spells its name oddly, with a c."
+    heard: "Versal"
+    expect: REVERT


### PR DESCRIPTION
## The bug

You say "urza spells mirza" to teach a mapping. The vocabulary pass rewrites the word before `spells` into the term it already knows, so the judge sees "Mirza spells mirza". The lesson is destroyed.

## The fix

`VocabularyJudge.teaching(in:changes:)` marks any substitution whose span is followed by the word `spells`. The judge reverts those without asking a model.

Measured on the four lessons in `tests/judge-cases.yaml`:

| arm | score |
| --- | --- |
| the rule | 4/4 |
| `gemma4:e4b-mlx` | 0/4 |
| `gemma3:4b` | 0/4 |

Both models answer KEEP to all four. The sentence looks exactly like one where a name was misheard, so a model reading it has nothing to go on.

`prompt` already described the pattern. It ended with "Keep those", which points the wrong way — keeping means the substitution stands. It moved neither model. Removed.

## Where it fires

Most lessons never reach the judge. "hey parrot, Tasmin spells T A S M E E N" is a spoken command, and the vocabulary stage is skipped for it. The rule is for the ones where the wake phrase was itself mangled — "Hey Barrot", "by the way pirate" — so the command was never recognised and the sentence arrived as ordinary dictation.

The rule is matched on the word after the span, not on the activation phrase, because that phrase is the part that is mangled.

## Two details in `Pipeline.judgeVocabulary`

- The check runs **before** the `config.llm.enabled` guard, so a machine with no Ollama still gets it.
- A lesson mixed with real questions is still shown to the model, so the numbering `question` writes and `verdicts` reads stays one list. Only the model's answer for that change is discarded.

## Cost

The honest false positive is a sentence really about spelling — "Vercel spells its name oddly" — which loses its substitution. `tests/spells-cases.yaml` records it as an expected REVERT. Nothing in the archive does this, and the cost is one name left as the decoder wrote it, which is where every other failure in this stage lands.

## Checks

- `scripts/check-spells-rule.sh` — 10/10 on `tests/spells-cases.yaml`, then sweeps all 59 substitutions in `tests/judge-cases.yaml` and fails if the rule fires anywhere but the 4 lessons. It fires on exactly 4. No model is called.
- `$PF --teaching "<sentence>" <word>` prints `REVERT` or `ASK`.
- Green: `check-verdicts` 24/24, `check-judge-prompt` 4/4, `check-pipeline` 71/71, `check-vocabulary-config` 61/61, `check-replacements` 23/23, `check-possessive` 35/35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)