### PR TITLE
fix: get past the version-manager shim, and stop trimming what a stage added

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3215,6 +3215,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         for press: Press
     ) {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        // What lands, which is not the same string. `trimmed` answers the
+        // questions — wake phrase, empty clip, inline instruction — and none of
+        // them care about the spaces at the ends. Delivery does: a stage that
+        // continues a sentence already in the box puts a space in front of its
+        // output, and trimming here is why that space never arrived.
+        //
+        // Newlines are still cut. A newline in a composer sends the message,
+        // and no stage has a reason to ask for one at either end.
+        let delivered = text.trimmingCharacters(in: .newlines)
 
         // Heard as a command, or nothing at all: no words are going to land,
         // so there is nothing to compare a pane against.
@@ -3249,7 +3258,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         Log.write("transcribed: \(trimmed)")
         lastTranscript = trimmed
-        insertDictation(trimmed, to: destination, for: press)
+        insertDictation(delivered, to: destination, for: press)
     }
 
     /// An instruction found inside a dictation: route it, run it over the words

--- a/Sources/ParrotFlow/CommandRunner.swift
+++ b/Sources/ParrotFlow/CommandRunner.swift
@@ -191,6 +191,7 @@ enum CommandRunner {
             environment["PARROTFLOW_PROTOCOL"] = "json"
             process.environment = environment
         }
+        applyInterpreterPath(to: process)
 
         let input = Pipe()
         let output = Pipe()
@@ -385,6 +386,85 @@ enum CommandRunner {
         let shellSyntax = CharacterSet(charactersIn: "|&;<>()$`\n")
         let prefix = arguments.rangeOfCharacter(from: shellSyntax) == nil ? "exec " : ""
         return prefix + quoted(program) + arguments
+    }
+
+    // MARK: - Getting past the version-manager shim
+
+    /// Where the real `python3` lives, resolved once per run of the app.
+    ///
+    /// A version manager puts a shell script on PATH in place of the
+    /// interpreter, and that script re-execs through its own launcher on every
+    /// call. Measured on a Mac with pyenv:
+    ///
+    ///     python3 -c pass  through the shim              301 ms
+    ///     python3 -c pass  through the real interpreter    20 ms
+    ///     repetitions.py   through the shim              308 ms
+    ///     repetitions.py   through the real interpreter    25 ms
+    ///
+    /// The interpreter reports its own path, so this asks it rather than
+    /// guessing at one manager's layout. pyenv, asdf, mise and a plain Homebrew
+    /// install all answer the same question.
+    private static let interpreterLock = NSLock()
+    /// Outer nil means "not asked yet", inner nil means "asked, found nothing".
+    nonisolated(unsafe) private static var interpreterDirectory: String??
+
+    private static func realInterpreterDirectory() -> String? {
+        interpreterLock.lock()
+        defer { interpreterLock.unlock() }
+        if let cached = interpreterDirectory { return cached }
+        let found = probeInterpreterDirectory()
+        interpreterDirectory = .some(found)
+        return found
+    }
+
+    private static func probeInterpreterDirectory() -> String? {
+        let probe = Process()
+        probe.executableURL = URL(fileURLWithPath: "/bin/sh")
+        probe.arguments = ["-c", "python3 -c 'import sys; print(sys.executable)'"]
+        let pipe = Pipe()
+        probe.standardOutput = pipe
+        probe.standardError = FileHandle.nullDevice
+
+        // The probe pays the shim once. Everything after it does not.
+        guard (try? probe.run()) != nil else { return nil }
+
+        // Read on another thread so the deadline below can still fire. A shim
+        // that hangs would otherwise hold every dictation from here on, and
+        // this optimisation is not worth a lost transcript.
+        let collected = Locked(Data())
+        let read = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            collected.mutate { $0 = data }
+            read.signal()
+        }
+        guard read.wait(timeout: .now() + Self.timeout) == .success else {
+            probe.terminate()
+            Log.write("command: python3 did not report its path in \(Self.timeout)s; kept PATH as it is")
+            return nil
+        }
+        probe.waitUntilExit()
+
+        let path = (String(data: collected.value, encoding: .utf8) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !path.isEmpty, FileManager.default.isExecutableFile(atPath: path) else { return nil }
+        Log.write("command: python3 resolves to \(path)")
+        return (path as NSString).deletingLastPathComponent
+    }
+
+    /// Put the real interpreter ahead of the shim for one subprocess.
+    ///
+    /// PATH rather than rewriting the command: the scripts say
+    /// `#!/usr/bin/env python3`, which is what makes them runnable by hand and
+    /// portable to a machine with a different layout. Changing what `env` finds
+    /// keeps both.
+    private static func applyInterpreterPath(to process: Process) {
+        guard let directory = realInterpreterDirectory() else { return }
+        var environment = process.environment ?? ProcessInfo.processInfo.environment
+        let existing = environment["PATH"] ?? ""
+        guard !existing.hasPrefix(directory + ":"), existing != directory else { return }
+        environment["PATH"] = existing.isEmpty ? directory : directory + ":" + existing
+        process.environment = environment
     }
 
     /// A path the shell will read as one word, whatever is in it.

--- a/Sources/ParrotFlow/CommandRunner.swift
+++ b/Sources/ParrotFlow/CommandRunner.swift
@@ -409,6 +409,9 @@ enum CommandRunner {
     nonisolated(unsafe) private static var interpreterDirectory: String??
 
     private static func realInterpreterDirectory() -> String? {
+        // Held across the probe on purpose. A second caller waits for the
+        // answer instead of starting a second probe, and the wait is bounded
+        // by the deadline in it. It happens once per run of the app.
         interpreterLock.lock()
         defer { interpreterLock.unlock() }
         if let cached = interpreterDirectory { return cached }
@@ -419,31 +422,58 @@ enum CommandRunner {
 
     private static func probeInterpreterDirectory() -> String? {
         let probe = Process()
-        probe.executableURL = URL(fileURLWithPath: "/bin/sh")
-        probe.arguments = ["-c", "python3 -c 'import sys; print(sys.executable)'"]
+        // `env`, not a shell. It execs the interpreter in place, so this holds
+        // one process and the deadline below signals the interpreter itself. A
+        // shell in between can hand stdout to a child that outlives it, and
+        // then nothing here knows what to terminate. PATH resolution is the
+        // whole point of the probe, and `env` is what does it.
+        probe.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        probe.arguments = ["python3", "-c", "import sys; print(sys.executable)"]
         let pipe = Pipe()
         probe.standardOutput = pipe
         probe.standardError = FileHandle.nullDevice
 
-        // The probe pays the shim once. Everything after it does not.
-        guard (try? probe.run()) != nil else { return nil }
-
-        // Read on another thread so the deadline below can still fire. A shim
-        // that hangs would otherwise hold every dictation from here on, and
-        // this optimisation is not worth a lost transcript.
+        // Read as it arrives, on Foundation's own queue. Reading to EOF from a
+        // thread of ours would hold that thread for as long as anything with
+        // the write end lives, and the deadline below cannot cut that short.
         let collected = Locked(Data())
-        let read = DispatchSemaphore(value: 0)
-        DispatchQueue.global(qos: .userInitiated).async {
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            collected.mutate { $0 = data }
-            read.signal()
+        let eof = DispatchSemaphore(value: 0)
+        let exited = DispatchSemaphore(value: 0)
+        pipe.fileHandleForReading.readabilityHandler = { handle in
+            let chunk = handle.availableData
+            if chunk.isEmpty {
+                handle.readabilityHandler = nil
+                eof.signal()
+            } else {
+                collected.mutate { $0.append(chunk) }
+            }
         }
-        guard read.wait(timeout: .now() + Self.timeout) == .success else {
-            probe.terminate()
-            Log.write("command: python3 did not report its path in \(Self.timeout)s; kept PATH as it is")
+        probe.terminationHandler = { _ in exited.signal() }
+
+        // The probe pays the shim once. Everything after it does not.
+        guard (try? probe.run()) != nil else {
+            pipe.fileHandleForReading.readabilityHandler = nil
             return nil
         }
-        probe.waitUntilExit()
+
+        if exited.wait(timeout: .now() + Self.timeout) == .timedOut {
+            // SIGTERM, then SIGKILL, which cannot be ignored. Waiting for the
+            // exit is what reaps it: returning from here with the process
+            // still running leaves a zombie nothing is watching.
+            probe.terminate()
+            if exited.wait(timeout: .now() + 0.5) == .timedOut {
+                kill(probe.processIdentifier, SIGKILL)
+                _ = exited.wait(timeout: .now() + 0.5)
+            }
+            pipe.fileHandleForReading.readabilityHandler = nil
+            Log.write("command: python3 did not say where it is in \(Self.timeout)s; left PATH alone")
+            return nil
+        }
+        // The line was written before the process exited, so this waits on the
+        // handoff from Foundation's queue and nothing longer. Whatever has
+        // arrived by then is what gets read.
+        _ = eof.wait(timeout: .now() + 0.25)
+        pipe.fileHandleForReading.readabilityHandler = nil
 
         let path = (String(data: collected.value, encoding: .utf8) ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,13 +133,34 @@ the text has moved on, because an undo fired against edited text is not an undo.
 | Bare-modifier polling | 25 ms, on top of the above |
 | Transcription of a normal sentence | about a second after you let go |
 | `replacements`, `fuzzy`, `numbers`, a `replace:` transform | 0.035 s measured on a line |
-| A `command:` transform | one process start — ~30 ms for `python3`, ~5 ms for a shell script |
+| A `command:` transform | one process start — ~25 ms for `python3`, ~5 ms for a shell script, ~300 ms if `python3` is a version-manager shim |
 | A `prompt:` transform, model warm | ~1.5 s |
 | A `prompt:` transform, model cold | 6.7 s, which `llm.keep_loaded` exists to avoid |
 
 The gap between the last three rows is the reason stages carry conditions: a
 `when:` that costs nothing is what keeps a stage that costs a second off the
 transcripts that never needed it.
+
+### The version-manager shim
+
+`python3` on a Mac with pyenv, asdf or mise is not the interpreter. It is a
+shell script that re-execs through the manager, on every call. Measured on one
+Mac with pyenv:
+
+| Command | Through the shim | Through the real interpreter |
+| --- | --- | --- |
+| `python3 -c pass` | 301 ms | 20 ms |
+| `repetitions.py` | 308 ms | 25 ms |
+
+Three Python transforms in a pipeline was about 0.9 s of launcher on every
+dictation. That is more than a warm `prompt:` stage costs, and a `command:`
+stage usually has no `when:` in front of it.
+
+`CommandRunner` asks the interpreter for `sys.executable` once per run of the
+app, then puts that directory in front of `PATH` for every command it starts.
+The same `sh -c exec` shape then costs 41 ms. It changes `PATH` rather than the
+command, so scripts keep their `#!/usr/bin/env python3` line and still run by
+hand.
 
 ### Start-up latency
 


### PR DESCRIPTION
Two bugs. Both were invisible because a number written down in `docs/architecture.md` was wrong.

## 1. Every `command:` transform paid the version-manager shim

`python3` on a Mac with pyenv is `~/.pyenv/shims/python3`. It is a shell script that re-execs through `pyenv exec`, on every call. Measured on one Mac:

| Command | Through the shim | Through the real interpreter |
| --- | --- | --- |
| `python3 -c pass` | 301 ms | 20 ms |
| `repetitions.py` | 308 ms | 25 ms |

Three Python transforms in a pipeline was about 0.9 s of launcher on every dictation. That is more than a warm `prompt:` stage costs, and a `command:` stage usually has no `when:` in front of it.

`CommandRunner` now asks the interpreter for `sys.executable` once per run of the app, then puts that directory in front of `PATH` for every command it starts. The same `sh -c exec` shape costs 41 ms after the change.

Three details:

- It changes `PATH`, not the command. The scripts keep `#!/usr/bin/env python3`, so they still run by hand and still work on a machine with a different layout.
- It asks the interpreter instead of guessing at a layout. pyenv, asdf, mise and a plain Homebrew install all answer the same question.
- The probe gets the same 2 s deadline a transform gets. It runs `/usr/bin/env python3` rather than a shell, so it is one process and the deadline signals the interpreter itself; on timeout it sends SIGTERM, then SIGKILL after 0.5 s, then waits, so nothing is left running or unreaped. Output is read by a `readabilityHandler` on Foundation's queue, so no thread of ours waits on the pipe. A shim that hangs cannot hold a dictation. On failure it caches "found nothing" and everything runs through `PATH` as before.

## 2. The app trimmed its own pipeline output

`finishTranscription` had one string:

```swift
let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
```

It fed both the decisions and `insertDictation`. So a leading space that a stage added on purpose was deleted by the app before delivery.

Now `trimmed` answers the questions about the transcript: a wake phrase, an empty clip, an inline instruction. None of those care about the spaces at the ends. A separate `delivered`, cut of newlines only, is what lands. Newlines stay cut because a newline in a composer sends the message.

This took four wrong diagnoses. The space failed identically in Slack, Gmail, Outlook and VS Code, and each report was read as new evidence about the app it failed in. Four unrelated surfaces behaving the same way is one cause upstream of all of them.

## 3. The stale figure

`docs/architecture.md` said a `command:` transform costs one process start, "~30 ms for `python3`". That is off by 10x on a machine with a version manager, and it is precisely why three unconditional Python stages looked free for months. The row now carries the measured numbers, and a new section explains the shim.

## Checks

Built with `swift build -c release`. All four scripts pass at their full numbers, the same as on `main`:

- `scripts/check-pipeline.sh` — 71/71
- `scripts/check-replacements.sh` — 23/23
- `scripts/check-default-config.sh` — pass (7 transforms, 7 pipeline steps)
- `scripts/check-dotted.sh` — 64/64, plus 2 known-unfixable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
