### PR TITLE
feat: read the input box, tag the words, and hand a transform the whole run

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -154,6 +154,14 @@ jobs:
       - name: The correction panel's spans
         run: scripts/check-spans.sh
 
+      # Where the `input` stage cuts a field, and where the caret lands in it.
+      # The capture itself needs TCC and a real focused field, so it is not
+      # scored anywhere; this is the string step, which is the half that fails
+      # silently — a caret off by the size of the cut still points at a real
+      # character and the text still reads fine.
+      - name: Where the input stage cuts a field
+        run: scripts/check-input.sh
+
       # Which app gets which treatment. The one part of the destination path
       # that runs without a screen or a real app in front, and a wrong entry is
       # silent both ways — one already was, matching any app named "codex".

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -897,6 +897,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
+        // The same press, the other half of the window. Gated separately
+        // because it is a separate disclosure: `context` reads the terminal
+        // around the box, this reads what you have typed into it, in every app.
+        if InputBox.isConfigured(in: config) {
+            let app = front?.app
+            let element = focusAtPress?.element
+            DispatchQueue.global(qos: .userInitiated).async {
+                InputBox.capturePress(app: app, element: element)
+            }
+        }
+
         // Before the recording starts, because starting it is what takes the
         // offer off the screen. A new dictation is one of the ways the offer
         // ends, so it is one of the ways the keys go back.

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -910,8 +910,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if startsDictation, InputBox.isConfigured(in: config) {
             let app = front?.app
             let element = focusAtPress?.element
+            // By run, not into one slot. `pressRun` was bumped above, so this
+            // is the run the dictation about to start will carry, and the one
+            // its pipeline asks for. Dictations overlap.
+            let run = pressRun
             DispatchQueue.global(qos: .userInitiated).async {
-                InputBox.capturePress(app: app, element: element)
+                InputBox.capturePress(run: run, app: app, element: element)
             }
         }
 
@@ -1461,7 +1465,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     beside: recording.url.deletingLastPathComponent()
                 ) {
                     let text = try await self?.transcriber.transcribe(
-                        url: recording.url, config: config, app: app,
+                        url: recording.url, config: config, app: app, press: press.run,
                         progress: { label in
                             Task { @MainActor [weak self] in
                                 // Still this dictation, and still one that has
@@ -2717,6 +2721,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// reach anything that is somehow left.
     private func dictationEnded(_ run: Int) {
         screenAtPress.removeValue(forKey: run)
+        InputBox.forget(run)
         pressesInFlight.remove(run)
         cancelledPresses.remove(run)
     }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -913,7 +913,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // By run, not into one slot. `pressRun` was bumped above, so this
             // is the run the dictation about to start will carry, and the one
             // its pipeline asks for. Dictations overlap.
+            //
+            // The slot is reserved here, on this thread, before the read is
+            // dispatched. It is what `dictationEnded` removes, and what a read
+            // that finishes late checks itself against.
             let run = pressRun
+            InputBox.beginPress(run)
             DispatchQueue.global(qos: .userInitiated).async {
                 InputBox.capturePress(run: run, app: app, element: element)
             }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -872,7 +872,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // ends one — the second press of a toggle, a stutter inside the release
         // tail — is not aiming a new pill, and taking a fresh snapshot there
         // would throw away the one the running dictation is going to need.
-        if !recorder.isRecording {
+        let startsDictation = !recorder.isRecording
+        if startsDictation {
             anchorAtPress = nil
             pressRun += 1
             readTheAnchor()
@@ -889,7 +890,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // one thing this handler may not do is delay recording. Gated on the
         // stage being configured, so a config that never asked for context pays
         // nothing for the question.
-        if Context.isConfigured(in: config) {
+        //
+        // And on the press starting one, for the reason the anchor above is.
+        // The second press of a toggle, and a stutter inside the release tail,
+        // belong to the dictation already running. Capturing there replaces
+        // what that dictation is going to read with the screen as it stands
+        // when it ends. There is one capture, not one per press.
+        if startsDictation, Context.isConfigured(in: config) {
             let app = front?.app
             let element = focusAtPress?.element
             DispatchQueue.global(qos: .userInitiated).async {
@@ -900,7 +907,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // The same press, the other half of the window. Gated separately
         // because it is a separate disclosure: `context` reads the terminal
         // around the box, this reads what you have typed into it, in every app.
-        if InputBox.isConfigured(in: config) {
+        if startsDictation, InputBox.isConfigured(in: config) {
             let app = front?.app
             let element = focusAtPress?.element
             DispatchQueue.global(qos: .userInitiated).async {

--- a/Sources/ParrotFlow/CommandRunner.swift
+++ b/Sources/ParrotFlow/CommandRunner.swift
@@ -275,8 +275,21 @@ enum CommandRunner {
                 Log.write("command: \"\(command)\" could not be given its context; sent bare text")
             }
         }
-        input.fileHandleForWriting.write(payload)
-        try? input.fileHandleForWriting.close()
+        // Off this thread, for the reason the stdout handler above is. The
+        // envelope now carries the trace, which holds every word the decoder
+        // produced with its timings, so a long dictation puts it past the 64 KB
+        // pipe buffer. A synchronous write of more than that blocks until the
+        // script reads it, and a script that never reads its stdin would hang
+        // here — before `exited.wait` and its timeout is ever reached.
+        //
+        // `write(contentsOf:)` rather than `write(_:)`: the throwing one. A
+        // script that exits before reading closes the pipe, and the
+        // non-throwing call raises an uncatchable exception on that.
+        let handed = payload
+        DispatchQueue.global(qos: .userInitiated).async {
+            try? input.fileHandleForWriting.write(contentsOf: handed)
+            try? input.fileHandleForWriting.close()
+        }
 
         if exited.wait(timeout: .now() + timeout) == .timedOut {
             stop(process)

--- a/Sources/ParrotFlow/CommandRunner.swift
+++ b/Sources/ParrotFlow/CommandRunner.swift
@@ -105,9 +105,28 @@ enum CommandRunner {
     }
 
     /// What goes in on stdin when a transform declares `returns: json`.
+    ///
+    /// `tokens` sits beside `text` rather than inside `ctx` on purpose. `ctx` is
+    /// the scope, and the scope is scalars because a `when:` condition compares
+    /// scalars. An array of records would drag `Scope.Value` somewhere it does
+    /// not need to go.
     private struct Envelope: Encodable {
         let text: String
         let ctx: Context
+        /// Recomputed per stage, against the text *this* stage was handed.
+        /// Caching it across stages would hand a script offsets into a string
+        /// that no longer exists, and at 0.29 ms there is nothing to save.
+        let tokens: [Tagger.Token]
+        /// Everything the trace has gathered for this dictation so far: the
+        /// decoder's own text with its per-word timings and confidences, the
+        /// speech segments, and the stages that already ran. Absent outside a
+        /// dictation — `--pipeline` has no collector.
+        let trace: Trace.Snapshot?
+        /// Whether `text` is still the decoder's own, and so whether the word
+        /// offsets in `trace.asr.words` line up with it. False as soon as any
+        /// stage rewrites. Stated rather than left to be worked out, because
+        /// acting on stale offsets fails silently.
+        let aligned: Bool
     }
 
     /// What must come back. Both keys optional, because a script that only
@@ -238,7 +257,19 @@ enum CommandRunner {
         var payload = Data(text.utf8)
         if structured, let context {
             let encoder = JSONEncoder()
-            if let encoded = try? encoder.encode(Envelope(text: text, ctx: context)) {
+            // The language the pipeline settled on, not one detected again
+            // here. Two sources for one field is how they disagree.
+            let language: String? = {
+                if case .string(let value)? = context.scope["language"] { return value }
+                return nil
+            }()
+            let snapshot = Trace.current?.snapshot()
+            let envelope = Envelope(
+                text: text, ctx: context,
+                tokens: Tagger.tokens(in: text, language: language),
+                trace: snapshot,
+                aligned: snapshot?.decodedText == text)
+            if let encoded = try? encoder.encode(envelope) {
                 payload = encoded
             } else {
                 Log.write("command: \"\(command)\" could not be given its context; sent bare text")

--- a/Sources/ParrotFlow/InputBox.swift
+++ b/Sources/ParrotFlow/InputBox.swift
@@ -69,6 +69,7 @@ enum InputBox {
         case unreadable = "the focused element publishes no value"
         case noInputBox = "no input box found between the rules this terminal draws"
         case noPress = "nothing was captured when the hotkey went down"
+        case reading = "the field was still being read when this stage was reached"
     }
 
     // MARK: - The capture, which happens when the hotkey goes down
@@ -85,28 +86,25 @@ enum InputBox {
     ///
     /// Not one slot. Dictations overlap — a second press while the first is
     /// still being transcribed is an ordinary thing to do, and the app already
-    /// keys `screenAtPress` and `pressesInFlight` the same way. With one slot
-    /// the second press cleared what the first dictation had not read yet, so
-    /// the first got `noPress` and then, once the second read finished, the
-    /// second field.
+    /// keys `screenAtPress`, `pressesInFlight` and `cancelledPresses` the same
+    /// way. With one slot the second press cleared what the first dictation had
+    /// not read yet, so the first got `noPress` and then, once the second read
+    /// finished, the second field.
     ///
-    /// Emptied by `forget(_:)` from `dictationEnded`, however the dictation
-    /// finished, and capped below in case a press ever ends without one.
+    /// **A run is only ever in here between `beginPress` and `forget`.** The
+    /// entry is reserved on the main thread at the press and removed by
+    /// `dictationEnded`, so a read that finishes after its dictation is over —
+    /// the accessibility value has been observed at 237k characters — finds no
+    /// entry to write into and is dropped. That is what keeps this from
+    /// growing, and it is the same invariant `pressesInFlight` already rests
+    /// on: every way a dictation ends goes through `dictationEnded`.
+    ///
+    /// No cap, deliberately. A cap has to evict something, and the only thing
+    /// it could evict is the oldest run — which in an overlap is a dictation
+    /// still in flight. A bound that corrupts live state is worse than no
+    /// bound.
     private static let pressLock = NSLock()
     nonisolated(unsafe) private static var presses: [Int: Press] = [:]
-
-    /// Runs whose dictation is over. A read is started at the press and can
-    /// finish after that dictation has ended — the accessibility value has been
-    /// observed at 237k characters — and storing it then would put back an
-    /// entry nothing will ever remove again. Kept so a late read can be
-    /// dropped instead.
-    nonisolated(unsafe) private static var ended: Set<Int> = []
-
-    /// How many to keep of each. Nothing needs more than the presses in
-    /// flight, which is one or two; these are bounds in case a run somehow
-    /// never reaches `forget`.
-    private static let maxPresses = 8
-    private static let maxEnded = 32
 
     static func capture(for run: Int) -> Press? {
         pressLock.lock()
@@ -114,14 +112,19 @@ enum InputBox {
         return presses[run]
     }
 
+    /// Reserve this run's slot. **Main thread, at the press**, before the read
+    /// is dispatched: it is what says the run is live, so a read that comes
+    /// back late has something to check itself against.
+    static func beginPress(_ run: Int) {
+        pressLock.lock()
+        presses[run] = Press(outcome: .failure(.reading), ms: 0)
+        pressLock.unlock()
+    }
+
     /// This dictation is over, however it ended.
     static func forget(_ run: Int) {
         pressLock.lock()
         presses.removeValue(forKey: run)
-        ended.insert(run)
-        if ended.count > maxEnded {
-            for old in ended.sorted().prefix(ended.count - maxEnded) { ended.remove(old) }
-        }
         pressLock.unlock()
     }
 
@@ -129,8 +132,9 @@ enum InputBox {
         config.transcription.pipelines.values.contains { $0.stages.contains(.input) }
     }
 
-    /// Call **after** recording has started, off the main thread. The element
-    /// was resolved on the main thread at press and must not be re-resolved.
+    /// Call **after** recording has started, off the main thread, and after
+    /// `beginPress` for the same run. The element was resolved on the main
+    /// thread at press and must not be re-resolved.
     static func capturePress(run: Int, app: Pipeline.App?, element: AXUIElement?) {
         guard let element else { return }
 
@@ -139,18 +143,14 @@ enum InputBox {
         let ms = (CFAbsoluteTimeGetCurrent() - started) * 1000
 
         pressLock.lock()
-        let stale = ended.contains(run)
-        if !stale {
-            presses[run] = Press(outcome: outcome, ms: ms)
-            if presses.count > maxPresses {
-                for old in presses.keys.sorted().prefix(presses.count - maxPresses) {
-                    presses.removeValue(forKey: old)
-                }
-            }
-        }
+        // Only into a slot that is still reserved. No slot means the dictation
+        // ended while this read was running, and writing then would put back an
+        // entry nothing will remove again.
+        let live = presses[run] != nil
+        if live { presses[run] = Press(outcome: outcome, ms: ms) }
         pressLock.unlock()
 
-        guard !stale else {
+        guard live else {
             Log.write(String(
                 format: "input: a %.0fms read finished after its dictation ended; dropped", ms))
             return

--- a/Sources/ParrotFlow/InputBox.swift
+++ b/Sources/ParrotFlow/InputBox.swift
@@ -81,19 +81,36 @@ enum InputBox {
         let ms: Double
     }
 
+    /// One capture per press, by press run.
+    ///
+    /// Not one slot. Dictations overlap — a second press while the first is
+    /// still being transcribed is an ordinary thing to do, and the app already
+    /// keys `screenAtPress` and `pressesInFlight` the same way. With one slot
+    /// the second press cleared what the first dictation had not read yet, so
+    /// the first got `noPress` and then, once the second read finished, the
+    /// second field.
+    ///
+    /// Emptied by `forget(_:)` from `dictationEnded`, however the dictation
+    /// finished, and capped below in case a press ever ends without one.
     private static let pressLock = NSLock()
-    nonisolated(unsafe) private static var press: Press?
+    nonisolated(unsafe) private static var presses: [Int: Press] = [:]
 
-    /// Which press the stored capture belongs to. Two reads can be in flight at
-    /// once and nothing makes them finish in order — see `Context.pressGeneration`,
-    /// which this mirrors deliberately rather than sharing, so one stage being
-    /// configured never starts the other one's read.
-    nonisolated(unsafe) private static var pressGeneration = 0
+    /// How many captures to keep. Nothing needs more than the presses in
+    /// flight, which is one or two; this is only a bound in case a run is
+    /// somehow never forgotten.
+    private static let maxPresses = 8
 
-    static var pressCapture: Press? {
+    static func capture(for run: Int) -> Press? {
         pressLock.lock()
         defer { pressLock.unlock() }
-        return press
+        return presses[run]
+    }
+
+    /// This dictation is over, however it ended.
+    static func forget(_ run: Int) {
+        pressLock.lock()
+        presses.removeValue(forKey: run)
+        pressLock.unlock()
     }
 
     static func isConfigured(in config: Config) -> Bool {
@@ -102,12 +119,7 @@ enum InputBox {
 
     /// Call **after** recording has started, off the main thread. The element
     /// was resolved on the main thread at press and must not be re-resolved.
-    static func capturePress(app: Pipeline.App?, element: AXUIElement?) {
-        pressLock.lock()
-        pressGeneration += 1
-        let mine = pressGeneration
-        press = nil
-        pressLock.unlock()
+    static func capturePress(run: Int, app: Pipeline.App?, element: AXUIElement?) {
         guard let element else { return }
 
         let started = CFAbsoluteTimeGetCurrent()
@@ -115,15 +127,14 @@ enum InputBox {
         let ms = (CFAbsoluteTimeGetCurrent() - started) * 1000
 
         pressLock.lock()
-        let newest = mine == pressGeneration
-        if newest { press = Press(outcome: outcome, ms: ms) }
+        presses[run] = Press(outcome: outcome, ms: ms)
+        if presses.count > maxPresses {
+            for old in presses.keys.sorted().prefix(presses.count - maxPresses) {
+                presses.removeValue(forKey: old)
+            }
+        }
         pressLock.unlock()
 
-        guard newest else {
-            Log.write(String(
-                format: "input: a %.0fms read was overtaken by a newer press; dropped", ms))
-            return
-        }
         switch outcome {
         case .success(let capture):
             Log.write(String(

--- a/Sources/ParrotFlow/InputBox.swift
+++ b/Sources/ParrotFlow/InputBox.swift
@@ -1,0 +1,222 @@
+import AppKit
+import ApplicationServices
+
+/// What is already in the field you are dictating into, and where the caret is.
+///
+/// The `input` pipeline stage is the only caller. It publishes what this
+/// returns as `input.*`, so a later stage can tell appending from inserting —
+/// a transcript joining the end of a paragraph wants different punctuation
+/// from one dropped into the middle of a sentence.
+///
+/// ## Why this is not part of `context`
+///
+/// `Context` reads the screen *around* the box and is terminals-only, because
+/// everywhere else that means walking a window's children. This reads the box
+/// itself, which is the focused element, which is one call in every surface
+/// `Surface` already handles — a native field, a browser, an Electron
+/// composer. The two stages cover opposite halves of the same window and cost
+/// completely different things.
+///
+/// They are also different disclosures. Naming `context` says "read my
+/// terminal". It must not also mean "read what I have typed in every app I
+/// dictate into", so this is a stage of its own and you turn it on by name.
+enum InputBox {
+
+    /// One read of the field, cut where the caret is.
+    ///
+    /// Three blocks rather than a string and an offset. An offset has to be
+    /// applied by whoever reads it, and applying it wrong is silent — a caret
+    /// off by the size of the window still points at a real character and the
+    /// text still reads fine. Two strings cannot be misapplied.
+    ///
+    /// `selection` is the third block because dictating over a selection
+    /// replaces it, and what is about to be replaced is worth seeing.
+    struct Capture {
+        /// What precedes the caret, or the start of the selection. Nil where
+        /// the surface publishes no caret — see `text`.
+        let before: String?
+        /// What is selected, empty for a plain caret. Nil with `before`.
+        let selection: String?
+        /// What follows the caret, or the end of the selection. Nil with
+        /// `before`.
+        let after: String?
+        /// The whole box, for a surface whose caret could not be located. A
+        /// terminal publishes the screen as its value, so the box is dug out
+        /// from between the rules the TUI draws and the offset does not survive
+        /// that. Never set at the same time as `before`: two shapes, and which
+        /// one you got says what the surface could answer.
+        let text: String?
+        /// The caret is at the very end with nothing selected. Computed before
+        /// windowing, so a truncated capture still answers it correctly.
+        let appending: Bool?
+        /// The whole field, before `maxChars` cut anything out of it.
+        let total: Int
+        let truncated: Bool
+
+        var chars: Int {
+            (before?.count ?? 0) + (selection?.count ?? 0)
+                + (after?.count ?? 0) + (text?.count ?? 0)
+        }
+    }
+
+    /// Why a read did not happen. Published as `input.declined`, because a box
+    /// that was empty and a box nobody was allowed to look at are different
+    /// answers and a condition should be able to tell them apart.
+    enum Declined: String, Error {
+        case noPermission = "accessibility is not granted"
+        case noApp = "the pipeline was not told which app this is for"
+        case nothingFocused = "nothing is focused"
+        case unreadable = "the focused element publishes no value"
+        case noInputBox = "no input box found between the rules this terminal draws"
+        case noPress = "nothing was captured when the hotkey went down"
+    }
+
+    // MARK: - The capture, which happens when the hotkey goes down
+
+    /// Read at the press for the same reason `Context` is: by the time the
+    /// pipeline runs, focus may be somewhere else, and "what was in the box you
+    /// were typing in" is not answerable from there.
+    struct Press {
+        let outcome: Result<Capture, Declined>
+        let ms: Double
+    }
+
+    private static let pressLock = NSLock()
+    nonisolated(unsafe) private static var press: Press?
+
+    /// Which press the stored capture belongs to. Two reads can be in flight at
+    /// once and nothing makes them finish in order — see `Context.pressGeneration`,
+    /// which this mirrors deliberately rather than sharing, so one stage being
+    /// configured never starts the other one's read.
+    nonisolated(unsafe) private static var pressGeneration = 0
+
+    static var pressCapture: Press? {
+        pressLock.lock()
+        defer { pressLock.unlock() }
+        return press
+    }
+
+    static func isConfigured(in config: Config) -> Bool {
+        config.transcription.pipelines.values.contains { $0.stages.contains(.input) }
+    }
+
+    /// Call **after** recording has started, off the main thread. The element
+    /// was resolved on the main thread at press and must not be re-resolved.
+    static func capturePress(app: Pipeline.App?, element: AXUIElement?) {
+        pressLock.lock()
+        pressGeneration += 1
+        let mine = pressGeneration
+        press = nil
+        pressLock.unlock()
+        guard let element else { return }
+
+        let started = CFAbsoluteTimeGetCurrent()
+        let outcome = read(app: app, from: element)
+        let ms = (CFAbsoluteTimeGetCurrent() - started) * 1000
+
+        pressLock.lock()
+        let newest = mine == pressGeneration
+        if newest { press = Press(outcome: outcome, ms: ms) }
+        pressLock.unlock()
+
+        guard newest else {
+            Log.write(String(
+                format: "input: a %.0fms read was overtaken by a newer press; dropped", ms))
+            return
+        }
+        switch outcome {
+        case .success(let capture):
+            Log.write(String(
+                format: "input: captured %d of %d chars at press in %.0fms, %@",
+                capture.chars, capture.total, ms,
+                capture.before == nil ? "caret unknown"
+                    : (capture.appending == true ? "appending" : "inserting")))
+        case .failure(let why):
+            Log.write(String(
+                format: "input: nothing captured at press (%@) in %.0fms", why.rawValue, ms))
+        }
+    }
+
+    /// How much of the field a later stage is allowed to see. `Context.maxChars`
+    /// reused rather than picked again — one number for "how much of your screen
+    /// may leave it".
+    static var maxChars: Int { Context.maxChars }
+
+    /// Read whatever is focused right now, or say why not. The door for
+    /// `--peek`; the stage takes `pressCapture`.
+    static func read(app: Pipeline.App?) -> Result<Capture, Declined> {
+        guard Permissions.accessibility == .granted else { return .failure(.noPermission) }
+        guard let element = SelectionReader.focusedElement(),
+              !SelectionReader.isOurs(element) else { return .failure(.nothingFocused) }
+        return read(app: app, from: element)
+    }
+
+    /// The same read, of an element the caller already has.
+    ///
+    /// Two surfaces, and the split is the same one `Surface` makes. A terminal's
+    /// accessibility value is the whole screen, so the box has to be dug out of
+    /// it between the rules the TUI draws — and what comes back is text with no
+    /// caret in it, because the offset the surface publishes is into the screen
+    /// and there is no honest way to carry it across that extraction. Everywhere
+    /// else the value *is* the box and the selection is a range into it.
+    static func read(
+        app: Pipeline.App?, from element: AXUIElement
+    ) -> Result<Capture, Declined> {
+        guard Permissions.accessibility == .granted else { return .failure(.noPermission) }
+        guard let app else { return .failure(.noApp) }
+        guard !SelectionReader.isOurs(element) else { return .failure(.nothingFocused) }
+        guard let value = SelectionReader.visibleText(of: element) else {
+            return .failure(.unreadable)
+        }
+
+        if AppProfile.of(app).readsPane {
+            guard let box = SelectionReader.joinedInputBox(in: value) else {
+                return .failure(.noInputBox)
+            }
+            return .success(Capture(
+                before: nil, selection: nil, after: nil,
+                text: String(box.suffix(maxChars)), appending: nil,
+                total: box.count, truncated: box.count > maxChars))
+        }
+
+        let total = value.count
+        guard let range = SelectionReader.selectedRange(of: element),
+              range.location != NSNotFound, range.location >= 0,
+              let span = Range(NSRange(location: range.location,
+                                       length: max(0, range.length)), in: value)
+        else {
+            return .success(Capture(
+                before: nil, selection: nil, after: nil,
+                text: String(value.suffix(maxChars)), appending: nil,
+                total: total, truncated: total > maxChars))
+        }
+
+        let cut = split(value, at: span, limit: maxChars)
+        return .success(Capture(
+            before: cut.before, selection: cut.selection, after: cut.after,
+            text: nil, appending: cut.appending,
+            total: total, truncated: cut.truncated))
+    }
+
+    /// The field cut into three at the selection, each side capped on its own.
+    ///
+    /// Each side keeps the end nearest the caret and gets half the budget. A
+    /// single window centred on the caret would let a long tail crowd out the
+    /// text immediately before it, which is the half a dictated sentence is
+    /// being joined to.
+    static func split(
+        _ value: String, at span: Range<String.Index>, limit: Int
+    ) -> (before: String, selection: String, after: String,
+          appending: Bool, truncated: Bool) {
+        let before = String(value[value.startIndex..<span.lowerBound])
+        let selection = String(value[span])
+        let after = String(value[span.upperBound...])
+        let half = limit / 2
+        return (String(before.suffix(half)),
+                String(selection.prefix(limit)),
+                String(after.prefix(half)),
+                after.isEmpty && selection.isEmpty,
+                before.count > half || after.count > half || selection.count > limit)
+    }
+
+}

--- a/Sources/ParrotFlow/InputBox.swift
+++ b/Sources/ParrotFlow/InputBox.swift
@@ -95,10 +95,18 @@ enum InputBox {
     private static let pressLock = NSLock()
     nonisolated(unsafe) private static var presses: [Int: Press] = [:]
 
-    /// How many captures to keep. Nothing needs more than the presses in
-    /// flight, which is one or two; this is only a bound in case a run is
-    /// somehow never forgotten.
+    /// Runs whose dictation is over. A read is started at the press and can
+    /// finish after that dictation has ended — the accessibility value has been
+    /// observed at 237k characters — and storing it then would put back an
+    /// entry nothing will ever remove again. Kept so a late read can be
+    /// dropped instead.
+    nonisolated(unsafe) private static var ended: Set<Int> = []
+
+    /// How many to keep of each. Nothing needs more than the presses in
+    /// flight, which is one or two; these are bounds in case a run somehow
+    /// never reaches `forget`.
     private static let maxPresses = 8
+    private static let maxEnded = 32
 
     static func capture(for run: Int) -> Press? {
         pressLock.lock()
@@ -110,6 +118,10 @@ enum InputBox {
     static func forget(_ run: Int) {
         pressLock.lock()
         presses.removeValue(forKey: run)
+        ended.insert(run)
+        if ended.count > maxEnded {
+            for old in ended.sorted().prefix(ended.count - maxEnded) { ended.remove(old) }
+        }
         pressLock.unlock()
     }
 
@@ -127,13 +139,22 @@ enum InputBox {
         let ms = (CFAbsoluteTimeGetCurrent() - started) * 1000
 
         pressLock.lock()
-        presses[run] = Press(outcome: outcome, ms: ms)
-        if presses.count > maxPresses {
-            for old in presses.keys.sorted().prefix(presses.count - maxPresses) {
-                presses.removeValue(forKey: old)
+        let stale = ended.contains(run)
+        if !stale {
+            presses[run] = Press(outcome: outcome, ms: ms)
+            if presses.count > maxPresses {
+                for old in presses.keys.sorted().prefix(presses.count - maxPresses) {
+                    presses.removeValue(forKey: old)
+                }
             }
         }
         pressLock.unlock()
+
+        guard !stale else {
+            Log.write(String(
+                format: "input: a %.0fms read finished after its dictation ended; dropped", ms))
+            return
+        }
 
         switch outcome {
         case .success(let capture):

--- a/Sources/ParrotFlow/InputTestCommand.swift
+++ b/Sources/ParrotFlow/InputTestCommand.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// `--input-test "<field>" <caret> [selected] [limit]` — prints the three
+/// blocks the `input` stage would publish, and reads nothing.
+///
+/// The one string step of the stage, which is also the only part of it that can
+/// be scored: the capture itself is at the mercy of TCC and of whatever is
+/// genuinely focused, and a fixture that stubbed a field would be scoring the
+/// stub. What is testable is where the cut falls and what each side keeps when
+/// the budget runs out.
+///
+/// `\n` in the argument is a newline, for the same reason `--context-test`
+/// expands it.
+enum InputTestCommand {
+
+    static func run(field: String, caret: Int, selected: Int, limit: Int) -> Int32 {
+        let text = ComposeCommand.expanded(field)
+        let start = text.index(text.startIndex, offsetBy: min(caret, text.count))
+        let end = text.index(start, offsetBy: min(selected, text.distance(from: start,
+                                                                         to: text.endIndex)))
+        let cut = InputBox.split(text, at: start..<end, limit: limit)
+        print(cut.truncated ? "truncated" : "whole")
+        print(cut.appending ? "appending" : "inserting")
+        // Delimited, because the blocks keep their own spaces — the leading
+        // one on `after` is a real character and a case file that trimmed it
+        // would score a different string from the one the stage publishes.
+        print("before ⟪\(cut.before)⟫")
+        print("selection ⟪\(cut.selection)⟫")
+        print("after ⟪\(cut.after)⟫", terminator: "")
+        return 0
+    }
+}

--- a/Sources/ParrotFlow/InputTestCommand.swift
+++ b/Sources/ParrotFlow/InputTestCommand.swift
@@ -15,10 +15,15 @@ enum InputTestCommand {
 
     static func run(field: String, caret: Int, selected: Int, limit: Int) -> Int32 {
         let text = ComposeCommand.expanded(field)
-        let start = text.index(text.startIndex, offsetBy: min(caret, text.count))
-        let end = text.index(start, offsetBy: min(selected, text.distance(from: start,
-                                                                         to: text.endIndex)))
-        let cut = InputBox.split(text, at: start..<end, limit: limit)
+        // Clamped at both ends. A caret past the end is a real case — the value
+        // and the selection are read in two calls and an edit can land between
+        // them — and a negative one traps rather than misbehaving. `main.swift`
+        // refuses negatives before getting here; this makes the function total.
+        let from = min(max(0, caret), text.count)
+        let start = text.index(text.startIndex, offsetBy: from)
+        let span = min(max(0, selected), text.distance(from: start, to: text.endIndex))
+        let end = text.index(start, offsetBy: span)
+        let cut = InputBox.split(text, at: start..<end, limit: max(0, limit))
         print(cut.truncated ? "truncated" : "whole")
         print(cut.appending ? "appending" : "inserting")
         // Delimited, because the blocks keep their own spaces — the leading

--- a/Sources/ParrotFlow/PeekCommand.swift
+++ b/Sources/ParrotFlow/PeekCommand.swift
@@ -172,6 +172,31 @@ enum PeekCommand {
             }
         }
 
+        // And what the `input` stage would publish, which is the other half of
+        // the same window: `context` reads around the box, this reads the box.
+        // The caret is marked with ‸ and a selection with [], because where the
+        // cut falls is the whole answer.
+        report("")
+        switch InputBox.read(app: front.map {
+            Pipeline.App(name: $0.localizedName ?? "", bundleID: $0.bundleIdentifier ?? "")
+        }) {
+        case .failure(let why):
+            report("as input: declined — \(why.rawValue)")
+        case .success(let got):
+            let placement = got.before == nil ? "caret unknown"
+                : (got.appending == true ? "appending" : "inserting")
+            report("as input: \(got.chars) of \(got.total) chars, \(placement)"
+                + (got.truncated ? " (truncated to \(InputBox.maxChars))" : ""))
+            if let whole = got.text {
+                report("  | \(whole)")
+            } else {
+                let selection = got.selection ?? ""
+                report("  | \(got.before ?? "")"
+                    + (selection.isEmpty ? "" : "[\(selection)]")
+                    + "‸\(got.after ?? "")")
+            }
+        }
+
         if let sentinel {
             guard let value, value.contains(sentinel) else {
                 report("sentinel  \"\(sentinel)\" NOT in the focused element — wrong window")

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -867,7 +867,7 @@ struct Pipeline: Equatable, Codable {
         case .context:
             return await readContext(on: text)
         case .input:
-            return readInputBox(on: text)
+            return readInputBox(on: text, scope: scope)
         case .vocabulary:
             return await judgeVocabulary(step, on: text, config: config, scope: scope,
                                          findings: findings)
@@ -952,12 +952,22 @@ struct Pipeline: Equatable, Codable {
     /// The box is not read here. It was read when the hotkey went down — see
     /// `InputBox.capturePress` — because by then focus may have moved.
     ///
+    /// The capture is fetched by press run, seeded as `press.run`. Dictations
+    /// overlap, and "the box you were typing in" is a question about one press.
+    /// No run in scope means no press at all, which is every entry point that
+    /// is not the hotkey — `--pipeline` above all.
+    ///
     /// `before`, `selection`, `after` and `appending` are absent rather than
     /// empty where the surface publishes no caret, which is every terminal.
     /// Absent throws in a condition and that is the point: `when: input.appending`
     /// should fail loudly on a surface that cannot answer it, not read as "no".
-    private func readInputBox(on text: String) -> StageResult {
-        switch InputBox.pressCapture?.outcome ?? .failure(.noPress) {
+    private func readInputBox(on text: String, scope: Scope) -> StageResult {
+        let capture: Result<InputBox.Capture, InputBox.Declined> = {
+            guard case .int(let run)? = scope["press.run"],
+                  let press = InputBox.capture(for: run) else { return .failure(.noPress) }
+            return press.outcome
+        }()
+        switch capture {
         case .failure(let why):
             Log.write("pipeline: input declined — \(why.rawValue)")
             // The same keys a successful read publishes, emptied, plus the

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -41,6 +41,10 @@ struct Pipeline: Equatable, Codable {
         /// What is on screen around the field, published as `context.*` and
         /// never written into the transcript. Terminals only — see `Context`.
         case context
+        /// What is already *in* the field, and where the caret is, published as
+        /// `input.*` and never written into the transcript. Works in every
+        /// surface, which is why it is not part of `context` — see `InputBox`.
+        case input
         /// Every substitution the vocabulary pass made, put to a model one
         /// at a time — see `VocabularyJudge`. The pipeline entry is
         /// `- vocabulary`, with no prompt file: the prompt is compiled in.
@@ -59,7 +63,7 @@ struct Pipeline: Equatable, Codable {
         /// that edits text moves them (F10). `replacements` is the exception it
         /// has to live with — the judge offers a rule's substitution back, so
         /// the rules must already have fired.
-        var editsText: Bool { self != .context && self != .vocabulary }
+        var editsText: Bool { self != .context && self != .input && self != .vocabulary }
 
         /// Whether it can be in a default nobody wrote.
         ///
@@ -72,7 +76,8 @@ struct Pipeline: Equatable, Codable {
         /// block would be a silent change to what the app looks at, which is the
         /// one kind of change that has to be asked for by name.
         var isAutomatic: Bool {
-            self != .transform && self != .context && self != .vocabulary
+            self != .transform && self != .context && self != .input
+                && self != .vocabulary
         }
     }
 
@@ -861,6 +866,8 @@ struct Pipeline: Equatable, Codable {
             return StageResult(text: done.text, vars: ["language": .string(done.language)])
         case .context:
             return await readContext(on: text)
+        case .input:
+            return readInputBox(on: text)
         case .vocabulary:
             return await judgeVocabulary(step, on: text, config: config, scope: scope,
                                          findings: findings)
@@ -933,6 +940,53 @@ struct Pipeline: Equatable, Codable {
                 "lines": .int(capture.lines),
                 "truncated": .bool(capture.truncated),
             ])
+        }
+    }
+
+    /// The field's own contents and the caret, as variables. Never as text.
+    ///
+    /// Like `context` this returns its input untouched, and for the same
+    /// reason: a stage that could put the field into the transcript could paste
+    /// what you already typed back on top of itself.
+    ///
+    /// The box is not read here. It was read when the hotkey went down — see
+    /// `InputBox.capturePress` — because by then focus may have moved.
+    ///
+    /// `before`, `selection`, `after` and `appending` are absent rather than
+    /// empty where the surface publishes no caret, which is every terminal.
+    /// Absent throws in a condition and that is the point: `when: input.appending`
+    /// should fail loudly on a surface that cannot answer it, not read as "no".
+    private func readInputBox(on text: String) -> StageResult {
+        switch InputBox.pressCapture?.outcome ?? .failure(.noPress) {
+        case .failure(let why):
+            Log.write("pipeline: input declined — \(why.rawValue)")
+            // The same keys a successful read publishes, emptied, plus the
+            // reason. A condition is written once and has to hold on the runs
+            // where nothing could be read.
+            return StageResult(text: text, vars: [
+                "ok": .bool(false),
+                "declined": .string(why.rawValue),
+                "text": .string(""),
+                "chars": .int(0),
+                "total": .int(0),
+                "truncated": .bool(false),
+            ])
+        case .success(let capture):
+            let placement = capture.before == nil ? "caret unknown"
+                : (capture.appending == true ? "appending" : "inserting")
+            Log.write("pipeline: input read \(capture.chars) of \(capture.total) chars, "
+                + placement + (capture.truncated ? ", truncated" : ""))
+            var vars: [String: Scope.Value] = [
+                "chars": .int(capture.chars),
+                "total": .int(capture.total),
+                "truncated": .bool(capture.truncated),
+            ]
+            if let before = capture.before { vars["before"] = .string(before) }
+            if let selection = capture.selection { vars["selection"] = .string(selection) }
+            if let after = capture.after { vars["after"] = .string(after) }
+            if let whole = capture.text { vars["text"] = .string(whole) }
+            if let appending = capture.appending { vars["appending"] = .bool(appending) }
+            return StageResult(text: text, vars: vars)
         }
     }
 

--- a/Sources/ParrotFlow/TagCommand.swift
+++ b/Sources/ParrotFlow/TagCommand.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// `--tag "<text>" [--lang fr]` — the tokens a `returns: json` transform is
+/// handed, as JSON on stdout.
+///
+/// Exists so the tagging can be read by hand and scored by a script. A case set
+/// that hard-coded the tags would be scoring a fixture; `scripts/check-join.sh`
+/// builds its envelopes from this, so it exercises the tagger the app ships.
+enum TagCommand {
+
+    static func run(text: String, language: String?) -> Int32 {
+        // NLTagger with no language returns `Other` for everything on a short
+        // string — it will not guess from four words. The pipeline always has
+        // one in scope; a bare command falls back to the first configured.
+        let resolved = language
+            ?? (try? ConfigStore.load())?.transcription.languages.first
+            ?? "en"
+        let tokens = Tagger.tokens(in: ComposeCommand.expanded(text), language: resolved)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(tokens) else { return 1 }
+        print(String(decoding: data, as: UTF8.self))
+        return 0
+    }
+}

--- a/Sources/ParrotFlow/TagCommand.swift
+++ b/Sources/ParrotFlow/TagCommand.swift
@@ -18,8 +18,9 @@ enum TagCommand {
         let tokens = Tagger.tokens(in: ComposeCommand.expanded(text), language: resolved)
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
-        guard let data = try? encoder.encode(tokens) else { return 1 }
-        print(String(decoding: data, as: UTF8.self))
+        guard let data = try? encoder.encode(tokens),
+              let json = String(bytes: data, encoding: .utf8) else { return 1 }
+        print(json)
         return 0
     }
 }

--- a/Sources/ParrotFlow/Tagger.swift
+++ b/Sources/ParrotFlow/Tagger.swift
@@ -1,0 +1,73 @@
+import Foundation
+import NaturalLanguage
+
+/// What kind of word each word is, for a stage that has to decide about one.
+///
+/// Handed to `returns: json` transforms as `tokens`, beside the transcript. The
+/// point is not analysis — nothing here builds a tree — it is that one question
+/// keeps coming up and cannot be answered from a string: **is this capital the
+/// decoder starting a clip, or the speaker naming somebody?**
+///
+/// `join` asked it first. Lowering the case of anything the dictionary knew
+/// turned "I called Sarah" into "I called sarah". A closed list of function
+/// words was the workaround and it left "the meeting is Postponed at noon"
+/// unfixed, because an open-class word cannot be judged by spelling.
+///
+/// `.nameTypeOrLexicalClass` answers it in one pass. Measured on clips as a
+/// stage actually receives them — standalone, capitalised, one sentence:
+///
+///     Postponed.  Verb            Sarah.      PersonalName
+///     Considered. Verb            Vercel.     PlaceName
+///     On.         Preposition     Tasmeen.    Noun
+///
+/// 0.29 ms for a sentence, 0.97 ms for two hundred words. A tenth of what
+/// starting the `python3` that receives it costs, so it is not conditional.
+enum Tagger {
+
+    struct Token: Encodable {
+        /// Character offset into the text this token describes, and its length.
+        /// Swift counts graphemes and Python counts code points; they differ
+        /// only on combining sequences, which dictation does not produce.
+        let at: Int
+        let len: Int
+        let text: String
+        /// `Verb`, `Noun`, `PersonalName`, `PlaceName`, `OrganizationName`,
+        /// `Determiner`, `Number`… one scheme, because the question "is this a
+        /// name" and the question "what part of speech" have one answer.
+        let tag: String
+        /// The dictionary form. Absent for a word no dictionary knows, which is
+        /// itself the signal for a term that may want a vocabulary entry.
+        let lemma: String?
+    }
+
+    /// Every word in `text`, tagged. `language` comes from the pipeline scope
+    /// rather than being detected again — two sources for one field is how they
+    /// disagree, and the scope already resolved it.
+    static func tokens(in text: String, language: String?) -> [Token] {
+        guard !text.isEmpty else { return [] }
+        let tagger = NLTagger(tagSchemes: [.nameTypeOrLexicalClass, .lemma])
+        tagger.string = text
+        if let language, !language.isEmpty {
+            tagger.setLanguage(NLLanguage(rawValue: language),
+                               range: text.startIndex..<text.endIndex)
+        }
+
+        var out: [Token] = []
+        tagger.enumerateTags(
+            in: text.startIndex..<text.endIndex, unit: .word,
+            scheme: .nameTypeOrLexicalClass,
+            options: [.omitWhitespace, .omitPunctuation]
+        ) { tag, range in
+            let lemma = tagger.tag(at: range.lowerBound, unit: .word, scheme: .lemma).0
+            out.append(Token(
+                at: text.distance(from: text.startIndex, to: range.lowerBound),
+                len: text.distance(from: range.lowerBound, to: range.upperBound),
+                text: String(text[range]),
+                tag: tag?.rawValue ?? "Other",
+                lemma: lemma?.rawValue
+            ))
+            return true
+        }
+        return out
+    }
+}

--- a/Sources/ParrotFlow/Trace.swift
+++ b/Sources/ParrotFlow/Trace.swift
@@ -159,6 +159,21 @@ enum Trace {
             final = text
         }
 
+        /// Everything gathered so far, for a `returns: json` transform.
+        ///
+        /// The same fields the record on disk carries, encoded by the same
+        /// types, so the file a sweep reads and the payload a script reads
+        /// cannot drift into two shapes.
+        ///
+        /// Mid-pipeline, so `stages` is what has run *before* this one and
+        /// `final` does not exist yet. `asr`, `vad` and `lang` are complete:
+        /// all of it is settled before the first stage starts.
+        func snapshot() -> Snapshot {
+            lock.lock(); defer { lock.unlock() }
+            return Snapshot(wav: wav, source: source.rawValue, lang: lang,
+                            asr: asr, vad: vad, stages: stages)
+        }
+
         fileprivate func record(at: String, app: App?) -> Record {
             lock.lock(); defer { lock.unlock() }
             return Record(
@@ -330,6 +345,24 @@ enum Trace {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
         return formatter.string(from: Date())
+    }
+
+    /// What a `returns: json` transform is handed as `trace`.
+    ///
+    /// Internal where `Record` is fileprivate, because this one leaves the
+    /// file. Same members, so the two cannot describe different things.
+    struct Snapshot: Encodable {
+        let wav: String
+        let source: String
+        let lang: String?
+        fileprivate let asr: ASR?
+        fileprivate let vad: VAD?
+        /// What ran before the stage reading this. Not the whole pipeline.
+        fileprivate let stages: [Stage]
+
+        /// What the decoder wrote, for a caller checking whether the text it
+        /// holds is still that. Nil outside a dictation.
+        var decodedText: String? { asr?.text }
     }
 
     fileprivate struct Record: Encodable {

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -109,8 +109,13 @@ actor Transcriber {
     // MARK: - Transcription
 
     /// Transcribes a finished recording. Returns the cleaned-up text.
+    /// - Parameter press: Which hotkey press this clip came from, published to
+    ///   the pipeline as `press.run`. It is how a stage reaches what was read
+    ///   at *its own* press: dictations overlap, so a stage that took the
+    ///   newest capture would describe the wrong field. Nil off the hotkey
+    ///   path, where there is no press to belong to.
     func transcribe(
-        url: URL, config: Config, app: Pipeline.App? = nil,
+        url: URL, config: Config, app: Pipeline.App? = nil, press: Int? = nil,
         progress: (@Sendable (String) -> Void)? = nil
     ) async throws -> String {
         try await prepare(config: config)
@@ -243,9 +248,7 @@ actor Transcriber {
         // the time — and a condition reading `asr.confidence` must not work on
         // the runs you are watching and quietly stop on the runs you are not.
         // So the trace consumes these; it does not own them.
-        return await Self.applyReplacements(
-            to: text, config: config, app: app,
-            seed: Scope(values: [
+        var seed = Scope(values: [
                 "asr.model": .string(Repo.parakeetV3.rawValue),
                 "asr.confidence": .double(Double(result.confidence)),
                 "asr.duration": .double(result.duration),
@@ -257,7 +260,12 @@ actor Transcriber {
                 // pipeline can read rather than an error about a missing path.
                 "vocabulary.count": .int(vocabularyCount),
                 "vocabulary.changes": .string(vocabularyChanges),
-            ]),
+        ])
+        // Only when there is one. Absent says "no press", which is the honest
+        // answer off the hotkey path and the one `input` declines on.
+        if let press { seed.set("press.run", .int(press)) }
+        return await Self.applyReplacements(
+            to: text, config: config, app: app, seed: seed,
             findings: findings,
             progress: progress
         )

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -350,6 +350,30 @@ if let index = arguments.firstIndex(of: "--context-test") {
     ))
 }
 
+if let index = arguments.firstIndex(of: "--tag") {
+    guard arguments.indices.contains(index + 1) else {
+        print("usage: ParrotFlow --tag \"<text>\" [--lang fr]")
+        exit(2)
+    }
+    exit(TagCommand.run(text: arguments[index + 1], language: languageList(arguments)?.first))
+}
+
+if let index = arguments.firstIndex(of: "--input-test") {
+    guard arguments.indices.contains(index + 2),
+          let caret = Int(arguments[index + 2]) else {
+        print("usage: ParrotFlow --input-test \"<field>\" <caret> [selected] [limit]")
+        exit(2)
+    }
+    let selected = arguments.indices.contains(index + 3)
+        ? (Int(arguments[index + 3]) ?? 0) : 0
+    let limit = arguments.indices.contains(index + 4)
+        ? Int(arguments[index + 4]) : nil
+    exit(InputTestCommand.run(
+        field: arguments[index + 1], caret: caret, selected: selected,
+        limit: limit ?? InputBox.maxChars
+    ))
+}
+
 if let index = arguments.firstIndex(of: "--compose") {
     guard arguments.indices.contains(index + 1) else {
         print("usage: ParrotFlow --compose \"<template>\" [name=value ...]")

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -359,15 +359,24 @@ if let index = arguments.firstIndex(of: "--tag") {
 }
 
 if let index = arguments.firstIndex(of: "--input-test") {
+    let usage = "usage: ParrotFlow --input-test \"<field>\" <caret> [selected] [limit]"
     guard arguments.indices.contains(index + 2),
           let caret = Int(arguments[index + 2]) else {
-        print("usage: ParrotFlow --input-test \"<field>\" <caret> [selected] [limit]")
+        print(usage)
         exit(2)
     }
     let selected = arguments.indices.contains(index + 3)
         ? (Int(arguments[index + 3]) ?? 0) : 0
     let limit = arguments.indices.contains(index + 4)
         ? Int(arguments[index + 4]) : nil
+    // All three are offsets or lengths into a string. A negative one traps
+    // rather than misbehaving, so it is refused here and not clamped: a
+    // clamped caret would print a cut nobody asked for and look right.
+    guard caret >= 0, selected >= 0, (limit ?? 0) >= 0 else {
+        print(usage)
+        print("caret, selected and limit must not be negative")
+        exit(2)
+    }
     exit(InputTestCommand.run(
         field: arguments[index + 1], caret: caret, selected: selected,
         limit: limit ?? InputBox.maxChars

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -224,8 +224,32 @@ then do with them.
            "language": "en",
            "vars": { "asr": { "confidence": 0.91, "duration": 4.2 },
                      "replacements": { "ran": true, "count": 1,
-                                       "changed": true, "ms": 0.4 } } } }
+                                       "changed": true, "ms": 0.4 } } },
+  "tokens": [ { "at": 2, "len": 6, "text": "python",
+                "tag": "Noun", "lemma": "python" } ],
+  "aligned": false,
+  "trace": { "wav": "…", "source": "live", "lang": "en",
+             "asr": { "text": "…", "confidence": 0.91, "words": [] },
+             "vad": { "speech": 3.1, "total": 4.2, "segments": [] },
+             "stages": [] } }
 ```
+
+- **`tokens`** is every word of `text`, tagged by macOS `NLTagger` under
+  `.nameTypeOrLexicalClass`: `Noun`, `Verb`, `PersonalName`, `PlaceName`,
+  `Determiner` and so on, plus the lemma. It answers the one question a script
+  cannot answer from a string — whether a capital is the decoder starting a clip
+  or the speaker naming somebody. Recomputed per stage against the text that
+  stage was handed, so `at` and `len` are always offsets into `text`. It costs
+  0.29 ms for a sentence and 0.97 ms for two hundred words, so it is not
+  conditional. `--tag "<text>" --lang en` prints the same thing.
+- **`trace`** is what the run has gathered so far: the decoder's own text with
+  per-word timings and confidences, the speech segments, and the stages that
+  already ran with their `before`, `after` and vars. It is absent under
+  `--pipeline`, which has no trace collector, so read it defensively.
+- **`aligned`** says whether `text` is still the decoder's own, and so whether
+  the word offsets in `trace.asr.words` line up with it. It is false as soon as
+  any stage rewrites. Check it before using a word offset: acting on a stale one
+  fails silently.
 
 **Out**, on stdout — and only what this stage contributes:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -555,6 +555,30 @@ jq -r '.stages[]? | select(.skip_reason) | .skip_reason' trace.jsonl |
 jq -r 'select(.kind == "correction") | [.via, .heard, .corrected] | @tsv' trace.jsonl
 ```
 
+### Watching it live
+
+```sh
+scripts/watch.py                       # follow live dictations
+scripts/watch.py --last 10             # the last 10, then follow
+scripts/watch.py --stage repetitions   # only where that stage changed something
+scripts/watch.py --all                 # include cli sweeps and evals
+```
+
+Tails `trace.jsonl` and prints one block per dictation: the decoder's text, then
+each stage as a **word-level diff** with what it cost and what it published. It
+calls no model and reads no log — the trace record turns up complete, and a
+dictation is one to three seconds end to end, so there is no middle to
+reassemble.
+
+Two things it does that are not obvious. It filters on `source: live`, because
+the Dev trace holds roughly three `cli` records for every one you spoke and a
+check script running in another terminal otherwise floods the output. And it
+parses only lines that arrived with a newline: records reach 17.8 KB, which is
+past the size where a single append is reliably atomic, so a read can land
+mid-record.
+
+`--archive <dir>` points it at another variant's directory.
+
 `--transcribe` writes a trace line too, which is what makes it worth having:
 change a table, re-run the clips, and both sets of numbers sit in one file
 joined to the same audio.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -323,6 +323,37 @@ real app in front, so it runs in CI. It does not check what an app actually does
 — that Codex refuses `AXManualAccessibility`, that a ⌘V lands — only that the
 classification is what the case file says.
 
+## What kind of word each word is
+
+```sh
+$PF --tag "he asked" --lang en
+$PF --tag "Sarah a reporté la réunion" --lang fr
+```
+
+Prints the tokens a `returns: json` transform is handed as `tokens`: the offset,
+the length, the word, its tag and its lemma. The tags come from macOS
+`NLTagger` under `.nameTypeOrLexicalClass`, so `Sarah` is a `PersonalName` and
+`Postponed` is a `Verb`. That is the one question a stage cannot answer from a
+string — whether a capital is the decoder starting a clip or the speaker naming
+somebody.
+
+`--lang` matters. `NLTagger` will not guess a language from four words and
+returns `Other` for everything without one. In a pipeline the language comes
+from the scope; here it falls back to the first configured language.
+
+## Where the input stage cuts a field
+
+```sh
+$PF --input-test "the quick brown fox" 4 5 [limit]
+```
+
+Takes a field, a caret, how much is selected and a budget. Prints the three
+blocks the `input` stage would publish, delimited with `⟪⟫` so their own spaces
+are visible. `scripts/check-input.sh` scores it against
+`tests/input-cases.txt`. The capture itself needs a real focused field and the
+accessibility grant, so it is not faked here — see
+[pipelines.md](pipelines.md#input-what-is-already-in-the-field).
+
 ## Text insertion, which is the risky path
 
 ```sh
@@ -401,6 +432,7 @@ scripts/check-default-config.sh    scripts/check-transform-folders.sh
 scripts/check-eval.sh              # every case set, scored
 scripts/check-compose.sh           # what a prompt says once the scope is in it
 scripts/check-context.sh           # what the context stage publishes for a screen
+scripts/check-input.sh             # where the input stage cuts a field, and the caret
 scripts/check-span.sh              # a composer-shaped page, or Slack, or Outlook
 scripts/check-vocabulary-config.sh # what vocabulary.yaml adds up to, old keys included
 scripts/check-possessive.sh        # whether a possessive survives a substitution

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -27,6 +27,7 @@ get every stage back — a missing section is silence, not a choice. Write
 | `fuzzy` | The same table against renderings you have not taught, so "super bays" reaches Supabase. Only words the spell checker does not know are eligible, which is what keeps "Excel" from becoming "Vercel". Needs `replacements` before it and says so if it does not have one, because on its own it swallows the preceding word. |
 | `numbers` | Spoken numbers as digits: "two hundred forty-three" → 243, plus ordinals, decimals, years and spoken digits. English and French, septante/huitante/nonante included, chosen per transcript. A number word on its own stays a word below ten, so "chapter three" and "on est deux" are left alone. |
 | `context` | What is on screen around the field, published as `context.*`. Never touches the transcript. Terminals only, and off unless you ask for it — see [Context](#context-what-is-on-screen-around-the-field). |
+| `input` | What is already *in* the field and where the caret is, published as `input.*`. Never touches the transcript. Every app, and off unless you ask for it — see [Input](#input-what-is-already-in-the-field). |
 | `vocabulary` | Every substitution the vocabulary pass made, put to the local model one at a time — see [The name judge](#the-name-judge). |
 | `transform` | One entry of `transforms:`, named — see below. The only stage that names something outside itself. |
 
@@ -976,6 +977,105 @@ open -na ParrotFlowDev --args --peek 6
 ```
 
 It prints what the stage would publish, in full, under `as context:`.
+
+## Input: what is already in the field
+
+`context` reads the screen *around* the box. `input` reads the box itself —
+what you have already typed, and where the caret sits in it.
+
+```yaml
+pipelines:
+  default:
+    - input
+    - stage: transform
+      transform: join
+      when: input.ok && !input.appending
+```
+
+| variable | |
+|---|---|
+| `input.before` | what precedes the caret, or the start of the selection |
+| `input.selection` | what is selected, empty for a plain caret |
+| `input.after` | what follows the caret, or the end of the selection |
+| `input.appending` | nothing after the caret and nothing selected |
+| `input.text` | the whole box, on a surface whose caret could not be located |
+| `input.total` | the size of the whole field, before the budget cut anything |
+| `input.chars`, `input.truncated` | how much came through, and whether it was cut |
+| `input.ok`, `input.declined` | whether anything was read, and why not when nothing was |
+
+**Three blocks, not a string and an offset.** An offset has to be applied by
+whoever reads it, and applying it wrong is silent: a caret off by the size of
+the cut still points at a real character and the text still reads fine. Two
+strings cannot be misapplied. `selection` is the third because dictating over a
+selection replaces it, and what is about to be replaced is worth seeing.
+
+**It never changes the transcript**, the same way `context` does not. A stage
+that could put the field into the transcript could paste what you already typed
+back on top of itself.
+
+**Why it is a separate stage.** Two reasons. `context` is terminals-only
+because reading the surrounding screen anywhere else means walking a window's
+children; the box *is* the focused element, so it is one call in a native field,
+a browser and an Electron composer alike. And naming `context` says "read my
+terminal". It must not also come to mean "read what I have typed in every app I
+dictate into". You turn each on by name.
+
+**Appending or inserting.** This is what the stage is for. A transcript joining
+the end of a paragraph wants a capital and a full stop. One dropped into the
+middle of a sentence wants neither, and nothing else in the pipeline can tell
+the two apart.
+
+**On a terminal you get `input.text` instead**, and `before`, `selection`,
+`after` and `appending` are absent. A terminal publishes the whole screen as its
+accessibility value, so the box is dug out from between the rules the TUI draws,
+and the offset does not survive that extraction. Ghostty is the measured case:
+it returns `AXError -25213` for the caret and advertises no selected range. Which
+keys you got says what the surface could answer.
+
+Absent throws in a condition, which is the point. `when: input.appending`
+should fail loudly where it cannot be answered rather than read as "no". Guard
+with `input.ok` first.
+
+**Each side gets half the budget** and keeps the end nearest the caret, where
+`context` keeps one tail over the whole screen. A single window centred on the
+caret would let a long tail crowd out the text immediately before it, which is
+the half a dictated sentence is being joined to. The budget is the same 2000
+characters `context` uses, so a plain caret discloses at most 2000. A selection
+is capped on its own at 2000 on top of that, because it is a third block and
+not part of either side.
+
+**Read at the press**, like `context`, and for the same reason: by the time the
+pipeline runs, focus may be elsewhere.
+
+**While the stage is on, the log holds what was in the field when you
+dictated** — the character counts and where the caret was, not the text itself.
+
+### Seeing what it captures
+
+`--pipeline` cannot, for the reason `context` cannot. TCC pins the
+accessibility grant to the app bundle, so a binary run from a terminal gets
+nothing and the stage declines every time.
+
+`--peek` can, because it runs inside the bundle:
+
+```sh
+open -na ParrotFlowDev --args --peek 6
+# click the field you want, then read the log
+```
+
+It prints what the stage would publish under `as input:`, with the caret marked
+`‸` and a selection in `[]`.
+
+What *is* exact is where the window lands and where the caret ends up in it,
+and getting that wrong is silent. So it is scored separately:
+
+```sh
+ParrotFlow --input-test "the quick brown fox" 4 5
+scripts/check-input.sh
+```
+
+`--input-test` takes a field, a caret, how much is selected and a budget. It
+prints the three blocks delimited with `⟪⟫`, so their own spaces are visible.
 
 ## Apps
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -784,8 +784,12 @@ publishes whatever it likes; see
 
 Before any stage runs, the scope already holds `text`, `app`, `bundle_id`,
 `language`, and what transcription measured — `asr.confidence`, `asr.duration`,
-`asr.processing`, `asr.words`. So a stage can stand down on a recording the
-recogniser was not sure about:
+`asr.processing`, `asr.words`. On a dictation it also holds `press.run`, which
+says which hotkey press this transcript came from. Dictations overlap, so a
+stage that reads something captured at the press has to ask for its own —
+`input` does. It is absent off the hotkey path, `--pipeline` included.
+
+So a stage can stand down on a recording the recogniser was not sure about:
 
 ```yaml
     - stage: transform
@@ -1046,6 +1050,11 @@ not part of either side.
 
 **Read at the press**, like `context`, and for the same reason: by the time the
 pipeline runs, focus may be elsewhere.
+
+**One capture per press.** The stage asks for the capture belonging to
+`press.run`, not for the newest one. Starting a second dictation while the
+first is still being transcribed is ordinary, and with one shared slot the
+first would read the second's field.
 
 **While the stage is on, the log holds what was in the field when you
 dictated** — the character counts and where the caret was, not the text itself.

--- a/scripts/check-input.sh
+++ b/scripts/check-input.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Scores where the `input` stage cuts a field, against tests/input-cases.txt.
+#
+#   scripts/check-input.sh
+#
+# Deterministic and offline. The stage has one string step — the field cut in
+# three at the selection, each side capped on its own — and it is the only part
+# with an exact answer. The capture itself depends on TCC and on whatever is
+# focused, so it is checked with `--peek` on a real surface and not faked here.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/release/ParrotFlow"
+CASES="$ROOT/tests/input-cases.txt"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+
+pass=0; total=0; failed=""
+while IFS='~' read -r field caret selected limit shape where before selection after; do
+  case "$field" in \#*) continue;; esac
+  caret="$(printf '%s' "$caret" | tr -d ' ')"
+  [ -z "$caret" ] && continue
+  total=$((total + 1))
+
+  # Trailing spaces belong to the separator; the blocks carry their own inside
+  # ⟪⟫, so trimming around the tildes is safe for them and necessary for a
+  # field that ends in a real space.
+  field="$(printf '%s' "$field" | sed 's/ *$//')"
+  selected="$(printf '%s' "$selected" | tr -d ' ')"
+  limit="$(printf '%s' "$limit" | tr -d ' ')"
+  trim() { printf '%s' "$1" | sed 's/^ *//; s/ *$//'; }
+  want="$(trim "$shape")
+$(trim "$where")
+before $(trim "$before")
+selection $(trim "$selection")
+after $(trim "$after")"
+
+  got="$("$BIN" --input-test "$field" "$caret" "$selected" "$limit" 2>/dev/null)"
+
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1))
+    printf '  ✓ %s\n' "${field:-(empty)} @$caret+$selected/$limit"
+  else
+    failed="$failed
+  ✗ ${field:-(empty)} @$caret+$selected/$limit
+      want  $(printf '%s' "$want" | tr '\n' '|')
+      got   $(printf '%s' "$got" | tr '\n' '|')"
+  fi
+done < "$CASES"
+
+[ -n "$failed" ] && printf '%s\n' "$failed"
+echo
+echo "$pass/$total"
+[ "$pass" = "$total" ]

--- a/scripts/watch.py
+++ b/scripts/watch.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Every transformation a dictation goes through, as it lands.
+
+    scripts/watch.py                    # follow live dictations
+    scripts/watch.py --last 10          # the last 10, then follow
+    scripts/watch.py --last 10 --no-follow
+    scripts/watch.py --stage repetitions   # only where that stage changed something
+    scripts/watch.py --all              # include cli sweeps and evals
+
+**No model call anywhere in this file.** It reads `trace.jsonl`, which the app
+already writes — one complete record per dictation, at the moment it finishes.
+
+Reads the trace rather than the log. The log streams prose while a dictation is
+in flight, but a dictation is one to three seconds end to end, so the middle of
+it is not worth reassembling. The trace record turns up complete.
+
+Two things that are not obvious and cost an afternoon each if you skip them.
+
+**`source` is filtered.** The Dev trace holds 11,948 `cli` records against
+3,789 `live` ones — every `--eval`, sweep and `--pipeline` writes to the same
+file. Unfiltered, a check script running in another terminal floods this one
+with things nobody dictated.
+
+**Records reach 17.8 KB**, which is past the size where a single append is
+reliably atomic, so a read can land mid-record. Only lines that arrived with a
+newline are parsed; the rest is held until the tail of it turns up.
+"""
+import argparse
+import difflib
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+# The dev app writes here. The release variant has its own directory and has
+# been uninstalled on this machine since 2026-08-03 — pass --archive for it.
+ARCHIVE = Path.home() / "Recordings/ParrotFlow Dev"
+
+C = {
+    "dim": "\033[2m", "red": "\033[31m", "green": "\033[32m",
+    "yellow": "\033[33m", "blue": "\033[34m", "bold": "\033[1m", "off": "\033[0m",
+}
+if not sys.stdout.isatty():
+    C = {k: "" for k in C}
+
+WORD = re.compile(r"\S+|\s+")
+
+
+def diff(before, after):
+    """What one stage changed, as words rather than as two sentences.
+
+    Seven stages printing their input and their output is fourteen copies of the
+    same line. The change is the only part worth reading.
+    """
+    a, b = WORD.findall(before or ""), WORD.findall(after or "")
+    out = []
+    for tag, i1, i2, j1, j2 in difflib.SequenceMatcher(None, a, b).get_opcodes():
+        if tag == "equal":
+            continue
+        gone, came = "".join(a[i1:i2]).strip(), "".join(b[j1:j2]).strip()
+        if tag == "delete" and gone:
+            out.append(f"{C['red']}−{gone}{C['off']}")
+        elif tag == "insert" and came:
+            out.append(f"{C['green']}+{came}{C['off']}")
+        elif gone or came:
+            out.append(f"{C['red']}{gone}{C['off']}"
+                       f"{C['dim']}→{C['off']}{C['green']}{came}{C['off']}")
+    return "  ".join(out)
+
+
+def render(record, only=None):
+    """One dictation, one block. Returns False when nothing was worth printing."""
+    stages = record.get("stages") or []
+    if only:
+        hit = [s for s in stages
+               if s.get("name") == only and s.get("before") != s.get("after")]
+        if not hit:
+            return False
+
+    asr = record.get("asr") or {}
+    app = (record.get("app") or {}).get("name") or "—"
+    when = (record.get("at") or "")[11:19]
+    head = (f"{C['bold']}{when}{C['off']}  {app}  {record.get('lang') or '?'}"
+            f"  {C['dim']}{record.get('source')}"
+            f"  {asr.get('duration', 0):.1f}s audio{C['off']}")
+    print(f"\n{head}")
+
+    text = asr.get("text")
+    if text is not None:
+        conf = asr.get("confidence")
+        print(f"  {C['bold']}{'asr':<14}{C['off']}  {text}"
+              + (f"  {C['dim']}conf {conf:.2f}{C['off']}" if conf is not None else ""))
+
+    for stage in stages:
+        # `transform punctuation` is a name and a target; the target is what
+        # you are reading for, so the word "transform" is what gets cut.
+        name = stage.get("name", "?").replace("transform ", "")[:13]
+        if stage.get("skipped") or stage.get("skip_reason"):
+            why = stage.get("skip_reason") or stage.get("skipped")
+            print(f"  {C['dim']}{name:<14}  skipped: {why}{C['off']}")
+            continue
+        before, after = stage.get("before"), stage.get("after")
+        ms = (stage.get("seconds") or 0) * 1000
+        cost = f"{C['dim']}{ms:6.1f}ms{C['off']}" if ms >= 0.05 else ""
+        if before == after:
+            print(f"  {C['dim']}{name:<14}  —{C['off']}        {cost}")
+        else:
+            print(f"  {C['yellow']}{name:<14}{C['off']}  {diff(before, after)}   {cost}")
+        # Only the variables a stage chose to publish; the pipeline's own
+        # ran/ok/ms are noise here because the line above already says them.
+        published = {k: v for k, v in (stage.get("vars") or {}).items()
+                     if k not in ("ran", "ok", "ms", "changed")}
+        if name == "input" and "before" in published:
+            # The three blocks are the whole point of this stage and a 40
+            # character sample of them says nothing. Shown as one line with the
+            # caret in place, which is how you read it anyway.
+            before, sel, after = (published.pop("before", ""),
+                                  published.pop("selection", ""),
+                                  published.pop("after", ""))
+            marked = (f"{C['dim']}…{before[-60:]}{C['off']}"
+                      + (f"{C['red']}[{sel}]{C['off']}" if sel else "")
+                      + f"{C['bold']}‸{C['off']}"
+                      + f"{C['dim']}{after[:60]}…{C['off']}")
+            print(f"  {'':<16}{marked}")
+        if published:
+            shown = "  ".join(f"{k}={json.dumps(v)[:40]}" for k, v in published.items())
+            print(f"  {C['dim']}{'':<16}{shown}{C['off']}")
+
+    final = record.get("final")
+    if final is not None and final != text:
+        print(f"  {C['blue']}{'=':<14}  {final}{C['off']}")
+    return True
+
+
+def records(path, tail_bytes=None):
+    """Parse whole lines from a file, skipping anything that will not decode."""
+    with path.open("rb") as handle:
+        if tail_bytes:
+            handle.seek(max(0, path.stat().st_size - tail_bytes))
+            handle.readline()
+        for line in handle:
+            try:
+                yield json.loads(line)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+
+
+def follow(path, wanted, only):
+    """Poll for appended lines. 200ms is imperceptible and beats fsevents for
+    a file this simple; a partial record is held until its newline arrives."""
+    with path.open("rb") as handle:
+        handle.seek(0, os.SEEK_END)
+        pending = b""
+        while True:
+            chunk = handle.read()
+            if not chunk:
+                time.sleep(0.2)
+                continue
+            pending += chunk
+            *lines, pending = pending.split(b"\n")
+            for line in lines:
+                if not line.strip():
+                    continue
+                try:
+                    record = json.loads(line)
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    continue
+                if wanted and record.get("source") not in wanted:
+                    continue
+                if record.get("kind") != "dictation":
+                    continue
+                render(record, only)
+                sys.stdout.flush()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--archive", default=str(ARCHIVE))
+    parser.add_argument("--last", type=int, default=0,
+                        help="replay this many recent records before following")
+    parser.add_argument("--stage", help="only records where this stage changed the text")
+    parser.add_argument("--all", action="store_true",
+                        help="include cli sweeps and evals, not just live dictations")
+    parser.add_argument("--no-follow", action="store_true")
+    args = parser.parse_args()
+
+    path = Path(args.archive) / "trace.jsonl"
+    if not path.exists():
+        print(f"no trace.jsonl in {args.archive}")
+        return 1
+    wanted = None if args.all else {"live"}
+
+    if args.last:
+        # Bounded read from the end: the Dev trace is tens of MB and almost all
+        # of it is sweeps nobody is asking for.
+        keep = []
+        for record in records(path, tail_bytes=4_000_000):
+            if wanted and record.get("source") not in wanted:
+                continue
+            if record.get("kind") != "dictation":
+                continue
+            keep.append(record)
+        for record in keep[-args.last:]:
+            render(record, args.stage)
+
+    if args.no_follow:
+        return 0
+    print(f"\n{C['dim']}watching {path}"
+          f"{'' if args.all else ' (live only)'} — ctrl-c to stop{C['off']}")
+    try:
+        follow(path, wanted, args.stage)
+    except KeyboardInterrupt:
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/input-cases.txt
+++ b/tests/input-cases.txt
@@ -1,0 +1,59 @@
+# Where the `input` stage cuts a field, and what each side keeps when the
+# budget runs out. Run with scripts/check-input.sh.
+#
+# The one string step of the stage, and the only part of it with an exact
+# answer. What is genuinely in a field depends on TCC and on whatever is
+# focused, so the capture is checked with `--peek` on a real surface and not
+# faked here — a fixture that stubbed a field would be scoring the stub.
+#
+# Three blocks rather than a string and an offset, because an offset has to be
+# applied by whoever reads it and applying it wrong is silent: a caret off by
+# the size of the cut still points at a real character and the text still reads
+# fine. So every case states all three sides.
+#
+# The blocks are delimited with ⟪⟫ because they keep their own spaces. The
+# leading space on `after` is a real character.
+#
+# field ~ caret ~ selected ~ limit ~ whole|truncated ~ appending|inserting ~ before ~ selection ~ after
+
+# --- nothing to cut ---
+the quick brown fox ~ 9 ~ 0 ~ 100 ~ whole ~ inserting ~ ⟪the quick⟫ ~ ⟪⟫ ~ ⟪ brown fox⟫
+the quick brown fox ~ 0 ~ 0 ~ 100 ~ whole ~ inserting ~ ⟪⟫ ~ ⟪⟫ ~ ⟪the quick brown fox⟫
+
+# Appending: nothing after the caret and nothing selected. This is the case the
+# punctuation rules turn on, and the one an off-by-one silently breaks.
+the quick brown fox ~ 19 ~ 0 ~ 100 ~ whole ~ appending ~ ⟪the quick brown fox⟫ ~ ⟪⟫ ~ ⟪⟫
+
+# An empty field is a real answer, not a decline — dictating into an empty box
+# is the commonest case there is, and it is also appending.
+ ~ 0 ~ 0 ~ 100 ~ whole ~ appending ~ ⟪⟫ ~ ⟪⟫ ~ ⟪⟫
+
+# --- a selection, which dictating over will replace ---
+the quick brown fox ~ 4 ~ 5 ~ 100 ~ whole ~ inserting ~ ⟪the ⟫ ~ ⟪quick⟫ ~ ⟪ brown fox⟫
+
+# A selection reaching the end is not appending: there is something to replace,
+# so the sentence is not being joined to what precedes it.
+the quick brown fox ~ 10 ~ 9 ~ 100 ~ whole ~ inserting ~ ⟪the quick ⟫ ~ ⟪brown fox⟫ ~ ⟪⟫
+
+# --- the budget, split per side ---
+# Each side gets half and keeps the end nearest the caret. A single window
+# centred on the caret would let a long tail crowd out the text immediately
+# before it, which is the half a dictated sentence is being joined to.
+abcdefghijklmnopqrstuvwxyz ~ 13 ~ 0 ~ 8 ~ truncated ~ inserting ~ ⟪jklm⟫ ~ ⟪⟫ ~ ⟪nopq⟫
+
+# Near an end the other side is not given the slack. Half is half, so a caret
+# at the top still discloses only half a budget of what follows it.
+abcdefghijklmnopqrstuvwxyz ~ 0 ~ 0 ~ 8 ~ truncated ~ inserting ~ ⟪⟫ ~ ⟪⟫ ~ ⟪abcd⟫
+abcdefghijklmnopqrstuvwxyz ~ 26 ~ 0 ~ 8 ~ truncated ~ appending ~ ⟪wxyz⟫ ~ ⟪⟫ ~ ⟪⟫
+
+# A caret past the end of the field is clamped, not trusted: the value and the
+# selection are read in two calls and an edit can land between them.
+abcdefghijklmnopqrstuvwxyz ~ 99 ~ 0 ~ 8 ~ truncated ~ appending ~ ⟪wxyz⟫ ~ ⟪⟫ ~ ⟪⟫
+
+# A field no larger than the budget is not truncated.
+abcdefgh ~ 4 ~ 0 ~ 8 ~ whole ~ inserting ~ ⟪abcd⟫ ~ ⟪⟫ ~ ⟪efgh⟫
+
+# The selection gets the whole budget rather than half of it. It is a third
+# block, not part of either side, and what is about to be replaced is worth
+# seeing in full where the sides are only context.
+abcdefghijklmnopqrstuvwxyz ~ 4 ~ 20 ~ 8 ~ truncated ~ inserting ~ ⟪abcd⟫ ~ ⟪efghijkl⟫ ~ ⟪yz⟫

--- a/tests/pipeline-cases.yaml
+++ b/tests/pipeline-cases.yaml
@@ -526,6 +526,36 @@ cases:
       context.ok: false
       context.changed: false
 
+  # --- input, which from here can only decline -----------------------------
+  #
+  # See tests/pipelines/input.yaml. Same shape as the context cases above and
+  # for the same reason: the field is read when the hotkey goes down, and
+  # `--pipeline` has no hotkey.
+  - name: input declines with no press to publish, and says which
+    pipeline: input
+    app: Slack com.tinyspeck.slackmacgap
+    input: super base has twenty one users
+    expect: Supabase has 21 users
+    expect_vars:
+      input.ran: true
+      input.ok: false
+      input.chars: 0
+      input.total: 0
+      input.declined: nothing was captured when the hotkey went down
+
+  # Every surface, not terminals only. That is the difference from `context`,
+  # so a terminal gets its own case rather than being assumed.
+  - name: input declines in a terminal too, and leaves the stages around it alone
+    pipeline: input
+    app: Ghostty com.mitchellh.ghostty
+    input: super base has twenty one users
+    expect: Supabase has 21 users
+    expect_vars:
+      input.ok: false
+      input.changed: false
+      replacements.count: 1
+      numbers.ran: true
+
   # --- the name judge, on what a `replacements` rule did -----------------------
   #
   # `--pipeline` has no audio, so these are the path that used to have no earlier

--- a/tests/pipelines/input.yaml
+++ b/tests/pipelines/input.yaml
@@ -1,0 +1,21 @@
+# The `input` stage, scored for the only thing a fixture can score about it.
+#
+# What it captures cannot be tested from here, for the same two reasons
+# `tests/pipelines/context.yaml` gives. The field is read when the hotkey goes
+# down and `--pipeline` has no hotkey, so there is never a capture to publish.
+# Behind that sits TCC, which pins the accessibility grant to the app bundle.
+#
+# What is worth scoring is the declining: a stage that cannot do its job leaves
+# the transcript exactly as it arrived. Where the cut falls, which is the other
+# half of this stage, is scored by `scripts/check-input.sh` instead.
+languages: [en]
+
+replacements:
+  Supabase: [super base]
+
+pipeline:
+  # Before and after, on purpose. A stage that publishes variables must not
+  # disturb the stages either side of it, including when it declines.
+  - replacements
+  - input
+  - numbers


### PR DESCRIPTION
## What this adds

Three things a pipeline stage could not ask for before.

### 1. The `input` stage

`context` reads the screen **around** the box. `input` reads the box itself:
what precedes the caret, what is selected, what follows, and whether the
dictation is appending or inserting.

It publishes `input.before`, `input.selection`, `input.after`,
`input.appending`, `input.total`, `input.chars`, `input.truncated`, `input.ok`
and `input.declined`. It never touches the transcript.

Why it is not part of `context`. Two reasons.

- `context` is terminals-only because reading the surrounding screen anywhere
  else means walking a window's children. The box **is** the focused element,
  so this is one call in a native field, a browser and an Electron composer
  alike.
- Naming `context` says "read my terminal". It must not also come to mean
  "read what I have typed in every app I dictate into". Each is turned on by
  name.

Read at the press, like `context`, because by then focus may have moved.

**Terminals are the exception.** Ghostty publishes no caret — `AXError -25213`,
and it advertises no selected range — so a terminal gets `input.text`, the
whole line, and no before/after. Which keys you got says what the surface could
answer, so a consumer has to handle that blind case.

Three blocks rather than a string and an offset. An offset has to be applied by
whoever reads it, and applying it wrong is silent: a caret off by the size of
the cut still points at a real character and the text still reads fine.

### 2. `Tagger`

Wraps macOS `NLTagger` with `.nameTypeOrLexicalClass` and `.lemma`. Measured at
0.29 ms a sentence and 0.97 ms over 200 words, so it is not conditional.

It answers one question that cannot be answered from a string: **is this
capital the decoder starting a clip, or the speaker naming somebody?**

```
Postponed.  Verb            Sarah.      PersonalName
Considered. Verb            Vercel.     PlaceName
On.         Preposition     Tasmeen.    Noun
```

The envelope now carries `tokens`, so a Python transform gets part-of-speech
without shelling out.

### 3. A richer envelope

`returns: json` transforms also get `trace` and `aligned`.

- `trace` is what the run has gathered so far: the decoder's own words with
  timings and confidences, the speech segments, and the stages that already ran
  with their `before`/`after` and vars. Absent under `--pipeline`, which has no
  collector.
- `aligned` says whether `text` is still the decoder's own, and therefore
  whether word offsets line up. False as soon as any stage rewrites. Stated
  rather than left to be worked out, because acting on stale offsets fails
  silently.

### New commands

- `--tag "<text>" --lang en` prints the tokens. The language matters: NLTagger
  will not guess from a short string and returns `Other` for everything without
  one.
- `--input-test "<field>" <caret> [selected] [limit]` prints the three blocks
  the stage would cut, delimited with `⟪⟫` so their own spaces are visible.
- `--peek` now also prints what the `input` stage would publish on a real field,
  under `as input:`, with the caret marked `‸`.

`scripts/watch.py` tails `~/Recordings/ParrotFlow Dev/trace.jsonl`, filters
`source: live`, and prints word-level diffs with the rule names. It is a
developer script and works because of this PR.

## One decision for the reviewer, not for me

**`input` is deliberately NOT in `config.example.yaml`.** I did not add it, and
I want the call made explicitly rather than by me.

The trade-off:

- **On by default** means every dictation reads the focused field through
  Accessibility, in every app. That is a real disclosure and a wider one than
  `context`, which only ever looked at terminals.
- **Off by default** means nobody finds it. The stage is useless on its own —
  it exists so a later stage can tell appending from inserting — and a feature
  nobody enables gets no field testing.

My recommendation: **leave it off**, and mention it in the release notes. The
consumer (`join`, in the follow-up PR) is not shipped by default either, so
turning `input` on by itself buys nothing today. When `join` is ready to be a
default, both go in together and the disclosure is worth something. Reading
what a person has typed, in every app, is exactly the kind of change that has
to be asked for by name — the same argument `docs/pipelines.md` already makes
for `context`.

**This is the reviewer's call.** Say the word and I add the line.

## Verification

| | |
|---|---|
| `swift build -c release` | clean, no new warnings |
| `scripts/check-input.sh` | 12/12 |
| `scripts/check-pipeline.sh` | 80/80 (was 73/73; this PR adds 2 cases, the follow-up adds 5) |
| `scripts/check-eval.sh` | 25/25 |
| `scripts/check-default-config.sh` | clean |
| `scripts/check-context.sh` | 7/7 |
| `scripts/check-replacements.sh` | 23/23 |
| `scripts/check-dotted.sh` | 64/64 |
| `ruff check scripts/watch.py` | clean (ruff 0.5.5) |
| `--tag "he asked" --lang en` | `Pronoun` / `Verb`, with lemmas |

`scripts/check-transform-folders.sh` reports 11/12, which it also does on clean
`main` — a microphone permission state, not a code fault.

## What is scored, and what cannot be

The capture itself is not faked. TCC pins the accessibility grant to the app
bundle, so a binary run from a terminal gets nothing and the stage declines
every time. A fixture that stubbed a field would be scoring the stub.

What **is** exact is where the window lands and where the caret ends up in it,
and getting that wrong is silent. That is `tests/input-cases.txt`, scored by
`scripts/check-input.sh`. The declining is scored by
`tests/pipelines/input.yaml` in the pipeline set. The live capture is read with
`--peek`.

## What the review changed

Greptile found four things. All four were real and all four are fixed.

1. **A press that ends a dictation was overwriting its capture.** `readTheAnchor()`
   three lines above is gated on `!recorder.isRecording`, with the reason
   written out. The captures were not. In toggle mode the stop press replaced
   the capture, so the stage read the screen as it stood when the dictation
   ended. `context` had this on `main` too; both take the guard now.
2. **`--input-test` trapped on a negative caret, selection or budget.** It
   prints the usage and exits 2, and `InputTestCommand.run` clamps as well.
3. **One capture slot for the whole app.** A second dictation started while the
   first was still transcribing cleared it, so the first read `noPress` and then
   the second field. Captures are keyed by press run now, reached through a new
   `press.run` in the pipeline scope. This is the change that matters most:
   without it `join` would format a clip against a box in another window.
4. **A read finishing after its dictation could resurrect the entry.** The slot
   is reserved on the main thread at the press and removed by `dictationEnded`,
   so a late read finds no slot and is dropped. One collection, no cap — a cap
   has to evict the oldest run, which in an overlap is a dictation still in
   flight.

`Context` still has the single-slot design for overlaps. It is unchanged here
beyond the press-ownership guard, and keying it by run is the same change on
top of the `press.run` seed this PR adds. That belongs in its own commit.

## Notes on files I did not simply copy in

- `PeekCommand.swift` was not in the original plan. `InputBox.read(app:)`
  existed with no caller, so I wired it into `--peek` rather than leave dead
  code.
- `tests/pipelines/input.yaml` and two pipeline cases are new, mirroring what
  `context` already has.
- `docs/authoring.md` documents `tokens`, `trace` and `aligned`, which are a
  public contract with scripts people write.
- The selection block is capped at the full budget while each side gets half,
  so a large selection can push the total past 2000. That is the existing
  behaviour; I documented it and added a case for it rather than change it
  silently.
- `scripts/check-input.sh` is wired into `.github/workflows/checks.yml`, beside
  the other deterministic sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
