### PR TITLE
feat: the offer says when the words may not be your words

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -188,6 +188,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// on the chance that a transcript from five minutes ago is still coming.
     private var screenAtPress: [Int: (text: String, at: Date)] = [:]
 
+    /// The decoder's own words for a press, before any stage rewrote them, and
+    /// the one confidence it gave the whole utterance.
+    ///
+    /// Kept per press for the same reason the pane is: dictations overlap, and
+    /// the offer that goes up belongs to one of them. Read once, by
+    /// `showCorrectOffer`, and dropped by `dictationEnded` however the dictation
+    /// finished. Only filled when something is going to read it — the colours
+    /// or the warning — so switching both off costs nothing but the word
+    /// timings the decoder already produced.
+    private var heardAtPress: [Int: Transcriber.Decode] = [:]
+
     /// How long a pane is worth keeping, for a press that is no longer in
     /// flight. Nothing waits this long: the whole chain is a decoder and at
     /// most a prompt stage.
@@ -300,6 +311,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `watchTheOfferKeys`. A config reloaded in between must not leave a
     /// letter claimed for a chip that is not on screen.
     private var offerOnScreen: [OfferedCommand]?
+    /// The headline and the reading the offer went up with, so the pill can be
+    /// drawn again without rebuilding what it is about. See `holdTheReturn`.
+    private var offerHeadline: String?
+    private var offerReading = Confidence.Reading()
+    /// Until when this offer's Return is held. Set when the offer goes up, so
+    /// an offer whose keys arrive late — a second dictation was still running —
+    /// gets whatever is left of the moment rather than a fresh one.
+    private var offerHoldsReturnUntil: Date?
     /// Gives the keys back when the offer simply runs out.
     ///
     /// The pill fades itself off screen after `offerSeconds` and tells nobody,
@@ -1431,6 +1450,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // needs the clip on disk once this dictation is over.
             defer { Recorder.discardIfNotKept(recording, config: config) }
             do {
+                // The decoder's own words, kept for the offer to colour. Only
+                // when something is going to draw them: the decoder produces
+                // the timings either way, and this is the one line that keeps a
+                // copy of them. Written out rather than left as a ternary in
+                // the call below, where the `nil` has no type to take.
+                var heard: (@Sendable (Transcriber.Decode) -> Void)?
+                if config.feedback.confidence || config.feedback.warnsOnLowConfidence {
+                    heard = { decode in
+                        Task { @MainActor [weak self] in
+                            self?.heardAtPress[press.run] = decode
+                        }
+                    }
+                }
                 // "Transcribing…" is the truth until the decoder is done, and
                 // a lie for the second a prompt or a script spends after it.
                 // A stage that wrote a `display:` says so itself.
@@ -1452,7 +1484,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                       self.transcriptionLabel != nil else { return }
                                 self.beginProgress(label)
                             }
-                        }
+                        },
+                        heard: heard
                     ) ?? ""
                     Trace.current?.recordFinal(text)
                     return text
@@ -2309,7 +2342,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             original: text, element: press.element, owner: press.owner, landing: landing
         ))
         let commands = offerCommands
-        pill.offer(commands, headline: headline, for: Self.offerSeconds)
+        // The decoder's words matched back onto the sentence that came out of
+        // the pipeline — see `Confidence.read`. Taken rather than copied: this
+        // press's dictation is over and nothing else can want them.
+        let decoded = heardAtPress.removeValue(forKey: press.run)
+        let words = decoded.map { Confidence.read($0.words, into: text) } ?? []
+        // The words are matched whenever anything wants them, and shown only
+        // when the colours were asked for. The warning reads the same list: a
+        // threshold is about the word you are looking at, so it is the written
+        // word that is measured and the written word that gets named.
+        let low = config.feedback.lowConfidence
+        let reading = Confidence.Reading(
+            words: config.feedback.confidence ? words : [],
+            overall: config.feedback.confidence ? decoded?.confidence : nil,
+            warning: Confidence.warning(
+                words, utterance: decoded?.confidence,
+                vocabulary: decoded?.vocabulary ?? [],
+                sentenceBelow: Float(low.sentence), wordBelow: Float(low.word)
+            )
+        )
+        if let warning = reading.warning { Log.write("offer: \(warning)") }
+        offerHeadline = headline
+        offerReading = reading
+        let hold = config.feedback.lowConfidence.holdReturn
+        offerHoldsReturnUntil = reading.warning != nil && hold > 0
+            ? Date().addingTimeInterval(hold)
+            : nil
+        pill.offer(commands, headline: headline, reading: reading, for: Self.offerSeconds)
         // The list is captured, not read again in the closure: a config
         // reloaded while the offer is up would otherwise renumber the chips
         // under the pointer, and the click would run whatever took the slot.
@@ -2394,7 +2453,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
         let letters = Set(commands.map(\.key).filter { !$0.isEmpty })
-        offerKeys.start(until: until, letters: letters) { [weak self] key in
+        // The hold is armed only for a dictation that raised the warning, and
+        // only until it has been spent. Re-armed from here on every call, so an
+        // offer that got its keys late — a dictation was still running — is
+        // still covered, and one that has already eaten a Return is not.
+        let holds = offerReading.stopped ? nil : offerHoldsReturnUntil
+        offerKeys.start(
+            until: until, letters: letters, holdingReturnUntil: holds
+        ) { [weak self] key in
             guard let self, self.offerIsUp else { return }
             switch key {
             case .letter(let typed):
@@ -2406,10 +2472,36 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 // two ways of running a command, or only one of them gets the
                 // guards the other one has.
                 self.pill.model.onPick?(index)
+            case .firstReturn:
+                self.holdTheReturn()
             case .dismiss:
                 self.dismissOffer(reason: "the keyboard")
             }
         }
+    }
+
+    /// A Return was taken rather than typed. Say so, and give the offer back
+    /// the time it takes to read that.
+    ///
+    /// The pill is raised again rather than edited in place: it is the same
+    /// offer with the same chips, and raising it restarts the fade, which is
+    /// the whole point — a warning that arrives with two seconds left on a
+    /// surface that is already half gone is a warning nobody reads.
+    ///
+    /// The keys are re-armed from the same call the offer normally uses, which
+    /// reads `offerReading` and finds the hold already spent. So the second
+    /// Return is not this app's business at all.
+    private func holdTheReturn() {
+        guard offerIsUp, offerReading.warning != nil, !offerReading.stopped else { return }
+        Log.write("offer: held the first Return; \(offerReading.warning ?? "")")
+        offerReading.warning = Confidence.stopped
+        offerReading.stopped = true
+        offerUntil = Date().addingTimeInterval(Self.offerSeconds)
+        pill.offer(
+            offerOnScreen ?? [], headline: offerHeadline, reading: offerReading,
+            for: Self.offerSeconds
+        )
+        watchTheOfferKeys()
     }
 
     /// A click anywhere but on the offer ends it, the same way Escape or
@@ -2699,6 +2791,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// reach anything that is somehow left.
     private func dictationEnded(_ run: Int) {
         screenAtPress.removeValue(forKey: run)
+        heardAtPress.removeValue(forKey: run)
         pressesInFlight.remove(run)
         cancelledPresses.remove(run)
     }

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -46,7 +46,12 @@ enum CheckConfigCommand {
         print("  ✓ min duration      \(config.audio.minDurationSeconds)s")
         print("  · speech gate       \(config.audio.speechGate ? "on" : "off")")
         print("  · feedback          sound=\(config.feedback.sound) overlay=\(config.feedback.overlay)"
-              + " correct_offer=\(config.feedback.correctOffer)")
+              + " correct_offer=\(config.feedback.correctOffer)"
+              + " confidence=\(config.feedback.confidence)")
+        print("  · low confidence    sentence<\(config.feedback.lowConfidence.sentence)"
+              + " AND word<\(config.feedback.lowConfidence.word)"
+              + " hold_return=\(config.feedback.lowConfidence.holdReturn)"
+              + (config.feedback.warnsOnLowConfidence ? "" : " (off)"))
         print("  · logging           text=\(config.logging.text ? "on" : "off")"
               + " audio=\(config.logging.audio ? "on" : "off")")
 

--- a/Sources/ParrotFlow/Confidence.swift
+++ b/Sources/ParrotFlow/Confidence.swift
@@ -1,0 +1,267 @@
+import SwiftUI
+
+/// How sure the decoder was of each word, coloured onto the sentence.
+///
+/// **There is no published threshold to read this against.** Parakeet emits one
+/// softmax probability per token and says nothing about what a value means;
+/// FluidAudio averages them into `ASRResult.confidence` and documents only the
+/// range. NVIDIA's own guidance for NeMo is that a raw probability is a weak
+/// correctness signal and that the operating point has to be found on your own
+/// data.
+///
+/// So the bands below are percentiles of this machine's own archive rather than
+/// anybody's recommendation: 184,146 words over 15,446 dictations in
+/// `trace.jsonl`, where the median word scores 0.995 and 68% sit at 1.0. A ramp
+/// anchored on the raw 0–1 scale would paint almost the whole sentence white and
+/// show nothing.
+enum Confidence {
+
+    /// A word of the finished sentence and what the decoder scored it.
+    struct Word: Equatable {
+        let text: String
+        /// Nil where no decoded word became this one — a figure the numbers
+        /// stage spelled out, a word a substitution inserted. Those have no
+        /// reading of their own and must not borrow one.
+        let score: Float?
+    }
+
+    // MARK: - The bands
+
+    /// p25. Above this a word is as sure as three quarters of everything ever
+    /// dictated here, and stays white.
+    static let sure: Float = 0.89
+    /// p10.
+    static let watch: Float = 0.60
+    /// p1. At and below it the word is as unsure as the worst one in a hundred,
+    /// and the colour stops moving.
+    static let doubtful: Float = 0.35
+
+    /// The white end of the ramp. Not pure white: the pill's own lettering is
+    /// not, and a word brighter than the surface it sits on reads as lit rather
+    /// than as ordinary.
+    static let clear = Color(white: 0.93)
+
+    /// White for sure, then amber, then scarlet — the plumage in the order the
+    /// feathers run, so the sentence uses the same colours as everything else.
+    static func tint(_ score: Float?) -> Color {
+        guard let score else { return Color.white.opacity(0.32) }
+        return ramp(score, sure: sure, watch: watch, doubtful: doubtful)
+    }
+
+    /// The ramp itself, taking the three anchors it runs between. A word and
+    /// the whole utterance are scored on scales that move very differently, so
+    /// they share the colours and not the numbers.
+    private static func ramp(
+        _ score: Float, sure: Float, watch: Float, doubtful: Float
+    ) -> Color {
+        if score >= sure { return clear }
+        if score >= watch {
+            return Parrot.mix(clear, Parrot.amber, Double((sure - score) / (sure - watch)))
+        }
+        if score >= doubtful {
+            return Parrot.mix(
+                Parrot.amber, Parrot.scarlet, Double((watch - score) / (watch - doubtful))
+            )
+        }
+        return Parrot.scarlet
+    }
+
+    /// The sentence as one run of text per word, each in its own colour.
+    ///
+    /// Concatenated `Text` rather than a row of views, so the line breaks where
+    /// a paragraph would break and the pill can hold a long dictation.
+    static func sentence(_ words: [Word]) -> Text {
+        words.enumerated().reduce(Text(verbatim: "")) { line, item in
+            let gap = item.offset > 0 ? Text(verbatim: " ") : Text(verbatim: "")
+            return line + gap
+                + Text(verbatim: item.element.text).foregroundStyle(tint(item.element.score))
+        }
+    }
+
+    // MARK: - The whole utterance
+
+    /// What the decoder scored the whole utterance, for under the words.
+    ///
+    /// This is `ASRResult.confidence`, FluidAudio's mean over the tokens. It is
+    /// not the sentence's worst word and does not follow one: over the 16,513
+    /// dictations in the archive it sits at 0.83 at p10 and 0.93 at the median,
+    /// and of the dictations holding a word below `watch` only 13% fall under
+    /// its own p10. It says how the decode went on average.
+    ///
+    /// Two decimals.
+    static func overall(_ score: Float) -> String {
+        String(format: "%.2f", score)
+    }
+
+    /// The utterance's own bands, percentiles of the same 16,513 dictations:
+    /// p25, p10, p1 of `asr.confidence` itself.
+    ///
+    /// Its own numbers rather than the word ones, because a mean over every
+    /// token in a sentence moves in a far narrower range than one word does.
+    /// Read against the word bands, 3 dictations in 4 would print white and
+    /// the colour would say nothing.
+    static let utteranceSure: Float = 0.89
+    static let utteranceWatch: Float = 0.83
+    static let utteranceDoubtful: Float = 0.73
+
+    /// The same ramp as the words, on the utterance's anchors. So white is a
+    /// decode as good as the best three quarters, and scarlet is one as bad as
+    /// the worst in a hundred — the same sentence the colour tells above.
+    static func overallTint(_ score: Float) -> Color {
+        ramp(score, sure: utteranceSure, watch: utteranceWatch, doubtful: utteranceDoubtful)
+    }
+
+    // MARK: - What the offer says
+
+    /// Everything the offer knows about how the decode went.
+    ///
+    /// One value rather than three arguments: the pill's height and width are
+    /// computed from all of it at once, and two of the three arrive together or
+    /// not at all.
+    struct Reading: Equatable {
+        /// The dictation word by word. Empty unless `feedback.confidence` is
+        /// on, and empty is what keeps the pill its old shape.
+        var words: [Word] = []
+        /// The decoder's score for the whole utterance. Drawn under the words,
+        /// so it only shows with them.
+        var overall: Float?
+        /// Why this dictation is worth a second look. Nil when it is not.
+        /// Drawn whether or not the words are, because it is one line and it is
+        /// the half that is worth having without asking for it.
+        var warning: String?
+        /// True once a Return has been taken rather than typed. The same pill,
+        /// asking rather than telling — see `Confidence.stopped`.
+        var stopped = false
+
+        var isEmpty: Bool { words.isEmpty && warning == nil }
+    }
+
+    /// Whether the words that landed may not be the words that were said.
+    ///
+    /// Both thresholds have to trip, not either. They are two views of the same
+    /// clip and each is wrong on its own: a mean over every token stays high
+    /// through one mangled name, and one low word is ordinary — a quarter of
+    /// all dictations here hold one, most of them a clipped `the` or a trailing
+    /// `uh` that changes nothing. A decode that is bad *overall* and holds a
+    /// word the decoder could not place is the one that is worth stopping for.
+    ///
+    /// Words the vocabulary pass wrote are not counted. They carry the score of
+    /// the decode they replaced — that is what `read` does, and it is right for
+    /// the colours — but that score is low by definition, because a shaky
+    /// decode is what made the pass fire. Measured over 3,724 substitutions
+    /// here, 38.8% of the words they replaced were under 0.60 against 9.9% of
+    /// words generally. Counting them would warn loudest about the names the
+    /// app has just fixed.
+    ///
+    /// Strictly below, so a threshold of zero turns the warning off.
+    static func warning(
+        _ reading: [Word], utterance: Float?, vocabulary: [String],
+        sentenceBelow: Float, wordBelow: Float
+    ) -> String? {
+        guard let utterance, utterance < sentenceBelow else { return nil }
+        let written = Set(
+            vocabulary.flatMap { $0.split(whereSeparator: \.isWhitespace) }.map { key(String($0)) }
+        )
+        let scored = reading.compactMap { word -> (String, Float)? in
+            guard let score = word.score, !written.contains(key(word.text)) else { return nil }
+            return (word.text, score)
+        }
+        guard let worst = scored.min(by: { $0.1 < $1.1 }), worst.1 < wordBelow else { return nil }
+        return "This may not be what you said · \(worst.0)"
+    }
+
+    /// What the pill says when it has just eaten a Return.
+    ///
+    /// Not a question and not an apology. It says what was taken, and what to
+    /// do to get it back, in that order — the key is already pressed by the
+    /// time this is read, so the first thing to establish is that it did not
+    /// go through.
+    static let stopped = "Enter held · check what was written, then press it again"
+
+    // MARK: - Putting the scores back on the words
+
+    /// What the decoder scored, carried onto the sentence that came out of the
+    /// pipeline.
+    ///
+    /// They are not the same list of words. Every stage after the decoder
+    /// rewrites text the token timings index — the vocabulary pass replaces
+    /// names, `numbers` spells figures out, substitutions fire — so the scores
+    /// have to be matched back rather than zipped. Measured over the archive,
+    /// 93.5% of decoded words reach the final text unchanged, and 44% of
+    /// dictations are untouched end to end.
+    ///
+    /// Matched words take their own score. A word the pipeline rewrote takes the
+    /// lowest score of the decoded words it replaced, because that rewrite is
+    /// about the same piece of audio — a name corrected from a shaky decode is
+    /// exactly the word worth colouring. Anything with no decoded word behind it
+    /// takes none.
+    static func read(_ heard: [Trace.Word], into text: String) -> [Word] {
+        let written = text.split(whereSeparator: \.isWhitespace).map(String.init)
+        guard !written.isEmpty else { return [] }
+        // The match below is quadratic in the two lengths. A minute of dictation
+        // is about 150 words, so this only ever trips on something that is not a
+        // dictation, and a sentence with no colour beats a stalled pill.
+        guard !heard.isEmpty, heard.count <= 400, written.count <= 400 else {
+            return written.map { Word(text: $0, score: nil) }
+        }
+
+        var scores = [Float?](repeating: nil, count: written.count)
+        let pairs = anchors(heard.map { key($0.word) }, written.map(key))
+
+        var lastHeard = -1
+        var lastWritten = -1
+        // The pairs, then one past the end of both, so the run after the last
+        // match is filled by the same loop that fills the runs between matches.
+        for (h, w) in pairs + [(heard.count, written.count)] {
+            let heardGap = (lastHeard + 1)..<min(h, heard.count)
+            let writtenGap = (lastWritten + 1)..<min(w, written.count)
+            if !heardGap.isEmpty, !writtenGap.isEmpty,
+               let worst = heardGap.map({ heard[$0].confidence }).min() {
+                for index in writtenGap { scores[index] = worst }
+            }
+            if h < heard.count, w < written.count { scores[w] = heard[h].confidence }
+            lastHeard = h
+            lastWritten = w
+        }
+
+        return written.enumerated().map { Word(text: $0.element, score: scores[$0.offset]) }
+    }
+
+    /// Case and punctuation are not what this is about. "Versal," and "versal"
+    /// are the same decode; the pipeline capitalises and punctuates all the
+    /// time, and matching on the raw string would call every sentence rewritten.
+    private static func key(_ word: String) -> String {
+        word.lowercased().trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+    }
+
+    /// The words the two lists agree on, in order — a longest common
+    /// subsequence, returned as index pairs.
+    private static func anchors(_ heard: [String], _ written: [String]) -> [(Int, Int)] {
+        var table = [[Int]](
+            repeating: [Int](repeating: 0, count: written.count + 1), count: heard.count + 1
+        )
+        for h in stride(from: heard.count - 1, through: 0, by: -1) {
+            for w in stride(from: written.count - 1, through: 0, by: -1) {
+                table[h][w] = heard[h] == written[w]
+                    ? table[h + 1][w + 1] + 1
+                    : max(table[h + 1][w], table[h][w + 1])
+            }
+        }
+
+        var pairs: [(Int, Int)] = []
+        var h = 0
+        var w = 0
+        while h < heard.count, w < written.count {
+            if heard[h] == written[w] {
+                pairs.append((h, w))
+                h += 1
+                w += 1
+            } else if table[h + 1][w] >= table[h][w + 1] {
+                h += 1
+            } else {
+                w += 1
+            }
+        }
+        return pairs
+    }
+}

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1614,11 +1614,87 @@ struct Config: Decodable, Equatable {
         /// recording happen and some people turn it off as noise; this is about
         /// what to do after one, and wanting one is no reason to want the other.
         var correctOffer: Bool = true
+        /// Colour the dictated sentence on the offer, word by word, by how sure
+        /// the decoder was of each one.
+        ///
+        /// Off by default, and it is the one thing on the pill that is about the
+        /// app rather than about your words: it puts the whole sentence back on
+        /// screen for nine seconds, which is a lot of pill for something you can
+        /// already read where it landed. Worth turning on while you are learning
+        /// what your own dictation is weak at — see `Confidence` for what the
+        /// colours are anchored to, and why they cannot be anchored to anything
+        /// the model documents.
+        ///
+        /// Needs `correct_offer`. There is no offer to draw it on without one.
+        var confidence: Bool = false
+
+        /// When the offer says a dictation is worth a second look.
+        ///
+        /// On by default, unlike `confidence`, and for the opposite reason: it
+        /// costs one line and only on the dictations that earned it, so it is
+        /// not a surface you have to want. It needs `correct_offer` for the
+        /// same reason the colours do.
+        var lowConfidence = LowConfidence()
+
+        /// Whether the warning is armed. Both thresholds have to trip, so
+        /// either one at zero turns it off and nothing has to be collected for
+        /// it.
+        var warnsOnLowConfidence: Bool { lowConfidence.sentence > 0 && lowConfidence.word > 0 }
+
+        /// The two thresholds a dictation is measured against. Both have to
+        /// trip — see `Confidence.warning` for why either alone is noise.
+        struct LowConfidence: Codable, Equatable {
+            /// The decode has to be poor overall: `asr.confidence` below this.
+            var sentence: Double = 0.80
+            /// And it has to hold a word this bad, ignoring the ones the
+            /// vocabulary pass wrote.
+            var word: Double = 0.50
+            /// How long after a warned dictation a bare Return is taken
+            /// instead of typed. Seconds. Zero lets every Return through.
+            ///
+            /// What this catches is the reflex press — the Return already on
+            /// its way down as the words land, before anything has been read.
+            /// Past this the press is a decision, and the key goes through even
+            /// though the warning is still on screen.
+            ///
+            /// One key, once, and only on the dictations that raised the
+            /// warning. The next Return goes through whatever happens — the tap
+            /// disarms itself as it takes the first, so nothing downstream can
+            /// hold a keyboard. Bare Return only: ⌘↩ is somebody who knows the
+            /// shortcut, and is left alone.
+            var holdReturn: Double = 1.5
+
+            /// Zero for either threshold turns the warning off, and the hold
+            /// with it — there is nothing to hold a key over.
+            init() {}
+
+            enum CodingKeys: String, CodingKey {
+                case sentence
+                case word
+                case holdReturn = "hold_return"
+            }
+
+            init(from decoder: Decoder) throws {
+                let c = try decoder.container(keyedBy: CodingKeys.self)
+                self.init()
+                if let s = try c.decodeIfPresent(Double.self, forKey: .sentence) {
+                    self.sentence = min(max(0, s), 1)
+                }
+                if let w = try c.decodeIfPresent(Double.self, forKey: .word) {
+                    self.word = min(max(0, w), 1)
+                }
+                if let hold = try c.decodeIfPresent(Double.self, forKey: .holdReturn) {
+                    self.holdReturn = max(0, hold)
+                }
+            }
+        }
 
         enum CodingKeys: String, CodingKey {
             case sound
             case overlay
             case correctOffer = "correct_offer"
+            case confidence
+            case lowConfidence = "low_confidence"
         }
 
         init() {}
@@ -1630,6 +1706,12 @@ struct Config: Decodable, Equatable {
             if let overlay = try c.decodeIfPresent(Bool.self, forKey: .overlay) { self.overlay = overlay }
             if let offer = try c.decodeIfPresent(Bool.self, forKey: .correctOffer) {
                 self.correctOffer = offer
+            }
+            if let shown = try c.decodeIfPresent(Bool.self, forKey: .confidence) {
+                self.confidence = shown
+            }
+            if let low = try c.decodeIfPresent(LowConfidence.self, forKey: .lowConfidence) {
+                self.lowConfidence = low
             }
         }
     }

--- a/Sources/ParrotFlow/Log.swift
+++ b/Sources/ParrotFlow/Log.swift
@@ -41,9 +41,12 @@ enum Log {
     ///   respects the setting.
     static func write(_ message: String, force: Bool = false) {
         let line = "\(timestampFormatter.string(from: Date()))  \(message)\n"
-        NSLog("[ParrotFlow] %@", message)
 
         guard force || textEnabled else { return }
+        // Behind the guard, not before it. The unified log outlives the
+        // process and `log show` reads it back, so a line carrying dictated
+        // text has to respect `logging.text` at this sink too.
+        NSLog("[ParrotFlow] %@", message)
         queue.async {
             guard let data = line.data(using: .utf8) else { return }
             let fm = FileManager.default

--- a/Sources/ParrotFlow/OfferKeys.swift
+++ b/Sources/ParrotFlow/OfferKeys.swift
@@ -52,6 +52,9 @@ final class OfferKeys {
         case dismiss
         /// Run the command this letter belongs to.
         case letter(String)
+        /// The first Return after a dictation the app is not sure about. Taken
+        /// once and given straight back — see `holdsReturn`.
+        case firstReturn
     }
 
     private var tap: CFMachPort?
@@ -61,6 +64,20 @@ final class OfferKeys {
     /// The letters the offer has claimed, uppercased. Empty is allowed — then
     /// only Escape and Return are watched.
     private var letters: Set<String> = []
+    /// Until when a bare Return is taken instead of typed.
+    ///
+    /// A moment, not a mode. What this is for is the Return already on its way
+    /// down as the words land — the reflex press, before the sentence has been
+    /// read. A second and a half after that, pressing Return is a decision, and
+    /// a decision is not something to take a key away from.
+    ///
+    /// Armed only for a dictation the app has warned about, and disarmed by
+    /// the first Return it takes as well as by the clock — so the very next one
+    /// goes through either way.
+    ///
+    /// Bare only. A Return with a modifier is somebody who knows what they are
+    /// doing — ⌘↩ sends in most chat apps — and is left alone.
+    private var holdReturnUntil = Date.distantPast
 
     var isRunning: Bool { tap != nil }
 
@@ -85,9 +102,13 @@ final class OfferKeys {
     /// `letters` must already be uppercased, which is the shape `Config` stores
     /// a `key:` in: the comparison below uppercases what was typed, so a
     /// lowercase entry here would claim a letter and then never match it.
-    func start(until: Date, letters: Set<String>, onKey: @escaping (Key) -> Void) {
+    func start(
+        until: Date, letters: Set<String>, holdingReturnUntil: Date? = nil,
+        onKey: @escaping (Key) -> Void
+    ) {
         stop()
         self.letters = letters
+        self.holdReturnUntil = holdingReturnUntil ?? .distantPast
         guard AXIsProcessTrusted() else {
             Log.write("offer keys: accessibility is not granted; the keys are not taken")
             return
@@ -168,6 +189,7 @@ final class OfferKeys {
         source = nil
         handler = nil
         letters = []
+        holdReturnUntil = .distantPast
         expiry = .distantPast
     }
 
@@ -210,7 +232,16 @@ final class OfferKeys {
         let key: Key
         var take = true
         let keycode = Int(event.getIntegerValueField(.keyboardEventKeycode))
-        if keycode == kVK_Escape, event.flags.isDisjoint(with: Self.anyModifier) {
+        if Date() < holdReturnUntil,
+           keycode == kVK_Return || keycode == kVK_ANSI_KeypadEnter,
+           event.flags.isDisjoint(with: Self.anyModifier) {
+            // Once. Disarmed here rather than by whoever handles it, so the
+            // second Return is through before the main loop has looked at the
+            // first — a key held twice by a slow handler is a key that does not
+            // work.
+            holdReturnUntil = .distantPast
+            key = .firstReturn
+        } else if keycode == kVK_Escape, event.flags.isDisjoint(with: Self.anyModifier) {
             key = .dismiss
         } else if event.flags.isDisjoint(with: Self.anyModifier),
                   !letters.isEmpty,

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -22,6 +22,37 @@ enum PanelsCommand {
     /// in its first sentence and a short one would not say whether it fits.
     private static let sampleMicName = "Tasmin's AirPods Pro Max"
 
+    /// What `feedback.confidence` draws. The scores walk the whole ramp — sure,
+    /// p25, p10, p1, and a word with no reading at all — because the question
+    /// this surface answers is whether the colours are told apart, and a
+    /// sentence the decoder was sure of would show one of them.
+    private static let sampleSentence = [
+        Confidence.Word(text: "We", score: 1.0),
+        Confidence.Word(text: "deployed", score: 0.97),
+        Confidence.Word(text: "Redcrawl", score: 0.74),
+        Confidence.Word(text: "on", score: 0.99),
+        Confidence.Word(text: "Vercel", score: 0.52),
+        Confidence.Word(text: "with", score: 0.91),
+        Confidence.Word(text: "Tasmin", score: 0.28),
+        Confidence.Word(text: "yesterday", score: nil)
+    ]
+
+    /// The decoder's own score for that whole utterance. Between p1 and p10 of
+    /// the archive, which is where a decode holding words this shaky lands, and
+    /// which puts the number mid-ramp: the panel is here to show the colours
+    /// being told apart, and the median would print plain white.
+    private static let sampleOverall: Float = 0.81
+
+    /// The warning the same dictation raises. It names the word rather than a
+    /// number: the number is for the person tuning the thresholds, and this
+    /// line is for the person who has just dictated.
+    private static let sampleWarning = "This may not be what you said · Vercel"
+
+    /// The three rows together, which is the tallest the pill ever gets.
+    private static let sampleReading = Confidence.Reading(
+        words: sampleSentence, overall: sampleOverall, warning: sampleWarning
+    )
+
     /// Draws every surface into one PNG, light beside dark.
     ///
     /// The panels are the one part of the app with no test: they are looked at,
@@ -47,9 +78,33 @@ enum PanelsCommand {
         let notice = pill(.notice("Grammar applied", .done))
         let caution = pill(.notice("Grammar copied — this app won't let me edit it", .caution))
         let thinking = pill(.working("Thinking…"))
-        let offer = pill(.offer(offerChips, nil))
+        let offer = pill(.offer(offerChips, nil, Confidence.Reading()))
         // Beside the plain one: the two endings must not look the same.
-        let offerCopied = pill(.offer(offerChips, "Nowhere to type · ⌘V"))
+        let offerCopied = pill(.offer(offerChips, "Nowhere to type · ⌘V", Confidence.Reading()))
+        // The warning on its own, which is what most people will ever see of
+        // this: `feedback.confidence` is off by default and the thresholds are
+        // not, so a shaky dictation raises one line and nothing else.
+        let offerWarned = pill(.offer(
+            offerChips, nil, Confidence.Reading(warning: sampleWarning)
+        ))
+        // And the same pill after it has taken a Return: one step further
+        // along the same ramp, which is the thing to check side by side —
+        // amber and scarlet have to read as an escalation, not as two moods.
+        let offerStopped = pill(.offer(
+            offerChips, nil, Confidence.Reading(warning: Confidence.stopped, stopped: true)
+        ))
+        // The same offer with `feedback.confidence` on.
+        let offerHeard = pill(.offer(offerChips, nil, sampleReading))
+        // And a dictation long enough to wrap. On the sheet because the wrap is
+        // the one thing here that is counted before it is drawn — a line count
+        // off by one clips the words rather than costing a few points of pill.
+        let offerHeardLong = pill(.offer(
+            offerChips, nil,
+            Confidence.Reading(
+                words: sampleSentence + sampleSentence, overall: sampleOverall,
+                warning: sampleWarning
+            )
+        ))
 
         let overlay = pill(.recording, icon: sampleIcon(), level: 0.75)
 
@@ -163,6 +218,16 @@ enum PanelsCommand {
              pillSize(offer), .dark, true),
             (AnyView(PillView().environmentObject(offerCopied)),
              pillSize(offerCopied), .dark, true),
+            // The same offer with `feedback.confidence` on: two rows instead of
+            // one, and the only pill on the sheet that is not a lozenge.
+            (AnyView(PillView().environmentObject(offerWarned)),
+             pillSize(offerWarned), .dark, true),
+            (AnyView(PillView().environmentObject(offerStopped)),
+             pillSize(offerStopped), .dark, true),
+            (AnyView(PillView().environmentObject(offerHeard)),
+             pillSize(offerHeard), .dark, true),
+            (AnyView(PillView().environmentObject(offerHeardLong)),
+             pillSize(offerHeardLong), .dark, true),
             // Not a pill state at all, and the only surface here that is
             // about the hardware rather than about the words. Next to the pill
             // because that is what it appears beside.
@@ -329,6 +394,14 @@ enum PanelsCommand {
             }
             pill.model.onPick = { index in
                 print("offer: chip \(index) — \(offerChips[index].title)")
+            }
+        // The same offer with `feedback.confidence` on — the only pill that is
+        // two rows, and the only one that is not a lozenge.
+        case "confidence":
+            pill.offer(offerChips, reading: sampleReading, for: AppDelegate.offerSeconds)
+            pill.model.onHover = { inside in
+                if !inside { pill.model.selected = nil }
+                pill.hovering(inside)
             }
         case "vocabulary":
             correction.show(selection: "I work with Tasmin and Mick on Versal")

--- a/Sources/ParrotFlow/ParrotStyle.swift
+++ b/Sources/ParrotFlow/ParrotStyle.swift
@@ -32,6 +32,32 @@ enum Parrot {
     /// Closes on scarlet so an angular gradient has no seam.
     static let wheel: [Color] = [scarlet, amber, leaf, sky, scarlet]
 
+    /// The wheel with the cool half taken out, for a surface that is a warning.
+    /// Still two colours and still turning, so it reads as the same rim in a
+    /// different mood rather than as a different app.
+    static let warned: [Color] = [amber, scarlet, amber, scarlet, amber]
+
+    /// And with the amber nearly gone, for the surface that has just taken a
+    /// keystroke. One step further along the same ramp, so the two states read
+    /// as an escalation rather than as two unrelated colours.
+    static let stopped: [Color] = [scarlet, scarlet, amber, scarlet, scarlet]
+
+    /// One plumage colour blended into the next, for a ramp rather than a step.
+    ///
+    /// Through sRGB components rather than through a SwiftUI gradient: this
+    /// colours a run of text, and `Text` takes a colour, not a shape style it
+    /// can fill with.
+    static func mix(_ from: Color, _ to: Color, _ amount: Double) -> Color {
+        let t = min(max(amount, 0), 1)
+        guard let a = NSColor(from).usingColorSpace(.sRGB),
+              let b = NSColor(to).usingColorSpace(.sRGB) else { return to }
+        return Color(
+            red: a.redComponent + (b.redComponent - a.redComponent) * t,
+            green: a.greenComponent + (b.greenComponent - a.greenComponent) * t,
+            blue: a.blueComponent + (b.blueComponent - a.blueComponent) * t
+        )
+    }
+
     /// The colour of anything you can act on: focus rings, the primary button,
     /// the header of a panel. Deliberately not `.accentColor` — a surface that
     /// changes colour with the system tint cannot also be the app's own.
@@ -84,13 +110,19 @@ extension View {
     /// launch panel — is not drawn yet, and the reasons written on this path
     /// would go with it. See "Not done" in
     /// `docs/proposals/hud-placement-and-offer.md`.
+    ///
+    /// `wash` is a colour laid over the ground, for a surface that has to be
+    /// read as a warning before it is read at all. Over the solid ground only:
+    /// the translucent ones already take their colour from what is behind
+    /// them, and a wash on top of that is paint on a window.
     func parrotSurface<S: InsettableShape>(
         _ shape: S, alive: Bool = false, glass: Bool = false, solid: Bool = false,
-        scrim: Double? = nil
+        scrim: Double? = nil, wash: Color? = nil, wheel: [Color] = Parrot.wheel
     ) -> some View {
         background {
             if solid {
                 shape.fill(Color(red: 0.035, green: 0.035, blue: 0.043).opacity(0.95))
+                if let wash { shape.fill(wash) }
             }
             // No `.regularMaterial` under glass. That blurs what is inside the
             // window, and on a panel with a clear background there is nothing
@@ -142,7 +174,7 @@ extension View {
         }
         // The lit edge is the rim's own inner hairline, weighted to the top —
         // not a line of its own. See `PlumageRim`.
-        .overlay { PlumageRim(shape: shape, alive: alive, glass: glass) }
+        .overlay { PlumageRim(shape: shape, alive: alive, glass: glass, wheel: wheel) }
     }
 }
 
@@ -153,6 +185,9 @@ struct PlumageRim<S: InsettableShape>: View {
     /// Weight the inner hairline toward the top, so it reads as light on the
     /// edge. See the hairline below.
     var glass: Bool = false
+    /// The colours it runs through. A wheel of two makes a rim that means one
+    /// thing, which is what a warning needs.
+    var wheel: [Color] = Parrot.wheel
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var angle: Double = -90
@@ -160,7 +195,7 @@ struct PlumageRim<S: InsettableShape>: View {
     var body: some View {
         shape
             .strokeBorder(
-                AngularGradient(colors: Parrot.wheel, center: .center, angle: .degrees(angle)),
+                AngularGradient(colors: wheel, center: .center, angle: .degrees(angle)),
                 lineWidth: alive ? 2 : 1.4
             )
             .opacity(alive ? 1 : 0.9)
@@ -434,6 +469,8 @@ enum ParrotGlass {
 struct PlumageBloom<S: InsettableShape>: View {
     let shape: S
     var alive: Bool = false
+    /// The colours the glow is made of. See `PlumageRim.wheel`.
+    var wheel: [Color] = Parrot.wheel
     /// How much of it there is. The same absolute spill reads as far less
     /// around a 900pt panel than around a 46pt pill — the glow is a proportion
     /// of the edge it comes off, and the edge here is twenty times longer.
@@ -479,7 +516,7 @@ struct PlumageBloom<S: InsettableShape>: View {
     private func bloom(width: CGFloat, blur: CGFloat, opacity: Double, angle: Double) -> some View {
         shape
             .strokeBorder(
-                AngularGradient(colors: Parrot.wheel, center: .center, angle: .degrees(angle)),
+                AngularGradient(colors: wheel, center: .center, angle: .degrees(angle)),
                 lineWidth: width
             )
             .blur(radius: blur)

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -53,7 +53,13 @@ enum PillState: Equatable {
     ///
     /// The headline is where the words went. Nil when they went into the field
     /// you were looking at, set for the endings nobody asked for.
-    case offer([OfferedCommand], String?)
+    ///
+    /// The reading is what the decoder made of the dictation — the sentence
+    /// word by word, its score for the whole utterance, and a warning when it
+    /// is worth a second look. An empty one is the whole difference: it is what
+    /// decides the pill's height, so nothing about this state changes shape for
+    /// a dictation that went fine.
+    case offer([OfferedCommand], String?, Confidence.Reading)
 }
 
 /// A command on the offer, and the letter that runs it.
@@ -188,11 +194,12 @@ final class PillHUD {
     /// frame. The keys and the chips work the whole way down; the fading only
     /// says how long is left.
     func offer(
-        _ commands: [OfferedCommand], headline: String? = nil, for duration: TimeInterval
+        _ commands: [OfferedCommand], headline: String? = nil,
+        reading: Confidence.Reading = Confidence.Reading(), for duration: TimeInterval
     ) {
         model.selected = nil
         offerFor = duration
-        set(.offer(commands, headline))
+        set(.offer(commands, headline, reading))
         decay(over: duration)
     }
 
@@ -739,8 +746,110 @@ enum PillMetrics {
     static let bleed: CGFloat = 52
 
     static func panelSize(for state: PillState, hasIcon: Bool) -> NSSize {
-        NSSize(width: width(for: state, hasIcon: hasIcon) + bleed * 2,
-               height: height + bleed * 2)
+        let width = width(for: state, hasIcon: hasIcon)
+        return NSSize(width: width + bleed * 2,
+                      height: height(for: state, width: width) + bleed * 2)
+    }
+
+    /// The face the dictated sentence is set in — the same one the chips use.
+    ///
+    /// Kept as an `NSFont` because the pill is sized before it is drawn, and
+    /// this sentence is the one thing on the surface long enough to wrap. The
+    /// chips are measured at a flat rate per character; a line count off by one
+    /// would clip the words instead of costing a few points of capsule.
+    static let sentenceFont: NSFont = {
+        let plain = NSFont.systemFont(ofSize: 13, weight: .medium)
+        guard let rounded = plain.fontDescriptor.withDesign(.rounded) else { return plain }
+        return NSFont(descriptor: rounded, size: 13) ?? plain
+    }()
+
+    /// One line of it, and the air above.
+    static let sentenceLine: CGFloat = ceil(
+        NSLayoutManager().defaultLineHeight(for: sentenceFont)
+    )
+    static let sentenceGap: CGFloat = 4
+
+    /// Extra air above the sentence, on top of what centring the two rows
+    /// already leaves. The chips sit in capsules of their own and carry their
+    /// own margin with them; the sentence is bare text and read as crowded
+    /// against the rim without this.
+    static let sentenceTop: CGFloat = 5
+
+    /// Past this the sentence wraps rather than the pill growing sideways. The
+    /// pill sits under the line you dictated into, and one wider than the window
+    /// is no longer pointing at anything.
+    static let sentenceWidth: CGFloat = 640
+
+    /// Three lines holds about 240 characters, which is the 99th percentile of
+    /// the dictations in this machine's archive. Past that it truncates: the
+    /// pill is on screen for nine seconds and a paragraph of it would cover the
+    /// words it is about.
+    static let sentenceLines = 3
+
+    /// The utterance score, set under the words.
+    static let readingFont: NSFont = .monospacedDigitSystemFont(ofSize: 15, weight: .semibold)
+    static let readingLine: CGFloat = ceil(
+        NSLayoutManager().defaultLineHeight(for: readingFont)
+    )
+
+    /// The warning, above everything. One line, never wrapped: it names one
+    /// word and one number, and a warning that wraps is a paragraph.
+    static let warningFont: NSFont = {
+        let plain = NSFont.systemFont(ofSize: 13, weight: .bold)
+        guard let rounded = plain.fontDescriptor.withDesign(.rounded) else { return plain }
+        return NSFont(descriptor: rounded, size: 13) ?? plain
+    }()
+    static let warningLine: CGFloat = ceil(
+        NSLayoutManager().defaultLineHeight(for: warningFont)
+    )
+
+    /// The capsule, plus whatever rows the reading puts above the chips.
+    ///
+    /// An offer with nothing to say about the decode is the height the pill has
+    /// always been, so a dictation that went fine changes nothing.
+    static func height(for state: PillState, width: CGFloat) -> CGFloat {
+        guard case .offer(_, _, let reading) = state else { return height }
+        let rows = readingRows(reading, width: width)
+        guard !rows.isEmpty else { return height }
+        return height + sentenceTop + rows.reduce(0, +) + sentenceGap * CGFloat(rows.count)
+    }
+
+    /// The height of each row the reading draws, top to bottom. The count is
+    /// also the number of `sentenceGap`s: one between each pair, one more
+    /// between the last row and the chips.
+    private static func readingRows(
+        _ reading: Confidence.Reading, width: CGFloat
+    ) -> [CGFloat] {
+        var rows: [CGFloat] = []
+        if reading.warning != nil { rows.append(warningLine) }
+        if !reading.words.isEmpty {
+            rows.append(sentenceLine * CGFloat(lines(reading.words, width: width)))
+            if reading.overall != nil { rows.append(readingLine) }
+        }
+        return rows
+    }
+
+    /// Where the sentence wraps at this width, counted ahead of time.
+    static func lines(_ sentence: [Confidence.Word], width: CGFloat) -> Int {
+        let available = width - padding * 2
+        guard available > 0 else { return 1 }
+        let box = run(sentence).boundingRect(
+            with: NSSize(width: available, height: .greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin],
+            attributes: [.font: sentenceFont]
+        )
+        return max(1, min(sentenceLines, Int((box.height / sentenceLine).rounded(.up))))
+    }
+
+    /// The sentence set on one line.
+    static func sentenceRun(_ sentence: [Confidence.Word]) -> CGFloat {
+        ceil(run(sentence).size(withAttributes: [.font: sentenceFont]).width)
+    }
+
+    /// The words with the spaces the pill draws between them — what is measured
+    /// has to be what is set. See `Confidence.sentence`.
+    private static func run(_ sentence: [Confidence.Word]) -> NSString {
+        sentence.map(\.text).joined(separator: " ") as NSString
     }
 
     static let padding: CGFloat = 17
@@ -762,7 +871,8 @@ enum PillMetrics {
         case .recording: return recording(hasIcon: hasIcon)
         case .working(let message): return text(message)
         case .notice(let message, _): return text(message)
-        case .offer(let commands, let headline): return offer(commands, headline: headline)
+        case .offer(let commands, let headline, let reading):
+            return offer(commands, headline: headline, reading: reading)
         }
     }
 
@@ -799,14 +909,28 @@ enum PillMetrics {
     ///
     /// A headline widens it and is meant to: then the sentence is on the
     /// clipboard and looking like a notice is the point.
-    static func offer(_ commands: [OfferedCommand], headline: String? = nil) -> CGFloat {
+    /// A sentence widens it too, up to `sentenceWidth`, and then wraps. So
+    /// does a warning, which never wraps.
+    static func offer(
+        _ commands: [OfferedCommand], headline: String? = nil,
+        reading: Confidence.Reading = Confidence.Reading()
+    ) -> CGFloat {
         // A chip is its keycap, its words and 10pt of padding either side; then
         // 4pt between one chip and the next.
         let chips = commands.reduce(CGFloat(0)) { total, command in
             total + 20 + (command.key.isEmpty ? 0 : keycap) + title(command.title)
         }
         let lead = headline.map { title($0) + gap } ?? 0
-        return padding * 2 + lead + chips + CGFloat(max(commands.count - 1, 0)) * 4
+        let row = padding * 2 + lead + chips + CGFloat(max(commands.count - 1, 0)) * 4
+        var widest = row
+        if !reading.words.isEmpty {
+            widest = max(widest, min(sentenceWidth, padding * 2 + sentenceRun(reading.words)))
+        }
+        if let warning = reading.warning {
+            let text = ceil((warning as NSString).size(withAttributes: [.font: warningFont]).width)
+            widest = max(widest, min(sentenceWidth, padding * 2 + dot + gap + text))
+        }
+        return widest
     }
 
     /// The keycap on a chip: one character at 11pt bold, 5pt either side, and
@@ -862,8 +986,8 @@ struct PillView: View {
             case .notice(let message, let tone):
                 MessageContent(message: message, tone: tone)
                     .transition(.opacity)
-            case .offer(let commands, let headline):
-                OfferContent(commands: commands, headline: headline)
+            case .offer(let commands, let headline, let reading):
+                OfferContent(commands: commands, headline: headline, reading: reading)
                     .transition(.opacity)
             }
         }
@@ -872,13 +996,25 @@ struct PillView: View {
         // must not read as leaving the pill. What leaving costs is decided by
         // whoever raised the offer — see `PillModel.onHover`.
         .onHover { inside in model.onHover?(inside) }
-        .parrotSurface(Capsule(), alive: isWorking, solid: true)
+        // Amber right through when the words may not be the words that were
+        // said. The line says it, but the line is on a pill you have already
+        // learned to ignore: the surface changing colour is what gets looked
+        // at, and it is the same signal the caution notices use.
+        .parrotSurface(
+            Self.shape, alive: isWorking, solid: true,
+            wash: warning?.wash, wheel: warning?.wheel ?? Parrot.wheel
+        )
         // Under the capsule, so it is the capsule's shape and not the glow's.
         .shadow(color: .black.opacity(0.22), radius: 7, y: 2)
         // Behind everything above it. `.background` applied last sits furthest
         // back, which is where the bloom has to be — over the fill it would be
         // a coloured film on the surface rather than light coming off the edge.
-        .background { PlumageBloom(shape: Capsule(), alive: isWorking) }
+        .background {
+            PlumageBloom(
+                shape: Self.shape, alive: isWorking,
+                wheel: warning?.wheel ?? Parrot.wheel
+            )
+        }
         // The transparent margin the bloom spills into. See `PillMetrics.bleed`.
         .padding(PillMetrics.bleed)
         // Bound to the state alone. The meter is fed about ten times a second
@@ -890,6 +1026,30 @@ struct PillView: View {
         if case .working = model.state { return true }
         return false
     }
+
+    /// How loud this pill is, when it is an offer with something to warn
+    /// about. Nil for every other state: a notice carries its tone in its dot,
+    /// and this is the one surface whose meaning is not already written on it.
+    ///
+    /// Amber for a dictation the app is unsure of, scarlet once it has taken a
+    /// Return over it — the same surface one step along, because the second
+    /// state is the first one being ignored.
+    private var warning: (wash: Color, wheel: [Color])? {
+        guard case .offer(_, _, let reading) = model.state, reading.warning != nil else {
+            return nil
+        }
+        return reading.stopped
+            ? (Parrot.scarlet.opacity(0.26), Parrot.stopped)
+            : (Parrot.amber.opacity(0.24), Parrot.warned)
+    }
+
+    /// A fixed radius, not a `Capsule`. At the 46pt the pill has always been the
+    /// two are the same shape — but an offer carrying the dictated sentence is
+    /// taller, and a capsule would round its ends to half of that. The glass
+    /// behind it cannot follow: `ParrotGlass.backdrop` takes its corner radius
+    /// once, when the panel is built. So the shape stops growing where the glass
+    /// stops, and a tall pill is a rounded rectangle rather than a lozenge.
+    static let shape = RoundedRectangle(cornerRadius: PillMetrics.height / 2, style: .circular)
 }
 
 private struct RecordingContent: View {
@@ -961,12 +1121,86 @@ private struct OfferContent: View {
     @EnvironmentObject private var model: PillModel
     let commands: [OfferedCommand]
     let headline: String?
+    /// What the decoder made of the dictation. See `Confidence.Reading`.
+    var reading = Confidence.Reading()
 
     /// The lit chip's lettering: leaf lightened almost to white, so the words
     /// stay readable over a fill of the same colour.
     private static let litText = Color(red: 0.89, green: 0.96, blue: 0.93)
 
     var body: some View {
+        VStack(alignment: .leading, spacing: PillMetrics.sentenceGap) {
+            if let warning = reading.warning { self.warning(warning) }
+            if !reading.words.isEmpty {
+                words
+                if let overall = reading.overall { score(overall) }
+            }
+            chips
+        }
+        // The whole block is centred in the pill's height, so this lands as air
+        // above the sentence rather than being split between the two rows.
+        // `PillMetrics.height(for:width:)` adds the same number.
+        .padding(.top, reading.isEmpty ? 0 : PillMetrics.sentenceTop)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+    }
+
+    /// What was dictated, each word in the colour of how sure the decoder was.
+    ///
+    /// Above the chips rather than beside them: it is the thing the chips are
+    /// about, and it is the one part of this surface you read rather than aim
+    /// at. Truncated rather than scrolled — the pill takes no keyboard focus and
+    /// there is nothing to scroll it with.
+    ///
+    /// Centred, unlike everything else on the pill. The chips are a row you aim
+    /// at and they start where every other pill's contents start; this is the
+    /// sentence the pill is about, and it sits in the middle of the surface it
+    /// gave its width to.
+    private var words: some View {
+        Confidence.sentence(reading.words)
+            .font(.system(size: 13, weight: .medium, design: .rounded))
+            .multilineTextAlignment(.center)
+            .lineLimit(PillMetrics.sentenceLines)
+            .truncationMode(.tail)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.horizontal, PillMetrics.padding)
+    }
+
+    /// Why this dictation is worth a second look, above everything else on the
+    /// pill.
+    ///
+    /// With the caution dot the notices use, and centred like the sentence:
+    /// the chips are a row you aim at, and both of these are things you read.
+    /// A warning off to one side of a pill that is mostly empty reads as a
+    /// label on the surface rather than as what the surface is about.
+    private func warning(_ text: String) -> some View {
+        HStack(spacing: PillMetrics.gap) {
+            ToneDot(tone: reading.stopped ? .failure : .caution)
+            Text(text)
+                .font(.system(size: 13, weight: .bold, design: .rounded))
+                .foregroundStyle(Color(white: 0.97))
+                .lineLimit(1)
+                .fixedSize()
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+        .padding(.horizontal, PillMetrics.padding)
+    }
+
+    /// The one number the decoder gives for the whole utterance, raw.
+    ///
+    /// Full strength and coloured on the utterance's own bands — see
+    /// `Confidence.overallTint`. Larger than the sentence rather than smaller:
+    /// it is the one thing on this pill you read at a glance instead of word
+    /// by word.
+    private func score(_ score: Float) -> some View {
+        Text(verbatim: Confidence.overall(score))
+            .font(.system(size: 15, weight: .semibold, design: .monospaced))
+            .foregroundStyle(Confidence.overallTint(score))
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.horizontal, PillMetrics.padding)
+    }
+
+    private var chips: some View {
         HStack(spacing: 4) {
             if let headline {
                 Text(headline)

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -108,10 +108,28 @@ actor Transcriber {
 
     // MARK: - Transcription
 
+    /// What the decoder made of one clip, for a surface that draws it.
+    struct Decode: Sendable {
+        /// The decoder's own words with their scores, before any stage
+        /// rewrote them.
+        let words: [Trace.Word]
+        /// Its one score for the whole utterance. See `Confidence.overall`.
+        let confidence: Float
+        /// The terms the vocabulary pass wrote into the text.
+        let vocabulary: [String]
+    }
+
     /// Transcribes a finished recording. Returns the cleaned-up text.
+    ///
+    /// `heard` is handed what the decoder made of the clip — see `Decode`.
+    /// Handed over rather than read back off `Trace` for the same reason
+    /// the scope values below are: the collector is only bound when somebody
+    /// asked for a trace, and a feature that worked on the runs you are watching
+    /// and stopped on the runs you are not would be worse than no feature.
     func transcribe(
         url: URL, config: Config, app: Pipeline.App? = nil,
-        progress: (@Sendable (String) -> Void)? = nil
+        progress: (@Sendable (String) -> Void)? = nil,
+        heard: (@Sendable (Decode) -> Void)? = nil
     ) async throws -> String {
         try await prepare(config: config)
 
@@ -234,6 +252,20 @@ actor Transcriber {
                 Log.write("vocabulary: \(error.localizedDescription); left as decoded")
             }
             setStatus(.ready)
+        }
+
+        // After the vocabulary pass rather than before it, though the words
+        // handed over are still the decoder's own. Whoever reads a score needs
+        // to know which words the pass wrote: those carry the score of the
+        // decode they replaced, which is low by definition — that is why the
+        // pass fired — and warning about a name the app has already fixed is
+        // warning about the fix. See `Confidence.warning`.
+        if let heard {
+            heard(Decode(
+                words: Trace.words(from: result.tokenTimings ?? []),
+                confidence: result.confidence,
+                vocabulary: findings?.proposals.filter(\.applied).map(\.term) ?? []
+            ))
         }
 
         // The same numbers the trace records, handed to the pipeline as well.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -36,6 +36,29 @@ feedback:
   # Click a chip to run it. Tapping the dictation hotkey — press and let go
   # — opens the correction panel too. Holding it starts the next dictation.
   correct_offer: true
+  # Put the sentence on the offer as well, each word coloured by how sure the
+  # decoder was of it: white, then amber, then scarlet. Off by default — it is
+  # for learning what your own dictation is weak at, not for every day.
+  confidence: false
+  # When the offer says the words may not be the words you said. The pill
+  # turns amber and carries one line naming the word. On by default, unlike
+  # `confidence`: it costs nothing on a dictation that went fine.
+  # Both thresholds have to trip, because either alone is noise:
+  #   sentence — the decoder's mean over the whole utterance. Below this the
+  #              decode went badly throughout, not just in one place.
+  #   word     — and it holds a word this bad. Words the vocabulary pass
+  #              wrote do not count: they carry the score of the decode they
+  #              replaced, which is low because that is why the pass fired.
+  # Zero for either turns the warning off.
+  # hold_return is how long, in seconds, a bare Return is taken rather than
+  # typed after a warned dictation — the pill turns red and asks you to check
+  # what was written. It catches the reflex press, not a considered one: past
+  # this the key goes through even with the warning still up. The next Return
+  # always goes through. Cmd+Return is left alone. 0 turns it off.
+  low_confidence:
+    sentence: 0.80
+    word: 0.50
+    hold_return: 1.5
 
 logging:
   # The line-by-line log at ~/Library/Logs/ParrotFlow.log — how

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -355,10 +355,22 @@ $PF --panel-sheet s.png   # draw every surface into one PNG, light beside dark
 ```
 
 `--panels` takes `pill`, `notice`, `caution`, `failure`, `thinking`, `offer`,
-`vocabulary`, `punctuation`, `rule`, `dictation`, `preview`, `microphone` or
-`sequence`.
+`confidence`, `vocabulary`, `punctuation`, `rule`, `dictation`, `preview`,
+`microphone` or `sequence`.
 `--panel-sheet` draws all of
 them at once, which is where drift between them shows up.
+
+`confidence` is the same offer with `feedback.confidence` on: the sentence
+above the chips, each word coloured by how sure the decoder was of it, and the
+decoder's score for the whole utterance under it, on bands of its own. It is
+the tallest pill there is — four rows when it also warns.
+
+The sheet carries two more: the warning on its own, an amber pill with one
+line, which is what `low_confidence` draws with the colours off and what most
+people will ever see of this; and the same pill in scarlet after it has held a
+Return. Those two have to read as one escalation rather than two moods, which
+is a thing you can only see side by side. See
+[configuration.md](configuration.md#low_confidence--when-the-words-may-not-be-your-words).
 
 `microphone` is the Bluetooth notice, with a made-up device name. It is the one
 surface with something to click besides the offer: *Why* opens the reasons and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -369,6 +369,140 @@ right after dictating.
 
 Off by setting it to `false`. Then no key is taken at any time.
 
+### `confidence` — how sure the decoder was
+
+Off by default. Set `feedback.confidence: true` and the offer carries the
+sentence you just dictated above the chips, one colour per word: white where
+the decoder was sure, then amber, then scarlet where it was not.
+
+It needs `correct_offer`. There is no offer to draw it on without one.
+
+**There is no published threshold this could be read against.** Parakeet gives
+one probability per token and documents nothing about what a value means.
+NVIDIA's own guidance for NeMo is that a raw probability is a weak correctness
+signal and that the operating point has to be found on your own data. So the
+colours are anchored on percentiles of the archive in `trace.jsonl` — the
+median word scores 0.995 and 68% sit at 1.0, so a ramp over the raw 0–1 scale
+would paint the whole sentence white. White is the top 75% of words, amber is
+around the bottom 10%, scarlet is the bottom 1%. Those numbers came from one
+person's voice and one microphone; `docs/cli.md` has the `jq` for measuring
+your own.
+
+Under the sentence sits one number: the decoder's own confidence for the whole
+utterance, printed raw. It is `ASRResult.confidence`, the mean over the tokens,
+the same value a pipeline condition reads as `asr.confidence` and the same one
+`trace.jsonl` records.
+
+It takes the same three colours as the words but not the same numbers. A mean
+over every token moves in a far narrower range than one word does: over 16,513
+dictations here it runs 0.73 at p1, 0.83 at p10 and 0.93 at the median. So its
+bands are the percentiles of that column — white above 0.89, amber around 0.83,
+scarlet at 0.73 and below. On the word bands three dictations in four would
+print white and the colour would say nothing.
+
+Read it knowing it barely moves. Of the dictations holding a word below the
+amber band, only 13% fall under its own p10. A sentence with one bad name in it
+still scores near 0.93 — the word colour catches that, and this number does
+not.
+
+A grey word is one with no reading at all: nothing the decoder said became it.
+That happens where a stage inserted a word — the question mark a punctuation
+pass added, a sentence a prompt rewrote whole. It is rare: 19 dictations in
+15,394 have one. A word the vocabulary or a substitution *replaced* is not
+grey — it takes the score of the decoded word it replaced, because that is the
+same piece of audio, and a name corrected from a shaky decode is exactly the
+word worth colouring.
+
+The pill grows to hold the sentence: up to 640pt wide and three lines, then it
+truncates. That is a lot of pill after every dictation, which is why this is
+off unless you ask for it. It is worth turning on for a while to learn which
+words your own dictation is weak at, and turning off again.
+
+### `low_confidence` — when the words may not be your words
+
+On by default, unlike `confidence`. A dictation that went fine costs nothing.
+
+```yaml
+feedback:
+  low_confidence:
+    sentence: 0.80   # the decode was poor overall
+    word: 0.50       # and it holds a word this bad
+```
+
+When both trip, the pill comes up amber — washed ground, amber rim, amber glow
+— and carries one line above the chips: `This may not be what you said`, then
+the word. The colour is the signal. The line says what it means.
+
+It needs `correct_offer`. It does not need `confidence`: the coloured sentence
+and the score are a separate, off-by-default view for tuning, and the warning
+is meant to work without them.
+
+**Both, not either.** Each threshold alone is noise. A mean over every token
+stays high through one mangled name — over 16,640 dictations here, one where
+the vocabulary pass had to fix a name scores a median 0.931 and one where it
+did not scores 0.931, identically. And one low word is ordinary: a fifth of all
+dictations hold a word under 0.40, usually a clipped `the` or a trailing `uh`
+that changes nothing. What is worth stopping for is a decode that is poor
+throughout *and* holds a word the decoder could not place.
+
+At the defaults that is 3.9% of dictations on this machine — about one in 26.
+The earlier either-one rule was 21.8%, better than one in five.
+
+| | rate |
+|---|---|
+| `sentence: 0.85`, `word: 0.50` | 11.0% |
+| `sentence: 0.80`, `word: 0.50` | 3.9% |
+| `sentence: 0.80`, `word: 0.40` | 3.2% |
+| `sentence: 0.75`, `word: 0.50` | 1.1% |
+
+Zero for either turns the warning off.
+
+**The reflex Return is held.** For 1.5 seconds after a warned dictation lands,
+a bare Return is taken instead of typed: the pill turns scarlet and says
+`Enter held · check what was written, then press it again`. The one after it
+goes through.
+
+```yaml
+feedback:
+  low_confidence:
+    hold_return: 1.5   # seconds; 0 lets every Return through
+```
+
+The number is what makes this a guard rather than a mode. What it catches is
+the Return already on its way down as the words land, before anything has been
+read. Past a second and a half, pressing Return is a decision — the warning is
+still on screen, and the key goes through anyway.
+
+Four more things bound it. It only arms on the 3.9% of dictations that raised
+the warning. It takes one key and disarms itself as it takes it, inside the
+tap, so nothing downstream can hold a keyboard even if it hangs. It only takes
+a bare Return — `⌘↩`, which is how most chat apps send, goes straight through.
+And it cannot outlive the offer: the tap is destroyed with the pill.
+
+It rides on the same `CGEvent` tap the offer's letters use, so it needs Input
+Monitoring in System Settings. Without that grant the tap is created and fed
+nothing — the log says so at every offer, and Return simply works as usual. A
+terminal with Secure Event Input on blocks it the same way.
+
+Set it to `0` to keep the warning and let every Return through.
+
+**Words the vocabulary pass wrote do not count.** A substituted word carries the
+score of the decode it replaced — see `confidence` above — and that score is low
+by definition, because a shaky decode is what made the pass fire. Measured here,
+38.8% of the words substitutions replaced were under 0.60 against 9.9% of words
+generally. Without this rule the warning would shout loudest about the names the
+app has just fixed for you.
+
+Worth knowing: at the defaults this rule changes nothing. All 651 warnings in
+the archive fire either way, because a decode poor enough to be under 0.80
+always holds a second bad word besides the substituted one. Loosen `sentence`
+to 0.90 and it starts to matter — 117 warnings suppressed there.
+
+**It cannot catch a confident mistake.** Confidence says how sure the decoder
+was, not whether it was right. The same archive has the vocabulary pass
+correcting words the decoder scored 0.987 and 1.000. A low score is good
+evidence something is wrong; a high one is not evidence anything is right.
+
 ## `logging`
 
 What gets written to disk about a dictation, apart from the transcript itself.


### PR DESCRIPTION
The decoder scores every token it emits and nothing read those scores. This puts them on the post-dictation offer, and uses them to catch the one failure dictation has no other guard against: words that landed, look fine, and are not what was said.

## What lands

**A warning, on by default.** When the decode was poor overall *and* holds a word the decoder could not place, the pill turns amber and says so, naming the word.

```
● This may not be what you said · Vercel
  [C Correct]  [G grammar]
```

**The first Return is held for 1.5 seconds.** Long enough to stop the reflex press that sends the message, short enough not to be a mode. The pill goes scarlet; the next Return goes through.

```
● Enter held · check what was written, then press it again
```

**The sentence and its score, off by default** — `feedback.confidence`. Each word in the colour of how sure the decoder was, and the utterance score under it. This is the tuning view: it is what the thresholds were picked with.

```yaml
feedback:
  confidence: false      # the coloured sentence and the score
  low_confidence:
    sentence: 0.80       # the decode was poor overall
    word: 0.50           # and it holds a word this bad
    hold_return: 1.5     # seconds; 0 lets every Return through
```

## Why these numbers

Measured over 16,640 dictations in one `trace.jsonl`.

**Two thresholds, both required.** They catch different failures and neither catches the other's. `asr.confidence` is a mean over every token, so it only sinks when the decode went badly throughout; one mangled name moves it by hundredths. Dictations where the vocabulary pass had to fix a name score a median 0.931, and dictations where it did not score 0.931 — identical. Meanwhile one low word is ordinary: a fifth of all dictations hold one, usually a clipped `the`. Together they fire on **3.9%** of dictations. Either one alone was 21.8%.

**Words the vocabulary pass wrote are not counted.** A substituted word inherits the score of the decode it replaced — correct for the colours, wrong for a warning. Of 3,724 words substitutions replaced, 38.8% were under 0.60 against 9.9% of words generally. Without this the warning would shout loudest about the names the app has just fixed. Honest note: at these thresholds the rule suppresses nothing — a decode under 0.80 always holds a second bad word. It starts to matter if `sentence` is loosened, 117 warnings at 0.90.

**Separate bands for the utterance score.** p25/p10/p1 of `asr.confidence` are 0.89/0.83/0.73, against 0.89/0.60/0.35 for words. Same three colours, different anchors.

## What it cannot do

Confidence says how sure the decoder was, not whether it was right. This archive has the vocabulary pass correcting words scored 0.987 and 1.000. A low score is evidence something is wrong; a high one is not evidence anything is right. This catches the mumbled word, not the confidently wrong one.

## Holding a key

The hold rides the `CGEvent` tap the offer's chip letters already use. Fenced five ways: it arms only on the 3.9% that warned; only for 1.5s; it disarms inside the tap callback as it takes the key, so a slow handler cannot hold a keyboard; bare Return only, so `⌘↩` is untouched; and it cannot outlive the offer. Without Input Monitoring the tap is fed nothing and Return simply works, which the log says at every offer.

## Checking it

`--panel-sheet` gains three pills: the warning alone, the same pill in scarlet after a held Return, and the full four-row version with the coloured sentence. The amber and the scarlet have to read as one escalation, which is only visible side by side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)