### PR TITLE
feat(config): name models, pick one per prompt, and keep the key in the keychain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ voice/
 # about a directory that is already under version control by another route.
 .claude/worktrees/
 .claude/skills/ste/SKILL.md
+
+# Session working files. Large and disposable.
+scratchpad/

--- a/README.md
+++ b/README.md
@@ -133,9 +133,15 @@ ParrotFlow requires Apple silicon and macOS 14 or later.
 curl -fsSL https://raw.githubusercontent.com/znat/parrotflow/main/scripts/install.sh | sh
 ```
 
-Setup will install the Parakeet speech model (1.2 GB,
-needed for dictation), and [Ollama](https://ollama.com/download) with a
-small [Gemma4](https://ollama.com/library/gemma4:e4b-mlx) model.
+Dictation works as soon as it is installed. The Parakeet speech model it needs
+(1.2 GB) downloads itself on your first dictation.
+
+Spoken commands and the vocabulary check need a language model as well, and
+that part is optional. Run one on your own Mac with
+[Ollama](https://ollama.com/download) and a small
+[Gemma4](https://ollama.com/library/gemma4:e4b-mlx) model, or name a hosted one
+under `models:` — see [docs/configuration.md](docs/configuration.md). The
+installer prints how to do either and installs neither.
 
 ## Documentation
 

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1562,13 +1562,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    private func llmConfig() -> LocalLLM.Config {
-        LocalLLM.Config(
-            endpoint: config.llm.endpoint,
-            model: config.llm.model,
-            timeout: config.llm.timeoutSeconds,
-            keepLoaded: config.llm.keepLoaded
-        )
+    /// The model a job runs on — see `Config.model(for:)`.
+    private func llmConfig(for job: Config.ModelJob = .general) -> ModelSpec {
+        config.model(for: job)
     }
 
     /// Loads the Ollama model now, so the first correction doesn't pay for it.
@@ -1581,9 +1577,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// config.yaml, and re-warming there would fire a multi-GB load each time
     /// the file is touched.
     private func warmUpLLM() {
-        guard config.llm.enabled, config.llm.keepLoaded else { return }
-
-        let llm = llmConfig()
+        // Whatever the router runs on: it is the call anybody waits on. Nothing
+        // to warm up when that is not a local model — `LocalLLM.warmUp` says so
+        // too, and this saves the task.
+        let llm = llmConfig(for: .router)
+        guard config.llm.enabled, llm.keepLoaded, llm.api == .ollama else { return }
         let system = Router.prompt(
             for: Catalogue(transforms: config.transforms), freeForm: config.freeForm
         )
@@ -1649,7 +1647,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func startKeepWarm() {
         keepWarmTimer?.invalidate()
         keepWarmTimer = nil
-        guard config.llm.enabled, config.llm.keepLoaded else { return }
+        let router = llmConfig(for: .router)
+        guard config.llm.enabled, router.keepLoaded, router.api == .ollama else { return }
 
         let timer = Timer.scheduledTimer(withTimeInterval: 15, repeats: true) { [weak self] _ in
             self?.keepWarmTick()
@@ -1666,7 +1665,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard !keepWarmInFlight else { return }
         guard Date().timeIntervalSince(LocalLLM.lastCallAt) >= 60 else { return }
 
-        let llm = llmConfig()
+        let llm = llmConfig(for: .router)
+        guard llm.api == .ollama else { return }
         // The same string the router will send, `free_form` included: what is
         // being kept warm is Ollama's prompt cache, and a system prompt that
         // differs by one line is a cache miss and the 3.5s this exists to avoid.
@@ -1714,7 +1714,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         beginProgress("Thinking…")
-        let llmConfig = llmConfig()
+        let llmConfig = llmConfig(for: .router)
         let freeForm = config.freeForm
 
         Task { [weak self] in
@@ -1798,7 +1798,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         case .prompt:
             guard let prompt = transform.asPrompt else { return text }
             return try await PromptRunner.run(
-                prompt: prompt, instruction: instruction, text: text, config: llmConfig()
+                prompt: prompt, instruction: instruction, text: text,
+                config: config.model(for: transform)
             )
         case .replace:
             // `expand:`, or a table reached by voice compiles `{{determiners}}`
@@ -3466,7 +3467,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         beginProgress("Thinking…")
-        let llm = llmConfig()
+        let llm = llmConfig(for: .router)
         let freeForm = config.freeForm
         Task { [weak self] in
             do {

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -519,6 +519,65 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// On change rather than on every load: the file is watched, so saving an
     /// unrelated line runs this again, and a notice that fires every time you
     /// edit your own config is one you learn to ignore.
+    /// Models already asked about this run, so saving config.yaml — which
+    /// reloads it — does not ask again for one that was declined.
+    private var askedForKey: Set<String> = []
+
+    /// Ask for the key of any keychain-backed model that has none.
+    ///
+    /// Modal, and this is the one place that is allowed to be. It runs on a
+    /// config load — launch, or a save of config.yaml — and not on the hotkey
+    /// path, which is what `runModal` may never block; see `startRecording`'s
+    /// catch and #95. Idle is checked anyway, because a save can land while a
+    /// dictation is in flight, and asked again on the next load if it is not.
+    ///
+    /// Declining is a normal answer. The model stays unusable, a transform
+    /// naming it declines with the transcript untouched, and the menu keeps
+    /// saying so.
+    private func askForMissingKeys() {
+        let wanted = config.modelsByName.values
+            .filter { $0.key.kind == .keychain && $0.key.resolve() == nil }
+            .filter { !askedForKey.contains($0.name) }
+            .sorted { $0.name < $1.name }
+        guard !wanted.isEmpty, !recorder.isRecording, runsInFlight <= 0 else { return }
+
+        var stored = false
+        for spec in wanted {
+            askedForKey.insert(spec.name)
+            NSApp.activate(ignoringOtherApps: true)
+            let alert = NSAlert()
+            alert.messageText = "\(spec.name) needs an API key"
+            alert.informativeText =
+                "\(spec.name) sends text to \(spec.url). Paste its key and it is "
+                + "kept in your \(Keychain.service) keychain — not in config.yaml, "
+                + "which is a file people paste to each other.\n\n"
+                + "You can do this later with: ParrotFlow --set-key \(spec.name)"
+            let field = KeyField(frame: NSRect(x: 0, y: 0, width: 320, height: 24))
+            field.placeholderString = "Paste the key"
+            alert.accessoryView = field
+            alert.addButton(withTitle: "Save")
+            alert.addButton(withTitle: "Not now")
+            alert.window.initialFirstResponder = field
+            guard alert.runModal() == .alertFirstButtonReturn else { continue }
+            let typed = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !typed.isEmpty else { continue }
+            do {
+                try Keychain.write(typed, account: spec.key.value)
+                Log.write("stored a keychain key for \(spec.name)")
+                stored = true
+            } catch {
+                Log.write("could not store a key for \(spec.name): \(error.localizedDescription)")
+                flash(error.localizedDescription, tone: .failure)
+            }
+        }
+        // The menu still carries the old "no key" line otherwise, and the
+        // problem it names is the one just fixed.
+        if stored {
+            configProblems = config.problems()
+            updateUI()
+        }
+    }
+
     private func announceIfNew(_ problems: [String]) {
         defer { announcedProblems = problems }
         guard problems != announcedProblems, let first = problems.first else { return }
@@ -544,6 +603,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // about your config belongs; the notice is for what changed.
         for notice in config.notices() { Log.write("config: \(notice)") }
         announceIfNew(configProblems)
+        // Async so a launch is not held behind a modal, and so the menu bar is
+        // up before anything sits in front of it.
+        DispatchQueue.main.async { [weak self] in self?.askForMissingKeys() }
 
         hotkeyError = nil
         hotKeys.onPress = { [weak self] in self?.handleHotKeyPress() }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1352,6 +1352,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         stopWatchingForEscape()
+        // Unconditional above, because a cancel takes the monitors whether or
+        // not a newer press is still running. This is the other half: cancelling
+        // can also be the moment the app goes idle, and what waits on idle —
+        // an offer's keys, a held key prompt — is the helper's to hand over. It
+        // guards on idle itself, so a cancelled transcription that is still in
+        // flight hands over nothing until it lands.
+        stopWatchingForEscapeIfIdle()
         if config.feedback.sound { NSSound(named: "Pop")?.play() }
         Log.write("escape: cancelled while \(recording ? "recording" : "transcribing")")
         flash(recording ? "Recording cancelled" : "Transcription cancelled", tone: .caution)

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -523,13 +523,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// reloads it — does not ask again for one that was declined.
     private var askedForKey: Set<String> = []
 
+    /// A key prompt a running dictation pushed back, waiting for idle.
+    private var keyPromptDeferred = false
+
     /// Ask for the key of any keychain-backed model that has none.
     ///
     /// Modal, and this is the one place that is allowed to be. It runs on a
     /// config load — launch, or a save of config.yaml — and not on the hotkey
     /// path, which is what `runModal` may never block; see `startRecording`'s
     /// catch and #95. Idle is checked anyway, because a save can land while a
-    /// dictation is in flight, and asked again on the next load if it is not.
+    /// dictation is in flight. One that does is held and asked the moment the
+    /// dictation ends — waiting for the next load means a model configured
+    /// mid-dictation stays keyless until a restart.
     ///
     /// Declining is a normal answer. The model stays unusable, a transform
     /// naming it declines with the transcript untouched, and the menu keeps
@@ -539,7 +544,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             .filter { $0.key.kind == .keychain && $0.key.resolve() == nil }
             .filter { !askedForKey.contains($0.name) }
             .sorted { $0.name < $1.name }
-        guard !wanted.isEmpty, !recorder.isRecording, runsInFlight <= 0 else { return }
+        guard !wanted.isEmpty else { return }
+        guard !recorder.isRecording, runsInFlight <= 0 else {
+            keyPromptDeferred = true
+            return
+        }
+        keyPromptDeferred = false
 
         var stored = false
         for spec in wanted {
@@ -1400,6 +1410,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // cancel, so an offer that was raised while a dictation was still
         // running can have its keys now. See `watchTheOfferKeys`.
         if offerIsUp, !offerKeys.isRunning { watchTheOfferKeys() }
+        // And a key prompt the same dictation pushed back. Async so this run's
+        // completion unwinds before a modal blocks the main queue.
+        if keyPromptDeferred {
+            keyPromptDeferred = false
+            DispatchQueue.main.async { [weak self] in self?.askForMissingKeys() }
+        }
     }
 
     private func stopWatchingForEscape() {

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -149,6 +149,33 @@ enum CheckConfigCommand {
         // resolved absolute path for that reason: what the config says is
         // `slack_mentions.py`, and that is exactly the string that cannot
         // answer it.
+        // Which model each job and each prompt ends up on.
+        //
+        // Not the same question as what `models:` says: a name resolves through
+        // `llm.default`, a transform's own `model:`, and whatever that overrides
+        // — and "was that the model I think it was" is the first question when a
+        // prompt starts answering differently. The key is described, never
+        // printed.
+        let models = config.modelsByName
+        print("  · models            \(models.count) reachable")
+        let modelWidth = models.keys.map(\.count).max() ?? 0
+        for name in models.keys.sorted() {
+            guard let spec = models[name] else { continue }
+            let padded = name.padding(toLength: max(modelWidth, 1), withPad: " ", startingAt: 0)
+            let key = spec.api.isLocal ? "" : "  \(spec.key.described)"
+            print("      \(padded)  \(spec.api.rawValue)  \(spec.model)  \(spec.url)"
+                + "  reasoning \(spec.reasoning.rawValue)\(key)")
+        }
+        print("  · runs on           default=\(config.modelName(for: .general))"
+            + "  router=\(config.modelName(for: .router))"
+            + "  vocabulary=\(config.modelName(for: .vocabulary))")
+        let moved = config.transforms.filter { transform in
+            transform.isPrompt && config.model(for: transform) != config.model()
+        }
+        for transform in moved {
+            print("      \(transform.name) → \(config.model(for: transform).described)")
+        }
+
         if !config.transforms.isEmpty {
             print("  · transforms        \(config.transforms.count) defined")
             let width = config.transforms.map(\.name.count).max() ?? 0
@@ -256,10 +283,14 @@ enum CheckConfigCommand {
             ok = false
         }
 
-        // LLM — only reachability is checked here; --command exercises it.
+        // LLM — what is where is in the models table above; this is the switch
+        // that turns all of it off, and the pinning that only Ollama has.
         if config.llm.enabled {
-            print("  · llm               \(config.llm.model) at \(config.llm.endpoint)")
-            print("  · keep loaded       \(config.llm.keepLoaded ? "on (pinned in RAM)" : "off (Ollama unloads after 5 min; +7-10s on a cold call)")")
+            let router = config.model(for: .router)
+            print("  · llm               enabled, \(config.modelsByName.count) model(s)")
+            if router.api == .ollama {
+                print("  · keep loaded       \(router.keepLoaded ? "on (\(router.model) pinned in RAM)" : "off (Ollama unloads after 5 min; +7-10s on a cold call)")")
+            }
         } else {
             print("  · llm               disabled — no free-form spoken commands")
         }

--- a/Sources/ParrotFlow/CommandTestCommand.swift
+++ b/Sources/ParrotFlow/CommandTestCommand.swift
@@ -54,12 +54,7 @@ enum CommandTestCommand {
             return 1
         }
 
-        let llmConfig = LocalLLM.Config(
-            endpoint: config.llm.endpoint,
-            model: config.llm.model,
-            timeout: config.llm.timeoutSeconds,
-            keepLoaded: config.llm.keepLoaded
-        )
+        let llmConfig = config.model(for: .general)
         let spelled = VoiceCommand.spellingSegments(in: command)
         if !spelled.isEmpty {
             let shown = spelled
@@ -85,7 +80,7 @@ enum CommandTestCommand {
                     command: command, lastTranscript: lastTranscript,
                     language: language, config: llmConfig
                 )
-                print(String(format: "→ %@ in %.2fs", config.llm.model, Date().timeIntervalSince(started)))
+                print(String(format: "→ %@ in %.2fs", llmConfig.model, Date().timeIntervalSince(started)))
                 describe(result)
             } catch {
                 print("✗ \(error.localizedDescription)")

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -26,6 +26,12 @@ struct Config: Decodable, Equatable {
     var feedback: Feedback = Feedback()
     var transcription: Transcription = Transcription()
     var llm: LLM = LLM()
+    /// Every model this config can reach, by the name it was given.
+    ///
+    /// A name is all a transform ever mentions — never a vendor, never an
+    /// endpoint. Empty means the one implied by `llm:`, which is what every
+    /// config written before this said and still says.
+    var models: [String: ModelSpec] = [:]
     var updates: UpdatePolicy = UpdatePolicy()
     var logging: Logging = Logging()
     /// Everything nameable: `transforms:`, plus anything still written under
@@ -81,7 +87,8 @@ struct Config: Decodable, Equatable {
     var lists: [String: [String]] = [:]
 
     enum CodingKeys: String, CodingKey {
-        case hotkey, audio, feedback, transcription, llm, transforms, prompts, updates, logging
+        case hotkey, audio, feedback, transcription, llm, models
+        case transforms, prompts, updates, logging
         case freeForm = "free_form"
         case lists
     }
@@ -651,10 +658,12 @@ struct Config: Decodable, Equatable {
         var offer = false
         /// `key: f` — the letter shown on its chip.
         var offerKey = ""
+        /// `model: gpt`, or `model: { use: gpt, reasoning: low }`.
+        var model: ModelRef?
 
         enum CodingKeys: String, CodingKey {
             case name, description, display, confirm, prompt, content, replace, command
-            case tests, returns, offer
+            case tests, returns, offer, model
             case offerKey = "key"
             case timeout = "timeout_seconds"
         }
@@ -719,6 +728,12 @@ struct Config: Decodable, Equatable {
             } else {
                 unreadable = "`tests:` is neither a filename nor `{ path: <filename> }`"
             }
+
+            // `try?` because a `model:` this cannot read is one setting gone
+            // wrong, not a transform worth dropping: it then runs on the
+            // default model, which is what it did before the key existed.
+            // `--check-config` names anything the mapping got wrong.
+            model = (try? c.decodeIfPresent(ModelRef.self, forKey: .model)) ?? nil
 
             offer = try c.decodeIfPresent(Bool.self, forKey: .offer) ?? false
             // One letter, upper case. The chip draws it as a keycap and a
@@ -897,7 +912,7 @@ struct Config: Decodable, Equatable {
                 confirm: entry.confirm, returnsJSON: entry.returnsJSON,
                 offer: entry.offer, offerKey: entry.offerKey,
                 body: body, source: entry.source,
-                tests: entry.tests
+                tests: entry.tests, model: entry.model
             ))
         }
         return (kept, unreadable)
@@ -992,6 +1007,12 @@ struct Config: Decodable, Equatable {
         /// `cases.yaml` every folder has by convention. Relative to the folder,
         /// like everything else a transform names.
         var tests: String?
+        /// Which model this prompt runs on, and what it changes about it.
+        ///
+        /// Nil is `llm.default`, which is what nearly every transform wants.
+        /// A `replace:` or `command:` transform asks no model anything, so it
+        /// is meaningless there and `--check-config` says so.
+        var model: ModelRef?
 
         enum Body: Equatable {
             /// Instructions for the local model.
@@ -1178,6 +1199,18 @@ struct Config: Decodable, Equatable {
         }
     }
 
+    /// Which model runs what, and the Ollama one this key used to be.
+    ///
+    /// `model:`, `endpoint:`, `timeout_seconds:` and `keep_loaded:` are the
+    /// whole of the old key and still read exactly as they did: together they
+    /// define a model named `local`, which is what everything points at when
+    /// nothing says otherwise. A config written before `models:` existed is
+    /// unchanged by all of this.
+    ///
+    /// `router` and `vocabulary` are named separately because they are not
+    /// like the others: they run on every dictation, they are what you wait
+    /// on with the pill on screen, and they carry your transcript. Local is
+    /// the right answer for both far longer than it is for a rewrite.
     struct LLM: Codable, Equatable {
         var enabled: Bool = true
         var model: String = "gemma4:e4b-mlx"
@@ -1186,9 +1219,17 @@ struct Config: Decodable, Equatable {
         /// Load the model at launch and pin it in Ollama's memory. Trades a few
         /// GB of RAM for corrections that answer in 1–2s instead of 7–10s.
         var keepLoaded: Bool = true
+        /// The model a transform runs on when it names none. Empty means
+        /// `local` — the one `model:` above describes.
+        var defaultModel: String = ""
+        /// The model behind "hey parrot, …". Empty means `default`.
+        var router: String = ""
+        /// The model behind the vocabulary judge. Empty means `default`.
+        var vocabulary: String = ""
 
         enum CodingKeys: String, CodingKey {
-            case enabled, model, endpoint
+            case enabled, model, endpoint, router, vocabulary
+            case defaultModel = "default"
             case timeoutSeconds = "timeout_seconds"
             case keepLoaded = "keep_loaded"
         }
@@ -1203,7 +1244,115 @@ struct Config: Decodable, Equatable {
             if let v = try c.decodeIfPresent(String.self, forKey: .endpoint) { endpoint = v }
             if let v = try c.decodeIfPresent(Double.self, forKey: .timeoutSeconds) { timeoutSeconds = v }
             if let v = try c.decodeIfPresent(Bool.self, forKey: .keepLoaded) { keepLoaded = v }
+            if let v = try c.decodeIfPresent(String.self, forKey: .defaultModel) { defaultModel = v }
+            if let v = try c.decodeIfPresent(String.self, forKey: .router) { router = v }
+            if let v = try c.decodeIfPresent(String.self, forKey: .vocabulary) { vocabulary = v }
         }
+    }
+
+    /// Which job a call belongs to, for `model(for:)`.
+    enum ModelJob: Equatable {
+        /// A transform, the free-form prompt, a correction — anything the
+        /// speaker asked for by name.
+        case general
+        /// "hey parrot, …", said before anything else and waited on.
+        case router
+        /// The KEEP/REVERT judge, which runs on every dictation.
+        case vocabulary
+    }
+
+    /// Every model this config can reach, by name.
+    ///
+    /// `local` is here whether or not `models:` mentions it: the old `llm:`
+    /// keys describe exactly one Ollama model, and that is the one everything
+    /// falls back to.
+    var modelsByName: [String: ModelSpec] {
+        var all = models
+        if all["local"] == nil {
+            all["local"] = ModelSpec(
+                name: "local", api: .ollama, model: llm.model, endpoint: llm.endpoint,
+                timeout: llm.timeoutSeconds, keepLoaded: llm.keepLoaded
+            )
+        }
+        return all
+    }
+
+    func model(named name: String) -> ModelSpec? {
+        modelsByName[name.trimmingCharacters(in: .whitespacesAndNewlines)]
+    }
+
+    /// The name a job runs under when nothing overrides it.
+    func modelName(for job: ModelJob) -> String {
+        func written(_ value: String) -> String {
+            value.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        let fallback = written(llm.defaultModel).isEmpty ? "local" : written(llm.defaultModel)
+        switch job {
+        case .general: return fallback
+        case .router: return written(llm.router).isEmpty ? fallback : written(llm.router)
+        case .vocabulary:
+            return written(llm.vocabulary).isEmpty ? fallback : written(llm.vocabulary)
+        }
+    }
+
+    /// The model a call runs on: what the call site named, else what the job
+    /// is bound to, else `local`.
+    ///
+    /// A name nothing defines falls back rather than failing. `--check-config`
+    /// refuses it by name, and a typo costing you the default model is better
+    /// than a typo costing you the sentence.
+    func model(for job: ModelJob = .general, override: ModelRef? = nil) -> ModelSpec {
+        let all = modelsByName
+        let asked = (override?.use).flatMap { $0.isEmpty ? nil : all[$0] }
+        let base = asked ?? all[modelName(for: job)] ?? all["local"] ?? ModelSpec()
+        return base.applying(override)
+    }
+
+    /// The model a transform's prompt runs on.
+    func model(for transform: Transform) -> ModelSpec {
+        model(for: .general, override: transform.model)
+    }
+
+    /// Everything `models:` and the keys pointing into it get wrong.
+    func modelProblems() -> [String] {
+        var found: [String] = []
+        let all = modelsByName
+        for name in all.keys.sorted() {
+            guard let spec = all[name] else { continue }
+            found += spec.refused.map { "models.\(name): \($0)" }
+            if spec.model.isEmpty {
+                found.append("models.\(name): no `model:` — nothing says what to ask for")
+            }
+            guard !spec.api.isLocal else { continue }
+            if !spec.key.isSet {
+                found.append("models.\(name): `api: \(spec.api.rawValue)` needs an `api_key:`")
+            } else if spec.key.resolve() == nil {
+                found.append("models.\(name): no key at \(spec.key.described)")
+            }
+        }
+        let names = all.keys.sorted().joined(separator: ", ")
+        for (key, written) in [
+            ("llm.default", llm.defaultModel), ("llm.router", llm.router),
+            ("llm.vocabulary", llm.vocabulary),
+        ] {
+            let name = written.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !name.isEmpty, all[name] == nil else { continue }
+            found.append("\(key): no model named \"\(name)\" — have: \(names)")
+        }
+        for transform in transforms {
+            guard let ref = transform.model else { continue }
+            found += ref.rejected.map { "transforms.\(transform.name).model: \($0)" }
+            let name = ref.use.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !name.isEmpty, all[name] == nil {
+                found.append("transforms: \"\(transform.name)\" names model \"\(name)\","
+                    + " which `models:` does not define — have: \(names)")
+            }
+            if !transform.isPrompt {
+                found.append("transforms: \"\(transform.name)\" has a `model:` and never"
+                    + " asks a model anything — only a `prompt:` does")
+            }
+        }
+        return found
     }
 
     /// Decodable and not Encodable, like `Config` itself and for the same
@@ -1874,6 +2023,15 @@ struct Config: Decodable, Equatable {
             self.transcription = transcription
         }
         if let llm = try c.decodeIfPresent(LLM.self, forKey: .llm) { self.llm = llm }
+        // Named after the key it was written under, because a spec cannot see
+        // its own name and every log line and check prints one.
+        if let models = try c.decodeIfPresent([String: ModelSpec].self, forKey: .models) {
+            self.models = models.reduce(into: [:]) { out, entry in
+                var spec = entry.value
+                spec.name = entry.key
+                out[entry.key] = spec
+            }
+        }
         if let updates = try c.decodeIfPresent(UpdatePolicy.self, forKey: .updates) {
             self.updates = updates
         }
@@ -1981,6 +2139,7 @@ struct Config: Decodable, Equatable {
         // they were read, so what runs is the default; said here, because a
         // setting that does nothing is exactly what this list is for.
         found += vocabulary.refused.map { "vocabulary: \($0)" }
+        found += modelProblems()
         found += replacementProblems()
         // A `path:` that named nothing readable. The entry is gone rather than
         // idle — the pipeline step that names it will say so too — and a
@@ -2049,6 +2208,22 @@ struct Config: Decodable, Equatable {
         var said: [String] = transforms.compactMap { transform in
             guard case .command(let command) = transform.body else { return nil }
             return "transforms: \"\(transform.name)\" runs a program — \(command)"
+        }
+
+        // A model that is not on this Mac means your dictation is sent to
+        // somebody else's server. Announced on every load for the same reason
+        // a `command:` transform is: it is one word in a config file, and the
+        // config may not be one you wrote.
+        let all = modelsByName
+        for name in all.keys.sorted() {
+            guard let spec = all[name], !spec.api.isLocal else { continue }
+            said.append("models: \"\(name)\" sends text off this Mac — \(spec.url),"
+                + " \(spec.model), key from \(spec.key.described)")
+        }
+        for transform in transforms where transform.isPrompt {
+            let spec = model(for: transform)
+            guard !spec.api.isLocal else { continue }
+            said.append("transforms: \"\(transform.name)\" runs on \(spec.described)")
         }
 
         // The name judge is a stage now. A pipeline that still names it as a

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1184,7 +1184,13 @@ struct Config: Decodable, Equatable {
     struct UpdatePolicy: Codable, Equatable {
         /// Negative never asks GitHub at all. Zero takes a release the day it
         /// is published. Anything else waits that many days.
-        var afterDays: Int = 7
+        ///
+        /// Zero by default, which is what `config.example.yaml` has always
+        /// shipped — the two disagreed, so a config with no `updates:` block
+        /// waited a week and a config seeded from the example did not. Anyone
+        /// who wants the waiting period sets it; see the note above for what
+        /// it is for.
+        var afterDays: Int = 0
 
         enum CodingKeys: String, CodingKey {
             case afterDays = "after_days"

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1327,7 +1327,9 @@ struct Config: Decodable, Equatable {
             if !spec.key.isSet {
                 found.append("models.\(name): `api: \(spec.api.rawValue)` needs an `api_key:`")
             } else if spec.key.resolve() == nil {
-                found.append("models.\(name): no key at \(spec.key.described)")
+                let fix = spec.key.kind == .keychain
+                    ? " — add one with `--set-key \(name)`" : ""
+                found.append("models.\(name): no key at \(spec.key.described)\(fix)")
             }
         }
         let names = all.keys.sorted().joined(separator: ", ")
@@ -2029,6 +2031,9 @@ struct Config: Decodable, Equatable {
             self.models = models.reduce(into: [:]) { out, entry in
                 var spec = entry.value
                 spec.name = entry.key
+                // The name is also the keychain account, and this is the first
+                // point at which the spec has one.
+                spec.key.adopt(account: entry.key, api: spec.api)
                 out[entry.key] = spec
             }
         }

--- a/Sources/ParrotFlow/EvalCommand.swift
+++ b/Sources/ParrotFlow/EvalCommand.swift
@@ -260,10 +260,8 @@ enum EvalCommand {
     private static func asked(
         _ prompt: Config.Prompt, _ text: String, instruction: String, config: Config
     ) -> (output: String, seconds: TimeInterval) {
-        let llm = LocalLLM.Config(
-            endpoint: config.llm.endpoint, model: config.llm.model,
-            timeout: config.llm.timeoutSeconds, keepLoaded: config.llm.keepLoaded
-        )
+        let llm = config.transform(named: prompt.name)
+            .map { config.model(for: $0) } ?? config.model()
         var output = text
         let started = Date()
         let done = DispatchSemaphore(value: 0)

--- a/Sources/ParrotFlow/KeyField.swift
+++ b/Sources/ParrotFlow/KeyField.swift
@@ -1,0 +1,38 @@
+import AppKit
+
+/// A secure text field that answers ⌘V.
+///
+/// ParrotFlow is an accessory app — `LSUIElement` in Info.plist, and
+/// `setActivationPolicy(.accessory)` in `main.swift` — and it builds no main
+/// menu at all. A text field's ⌘V is not handled by the field: it is a key
+/// equivalent on the Edit ▸ Paste menu item, which this app does not have. So
+/// the keystroke arrives and nothing happens, which is what the key dialog did
+/// on its first outing.
+///
+/// One field knowing five shortcuts, rather than the app growing a menu bar.
+/// A menu exists to be seen, and an accessory app that sprouts File and Edit
+/// the moment a dialog opens is the stranger change.
+final class KeyField: NSSecureTextField {
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        guard modifiers == .command,
+              let pressed = event.charactersIgnoringModifiers?.lowercased()
+        else { return super.performKeyEquivalent(with: event) }
+
+        // Sent to nil, so the field editor — the responder that actually holds
+        // the text — is what receives it. Cut and copy are listed for the
+        // shortcuts people try; a secure field refuses them itself, which is
+        // the right answer and not this type's business to make.
+        let action: Selector
+        switch pressed {
+        case "v": action = #selector(NSText.paste(_:))
+        case "c": action = #selector(NSText.copy(_:))
+        case "x": action = #selector(NSText.cut(_:))
+        case "a": action = #selector(NSText.selectAll(_:))
+        case "z": action = Selector(("undo:"))
+        default: return super.performKeyEquivalent(with: event)
+        }
+        return NSApp.sendAction(action, to: nil, from: self)
+    }
+}

--- a/Sources/ParrotFlow/Keychain.swift
+++ b/Sources/ParrotFlow/Keychain.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Security
+
+/// API keys in the login keychain, one item per model named in `models:`.
+///
+/// The point is that nothing has to be written into `config.yaml`, which is a
+/// file people paste to each other. A model entry names no key at all and the
+/// key lives here instead — see `KeySource.Kind.keychain`.
+///
+/// **Access is scoped to the code signature, not to the path.** The installed
+/// app is signed (`scripts/release.sh`) and keeps its access across upgrades
+/// signed with the same certificate. A `swift build` binary is not signed, so
+/// macOS sees a different application and asks the user to allow it — once per
+/// build, because an unsigned binary's identity changes every compile. That is
+/// expected in development and invisible in the shipped app. `file:` still
+/// works and is the way out of it.
+enum Keychain {
+
+    /// `ParrotFlow` or `ParrotFlow Dev`, split for the same reason
+    /// `AppVariant.configDirectory` is: a key added while testing must not
+    /// reach the copy that does your work, and neither may overwrite the other.
+    static var service: String { AppVariant.displayName }
+
+    /// What went wrong, in the words `--set-key` prints.
+    struct Failure: LocalizedError {
+        let status: OSStatus
+        let doing: String
+        var errorDescription: String? {
+            let said = SecCopyErrorMessageString(status, nil) as String?
+            return "could not \(doing) the keychain: \(said ?? "OSStatus \(status)")"
+        }
+    }
+
+    private static func query(_ account: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+    }
+
+    /// The key stored for a model, or nil when there is none.
+    ///
+    /// Nil for a denied prompt as well as for a missing item, and deliberately
+    /// so: both mean this call cannot go out, and the caller — `LLM` — already
+    /// has one path for that which leaves the transcript untouched.
+    static func read(_ account: String) -> String? {
+        var q = query(account)
+        q[kSecReturnData as String] = true
+        q[kSecMatchLimit as String] = kSecMatchLimitOne
+        var item: CFTypeRef?
+        guard SecItemCopyMatching(q as CFDictionary, &item) == errSecSuccess,
+              let data = item as? Data,
+              let text = String(data: data, encoding: .utf8)
+        else { return nil }
+        let key = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return key.isEmpty ? nil : key
+    }
+
+    static func has(_ account: String) -> Bool { read(account) != nil }
+
+    /// Write the key for a model, replacing whatever was there.
+    ///
+    /// `AfterFirstUnlockThisDeviceOnly`: never synced to iCloud, and readable
+    /// after a reboot without the app being frontmost — the pipeline runs from
+    /// a hotkey and cannot wait for someone to unlock anything.
+    static func write(_ key: String, account: String) throws {
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let data = trimmed.data(using: .utf8), !trimmed.isEmpty else {
+            throw Failure(status: errSecParam, doing: "write an empty key to")
+        }
+        let existing = query(account)
+        let update = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+        ] as [String: Any]
+        let updated = SecItemUpdate(existing as CFDictionary, update as CFDictionary)
+        if updated == errSecSuccess { return }
+        guard updated == errSecItemNotFound else {
+            throw Failure(status: updated, doing: "update")
+        }
+        var add = existing
+        add[kSecValueData as String] = data
+        add[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        let added = SecItemAdd(add as CFDictionary, nil)
+        guard added == errSecSuccess else { throw Failure(status: added, doing: "add to") }
+    }
+
+    /// Forget the key for a model. Missing is not an error: the end state is
+    /// the one asked for either way.
+    static func delete(_ account: String) throws {
+        let status = SecItemDelete(query(account) as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw Failure(status: status, doing: "delete from")
+        }
+    }
+}

--- a/Sources/ParrotFlow/LLM.swift
+++ b/Sources/ParrotFlow/LLM.swift
@@ -1,0 +1,265 @@
+import Foundation
+
+/// One call, whichever protocol the model on the other end speaks.
+///
+/// Three envelopes and no more: everything past Ollama, OpenAI and Anthropic
+/// speaks one of the three. What differs between providers inside a protocol —
+/// which field carries the token budget, whether temperature is allowed at all
+/// — is settled here per api, and `params:` is what reaches anything this file
+/// has not heard of.
+///
+/// Every failure is thrown rather than swallowed. The pipeline turns a throw
+/// back into the transcript untouched, which is the rule a cloud model must
+/// obey as strictly as a local one: a rewrite is worth less than a sentence.
+enum LLM {
+
+    enum Failure: LocalizedError {
+        case noKey(ModelSpec)
+        case unreachable(ModelSpec)
+        case badStatus(ModelSpec, Int, String)
+        case emptyResponse(ModelSpec)
+
+        var errorDescription: String? {
+            switch self {
+            case .noKey(let model):
+                return "\(model.name): no API key — \(model.key.described)."
+            case .unreachable(let model):
+                return "Can't reach \(model.name) at \(model.url)."
+            case .badStatus(let model, let code, let detail):
+                let said = detail.isEmpty ? "" : " — \(detail)"
+                return "\(model.name) returned HTTP \(code)\(said)."
+            case .emptyResponse(let model):
+                return "\(model.name) returned nothing."
+            }
+        }
+    }
+
+    /// One-shot completion. `json` asks for valid JSON where the protocol has a
+    /// way to ask; `maxTokens` is the caller's budget, which a model's own
+    /// `max_tokens:` replaces.
+    static func complete(
+        system: String,
+        user: String,
+        json: Bool,
+        maxTokens: Int = 32,
+        config: ModelSpec
+    ) async throws -> String {
+        let budget = config.maxTokens ?? maxTokens
+        switch config.api {
+        case .ollama:
+            return try await LocalLLM.complete(
+                system: system, user: user, json: json, maxTokens: budget, config: config
+            )
+        case .openai:
+            return try await openAI(
+                system: system, user: user, json: json, maxTokens: budget, config: config
+            )
+        case .anthropic:
+            return try await anthropic(
+                system: system, user: user, maxTokens: budget, config: config
+            )
+        }
+    }
+
+    /// Whether this model is worth offering — greys a menu out rather than
+    /// letting it fail at the moment of use.
+    ///
+    /// Only the local one is asked over the network. A cloud model is "there"
+    /// when a key is, because the alternative is a billed request every time a
+    /// menu opens, and a 401 is not something a menu can tell you anyway.
+    static func available(config: ModelSpec) async -> Bool {
+        switch config.api {
+        case .ollama: return await LocalLLM.isAvailable(config: config)
+        case .openai, .anthropic: return config.key.resolve() != nil
+        }
+    }
+
+    // MARK: - OpenAI
+
+    /// Anything speaking the OpenAI chat API: OpenAI itself, and the providers
+    /// that copied it.
+    ///
+    /// `max_completion_tokens`, not `max_tokens`: the reasoning models only
+    /// accept the newer name. A server that only knows the old one is a
+    /// `params: { max_tokens: N }` away, which drops ours — see `body`.
+    ///
+    /// No temperature unless the config asked for one. The GPT-5 family rejects
+    /// it outright, and a rejected request is a lost sentence.
+    private static func openAI(
+        system: String, user: String, json: Bool, maxTokens: Int, config: ModelSpec
+    ) async throws -> String {
+        guard let key = config.key.resolve() else { throw Failure.noKey(config) }
+        guard let url = URL(string: "\(config.url)/chat/completions") else {
+            throw Failure.unreachable(config)
+        }
+
+        var body: [String: Any] = [
+            "model": config.model,
+            "messages": [
+                ["role": "system", "content": system],
+                ["role": "user", "content": user],
+            ],
+            "max_completion_tokens": maxTokens,
+            // none | minimal | low | medium | high. `off` is `none` rather than
+            // an omitted field: GPT-5.1 and later default to reasoning, and a
+            // one-line rewrite that thinks first costs seconds nobody asked for.
+            "reasoning_effort": config.reasoning == .off ? "none" : config.reasoning.rawValue,
+        ]
+        if let temperature = config.temperature { body["temperature"] = temperature }
+        if json { body["response_format"] = ["type": "json_object"] }
+        // An older server wants `max_tokens`. Sending both is a 400 on the
+        // strict ones, so naming it in `params:` takes ours out.
+        if config.params["max_tokens"] != nil { body.removeValue(forKey: "max_completion_tokens") }
+        merge(config.params, into: &body)
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        request.timeoutInterval = config.timeout
+
+        let data = try await send(request, config: config)
+        guard
+            let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let choices = object["choices"] as? [[String: Any]],
+            let message = choices.first?["message"] as? [String: Any],
+            let text = message["content"] as? String
+        else { throw Failure.emptyResponse(config) }
+
+        // `reasoning_content` sits beside `content` on the reasoning models of
+        // several providers and is never read here. What still has to be taken
+        // out is thinking a server inlines into the answer — a `<think>` block
+        // pasted into your document is what happens otherwise.
+        let answer = stripThinking(text)
+        guard !answer.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw Failure.emptyResponse(config)
+        }
+        return answer
+    }
+
+    // MARK: - Anthropic
+
+    /// The Messages API.
+    ///
+    /// `max_tokens` is required, and thinking tokens count against it — so a
+    /// caller's 32-token budget would truncate the answer before it started.
+    /// A rung above `off` therefore raises the floor.
+    ///
+    /// No `budget_tokens`: the current models reject it. Depth is
+    /// `output_config.effort` next to adaptive thinking, and `off` is thinking
+    /// turned off outright.
+    private static func anthropic(
+        system: String, user: String, maxTokens: Int, config: ModelSpec
+    ) async throws -> String {
+        guard let key = config.key.resolve() else { throw Failure.noKey(config) }
+        guard let url = URL(string: "\(config.url)/v1/messages") else {
+            throw Failure.unreachable(config)
+        }
+
+        let thinking = config.reasoning != .off
+        var body: [String: Any] = [
+            "model": config.model,
+            "max_tokens": thinking ? max(maxTokens, 4096) : maxTokens,
+            "system": system,
+            "messages": [["role": "user", "content": user]],
+        ]
+        if thinking {
+            body["thinking"] = ["type": "adaptive"]
+            // The API's ladder starts at low; `minimal` is this app's rung, not
+            // one it has.
+            body["output_config"] = ["effort": config.reasoning == .minimal
+                ? "low" : config.reasoning.rawValue]
+        } else {
+            body["thinking"] = ["type": "disabled"]
+        }
+        // Same reason as the OpenAI envelope: current models refuse it, so it
+        // goes only when the config insisted.
+        if let temperature = config.temperature { body["temperature"] = temperature }
+        merge(config.params, into: &body)
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(key, forHTTPHeaderField: "x-api-key")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        request.timeoutInterval = config.timeout
+
+        let data = try await send(request, config: config)
+        guard
+            let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let blocks = object["content"] as? [[String: Any]]
+        else { throw Failure.emptyResponse(config) }
+
+        // Text blocks only. A thinking block is in the same array, and pasting
+        // one into your document is the failure this exists to prevent.
+        let answer = blocks
+            .filter { $0["type"] as? String == "text" }
+            .compactMap { $0["text"] as? String }
+            .joined()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !answer.isEmpty else { throw Failure.emptyResponse(config) }
+        return answer
+    }
+
+    // MARK: - Shared
+
+    /// `params:` over whatever the envelope built. A `null` deletes the key
+    /// rather than sending one — see `ModelParam`.
+    static func merge(_ params: [String: ModelParam], into body: inout [String: Any]) {
+        for (name, value) in params {
+            if case .null = value {
+                body.removeValue(forKey: name)
+            } else {
+                body[name] = value.json
+            }
+        }
+    }
+
+    private static func send(_ request: URLRequest, config: ModelSpec) async throws -> Data {
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            throw Failure.unreachable(config)
+        }
+        guard let http = response as? HTTPURLResponse else { throw Failure.unreachable(config) }
+        guard http.statusCode == 200 else {
+            throw Failure.badStatus(config, http.statusCode, message(in: data))
+        }
+        return data
+    }
+
+    /// The provider's own words for what was wrong, when it wrote any. Both
+    /// protocols nest it under `error.message`, and it is the difference
+    /// between "HTTP 400" and "unsupported value: temperature".
+    private static func message(in data: Data) -> String {
+        guard
+            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let error = object["error"] as? [String: Any],
+            let said = error["message"] as? String
+        else { return "" }
+        return said.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Removes a `<think>` block a server left in the answer.
+    ///
+    /// Not every OpenAI-compatible server keeps reasoning out of `content`.
+    /// Ollama's own compatibility layer is one that does not, depending on the
+    /// model, and the result reads as the model rambling rather than as a
+    /// protocol difference.
+    static func stripThinking(_ raw: String) -> String {
+        guard raw.contains("<think>") || raw.contains("</think>") else { return raw }
+        var text = raw
+        if let close = text.range(of: "</think>", options: .backwards) {
+            text = String(text[close.upperBound...])
+        } else if let open = text.range(of: "<think>") {
+            // Opened and never closed: the answer was cut off inside the
+            // thinking, so there is nothing to keep.
+            text = String(text[..<open.lowerBound])
+        }
+        return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Sources/ParrotFlow/LocalLLM.swift
+++ b/Sources/ParrotFlow/LocalLLM.swift
@@ -9,14 +9,6 @@ import Foundation
 /// feature degrades to "not available" rather than failing.
 enum LocalLLM {
 
-    struct Config {
-        var endpoint: String
-        var model: String
-        var timeout: TimeInterval
-        /// Hold the model in Ollama's memory between calls — see `keepAlive`.
-        var keepLoaded: Bool = true
-    }
-
     /// Ollama's `keep_alive` value meaning "never unload".
     ///
     /// Its default is 5 minutes, and a call after that pays to read the model
@@ -81,28 +73,36 @@ enum LocalLLM {
         user: String,
         json: Bool,
         maxTokens: Int = 32,
-        config: Config
+        config: ModelSpec
     ) async throws -> String {
-        guard let url = URL(string: "\(config.endpoint)/api/generate") else {
+        guard let url = URL(string: "\(config.url)/api/generate") else {
             throw LLMError.unreachable
         }
+
+        // gemma4 and friends think by default, which for a one-line answer
+        // means ~1000 wasted tokens: measured 98s with it on, 4.5s off. `off`
+        // is that measurement; a rung above it names a level, which only the
+        // models that reason accept.
+        var think: Any = false
+        if config.reasoning != .off { think = config.reasoning.rawValue }
+
+        let options: [String: Any] = [
+            // Deterministic: this is extraction, not writing.
+            "temperature": config.temperature ?? 0,
+            "num_predict": maxTokens,
+        ]
 
         var body: [String: Any] = [
             "model": config.model,
             "system": system,
             "prompt": user,
             "stream": false,
-            // gemma4 and friends think by default, which for a one-line answer
-            // means ~1000 wasted tokens: measured 98s with it on, 4.5s off.
-            "think": false,
-            "options": [
-                // Deterministic: this is extraction, not writing.
-                "temperature": 0,
-                "num_predict": maxTokens,
-            ],
+            "think": think,
+            "options": options,
         ]
         if json { body["format"] = "json" }
         if config.keepLoaded { body["keep_alive"] = pinned }
+        LLM.merge(config.params, into: &body)
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -153,7 +153,8 @@ enum LocalLLM {
     /// prompt cache too. The router is the call the user waits on with
     /// "Thinking…" on screen, so it is the one worth holding warm.
     @discardableResult
-    static func keepWarm(system: String, config: Config) async -> Bool {
+    static func keepWarm(system: String, config: ModelSpec) async -> Bool {
+        guard config.api == .ollama else { return false }
         let reply = try? await complete(
             system: system, user: "instruction: hello",
             json: false, maxTokens: 1, config: config
@@ -176,8 +177,11 @@ enum LocalLLM {
     /// bounded by disk speed on a multi-GB file, not by how long a user will
     /// wait — nobody is watching this one.
     @discardableResult
-    static func warmUp(config: Config) async -> Bool {
-        guard let url = URL(string: "\(config.endpoint)/api/generate") else { return false }
+    static func warmUp(config: ModelSpec) async -> Bool {
+        // Loading and pinning are Ollama's, and so is the cold start they pay
+        // off. A cloud model has neither.
+        guard config.api == .ollama else { return false }
+        guard let url = URL(string: "\(config.url)/api/generate") else { return false }
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -198,8 +202,9 @@ enum LocalLLM {
 
     /// True when the server answers and has the model. Used to grey out
     /// features rather than let them fail at the moment of use.
-    static func isAvailable(config: Config) async -> Bool {
-        guard let url = URL(string: "\(config.endpoint)/api/tags") else { return false }
+    static func isAvailable(config: ModelSpec) async -> Bool {
+        guard config.api == .ollama else { return false }
+        guard let url = URL(string: "\(config.url)/api/tags") else { return false }
         var request = URLRequest(url: url)
         request.timeoutInterval = 3
         guard
@@ -467,7 +472,7 @@ enum VoiceCommand {
         command: String,
         lastTranscript: String?,
         language: String = "en",
-        config: LocalLLM.Config
+        config: ModelSpec
     ) async throws -> VoiceCommand {
         let system = extractionPrompt(for: language)
 
@@ -476,7 +481,7 @@ enum VoiceCommand {
             user = "source: (nothing yet)\ncorrection: \(command)"
         }
 
-        let raw = try await LocalLLM.complete(
+        let raw = try await LLM.complete(
             system: system, user: user, json: false, config: config
         )
         let reply = raw.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/ParrotFlow/ModelSpec.swift
+++ b/Sources/ParrotFlow/ModelSpec.swift
@@ -1,0 +1,328 @@
+import Foundation
+
+/// One model this config can reach, resolved and ready to call.
+///
+/// `api` is the wire protocol, not the vendor. Three exist and everyone else
+/// speaks one of them, so a provider ParrotFlow has never heard of is an
+/// `endpoint:` away rather than an adapter away.
+///
+/// The knobs below are the ones every protocol has some answer for. Anything
+/// else goes in `params`, which is merged into the request body untouched —
+/// see there.
+struct ModelSpec: Equatable {
+    enum API: String, Equatable, CaseIterable {
+        case ollama, openai, anthropic
+
+        var defaultEndpoint: String {
+            switch self {
+            case .ollama: return "http://localhost:11434"
+            case .openai: return "https://api.openai.com/v1"
+            case .anthropic: return "https://api.anthropic.com"
+            }
+        }
+
+        /// Whether a call leaves this Mac. `--check-config` says so out loud:
+        /// naming a model on a transform is what sends your dictation to
+        /// somebody else's server, and it is one word in a config file.
+        var isLocal: Bool { self == .ollama }
+    }
+
+    /// How hard the model may think, in five rungs that mean the same thing on
+    /// every protocol.
+    ///
+    /// A ladder rather than a passthrough. Each envelope maps it to whatever
+    /// its provider actually has — `think:`, `reasoning_effort`, adaptive
+    /// thinking plus an effort — and a provider with no such knob sends
+    /// nothing. `params:` overrides the result where a model wants a rung this
+    /// does not have.
+    enum Reasoning: String, Equatable, CaseIterable {
+        case off, minimal, low, medium, high
+    }
+
+    /// The name it was given in `models:`, for logs and `--check-config`.
+    var name: String = "local"
+    var api: API = .ollama
+    var model: String = ""
+    /// Empty means `api.defaultEndpoint`.
+    var endpoint: String = ""
+    var key: KeySource = KeySource()
+    var reasoning: Reasoning = .off
+    /// Nil means the envelope's own default — which for a cloud model is to
+    /// send no temperature at all, because reasoning models reject it.
+    var temperature: Double?
+    /// Replaces the budget the caller worked out. Nil leaves it alone — which
+    /// is usually right, since a prompt that rewrites a paragraph and one that
+    /// answers with a single word already ask for different numbers.
+    var maxTokens: Int?
+    var timeout: TimeInterval = 20
+    /// Ollama only — see `LocalLLM.pinned`. Ignored by every other api.
+    var keepLoaded: Bool = true
+    /// Merged into the request body last, unvalidated.
+    ///
+    /// The escape hatch that makes a provider this app has never been run
+    /// against usable without a release: `params: { top_k: 40 }`. A key here
+    /// replaces whatever the envelope computed under the same name.
+    var params: [String: ModelParam] = [:]
+    /// What this entry said that could not be read, in words. The value is
+    /// ignored and the default stands; `--check-config` prints these.
+    var refused: [String] = []
+
+    /// The endpoint with no trailing slash, so paths can be appended.
+    var url: String {
+        let written = endpoint.trimmingCharacters(in: .whitespacesAndNewlines)
+        let base = written.isEmpty ? api.defaultEndpoint : written
+        return base.hasSuffix("/") ? String(base.dropLast()) : base
+    }
+
+    /// How it reads in a log line or a check: `gpt (openai, gpt-5.6-luna, reasoning low)`.
+    var described: String {
+        "\(name) (\(api.rawValue), \(model.isEmpty ? "no model" : model),"
+            + " reasoning \(reasoning.rawValue))"
+    }
+
+    /// The same spec with a call site's overrides applied — see `ModelRef`.
+    func applying(_ ref: ModelRef?) -> ModelSpec {
+        guard let ref else { return self }
+        var out = self
+        if let value = ref.reasoning { out.reasoning = value }
+        if let value = ref.temperature { out.temperature = value }
+        if let value = ref.maxTokens { out.maxTokens = value }
+        if let value = ref.timeout { out.timeout = value }
+        out.params.merge(ref.params) { _, new in new }
+        return out
+    }
+}
+
+// MARK: - Where a key comes from
+
+/// A reference to an API key, rather than a key.
+///
+/// `config.yaml` is a plain file that people paste to each other, so the
+/// supported forms name somewhere else to look. A literal key still works —
+/// refusing it would only move it into a shell history — and is announced by
+/// `--check-config` every time.
+///
+/// `env:` is right for the CLI and useless in the app: ParrotFlow launches
+/// from Finder, which hands it none of your shell's environment. `file:` is
+/// the one that works in both.
+struct KeySource: Equatable {
+    enum Kind: Equatable { case absent, environment, file, literal }
+
+    var kind: Kind = .absent
+    /// The variable name, the path, or the key itself.
+    var value: String = ""
+
+    init() {}
+
+    init(written raw: String) {
+        let text = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        if text.hasPrefix("env:") {
+            kind = .environment
+            value = String(text.dropFirst(4)).trimmingCharacters(in: .whitespaces)
+        } else if text.hasPrefix("file:") {
+            kind = .file
+            value = String(text.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+        } else {
+            kind = .literal
+            value = text
+        }
+    }
+
+    var isSet: Bool { kind != .absent && !value.isEmpty }
+
+    /// The key, or nil when the place it names holds nothing.
+    func resolve() -> String? {
+        switch kind {
+        case .absent:
+            return nil
+        case .literal:
+            return value.isEmpty ? nil : value
+        case .environment:
+            let found = ProcessInfo.processInfo.environment[value]?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return (found?.isEmpty == false) ? found : nil
+        case .file:
+            let path = (value as NSString).expandingTildeInPath
+            let found = try? String(contentsOfFile: path, encoding: .utf8)
+            let key = found?.trimmingCharacters(in: .whitespacesAndNewlines)
+            return (key?.isEmpty == false) ? key : nil
+        }
+    }
+
+    /// Where the key comes from and whether it is there — never the key.
+    var described: String {
+        switch kind {
+        case .absent:
+            return "no api_key"
+        case .literal:
+            return "a key written into config.yaml"
+        case .environment:
+            return "$\(value)" + (resolve() == nil ? " (not set)" : "")
+        case .file:
+            return value + (resolve() == nil ? " (unreadable or empty)" : "")
+        }
+    }
+}
+
+// MARK: - What a call site may change
+
+/// A transform naming a model, and what it changes about it.
+///
+/// Written as a scalar when it only picks one — `model: gpt` — or as a mapping
+/// when it also changes a setting. Only call-site settings may be changed:
+/// `api`, `endpoint`, `model` and `api_key` describe a connection, and a
+/// different connection is a different entry in `models:` rather than an
+/// override buried in a transform.
+struct ModelRef: Equatable, Decodable {
+    /// The name in `models:`. Empty means "the default model, with these
+    /// settings changed".
+    var use: String = ""
+    var reasoning: ModelSpec.Reasoning?
+    var temperature: Double?
+    var maxTokens: Int?
+    var timeout: Double?
+    var params: [String: ModelParam] = [:]
+    /// What was written here that only a `models:` entry may say, in words.
+    /// Reported by `--check-config`; the key itself is ignored.
+    var rejected: [String] = []
+
+    enum CodingKeys: String, CodingKey {
+        case use, reasoning, temperature, params
+        case maxTokens = "max_tokens"
+        case timeout = "timeout_seconds"
+        case api, endpoint, model
+        case apiKey = "api_key"
+    }
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        if let scalar = try? decoder.singleValueContainer().decode(String.self) {
+            use = scalar.trimmingCharacters(in: .whitespacesAndNewlines)
+            return
+        }
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        use = (try c.decodeIfPresent(String.self, forKey: .use) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        // Read as a string and mapped by hand: an unknown rung is reported and
+        // ignored rather than throwing, so one mistyped word cannot take the
+        // whole config with it.
+        if let written = try c.decodeIfPresent(String.self, forKey: .reasoning) {
+            if let rung = ModelSpec.Reasoning(rawValue: written.lowercased()) {
+                reasoning = rung
+            } else {
+                rejected.append("reasoning: \(written) — have: "
+                    + ModelSpec.Reasoning.allCases.map(\.rawValue).joined(separator: ", "))
+            }
+        }
+        temperature = try c.decodeIfPresent(Double.self, forKey: .temperature)
+        maxTokens = try c.decodeIfPresent(Int.self, forKey: .maxTokens)
+        timeout = try c.decodeIfPresent(Double.self, forKey: .timeout)
+        params = try c.decodeIfPresent([String: ModelParam].self, forKey: .params) ?? [:]
+
+        for key in [CodingKeys.api, .endpoint, .model, .apiKey] {
+            guard c.contains(key) else { continue }
+            rejected.append("`\(key.stringValue):` describes a connection —"
+                + " put it in `models:` and name it with `use:`")
+        }
+    }
+}
+
+// MARK: - Anything a request body can carry
+
+/// A value written under `params:`, on its way into JSON.
+///
+/// `null` is not a value but a deletion: it takes the key out of the body
+/// instead of sending it. That is how a server that refuses a field this app
+/// sends by default — `reasoning_effort` on a model that does not reason — is
+/// dealt with in the config rather than in a release.
+enum ModelParam: Equatable {
+    case null
+    case string(String)
+    case bool(Bool)
+    case int(Int)
+    case double(Double)
+    case list([ModelParam])
+    case map([String: ModelParam])
+
+    var json: Any {
+        switch self {
+        case .null: return NSNull()
+        case .string(let value): return value
+        case .bool(let value): return value
+        case .int(let value): return value
+        case .double(let value): return value
+        case .list(let values): return values.map(\.json)
+        case .map(let values): return values.mapValues(\.json)
+        }
+    }
+}
+
+extension ModelParam: Decodable {
+    init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        if c.decodeNil() { self = .null; return }
+        // Bool before Int, or YAML's `true` arrives as a number on some
+        // decoders. Int before Double, so `40` is not sent as `40.0`.
+        if let value = try? c.decode(Bool.self) { self = .bool(value); return }
+        if let value = try? c.decode(Int.self) { self = .int(value); return }
+        if let value = try? c.decode(Double.self) { self = .double(value); return }
+        if let value = try? c.decode(String.self) { self = .string(value); return }
+        if let value = try? c.decode([ModelParam].self) { self = .list(value); return }
+        if let value = try? c.decode([String: ModelParam].self) { self = .map(value); return }
+        throw DecodingError.dataCorruptedError(
+            in: c, debugDescription: "not a value a request body can carry"
+        )
+    }
+}
+
+// MARK: - Reading one out of config.yaml
+
+extension ModelSpec: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case api, model, endpoint, reasoning, temperature, params
+        case apiKey = "api_key"
+        case maxTokens = "max_tokens"
+        case timeoutSeconds = "timeout_seconds"
+        case keepLoaded = "keep_loaded"
+    }
+
+    init(from decoder: Decoder) throws {
+        self.init()
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        if let written = try c.decodeIfPresent(String.self, forKey: .api) {
+            let name = written.trimmingCharacters(in: .whitespaces).lowercased()
+            if let known = API(rawValue: name) {
+                api = known
+            } else {
+                refused.append("api: \(written) — have: "
+                    + API.allCases.map(\.rawValue).joined(separator: ", "))
+            }
+        }
+        model = (try c.decodeIfPresent(String.self, forKey: .model) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        endpoint = (try c.decodeIfPresent(String.self, forKey: .endpoint) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let written = try c.decodeIfPresent(String.self, forKey: .apiKey) {
+            key = KeySource(written: written)
+        }
+        if let written = try c.decodeIfPresent(String.self, forKey: .reasoning) {
+            if let rung = Reasoning(rawValue: written.trimmingCharacters(in: .whitespaces).lowercased()) {
+                reasoning = rung
+            } else {
+                refused.append("reasoning: \(written) — have: "
+                    + Reasoning.allCases.map(\.rawValue).joined(separator: ", "))
+            }
+        }
+        temperature = try c.decodeIfPresent(Double.self, forKey: .temperature)
+        maxTokens = try c.decodeIfPresent(Int.self, forKey: .maxTokens)
+        if let value = try c.decodeIfPresent(Double.self, forKey: .timeoutSeconds) {
+            timeout = value
+        }
+        if let value = try c.decodeIfPresent(Bool.self, forKey: .keepLoaded) {
+            keepLoaded = value
+        }
+        params = try c.decodeIfPresent([String: ModelParam].self, forKey: .params) ?? [:]
+    }
+}

--- a/Sources/ParrotFlow/ModelSpec.swift
+++ b/Sources/ParrotFlow/ModelSpec.swift
@@ -105,11 +105,14 @@ struct ModelSpec: Equatable {
 /// `env:` is right for the CLI and useless in the app: ParrotFlow launches
 /// from Finder, which hands it none of your shell's environment. `file:` is
 /// the one that works in both.
+///
+/// `keychain` is the default for a cloud model that names no key at all, so
+/// the common case is nothing in the file and nothing on disk. See `Keychain`.
 struct KeySource: Equatable {
-    enum Kind: Equatable { case absent, environment, file, literal }
+    enum Kind: Equatable { case absent, environment, file, literal, keychain }
 
     var kind: Kind = .absent
-    /// The variable name, the path, or the key itself.
+    /// The variable name, the path, the keychain account, or the key itself.
     var value: String = ""
 
     init() {}
@@ -117,7 +120,12 @@ struct KeySource: Equatable {
     init(written raw: String) {
         let text = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { return }
-        if text.hasPrefix("env:") {
+        if text == "keychain" {
+            kind = .keychain
+            // Filled in with the model's own name once it has one — a spec
+            // cannot see the key it was written under. See `adopt(account:)`.
+            value = ""
+        } else if text.hasPrefix("env:") {
             kind = .environment
             value = String(text.dropFirst(4)).trimmingCharacters(in: .whitespaces)
         } else if text.hasPrefix("file:") {
@@ -129,7 +137,23 @@ struct KeySource: Equatable {
         }
     }
 
-    var isSet: Bool { kind != .absent && !value.isEmpty }
+    var isSet: Bool { kind == .keychain || (kind != .absent && !value.isEmpty) }
+
+    /// Give this source the model's name, which is the account it reads.
+    ///
+    /// Two things happen here, both needing a name the spec did not have while
+    /// it was being decoded: an explicit `api_key: keychain` learns its
+    /// account, and a cloud model that named no key at all becomes a keychain
+    /// one. An `ollama` entry is left alone — it needs no key, and turning its
+    /// silence into a keychain lookup would report a missing key for a model
+    /// that never wanted one.
+    mutating func adopt(account: String, api: ModelSpec.API) {
+        if kind == .keychain, value.isEmpty { value = account }
+        if kind == .absent, !api.isLocal {
+            kind = .keychain
+            value = account
+        }
+    }
 
     /// The key, or nil when the place it names holds nothing.
     func resolve() -> String? {
@@ -142,6 +166,8 @@ struct KeySource: Equatable {
             let found = ProcessInfo.processInfo.environment[value]?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             return (found?.isEmpty == false) ? found : nil
+        case .keychain:
+            return Keychain.read(value)
         case .file:
             let path = (value as NSString).expandingTildeInPath
             let found = try? String(contentsOfFile: path, encoding: .utf8)
@@ -159,6 +185,8 @@ struct KeySource: Equatable {
             return "a key written into config.yaml"
         case .environment:
             return "$\(value)" + (resolve() == nil ? " (not set)" : "")
+        case .keychain:
+            return "the Keychain" + (resolve() == nil ? " (no key yet)" : "")
         case .file:
             return value + (resolve() == nil ? " (unreadable or empty)" : "")
         }

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -1154,16 +1154,13 @@ struct Pipeline: Equatable, Codable {
 
         let reply: String
         do {
-            reply = try await LocalLLM.complete(
+            reply = try await LLM.complete(
                 system: system, user: user, json: false,
                 // A line per change and whatever the model wraps them in.
                 // Anything longer is a model explaining itself, which this
                 // shape does not read.
                 maxTokens: 8 * changes.count + 8,
-                config: LocalLLM.Config(
-                    endpoint: config.llm.endpoint, model: config.llm.model,
-                    timeout: config.llm.timeoutSeconds, keepLoaded: config.llm.keepLoaded
-                )
+                config: config.model(for: .vocabulary)
             )
         } catch {
             return declined("\(error.localizedDescription); kept as they are",
@@ -1198,7 +1195,7 @@ struct Pipeline: Equatable, Codable {
             "reverted": .string(reverted.joined(separator: "; ")),
             "judged": .string(chosen),
             "reply": .string(reply.trimmingCharacters(in: .whitespacesAndNewlines)),
-            "model": .string(config.llm.model),
+            "model": .string(config.model(for: .vocabulary).model),
         ])
     }
 
@@ -1283,10 +1280,11 @@ struct Pipeline: Equatable, Codable {
             Log.write("pipeline: skipped prompt \(name) — llm.enabled is false")
             return StageResult(text: text, vars: ["ok": .bool(false)])
         }
-        guard let prompt = config.transform(named: name)?.asPrompt else {
+        guard let transform = config.transform(named: name), let prompt = transform.asPrompt else {
             Log.write("pipeline: no prompt named \"\(name)\"; skipped")
             return StageResult(text: text, vars: ["ok": .bool(false)])
         }
+        let model = config.model(for: transform)
 
         do {
             let result = try await PromptRunner.run(
@@ -1300,12 +1298,7 @@ struct Pipeline: Equatable, Codable {
                 // What every stage before this one published. A prompt reads it
                 // by the same names a condition does.
                 scope: scope,
-                config: LocalLLM.Config(
-                    endpoint: config.llm.endpoint,
-                    model: config.llm.model,
-                    timeout: config.llm.timeoutSeconds,
-                    keepLoaded: config.llm.keepLoaded
-                )
+                config: model
             )
             guard !result.isEmpty else {
                 Log.write("pipeline: prompt \(name) returned nothing; kept the transcript")
@@ -1320,7 +1313,7 @@ struct Pipeline: Equatable, Codable {
             // nobody sees happen, and "was that the model I think it was" is
             // the first question when its answers change shape between two
             // runs — the same question `Trace` logs `asr.model` to answer.
-            return StageResult(text: result, vars: ["model": .string(config.llm.model)])
+            return StageResult(text: result, vars: ["model": .string(model.model)])
         } catch {
             Log.write("pipeline: prompt \(name) failed (\(error.localizedDescription));"
                 + " kept the transcript")

--- a/Sources/ParrotFlow/PromptRunCommand.swift
+++ b/Sources/ParrotFlow/PromptRunCommand.swift
@@ -34,12 +34,7 @@ enum PromptRunCommand {
             return 1
         }
 
-        let llmConfig = LocalLLM.Config(
-            endpoint: config.llm.endpoint,
-            model: config.llm.model,
-            timeout: config.llm.timeoutSeconds,
-            keepLoaded: config.llm.keepLoaded
-        )
+        let llmConfig = config.model(for: .general)
 
         var code: Int32 = 0
         let done = DispatchSemaphore(value: 0)
@@ -57,7 +52,7 @@ enum PromptRunCommand {
                     print("in:          \(text)")
                     print("out:         \(result)")
                     print(String(format: "             %@ in %.2fs",
-                                 config.llm.model, Date().timeIntervalSince(started)))
+                                 llmConfig.model, Date().timeIntervalSince(started)))
                 }
             } catch {
                 print("✗ \(error.localizedDescription)")

--- a/Sources/ParrotFlow/PromptRunner.swift
+++ b/Sources/ParrotFlow/PromptRunner.swift
@@ -56,12 +56,12 @@ enum PromptRunner {
         instruction: String,
         text: String,
         scope: Scope = Scope(),
-        config: LocalLLM.Config
+        config: ModelSpec
     ) async throws -> String {
         let composed = compose(
             prompt: prompt, instruction: instruction, text: text, scope: scope
         )
-        let raw = try await LocalLLM.complete(
+        let raw = try await LLM.complete(
             system: composed.system,
             user: composed.user,
             json: false,

--- a/Sources/ParrotFlow/RouteTestCommand.swift
+++ b/Sources/ParrotFlow/RouteTestCommand.swift
@@ -38,12 +38,7 @@ enum RouteTestCommand {
             return 1
         }
 
-        let llmConfig = LocalLLM.Config(
-            endpoint: config.llm.endpoint,
-            model: config.llm.model,
-            timeout: config.llm.timeoutSeconds,
-            keepLoaded: config.llm.keepLoaded
-        )
+        let llmConfig = config.model(for: .router)
 
         var code: Int32 = 0
         let done = DispatchSemaphore(value: 0)
@@ -57,7 +52,7 @@ enum RouteTestCommand {
                     config: llmConfig
                 )
                 let elapsed = Date().timeIntervalSince(started)
-                let timing = String(format: "(%@ in %.2fs)", config.llm.model, elapsed)
+                let timing = String(format: "(%@ in %.2fs)", llmConfig.model, elapsed)
                 switch decision {
                 case .matched(let capability):
                     print(quiet ? capability.name : "→ \(capability.name)  \(timing)")

--- a/Sources/ParrotFlow/Router.swift
+++ b/Sources/ParrotFlow/Router.swift
@@ -75,12 +75,12 @@ enum Router {
         instruction: String,
         catalogue: Catalogue,
         freeForm: Bool = false,
-        config: LocalLLM.Config
+        config: ModelSpec
     ) async throws -> Decision {
         let trimmed = instruction.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return .none }
 
-        let raw = try await LocalLLM.complete(
+        let raw = try await LLM.complete(
             system: prompt(for: catalogue, freeForm: freeForm),
             user: "instruction: \(trimmed)",
             json: false,

--- a/Sources/ParrotFlow/SetKeyCommand.swift
+++ b/Sources/ParrotFlow/SetKeyCommand.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// `--set-key <model>` — store an API key in the keychain, read from stdin.
+///
+///     printf '%s' "$KEY" | ParrotFlow --set-key gpt
+///     ParrotFlow --set-key gpt          # prompts, and does not echo
+///     ParrotFlow --set-key gpt --forget
+///
+/// The key never appears in an argument, so it stays out of `ps` and out of
+/// shell history. Everything printed names the model and the outcome, never
+/// the key.
+enum SetKeyCommand {
+
+    static func run(model name: String, forget: Bool) -> Int32 {
+        let config = try? ConfigStore.load()
+        guard let spec = config?.model(named: name) else {
+            let known = (config?.modelsByName.keys.sorted() ?? []).joined(separator: ", ")
+            print("no model named \(name) in models: — have: \(known)")
+            return 2
+        }
+        // Refusing rather than storing a key nothing will read. A local model
+        // sends no key at all, and `file:`/`env:` say where to look already; a
+        // key written here would sit in the keychain unused, and the next
+        // "why is it still saying no key" is unanswerable.
+        guard spec.key.kind == .keychain else {
+            if spec.api.isLocal {
+                print("\(name) is an ollama model and needs no key.")
+            } else {
+                print("\(name) reads its key from \(spec.key.described)."
+                    + " Drop `api_key:` from its entry in models: to use the keychain.")
+            }
+            return 2
+        }
+        let account = spec.key.value
+
+        if forget {
+            do {
+                try Keychain.delete(account)
+                print("forgot the key for \(name).")
+                return 0
+            } catch {
+                print(error.localizedDescription)
+                return 1
+            }
+        }
+
+        guard let key = read() else {
+            print("no key given.")
+            return 2
+        }
+        do {
+            try Keychain.write(key, account: account)
+            print("stored a key for \(name) in the \(Keychain.service) keychain.")
+            return 0
+        } catch {
+            print(error.localizedDescription)
+            return 1
+        }
+    }
+
+    /// The key from a pipe, or typed with no echo.
+    ///
+    /// `isatty` decides. Piped input has no prompt because there is nobody to
+    /// read one, and printing it would land the word "key:" in whatever the
+    /// caller captured.
+    private static func read() -> String? {
+        if isatty(FileHandle.standardInput.fileDescriptor) == 1 {
+            guard let entered = String(
+                validatingUTF8: getpass("key (not echoed): ")
+            ) else { return nil }
+            let key = entered.trimmingCharacters(in: .whitespacesAndNewlines)
+            return key.isEmpty ? nil : key
+        }
+        let data = FileHandle.standardInput.readDataToEndOfFile()
+        let key = String(decoding: data, as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return key.isEmpty ? nil : key
+    }
+}

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -80,6 +80,17 @@ if arguments.contains("--audio-recovery") {
     exit(AudioRecoveryCommand.run(casesPath: casesPath))
 }
 
+if let index = arguments.firstIndex(of: "--set-key") {
+    guard arguments.indices.contains(index + 1) else {
+        print("usage: ParrotFlow --set-key <model> [--forget]")
+        exit(2)
+    }
+    exit(SetKeyCommand.run(
+        model: arguments[index + 1],
+        forget: arguments.contains("--forget")
+    ))
+}
+
 if let index = arguments.firstIndex(of: "--transcribe") {
     guard arguments.indices.contains(index + 1) else {
         print("usage: ParrotFlow --transcribe <file.wav> [--no-vocab]")

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -154,17 +154,33 @@ llm:
 # A model that is not `ollama` sends your dictation to somebody else's server.
 # `--check-config` says so, every time, and names which transforms do it.
 #
-# api_key: never the key itself. `env:NAME` reads the environment, which the
-# app does not have when it is launched from Finder — `file:` is the form that
-# works in both places. A key written in full still works and is announced as
-# plain text on every load.
+# api_key: leave it out. A cloud model with no `api_key:` reads the keychain,
+# and the app asks for the key the first time it loads a config that names one.
+# `ParrotFlow --set-key gpt` does the same from a terminal, reading stdin so
+# the key never lands in argv or shell history.
+#
+# The other forms still work, for a setup that needs them. `file:~/path` is the
+# one to use if you want the key on disk. `env:NAME` reads the environment,
+# which the app does not have when it is launched from Finder, so it works from
+# a terminal and silently does not in the app. A key written here in full works
+# too and is announced as plain text on every load.
 #
 # models:
+#   # An Ollama entry belongs here like any other. Naming the local model
+#   # explicitly is how a second one gets a name too — a small model for the
+#   # router, a larger one for a rewrite, both on this Mac.
+#   gemma:
+#     api: ollama
+#     model: gemma4:e4b-mlx
+#     endpoint: http://localhost:11434
+#     # Only ollama reads this. Pinned in RAM, or a cold call waits 7-10s.
+#     keep_loaded: true
+#
+#   # No `api_key:`, so the key is in the keychain and the app asks for it.
 #   gpt:
 #     api: openai
 #     model: gpt-5.6-luna
 #     endpoint: https://api.openai.com/v1
-#     api_key: file:~/.config/parrotflow/openai.key
 #     # off | minimal | low | medium | high. One ladder, whatever the provider
 #     # calls its own knob. `off` is the right default for a rewrite.
 #     reasoning: off
@@ -173,7 +189,6 @@ llm:
 #   claude:
 #     api: anthropic
 #     model: claude-sonnet-5
-#     api_key: env:ANTHROPIC_API_KEY
 #     reasoning: off
 
 # One call a day to GitHub's release API — the only request this app makes on

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -124,6 +124,9 @@ transcription:
 
 # The local Ollama model behind spoken commands. Without it, dictation still
 # works, and every `prompt:` transform below stops.
+#
+# These four keys describe one model, and it is named `local`. Everything runs
+# on it unless something says otherwise — see `models:` below.
 llm:
   enabled: true
   model: gemma4:e4b-mlx
@@ -131,6 +134,47 @@ llm:
   # Pin the model in RAM at launch. Otherwise Ollama drops it after five
   # minutes, and the next command waits 7-10s for the reload.
   keep_loaded: true
+
+  # Which model runs what, by name. `default` is what a `prompt:` transform
+  # uses when it names none; the other two are jobs that run on every
+  # dictation and are worth keeping local — the router is what you wait on
+  # with the pill on screen, and both carry your transcript.
+  # default: local
+  # router: local
+  # vocabulary: local
+
+# More models, under names you pick. A transform names one with `model:`.
+#
+# `api:` is the protocol, not the company: ollama, openai or anthropic.
+# Everyone else speaks one of the three, so Groq, OpenRouter, DeepSeek, LM
+# Studio and vLLM are an `endpoint:` away rather than a new version of this
+# app. `params:` is put into the request body untouched, for anything these
+# keys do not cover.
+#
+# A model that is not `ollama` sends your dictation to somebody else's server.
+# `--check-config` says so, every time, and names which transforms do it.
+#
+# api_key: never the key itself. `env:NAME` reads the environment, which the
+# app does not have when it is launched from Finder — `file:` is the form that
+# works in both places. A key written in full still works and is announced as
+# plain text on every load.
+#
+# models:
+#   gpt:
+#     api: openai
+#     model: gpt-5.6-luna
+#     endpoint: https://api.openai.com/v1
+#     api_key: file:~/.config/parrotflow/openai.key
+#     # off | minimal | low | medium | high. One ladder, whatever the provider
+#     # calls its own knob. `off` is the right default for a rewrite.
+#     reasoning: off
+#     timeout_seconds: 30
+#
+#   claude:
+#     api: anthropic
+#     model: claude-sonnet-5
+#     api_key: env:ANTHROPIC_API_KEY
+#     reasoning: off
 
 # One call a day to GitHub's release API — the only request this app makes on
 # its own. The number is a waiting period, not a poll interval: -1 never
@@ -193,7 +237,10 @@ lists:
 #   name          the id a pipeline or `when:` names
 #   description   matched against what you say — write it as you would say it
 #   display       shown on the menu bar while the transform runs
-#   prompt:       asks the local model, about a second
+#   prompt:       asks a model, about a second on the local one
+#   model:        which model this prompt runs on — a name from `models:`, or
+#                 `{ use: gpt, reasoning: low }` to change a setting for this
+#                 prompt alone. Left out, it runs on `llm.default`.
 #   replace:      a substitution table, costs nothing
 #   command:      a program of yours — transcript in on stdin, rewrite out on stdout
 #   confirm       shows the result first; set to false to skip that

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@
 | Numbers | `NumberGrammar*.swift` | Spoken numbers as digits, English and French, no model |
 | Transforms | `PromptRunner.swift`, `CommandRunner.swift` | A prompt to the local model, or a program of yours on stdin/stdout |
 | Routing | `Router.swift`, `FreeForm.swift` | Which transform an instruction reaches, and what happens when none does |
-| Spoken commands | `LocalLLM.swift` | HTTP to a local Ollama; degrades to "unavailable" when it isn't there |
+| Spoken commands | `LLM.swift`, `LocalLLM.swift` | One call, three protocols — `ollama`, `openai`, `anthropic`. `ModelSpec.swift` is what a config resolves to; every failure degrades to "unavailable" rather than costing the transcript |
 | Config | `Config.swift` | Yams + a `DispatchSource` file watcher for live reload |
 | Permissions | `Permissions.swift` | `AVCaptureDevice` for mic, `AXIsProcessTrusted` for Accessibility |
 | Text insertion | `TextInserter.swift`, `SelectionReader.swift` | Paste-via-clipboard, then the pasteboard is put back |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -240,6 +240,30 @@ the previous transcript does it target.
 `--learn` adds a pronunciation to `vocabulary.yaml` from the terminal, the
 same one the correction panel would have written.
 
+## Giving a model its API key
+
+```sh
+$PF --set-key <model>            # prompts, and does not echo
+printf '%s' "$KEY" | $PF --set-key <model>
+$PF --set-key <model> --forget
+```
+
+A cloud model in `models:` with no `api_key:` line reads the keychain. This is
+how the key gets there without the app asking. The key comes from stdin, never
+from an argument, so it is not in `ps` and not in your shell history.
+
+Only for a model that actually uses the keychain. One with `file:` or `env:`
+already says where to look, and an `ollama` model needs no key at all; both are
+refused rather than storing a key nothing will read.
+
+```
+$ printf '%s' "$OPENAI_KEY" | ParrotFlow --set-key gpt
+stored a key for gpt in the ParrotFlow keychain.
+
+$ ParrotFlow --check-config | grep gpt
+      gpt     openai  gpt-5.6-luna  https://api.openai.com/v1  reasoning off  the Keychain
+```
+
 ## Forgetting what a name sounds like
 
 ```sh

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,9 +31,17 @@ transcription:
 
 llm:
   enabled: true
-  model: gemma4:e4b
+  model: gemma4:e4b     # these four keys are the model named `local`
   endpoint: http://localhost:11434
   keep_loaded: true
+  default: local        # what a prompt runs on when it names none
+
+models:                 # more models, under names you pick
+  gpt:
+    api: openai         # ollama | openai | anthropic — the protocol, not the vendor
+    model: gpt-5.6-luna
+    api_key: file:~/.config/parrotflow/openai.key
+    reasoning: off      # off | minimal | low | medium | high
 
 updates:
   after_days: 7
@@ -283,14 +291,170 @@ one alternation and measures clean, because the words do not collide.
 
 ## `llm`
 
-The local Ollama model behind spoken commands and every `prompt:` transform.
-Without it dictation still works and those stages stop.
+What is behind spoken commands and every `prompt:` transform. Without a model
+dictation still works and those stages stop.
+
+`model:`, `endpoint:`, `timeout_seconds:` and `keep_loaded:` describe one
+Ollama model, and it is named `local`. Everything runs on it unless something
+names another. A config written before `models:` existed keeps working exactly
+as it did.
 
 `keep_loaded: true` pins the model in RAM at launch. Ollama otherwise drops it
 after five minutes idle and the next command waits for a reload — measured
 **6.7 s cold against 1.5 s warm**, so in practice almost every correction paid
 for one. The cost is the model sitting in memory for as long as the app runs:
-9.6 GB for `gemma4:e4b`. On a 16 GB Mac, turn it off. On 32 GB, do not.
+9.6 GB for `gemma4:e4b`. On a 16 GB Mac, turn it off. On 32 GB, do not. It is
+an Ollama setting; the other protocols have nothing to pin.
+
+Three keys say which model runs what:
+
+| Key | What it decides | Default |
+|---|---|---|
+| `default` | what a `prompt:` transform runs on when it names none | `local` |
+| `router` | "hey parrot, …" — the call you wait on with the pill on screen | `default` |
+| `vocabulary` | the KEEP/REVERT judge, which runs on every dictation | `default` |
+
+Keep `router` and `vocabulary` local for as long as you can. They run on every
+dictation, they are timed in tenths of a second, and they see every word you
+say.
+
+## `models`
+
+Every model this config can reach, under a name you choose. The name is the
+only thing a transform mentions.
+
+```yaml
+models:
+  gpt:
+    api: openai
+    model: gpt-5.6-luna
+    endpoint: https://api.openai.com/v1
+    api_key: file:~/.config/parrotflow/openai.key
+    reasoning: off
+    timeout_seconds: 30
+
+  claude:
+    api: anthropic
+    model: claude-sonnet-5
+    api_key: env:ANTHROPIC_API_KEY
+    reasoning: off
+
+  fast:
+    api: openai              # Ollama's own OpenAI surface, same server
+    endpoint: http://localhost:11434/v1
+    model: gpt-oss:20b
+```
+
+| Key | What it is |
+|---|---|
+| `api` | The protocol: `ollama`, `openai` or `anthropic`. Not the vendor — everyone else speaks one of the three. |
+| `model` | The model id, as that provider spells it. |
+| `endpoint` | Where to send it. Left out, the default for the protocol. |
+| `api_key` | Where the key is — see below. Not needed by `ollama`. |
+| `reasoning` | `off`, `minimal`, `low`, `medium` or `high`. |
+| `temperature` | Sent only if you write it. The reasoning models reject it. |
+| `max_tokens` | Replaces whatever budget the caller worked out. |
+| `timeout_seconds` | How long before the transcript is let through untouched. |
+| `keep_loaded` | Ollama only. |
+| `params` | Put into the request body untouched — see below. |
+
+### `reasoning` is one ladder
+
+Five rungs that mean the same thing everywhere. Each protocol maps them to
+whatever it actually has:
+
+| | `off` | `low`, `medium`, `high` |
+|---|---|---|
+| `ollama` | `think: false` | `think: <rung>` |
+| `openai` | `reasoning_effort: none` | `reasoning_effort: <rung>` |
+| `anthropic` | thinking disabled | adaptive thinking, `effort: <rung>` |
+
+`minimal` is OpenAI's own rung; on Anthropic it is sent as `low`. A provider
+with no such knob gets nothing extra in the body rather than an error.
+
+Reasoning text never reaches your document. `reasoning_content` is not read,
+Anthropic thinking blocks are skipped, and a `<think>` block inlined into the
+answer is cut out — which some OpenAI-compatible servers do.
+
+### `params` reaches everything else
+
+Merged into the request body last, unchecked. It is what makes a provider this
+app has never been run against usable without a new release:
+
+```yaml
+  deepseek:
+    api: openai
+    endpoint: https://api.deepseek.com/v1
+    model: deepseek-chat
+    api_key: env:DEEPSEEK_API_KEY
+    params:
+      top_p: 0.9
+```
+
+A key here replaces whatever the envelope worked out under the same name, and
+`null` **removes** it:
+
+```yaml
+    params:
+      reasoning_effort: null    # this server has no such field
+```
+
+That is the way out of any field this app sends by default and a given server
+refuses. One special case is handled without it: naming `max_tokens` removes
+the `max_completion_tokens` that goes out by default, for a server that only
+knows the older name.
+
+### Where the key comes from
+
+`api_key:` takes a reference, not a key:
+
+| Written | Read from |
+|---|---|
+| `env:OPENAI_API_KEY` | the environment |
+| `file:~/.config/parrotflow/openai.key` | that file, trimmed |
+| anything else | taken as the key itself |
+
+ParrotFlow launches from Finder, which hands it none of your shell's
+environment — so `env:` works for `--pipeline` and `--eval` and is empty in the
+app. `file:` is the form that works in both. A key written in full works too,
+and `--check-config` announces it as plain text in your config every time.
+
+### Naming one on a transform
+
+```yaml
+transforms:
+  - name: terse
+    description: shorten text without losing anything it says
+    model: gpt
+    prompt: |
+      …
+
+  - name: plan
+    description: turn what I said into a short plan
+    model:
+      use: gpt          # a name from `models:`
+      reasoning: low    # gpt is `off` by default; this prompt gets to think
+      max_tokens: 800
+    prompt: |
+      …
+```
+
+The mapping form may change `reasoning`, `temperature`, `max_tokens`,
+`timeout_seconds` and `params` — the settings of one call. It may not change
+`api`, `model`, `endpoint` or `api_key`: a different connection is another
+entry in `models:`, not an override buried in a transform. Writing one there is
+refused by name.
+
+A name nothing defines falls back to the default model rather than failing.
+`--check-config` refuses it by name — a typo should cost you the model you
+meant, never the sentence.
+
+### Failing open
+
+Every way a model call goes wrong leaves the transcript exactly as it arrived:
+no key, an expired key, a rate limit, a timeout, a dead network. This is the
+same rule Ollama has always had here, and a cloud model needs it more, not
+less.
 
 ## `updates`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,7 +40,6 @@ models:                 # more models, under names you pick
   gpt:
     api: openai         # ollama | openai | anthropic — the protocol, not the vendor
     model: gpt-5.6-luna
-    api_key: file:~/.config/parrotflow/openai.key
     reasoning: off      # off | minimal | low | medium | high
 
 updates:
@@ -329,14 +328,12 @@ models:
     api: openai
     model: gpt-5.6-luna
     endpoint: https://api.openai.com/v1
-    api_key: file:~/.config/parrotflow/openai.key
     reasoning: off
     timeout_seconds: 30
 
   claude:
     api: anthropic
     model: claude-sonnet-5
-    api_key: env:ANTHROPIC_API_KEY
     reasoning: off
 
   fast:
@@ -350,7 +347,7 @@ models:
 | `api` | The protocol: `ollama`, `openai` or `anthropic`. Not the vendor — everyone else speaks one of the three. |
 | `model` | The model id, as that provider spells it. |
 | `endpoint` | Where to send it. Left out, the default for the protocol. |
-| `api_key` | Where the key is — see below. Not needed by `ollama`. |
+| `api_key` | Where the key is — see below. Omit it for the keychain. Not needed by `ollama`. |
 | `reasoning` | `off`, `minimal`, `low`, `medium` or `high`. |
 | `temperature` | Sent only if you write it. The reasoning models reject it. |
 | `max_tokens` | Replaces whatever budget the caller worked out. |
@@ -386,7 +383,6 @@ app has never been run against usable without a new release:
     api: openai
     endpoint: https://api.deepseek.com/v1
     model: deepseek-chat
-    api_key: env:DEEPSEEK_API_KEY
     params:
       top_p: 0.9
 ```
@@ -406,10 +402,46 @@ knows the older name.
 
 ### Where the key comes from
 
-`api_key:` takes a reference, not a key:
+Leave `api_key:` out. A model whose `api` is not `ollama` and which names no
+key reads your keychain, and nothing about the key goes in `config.yaml`:
+
+```yaml
+models:
+  gpt:
+    api: openai
+    model: gpt-5.6-luna
+```
+
+The first time the app loads a config like that, it asks for the key and puts
+it in the keychain. Declining is fine — the model stays unusable, a transform
+naming it declines with your transcript untouched, and the menu says so until
+you add one. From a terminal:
+
+```
+ParrotFlow --set-key gpt              # prompts, and does not echo
+printf '%s' "$KEY" | ParrotFlow --set-key gpt
+ParrotFlow --set-key gpt --forget
+```
+
+The key is read from stdin, never from an argument, so it stays out of `ps` and
+out of your shell history.
+
+Keys are stored under the service `ParrotFlow`, or `ParrotFlow Dev` for the dev
+build, with the model's own name as the account. The dev and release apps
+therefore never see each other's keys, the same split as `~/.config/parrotflow`
+and `~/.config/parrotflow-dev`.
+
+**Keychain access follows the code signature.** The installed app is signed and
+keeps its access across upgrades. A `swift build` binary is not, so macOS asks
+you to allow it — once per build, because an unsigned binary's identity changes
+every compile. Use `file:` during development if that gets tiring.
+
+`api_key:` still takes a reference for the setups that need one:
 
 | Written | Read from |
 |---|---|
+| *omitted* | the keychain, for any `api` but `ollama` |
+| `keychain` | the keychain, said out loud |
 | `env:OPENAI_API_KEY` | the environment |
 | `file:~/.config/parrotflow/openai.key` | that file, trimmed |
 | anything else | taken as the key itself |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,7 +43,7 @@ models:                 # more models, under names you pick
     reasoning: off      # off | minimal | low | medium | high
 
 updates:
-  after_days: 7
+  after_days: 0
 
 free_form: true
 
@@ -495,8 +495,11 @@ about what you dictate.
 
 The number is a waiting period, not a frequency: `-1` never asks, `0` offers a
 release the day it is published, `7` only offers one that has existed for a
-week. The wait is the point — a bad release is one that gets noticed and
-pulled, and a week of distance means your Mac never saw it.
+week. `0` is the default.
+
+A wait has a point — a bad release is one that gets noticed and pulled, and a
+week of distance means your Mac never saw it. Set `after_days: 7` if you want
+that; the default takes the release the day it ships.
 
 ## `free_form`
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -216,6 +216,13 @@ from the menu bar, and go to **Hand over**.
 
 **Yes** → keep going.
 
+**Or a hosted model instead.** Everything below runs Gemma on their own Mac,
+which is the private option and the default. Someone who would rather not
+download 10 GB can name a hosted model under `models:` in config.yaml and give
+it an API key — the app asks for the key on its next launch and keeps it in the
+keychain. That sends what they dictate to somebody else's server, so say so and
+let them choose. See [configuration.md](configuration.md).
+
 **Ollama runs the model.** These answer whether it is installed and running:
 
 ```sh

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -27,7 +27,8 @@
 #
 #   PARROTFLOW_VERSION=0.2.0   install a specific version instead of the latest
 #   PARROTFLOW_DEST=~/Applications   install somewhere other than /Applications
-#   PARROTFLOW_SETUP_VOICE=0   skip installing Ollama and pulling the Gemma model
+#   PARROTFLOW_SETUP_VOICE=1   install Ollama and pull the model here, rather
+#                              than printing how to
 set -eu
 
 REPO="znat/parrotflow"
@@ -191,11 +192,13 @@ EOF
 # on first use, with a progress figure and without blocking recording, which
 # this script cannot match. See docs/distribution.md.
 #
-# Ollama and the Gemma model are installed here by default. This is not the
-# grammar checker or a nice extra: the vocabulary judge that keeps a matched
-# name from landing in the wrong sentence runs on this model, so a Mac without
-# it gets rule matches with nothing reviewing them. PARROTFLOW_SETUP_VOICE=0
-# skips it, for a script or a machine that wants the app alone.
+# Ollama is reported, never installed. `models:` in config.yaml names a model
+# per job, and an entry there may be an OpenAI- or Anthropic-shaped endpoint as
+# well as a local one — so running the vocabulary judge and spoken commands no
+# longer means running a model on this Mac. What is still true is that they
+# need *a* model: without one, a rule match ships with nothing reviewing it.
+# So this prints both ways and installs neither. PARROTFLOW_SETUP_VOICE=1 does
+# the local one here, for a machine that wants it all in one command.
 #
 # Every check below asks the filesystem or another program, never the app we
 # just installed. That is the rule, and the reason is the URLs: this script is
@@ -220,19 +223,21 @@ if [ -f "$CONFIG" ]; then
     [ -n "$NAMED" ] && MODEL="$NAMED"
 fi
 
-# Set unless the caller opted out. Read once, here, so every branch below
-# tests the same value instead of re-reading the environment.
-SETUP_VOICE="${PARROTFLOW_SETUP_VOICE:-1}"
+# Off unless the caller opted in. Read once, here, so every branch below tests
+# the same value instead of re-reading the environment.
+SETUP_VOICE="${PARROTFLOW_SETUP_VOICE:-0}"
 
 # Set by any branch below that finds something to do, so the end of this
 # section can say plainly that nothing was needed — silence reads as "did
 # this even run", not as "already done".
 NEEDED_SETUP=""
 
-# What Ollama backs: not only spoken commands, but also the check that a
+# What a model backs: not only spoken commands, but also the check that a
 # vocabulary term applied in the right context. Dictation and the deterministic
-# match still work without Ollama; that match then ships unchecked instead of
+# match still work without one; that match then ships unchecked instead of
 # reviewed, so a name can land in the wrong place with nothing to catch it.
+# Ollama is the way to run that model on this Mac, and `models:` in config.yaml
+# is the way to run it somewhere else.
 #
 # Three checks in sequence, not mutually exclusive branches: installing Ollama
 # still leaves the model to pull, and starting a stopped Ollama still leaves
@@ -241,27 +246,33 @@ NEEDED_SETUP=""
 # was actually present.
 if ! command -v ollama >/dev/null 2>&1; then
     NEEDED_SETUP=1
-    printf '    Ollama is not on this Mac. It runs the language model behind two\n'
-    printf '    things: spoken commands, and the check that a vocabulary match fits\n'
-    printf '    its sentence before it is kept. Without it, dictation still works,\n'
-    printf '    and vocabulary still matches — the match just ships unreviewed.\n\n'
-    if [ "$SETUP_VOICE" != "0" ]; then
+    printf '    Ollama is not on this Mac, and it is optional. A language model\n'
+    printf '    backs two things: spoken commands, and the check that a vocabulary\n'
+    printf '    match fits its sentence before it is kept. Without any model,\n'
+    printf '    dictation still works, and vocabulary still matches — the match\n'
+    printf '    just ships unreviewed.\n\n'
+    if [ "$SETUP_VOICE" = "1" ]; then
         printf '    ParrotFlow is already running and dictation already works — this\n'
         printf '    download only unlocks spoken commands and the vocabulary check.\n\n'
         say "Installing Ollama"
         brew install ollama && brew services start ollama \
             || die "could not install or start Ollama"
     else
+        printf '    To run the model here, on this Mac:\n\n'
         printf '      brew install ollama && brew services start ollama\n'
         printf '      ollama pull %s\n\n' "$MODEL"
+        printf '    Or run it somewhere else: `models:` in config.yaml takes an\n'
+        printf '    OpenAI- or Anthropic-shaped endpoint, and a transform names one\n'
+        printf '    with `model:`. That sends your dictation off this Mac, and\n'
+        printf '    --check-config says so every time. See docs/configuration.md.\n\n'
     fi
 fi
 
 if command -v ollama >/dev/null 2>&1 && ! INSTALLED="$(ollama list 2>/dev/null)"; then
     NEEDED_SETUP=1
-    printf '    Ollama is installed but not answering, so spoken commands and the\n'
-    printf '    vocabulary context check will not work. Start it:\n\n'
-    if [ "$SETUP_VOICE" != "0" ]; then
+    printf '    Ollama is installed but not answering, so anything pointed at it\n'
+    printf '    will not work. Start it:\n\n'
+    if [ "$SETUP_VOICE" = "1" ]; then
         say "Starting Ollama"
         brew services start ollama || die "could not start Ollama"
         # Bounded poll, not a fixed sleep: freshly started is not freshly
@@ -295,7 +306,7 @@ if command -v ollama >/dev/null 2>&1 \
     if [ "$MODEL" = "gemma4:e4b-mlx" ]; then
         printf '    About 8.8 GB.\n\n'
     fi
-    if [ "$SETUP_VOICE" != "0" ]; then
+    if [ "$SETUP_VOICE" = "1" ]; then
         printf '    ParrotFlow is already running and dictation already works — this\n'
         printf '    download only unlocks spoken commands and the vocabulary check.\n\n'
         say "Downloading $MODEL — this runs in the background, and dictation"


### PR DESCRIPTION
`llm:` described one Ollama model. It now says which model runs what, and a
`models:` block holds the rest under names you pick. A model that is not local
needs a key, so the second half of this is where that key lives.

## Naming models

- `api:` is the protocol, not the vendor: ollama, openai, anthropic. Everyone
  else speaks one of the three, so another provider is an `endpoint:` away
  rather than a new version of this app.
- `reasoning:` is one ladder — off, minimal, low, medium, high — mapped per
  protocol: `think:`, `reasoning_effort`, adaptive thinking plus an effort.
- A transform names a model with `model: gpt`, or changes a setting for that
  prompt alone with `model: { use: gpt, reasoning: low }`.
- `llm.router` and `llm.vocabulary` are named separately. Both run on every
  dictation and both carry the transcript, so both stay local by default.
- `params:` goes into the request body untouched, and `null` removes a key.
- Reasoning text never reaches the document.
- `--check-config` prints every model, where each job runs, and which
  transforms send text off the Mac.

## Where the key lives

A cloud model with no `api_key:` line reads the login keychain:

```yaml
models:
  gpt:
    api: openai
    model: gpt-5.6-luna
```

The first config load that names one asks for the key in a dialog and stores
it. `--set-key gpt` does the same from a terminal, reading stdin so the key
stays out of `ps` and shell history; `--forget` undoes it.

Stored under service `ParrotFlow` / `ParrotFlow Dev`, account = the model's
name — the same variant split as `~/.config/parrotflow`. Accessibility is
`AfterFirstUnlockThisDeviceOnly`, so it never syncs to iCloud and is readable
after a reboot without the app being frontmost.

`env:` and `file:` still work. `file:` is the one to reach for in development,
because keychain access follows the code signature and a `swift build` binary
is asked about once per build.

## Ollama became optional

So `scripts/install.sh` stopped installing it. `PARROTFLOW_SETUP_VOICE` flips
from opt-out to opt-in: the default prints both routes and installs neither.
They still need *a* model — without one a vocabulary match ships with nothing
reviewing it, and the text says so.

## Notes

- No existing config changes meaning. The old `llm:` keys define the model
  named `local`, and everything falls back to it.
- Every failure still leaves the transcript exactly as it arrived: no key, a
  rate limit, a timeout, a dead network.
- `LLM.swift` is unchanged by the keychain work — it already asked `KeySource`
  for a key and already had one path for not getting one.
- `KeyField` exists because ⌘V did nothing at first. A text field does not
  handle paste itself; it is a key equivalent on Edit ▸ Paste, which an
  accessory app with no main menu does not have.

## Testing

- `check-default-config.sh`, `check-vocabulary-config.sh`, `check-pipeline.sh`,
  `check-transform-folders.sh` pass. Debug and release both build.
- Key round-trip verified end to end in the installed dev app: dialog, paste,
  store, and `--check-config` reading it back.
- The store/forget/refusal paths were checked from the CLI with the right exit
  codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)