### PR TITLE
feat: name the word lists once, and let dotted hear dash and slash

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1768,7 +1768,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 prompt: prompt, instruction: instruction, text: text, config: llmConfig()
             )
         case .replace:
-            return Replacements.applyExact(to: text, rules: transform.rules)
+            // `expand:`, or a table reached by voice compiles `{{determiners}}`
+            // to nothing while the same table in a pipeline works.
+            return Replacements.exact(
+                to: text, rules: transform.rules, expand: config.expanded
+            ).text
         case .command(let command):
             // Nil is every way a program can fail, and in a pipeline it means
             // keep the text — a stage that fails must not cost you a sentence.

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -66,10 +66,65 @@ struct Config: Decodable, Equatable {
     /// It is maintained by the app rather than by hand — see `Vocabulary`.
     var vocabulary: Vocabulary = Vocabulary()
 
+    /// Named word lists, written once and referred to by name.
+    ///
+    /// The same list — "the determiners, so this is prose and not a name" —
+    /// was pasted into nine regexes across two config files and one Python set,
+    /// and the copies had already drifted: one said `the|a|an`, another held
+    /// forty French words. A `replace:` pattern now writes `{{determiners}}`
+    /// and a transform script reads the same list out of the scope, so there
+    /// is one definition and adding a language is adding words to it.
+    ///
+    /// Deliberately not per language. `dotted` has always merged English and
+    /// French into one alternation and it measures clean, because the words do
+    /// not collide.
+    var lists: [String: [String]] = [:]
 
     enum CodingKeys: String, CodingKey {
         case hotkey, audio, feedback, transcription, llm, transforms, prompts, updates, logging
         case freeForm = "free_form"
+        case lists
+    }
+
+    private static let listReference = try? NSRegularExpression(pattern: #"\{\{(\w+)\}\}"#)
+
+    /// Every `{{name}}` a pattern refers to, in the order written.
+    static func listNames(in pattern: String) -> [String] {
+        guard pattern.contains("{{"), let expression = listReference else { return [] }
+        return expression
+            .matches(in: pattern, range: NSRange(pattern.startIndex..., in: pattern))
+            .compactMap { Range($0.range(at: 1), in: pattern).map { String(pattern[$0]) } }
+    }
+
+    /// `{{name}}` replaced by the list, as a regex alternation.
+    ///
+    /// Longest first, so `semi colon` cannot be eaten by `colon` sitting
+    /// earlier in the same alternation.
+    ///
+    /// A name that is unknown, or defined and empty, is left alone rather than
+    /// emptied: `(?:)` matches everywhere, so `(?!(?:{{determiners}})\b)` would
+    /// never match and the rule would silently stop firing. Left literal it
+    /// matches nothing, which fails the other way. `replacementProblems` names
+    /// both cases before either can happen.
+    func expanded(_ pattern: String) -> String {
+        guard pattern.contains("{{") else { return pattern }
+        var out = pattern
+        for (name, words) in lists where !words.isEmpty {
+            let alternation = words
+                .sorted { $0.count > $1.count }
+                .map { NSRegularExpression.escapedPattern(for: $0) }
+                .joined(separator: "|")
+            out = out.replacingOccurrences(of: "{{\(name)}}", with: alternation)
+        }
+        return out
+    }
+
+    /// The lists as scope values, for a transform that is a program rather than
+    /// a table. Joined on `; ` because a `Scope.Value` is a scalar.
+    var listVariables: [String: Scope.Value] {
+        lists.reduce(into: [:]) { out, entry in
+            out[entry.key] = .string(entry.value.joined(separator: "; "))
+        }
     }
 
     /// The words you dictate that the recogniser gets wrong, and what the app
@@ -752,6 +807,26 @@ struct Config: Decodable, Equatable {
             }
             if let why = entry.unreadable {
                 let said = "transforms: \"\(entry.name)\" \(why); skipped"
+                Log.write(said)
+                unreadable.append(said)
+                continue
+            }
+            // A name the scope already uses. Dropped rather than reported and
+            // kept, because a stage files its variables under its own name and
+            // this one would write over `lists.determiners` or `asr.confidence`.
+            //
+            // Asked here, where the name is declared, because `Pipeline
+            // .validate` asks it of the spelling a *step* wrote and the two are
+            // not the same question. And asked case-insensitively, because
+            // `transform(named:)` is: a step spelled `lists` reaches a transform
+            // declared `Lists`, and `Pipeline.namespace` then files it under the
+            // step's spelling. Either casing is a way into the same namespace,
+            // so neither may be declared.
+            if let taken = Scope.reserved.first(where: {
+                $0.caseInsensitiveCompare(entry.name) == .orderedSame
+            }) {
+                let said = "transforms: \"\(entry.name)\" would file its variables where"
+                    + " \(taken) already is; skipped — rename it"
                 Log.write(said)
                 unreadable.append(said)
                 continue
@@ -1693,6 +1768,12 @@ struct Config: Decodable, Equatable {
         if let freeForm = try c.decodeIfPresent(Bool.self, forKey: .freeForm) {
             self.freeForm = freeForm
         }
+        // Decoded here because this initialiser is hand-rolled. A property and
+        // a CodingKey are not enough: miss this line and the lists work in a
+        // `--pipeline` fixture and are empty in the app.
+        if let lists = try c.decodeIfPresent([String: [String]].self, forKey: .lists) {
+            self.lists = lists
+        }
     }
 
     /// Everything the config says that will not do what it looks like it does.
@@ -1719,6 +1800,27 @@ struct Config: Decodable, Equatable {
     /// wherever it is written.
     func replacementProblems() -> [String] {
         var found: [String] = []
+        // A pattern naming a list that is not there, or is there and empty.
+        // Both are left literal at runtime — an emptied alternation would match
+        // everywhere — so the rule simply never fires, and this is the only
+        // place that says so.
+        let defined = lists.keys.sorted()
+        for rule in transcription.rules + transforms.flatMap(\.rules) {
+            for name in Config.listNames(in: rule.pattern) {
+                guard let words = lists[name] else {
+                    found.append("lists: \"\(rule.source)\" names {{\(name)}}, which nothing"
+                        + " defines"
+                        + (defined.isEmpty ? " — there is no lists: section"
+                            : " — have: \(defined.joined(separator: ", "))")
+                        + "; the rule never fires")
+                    continue
+                }
+                if words.isEmpty {
+                    found.append("lists: \"\(rule.source)\" names {{\(name)}}, which is defined"
+                        + " with no words in it; the rule never fires")
+                }
+            }
+        }
         // A template referring to a group the pattern never captures is
         // written as nothing at all — the rule fires, the output is quietly
         // short, and the log shows a substitution that looks like it worked.

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -101,15 +101,21 @@ struct Config: Decodable, Equatable {
     /// Longest first, so `semi colon` cannot be eaten by `colon` sitting
     /// earlier in the same alternation.
     ///
-    /// A name that is unknown, or defined and empty, is left alone rather than
-    /// emptied: `(?:)` matches everywhere, so `(?!(?:{{determiners}})\b)` would
-    /// never match and the rule would silently stop firing. Left literal it
-    /// matches nothing, which fails the other way. `replacementProblems` names
-    /// both cases before either can happen.
-    func expanded(_ pattern: String) -> String {
+    /// Nil when a name is unknown or names an empty list. The rule is then
+    /// skipped, the way one with an invalid pattern is.
+    ///
+    /// Skipped rather than expanded to something, because no expansion is safe
+    /// both ways. Emptied, `(?:)` matches everywhere: a positive rule fires on
+    /// every word. Left literal it matches nothing, so
+    /// `(?!(?:{{determiners}})\b)` always succeeds and `dotted` rewrites prose.
+    /// A guard and a plain match want opposite fallbacks, so not running is the
+    /// only answer that is right for both. `replacementProblems` refuses the
+    /// config first; this is what happens if one is loaded anyway.
+    func expanded(_ pattern: String) -> String? {
         guard pattern.contains("{{") else { return pattern }
         var out = pattern
-        for (name, words) in lists where !words.isEmpty {
+        for name in Config.listNames(in: pattern) {
+            guard let words = lists[name], !words.isEmpty else { return nil }
             let alternation = words
                 .sorted { $0.count > $1.count }
                 .map { NSRegularExpression.escapedPattern(for: $0) }

--- a/Sources/ParrotFlow/EvalCases.swift
+++ b/Sources/ParrotFlow/EvalCases.swift
@@ -28,6 +28,14 @@ struct EvalCases {
     /// assumes instead of inheriting this machine's config. Decoded by `Config`
     /// rather than re-read here, the way a `--pipeline` fixture is.
     var transforms: [Config.Transform] = []
+    /// A `lists:` section of its own, for the same reason. A transform the set
+    /// carries can guard on `{{determiners}}`, and without this the words would
+    /// come from whichever machine the set is scored on.
+    ///
+    /// Optional rather than empty-by-default, so `lists: {}` and no `lists:` at
+    /// all are different things. The first says "no words, and I mean it" and
+    /// the second says "whatever this machine has".
+    var lists: [String: [String]]?
     var cases: [Case] = []
 
     /// What the first stage of a two-stage transform should return on its own.
@@ -62,6 +70,14 @@ struct EvalCases {
         /// files to gain nothing.
         var probe: String { fields["probe"] ?? fields["category"] ?? "" }
         var name: String { fields["name"] ?? input }
+        /// `lang: fr` — which language this case is in.
+        ///
+        /// Stated rather than detected. The pipeline detects when nothing says
+        /// otherwise, and detection is unreliable on the length a case is:
+        /// "C'est vraiment fantastique." comes back `en`. A French case scored
+        /// under English rules passes for the wrong reason, which is the one
+        /// failure a set cannot see.
+        var language: String? { fields["lang"] ?? fields["language"] }
         /// True when this case must come back byte for byte.
         var mustNotChange: Bool { expect == input }
     }
@@ -99,7 +115,7 @@ struct EvalCases {
 
 extension EvalCases: Decodable {
     enum CodingKeys: String, CodingKey {
-        case transform, instruction, control, intermediate, transforms, cases
+        case transform, instruction, control, intermediate, transforms, lists, cases
     }
 
     init(from decoder: Decoder) throws {
@@ -114,6 +130,7 @@ extension EvalCases: Decodable {
         if c.contains(.transforms) {
             transforms = try Config.transforms(from: try c.superDecoder(forKey: .transforms))
         }
+        lists = try c.decodeIfPresent([String: [String]].self, forKey: .lists)
         cases = try c.decodeIfPresent([Case].self, forKey: .cases) ?? []
     }
 }

--- a/Sources/ParrotFlow/EvalCommand.swift
+++ b/Sources/ParrotFlow/EvalCommand.swift
@@ -26,7 +26,7 @@ enum EvalCommand {
     static func run(
         target: String, cases override: String?, probe: String?, verbose: Bool
     ) -> Int32 {
-        let config: Config
+        var config: Config
         do {
             config = try ConfigStore.load()
         } catch {
@@ -36,6 +36,29 @@ enum EvalCommand {
 
         guard let found = locate(target, cases: override, config: config) else { return 1 }
         let (file, set, transform) = found
+
+        // A set that carries its own `lists:` states what it assumes, the way
+        // it already can with `transforms:`. Without this a `{{name}}` in a
+        // transform the set carries would resolve against whichever machine is
+        // scoring it. All of them, not merged: a set says what it assumes, and
+        // `lists: {}` therefore means none rather than "this machine's".
+        if let stated = set.lists { config.lists = stated }
+
+        // The rules that are about to run, checked before anything is scored.
+        // A `{{name}}` that resolves to nothing makes the rule match nothing,
+        // and a set would score that as "the transform did not fire" — a wrong
+        // number rather than an error, which is the failure a case set exists
+        // to prevent. Only this transform's rules: another entry's mistake is
+        // `--check-config`'s to report, not this run's to fail on.
+        var underTest = Config()
+        underTest.lists = config.lists
+        underTest.transforms = [transform]
+        let ruleProblems = underTest.replacementProblems()
+        guard ruleProblems.isEmpty else {
+            print("✗ \(short(file.path)) scores \"\(transform.name)\":")
+            for problem in ruleProblems { print("    \(problem)") }
+            return 1
+        }
 
         // What `--probe` selected, decided once and handed to everything that
         // reads a case — validation, the gold check, the scoring. Deciding it
@@ -172,6 +195,10 @@ enum EvalCommand {
                 + " and not in the file")
             return nil
         }
+        // The same refusal `Pipeline.validate` makes, made here because
+        // `--eval` builds its one-step pipeline rather than loading one. A
+        // transform called `lists` or `asr` would file its variables where the
+        // runner has already put something, and score against its own damage.
         return (file, set, transform)
     }
 
@@ -183,7 +210,8 @@ enum EvalCommand {
     /// the app runs, including the part where every way of failing returns the
     /// transcript exactly as it arrived.
     private static func through(
-        _ transform: Config.Transform, _ text: String, config: Config, instruction: String
+        _ transform: Config.Transform, _ text: String, config: Config, instruction: String,
+        language: String? = nil
     ) -> (output: String, seconds: TimeInterval) {
         // A prompt reached by voice is given what the speaker actually said,
         // and the same prompt in a pipeline is given nothing — "format those
@@ -211,8 +239,12 @@ enum EvalCommand {
         var output = text
         let started = Date()
         let done = DispatchSemaphore(value: 0)
+        // Seeded, so `Pipeline` keeps it instead of detecting one. Absent, the
+        // detector runs exactly as it does for a real dictation.
+        var seed = Scope()
+        if let language { seed.set("language", .string(language)) }
         Task {
-            output = await pipeline.run(text, config: config)
+            output = await pipeline.run(text, config: config, seed: seed)
             done.signal()
         }
         done.wait()
@@ -311,11 +343,13 @@ enum EvalCommand {
         // is a case that is about to be scored anyway, so this costs one extra
         // run of one input rather than one of an input nobody asked for.
         if let first = selected.first {
-            _ = through(transform, first.input, config: config, instruction: instruction)
+            _ = through(transform, first.input, config: config, instruction: instruction,
+                        language: first.language)
         }
 
         for one in selected {
-            let (got, seconds) = through(transform, one.input, config: config, instruction: instruction)
+            let (got, seconds) = through(transform, one.input, config: config,
+                                         instruction: instruction, language: one.language)
             let correct = got == one.expect
             scored.overall.add(correct)
             scored.latencies.append(seconds)

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -686,6 +686,12 @@ struct Pipeline: Equatable, Codable {
             scope.set("vocabulary.count", .int(0))
             scope.set("vocabulary.changes", .string(""))
         }
+        // The named lists, so a transform that is a program reads the same
+        // words a `replace:` pattern writes as `{{determiners}}`. Under one
+        // namespace, so a script asks `ctx["vars"]["lists"]["determiners"]`.
+        for (name, value) in config.listVariables {
+            scope.set("lists.\(name)", value)
+        }
 
         for step in steps {
             let named = step.transform.map { "\(step.stage.name) \($0)" } ?? step.stage.name
@@ -825,7 +831,8 @@ struct Pipeline: Equatable, Codable {
             // person wrote; `vocabulary.yaml` holds the names the app learnt.
             // One pass, so a rule behaves the same whichever file it came from.
             let done = Replacements.exact(
-                to: text, rules: config.transcription.rules + config.vocabularyRules
+                to: text, rules: config.transcription.rules + config.vocabularyRules,
+                expand: config.expanded
             )
             // `changes` as well as `count`, so a later stage can judge what
             // this one did. A stage handed only the finished sentence cannot
@@ -1222,7 +1229,8 @@ struct Pipeline: Equatable, Codable {
             // exactly what a later stage must not undo. `dotted` writes the dot
             // in `user.name` and `join` would otherwise read it as one the
             // decoder invented.
-            let done = Replacements.exact(to: text, rules: transform.rules)
+            let done = Replacements.exact(to: text, rules: transform.rules,
+                                          expand: config.expanded)
             if done.text != text {
                 Log.write("pipeline: transform \(name) rewrote the transcript")
                 Log.write("    before: \(text)")

--- a/Sources/ParrotFlow/PipelineCommand.swift
+++ b/Sources/ParrotFlow/PipelineCommand.swift
@@ -43,9 +43,13 @@ enum PipelineCommand {
         /// what to do about it — the answer comes from a model and is not
         /// deterministic, so it is not a thing a case set can hold.
         var llm: Config.LLM?
+        /// Its own `lists:`. A pattern that says `{{determiners}}` compiles to
+        /// nothing without them, and a guard that silently stops guarding is
+        /// the failure a fixture exists to catch.
+        var lists: [String: [String]] = [:]
 
         enum CodingKeys: String, CodingKey {
-            case languages, replacements, pipeline, transforms, vocabulary, llm
+            case languages, replacements, pipeline, transforms, vocabulary, llm, lists
         }
 
         init(from decoder: Decoder) throws {
@@ -62,6 +66,9 @@ enum PipelineCommand {
                 // section is handed back to the type that reads the real one.
                 let nested = try c.superDecoder(forKey: .transforms)
                 transforms = try Config.transforms(from: nested)
+            }
+            if let v = try c.decodeIfPresent([String: [String]].self, forKey: .lists) {
+                lists = v
             }
             vocabulary = try c.decodeIfPresent(Config.Vocabulary.self, forKey: .vocabulary)
             llm = try c.decodeIfPresent(Config.LLM.self, forKey: .llm)
@@ -130,6 +137,7 @@ enum PipelineCommand {
         config.transcription.replacements = fixture.replacements
         config.transcription.pipelines = ["default": pipeline]
         config.transforms = fixture.transforms
+        config.lists = fixture.lists
         if let vocabulary = fixture.vocabulary { config.vocabulary = vocabulary }
         if let llm = fixture.llm { config.llm = llm }
 

--- a/Sources/ParrotFlow/Replacements.swift
+++ b/Sources/ParrotFlow/Replacements.swift
@@ -91,12 +91,13 @@ enum Replacements {
     ///   purpose. A `replace:` transform has no code of its own to publish
     ///   from, so this pass publishes on its behalf.
     ///
-    /// `expand` turns `{{determiners}}` in a pattern into the list it names.
-    /// Passed in rather than reached for, because this type knows about rules
-    /// and not about the config they came from.
+    /// `expand` turns `{{determiners}}` in a pattern into the list it names,
+    /// and returns nil for a name that resolves to nothing. Passed in rather
+    /// than reached for, because this type knows about rules and not about the
+    /// config they came from.
     static func exact(
         to text: String, rules: [Config.Transcription.Rule],
-        expand: (String) -> String = { $0 }
+        expand: (String) -> String? = { $0 }
     ) -> (text: String, count: Int, changes: String, protected: String) {
         var output = text
         var deleted = false
@@ -105,8 +106,13 @@ enum Replacements {
         var written: [String] = []
 
         for rule in rules {
+            guard let source = expand(rule.pattern) else {
+                Log.write("replacements: \"\(rule.source)\" names a word list that is not"
+                    + " there; skipped")
+                continue
+            }
             guard let pattern = try? NSRegularExpression(
-                pattern: expand(rule.pattern), options: [.caseInsensitive]
+                pattern: source, options: [.caseInsensitive]
             ) else {
                 Log.write("replacements: \"\(rule.source)\" is not a valid pattern; skipped")
                 continue

--- a/Sources/ParrotFlow/Replacements.swift
+++ b/Sources/ParrotFlow/Replacements.swift
@@ -58,6 +58,10 @@ enum Replacements {
 
     /// Literal on word boundaries, or a regular expression when the source is
     /// wrapped in slashes. Case-insensitive either way.
+    ///
+    /// No `{{name}}` expansion. For rules built in code from words a person
+    /// typed, never for a table out of the config — those go through `exact`
+    /// with `config.expanded`.
     static func applyExact(to text: String, rules: [Config.Transcription.Rule]) -> String {
         exact(to: text, rules: rules).text
     }
@@ -86,8 +90,13 @@ enum Replacements {
     ///   decoder invented, and neither is right on something a table wrote on
     ///   purpose. A `replace:` transform has no code of its own to publish
     ///   from, so this pass publishes on its behalf.
+    ///
+    /// `expand` turns `{{determiners}}` in a pattern into the list it names.
+    /// Passed in rather than reached for, because this type knows about rules
+    /// and not about the config they came from.
     static func exact(
-        to text: String, rules: [Config.Transcription.Rule]
+        to text: String, rules: [Config.Transcription.Rule],
+        expand: (String) -> String = { $0 }
     ) -> (text: String, count: Int, changes: String, protected: String) {
         var output = text
         var deleted = false
@@ -97,7 +106,7 @@ enum Replacements {
 
         for rule in rules {
             guard let pattern = try? NSRegularExpression(
-                pattern: rule.pattern, options: [.caseInsensitive]
+                pattern: expand(rule.pattern), options: [.caseInsensitive]
             ) else {
                 Log.write("replacements: \"\(rule.source)\" is not a valid pattern; skipped")
                 continue

--- a/Sources/ParrotFlow/Scope.swift
+++ b/Sources/ParrotFlow/Scope.swift
@@ -93,9 +93,13 @@ struct Scope: Equatable {
     /// answer. `instruction` joined it when prompts learned to read the scope —
     /// `PromptRunner.compose` puts the spoken instruction there, so it is a bare
     /// name for exactly the same reason.
+    /// `lists` joined for the ordinary reason: the runner publishes every named
+    /// word list under `lists.*` before any stage runs, so a transform of that
+    /// name would overwrite them and a script reading
+    /// `ctx["vars"]["lists"]["determiners"]` would get whatever it wrote.
     static let reserved: Set<String> = [
         "text", "app", "bundle_id", "language", "instruction",
-        "asr", "vad", "vocabulary",
+        "asr", "vad", "vocabulary", "lists",
     ]
 
     init(values: [String: Value] = [:]) {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -116,6 +116,44 @@ llm:
 updates:
   after_days: 0
 
+# Word lists, written once and named. A `replace:` pattern refers to one as
+# `{{determiners}}` and a transform that is a program reads the same words from
+# `ctx["vars"]["lists"]`, so there is one definition rather than a copy in every
+# regex — there were nine, and they had already drifted apart.
+#
+# Not split by language. `dotted` has always merged English and French into one
+# alternation and it measures clean, because the words do not collide. Adding a
+# language is adding words here, not adding a file.
+#
+# Every entry is quoted. `on`, `no` and `off` are booleans in YAML 1.1, which is
+# what the check scripts parse with, and an unquoted `on` reaches them as the
+# word `true`.
+lists:
+  # What may sit in front of a spoken name. A determiner there means the words
+  # are prose: "the dot com bubble", "le point sur les tests".
+  determiners: ["le", "la", "les", "l", "un", "une", "des", "du", "de", "d", "ce", "cet", "cette", "ces", "mon", "ma", "mes", "ton", "ta", "tes", "son", "sa", "ses", "notre", "nos", "votre", "vos", "leur", "leurs", "au", "aux", "à", "quel", "quelle", "chaque", "autre", "même", "premier", "première", "deuxième", "dernier", "dernière", "seul", "seule", "bon", "bonne", "mauvais", "certain", "tel", "telle", "quelque", "the", "a", "an"]
+
+  # Words that mean the speaker is joining ideas, not names. Only `dash` needs
+  # these, being an ordinary word in a way `hyphen` is not.
+  connectors: ["this", "that", "about", "and", "or", "it"]
+
+  # What may sit in front of a slash that starts a path rather than joining two
+  # words: "available in slash tmp slash x".
+  path_lead: ["in", "to", "at", "from", "on", "of", "into", "onto", "under", "sure", "is", "was", "be"]
+
+  # What may follow "point"/"dot" in prose. Mostly French, because "point" is an
+  # everyday French word and English "dot" is not: "point de vue", "point
+  # commun", "point final". The last few are the English set phrases.
+  prose_after_point: ["de", "du", "des", "d", "le", "la", "les", "l", "un", "une", "sur", "dans", "en", "et", "ou", "que", "qui", "où", "à", "au", "aux", "pour", "par", "avec", "sans", "est", "sont", "était", "sera", "me", "te", "se", "ne", "n", "c", "il", "elle", "je", "tu", "nous", "vous", "ils", "elles", "ce", "plus", "moins", "très", "mais", "donc", "car", "si", "comme", "final", "finale", "barre", "virgule", "commun", "commune", "faible", "faibles", "fort", "forts", "mort", "culminant", "névralgique", "chaud", "sensible", "positif", "négatif", "clé", "focal", "nommé", "com", "net", "org", "matrix", "product", "notation", "plot"]
+
+  # Ordinary English function words. A real hyphen-join has a name part on its
+  # right, never a preposition — this is what leaves "a mad dash to the door".
+  function_words: ["to", "the", "a", "an", "of", "for", "in", "on", "at", "from", "with", "is", "was", "are", "were", "and", "or", "it", "its", "this", "that"]
+
+  # The names of the marks themselves. Saying them is talking about them, which
+  # is why "add slash semicolon ellipsis" comes back as words.
+  mark_names: ["semicolon", "semi", "ellipsis", "comma", "colon", "dot", "dash", "hyphen", "underscore", "period", "quote", "unquote", "bracket", "brackets", "paren", "parens", "parenthesis", "point", "virgule"]
+
 # What the activation phrase can reach, and what a pipeline can name.
 #
 #   name          the id a pipeline or `when:` names
@@ -170,15 +208,34 @@ transforms:
   # use there, or "voilà le point sur les tests" becomes "voilà le.sur les
   # tests". First list: what may not precede. Second: what may not follow.
   #
-  # Hyphen and underscore reuse both lists — same risk shape. `dash` is left
-  # out: an ordinary word ("a mad dash to the door") with no guard measured
-  # against it, unlike `dot`/`point`.
+  # Hyphen and underscore reuse both lists — same risk shape.
+  #
+  # `dash` was left out until it was measured. Over 3,759 archived clips
+  # "hyphen" was said 0 times and "dash" 8, 6 of them joining a real name. It is
+  # also an ordinary word, so it carries a longer before-list and an English
+  # after-list of its own: a real join has a name part on its right, never a
+  # preposition, and that is what leaves "a mad dash to the door" alone.
+  #
+  # A single letter either side — "A dot B", "a underscore b" — is never prose.
+  # The article guard was throwing it away.
   - name: dotted
-    description: spoken dot, hyphen and underscore paths as code
+    description: spoken dot, hyphen, dash, slash and underscore paths as code
     replace:
-      '$1.': ['/\b(?!(?:le|la|les|l|un|une|des|du|de|d|ce|cet|cette|ces|mon|ma|mes|ton|ta|tes|son|sa|ses|notre|nos|votre|vos|leur|leurs|au|aux|à|quel|quelle|chaque|autre|même|premier|première|deuxième|dernier|dernière|seul|seule|bon|bonne|mauvais|certain|tel|telle|quelque|the|a|an)\b)(\w+) (?:dot|point) (?!(?:de|du|des|d|le|la|les|l|un|une|sur|dans|en|et|ou|que|qui|où|à|au|aux|pour|par|avec|sans|est|sont|était|sera|me|te|se|ne|n|c|il|elle|je|tu|nous|vous|ils|elles|ce|plus|moins|très|mais|donc|car|si|comme|final|finale|barre|virgule|commun|commune|faible|faibles|fort|forts|mort|culminant|névralgique|chaud|sensible|positif|négatif|clé|focal|nommé|com|net|org|matrix|product|notation|plot)\b)(?=\w)/']
-      '$1-': ['/\b(?!(?:le|la|les|l|un|une|des|du|de|d|ce|cet|cette|ces|mon|ma|mes|ton|ta|tes|son|sa|ses|notre|nos|votre|vos|leur|leurs|au|aux|à|quel|quelle|chaque|autre|même|premier|première|deuxième|dernier|dernière|seul|seule|bon|bonne|mauvais|certain|tel|telle|quelque|the|a|an)\b)(\w+) (?:hyphen|tiret(?! bas)) (?!(?:de|du|des|d|le|la|les|l|un|une|sur|dans|en|et|ou|que|qui|où|à|au|aux|pour|par|avec|sans|est|sont|était|sera|me|te|se|ne|n|c|il|elle|je|tu|nous|vous|ils|elles|ce|plus|moins|très|mais|donc|car|si|comme|final|finale|barre|virgule|commun|commune|faible|faibles|fort|forts|mort|culminant|névralgique|chaud|sensible|positif|négatif|clé|focal|nommé|com|net|org|matrix|product|notation|plot)\b)(?=\w)/']
-      '$1_': ['/\b(?!(?:le|la|les|l|un|une|des|du|de|d|ce|cet|cette|ces|mon|ma|mes|ton|ta|tes|son|sa|ses|notre|nos|votre|vos|leur|leurs|au|aux|à|quel|quelle|chaque|autre|même|premier|première|deuxième|dernier|dernière|seul|seule|bon|bonne|mauvais|certain|tel|telle|quelque|the|a|an)\b)(\w+) (?:underscore|souligné|tiret bas) (?!(?:de|du|des|d|le|la|les|l|un|une|sur|dans|en|et|ou|que|qui|où|à|au|aux|pour|par|avec|sans|est|sont|était|sera|me|te|se|ne|n|c|il|elle|je|tu|nous|vous|ils|elles|ce|plus|moins|très|mais|donc|car|si|comme|final|finale|barre|virgule|commun|commune|faible|faibles|fort|forts|mort|culminant|névralgique|chaud|sensible|positif|négatif|clé|focal|nommé|com|net|org|matrix|product|notation|plot)\b)(?=\w)/']
+      '$1.': ['/\b(?!(?:{{determiners}})\b)(\w+) (?:dot|point) (?!(?:{{prose_after_point}})\b)(?=\w)/',
+              '/\b([A-Za-z]) (?:dot|point) (?=[A-Za-z]\b)/']
+      '$1-': ['/\b(?!(?:{{determiners}})\b)(\w+) (?:hyphen|tiret(?! bas)) (?!(?:{{prose_after_point}})\b)(?=\w)/',
+              '/\b(?!(?:{{determiners}}|{{connectors}})\b)(\w+) (?:dash) (?!(?:{{prose_after_point}}|{{function_words}})\b)(?=\w)/',
+              '/\b([A-Za-z]) (?:hyphen|tiret(?! bas)|dash) (?=[A-Za-z]\b)/']
+      # A path, or the and/or sense ("a technical slash product decision").
+      # `(?<!slash )` is what keeps a leading-slash path from half-converting:
+      # "in slash tmp slash x" declines whole rather than becoming
+      # "in slash tmp/x". A `replace:` table is a Swift dictionary, so its rules
+      # run in an arbitrary order and no two-step rewrite can be relied on.
+      # The mark names in the after-list are why "add slash semicolon ellipsis"
+      # is left as words.
+      '$1/': ['/\b(?!(?:{{determiners}}|{{path_lead}})\b)(?<!slash )(?<!barre oblique )(\w+) (?:slash|barre oblique) (?!(?:{{mark_names}})\b)(?=\w)/']
+      '$1_': ['/\b(?!(?:{{determiners}})\b)(\w+) (?:underscore|souligné|tiret bas) (?!(?:{{prose_after_point}})\b)(?=\w)/',
+              '/\b([A-Za-z]) (?:underscore|souligné|tiret bas) (?=[A-Za-z]\b)/']
 
   - name: backticks
     description: wrap dotted paths in backticks, for chat

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -346,8 +346,8 @@ and you stop running it.
   beats a refusal on any set without negatives. `examples/transforms/code_identifiers/cases.yaml`
   is 32 of 75 cases that must come back untouched, and that half is the one that
   catches regressions.
-- **Keep the residue in, failing.** `examples/transforms/dotted/cases.txt` scores 54/54 and
-  carries two more it cannot do. A set that reaches 100% by dropping what it
+- **Keep the residue in, failing.** `examples/transforms/dotted/cases.txt` scores 73/73 and
+  carries three more it cannot do. A set that reaches 100% by dropping what it
   cannot do is worse than a number.
 - **Write the contract at the top of the file**, in prose: what counts as a
   case for this feature and what is deliberately out of scope. It is the thing
@@ -358,6 +358,10 @@ and you stop running it.
   the case file scores that too, on the same cases. It is the only thing that
   answers "is the model earning its place", and twice in this repo the answer
   was no.
+- **State the language with `lang:`** on any case that is not in your first
+  one. Without it the pipeline detects, and detection is unreliable at the
+  length a case is — "C'est vraiment fantastique." comes back `en`. A French
+  case scored under English rules passes for the wrong reason.
 
 The sets that exist. A transform's set lives in its folder; the ones belonging
 to a built-in stage or to the router have nowhere else to be and stay in
@@ -365,7 +369,7 @@ to a built-in stage or to the router have nowhere else to be and stay in
 
 | Where | Sets |
 |---|---|
-| `examples/transforms/<name>/` | `code_identifiers` (78), `dotted` (56), `grammar` (17), `email` (26), `repetitions` (60) |
+| `examples/transforms/<name>/` | `code_identifiers` (78), `dotted` (76), `grammar` (17), `email` (26), `repetitions` (60) |
 | `tests/` | `spelling` (62), `french` (45), `numbers` (97), `routing` (45), `wake` (25), `split` (14), `generic`, `dates`, `inplace`, `pipeline`, `replacement` |
 
 Each has a runner in `scripts/`; the transform sets can also be scored with

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -239,6 +239,48 @@ and spacing included.
 The table runs as the `replacements` stage — a pipeline stage, so whether it
 runs at all is [pipelines.md](pipelines.md).
 
+## `lists`
+
+Word lists, written once and named. A pattern refers to one as `{{name}}`:
+
+```yaml
+lists:
+  determiners: ["the", "a", "an", "le", "la", "les", "un", "une"]
+
+transforms:
+  - name: dotted
+    description: spoken dotted paths as code
+    replace:
+      '$1.': ['/\b(?!(?:{{determiners}})\b)(\w+) dot (?=\w)/']
+```
+
+`{{determiners}}` becomes the words as a regex alternation, longest first —
+otherwise `colon` sitting earlier in the list eats `semi colon`. It works in
+`replacements:` and in any `replace:` transform.
+
+`--check-config` refuses a name nothing defines, and a list defined with no
+words in it, and says which rule named it. If one reaches the app anyway it is
+left as the literal `{{name}}`, so the rule matches nothing — an emptied
+alternation matches everywhere, and a guard that silently stops guarding is the
+worse of the two failures.
+
+`lists` is a reserved name. The words are published under `lists.*` before any
+stage runs, so a transform declared with that name would write over them. It is
+dropped where transforms are assembled, and `--check-config` says so — the same
+treatment an entry with no body gets. `text`, `app`, `bundle_id`, `language`,
+`instruction`, `asr`, `vad` and `vocabulary` are reserved for the same reason.
+
+A transform that is a program reads the same words from
+`ctx["vars"]["lists"]["determiners"]`, joined by `; `. So one list serves a
+table and a script, and adding a language is adding words here.
+
+**Quote every entry.** `on`, `no` and `off` are booleans in YAML 1.1, which is
+what the check scripts in `scripts/` parse with. An unquoted `on` reaches them
+as the word `true`, so the list silently stops holding the word you wrote.
+
+The lists are not split by language. `dotted` merges English and French into
+one alternation and measures clean, because the words do not collide.
+
 ## `llm`
 
 The local Ollama model behind spoken commands and every `prompt:` transform.

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -463,16 +463,32 @@ at least one side is nearly always a determiner, a preposition, or the head of a
 set phrase — `le point de vue`, `un bon point pour`, `a dot product`.
 
 ```
-\b(?!(?:le|la|les|…|the|a|an)\b)(\w+) (?:dot|point) (?!(?:de|du|…|product)\b)(?=\w)
+\b(?!(?:{{determiners}})\b)(\w+) (?:dot|point) (?!(?:{{prose_after_point}})\b)(?=\w)
 ```
 
 The second word is matched but not consumed, which is what lets a chain work:
 `user point profile point name` → `user.profile.name`. Consuming it would leave
 the middle token unavailable to the next match.
 
-**54/54 on `examples/transforms/dotted/cases.txt`, plus two it cannot do.** Two ordinary words
+The two lists are named rather than written out. They are in `lists:` in
+config.yaml, one definition read by every rule that needs them — see
+[configuration.md](configuration.md#lists). `dash`, `slash`, `hyphen` and
+`underscore` are the same rule with the same lists, plus one of their own where
+the trigger is also an ordinary word: `dash` needs an after-list of English
+function words, because a real join has a name part on its right and "a mad
+dash to the door" does not.
+
+A single letter either side is its own rule — "A dot B", "a underscore b". The
+before-list would otherwise throw it away, and one letter is never prose.
+
+A leading-slash path declines whole rather than half-converting: "in slash tmp
+slash x" stays words. `(?<!slash )` is what does it. Half a path is worse than
+none, and half is what a two-step rewrite would give — a `replace:` table is
+built from a Swift dictionary, so its rules run in an unspecified order.
+
+**73/73 on `examples/transforms/dotted/cases.txt`, plus three it cannot do.** Two ordinary words
 either side — "réunion point hebdomadaire" — is a shape only a dictionary would
-tell from code, and both residual cases are kept in the set, failing, rather
+tell from code, and every residual case is kept in the set, failing, rather
 than dropped to make the number look better. They are unlikely in a terminal or
 a chat window, which together with the `app:` scoping is the only reason this is
 on by default; in `replacements:` it would run everywhere and would not be
@@ -908,11 +924,13 @@ nothing — otherwise the speaker's own punctuation would be read as a rule's
 work. `tests/pipelines/protected.yaml` holds both halves down.
 
 Before any stage runs, the scope already holds `text`, `app`, `bundle_id`,
-`language`, and what transcription measured — `asr.confidence`, `asr.duration`,
-`asr.processing`, `asr.words`. On a dictation it also holds `press.run`, which
-says which hotkey press this transcript came from. Dictations overlap, so a
-stage that reads something captured at the press has to ask for its own —
-`input` does. It is absent off the hotkey path, `--pipeline` included.
+`language`, every named word list under `lists.*` — see
+[configuration.md](configuration.md#lists) — and what transcription measured:
+`asr.confidence`, `asr.duration`, `asr.processing`, `asr.words`. On a dictation
+it also holds `press.run`, which says which hotkey press this transcript came
+from. Dictations overlap, so a stage that reads something captured at the press
+has to ask for its own — `input` does. It is absent off the hotkey path,
+`--pipeline` included.
 
 So a stage can stand down on a recording the recogniser was not sure about:
 

--- a/examples/transforms/dotted/cases.txt
+++ b/examples/transforms/dotted/cases.txt
@@ -83,9 +83,32 @@ FR|le mot souligné dans le texte|le mot souligné dans le texte
 
 EN|the hyphen key on your keyboard|the hyphen key on your keyboard
 
-# `dash` is not a trigger: an ordinary word, unguarded unlike `dot`/`point`.
+# `dash` is a trigger now, measured: over 3,759 archived clips "hyphen" was said
+# 0 times and "dash" 8, 6 of them joining a real name. It carries an after-list
+# of its own — a real join's right-hand side is a name part, never a preposition
+# — which is what leaves "a mad dash to the door" alone. Two content words
+# either side is the same residue "dot" has, and "yard dash record" is it.
 EN|a mad dash to the door|a mad dash to the door
-EN|the hundred yard dash record|the hundred yard dash record
+RESIDUE|the hundred yard dash record|the hundred yard dash record
+EN|shingrix dash test|shingrix-test
+EN|can you find the branch aeo dash prototype|can you find the branch aeo-prototype
+EN|A dash B|A-B
+EN|a underscore b|a_b
+EN|A dot B|A.B
+
+# `slash` — a path, or the and/or sense. The mark names in the after-list are
+# why a sentence listing them is left as words.
+EN|it is a technical slash product decision|it is a technical/product decision
+EN|folder slash file|folder/file
+FR|le dossier barre oblique fichier|le dossier/fichier
+EN|you should add slash semicolon ellipsis|you should add slash semicolon ellipsis
+
+# A leading-slash path declines whole, and that is the intent rather than a
+# miss. `/tmp/random` is what you wanted; half of it is worse than none, and
+# half is what a two-step rewrite would give — a `replace:` table is built from
+# a Swift dictionary, so its rules run in an unspecified order. `(?<!slash )`
+# is what makes the whole sentence decline together.
+EN|examples are available in slash tmp slash random|examples are available in slash tmp slash random
 
 # The residue. Two content words either side, so nothing in the sentence says
 # which one it is. Both are unlikely in a terminal or a chat window, which is

--- a/scripts/check-dotted.sh
+++ b/scripts/check-dotted.sh
@@ -42,6 +42,9 @@ if not any(t["name"] == "dotted" for t in transforms):
 def fixture(steps):
     return yaml.safe_dump({
         "languages": doc["transcription"]["languages"],
+        # The patterns say `{{determiners}}`; without the lists they compile to
+        # nothing and every guard silently stops guarding.
+        "lists": doc.get("lists") or {},
         "transforms": transforms,
         "pipeline": [{"transform": name} for name in steps],
     }, allow_unicode=True, sort_keys=False)

--- a/scripts/check-eval.sh
+++ b/scripts/check-eval.sh
@@ -185,6 +185,108 @@ check "a case with no expect: is detected as must-not-change" \
      | grep -E '^  keep' | sed 's/ <-.*//;s/  */ /g;s/^ //;s/ $//')" \
   "keep 1/1 = 100%"
 
+# --- `lists:` on a set ------------------------------------------------------
+#
+# A set that carries its own transform can carry the words it guards on too,
+# the same way a `--pipeline` fixture does. Without it a `{{name}}` would
+# resolve against whichever machine is scoring, and the number would be about
+# that machine.
+cat > "$WORK/elsewhere/list-cases.yaml" <<'YAML'
+transform: guarded
+lists:
+  determiners: [the, a, an]
+transforms:
+  - name: guarded
+    description: a spoken dot as a dot, unless a determiner is in front
+    replace:
+      '$1.': ['/\b(?!(?:{{determiners}})\b)(\w+) dot (?=\w)/']
+cases:
+  - input: read user dot name
+    expect: read user.name
+  - input: the dot com bubble
+YAML
+
+check "a set carries the word lists its own transform guards on" \
+  "$("$BIN" --eval "$WORK/elsewhere/list-cases.yaml" 2>/dev/null \
+     | grep -E '^  overall' | sed 's/  */ /g;s/^ //')" \
+  "overall 2/2 = 100%"
+
+# `lists: {}` is not the same as no `lists:` at all. The first says "no words,
+# and I mean it", so the guard is refused rather than filled from this machine.
+cat > "$WORK/elsewhere/no-lists-cases.yaml" <<'YAML'
+transform: guarded
+lists: {}
+transforms:
+  - name: guarded
+    description: a guard naming a list the set deliberately empties
+    replace:
+      '$1.': ['/\b(?!(?:{{determiners}})\b)(\w+) dot (?=\w)/']
+cases:
+  - input: read user dot name
+    expect: read user.name
+YAML
+
+check "an empty lists: on a set means none, not this machine's" \
+  "$("$BIN" --eval "$WORK/elsewhere/no-lists-cases.yaml" 2>/dev/null \
+     | grep -c 'which nothing defines')" \
+  "1"
+
+# A transform named after something the runner already publishes. Dropped
+# where every transform is assembled, so a set cannot smuggle one in either.
+cat > "$WORK/elsewhere/reserved-cases.yaml" <<'YAML'
+transform: lists
+transforms:
+  - name: lists
+    description: collides with the named word lists
+    replace:
+      hush: [shout]
+cases:
+  - input: please shout about it
+    expect: please hush about it
+YAML
+
+check "a set carrying a transform named after a reserved namespace scores nothing" \
+  "$("$BIN" --eval "$WORK/elsewhere/reserved-cases.yaml" 2>/dev/null \
+     | grep -c 'not in your config and not in the file')" \
+  "1"
+
+# --- `lang:` on a case ------------------------------------------------------
+#
+# The case states its language and the pipeline keeps it. Detection is
+# unreliable at the length a case is — "C'est vraiment fantastique." comes back
+# `en` — and a French case scored under English rules passes for the wrong
+# reason. `de` is here because nothing configures it: what the case says wins.
+mkdir -p "$WORK/transforms/echolang"
+cat > "$WORK/transforms/echolang/echolang.py" <<'PY'
+#!/usr/bin/env python3
+"""The language the pipeline resolved, as the whole output."""
+import json
+import sys
+
+envelope = json.load(sys.stdin)
+print(json.dumps({"text": envelope["ctx"].get("language") or "none"}))
+PY
+chmod +x "$WORK/transforms/echolang/echolang.py"
+cat > "$WORK/transforms/echolang/cases.yaml" <<'YAML'
+cases:
+  - input: Il faut trois choses
+    lang: fr
+    expect: fr
+  - input: we ship today
+    lang: de
+    expect: de
+YAML
+cat >> "$WORK/config.yaml" <<'YAML'
+  - name: echolang
+    description: reports the language the pipeline resolved
+    command: echolang.py
+    returns: json
+YAML
+
+check "a case states its own language, and the pipeline keeps it" \
+  "$("$BIN" --eval echolang 2>/dev/null | grep -E '^  overall' | sed 's/  */ /g;s/^ //')" \
+  "overall 2/2 = 100%"
+
 # --- `tests:` on the transform ----------------------------------------------
 #
 # A transform whose default set is not cases.yaml says so once, in the config,

--- a/scripts/check-transform-folders.sh
+++ b/scripts/check-transform-folders.sh
@@ -119,6 +119,73 @@ check "and that is a fault, so --check-config exits 1" \
   "$(PARROTFLOW_CONFIG_DIR="$WORK/outside" "$BIN" --check-config > /dev/null 2>&1; echo $?)" \
   "1"
 
+# --- a transform named after something the runner already publishes ---------
+#
+# Asked where the name is declared, not where a pipeline step spells it.
+# `transform(named:)` resolves case-insensitively, so a step written `Lists`
+# reaches a transform declared `lists` and files under `lists.*` regardless of
+# how the step was spelled.
+RESERVED="$WORK/reserved"
+mkdir -p "$RESERVED"
+cat > "$RESERVED/config.yaml" <<'YAML'
+lists:
+  determiners: ["the", "a", "an"]
+transforms:
+  - name: lists
+    description: collides with the named word lists
+    replace:
+      hush: [shout]
+transcription:
+  pipelines:
+    default:
+      - transform: Lists
+YAML
+reserved="$(PARROTFLOW_CONFIG_DIR="$RESERVED" "$BIN" --check-config 2>/dev/null)"
+
+check "a transform declared with a reserved name is dropped, and said so" \
+  "$(printf '%s\n' "$reserved" | grep -c 'transforms: "lists" would file its variables')" \
+  "1"
+
+check "and that is a fault, whatever spelling the pipeline step used" \
+  "$(PARROTFLOW_CONFIG_DIR="$RESERVED" "$BIN" --check-config > /dev/null 2>&1; echo $?)" \
+  "1"
+
+# Dropped, so the step naming it names nothing — which is the second half of
+# the same message. Reported and kept, it would have run.
+check "so the pipeline step that named it reaches nothing" \
+  "$(printf '%s\n' "$reserved" | grep -c 'no transform named "Lists"')" \
+  "1"
+
+# And the same the other way round. `transform(named:)` resolves
+# case-insensitively and `Pipeline.namespace` files a stage under the spelling
+# the *step* wrote, so a transform declared `Lists` reached by a step spelled
+# `lists` lands in `lists.*` all the same. Either casing is a way into the same
+# namespace, so neither may be declared.
+CASED="$WORK/cased"
+mkdir -p "$CASED"
+cat > "$CASED/config.yaml" <<'YAML'
+lists:
+  determiners: ["the", "a", "an"]
+transforms:
+  - name: Lists
+    description: the same collision, spelled differently
+    replace:
+      hush: [shout]
+transcription:
+  pipelines:
+    default:
+      - transform: lists
+YAML
+cased="$(PARROTFLOW_CONFIG_DIR="$CASED" "$BIN" --check-config 2>/dev/null)"
+
+check "a reserved name is taken whatever its casing" \
+  "$(printf '%s\n' "$cased" | grep -c 'transforms: "Lists" would file its variables where lists')" \
+  "1"
+
+check "and the step spelled the other way reaches nothing" \
+  "$(printf '%s\n' "$cased" | grep -c 'no transform named "lists"')" \
+  "1"
+
 # --- prompt: { path: }, through a whole config ------------------------------
 #
 # A prompt body cannot be scored without a model, so what is checked here is

--- a/tests/pipeline-cases.yaml
+++ b/tests/pipeline-cases.yaml
@@ -776,6 +776,49 @@ cases:
       replacements.changes: Versal -> Vercel
       vocabulary.slots: 1
 
+  # --- named word lists ------------------------------------------------------
+  #
+  # `{{name}}` in a pattern is the list of that name, as an alternation. The
+  # same words were pasted into nine regexes before this and had already
+  # drifted apart.
+  - name: a list expands into a pattern, and the guard fires
+    pipeline: lists
+    input: the dot com bubble
+    expect: unchanged
+
+  - name: the same rule still fires where no determiner is in front
+    pipeline: lists
+    input: read user dot name
+    expect: read user.name
+
+  # Longest word first, or `colon` sitting earlier in the alternation eats
+  # `semi colon`. The fixture writes the two the wrong way round on purpose.
+  - name: a longer phrase wins over a shorter one inside it
+    pipeline: lists
+    input: he paused semi colon then went on
+    expect: he paused MARK then went on
+
+  # A second list in the same pattern, so a rule can guard on two.
+  - name: a lead word declines the whole path
+    pipeline: lists
+    input: it is in slash tmp
+    expect: unchanged
+
+  - name: and the same rule fires without one
+    pipeline: lists
+    input: folder slash file
+    expect: folder/file
+
+  # And the words reach a script as well as a pattern, under one namespace.
+  # One word, because `expect_vars` splits its own entries on `;` and a joined
+  # list is full of them.
+  - name: the lists are published into the scope
+    pipeline: lists
+    input: read user dot name
+    expect: read user.name
+    expect_vars:
+      lists.path_lead: in
+
 # Pipelines that must not load at all.
 #
 # Scored separately because the property is different: these never reach a
@@ -839,3 +882,23 @@ refused:
   - name: a cap on the retired menu is refused
     pipeline: vocabulary-max-readings
     expect_problem: max_readings is 16
+
+  # A pattern naming a list nothing defines. The name is left literal at
+  # runtime, so the rule matches nothing and looks exactly like a rule that is
+  # working. Emptying it instead would be worse: `(?:)` matches everywhere.
+  - name: a pattern naming a list nothing defines is refused
+    pipeline: unknown-list
+    expect_problem: names {{determinors}}, which nothing defines
+
+  # And a list that is defined with nothing in it. Same outcome, and the worse
+  # of the two if it expanded: `(?:)` matches everywhere, so the guard in front
+  # of it would stop the rewrite on every transcript.
+  - name: a pattern naming an empty list is refused
+    pipeline: empty-list
+    expect_problem: which is defined with no words in it
+
+  # The lists are published under `lists.*` before any stage runs, so a
+  # transform of that name would overwrite them.
+  - name: a transform named after the word lists is refused
+    pipeline: reserved-lists
+    expect_problem: a transform called "lists" would file its variables

--- a/tests/pipelines/lists.yaml
+++ b/tests/pipelines/lists.yaml
@@ -1,0 +1,29 @@
+# Named word lists, and what `{{name}}` does to a pattern.
+#
+# `marks` is written shortest first on purpose. `expanded` sorts the words
+# longest first, and this fixture fails if it stops.
+languages: [en, fr]
+lists:
+  determiners: [the, a, an, le, la]
+  marks: [colon, semi colon]
+  path_lead: [in]
+transforms:
+  - name: dotted
+    description: a spoken dot as a dot, unless a determiner is in front
+    replace:
+      '$1.': ['/\b(?!(?:{{determiners}})\b)(\w+) dot (?=\w)/']
+
+  - name: marked
+    description: the mark words, longest phrase first
+    replace:
+      MARK: ['/\b(?:{{marks}})\b/']
+
+  - name: pathed
+    description: a spoken slash as a slash, unless the path is the leading one
+    replace:
+      '$1/': ['/\b(?!(?:{{path_lead}})\b)(\w+) slash (?=\w)/']
+
+pipeline:
+  - transform: dotted
+  - transform: marked
+  - transform: pathed

--- a/tests/pipelines/refused/empty-list.yaml
+++ b/tests/pipelines/refused/empty-list.yaml
@@ -1,0 +1,14 @@
+# A list that is defined and has no words in it. Refused for the same reason a
+# name nothing defines is: the placeholder is left literal, so the rule matches
+# nothing. Expanded to `(?:)` instead it would match everywhere, and the guard
+# in front of it would stop the rewrite on every transcript.
+languages: [en]
+lists:
+  determiners: []
+transforms:
+  - name: guarded
+    description: a guard naming a list with nothing in it
+    replace:
+      '$1.': ['/\b(?!(?:{{determiners}})\b)(\w+) dot (?=\w)/']
+pipeline:
+  - transform: guarded

--- a/tests/pipelines/refused/reserved-lists.yaml
+++ b/tests/pipelines/refused/reserved-lists.yaml
@@ -1,0 +1,13 @@
+# A transform named after the word lists. The runner publishes every list under
+# `lists.*` before any stage runs, so this one would overwrite them and a script
+# reading `ctx["vars"]["lists"]["determiners"]` would get whatever it wrote.
+languages: [en]
+lists:
+  determiners: [the, a, an]
+transforms:
+  - name: lists
+    description: collides with the named word lists
+    command: counter.py --count 1
+    returns: json
+pipeline:
+  - transform: lists

--- a/tests/pipelines/refused/unknown-list.yaml
+++ b/tests/pipelines/refused/unknown-list.yaml
@@ -1,0 +1,13 @@
+# A pattern naming a list nothing defines. Refused rather than run: the name is
+# left literal, so the rule matches nothing and every transcript comes through
+# looking exactly as it would if the rule were working.
+languages: [en]
+lists:
+  determiners: [the, a, an]
+transforms:
+  - name: guarded
+    description: a guard naming a list that is not there
+    replace:
+      '$1.': ['/\b(?!(?:{{determinors}})\b)(\w+) dot (?=\w)/']
+pipeline:
+  - transform: guarded


### PR DESCRIPTION
## The problem

The same word list — "the determiners, so this is prose and not a name" — was pasted into nine regexes across two config files and one Python set. The copies had already drifted: one said `the|a|an`, another held forty French words.

## What changes

`lists:` in config.yaml is the one definition. A `replace:` pattern refers to a list as `{{determiners}}`, and a transform that is a program reads the same words from `ctx["vars"]["lists"]["determiners"]`.

```yaml
lists:
  determiners: ["the", "a", "an", "le", "la", "les", "un", "une"]

transforms:
  - name: dotted
    replace:
      '$1.': ['/\b(?!(?:{{determiners}})\b)(\w+) dot (?=\w)/']
```

Four decisions worth defending.

**Lists are flat, not per language.** `dotted` has always merged English and French into one alternation and it measures clean, because the words do not collide. Nothing could pick a language for a scored run either: a `--pipeline` fixture states a `languages:` list and the stage detects. A per-language table would have shipped untestable.

**`expanded` sorts longest word first**, or `colon` sitting earlier in the alternation eats `semi colon`. `tests/pipelines/lists.yaml` writes the two the wrong way round on purpose, and a case fails if the sort goes.

**A `{{name}}` that resolves to nothing is refused, and left literal if it gets through.** That is a name nothing defines, and a list defined with no words in it. `--check-config` and `--pipeline` both refuse it and say which rule named it. If one reaches the app anyway the name stays as the literal `{{name}}` and the rule matches nothing. Expanding it to `(?:)` is the worse failure: that matches everywhere, so `(?!(?:{{determiners}})\b)` would never match and the rewrite would silently stop.

**`lists` is a reserved name.** The words are published under `lists.*` before any stage runs, so a transform called `lists` would overwrite them and a script reading `ctx["vars"]["lists"]["determiners"]` would get whatever it wrote. Refused at load, beside `asr`, `vad` and `vocabulary`.

**A case set can carry its own `lists:`,** the way it already carries `transforms:`. Without it a set whose own transform guards on `{{determiners}}` would score against whichever machine ran it. The field is optional rather than empty-by-default, so `lists: {}` means "no words, and I mean it" and an absent `lists:` means "this machine's".

**Both scoring commands refuse a rule that cannot fire.** `--pipeline` already did; `--eval` now checks the transform under test before scoring a case, because a rule matching nothing would be scored as "the transform did not fire" — a wrong number rather than an error. The live path keeps failing open, and reports the same fault through `config.problems()` in the log, the menu bar and `--check-config`.

**Every list entry is quoted.** `on`, `no` and `off` are booleans in YAML 1.1, which is what the check scripts parse config.example.yaml with. An unquoted `on` reaches them as the word `true`, so `path_lead` and `function_words` were silently losing it.

## `dotted` gains dash, slash and single letters

Measured over 3,759 archived clips.

**`dash` beside `hyphen`.** "hyphen" was said 0 times there and "dash" 8, 6 of them joining a real name. `dash` carries a longer before-list because it is also an ordinary word, and an English after-list of its own: a real join has a name part on its right, never a preposition. That is what leaves "a mad dash to the door" alone.

**A single letter either side** — "A dot B", "a underscore b". The article guard was throwing these away, and one letter is never prose.

**`slash`** — a path, or the and/or sense ("a technical slash product decision"). A leading-slash path declines whole rather than half-converting: "in slash tmp slash x" stays words. `(?<!slash )` is what does it. Half a path is worse than none, and half is what a two-step rewrite would give — a `replace:` table is built by `table.flatMap` over a Swift dictionary, so **rule order is unspecified** and no two-step rewrite can be relied on.

That case was written as RESIDUE. It is not: it declines deterministically, and `check-dotted.sh` said so ("now passes — move it out of RESIDUE"). It is an ordinary case now.

## `lang:` on a case

A case can state its language. Detection is unreliable at the length a case is — "C'est vraiment fantastique." comes back `en` — and a French case scored under English rules passes for the wrong reason.

## Three traps, all commented in the code

- `Config` has a **custom `init(from:)`**. Adding the property and the CodingKey is not enough; `lists` has to be decoded there by name. Miss it and the feature works in `--pipeline` fixtures and is inert in the app.
- A `--pipeline` fixture that omits `lists:` compiles `{{…}}` to nothing and every guard silently stops guarding. `PipelineCommand` reads `lists:`, `check-dotted.sh` passes the real ones through, and a name nothing defines is now refused rather than run.
- A table reached **by voice** goes through `AppDelegate.perform`, not the pipeline. It needed `expand:` too, or "hey parrot, dotted" would compile the guards to nothing while the same table in a pipeline worked.

## Scores

| | |
|---|---|
| `scripts/check-dotted.sh` | 73/73 plus 3 known-unfixable (was 72/72 plus 4) |
| `scripts/check-pipeline.sh` | 82/82 (was 73/73; 9 new cases for the lists) |
| `scripts/check-eval.sh` | 29/29 (was 25/25; `lang:`, sets that own their lists, two refusals) |
| `scripts/check-replacements.sh` | 23/23 |
| `scripts/check-default-config.sh` | clean |
| `scripts/check-compose.sh` | 21/21 |
| `swift build -c release` | clean |

Docs: `lists` in configuration.md, `lang:` in authoring.md, and the `dotted` section of pipelines.md rewritten for the new rules and counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
