### PR TITLE
feat: a table says what it wrote, and join fits a clip to the box

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -162,6 +162,13 @@ jobs:
       - name: Where the input stage cuts a field
         run: scripts/check-input.sh
 
+      # Fitting a clip to the text either side of the caret. Runs the deployed
+      # script on the envelope it really receives — `--eval` cannot, because the
+      # transform reads `ctx.vars.input.*`. The tags come from the binary's
+      # `--tag`, so this scores the tagger the app ships rather than a fixture.
+      - name: Joining a clip to the box
+        run: scripts/check-join.sh
+
       # Which app gets which treatment. The one part of the destination path
       # that runs without a screen or a real app in front, and a wrong entry is
       # silent both ways — one already was, matching any app named "codex".

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -849,6 +849,7 @@ struct Pipeline: Equatable, Codable {
                 "count": .int(done.count),
                 "changes": .string(done.changes),
                 "before": .string(text),
+                "protected": .string(done.protected),
             ])
         case .fuzzy:
             // From the rules, not from the table's keys. Fuzzy matching
@@ -1214,16 +1215,23 @@ struct Pipeline: Equatable, Codable {
         case .prompt:
             return await runPrompt(step, named: name, on: text, config: config, scope: scope)
         case .replace:
-            // Exact and free, so there is nothing to guard and nothing to
-            // report beyond what the table did — the log line is the same one
-            // `replacements` writes, with the name that asked for it.
+            // Exact and free, so there is nothing to guard — the log line is
+            // the same one `replacements` writes, with the name that asked for
+            // it. `protected` is the exception to "nothing to report": a table
+            // has no code of its own to publish from, and what it wrote is
+            // exactly what a later stage must not undo. `dotted` writes the dot
+            // in `user.name` and `join` would otherwise read it as one the
+            // decoder invented.
             let done = Replacements.exact(to: text, rules: transform.rules)
             if done.text != text {
                 Log.write("pipeline: transform \(name) rewrote the transcript")
                 Log.write("    before: \(text)")
                 Log.write("    after:  \(done.text)")
             }
-            return StageResult(text: done.text, vars: ["count": .int(done.count)])
+            return StageResult(text: done.text, vars: [
+                "count": .int(done.count),
+                "protected": .string(done.protected),
+            ])
         case .command(let command):
             // Someone else's program, so this is the second stage that can
             // fail and the second that must not fail loudly. `run` returns nil

--- a/Sources/ParrotFlow/Replacements.swift
+++ b/Sources/ParrotFlow/Replacements.swift
@@ -73,17 +73,27 @@ enum Replacements {
     /// Counted per *rule*, not per substitution: "two rules fired" is the
     /// question a condition is asking, and a rule that replaced the same word
     /// four times did one thing, not four.
-    /// - Returns: the rewritten text, how many rules fired, and what each one
-    ///   wrote — `heard -> written`, joined by `; `. The third is for a stage
-    ///   that has to judge the substitutions rather than make them: a judge
-    ///   handed only the finished sentence cannot see what changed in it.
+    /// - Returns: the rewritten text, how many rules fired, what each one wrote
+    ///   — `heard -> written`, joined by `; ` — and the substitutions
+    ///   themselves. The third is for a stage that has to judge the
+    ///   substitutions rather than make them: a judge handed only the finished
+    ///   sentence cannot see what changed in it.
+    ///
+    ///   The fourth is `protected`: the text this pass actually put in, with
+    ///   the templates expanded, so `$1.` on "user dot name" reports `user.`
+    ///   and not `$1.`. A later stage reads it to leave those characters alone.
+    ///   `join` re-cases the first word of a clip and splits a dot it thinks the
+    ///   decoder invented, and neither is right on something a table wrote on
+    ///   purpose. A `replace:` transform has no code of its own to publish
+    ///   from, so this pass publishes on its behalf.
     static func exact(
         to text: String, rules: [Config.Transcription.Rule]
-    ) -> (text: String, count: Int, changes: String) {
+    ) -> (text: String, count: Int, changes: String, protected: String) {
         var output = text
         var deleted = false
         var fired = 0
         var changes: [String] = []
+        var written: [String] = []
 
         for rule in rules {
             guard let pattern = try? NSRegularExpression(
@@ -93,11 +103,24 @@ enum Replacements {
                 continue
             }
             let before = output
-            output = pattern.stringByReplacingMatches(
-                in: output,
-                range: NSRange(output.startIndex..., in: output),
-                withTemplate: rule.template
-            )
+            // Match by match, back to front, rather than one
+            // `stringByReplacingMatches`. Same result, and it is the only way
+            // to see what each substitution actually put in: the all-at-once
+            // call hands back the finished string and keeps the expansions.
+            // Back to front so an earlier replacement cannot move a later match.
+            let found = pattern.matches(
+                in: output, range: NSRange(output.startIndex..., in: output))
+            var wrote: [String] = []
+            for match in found.reversed() {
+                let expanded = pattern.replacementString(
+                    for: match, in: output, offset: 0, template: rule.template)
+                guard let range = Range(match.range, in: output) else { continue }
+                output.replaceSubrange(range, with: expanded)
+                if !rule.isDeletion, !expanded.isEmpty { wrote.append(expanded) }
+            }
+            // Back into reading order. The walk is backwards; the list a later
+            // stage searches should still run left to right.
+            written.append(contentsOf: wrote.reversed())
             if output != before {
                 fired += 1
                 if rule.isDeletion { deleted = true }
@@ -107,7 +130,11 @@ enum Replacements {
 
         return (
             deleted ? tidy(output) : output, fired,
-            changes.joined(separator: "; ")
+            changes.joined(separator: "; "),
+            // Deduplicated and order-stable: a rule that fired four times wrote
+            // one term to protect, not four.
+            NSOrderedSet(array: written).array.compactMap { $0 as? String }
+                .joined(separator: "; ")
         )
     }
 

--- a/Sources/ParrotFlow/Replacements.swift
+++ b/Sources/ParrotFlow/Replacements.swift
@@ -115,8 +115,15 @@ enum Replacements {
                 let expanded = pattern.replacementString(
                     for: match, in: output, offset: 0, template: rule.template)
                 guard let range = Range(match.range, in: output) else { continue }
+                // What stood there before this rule touched it. A match whose
+                // expansion is the text already present wrote nothing, so there
+                // is nothing to protect: publishing it would have a later stage
+                // treat the speaker's own punctuation as a rule's work.
+                let matched = String(output[range])
                 output.replaceSubrange(range, with: expanded)
-                if !rule.isDeletion, !expanded.isEmpty { wrote.append(expanded) }
+                if !rule.isDeletion, !expanded.isEmpty, expanded != matched {
+                    wrote.append(expanded)
+                }
             }
             // Back into reading order. The walk is backwards; the list a later
             // stage searches should still run left to right.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -433,6 +433,7 @@ scripts/check-eval.sh              # every case set, scored
 scripts/check-compose.sh           # what a prompt says once the scope is in it
 scripts/check-context.sh           # what the context stage publishes for a screen
 scripts/check-input.sh             # where the input stage cuts a field, and the caret
+scripts/check-join.sh              # fitting a clip to the text either side of the caret
 scripts/check-span.sh              # a composer-shaped page, or Slack, or Outlook
 scripts/check-vocabulary-config.sh # what vocabulary.yaml adds up to, old keys included
 scripts/check-possessive.sh        # whether a possessive survives a substitution

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -507,6 +507,89 @@ Add the step if your chat app renders pasted markup. Getting this to work
 properly means putting rich text on the clipboard rather than markdown
 characters, which is a different feature.
 
+### `join`, which fits a clip to the box it lands in
+
+`examples/transforms/join/join.py` reads `input.*` and decides two things: what
+goes at the leading edge of the clip, and whether the trailing full stop
+survives.
+
+```yaml
+transforms:
+  - name: join
+    description: space and case the transcript to fit where the caret is
+    command: join.py
+    returns: json
+
+pipelines:
+  default:
+    - input
+    - transform: code_identifiers
+    - stage: transform
+      transform: join
+      when: input.ok
+```
+
+**The problem it solves.** The decoder writes every clip as a standalone
+sentence — leading capital, trailing stop — because it never saw what surrounds
+it. That is right when you are appending to a paragraph and wrong every other
+time: dictating into the middle of a sentence gets you a capital and a stop you
+did not want.
+
+**The leading edge is a first-match-wins table.** Five rules over what precedes
+the caret, in precedence order:
+
+| rule | when | |
+|---|---|---|
+| `line start` | a newline behind, or one in front | no space, capital |
+| `compound` | after a hyphen or a slash | no space, lower case |
+| `glued` | after a bracket or a quote | no space, lower case |
+| `new sentence` | after `.`, `!`, `?` or `…` | space, capital |
+| `mid sentence` | anything else | space, lower case |
+
+Each rule reports its own name in `join.applied`, so the trace says which branch
+decided a sentence. That is the whole reason they are named: as an `if`/`elif`
+chain the only way to find out which branch fired was to read the file and
+guess, which produced three wrong diagnoses in one evening.
+
+**Only the tagger lowers a capital.** The envelope's `tokens` say what the first
+word is. `Verb`, `Determiner`, `Adjective` and the rest of the closed classes
+are lowered; `PersonalName` and `Noun` are not. `Noun` is deliberately on the
+safe side — `User`, `Release` and `Tasmeen` all tag `Noun`, and so does any name
+the tagger does not recognise. With no tag at all nothing is lowered: a stray
+capital is a character you can see and delete, a lowercased name reads as
+correct.
+
+**It also removes a stop the decoder wrote at a hesitation.** "I think you
+should. try this" is the decoder hearing a pause. The signal is the lower-case
+word after the stop, because the decoder capitalises after a boundary it means.
+Measured over 369 mid-clip stops in one archive, 16 had a lower-case word after
+them and nearly all were wrong. Over 3,785 archived clips the rule fired 10
+times and every one was right.
+
+**The glued version of that rule was deleted.** `should.try`, with no space, is
+indistinguishable from `join.py`, `package.json` and `Method.variable`. Over the
+same 3,785 clips it fired 24 times: 19 on real dotted names and at most 2
+usefully. A word list of extensions held some and could never hold the rest —
+`work`, `example` and `variable` are ordinary words that happen to sit right of
+a dot. Deleted rather than tuned.
+
+**It respects `protected`.** A dot an earlier stage wrote is not a guess, and an
+identifier an earlier stage cased keeps that case. Without this, `max_retries`
+at a line start became `Max_retries`. See
+[`protected`](#protected-what-a-later-stage-must-not-undo).
+
+**In a terminal it still runs, and does less.** No caret is readable there, so
+no question about the edges has an answer and every leading-edge rule stands
+down. The stops inside the sentence are a different question and need no caret,
+so that half still fires.
+
+`scripts/check-join.sh` scores it — 44/44 — against
+`examples/transforms/join/cases.yaml`. It runs the deployed script on the
+envelope it really receives, because `--eval` feeds a transcript and nothing
+else. The tags come from `--tag` rather than from the case file, so what is
+scored is the tagger the app ships. A case may name the `rule:` it expects, and
+a right answer reached by the wrong rule counts as a miss.
+
 ### Writing to people: `email` and `slack`
 
 Two prompts scoped to one kind of window each, and the first stages that ask
@@ -781,6 +864,35 @@ the `replacements` ones: `changes` says which rules fired and `before` says
 *where*, because the rules leave no positions behind. A `command:` transform
 publishes whatever it likes; see
 [docs/authoring.md](authoring.md#recipe-a-program-that-reports-what-it-did).
+
+### `protected`: what a later stage must not undo
+
+`protected` is one variable with a meaning agreed across stages: **the exact
+characters this stage wrote on purpose.** A later stage reads it and leaves
+those characters alone.
+
+It is one string, terms joined on `; `, because a scope value is a scalar. A
+condition reads it as `code_identifiers.protected.contains("max_retries")`.
+
+Two stages publish it today.
+
+- `code_identifiers` publishes the identifiers it wrote — `max_retries`,
+  `UserProfile`.
+- A `replace:` table publishes what its rules put in, as does the `replacements`
+  stage. A table has no code of its own, so `Replacements.exact` publishes on
+  its behalf. The value is the **template expanded**: `dotted` writes `$1.` and
+  publishes `user.`, not `$1.`.
+
+`join` is the consumer. It re-cases the first word of a clip and it removes a
+full stop the decoder wrote at a hesitation. Neither is right on something a
+stage wrote deliberately, and no amount of part-of-speech tagging fixes that:
+`max_retries` is a name because a stage made it one, which is a fact about the
+pipeline and not about the language.
+
+Any stage that writes a term it does not want undone publishes the same key.
+Nothing in `join` knows about `code_identifiers` in particular — `ctx.vars`
+already nests by stage name, so the stage that wrote a term names itself by
+where the value lands.
 
 Before any stage runs, the scope already holds `text`, `app`, `bundle_id`,
 `language`, and what transcription measured — `asr.confidence`, `asr.duration`,

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -894,6 +894,19 @@ Nothing in `join` knows about `code_identifiers` in particular — `ctx.vars`
 already nests by stage name, so the stage that wrote a term names itself by
 where the value lands.
 
+**Values, not offsets.** A range published by an earlier stage is stale by the
+time a later one reads it: the stages in between rewrite the text and none of
+them can adjust somebody else's ranges. That is the same fact the envelope
+states as `aligned`. The cost is that two identical strings in one clip cannot
+be told apart, so a term a rule wrote protects an untouched twin as well. That
+errs the safe way — over-protecting leaves a capital you can see and delete,
+under-protecting turns `max_retries` into `Max_retries`.
+
+**Only what a pass actually wrote.** A pattern can match a term already written
+the way the rule would write it. That match changed nothing, so it publishes
+nothing — otherwise the speaker's own punctuation would be read as a rule's
+work. `tests/pipelines/protected.yaml` holds both halves down.
+
 Before any stage runs, the scope already holds `text`, `app`, `bundle_id`,
 `language`, and what transcription measured — `asr.confidence`, `asr.duration`,
 `asr.processing`, `asr.words`. On a dictation it also holds `press.run`, which

--- a/examples/transforms/join/cases.yaml
+++ b/examples/transforms/join/cases.yaml
@@ -328,3 +328,28 @@ cases:
     input: 'He said "we ship. then we rest" today.'
     rule:   "stop at a pause"
     expect: 'He said "we ship then we rest" today.'
+
+  # --- what a value cannot say, written down rather than left to be found ---
+  # `protected` carries values, not offsets, because an offset published by an
+  # earlier stage is stale by the time this one runs — see `protected_terms`.
+  # The price is here: the same string twice, one occurrence written by a rule
+  # and one not, and nothing can tell them apart. Both are kept.
+  #
+  # Scored on purpose, in the direction it errs. Over-protecting leaves a stop
+  # you can see and delete; under-protecting removes one a stage put there
+  # deliberately. `applied` names the attribution once per occurrence, so the
+  # trace says plainly that this happened.
+  - probe: protected
+    before: ~
+    after: ~
+    protected: {replacements: "Update."}
+    input: "Update. then we ship and Update. then we rest"
+    expect: "Update. then we ship and Update. then we rest"
+  # The same sentence with nobody vouching for either. Both stops go, which is
+  # what says the case above is about the attribution and not about the text.
+  - probe: stop
+    before: ~
+    after: ~
+    input: "Update. then we ship and Update. then we rest"
+    rule:   "stop at a pause"
+    expect: "Update then we ship and Update then we rest"

--- a/examples/transforms/join/cases.yaml
+++ b/examples/transforms/join/cases.yaml
@@ -1,0 +1,330 @@
+# Validation set for `join`. Scored with scripts/check-join.sh.
+#
+# Each case is the transcript plus what the caret sits between. `‸` is not in
+# the data — `before` and `after` are separate fields, and the caret is where
+# they meet.
+#
+# Two halves, and `keep` is the one that decides: a stage that reformats a
+# sentence that was already right costs you your own wording, silently. Every
+# case with `expect` equal to `input` is that half.
+#
+# The recogniser writes every clip as a standalone sentence — leading capital,
+# trailing stop — because it has never seen what surrounds it. That is right
+# when appending and wrong every other time.
+
+cases:
+  # --- a stop the decoder wrote at a pause, not at a sentence end ---
+  # The decoder capitalises after a boundary it means, so a lower-case word
+  # after a stop is the sign it heard a hesitation. Highest-precision signal
+  # there is: of 369 mid-clip stops in one archive, 16 had a lower-case word
+  # after them and nearly all were wrong.
+  - probe: stop
+    before: ~
+    after: ~
+    input: "i think you should. try this"
+    rule:   "stop at a pause"
+    expect: "i think you should try this"
+  # No space after the stop and it is left alone. That shape is
+  # indistinguishable from `join.py`, `package.json` and `Method.variable`, and
+  # measured over 3,785 clips it was a real name 19 times out of 24. The rule
+  # that used to split it is gone; see `unstopped`.
+  - probe: stop
+    before: ~
+    after: ~
+    input: "I think you should.try this"
+
+  # A real boundary is followed by a capital and is left alone.
+  - probe: stop
+    before: ~
+    after: ~
+    input: "That is done. Then we ship."
+
+  # A dotted name is built one stage earlier by `dotted` and
+  # `code_identifiers`. Undoing one is worse than leaving a stop in, because
+  # the name cannot be recovered from the sentence.
+  - probe: stop
+    before: ~
+    after: ~
+    input: "run join.py now"
+  - probe: stop
+    before: ~
+    after: ~
+    input: "visit example.com today"
+
+  # Abbreviations are spelled with dots and are followed by lower case.
+  - probe: stop
+    before: ~
+    after: ~
+    input: "e.g. this one"
+  - probe: stop
+    before: ~
+    after: ~
+    input: "U.S. policy is clear"
+
+  # --- appending: the decoder was right, change nothing ---
+  - probe: append
+    before: "I sent the report. "
+    after: ""
+    input: "It should be there by now."
+    expect: "It should be there by now."
+  - probe: append
+    before: ""
+    after: ""
+    input: "Hello there."
+    expect: "Hello there."
+
+  # A stop with no space after it still needs one.
+  - probe: append
+    before: "I sent the report."
+    after: ""
+    input: "It should be there."
+    expect: " It should be there."
+
+  # --- inserting mid-sentence: lower the case, drop the stop ---
+  - probe: insert
+    before: "One, two, three, "
+    after: "four, five, six."
+    input: "Three and a half."
+    expect: "three and a half "
+  - probe: insert
+    before: "we should ship "
+    after: " tomorrow"
+    input: "The release."
+    expect: "the release"
+  # This was a known miss while the rule was a closed word list: "postponed"
+  # is open-class, so its capital was left alone. The tagger calls it a Verb
+  # and the case now passes, while "Sarah" stays a PersonalName and does not.
+  - probe: insert
+    before: "the meeting is"
+    after: "at noon"
+    input: "Postponed."
+    rule:   "mid sentence"
+    expect: " postponed "
+
+  # --- a name must survive the lowercasing ---
+  # The dictionary does not know it, so the case is left alone. A missed
+  # lowercase is a capital you can see; a lost name is not recoverable.
+  - probe: name
+    before: "we deployed it on "
+    after: " last night"
+    input: "Vercel."
+    expect: "Vercel"
+  - probe: name
+    before: "ask "
+    after: " about it"
+    input: "Tasmeen."
+    expect: "Tasmeen"
+  - probe: name
+    before: "it broke because "
+    after: " was down"
+    input: "AWS."
+    expect: "AWS"
+
+  # "I" is a word in English and is never lowered.
+  - probe: name
+    before: "he said that "
+    after: " should go"
+    input: "I."
+    expect: "I"
+
+  # --- after a clause boundary: lower case, keep going ---
+  - probe: clause
+    before: "we could ship it,"
+    after: ""
+    input: "But the tests are red."
+    expect: " but the tests are red."
+
+  # --- glued: no space, no capital ---
+  # Inside a bracket a name is plausible — "(Vercel deploy)" — so the open
+  # class is left alone here too. Only a compound hyphen lowers anything.
+  - probe: glue
+    before: "the function ("
+    after: ")"
+    input: "User name."
+    expect: "User name"
+  - probe: glue
+    before: "a well-"
+    after: " approach"
+    input: "Considered."
+    rule:   "compound"
+    expect: "considered"
+
+  # --- the trailing edge ---
+  # Punctuation already there: no space of ours, and the stop would double.
+  - probe: tail
+    before: "I called "
+    after: ", then left"
+    input: "Sarah."
+    expect: "Sarah"
+  # A question mark carries meaning a full stop does not, so it survives where
+  # a stop would be dropped.
+  - probe: tail
+    before: "she asked, "
+    after: " and nobody knew"
+    input: "Is it ready?"
+    expect: "is it ready?"
+  # A space already there is not doubled.
+  - probe: tail
+    before: "put it "
+    after: " the shelf"
+    input: "On."
+    expect: "on"
+
+  # --- more than one sentence keeps its last stop ---
+  - probe: multi
+    before: "here is the plan. "
+    after: " We ship on Friday."
+    input: "First we test. Then we review."
+    expect: "First we test. Then we review."
+
+  # Shift-enter in Slack: the caret is reported in front of the newline rather
+  # than after it, so `before` looks identical to no line break at all. The
+  # newline in `after` is the only sign, and the break is already a separator.
+  - probe: newline
+    before: "That's fantastic."
+    after: "\n"
+    input: "Even better."
+    rule:   "line start"
+    expect: "Even better."
+
+  # --- a new line starts a sentence, with no leading space ---
+  - probe: newline
+    before: "the first point\n"
+    after: ""
+    input: "The second point."
+    expect: "The second point."
+
+  # --- nothing known: the terminal case, and the stage declining ---
+  # `before` and `after` both absent means the transcript ships untouched.
+  - probe: blind
+    before: ~
+    after: ~
+    input: "Three and a half."
+    expect: "Three and a half."
+
+  # --- an identifier an earlier stage wrote ---
+  # `code_identifiers` publishes `protected` — the names it built. Without that
+  # list `join` capitalises the first word of a clip like any other, and
+  # `max_retries` lands as `Max_retries`. The tagger cannot save this: the word
+  # is a name because a stage made it one, which is a fact about the pipeline.
+  - probe: protected
+    before: "The limit is wrong.\n"
+    after: ~
+    protected: {code_identifiers: "max_retries"}
+    input: "max_retries should be higher."
+    rule:   "max_retries written by code_identifiers"
+    expect: "max_retries should be higher."
+  - probe: protected
+    before: "We renamed it. "
+    after: ~
+    protected: {code_identifiers: "retryCount"}
+    input: "retryCount is the field."
+    rule:   "retryCount written by code_identifiers"
+    expect: "retryCount is the field."
+  # The same clip with nothing protecting it is capitalised, as it should be.
+  - probe: protected
+    before: "The limit is wrong.\n"
+    after: ~
+    input: "max_retries should be higher."
+    rule:   "line start"
+    expect: "Max_retries should be higher."
+  # A protected term mid-sentence is not lowercased either.
+  - probe: protected
+    before: "we passed it to "
+    after: ~
+    protected: {code_identifiers: "UserProfile"}
+    input: "UserProfile takes it."
+    rule:   "UserProfile written by code_identifiers"
+    expect: "UserProfile takes it."
+
+  # Nothing in the contract is about identifiers. `punctuation` publishes the
+  # same key for the segment between "quote" and "unquote", and a quotation is
+  # verbatim: the capital this stage gives the first word of a clip would put a
+  # word in the speaker's mouth, who said "we".
+  - probe: protected
+    before: "The plan is clear.\n"
+    after: ~
+    protected: {punctuation: "we should ship this"}
+    input: '"we should ship this" is what he said.'
+    rule:   "we should ship this written by punctuation"
+    expect: '"we should ship this" is what he said.'
+  # And without it, the capital is right — this is not a rule about quotations.
+  - probe: protected
+    before: "The plan is clear.\n"
+    after: ~
+    input: '"we should ship this" is what he said.'
+    rule:   "line start"
+    expect: '"We should ship this" is what he said.'
+
+  # A stop an earlier stage wrote, not one the decoder invented. `dotted`
+  # publishes `method.` — the exact characters it put in — and the glued-stop
+  # rule reads that by position: the dot it wrote is that term's last character.
+  - probe: protected
+    before: ~
+    after: ~
+    protected: {dotted: "method."}
+    input: "So now if I say method.variable it should work."
+    expect: "So now if I say method.variable it should work."
+  # The same sentence with nobody vouching for the dot. It used to be split and
+  # is not any more: the attribution decides whether the dot is deliberate, and
+  # with no attribution the answer is "leave it", not "guess".
+  - probe: protected
+    before: ~
+    after: ~
+    input: "So now if I say method.variable it should work."
+
+  # --- the dotted names the glued rule used to damage ---
+  # Every one of these is a real name the decoder emitted whole, so no stage
+  # vouches for it. `work`, `example` and `variable` are ordinary English words
+  # sitting right of a dot, which is why no list of extensions could hold them.
+  - probe: stop
+    before: ~
+    after: ~
+    input: "The method.variable worked really well."
+  - probe: stop
+    before: ~
+    after: ~
+    input: "Looking only at the package.json files, what changed?"
+  - probe: stop
+    before: ~
+    after: ~
+    input: "ça me demande d'aller vers api.work OS.com."
+  - probe: stop
+    before: ~
+    after: ~
+    input: "It ships in the repo from the config.example."
+  - probe: stop
+    before: ~
+    after: ~
+    input: "Annotated examples are in slash tmp slash random.cases dot yaml."
+  # The spaced rule is the one that stays. All ten of its archive firings were
+  # real: the decoder wrote a stop at a hesitation and a lower-case word follows.
+  - probe: stop
+    before: ~
+    after: ~
+    input: "it is the responsibility of scripts. if they are implemented"
+    rule:   "stop at a pause"
+    expect: "it is the responsibility of scripts if they are implemented"
+  - probe: stop
+    before: ~
+    after: ~
+    input: "There is no explicit cap. was to only"
+    rule:   "stop at a pause"
+    expect: "There is no explicit cap was to only"
+
+  # `covering` still earns its place on the spaced rule. `punctuation` publishes
+  # a quoted segment, and a stop the speaker dictated inside one is not the
+  # decoder hesitating.
+  - probe: protected
+    before: ~
+    after: ~
+    protected: {punctuation: "we ship. then we rest"}
+    input: 'He said "we ship. then we rest" today.'
+    rule:   "we ship. then we rest written by punctuation"
+    expect: 'He said "we ship. then we rest" today.'
+  - probe: stop
+    before: ~
+    after: ~
+    input: 'He said "we ship. then we rest" today.'
+    rule:   "stop at a pause"
+    expect: 'He said "we ship then we rest" today.'

--- a/examples/transforms/join/join.py
+++ b/examples/transforms/join/join.py
@@ -165,6 +165,18 @@ def protected_terms(envelope):
 
     Nothing here knows about code_identifiers in particular. Any stage that
     writes a term it does not want undone publishes the same key.
+
+    **Values, not offsets, and not by choice of encoding.** An offset published
+    by an earlier stage is stale by the time this one runs: `dotted`, `numbers`
+    and any prompt stage rewrite the text in between, and none of them can
+    adjust somebody else's ranges. That is the same fact the envelope states as
+    `aligned`, which is false as soon as any stage rewrites. A value survives a
+    rewrite; a range does not.
+
+    The cost is that two identical strings in one clip cannot be told apart, so
+    a term a rule wrote protects an untouched twin as well. That errs on the
+    safe side: over-protecting leaves a capital you can see and delete, while
+    under-protecting turns `max_retries` into `Max_retries`.
     """
     found = {}
     for stage, published in ((envelope.get("ctx") or {}).get("vars") or {}).items():

--- a/examples/transforms/join/join.py
+++ b/examples/transforms/join/join.py
@@ -385,21 +385,21 @@ def main():
         sys.stdout.write(raw)
         return
 
-    tokens = envelope.get("tokens") or []
-    tag = tokens[0].get("tag") if tokens else None
-    box = ((envelope.get("ctx") or {}).get("vars") or {}).get("input") or {}
-    before, after = box.get("before"), box.get("after")
-    protected = protected_terms(envelope)
-    if before is None and after is None:
-        # No caret, so nothing can be decided about the edges. The stops inside
-        # the sentence are a different question and do not need one, which is
-        # what makes this worth running in a terminal.
-        out, applied = unstopped(text, protected)
-        print(json.dumps({"text": out, "vars": reported(applied)}))
-        return
-
+    # One guard over the whole decision, not one over half of it. Every branch
+    # below is formatting, and none of it is worth a lost transcript.
     try:
-        out, applied = join(text, before, after, tag, protected)
+        tokens = envelope.get("tokens") or []
+        tag = tokens[0].get("tag") if tokens else None
+        box = ((envelope.get("ctx") or {}).get("vars") or {}).get("input") or {}
+        before, after = box.get("before"), box.get("after")
+        protected = protected_terms(envelope)
+        if before is None and after is None:
+            # No caret, so nothing can be decided about the edges. The stops
+            # inside the sentence are a different question and need none, which
+            # is what makes this worth running in a terminal.
+            out, applied = unstopped(text, protected)
+        else:
+            out, applied = join(text, before, after, tag, protected)
     except Exception:
         out, applied = text, []
     print(json.dumps({"text": out, "vars": reported(applied)}))

--- a/examples/transforms/join/join.py
+++ b/examples/transforms/join/join.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""Fit a dictated sentence to the text it is landing in. Envelope on stdin.
+
+    - name: join
+      description: space and case the transcript to fit where the caret is
+      command: join.py
+      returns: json
+      when: input.ok
+
+Needs the `input` stage above it, which publishes what is either side of the
+caret. Without that this is blind and returns the transcript untouched — which
+is also what happens in a terminal, where the caret is not readable at all. See
+docs/pipelines.md on Input.
+
+Two decisions, taken from the two neighbours:
+
+    before   whether to add a space, and whether the first letter is a capital
+    after    whether to add a space, and whether a trailing full stop survives
+
+The recogniser writes every clip as a standalone sentence — leading capital,
+trailing stop — because it has never seen what surrounds it. That is right when
+you are appending and wrong every other time. This is the stage that knows.
+
+**Only a closed class of words has its capital lowered.** The first attempt
+lowered anything the dictionary knew and turned "I called Sarah" into "I called
+sarah" — `sarah` is in `data/common-words-en.txt`. Nothing in a capitalised word
+says whether the capital is the decoder starting a clip or the speaker naming
+somebody, so the open class is left alone. A stray capital mid-sentence is a
+character you can see and delete; a lowercased name reads as correct.
+
+That list is gone. The envelope carries `tokens`, tagged by `NLTagger` in the
+app, and the first token's `tag` answers the question directly: `Verb` and
+`Determiner` are lowered, `PersonalName` and `Noun` are not. "Postponed" is
+fixed; "Sarah" and "Tasmeen" are safe.
+
+**No tag, no lowering.** Run by hand, or by an app build older than `Tagger`,
+this leaves every capital alone rather than falling back to a guess.
+"""
+import json
+import re
+import sys
+
+# Ends a sentence. `…` included because the decoder writes it.
+SENTENCE_END = ".!?…"
+# After one of these a new sentence starts: space, then a capital.
+OPENS_SENTENCE = re.compile(r"[" + re.escape(SENTENCE_END) + r"][\"'”’)\]]*\s*$")
+# A clause boundary used to be its own rule. Writing the rules out showed it
+# did exactly what the fallback does — space, then lower case — so there is one
+# branch now. Kept as a note rather than a pattern: if a comma ever needs to
+# differ from an ordinary word, this is where that starts.
+# Nothing goes between these and what follows them.
+GLUES = re.compile(r"[(\[{\"'“‘\-–—/@#]\s*$")
+# A hyphen or a slash joins two halves of one word, and the second half of a
+# word is not a name. "a well-Considered approach" has no reading where the
+# capital is right, so this is the one place the open class is lowered too.
+COMPOUND = re.compile(r"[\-–—/]$")
+
+WORD = re.compile(r"[^\W\d_]+", re.UNICODE)
+
+# Tags whose capital is always the decoder's, because the word is never a name.
+# `Noun` is deliberately absent: "User", "Release" and "Tasmeen" all tag Noun,
+# and so would any name the tagger does not recognise.
+LOWERABLE_TAGS = {
+    "Verb", "Adjective", "Adverb", "Number", "Determiner", "Pronoun",
+    "Preposition", "Conjunction", "Particle", "Interjection",
+}
+
+
+def lowered(text, anything=False, tag=None):
+    """The transcript with its first word lowercased, when that is safe.
+
+    `anything` drops the closed-class guard, for the one position where no
+    capital can be right — see `COMPOUND`.
+    """
+    match = WORD.search(text)
+    if not match:
+        return text
+    first = match.group()
+    # "I" is a word, and lowering it is wrong in every sentence in English.
+    if first == "I":
+        return text
+    if first.isupper() and len(first) > 1:          # an acronym, not a capital
+        return text
+    # The tagger decides, and only the tagger. A closed list of function words
+    # stood here first and was a second, weaker implementation of the same
+    # question — the two disagreed on `half` and on `second`, which is what two
+    # implementations of one decision always come to. With no tag there is no
+    # evidence, and no evidence means the capital stays: a stray capital is a
+    # character you can see, a lowercased name reads as correct.
+    if not anything and tag not in LOWERABLE_TAGS:
+        return text
+    if first[:1].islower():
+        return text
+    return text[:match.start()] + first[0].lower() + text[match.start() + 1:]
+
+
+def capitalised(text):
+    match = WORD.search(text)
+    if not match:
+        return text
+    first = match.group()
+    if first[:1].isupper():
+        return text
+    return text[:match.start()] + first[0].upper() + text[match.start() + 1:]
+
+
+# A stop that is not the end of a sentence. Case matters: the decoder writes a
+# capital after a real boundary, so a lower-case word following one is the sign
+# that the stop came from a pause rather than from a full stop.
+SPURIOUS_STOP = re.compile(r"(?<=[^\W\d_])\.(\s+)([a-zà-öø-ÿ])")
+
+# Written with a dot and followed by lower case on purpose.
+ABBREVIATIONS = {
+    "e.g", "i.e", "etc", "vs", "cf", "approx", "al", "ca", "dr", "mr", "mrs",
+    "ms", "st", "no", "fig", "vol", "ed", "p", "pp", "resp", "env",
+}
+
+
+def unstopped(text, protected=None):
+    """Stops the decoder wrote at a pause rather than at the end of a sentence.
+
+    A boundary it means is followed by a capital, because it capitalises after
+    one. A lower-case word after a stop is the decoder having heard a hesitation
+    — "I think you should. try this" — and it is the highest-precision signal
+    there is for that: measured over 369 mid-clip stops in one archive, 16 had a
+    lower-case word after them and nearly all were wrong.
+
+    Only the spaced shape. `should.try`, with no space, is indistinguishable
+    from `join.py`, `package.json` and `Method.variable` — and measured over
+    3,785 archived clips that second rule fired 24 times, of which 19 were real
+    dotted names and at most 2 were stops worth removing. A word list of
+    extensions held some of them and could never hold the rest: `work` and
+    `example` and `variable` are ordinary words that happen to sit right of a
+    dot. Deleted rather than tuned.
+
+    What survives the deletion is a dot an earlier stage wrote, which is not a
+    guess: `dotted` publishes `method.` and that is checked below.
+    """
+    fired = []
+
+    def spaced(match):
+        term, wrote = covering(text, match.start(), protected)
+        if wrote:
+            fired.append(f"{term} written by {wrote}")
+            return match.group(0)
+        words = text[:match.start()].split()
+        head = words[-1].lower().strip(".,;:!?") if words else ""
+        # A dot still inside the word is an abbreviation spelled with them —
+        # "U.S.", "e.g." — and the stop after it is part of the spelling.
+        if "." in head or head in ABBREVIATIONS:
+            return match.group(0)
+        fired.append("stop at a pause")
+        return match.group(1) + match.group(2)
+
+    return SPURIOUS_STOP.sub(spaced, text), list(dict.fromkeys(fired))
+
+
+def protected_terms(envelope):
+    """Terms an earlier stage wrote on purpose, by the stage that wrote them.
+
+    The attribution is free. `ctx.vars` already nests by stage name, so a stage
+    that publishes `protected` names itself by where the value lands —
+    `{"code_identifiers": ["max_retries", "UserProfile"]}`. Joined on "; " on
+    the way in because a scope value is a scalar.
+
+    Nothing here knows about code_identifiers in particular. Any stage that
+    writes a term it does not want undone publishes the same key.
+    """
+    found = {}
+    for stage, published in ((envelope.get("ctx") or {}).get("vars") or {}).items():
+        if not isinstance(published, dict):
+            continue
+        terms = [t for t in str(published.get("protected") or "").split("; ") if t]
+        if terms:
+            found[stage] = terms
+    return found
+
+
+def covering(text, index, protected):
+    """The term covering `text[index]` and the stage that wrote it, or (None, None).
+
+    By position, not by word: the question a stop asks is "did somebody put this
+    exact character here on purpose", and the character sits inside a term
+    rather than at the start of one. `dotted` publishes `method.` and the dot it
+    wrote is that term's last character.
+    """
+    for stage, terms in (protected or {}).items():
+        for term in terms:
+            at = text.find(term)
+            while at >= 0:
+                if at <= index < at + len(term):
+                    return term, stage
+                at = text.find(term, at + 1)
+    return None, None
+
+
+def owner(head, protected):
+    """The term at the start of `head` and the stage that wrote it, or (None, None).
+
+    Matched against the text rather than against a token, because `WORD` here
+    is letters only — it sees `max` in `max_retries`, which is the whole reason
+    the identifier was being re-cased. Longest first, so `user_id` wins over a
+    `user` some other stage claimed.
+    """
+    for stage, terms in (protected or {}).items():
+        for term in sorted(terms, key=len, reverse=True):
+            if head.startswith(term):
+                return term, stage
+    return None, None
+
+
+class Neighbourhood:
+    """What sits either side of the caret, asked in words rather than in regex.
+
+    Every question a rule needs is a property here, so a rule reads as the
+    sentence it is — `n.opens_sentence`, not `OPENS_SENTENCE.search(before)`.
+    The patterns stay above; what moves is where they are consulted.
+
+    `blind` is the terminal case and the `--pipeline` case: no caret was
+    readable, so no question about the edges has an answer and the rules that
+    ask must not fire.
+    """
+
+    def __init__(self, before, after):
+        self.before = before
+        self.after = after
+
+    # --- what is known at all ---
+    @property
+    def blind(self):
+        return self.before is None
+
+    # --- the leading edge ---
+    @property
+    def line_start(self):
+        """The caret is at the start of a line.
+
+        Two ways to be: a newline behind, or a newline in front. The second is
+        Slack — press shift-enter after "That's fantastic." and the box reports
+        total 18, before 17, after "\n". The caret is given as 17, in front of
+        the newline, while the text lands after it. The break is the separator
+        either way, so nothing goes in front of it.
+        """
+        if self.blind:
+            return False
+        return (not self.before.strip()
+                or self.before.endswith("\n")
+                or (self.after is not None and self.after.startswith("\n")))
+
+    @property
+    def opens_sentence(self):
+        return not self.blind and bool(OPENS_SENTENCE.search(self.before))
+
+    @property
+    def glued(self):
+        """A bracket or a quote: what follows closes up against it."""
+        return not self.blind and bool(GLUES.search(self.before))
+
+    @property
+    def after_compound(self):
+        """A hyphen or a slash — the second half of one word, never a name."""
+        return not self.blind and bool(COMPOUND.search(self.before.rstrip()))
+
+    @property
+    def spaced_already(self):
+        return not self.blind and self.before.endswith((" ", "\t"))
+
+    # --- the trailing edge ---
+    @property
+    def appending(self):
+        """Nothing but whitespace follows, so the decoder's stop belongs."""
+        return self.after is None or not self.after.strip()
+
+    @property
+    def rest(self):
+        return "" if self.after is None else self.after.lstrip()
+
+    @property
+    def carries_on(self):
+        """The sentence continues past the caret, so a stop of ours is wrong."""
+        if self.appending:
+            return False
+        head = self.rest[:1]
+        return head in SENTENCE_END + ",;:)]}\"'" or head.islower()
+
+    @property
+    def closes_up(self):
+        """Something already occupies this position, so no space of ours."""
+        if self.after is None or self.after == "":
+            return False
+        return self.after[:1] in " \t\n" or self.rest[:1] in SENTENCE_END + ",;:)]}"
+
+
+class Rule:
+    """One decision about the leading edge, as a thing with a name.
+
+    A name is the point. The rules were an `elif` chain and it worked, but when
+    a sentence came out wrong the only way to find out which branch did it was
+    to read the file and guess — which is how three wrong diagnoses happened in
+    one evening. A rule that can say its own name puts the answer in the trace:
+
+        join   he asked → he asked   34ms
+               applied="new sentence, stop at a pause"
+
+    `space` is whether a separator is wanted, not whether one is written: an
+    existing space is never doubled. `case` is `upper`, `lower`, `lower-any`
+    (past the closed-class guard, for a compound) or `keep`.
+    """
+
+    __slots__ = ("name", "when", "space", "case")
+
+    def __init__(self, name, when, space, case):
+        self.name, self.when, self.space, self.case = name, when, space, case
+
+
+# First match wins, so the order is the precedence. A line start beats
+# everything, a compound hyphen beats the bracket it might sit inside, and
+# "somewhere in a sentence" is what is left.
+LEADING = (
+    Rule("line start", lambda n: n.line_start, space=False, case="upper"),
+    Rule("compound", lambda n: n.glued and n.after_compound,
+         space=False, case="lower-any"),
+    Rule("glued", lambda n: n.glued, space=False, case="lower"),
+    Rule("new sentence", lambda n: n.opens_sentence, space=True, case="upper"),
+    Rule("mid sentence", lambda n: True, space=True, case="lower"),
+)
+
+
+def one_sentence(text):
+    """No sentence end except possibly the last character."""
+    return not any(c in SENTENCE_END for c in text.rstrip()[:-1])
+
+
+def join(text, before, after, tag=None, protected=None):
+    """The fitted transcript, and the names of the rules that fitted it."""
+    n = Neighbourhood(before, after)
+    body, applied = unstopped(text.strip(), protected)
+    if not body:
+        return text, applied
+
+    lead = ""
+    if not n.blind:
+        rule = next(r for r in LEADING if r.when(n))
+        applied.append(rule.name)
+        # An identifier an earlier stage wrote keeps the case that stage chose.
+        # `max_retries` at a line start was becoming `Max_retries`, and no
+        # amount of tagging fixes that: the word is a name because a stage made
+        # it one, which is a fact about the pipeline and not about the language.
+        first = WORD.search(body)
+        term, wrote = owner(body[first.start():], protected) if first else (None, None)
+        if wrote:
+            applied.append(f"{term} written by {wrote}")
+        elif rule.case == "upper":
+            body = capitalised(body)
+        elif rule.case == "lower":
+            body = lowered(body, tag=tag)
+        elif rule.case == "lower-any":
+            body = lowered(body, anything=True, tag=tag)
+        if rule.space and not n.spaced_already:
+            lead = " "
+
+    # The trailing edge. The decoder ends every clip with a stop because it
+    # never saw what follows; landing inside a sentence, that stop is an
+    # artefact. Not a `Rule`: these are two independent decisions rather than
+    # one choice among several, and forcing them into first-match-wins would
+    # describe them wrongly.
+    tail = ""
+    if not n.appending:
+        if n.carries_on and body.endswith(".") and one_sentence(body):
+            body = body[:-1]
+            applied.append("clip stop dropped")
+        tail = "" if n.closes_up else " "
+
+    return lead + body + tail, applied
+
+
+def main():
+    raw = sys.stdin.read()
+    try:
+        envelope = json.loads(raw)
+        text = envelope["text"]
+    except (json.JSONDecodeError, KeyError, TypeError):
+        # A bare command protocol, or something unreadable. Fail open: the
+        # transcript is worth more than the formatting.
+        sys.stdout.write(raw)
+        return
+
+    tokens = envelope.get("tokens") or []
+    tag = tokens[0].get("tag") if tokens else None
+    box = ((envelope.get("ctx") or {}).get("vars") or {}).get("input") or {}
+    before, after = box.get("before"), box.get("after")
+    protected = protected_terms(envelope)
+    if before is None and after is None:
+        # No caret, so nothing can be decided about the edges. The stops inside
+        # the sentence are a different question and do not need one, which is
+        # what makes this worth running in a terminal.
+        out, applied = unstopped(text, protected)
+        print(json.dumps({"text": out, "vars": reported(applied)}))
+        return
+
+    try:
+        out, applied = join(text, before, after, tag, protected)
+    except Exception:
+        out, applied = text, []
+    print(json.dumps({"text": out, "vars": reported(applied)}))
+
+
+def reported(applied):
+    """The rules that fired, as one scalar.
+
+    A comma-joined string rather than a list, because `Scope.Value` is
+    `string | int | double | bool` — a `when:` condition compares scalars, and
+    growing that type for one field is not worth it.
+    """
+    return {"applied": ", ".join(applied), "rules": len(applied)}
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-join.sh
+++ b/scripts/check-join.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Scores the `join` transform against examples/transforms/join/cases.yaml.
+#
+#   scripts/check-join.sh
+#
+# Runs the deployed script, on the envelope it really receives — `--eval` cannot,
+# because this transform reads `ctx.vars.input.*` and the eval harness feeds a
+# transcript and nothing else. Same reason `code_identifiers` has a runner of
+# its own.
+#
+# Counts the two failures separately. Leaving a transcript unjoined is a miss.
+# Reformatting one that was already right is a rewrite, and that is the one this
+# stage exists not to do — it costs you your own wording, silently.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# The tags come from the app, so the binary is a prerequisite and not an
+# optional extra: without it every case is scored against no tags at all.
+[ -x "$ROOT/.build/release/ParrotFlow" ] || {
+  echo "build first: swift build -c release"; exit 1; }
+exec python3 - "$ROOT" <<'PY'
+import json, subprocess, sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("pip install pyyaml")
+
+root = Path(sys.argv[1])
+transform = root / "examples/transforms/join/join.py"
+cases = yaml.safe_load((root / "examples/transforms/join/cases.yaml").read_text())["cases"]
+
+passed = missed = rewrote = 0
+for case in cases:
+    # Tags come from the app, not from the case file: a fixture would score
+    # itself rather than the tagger the transform actually receives.
+    # `--lang` is passed rather than left to fall back to the first configured
+    # language, so the score does not move with whoever's config is on the
+    # machine. A case says `lang: fr` when it needs the French tagger.
+    tagged = subprocess.run([str(root / ".build/release/ParrotFlow"),
+                             "--tag", case["input"], "--lang", case.get("lang", "en")],
+                            capture_output=True, text=True)
+    try:
+        tokens = json.loads(tagged.stdout.strip().splitlines()[-1])
+    except Exception:
+        tokens = []
+    vars = {"input": {"before": case.get("before"), "after": case.get("after")}}
+    # `protected:` is a mapping of stage -> terms, because that is the shape the
+    # transform reads: `ctx.vars` nests by stage, so the stage that wrote a term
+    # is the namespace it arrives under. A case says who protected what.
+    for stage, terms in (case.get("protected") or {}).items():
+        vars[stage] = {"protected": terms}
+    envelope = {"text": case["input"], "tokens": tokens, "ctx": {"vars": vars}}
+    done = subprocess.run([sys.executable, str(transform)],
+                          input=json.dumps(envelope), capture_output=True, text=True)
+    try:
+        reply = json.loads(done.stdout)
+        got = reply["text"]
+        applied = (reply.get("vars") or {}).get("applied", "")
+    except Exception:
+        got, applied = f"<unparseable: {done.stdout[:60]!r} {done.stderr[:60]!r}>", ""
+    want = case.get("expect", case["input"])
+    # `rule:` is optional and asserts *why*. A case that passes for the wrong
+    # reason is the failure an input/output set cannot see, and this evening
+    # produced three of them.
+    rule = case.get("rule")
+    if rule and rule not in applied.split(", "):
+        missed += 1
+        print(f"  ✗ [{case.get('probe','')}] {case['input']!r} — right answer, wrong rule")
+        print(f"      want rule {rule!r}")
+        print(f"      applied   {applied!r}")
+        continue
+
+    if got == want:
+        passed += 1
+        print(f"  ✓ [{case.get('probe','')}] {case['input']!r}"
+              + (f"  {applied}" if applied else ""))
+    else:
+        if want == case["input"]:
+            rewrote += 1
+            mark = "rewrote something correct"
+        else:
+            missed += 1
+            mark = "not the join it wanted"
+        print(f"  ✗ [{case.get('probe','')}] {case['input']!r} — {mark}")
+        print(f"      before {case.get('before')!r}  after {case.get('after')!r}")
+        print(f"      want   {want!r}")
+        print(f"      got    {got!r}")
+
+print()
+print(f"{passed}/{len(cases)}   missed {missed}   rewrote {rewrote}")
+sys.exit(0 if passed == len(cases) else 1)
+PY

--- a/scripts/check-pipeline.sh
+++ b/scripts/check-pipeline.sh
@@ -52,7 +52,7 @@ while IFS='|' read -r name fixture app noprompts input expect vars; do
   # regression this is here to catch.
   missing=""
   if [ -n "$vars" ]; then
-    old="$IFS"; IFS=';'
+    old="$IFS"; IFS=$'\x1f'
     for pair in $vars; do
       [ -z "$pair" ] && continue
       printf '%s\n' "$full" | grep -qxF "var   $pair" || missing="$missing
@@ -93,7 +93,9 @@ def printed(value):
 for c in yaml.safe_load(open(sys.argv[1]))["cases"]:
     fields = [str(c.get(k, "")) for k in
               ("name", "pipeline", "app", "no_prompts", "input", "expect")]
-    fields.append(";".join("%s = %s" % (path, printed(value))
+    # \x1f, not ";". `protected` joins its own terms on "; ", so a semicolon
+    # here split one expectation into two that matched nothing.
+    fields.append("\x1f".join("%s = %s" % (path, printed(value))
                            for path, value in (c.get("expect_vars") or {}).items()))
     print("|".join(fields))
 ' "$ROOT/tests/pipeline-cases.yaml")

--- a/tests/pipeline-cases.yaml
+++ b/tests/pipeline-cases.yaml
@@ -579,6 +579,29 @@ cases:
       replacements.count: 1
       replacements.protected: ""
 
+  # A pattern can match a term that is already written the way the rule would
+  # write it. That match wrote nothing, so there is nothing to protect —
+  # publishing it would have `join` read the speaker's own word as a rule's
+  # work and leave it alone where it should be re-cased.
+  - name: a match that changed nothing protects nothing
+    pipeline: protected
+    input: we deployed on Vercel
+    expect: unchanged
+    expect_vars:
+      replacements.count: 0
+      replacements.changed: false
+      replacements.protected: ""
+
+  # The same rule, the spelling it exists for. This is the half that must keep
+  # working, and it is why the case above cannot be got by deleting the rule.
+  - name: and the same rule protects what it did write
+    pipeline: protected
+    input: we deployed on Versal
+    expect: we deployed on Vercel
+    expect_vars:
+      replacements.count: 1
+      replacements.protected: Vercel
+
   # --- input, which from here can only decline -----------------------------
   #
   # See tests/pipelines/input.yaml. Same shape as the context cases above and

--- a/tests/pipeline-cases.yaml
+++ b/tests/pipeline-cases.yaml
@@ -526,6 +526,59 @@ cases:
       context.ok: false
       context.changed: false
 
+  # --- protected, which a table publishes on its own behalf ----------------
+  #
+  # `protected` is the text a pass actually put in, so a later stage can leave
+  # those characters alone. A `replace:` table has no code of its own, so
+  # `Replacements.exact` publishes for it. The value is the template expanded,
+  # which is the part that needed the change: the all-at-once regex call keeps
+  # the expansion to itself and hands back only the finished string.
+  - name: a replace transform publishes the expanded template, not the template
+    pipeline: vars-shipped
+    input: read user dot name
+    expect: read user.name
+    expect_vars:
+      dotted.count: 1
+      dotted.protected: user.name
+
+  # The same rule twice in one sentence. Both are protected, and the pass walks
+  # the matches back to front so the second one's offsets are still good when
+  # the first is written.
+  - name: a replace transform publishes both substitutions it wrote
+    pipeline: vars-shipped
+    input: read user dot name and config dot yaml
+    expect: read user.name and config.yaml
+    expect_vars:
+      dotted.count: 1
+      dotted.protected: "user.name; config.yaml"
+
+  # Nothing fired, so there is nothing to protect. Empty rather than absent, so
+  # a condition reading it does not fault.
+  - name: a replace transform that fired publishes nothing when it wrote nothing
+    pipeline: vars-shipped
+    input: a python function called max retries
+    expect: a python function called max_retries
+    expect_vars:
+      dotted.ran: false
+
+  # The `replacements` stage publishes it too, from the same pass. A literal
+  # rule protects the term it wrote, and a deletion protects nothing — there is
+  # no text to leave alone.
+  - name: the replacements stage publishes what its rules wrote
+    pipeline: replacements
+    input: our app is deployed on Versailles
+    expect: our app is deployed on Vercel
+    expect_vars:
+      replacements.protected: Vercel
+
+  - name: a deletion protects nothing
+    pipeline: replacements
+    input: our app is um deployed on Vercel
+    expect: Our app is deployed on Vercel
+    expect_vars:
+      replacements.count: 1
+      replacements.protected: ""
+
   # --- input, which from here can only decline -----------------------------
   #
   # See tests/pipelines/input.yaml. Same shape as the context cases above and

--- a/tests/pipelines/protected.yaml
+++ b/tests/pipelines/protected.yaml
@@ -1,0 +1,17 @@
+# What `protected` publishes, and what it must not.
+#
+# `protected` is the text a pass actually put in, so a later stage can leave
+# those characters alone. The rule here matches a term that is already written
+# the way it would be written, which is how a pattern can fire and change
+# nothing. Publishing that would have `join` treat the speaker's own word as
+# something a rule wrote, and leave it alone where it should be re-cased.
+#
+# One rule, two spellings, one of them already correct. That is the whole
+# fixture: the alternation is what makes a no-op match reachable at all.
+languages: [en]
+
+replacements:
+  Vercel: ['/\b(?:Versal|Vercel)\b/']
+
+pipeline:
+  - replacements


### PR DESCRIPTION
> Was stacked on #147, which is merged. Rebased onto `main`; this now targets
> `main` and the diff is only this PR's own work.

## What this adds

### `protected`, across stages

`protected` is the contract: **a stage names the exact characters it wrote, and
no later stage may undo them.**

`code_identifiers` already publishes it (merged in #146) and had no consumer.
This PR is that consumer, and adds the second publisher.

A `replace:` table has no code of its own, so `Replacements.exact` publishes on
its behalf. That meant it had to stop using `stringByReplacingMatches`, which
applies every match at once and keeps the expansions to itself — it hands back
only the finished string. It now walks matches **back to front** with
`replacementString(for:in:offset:template:)`:

- back to front, so an earlier write cannot move a later match;
- the per-rule list is reversed before publishing, so the value still reads left
  to right;
- deduplicated, because a rule that fired four times wrote one term to protect.

The value is the template **expanded**: `dotted` writes `$1.` and publishes
`user.`, not `$1.`.

### `join`

`examples/transforms/join/join.py` fits a dictated clip to what is already in
the box.

The decoder writes every clip as a standalone sentence — leading capital,
trailing stop — because it never saw what surrounds it. That is right when
appending and wrong every other time.

**The leading edge is a first-match-wins `Rule` table** over a `Neighbourhood`
object:

| rule | when | |
|---|---|---|
| `line start` | a newline behind, or one in front | no space, capital |
| `compound` | after a hyphen or a slash | no space, lower case |
| `glued` | after a bracket or a quote | no space, lower case |
| `new sentence` | after `.`, `!`, `?` or `…` | space, capital |
| `mid sentence` | anything else | space, lower case |

Every rule reports its own name in `join.applied`. That is the point of the
table: as an `if`/`elif` chain the only way to find out which branch fired was
to read the file and guess, which produced three wrong diagnoses in one
evening. `check-join.sh` can now assert *why* a case passed, not only that it
did.

**Only the tagger lowers a capital.** `Verb`, `Determiner` and the other closed
classes are lowered; `PersonalName` and `Noun` are not. `Noun` is deliberately
on the safe side — `User`, `Release` and `Tasmeen` all tag `Noun`, and so does
any name the tagger does not recognise. With no tag at all, nothing is lowered.
A stray capital is a character you can see and delete; a lowercased name reads
as correct.

**It removes a stop the decoder wrote at a hesitation.** "I think you should.
try this" is a pause, not a sentence end. The signal is the lower-case word
after the stop, because the decoder capitalises after a boundary it means.

## Two measured facts worth keeping

- **The spaced spurious-stop rule fired 10 times in 3,785 archived clips, and
  every one was right.** Of 369 mid-clip stops in one archive, 16 had a
  lower-case word after them and nearly all were wrong.

- **The glued version of that rule was deleted.** `should.try`, with no space,
  is indistinguishable from `join.py`, `package.json` and `Method.variable`.
  Over the same 3,785 clips it fired 24 times: **19 on real dotted names**
  (`package.json`, `api.work`, `Method.variable`) and at most 2 usefully. A word
  list of extensions held some of them and could never hold the rest — `work`,
  `example` and `variable` are ordinary words that happen to sit right of a dot.
  Deleted rather than tuned.

## The same question as #147, asked once for both

**`join` is NOT in `config.example.yaml`, and it depends on `input`, which is
also not.** Neither was added by me, and the call belongs to the reviewer.

They only make sense together: `input` on its own publishes variables nobody
reads, and `join` without `input` is blind and returns the transcript
untouched.

My recommendation: **leave both off for this release**, ship them documented,
and turn them on together once `join` has run on real dictation for a while.
The reason is asymmetric cost. `join` reformats text it did not have to touch;
`check-join.sh` counts that failure separately ("rewrote") and it is currently
0, but 44 cases is not a distribution. Turning `input` on is also a real
disclosure — every dictation reads the focused field through Accessibility, in
every app.

Say the word and I add both lines.

## Verification

| | |
|---|---|
| `scripts/check-join.sh` | **44/44**, missed 0, rewrote 0 (wired into CI) |
| `scripts/check-pipeline.sh` | 80/80 (5 new cases here, 2 in #147) |
| `scripts/check-eval.sh` | 25/25 |
| `scripts/check-input.sh` | 12/12 |
| `scripts/check-replacements.sh` | 23/23 |
| `scripts/check-dotted.sh` | 64/64 plus 2 known-unfixable |
| `scripts/check-numbers.sh` | 97/97 |
| `scripts/check-possessive.sh` | 35/35 |
| `scripts/check-vocabulary-config.sh` | 61/61 |
| `scripts/check-default-config.sh` | clean |
| `ruff check examples/transforms/join/join.py` | clean (ruff 0.5.5) |

No transcript text changes on any existing set. `Replacements.exact` produces
the same string as before — the back-to-front walk is a different way to reach
the same result, and `check-replacements.sh`, `check-dotted.sh` and
`check-possessive.sh` all hold.

## One change outside the feature

`scripts/check-pipeline.sh` separated `expect_vars` entries on `;`, which is the
character `protected` joins its own terms on. A case asserting two protected
terms was silently split into two expectations that matched nothing. Changed to
`\x1f`. Without it the contract cannot be asserted at all.

## Things I fixed in the copied code

- `unstopped()` had an unreachable second `return out, ...` referring to an
  undefined name — `ruff` F821. Removed.
- `ABBREVIATIONS` listed `cf` twice.
- `Neighbourhood.tag` was stored and never read. Removed.
- `check-join.sh` called `--tag` with no `--lang`, so the score moved with
  whoever's config was on the machine. It now passes `--lang en`, with a
  per-case `lang:` override.
- `check-join.sh` did not check that the binary exists. Without it, every case
  scores against no tags at all and the failure looks like a transform bug.
- The blind path — a terminal, where no caret is readable — sat outside the
  guard that catches everything else. One `try` covers the whole decision now.
  Every branch under it is formatting, and none of it is worth a lost
  transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
