### PR TITLE
feat: code_identifiers publishes the identifiers it wrote

### DIFF
--- a/examples/transforms/code_identifiers/code_identifiers.py
+++ b/examples/transforms/code_identifiers/code_identifiers.py
@@ -132,7 +132,10 @@ def cased(words, style):
 
 
 def convert(text, converted=None):
-    """The rewrite. `converted`, if given, is appended one entry per name taken.
+    """The rewrite. `converted`, if given, gets one entry per name taken: the
+    identifier as written, `max_retries`, and not the "max retries" that was
+    heard. A later stage needs the written form to leave it alone. The spoken
+    form appears nowhere in the text it will be handed.
 
     An out-parameter rather than a second return value because
     `scripts/validate-code-identifiers.py` calls this as `shipped.convert` and
@@ -163,9 +166,10 @@ def convert(text, converted=None):
         # ordinary prose, and a search would rewrite that copy instead.
         start = match.end() + (len(window) - len(window.lstrip()))
         end = start + len(span)
-        out = out[:start] + cased(words, style_for(text, text[:match.start()])) + out[end:]
+        written = cased(words, style_for(text, text[:match.start()]))
+        out = out[:start] + written + out[end:]
         if converted is not None:
-            converted.append(span)
+            converted.append(written)
     return out
 
 
@@ -289,10 +293,10 @@ def place(reply, text, converted=None):
             if len(marked) != 1:
                 continue
             start = marked[0]
-        out = (out[:start] + cased(words, style_for(out, out[:start], language))
-               + out[start + len(span):])
+        written = cased(words, style_for(out, out[:start], language))
+        out = out[:start] + written + out[start + len(span):]
         if converted is not None:
-            converted.append(span)
+            converted.append(written)
     return out
 
 
@@ -343,7 +347,16 @@ if __name__ == "__main__":
     # re-derive the judgement from the words. `asked` is for the log rather than
     # for a condition — it is the difference between a stage that cost nothing
     # and one that cost a second, and it was previously invisible.
+    # `protected` is what a later stage reads to leave these words alone:
+    # identifiers this stage wrote on purpose. `join` capitalises the first word
+    # of a clip, and turned `max_retries` into `Max_retries` until it could ask.
+    # One string joined on "; " because a scope value is a scalar, so a
+    # condition reads it as `code_identifiers.protected.contains("max_retries")`.
     sys.stdout.write(json.dumps({
         "text": out,
-        "vars": {"count": len(converted), "asked_model": asked},
+        "vars": {
+            "count": len(converted),
+            "asked_model": asked,
+            "protected": "; ".join(dict.fromkeys(converted)),
+        },
     }))

--- a/tests/pipeline-cases.yaml
+++ b/tests/pipeline-cases.yaml
@@ -434,20 +434,47 @@ cases:
 
   # The shipped script, speaking the protocol, with the stage below it gated on
   # what it published. A sentence it takes:
+  #
+  # `protected` is the written identifier and not the words that were said. The
+  # spoken form appears nowhere in the text a later stage is handed, so a stage
+  # asked to leave a name alone could not find it.
   - name: the shipped transform publishes what it converted
     pipeline: vars-shipped
     input: a python function called max retries
     expect: a python function called max_retries
     expect_vars:
       code_identifiers.count: 1
+      code_identifiers.asked_model: false
+      code_identifiers.protected: max_retries
       dotted.ran: false
+  # A class, so the written form is the one thing the two can differ by: the
+  # words are the same and only the convention changed.
+  - name: and publishes it in the convention it wrote
+    pipeline: vars-shipped
+    input: a python class called user profile
+    expect: a python class called UserProfile
+    expect_vars:
+      code_identifiers.count: 1
+      code_identifiers.protected: UserProfile
+  # The same name twice. `count` says how much work the stage did and stays 2;
+  # `protected` is the list of words to leave alone, so it holds one entry.
+  - name: and names a repeated identifier once
+    pipeline: vars-shipped
+    input: a python function called max retries and another python function called max retries
+    expect: a python function called max_retries and another python function called max_retries
+    expect_vars:
+      code_identifiers.count: 2
+      code_identifiers.protected: max_retries
   # And one it declines, which is what lets the stage below it have a turn.
+  # Nothing converted means nothing to protect, so the list is empty rather
+  # than absent — a condition reading it must not fault.
   - name: and stands aside for the next stage when it converted nothing
     pipeline: vars-shipped
     input: read user dot name
     expect: read user.name
     expect_vars:
       code_identifiers.count: 0
+      code_identifiers.protected: ""
       dotted.ran: true
       dotted.changed: true
 


### PR DESCRIPTION
## The point

`code_identifiers` turns a spoken naming into an identifier. "a python function
called max retries" becomes "a python function called max_retries".

It already tracked every name it took, in a list called `converted`, and
published only the length as `count`. It recorded the wrong side. Both call
sites appended the **spoken input**:

```python
converted.append(span)        # "max retries"
```

The spoken form appears nowhere in the text a later stage is handed. No reader
could use it.

Both call sites now append the **written output**:

```python
converted.append(written)     # "max_retries"
```

`cased(...)` already computes it one line above. The change is two one-line
edits, one in `convert()` and one in `place()`, plus a new published variable:

```json
"vars": {"count": 1, "asked_model": false, "protected": "max_retries"}
```

## Why `protected`

`protected` is what a later stage reads to leave those words alone.

The `join` transform, in a separate later PR, capitalises the first word of a
dictated clip. Without this list it turned `max_retries` into `Max_retries`.
No amount of part-of-speech tagging fixes that. The word is a name because a
stage made it one. That is a fact about the pipeline, not about the language.

One string, joined on `"; "`, because a scope value is a scalar. It is read as
a condition:

```yaml
- transform: join
  unless: code_identifiers.protected.contains("max_retries")
```

Verified end to end with `--pipeline ... --vars`. With an identifier present:

```
code_identifiers.count = 1  code_identifiers.protected = "max_retries"
```

With nothing named, `protected` is `""` and the gated stage is skipped:

```
⊘ transform — skipped, when code_identifiers.protected.contains("max_retries")
              did not match (code_identifiers.protected = "")
```

## Why `place()` changes too

`place()` is the half that applies what a model extracted. The model only
extracts the language and the names. `place()` does the writing, and shares
`cased` and `style_for` with the rules half. So the written term is known
whether a model was asked or not, and both call sites change identically.

## The contract is held down by the pipeline set

`tests/pipeline-cases.yaml` gains four cases on `tests/pipelines/vars-shipped.yaml`.
That fixture declares `returns: json` and reaches the shipped script by symlink,
so the cases run the real binary over the real protocol against the file this PR
changes.

| case | assertion |
|---|---|
| written form | `a python function called max retries` → `protected = "max_retries"` |
| the convention | `a python class called user profile` → `protected = "UserProfile"` |
| deduplicated | the same name twice → `count = 2`, `protected = "max_retries"` |
| empty | nothing converted → `protected = ""` |

The first also pins `asked_model: false`, which already shipped unasserted.

The cases can fail. With `main`'s version of the script in place all four fail,
each on `protected` alone and none on the text. `scripts/check-pipeline.sh` is
73/73, up from 71/71 on `main`.

They are not in `scripts/validate-code-identifiers.py` because that scoreboard
imports the module and calls `convert` as a function. It never starts a process,
so it never sets `PARROTFLOW_PROTOCOL=json` and never reaches the block where
`protected` is built.

## On its own this changes no transcript text

`--eval code_identifiers`, against `main` and against this branch:

| | main | this PR |
|---|---|---|
| change | 38/43 = 88% | 38/43 = 88% |
| keep | 31/35 = 89% | 31/35 = 89% |
| overall | **69/78 = 88%** | **69/78 = 88%** |

Byte-identical, per-category grid included. The 9 failures are pre-existing and
model-only: the rules decline a naming with no marker word in front of it, by
design.

`convert()` and `place()` were also imported from both versions and compared
directly over every `input:` in `cases.yaml`:

- `convert()` — 78 calls, **0 differences**
- `place()` — 10458 calls (every 2 to 4 word span of every case, across 7
  `lang:` values), **0 differences** in output text and in the number of
  entries recorded

Other checks:

- `python3 scripts/validate-code-identifiers.py --code-only none` — 69/78 = 88%
- `ruff check examples/transforms/code_identifiers/code_identifiers.py` — clean,
  no config file and no per-line ignores
- `scripts/check-transform-folders.sh` — 11/12, the same 11/12 as `main` on this
  machine. The one failure is "a seeded config is clean", and it is
  `✗ microphone Not requested` in `--check-config`. That is a permission state
  on this Mac, not a code fault.

## Notes for the reviewer

- `count` stays `len(converted)` and counts every name taken. `protected` is
  deduplicated with `dict.fromkeys`, so a sentence that names the same
  identifier twice reports `count: 2` and one entry. The two answer different
  questions: how much work the stage did, and which words are now spoken for.
- The order of `protected` is not part of the contract. `convert()` scans right
  to left and `place()` follows the model's reply, so the two halves already
  disagree. Readers do membership tests.
- `"; "` can never appear inside an entry. `cased()` joins words with `_` or
  with nothing, and the words come from `re.split(r"[^\w'’]+", span)`.
- `docs/cli.md` shows a sample `--vars` dump that lists `count`. It does not
  list `asked_model` either, which already ships. That sample is illustrative,
  not a registry, and `docs/pipelines.md` says a `command:` transform
  "publishes whatever it likes". Documentation for `protected` belongs with the
  `join` PR, where there is a working example to document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
