### PR TITLE
fix: a repeat holding "I" is no longer kept as a spelled letter

### DIFF
--- a/examples/transforms/repetitions/cases.yaml
+++ b/examples/transforms/repetitions/cases.yaml
@@ -111,6 +111,18 @@ cases:
   - probe: phrase
     input: "We can um can um with ITN we can write"
     expect: "We can um with ITN we can write"
+  # "I" is a pronoun and a spellable letter. The `spelled aloud` guard used to
+  # scan the whole run with `any`, so one capital "I" anywhere kept the repeat
+  # and no English phrase starting "I ..." was ever collapsed.
+  - probe: phrase
+    input: "I mean I mean what I want is this."
+    expect: "I mean what I want is this."
+  - probe: phrase
+    input: "I mean I mean I want want this."
+    expect: "I mean I want this."
+  - probe: phrase
+    input: "I think I think we should try it."
+    expect: "I think we should try it."
 
   # --- meant ---
   - probe: meant
@@ -179,3 +191,9 @@ cases:
   # A spelled name. The letter sits among other single letters.
   - probe: meant
     input: "she spells it m a r c but says Marc"
+  # A doubled capital letter is still a spelling. This is why the guard's
+  # capital-letter test stays, scoped to a one-word run.
+  - probe: meant
+    input: "the source is B B C news"
+  - probe: meant
+    input: "it takes A A batteries"

--- a/examples/transforms/repetitions/repetitions.py
+++ b/examples/transforms/repetitions/repetitions.py
@@ -7,6 +7,9 @@ on stdout.
       command: repetitions.py
       when: /\\b(\\w+(?:\\s+\\w+){0,3})\\s+\\1\\b/
 
+Add `returns: json` and it also publishes `repetitions.applied`, the names of
+the passes that fired, and `repetitions.edits`, how many cuts they made.
+
 Not `disfluency`, which asks a model to resolve what you meant ("with John, no,
 with Mark") and is reached by voice. This one deletes only an exact copy of
 what is already there, so it can run on every transcript — no model, no
@@ -19,8 +22,11 @@ the uh the summary") and after `numbers` ("two two three" is 223, not 23 with
 Timing is not used to tell a stutter from an intentional repeat — measured and
 found not to separate them. See scripts/disfluency-signals.py.
 """
+import json
+import os
 import re
 import sys
+from collections import namedtuple
 
 # Longest repeated phrase considered; longer than 3 words is unseen in the archive.
 MAX_PHRASE = 4
@@ -73,42 +79,72 @@ def is_letter(token):
     return len(token) == 1 and token.isalpha()
 
 
-def protected(tokens, i, n, text, words):
-    """Is this repeat one the speaker meant?
+class Repeat:
+    """One candidate repetition: `tokens[i:i+n]` followed by `tokens[i+n:i+2n]`.
 
-    The repeat is `tokens[i:i+n]` followed by `tokens[i+n:i+2n]`. `words` holds
-    the match objects, for the raw spelling and the text between the copies.
+    `words` holds the match objects, so the raw spelling and the text between
+    the copies stay reachable.
     """
-    unit = tokens[i:i + n]
 
-    if any(w in NEVER_COLLAPSE for w in unit):
-        return True
+    __slots__ = ("tokens", "i", "n", "text", "words")
 
+    def __init__(self, tokens, i, n, text, words):
+        self.tokens, self.i, self.n = tokens, i, n
+        self.text, self.words = text, words
+
+    @property
+    def unit(self):
+        """The repeated run, lowercased."""
+        return self.tokens[self.i:self.i + self.n]
+
+    @property
+    def raw(self):
+        """The same run as it is actually spelled."""
+        return [self.words[j].group() for j in range(self.i, self.i + self.n)]
+
+    @property
+    def neighbours(self):
+        """The words either side of the pair, for judging a lone letter."""
+        before = self.words[self.i - 1].group() if self.i > 0 else ""
+        after_at = self.i + 2 * self.n
+        after = self.words[after_at].group() if after_at < len(self.words) else ""
+        return before, after
+
+    @property
+    def between(self):
+        """What sits between the two copies."""
+        return self.text[self.words[self.i + self.n - 1].end():
+                         self.words[self.i + self.n].start()]
+
+
+# A reason to leave a repeat alone, with a name. `holds(repeat)` is the test.
+Guard = namedtuple("Guard", ("name", "holds"))
+
+# First match wins. The order only decides which name is reported when several
+# guards hold. Every one of these was a real transcript the naive rule damaged.
+KEPT = (
+    Guard("meant twice", lambda r: any(w in NEVER_COLLAPSE for w in r.unit)),
     # A number read as digits — losing one is unrecoverable.
-    if any(w.isdigit() for w in unit):
-        return True
+    Guard("a number", lambda r: any(w.isdigit() for w in r.unit)),
+    Guard("a list", lambda r: r.n > 1 and any(w in CONJUNCTIONS for w in r.unit)),
+    # A spelled name: one doubled capital letter, or a run that is all letters.
+    # The capital-letter test is n == 1 only. Scanning a longer run with `any`
+    # kept every English repeat holding "I" — "I mean I mean".
+    Guard("spelled aloud",
+          lambda r: (r.n == 1 and is_letter(r.raw[0]) and r.raw[0].isupper())
+          or (r.n > 1 and all(is_letter(x) for x in r.raw))),
+    # A lone lower-case letter is only a spelling if it sits among letters.
+    Guard("a letter among letters",
+          lambda r: r.n == 1 and is_letter(r.raw[0])
+          and any(is_letter(x) for x in r.neighbours)),
+    Guard("across a stop", lambda r: bool(SENTENCE_END.search(r.between))),
+)
 
-    if n > 1 and any(w in CONJUNCTIONS for w in unit):
-        return True
 
-    # A spelled name: doubled uppercase letter, starts with one, or the whole
-    # unit is single letters.
-    raw = [words[j].group() for j in range(i, i + n)]
-    if any(is_letter(r) and r.isupper() for r in raw):
-        return True
-    if n > 1 and all(is_letter(r) for r in raw):
-        return True
-    # Lowercase single letter: only a spelling if it sits among other letters.
-    if n == 1 and is_letter(raw[0]):
-        before = words[i - 1].group() if i > 0 else ""
-        after = words[i + 2 * n].group() if i + 2 * n < len(words) else ""
-        if is_letter(before) or is_letter(after):
-            return True
-
-    if SENTENCE_END.search(text[words[i + n - 1].end():words[i + n].start()]):
-        return True
-
-    return False
+def protecting(tokens, i, n, text, words):
+    """The name of the guard that holds this repeat, or None."""
+    repeat = Repeat(tokens, i, n, text, words)
+    return next((g.name for g in KEPT if g.holds(repeat)), None)
 
 
 # Single letters that are real words — deleting one as a false start breaks
@@ -120,7 +156,7 @@ def protected(tokens, i, n, text, words):
 SINGLE_LETTER_WORDS = {"a", "i", "y", "à", "o", "ô"}
 
 
-def drop_fragments(text):
+def drop_fragments(text, applied):
     """A word begun, abandoned, and restarted: "I mean w we can try" -> "I
     mean we can try". Only the adjacent single-letter case; a longer fragment
     ("in the tr in the terminal") isn't reached. Thin evidence — 2 examples in
@@ -158,6 +194,7 @@ def drop_fragments(text):
         if edit is None:
             return text
 
+        applied.append("false start")
         head = text[:words[edit].start()]
         tail = text[words[edit + 1].start():]
         if words[edit].group()[:1].isupper() and tail[:1].islower():
@@ -165,17 +202,20 @@ def drop_fragments(text):
         text = head + tail
 
 
-def collapse(text):
+def collapse(text, applied):
     """Both passes, to a fixed point — a dropped fragment can expose a new
-    repetition ("w we we can")."""
+    repetition ("w we we can").
+
+    `applied` is the list each pass names itself into, once per cut.
+    """
     while True:
-        out = collapse_repeats(drop_fragments(text))
+        out = collapse_repeats(drop_fragments(text, applied), applied)
         if out == text:
             return out
         text = out
 
 
-def collapse_repeats(text):
+def collapse_repeats(text, applied):
     """Delete the earlier copy of each repetition; the last copy is kept (it
     carries the trailing punctuation/spacing). Longest phrase first, then
     restart — a short match collapsed first can hide a longer one.
@@ -189,7 +229,7 @@ def collapse_repeats(text):
             for i in range(len(tokens) - 2 * n + 1):
                 if tokens[i:i + n] != tokens[i + n:i + 2 * n]:
                     continue
-                if protected(tokens, i, n, text, words):
+                if protecting(tokens, i, n, text, words):
                     continue
                 edit = (i, n)
                 break
@@ -200,6 +240,7 @@ def collapse_repeats(text):
             return text
 
         i, n = edit
+        applied.append("phrase said twice" if n > 1 else "word said twice")
         # Whatever sits between the two copies goes with the cut.
         head, tail = text[:words[i].start()], text[words[i + n].start():]
         # Keep the deleted copy's case: "The the prompt" -> "The prompt".
@@ -209,12 +250,29 @@ def collapse_repeats(text):
 
 
 def main():
-    text = sys.stdin.read()
+    # ParrotFlow sets PARROTFLOW_PROTOCOL=json when the transform declares
+    # `returns: json`, so the config stays the only place the protocol is
+    # named. Unset is the plain path, which is what the scorers pipe.
+    structured = os.environ.get("PARROTFLOW_PROTOCOL") == "json"
+    raw = sys.stdin.read()
+    text = json.loads(raw)["text"] if structured else raw
+
+    applied = []
     try:
-        sys.stdout.write(collapse(text))
+        out = collapse(text, applied)
     except Exception:
         # Fail open — never drop the whole transcript because a guard threw.
-        sys.stdout.write(text)
+        out = text
+        applied.clear()
+
+    if not structured:
+        sys.stdout.write(out)
+        return
+    print(json.dumps({
+        "text": out,
+        # Deduplicated: three of the same fault name it once.
+        "vars": {"applied": ", ".join(dict.fromkeys(applied)), "edits": len(applied)},
+    }))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The bug

`repetitions.py` deletes a word or phrase said twice by accident. The
`spelled aloud` guard kept a repeat that looked like a name being spelled out.
It scanned the whole repeated run for a capital letter:

```python
any(is_letter(x) and x.isupper() for x in r.raw)
```

`"I"` is one uppercase character. So every English repeat containing "I" was
protected. `I mean I mean`, `I think I think` and `I want I want` were never
collapsible. Confirmed against the script on `main`:

```
$ printf 'I mean I mean what I want is this.' | python3 repetitions.py
I mean I mean what I want is this.
```

## The fix

The capital-letter test is scoped to `n == 1`. That is all it ever needed. The
second clause of the guard already covers spelled runs longer than one word.

```
I mean I mean what I want is this.  ->  I mean what I want is this.
B B C news                          ->  unchanged
it takes A A batteries              ->  unchanged
```

The two keep cases are why the test stays at all. A variant that treats `I` and
`A` as ordinary words fixes `I I think so` but breaks both of them, so it was
rejected. `I I think so.` is still not collapsed. That is deliberate.

Three change cases and two keep cases are added to `cases.yaml` to hold this.

## The refactor that found it

Eight `if` tests in `protected()` became six named `Guard` values over a
`Repeat` context object, in a first-match-wins tuple called `KEPT`.

The names are the point. The pass could only ever answer yes or no. A repeat
that survived when it should not have gave no clue which test held it, so you
read the ladder and guessed. `protecting()` returns the guard's name instead.
`protected()` is gone; nothing called it.

## `returns: json`

The script now reads `PARROTFLOW_PROTOCOL`, as `docs/authoring.md` prescribes
and `code_identifiers.py` does. Under `returns: json` it publishes two
variables:

- `repetitions.applied` — the names of the passes that fired, deduplicated:
  `false start`, `word said twice`, `phrase said twice`.
- `repetitions.edits` — how many cuts they made.

`config.example.yaml` is unchanged, so nothing runs the JSON path yet. A
transform folder is written on first launch and never overwritten, so the
script has to support the key before a config can declare it. That is the order
`docs/authoring.md` asks for.

`echo "the the" | ./repetitions.py` still works by hand, which is what every
harness in `scripts/` does.

## Verification

```
$ PARROTFLOW_CONFIG_DIR="$HOME/.config/parrotflow-dev" ParrotFlow --eval repetitions
  change   39/39 = 100%
  keep     26/26 = 100%
  overall  65/65 = 100%
  fragment 3/3   meant 26/26   phrase 11/11   word 25/25

$ ./scripts/check-eval.sh
  25/25

$ ruff check examples/transforms/repetitions/repetitions.py
All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
