### PR TITLE
feat: the update offer draws its notes, and a dev build stops trying to install one

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -97,6 +97,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let previewPanel = PreviewPanel()
     /// Says once per microphone that this one will cost you words.
     private let micNotice = MicNotice()
+    /// The release notes, and the three answers to them.
+    private let updatePanel = UpdatePanel()
     private var pendingSelection: SelectionReader.Selection?
     /// Captured the moment the hotkey goes down — see SelectionReader.snapshot.
     private var selectionAtPress: SelectionReader.Selection?
@@ -833,54 +835,39 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// The release notes, and the three answers to them.
     ///
-    /// No download button yet: taking the update in place means replacing a
-    /// running bundle, which is a separate piece of work and a worse thing to
-    /// get wrong than a missing button. Until then the command is the same one
-    /// that installed the app, and it is put on the clipboard rather than
-    /// printed for retyping.
+    /// The notes are drawn as Markdown in a panel of their own — see
+    /// `ReleaseNotes` and `UpdatePanel`.
     @objc private func showUpdate() {
         guard let release = updateAvailable else { return }
 
-        NSApp.activate(ignoringOtherApps: true)
-        let alert = NSAlert()
-        alert.messageText = "ParrotFlow \(release.version) is available"
-        alert.informativeText = (release.notes.isEmpty ? "No release notes." : release.notes)
-            + "\n\nYou are running \(Updates.current ?? "an unknown version")."
-        alert.alertStyle = .informational
-        // Installing in place is only offered when it can actually be done.
-        // An app in a read-only location, or one someone put somewhere odd,
-        // still gets the command it was installed with rather than a button
-        // that fails after downloading 3 MB.
-        let canInstall = UpdateInstaller.canInstallInPlace
-        if canInstall { alert.addButton(withTitle: "Update and restart") }
-        alert.addButton(withTitle: "Copy the upgrade command")
-        alert.addButton(withTitle: "Skip this version")
-        alert.addButton(withTitle: "Later")
-
-        var answer = alert.runModal()
-        if canInstall, answer == .alertFirstButtonReturn {
-            install(release)
-            return
-        }
-        // With the install button present every other answer sits one place
-        // further along, so it is shifted back rather than each case being
-        // written twice.
-        if canInstall { answer = NSApplication.ModalResponse(rawValue: answer.rawValue - 1) }
-
-        switch answer {
-        case .alertFirstButtonReturn:
-            NSPasteboard.general.clearContents()
-            NSPasteboard.general.setString(Updates.installCommand, forType: .string)
-            flash("Upgrade command copied — paste it into a terminal", tone: .done)
-        case .alertSecondButtonReturn:
-            Updates.skip(release.version)
-            updateAvailable = nil
-            updateUI()
-        default:
-            Updates.remindLater()
-            updateAvailable = nil
-            updateUI()
-        }
+        // Installing in place is only offered when it can actually be done: a
+        // dev build, or an app in a read-only location, gets the reason and the
+        // command it was installed with rather than a button that fails after
+        // downloading 3 MB.
+        let blocker = UpdateInstaller.blocker
+        updatePanel.show(
+            release: release,
+            current: Updates.current,
+            blocker: blocker,
+            answers: UpdatePanel.Answers(
+                install: blocker == nil ? { [weak self] in self?.install(release) } : nil,
+                copyCommand: { [weak self] in
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(Updates.installCommand, forType: .string)
+                    self?.flash("Upgrade command copied — paste it into a terminal", tone: .done)
+                },
+                skip: { [weak self] in
+                    Updates.skip(release.version)
+                    self?.updateAvailable = nil
+                    self?.updateUI()
+                },
+                later: { [weak self] in
+                    Updates.remindLater()
+                    self?.updateAvailable = nil
+                    self?.updateUI()
+                }
+            )
+        )
     }
 
     private func watchConfig() {

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -22,6 +22,46 @@ enum PanelsCommand {
     /// in its first sentence and a short one would not say whether it fits.
     private static let sampleMicName = "Tasmin's AirPods Pro Max"
 
+    /// A release body longer than the panel is tall — a heading, two sections,
+    /// and two links on every line. Longer on purpose: the pane only scrolls
+    /// when the notes outgrow it, so a sample that fits proves nothing.
+    private static let sampleRelease = Updates.Release(
+        version: "0.7.0",
+        publishedAt: Date(timeIntervalSince1970: 1_755_561_600),
+        notes: """
+            ## [0.7.0](https://github.com/znat/parrotflow/compare/v0.6.0...v0.7.0) (2026-08-19)
+
+            ### Features
+
+            * a spelling lesson keeps the word it is teaching ([#143](https://github.com/znat/parrotflow/issues/143)) ([7e19a7e](https://github.com/znat/parrotflow/commit/7e19a7e74d6e56c153912b3f53890b2501854d49))
+            * a table says what it wrote, and `join` fits a clip to the box ([#148](https://github.com/znat/parrotflow/issues/148)) ([461ea43](https://github.com/znat/parrotflow/commit/461ea4332725a905f294cfb358b0657b8268fed8))
+            * **code_identifiers** publishes the identifiers it wrote ([#146](https://github.com/znat/parrotflow/issues/146)) ([649b08c](https://github.com/znat/parrotflow/commit/649b08c7962f405f72aeaec25c9bf96e514cb8d6))
+            * name the word lists once, and let dotted hear dash and slash ([#149](https://github.com/znat/parrotflow/issues/149)) ([aadf036](https://github.com/znat/parrotflow/commit/aadf036a1bc8451132159a9566313caabc391f64))
+            * punctuation gains brackets, semicolon, ellipsis and French ([#150](https://github.com/znat/parrotflow/issues/150)) ([dbf028c](https://github.com/znat/parrotflow/commit/dbf028c951d88f914f4cd910af668848b7526e6b))
+            * read the input box, tag the words, and hand a transform the whole run ([#147](https://github.com/znat/parrotflow/issues/147)) ([f079683](https://github.com/znat/parrotflow/commit/f0796833ac8569b2d31350a4fc9bf4db28e3bafb))
+            * the offer says when the words may not be your words ([#151](https://github.com/znat/parrotflow/issues/151)) ([e9c8578](https://github.com/znat/parrotflow/commit/e9c857869ef38665f7479cec27a6233f18d080ae))
+
+            ### Fixes
+
+            * a repeat holding "I" is no longer kept as a spelled letter ([#145](https://github.com/znat/parrotflow/issues/145)) ([0dc8153](https://github.com/znat/parrotflow/commit/0dc81535c04b2e55856ac5dfff51259b6db36e1b))
+            * get past the version-manager shim, and stop trimming what a stage added ([#144](https://github.com/znat/parrotflow/issues/144)) ([a0c5d17](https://github.com/znat/parrotflow/commit/a0c5d17e66056d90dc32a76a841bef7ec9239dda))
+            * the pill no longer keeps the icon of an app that has quit ([#141](https://github.com/znat/parrotflow/issues/141)) ([b31c0a2](https://github.com/znat/parrotflow/commit/b31c0a2f5d1e4c8a9b7e6f3d2c1a0b9e8d7c6f5a))
+            * a dictation that lands nowhere says so before it copies ([#140](https://github.com/znat/parrotflow/issues/140)) ([c42d1b3](https://github.com/znat/parrotflow/commit/c42d1b3a6e2f5d9c8b7a6e5f4d3c2b1a0f9e8d7c))
+            * the vocabulary judge stops asking Ollama about an empty match ([#138](https://github.com/znat/parrotflow/issues/138)) ([d53e2c4](https://github.com/znat/parrotflow/commit/d53e2c4b7f3a6e0d9c8b7a6f5e4d3c2b1a0f9e8d))
+            * two builds no longer fight over the same recording directory ([#137](https://github.com/znat/parrotflow/issues/137)) ([e64f3d5](https://github.com/znat/parrotflow/commit/e64f3d5c8a4b7f1e0d9c8b7a6f5e4d3c2b1a0f9e))
+            * a hotkey held through a screen lock releases on the way back ([#136](https://github.com/znat/parrotflow/issues/136)) ([f75a4e6](https://github.com/znat/parrotflow/commit/f75a4e6d9b5c8a2f1e0d9c8b7a6f5e4d3c2b1a0f))
+            * the log stops growing without bound on a machine left running ([#135](https://github.com/znat/parrotflow/issues/135)) ([a86b5f7](https://github.com/znat/parrotflow/commit/a86b5f7e0c6d9b3a2f1e0d9c8b7a6f5e4d3c2b1a))
+            * a spelled word ending in a full stop keeps the full stop ([#134](https://github.com/znat/parrotflow/issues/134)) ([b97c6a8](https://github.com/znat/parrotflow/commit/b97c6a8f1d7e0c4b3a2f1e0d9c8b7a6f5e4d3c2b))
+            * the preview panel stops reopening on the screen you left ([#133](https://github.com/znat/parrotflow/issues/133)) ([ca8d7b9](https://github.com/znat/parrotflow/commit/ca8d7b9a2e8f1d5c4b3a2f1e0d9c8b7a6f5e4d3c))
+            * numbers said as digits survive the grammar stage ([#132](https://github.com/znat/parrotflow/issues/132)) ([db9e8ca](https://github.com/znat/parrotflow/commit/db9e8ca3f9a2e6d5c4b3a2f1e0d9c8b7a6f5e4d3))
+            * a transform that writes nothing no longer clears the line ([#131](https://github.com/znat/parrotflow/issues/131)) ([ecaf9db](https://github.com/znat/parrotflow/commit/ecaf9db4a0b3f7e6d5c4b3a2f1e0d9c8b7a6f5e4))
+            * the menu bar icon returns after a display is unplugged ([#130](https://github.com/znat/parrotflow/issues/130)) ([fdb0aec](https://github.com/znat/parrotflow/commit/fdb0aec5b1c4a8f7e6d5c4b3a2f1e0d9c8b7a6f5))
+            * a second hotkey press during the release tail is ignored ([#129](https://github.com/znat/parrotflow/issues/129)) ([aec1bfd](https://github.com/znat/parrotflow/commit/aec1bfd6c2d5b9a8f7e6d5c4b3a2f1e0d9c8b7a6))
+            """,
+        zip: URL(string: "https://example.invalid/ParrotFlow.zip")!,
+        checksum: URL(string: "https://example.invalid/ParrotFlow.zip.sha256")!
+    )
+
     /// What `feedback.confidence` draws. The scores walk the whole ramp — sure,
     /// p25, p10, p1, and a word with no reading at all — because the question
     /// this surface answers is whether the colours are told apart, and a
@@ -353,6 +393,7 @@ enum PanelsCommand {
         let correction = CorrectionPanel()
         let preview = PreviewPanel()
         let micNotice = MicNotice()
+        let updatePanel = UpdatePanel()
         var ticker: Timer?
 
         switch surface {
@@ -419,6 +460,21 @@ enum PanelsCommand {
         // machine whose microphone is wired.
         case "microphone":
             micNotice.show(mic: sampleMicName)
+        // The one surface that is a window rather than a floating panel over
+        // the words. Sized from the notes it is given, so a long release is
+        // what shows whether it scrolls.
+        case "update":
+            updatePanel.show(
+                release: sampleRelease,
+                current: "0.6.0",
+                blocker: UpdateInstaller.blocker,
+                answers: UpdatePanel.Answers(
+                    install: UpdateInstaller.blocker == nil ? { print("update: install") } : nil,
+                    copyCommand: { print("update: copy the command") },
+                    skip: { print("update: skip") },
+                    later: { print("update: later") }
+                )
+            )
         case "pill":
             pill.recording(icon: sampleIcon())
             // A meter frozen at zero says nothing about how the meter looks.
@@ -460,7 +516,7 @@ enum PanelsCommand {
         default:
             print("usage: ParrotFlow --panels <notice|caution|failure|thinking|offer"
                 + "|vocabulary|punctuation|rule|dictation|preview|microphone|pill"
-                + "|sequence> [seconds]")
+                + "|update|sequence> [seconds]")
             return 2
         }
 

--- a/Sources/ParrotFlow/ReleaseNotes.swift
+++ b/Sources/ParrotFlow/ReleaseNotes.swift
@@ -103,11 +103,6 @@ enum ReleaseNotes {
             case .header(let level):
                 size = level <= 2 ? bodySize + 2 : bodySize + 1
                 weight = .semibold
-            case .listItem(let ordinal):
-                // The marker belongs to the innermost list, so it is taken from
-                // the list intent that follows this item, not from the ordinal
-                // alone: an ordered list needs the number, a bullet does not.
-                bullet = kinds.contains(where: isOrdered) ? "\(ordinal)." : "•"
             case .unorderedList, .orderedList:
                 depth += 1
             case .codeBlock:
@@ -117,6 +112,15 @@ enum ReleaseNotes {
             default:
                 break
             }
+        }
+
+        // Intents run innermost first, so a nested item carries its own
+        // `listItem` and then its parent's. The first one is this item, and the
+        // list that owns it is the first list after it — without that, a bullet
+        // inside a numbered list takes the number.
+        if let item = kinds.firstIndex(where: isListItem),
+           case .listItem(let ordinal) = kinds[item] {
+            bullet = isOrdered(kinds[(item + 1)...].first(where: isList)) ? "\(ordinal)." : "•"
         }
 
         let indent = CGFloat(max(depth, 0)) * 16
@@ -162,7 +166,18 @@ enum ReleaseNotes {
         return out
     }
 
-    private static func isOrdered(_ kind: PresentationIntent.Kind) -> Bool {
+    private static func isListItem(_ kind: PresentationIntent.Kind) -> Bool {
+        if case .listItem = kind { return true }
+        return false
+    }
+
+    private static func isList(_ kind: PresentationIntent.Kind) -> Bool {
+        if case .orderedList = kind { return true }
+        if case .unorderedList = kind { return true }
+        return false
+    }
+
+    private static func isOrdered(_ kind: PresentationIntent.Kind?) -> Bool {
         if case .orderedList = kind { return true }
         return false
     }

--- a/Sources/ParrotFlow/ReleaseNotes.swift
+++ b/Sources/ParrotFlow/ReleaseNotes.swift
@@ -1,0 +1,238 @@
+import AppKit
+import Foundation
+
+/// The release body, drawn as the Markdown it is.
+///
+/// GitHub sends it as text. release-please writes it with a heading, a bullet
+/// per change, and two links on every bullet — the issue and the commit. Shown
+/// raw that is more URL than sentence: a ten line release fills the screen and
+/// the words are the smallest part of it.
+///
+/// So it is parsed and drawn. Headings read as headings, bullets as bullets,
+/// and a link as the words it was written on, still clickable. The notes then
+/// go in a scroll view rather than in the alert's own text, because an alert
+/// grows to fit its text and a long release pushed the buttons off the screen.
+enum ReleaseNotes {
+
+    // MARK: - Markdown
+
+    /// Bold, italic and code survive the first pass as a bitmask and become
+    /// fonts in the second, once the block they landed in has said what size it
+    /// is. A heading's bold and a bullet's bold are not the same font.
+    private static let traits = NSAttributedString.Key("pf.markdown.traits")
+    private static let bold = 1, italic = 2, code = 4
+
+    private static let bodySize: CGFloat = 12
+
+    static func attributed(_ markdown: String) -> NSAttributedString {
+        let options = AttributedString.MarkdownParsingOptions(
+            allowsExtendedAttributes: true,
+            interpretedSyntax: .full,
+            failurePolicy: .returnPartiallyParsedIfPossible
+        )
+        guard let parsed = try? AttributedString(markdown: markdown, options: options) else {
+            return NSAttributedString(
+                string: markdown,
+                attributes: [
+                    .font: NSFont.systemFont(ofSize: bodySize),
+                    .foregroundColor: NSColor.labelColor,
+                ]
+            )
+        }
+
+        var blocks: [(intent: PresentationIntent?, text: NSMutableAttributedString)] = []
+        for run in parsed.runs {
+            let piece = inline(String(parsed[run.range].characters), run: run)
+            let intent = run.presentationIntent
+            if let last = blocks.last, same(last.intent, intent) {
+                last.text.append(piece)
+            } else {
+                blocks.append((intent, NSMutableAttributedString(attributedString: piece)))
+            }
+        }
+
+        let out = NSMutableAttributedString()
+        for (index, block) in blocks.enumerated() {
+            if index > 0 { out.append(NSAttributedString(string: "\n")) }
+            out.append(rendered(block.text, intent: block.intent, first: index == 0))
+        }
+        return out
+    }
+
+    /// Two runs belong to the same block when the innermost intent they carry
+    /// is the same one. Every block the parser finds gets its own identity,
+    /// which is the only thing that separates two bullets in a row.
+    private static func same(_ a: PresentationIntent?, _ b: PresentationIntent?) -> Bool {
+        guard let a, let b else { return a == nil && b == nil }
+        return a.components.first?.identity == b.components.first?.identity
+    }
+
+    private static func inline(
+        _ text: String, run: AttributedString.Runs.Run
+    ) -> NSAttributedString {
+        var attributes: [NSAttributedString.Key: Any] = [:]
+
+        var mask = 0
+        if let intent = run.inlinePresentationIntent {
+            if intent.contains(.stronglyEmphasized) { mask |= bold }
+            if intent.contains(.emphasized) { mask |= italic }
+            if intent.contains(.code) { mask |= code }
+            if intent.contains(.strikethrough) {
+                attributes[.strikethroughStyle] = NSUnderlineStyle.single.rawValue
+            }
+        }
+        if mask != 0 { attributes[traits] = mask }
+        if let link = run.link { attributes[.link] = link }
+
+        return NSAttributedString(string: text, attributes: attributes)
+    }
+
+    private static func rendered(
+        _ text: NSMutableAttributedString, intent: PresentationIntent?, first: Bool
+    ) -> NSAttributedString {
+        let kinds = intent?.components.map(\.kind) ?? []
+
+        var size = bodySize
+        var weight = NSFont.Weight.regular
+        var monospaced = false
+        var bullet = ""
+        var depth = 0
+
+        for kind in kinds {
+            switch kind {
+            case .header(let level):
+                size = level <= 2 ? bodySize + 2 : bodySize + 1
+                weight = .semibold
+            case .listItem(let ordinal):
+                // The marker belongs to the innermost list, so it is taken from
+                // the list intent that follows this item, not from the ordinal
+                // alone: an ordered list needs the number, a bullet does not.
+                bullet = kinds.contains(where: isOrdered) ? "\(ordinal)." : "•"
+            case .unorderedList, .orderedList:
+                depth += 1
+            case .codeBlock:
+                monospaced = true
+            case .blockQuote:
+                depth += 1
+            default:
+                break
+            }
+        }
+
+        let indent = CGFloat(max(depth, 0)) * 16
+        let style = NSMutableParagraphStyle()
+        style.paragraphSpacing = bullet.isEmpty ? 6 : 2
+        style.paragraphSpacingBefore = first ? 0 : (weight == .semibold ? 8 : 0)
+        style.lineSpacing = 1
+        style.firstLineHeadIndent = indent
+        style.headIndent = indent + (bullet.isEmpty ? 0 : 14)
+        if !bullet.isEmpty {
+            style.tabStops = [NSTextTab(textAlignment: .left, location: indent + 14)]
+        }
+
+        let base =
+            monospaced
+            ? NSFont.monospacedSystemFont(ofSize: size - 1, weight: weight)
+            : NSFont.systemFont(ofSize: size, weight: weight)
+
+        let out = NSMutableAttributedString()
+        if !bullet.isEmpty {
+            out.append(NSAttributedString(string: "\(bullet)\t"))
+        }
+        out.append(text)
+
+        let whole = NSRange(location: 0, length: out.length)
+        out.addAttributes([.font: base, .foregroundColor: NSColor.labelColor, .paragraphStyle: style], range: whole)
+
+        out.enumerateAttribute(traits, in: whole) { value, range, _ in
+            guard let mask = value as? Int else { return }
+            var font = base
+            if mask & code != 0 {
+                font = NSFont.monospacedSystemFont(ofSize: size - 1, weight: weight)
+            }
+            if mask & bold != 0 {
+                font = NSFontManager.shared.convert(font, toHaveTrait: .boldFontMask)
+            }
+            if mask & italic != 0 {
+                font = NSFontManager.shared.convert(font, toHaveTrait: .italicFontMask)
+            }
+            out.addAttribute(.font, value: font, range: range)
+        }
+        out.removeAttribute(traits, range: whole)
+        return out
+    }
+
+    private static func isOrdered(_ kind: PresentationIntent.Kind) -> Bool {
+        if case .orderedList = kind { return true }
+        return false
+    }
+
+    // MARK: - The view it goes in
+
+    /// The notes in a scroll view sized to fit them, up to a ceiling.
+    ///
+    /// Short notes get exactly their own height and no scroller. Long ones stop
+    /// at `maxHeight` and scroll, which is the case this exists for: an NSAlert
+    /// lays its own text out at whatever height it needs, so a full release
+    /// pushed the buttons past the bottom of the screen.
+    ///
+    /// Wide enough that the buttons sit in one row. NSAlert stacks them the
+    /// moment they do not fit its width, and its width is whatever this view
+    /// asks for — four buttons need about 680 points between them.
+    ///
+    /// It draws its own background rather than sitting on the alert's, so the
+    /// notes read as a panel of someone else's text inside the dialog and not
+    /// as more of the dialog's own words.
+    static func scrollingView(
+        _ notes: NSAttributedString, width: CGFloat = 700, maxHeight: CGFloat = 360
+    ) -> NSScrollView {
+        let padding: CGFloat = 10
+        let scroll = NSScrollView(frame: NSRect(x: 0, y: 0, width: width, height: maxHeight))
+        scroll.hasVerticalScroller = true
+        scroll.hasHorizontalScroller = false
+        scroll.autohidesScrollers = true
+        // Fixed values, not `textBackgroundColor` and `separatorColor`: this
+        // sits on the panel's own near-black ground, which does not follow the
+        // system, and a layer's border colour is resolved once when it is set —
+        // before this view has been put in a window with an appearance.
+        scroll.drawsBackground = true
+        scroll.backgroundColor = NSColor(white: 1, alpha: 0.05)
+        scroll.borderType = .noBorder
+        scroll.wantsLayer = true
+        scroll.layer?.cornerRadius = 8
+        scroll.layer?.masksToBounds = true
+        scroll.layer?.borderWidth = 1
+        scroll.layer?.borderColor = NSColor(white: 1, alpha: 0.10).cgColor
+
+        let text = NSTextView(frame: NSRect(x: 0, y: 0, width: width, height: maxHeight))
+        text.isEditable = false
+        text.isSelectable = true
+        text.drawsBackground = false
+        text.textContainerInset = NSSize(width: padding, height: padding)
+        text.isVerticallyResizable = true
+        text.isHorizontallyResizable = false
+        text.autoresizingMask = [.width]
+        text.textContainer?.widthTracksTextView = true
+        text.textContainer?.containerSize = NSSize(
+            width: width - padding * 2, height: .greatestFiniteMagnitude
+        )
+        text.linkTextAttributes = [
+            .foregroundColor: NSColor.linkColor,
+            .underlineStyle: NSUnderlineStyle.single.rawValue,
+            .cursor: NSCursor.pointingHand,
+        ]
+        text.textStorage?.setAttributedString(notes)
+        scroll.documentView = text
+
+        // Laid out before it is measured: `usedRect` on an unlaid container
+        // answers with the empty rect, which collapses the alert.
+        if let container = text.textContainer, let layout = text.layoutManager {
+            layout.ensureLayout(for: container)
+            let used = ceil(layout.usedRect(for: container).height) + padding * 2
+            scroll.frame = NSRect(
+                x: 0, y: 0, width: width, height: min(max(used, 60), maxHeight)
+            )
+        }
+        return scroll
+    }
+}

--- a/Sources/ParrotFlow/UpdateInstallCommand.swift
+++ b/Sources/ParrotFlow/UpdateInstallCommand.swift
@@ -37,7 +37,7 @@ enum UpdateInstallCommand {
                 print("checksum           matches the published one")
                 print("signature          valid")
                 print("certificate        \(try UpdateInstaller.certificateFingerprint(of: app))")
-                print("identity           \(Bundle.main.bundleIdentifier ?? "?")")
+                print("identity           \(Updates.releaseBundleIdentifier)")
                 print("verified           \(app.path)")
 
                 guard !dryRun else {
@@ -45,8 +45,8 @@ enum UpdateInstallCommand {
                     done.signal()
                     return
                 }
-                guard UpdateInstaller.canInstallInPlace else {
-                    print("✗ \(UpdateInstaller.destination.path) cannot be replaced from here")
+                if let blocker = UpdateInstaller.blocker {
+                    print("✗ \(blocker)")
                     code = 1
                     done.signal()
                     return

--- a/Sources/ParrotFlow/UpdateInstaller.swift
+++ b/Sources/ParrotFlow/UpdateInstaller.swift
@@ -22,7 +22,7 @@ enum UpdateInstaller {
         case signature(String)
         case certificate(expected: String, got: String)
         case contents(String)
-        case notWritable(String)
+        case cannotInstall(String)
 
         var errorDescription: String? {
             switch self {
@@ -38,18 +38,38 @@ enum UpdateInstaller {
                     + "(expected \(expected.prefix(12))…, found \(got.prefix(12))…)"
             case .contents(let what):
                 return "the download is not what it should be: \(what)"
-            case .notWritable(let path):
-                return "\(path) cannot be written to, so the update has to be installed by hand"
+            case .cannotInstall(let why):
+                return why
             }
         }
     }
 
-    /// Where this app is, and whether it can be replaced in place.
+    /// Where this app is.
     static var destination: URL { Bundle.main.bundleURL }
 
-    static var canInstallInPlace: Bool {
-        FileManager.default.isWritableFile(atPath: destination.deletingLastPathComponent().path)
+    /// Why this build cannot take an update in place, or nil when it can.
+    ///
+    /// A dev build cannot, and not for a reason more code would fix. The
+    /// release archive holds ParrotFlow.app signed as com.parrotflow.app; a dev
+    /// bundle is ParrotFlowDev.app signed as com.parrotflow.app.dev. Moving one
+    /// over the other does not update the dev build, it puts the released app
+    /// under the dev build's name — reading the other config directory, writing
+    /// the other log, listening to the other key, and asking for the microphone
+    /// again. A dev build is built from the source tree, and that is where its
+    /// updates come from.
+    static var blocker: String? {
+        if AppVariant.isDev {
+            return "This is a dev build, so a release cannot be installed over it. "
+                + "Build it from the source tree instead."
+        }
+        let parent = destination.deletingLastPathComponent().path
+        guard FileManager.default.isWritableFile(atPath: parent) else {
+            return "\(parent) cannot be written to, so the update has to be installed by hand."
+        }
+        return nil
     }
+
+    static var canInstallInPlace: Bool { blocker == nil }
 
     // MARK: - Fetch and verify
 
@@ -76,9 +96,12 @@ enum UpdateInstaller {
         guard run("/usr/bin/ditto", ["-x", "-k", zip.path, unpacked.path]).status == 0 else {
             throw Failure.contents("could not unpack the archive")
         }
-        let app = unpacked.appendingPathComponent(destination.lastPathComponent)
+        // The name the release ships under, not the name this bundle happens to
+        // carry. The two differ on a dev build, and for anyone who renamed the
+        // app after installing it.
+        let app = unpacked.appendingPathComponent(Updates.releaseAppName)
         guard FileManager.default.fileExists(atPath: app.path) else {
-            throw Failure.contents("the archive does not contain \(destination.lastPathComponent)")
+            throw Failure.contents("the archive does not contain \(Updates.releaseAppName)")
         }
 
         try verify(app, expecting: release.version)
@@ -105,8 +128,8 @@ enum UpdateInstaller {
               let shipped = plist["CFBundleShortVersionString"] as? String else {
             throw Failure.contents("no readable Info.plist")
         }
-        guard identifier == Bundle.main.bundleIdentifier else {
-            throw Failure.contents("it is \(identifier), not \(Bundle.main.bundleIdentifier ?? "us")")
+        guard identifier == Updates.releaseBundleIdentifier else {
+            throw Failure.contents("it is \(identifier), not \(Updates.releaseBundleIdentifier)")
         }
         guard shipped == version else {
             throw Failure.contents("the archive says \(shipped), the release says \(version)")
@@ -137,9 +160,7 @@ enum UpdateInstaller {
     /// space in it would otherwise become two words at the worst possible
     /// moment.
     static func swapAndRelaunch(newApp: URL) throws {
-        guard canInstallInPlace else {
-            throw Failure.notWritable(destination.deletingLastPathComponent().path)
-        }
+        if let blocker { throw Failure.cannotInstall(blocker) }
 
         // The outcome goes to the log because by then there is nobody left to
         // tell. This process has exited, and the app that comes back up is

--- a/Sources/ParrotFlow/UpdatePanel.swift
+++ b/Sources/ParrotFlow/UpdatePanel.swift
@@ -54,7 +54,12 @@ final class UpdatePanel {
             answers.later()
         }
 
-        if panel == nil { build() }
+        // Built fresh every time, not reused. The notes are an AppKit view
+        // handed to SwiftUI, and SwiftUI keeps the view it already made: a
+        // second offer drew the new version's title over the old version's
+        // notes.
+        panel?.orderOut(nil)
+        build()
         resize()
         centre()
         NSApp.activate(ignoringOtherApps: true)

--- a/Sources/ParrotFlow/UpdatePanel.swift
+++ b/Sources/ParrotFlow/UpdatePanel.swift
@@ -1,0 +1,233 @@
+import AppKit
+import SwiftUI
+
+/// The window a new release is offered in.
+///
+/// An NSAlert until it could not do the job. Two things it will not do: it lays
+/// its own text out at whatever height that text needs, so a release with ten
+/// bullets on it grew past the bottom of the screen; and it puts at most two
+/// buttons in a row — measured, on macOS 26 — so three answers came out stacked
+/// in a column. This is the app's own surface instead, the same dark ground and
+/// plumage rim as the correction and preview panels.
+///
+/// The notes go in a scroll view with a ground of their own. They are the one
+/// piece of text in the app written somewhere else, by whoever wrote the
+/// release, and a panel of it reads as quoted rather than as the app talking.
+final class UpdatePanel {
+
+    private var panel: NSPanel?
+    private let model = UpdateModel()
+
+    /// The three answers, plus the one the window itself gives when it is
+    /// closed without an answer: nothing.
+    struct Answers {
+        let install: (() -> Void)?
+        let copyCommand: () -> Void
+        let skip: () -> Void
+        let later: () -> Void
+    }
+
+    func show(
+        release: Updates.Release, current: String?, blocker: String?, answers: Answers
+    ) {
+        model.version = release.version
+        model.current = current
+        model.blocker = blocker
+        // The notes view is built here rather than in the SwiftUI body: it
+        // measures itself, and the panel needs that height to size itself
+        // before anything is on screen.
+        model.notes = ReleaseNotes.scrollingView(
+            ReleaseNotes.attributed(release.notes.isEmpty ? "No release notes." : release.notes),
+            maxHeight: notesCeiling()
+        )
+        model.canInstall = answers.install != nil
+        model.onPrimary = { [weak self] in
+            self?.dismiss()
+            if let install = answers.install { install() } else { answers.copyCommand() }
+        }
+        model.onSkip = { [weak self] in
+            self?.dismiss()
+            answers.skip()
+        }
+        model.onLater = { [weak self] in
+            self?.dismiss()
+            answers.later()
+        }
+
+        if panel == nil { build() }
+        resize()
+        centre()
+        NSApp.activate(ignoringOtherApps: true)
+        panel?.riseIntoView(makeKey: true)
+    }
+
+    private func dismiss() {
+        panel?.orderOut(nil)
+    }
+
+    /// How tall the notes may get on the screen they are about to appear on.
+    /// The rest of the panel is about 200 points, and a window taller than the
+    /// screen has its buttons under the dock.
+    private func notesCeiling() -> CGFloat {
+        let room = (NSScreen.main?.visibleFrame.height ?? 900) - 260
+        return max(120, min(380, room))
+    }
+
+    private func build() {
+        let hosting = NSHostingView(rootView: UpdateView().environmentObject(model))
+        let panel = UpdateKeyPanel(
+            contentRect: NSRect(x: 0, y: 0, width: UpdateMetrics.width, height: 300),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.contentView = hosting
+        panel.isFloatingPanel = true
+        panel.level = .modalPanel
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.hasShadow = true
+        panel.hidesOnDeactivate = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.adoptParrotAppearance()
+        panel.onCancel = { [weak self] in self?.model.onLater?() }
+        self.panel = panel
+    }
+
+    /// The height SwiftUI works out for itself, rather than a number kept in
+    /// step by hand: the notes are as tall as the release is long, and the
+    /// blocker line is there or it is not.
+    private func resize() {
+        guard let panel, let hosting = panel.contentView else { return }
+        hosting.layoutSubtreeIfNeeded()
+        let height = hosting.fittingSize.height
+        panel.setFrame(
+            NSRect(x: panel.frame.origin.x, y: panel.frame.origin.y,
+                   width: UpdateMetrics.width, height: height),
+            display: false
+        )
+    }
+
+    private func centre() {
+        guard let panel, let screen = NSScreen.main?.visibleFrame else { return }
+        panel.setFrameOrigin(NSPoint(
+            x: screen.midX - panel.frame.width / 2,
+            // A little above centre. A dialog placed dead centre sits low,
+            // because the eye reads the middle of a screen as higher than it is.
+            y: screen.midY - panel.frame.height / 2 + 40
+        ))
+    }
+}
+
+enum UpdateMetrics {
+    /// The notes are the widest thing in the app, and deliberately: a release
+    /// bullet carries a sentence and two links, and at 500 points every one of
+    /// them wrapped.
+    static let notesWidth: CGFloat = 700
+    static var width: CGFloat { notesWidth + Parrot.panelPadding * 2 }
+}
+
+final class UpdateModel: ObservableObject {
+    @Published var version = "0.0.0"
+    @Published var current: String?
+    @Published var blocker: String?
+    @Published var notes: NSScrollView?
+    @Published var canInstall = true
+    var onPrimary: (() -> Void)?
+    var onSkip: (() -> Void)?
+    var onLater: (() -> Void)?
+}
+
+struct UpdateView: View {
+    @EnvironmentObject private var model: UpdateModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .center, spacing: 11) {
+                Image(nsImage: NSApp.applicationIconImage)
+                    .resizable()
+                    .frame(width: 38, height: 38)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("\(AppVariant.displayName) \(model.version) is available")
+                        .font(.system(size: 15, weight: .semibold, design: .rounded))
+                    Text("You are running \(model.current ?? "an unknown version").")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 0)
+            }
+
+            if let notes = model.notes {
+                NotesBox(scroll: notes)
+                    .frame(width: UpdateMetrics.notesWidth, height: notes.frame.height)
+            }
+
+            if let blocker = model.blocker {
+                HStack(alignment: .top, spacing: 7) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 11))
+                        .foregroundStyle(Parrot.amber)
+                        .padding(.top, 1)
+                    Text(blocker)
+                        .font(.system(size: 11.5))
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            HStack(spacing: 10) {
+                Spacer(minLength: 12)
+
+                ActionButton(title: "Later", key: "esc", filled: false, quiet: true) {
+                    model.onLater?()
+                }
+                .keyboardShortcut(.cancelAction)
+
+                ActionButton(title: "Skip this version", key: "", filled: false, quiet: true) {
+                    model.onSkip?()
+                }
+
+                ActionButton(
+                    title: model.canInstall ? "Update and restart" : "Copy the upgrade command",
+                    key: "↩", filled: true
+                ) {
+                    model.onPrimary?()
+                }
+                .keyboardShortcut(.return, modifiers: [])
+            }
+        }
+        .padding(Parrot.panelPadding)
+        .frame(width: UpdateMetrics.width, alignment: .leading)
+        .parrotSurface(
+            RoundedRectangle(cornerRadius: Parrot.panelRadius, style: .continuous),
+            solid: true
+        )
+    }
+}
+
+/// The measured scroll view, handed to SwiftUI as it is. Rebuilding it in
+/// `makeNSView` would measure it a second time, and the panel has already been
+/// sized from the first answer.
+private struct NotesBox: NSViewRepresentable {
+    typealias NSViewType = NSScrollView
+    // Spelled out rather than as `Context`: this module has a `Context` of its
+    // own — the screen-capture stage — and it shadows the protocol's typealias.
+    typealias Ctx = NSViewRepresentableContext<NotesBox>
+
+    let scroll: NSScrollView
+
+    func makeNSView(context: Ctx) -> NSScrollView { scroll }
+    func updateNSView(_ view: NSScrollView, context: Ctx) {}
+}
+
+/// Borderless panels refuse key status, and this one has a default button and
+/// an escape.
+private final class UpdateKeyPanel: NSPanel {
+    var onCancel: (() -> Void)?
+
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { true }
+
+    override func cancelOperation(_ sender: Any?) { onCancel?() }
+}

--- a/Sources/ParrotFlow/Updates.swift
+++ b/Sources/ParrotFlow/Updates.swift
@@ -21,6 +21,15 @@ enum Updates {
 
     static let repo = "znat/parrotflow"
 
+    /// What the release archive holds, whoever is asking.
+    ///
+    /// Constants, not `Bundle.main`: a dev build asking these questions of
+    /// itself gets ParrotFlowDev.app and com.parrotflow.app.dev, which is not
+    /// what any release has ever contained. `scripts/install.sh` pins the same
+    /// two values.
+    static let releaseAppName = "ParrotFlow.app"
+    static let releaseBundleIdentifier = "com.parrotflow.app"
+
     /// SHA-256 of the leaf certificate every release is signed with.
     ///
     /// The same value `scripts/install.sh` pins, and it has to stay the same

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -481,7 +481,7 @@ if let index = arguments.firstIndex(of: "--panel-sheet") {
 
 if let index = arguments.firstIndex(of: "--panels") {
     guard arguments.indices.contains(index + 1) else {
-        print("usage: ParrotFlow --panels <notice|caution|failure|thinking|offer|vocabulary|punctuation|rule|dictation|preview|pill|sequence> [seconds]")
+        print("usage: ParrotFlow --panels <notice|caution|failure|thinking|offer|vocabulary|punctuation|rule|dictation|preview|pill|update|sequence> [seconds]")
         exit(2)
     }
     let seconds = arguments.indices.contains(index + 2) ? Double(arguments[index + 2]) : nil

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -419,7 +419,7 @@ $PF --panel-sheet s.png   # draw every surface into one PNG, light beside dark
 
 `--panels` takes `pill`, `notice`, `caution`, `failure`, `thinking`, `offer`,
 `confidence`, `vocabulary`, `punctuation`, `rule`, `dictation`, `preview`,
-`microphone` or `sequence`.
+`microphone`, `update` or `sequence`.
 `--panel-sheet` draws all of
 them at once, which is where drift between them shows up.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -501,6 +501,12 @@ A wait has a point — a bad release is one that gets noticed and pulled, and a
 week of distance means your Mac never saw it. Set `after_days: 7` if you want
 that; the default takes the release the day it ships.
 
+When one is offered you get a panel with the release notes and three answers:
+**Update and restart**, which downloads, checks and replaces the app; **Skip
+this version**, which never offers that version again; and **Later**. A dev
+build offers the install command instead of the button — see
+[distribution.md](distribution.md#updates).
+
 ## `free_form`
 
 Do what was asked even when no transform description matches: "hey parrot, use

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -164,14 +164,29 @@ Notes on getting this right:
 
 ## Updates
 
-Re-running the install line upgrades in place — it replaces the bundle and
-relaunches. That is the whole update story for now, and it is enough while the
-audience is people who are comfortable with a curl line.
+The app checks GitHub hourly and offers the release itself. The panel shows the
+release notes as Markdown — see `UpdatePanel` and `ReleaseNotes` — and takes
+three answers: install and restart, skip this version, or later. Installing runs
+the same three checks `install.sh` runs, in the same order: the published
+SHA-256, the code signature, and the pinned leaf certificate. Nothing is
+replaced until all three agree. See `UpdateInstaller`.
 
-It is not enough later, because it requires the user to think of it. [Sparkle](https://sparkle-project.org)
-is the standard answer: an appcast XML feed, EdDSA signatures, in-app prompts.
-Worth adding once there are users to update; a "new version available" item in
-the menu bar is a cheap intermediate step.
+Re-running the install line still upgrades in place, and it is still the way in
+when the app cannot install over itself.
+
+A dev build cannot. The archive holds `ParrotFlow.app` signed as
+`com.parrotflow.app`; a dev bundle is `ParrotFlowDev.app` signed as
+`com.parrotflow.app.dev`. Moving one over the other would not update the dev
+build — it would leave the released app under the dev build's name, reading the
+other config directory, writing the other log, and listening to the other key.
+So the dev build says a release exists and offers the install command instead of
+the button. A dev build is updated by building it.
+
+[Sparkle](https://sparkle-project.org) is what most apps use for this, and the
+window everyone recognises is Sparkle's. It was not adopted: it brings an
+appcast XML feed to publish on every release and an EdDSA key to sign with, and
+it replaces the pinned-certificate check that already ties the update path to
+`install.sh`.
 
 Note that the upgrade path is exactly where the stable signing certificate earns
 its keep. Replacing the bundle with one signed by a different identity loses


### PR DESCRIPTION
Two things, both hit while taking the 0.7.0 update.

## The dialog could not be read

The release body was raw Markdown in an NSAlert. Two links per bullet meant most
of the window was URLs, and an alert grows to fit its text, so a long release
pushed its own buttons off the screen.

`ReleaseNotes` now parses it and draws it — headings, bullets, `code`, **bold**,
and a link as the words it was written on, still clickable. The notes sit in a
scroll view with a ground of their own. The pane takes the height of the notes,
capped at 380 points or the screen minus 260. Measured, not judged by eye:

```
2 fixes:  pane=108  text=88   scrolls=false
24 fixes: pane=380  text=484  scrolls=true
```

`UpdatePanel` replaces the alert. NSAlert could not do the layout: with an
accessory view it puts at most two short buttons in a row, so three answers came
out stacked. The panel is the app's own surface, with Later, Skip this version
and Update and restart in one row.

There is no Apple-provided update window. The one every app shows is Sparkle's.
It was not adopted, and `docs/distribution.md` says why.

## A dev build could not install an update

It unpacked the archive, looked inside for `ParrotFlowDev.app`, and stopped with
"the archive does not contain ParrotFlowDev.app". No release has ever contained
that. The identity check had the same shape — it compared against
`Bundle.main.bundleIdentifier`, which on a dev build is `com.parrotflow.app.dev`.

Both now use what the release actually ships, `ParrotFlow.app` and
`com.parrotflow.app`, the same two values `scripts/install.sh` pins. That also
fixes it for anyone who renamed the app after installing it.

A dev build still cannot take an update, and should not: moving `ParrotFlow.app`
over `ParrotFlowDev.app` leaves the released app under the dev build's name,
reading the other config directory, writing the other log, and listening to the
other key. `UpdateInstaller.blocker` says so before anything is downloaded, and
covers the read-only case it used to handle alone. Those builds get "Copy the
upgrade command" and the reason.

## How it was checked

- `--panels update` puts the panel on screen with a release long enough to
  scroll. Run from this branch's build.
- `scripts/check-pinned-certificate.sh` passes — both install paths still pin
  the same certificate.
- Notes height measured against short and long bodies, numbers above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)