### PR TITLE
feat!: every model in one place, and names are one stage

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -31,6 +31,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// Shown only while `config.problems()` has something in it.
     private var configProblemsItem: NSMenuItem!
+    private var addKeyItem: NSMenuItem!
 
     /// What was last said out loud, so a problem is announced when it appears
     /// and not on every save of an unrelated setting.
@@ -519,12 +520,50 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// On change rather than on every load: the file is watched, so saving an
     /// unrelated line runs this again, and a notice that fires every time you
     /// edit your own config is one you learn to ignore.
+    private func announceIfNew(_ problems: [String]) {
+        defer { announcedProblems = problems }
+        guard problems != announcedProblems, let first = problems.first else { return }
+        let others = problems.count - 1
+        flash(others > 0 ? "\(first)  (+\(others) more)" : first, tone: .caution)
+    }
+
     /// Models already asked about this run, so saving config.yaml — which
     /// reloads it — does not ask again for one that was declined.
+    ///
+    /// Declining is meant to stick, which is why nothing clears this. The way
+    /// back is the menu — see `addKeyItem` — and not commenting the model out
+    /// and back in, which reloads the config but leaves the name in here.
     private var askedForKey: Set<String> = []
 
     /// A key prompt a running dictation pushed back, waiting for idle.
     private var keyPromptDeferred = false
+
+    /// Cloud models with no key in the keychain yet, for the menu row that
+    /// offers to add one.
+    ///
+    /// Held rather than worked out in `updateUI`, which runs on every change of
+    /// state: each name costs a keychain lookup, and an unsigned build is asked
+    /// about by macOS on every one of them. Refreshed where the answer can
+    /// change — a config load, and a key being stored.
+    private var keylessModels: [String] = []
+
+    private func refreshKeylessModels() {
+        keylessModels = config.modelsByName.values
+            .filter { $0.key.kind == .keychain && $0.key.resolve() == nil }
+            .map(\.name)
+            .sorted()
+    }
+
+    /// The menu's way in, for a key that was declined or never offered.
+    ///
+    /// Declining is remembered for the run, so the dialog does not come back on
+    /// its own — and commenting the model out and back in does not bring it
+    /// back either, because the name stays in `askedForKey`. This is the way
+    /// back, and it is a menu row rather than a terminal command.
+    @objc private func addMissingKeys() {
+        for name in keylessModels { askedForKey.remove(name) }
+        askForMissingKeys()
+    }
 
     /// Ask for the key of any keychain-backed model that has none.
     ///
@@ -556,12 +595,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             askedForKey.insert(spec.name)
             NSApp.activate(ignoringOtherApps: true)
             let alert = NSAlert()
-            alert.messageText = "\(spec.name) needs an API key"
-            alert.informativeText =
-                "\(spec.name) sends text to \(spec.url). Paste its key and it is "
-                + "kept in your \(Keychain.service) keychain — not in config.yaml, "
-                + "which is a file people paste to each other.\n\n"
-                + "You can do this later with: ParrotFlow --set-key \(spec.name)"
+            alert.messageText = "API key for \(spec.name)"
+            // One line, and it is the one worth reading: naming the host is how
+            // somebody sees where their words are about to go.
+            alert.informativeText = "Sent to \(spec.host). Kept in your keychain."
             let field = KeyField(frame: NSRect(x: 0, y: 0, width: 320, height: 24))
             field.placeholderString = "Paste the key"
             alert.accessoryView = field
@@ -584,15 +621,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // problem it names is the one just fixed.
         if stored {
             configProblems = config.problems()
+            refreshKeylessModels()
             updateUI()
         }
-    }
-
-    private func announceIfNew(_ problems: [String]) {
-        defer { announcedProblems = problems }
-        guard problems != announcedProblems, let first = problems.first else { return }
-        let others = problems.count - 1
-        flash(others > 0 ? "\(first)  (+\(others) more)" : first, tone: .caution)
     }
 
     private func applyConfig() {
@@ -613,6 +644,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // about your config belongs; the notice is for what changed.
         for notice in config.notices() { Log.write("config: \(notice)") }
         announceIfNew(configProblems)
+        refreshKeylessModels()
         // Async so a launch is not held behind a modal, and so the menu bar is
         // up before anything sits in front of it.
         DispatchQueue.main.async { [weak self] in self?.askForMissingKeys() }
@@ -3994,6 +4026,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         configProblemsItem.isHidden = true
         menu.addItem(configProblemsItem)
 
+        // Beside the problem it answers. A model with no key is reported by the
+        // row above and fixed by this one, so the reading and the remedy are
+        // one line apart.
+        addKeyItem = NSMenuItem(title: "", action: #selector(addMissingKeys), keyEquivalent: "")
+        addKeyItem.target = self
+        addKeyItem.isHidden = true
+        menu.addItem(addKeyItem)
+
         updateItem = NSMenuItem(title: "", action: #selector(showUpdate), keyEquivalent: "")
         updateItem.target = self
         updateItem.isHidden = true
@@ -4116,6 +4156,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         } else {
             statusInfoItem.title = "Idle  ·  \(shortcut)"
         }
+
+        addKeyItem.isHidden = keylessModels.isEmpty
+        addKeyItem.title = keylessModels.count == 1
+            ? "Add API Key for \(keylessModels[0])…"
+            : "Add API Keys…"
 
         configProblemsItem.isHidden = configProblems.isEmpty
         configProblemsItem.title = configProblems.count == 1

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1820,6 +1820,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         beginProgress("Thinking…")
         let llmConfig = llmConfig(for: .router)
         let freeForm = config.freeForm
+        let catchAll = config.commands.catchAll
 
         Task { [weak self] in
             do {
@@ -1840,7 +1841,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         // the whole specification, so it goes through unsplit,
                         // exactly as it would to a prompt of your own.
                         Log.write("router: \"\(command)\" → \(FreeForm.name)")
-                        self.runTransform(FreeForm.prompt(for: command).asTransform, instruction: command)
+                        self.runTransform(
+                            FreeForm.prompt(for: command).asTransform(model: catchAll),
+                            instruction: command
+                        )
                     case .none:
                         // Nothing fits. Deliberately not falling through to
                         // dictation: the wake phrase means you were not
@@ -3573,6 +3577,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         beginProgress("Thinking…")
         let llm = llmConfig(for: .router)
         let freeForm = config.freeForm
+        let catchAll = config.commands.catchAll
         Task { [weak self] in
             do {
                 let decision = try await Router.route(
@@ -3592,7 +3597,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         )
                     case .anything:
                         Log.write("inline router: \"\(instruction)\" → \(FreeForm.name)")
-                        run(FreeForm.prompt(for: instruction).asTransform)
+                        run(FreeForm.prompt(for: instruction).asTransform(model: catchAll))
                     case .none:
                         giveUp("Not something to change in the text: \"\(instruction)\"")
                     }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3579,7 +3579,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         guard config.llmEnabled else {
-            giveUp("\"\(instruction)\" needs the local model — llm.enabled is false")
+            giveUp("\"\(instruction)\" needs a model — `models:` defines none")
             return
         }
 

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1698,7 +1698,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // to warm up when that is not a local model — `LocalLLM.warmUp` says so
         // too, and this saves the task.
         let llm = llmConfig(for: .router)
-        guard config.llm.enabled, llm.keepLoaded, llm.api == .ollama else { return }
+        guard config.llmEnabled, llm.keepLoaded, llm.api == .ollama else { return }
         let system = Router.prompt(
             for: Catalogue(transforms: config.transforms), freeForm: config.freeForm
         )
@@ -1765,7 +1765,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         keepWarmTimer?.invalidate()
         keepWarmTimer = nil
         let router = llmConfig(for: .router)
-        guard config.llm.enabled, router.keepLoaded, router.api == .ollama else { return }
+        guard config.llmEnabled, router.keepLoaded, router.api == .ollama else { return }
 
         let timer = Timer.scheduledTimer(withTimeInterval: 15, repeats: true) { [weak self] _ in
             self?.keepWarmTick()
@@ -1825,7 +1825,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        guard config.llm.enabled else {
+        guard config.llmEnabled else {
             flash("Didn't understand \"\(command)\" — enable llm in config for free-form commands", tone: .caution)
             return
         }
@@ -1957,7 +1957,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// The spelling extractor, which is a second model call rather than part of
     /// routing — it reads the last transcript and returns a rule, not a name.
     private func interpretSpelling(_ command: String) {
-        guard config.llm.enabled else {
+        guard config.llmEnabled else {
             endProgress()
             flash("Didn't understand \"\(command)\" — enable llm in config for free-form commands", tone: .caution)
             return
@@ -3578,7 +3578,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        guard config.llm.enabled else {
+        guard config.llmEnabled else {
             giveUp("\"\(instruction)\" needs the local model — llm.enabled is false")
             return
         }
@@ -3646,7 +3646,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // "…by the way parrot, Tasmin spells T A S M E E N" — the rule has
             // to be read out of the instruction first, which is a model call of
             // its own and not part of routing.
-            guard config.llm.enabled else {
+            guard config.llmEnabled else {
                 giveUpInline(
                     text,
                     why: "\"\(instruction)\" needs the local model to read the spelling",

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -168,7 +168,7 @@ enum CheckConfigCommand {
         }
         print("  · runs on           default=\(config.modelName(for: .general))"
             + "  router=\(config.modelName(for: .router))"
-            + "  vocabulary=\(config.modelName(for: .vocabulary))")
+            + "  spelling=\(config.modelName(for: .spelling))")
         let moved = config.transforms.filter { transform in
             transform.isPrompt && config.model(for: transform) != config.model()
         }
@@ -214,7 +214,7 @@ enum CheckConfigCommand {
         if config.freeForm {
             print("      free-form  \(FreeForm.name) — \(FreeForm.prompt.description)")
         } else {
-            print("  · free_form         off — an instruction no prompt covers is refused")
+            print("  · catch_all         off — an instruction no prompt covers is refused")
         }
 
         // How many rules each table holds, which nothing else says. The
@@ -285,14 +285,15 @@ enum CheckConfigCommand {
 
         // LLM — what is where is in the models table above; this is the switch
         // that turns all of it off, and the pinning that only Ollama has.
-        if config.llm.enabled {
+        if config.llmEnabled {
             let router = config.model(for: .router)
-            print("  · llm               enabled, \(config.modelsByName.count) model(s)")
+            print("  · models            \(config.modelsByName.count), default"
+                + " \(config.defaultModelName)")
             if router.api == .ollama {
                 print("  · keep loaded       \(router.keepLoaded ? "on (\(router.model) pinned in RAM)" : "off (Ollama unloads after 5 min; +7-10s on a cold call)")")
             }
         } else {
-            print("  · llm               disabled — no free-form spoken commands")
+            print("  · models            none — nothing calls a model")
         }
 
         switch config.updates.afterDays {

--- a/Sources/ParrotFlow/CommandTestCommand.swift
+++ b/Sources/ParrotFlow/CommandTestCommand.swift
@@ -50,7 +50,7 @@ enum CommandTestCommand {
         }
 
         guard config.llmEnabled else {
-            print("→ needs the LLM, but llm.enabled is false")
+            print("→ needs a model, but `models:` defines none")
             return 1
         }
 

--- a/Sources/ParrotFlow/CommandTestCommand.swift
+++ b/Sources/ParrotFlow/CommandTestCommand.swift
@@ -49,7 +49,7 @@ enum CommandTestCommand {
             return 0
         }
 
-        guard config.llm.enabled else {
+        guard config.llmEnabled else {
             print("→ needs the LLM, but llm.enabled is false")
             return 1
         }

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1603,14 +1603,16 @@ struct Config: Decodable, Equatable {
         ///     - vocabulary
         ///     - stage: vocabulary
         ///       when: vocabulary.count > 0
-        ///       fuzzy: false
+        ///       near_misses: false
+        ///       review: gpt
         ///       max_slots: 4
         struct PipelineEntry: Decodable {
             let name: String
             var transform: String?
             var prompt: String?
             var caps: VocabularyJudge.Caps?
-            var fuzzy: Bool?
+            var nearMisses: Bool?
+            var review: String?
             var when: String?
             var unless: String?
             var app: String?
@@ -1618,7 +1620,9 @@ struct Config: Decodable, Equatable {
             var namesBoth = false
 
             private enum CodingKeys: String, CodingKey {
-                case stage, transform, prompt, vocabulary, fuzzy, when, unless, app
+                case stage, transform, prompt, vocabulary, when, unless, app
+                case nearMisses = "near_misses"
+                case review
                 case maxSlots = "max_slots"
                 case maxReadings = "max_readings"
                 case maxPerSlot = "max_per_slot"
@@ -1669,7 +1673,8 @@ struct Config: Decodable, Equatable {
                     // Read only so `Caps.problems` can refuse it by name.
                     caps.readings = try c.decodeIfPresent(Int.self, forKey: .maxReadings)
                     self.caps = caps
-                    fuzzy = try c.decodeIfPresent(Bool.self, forKey: .fuzzy)
+                    nearMisses = try c.decodeIfPresent(Bool.self, forKey: .nearMisses)
+                    review = try c.decodeIfPresent(String.self, forKey: .review)
                 }
                 when = try c.decodeIfPresent(String.self, forKey: .when)
                 unless = try c.decodeIfPresent(String.self, forKey: .unless)
@@ -1729,10 +1734,6 @@ struct Config: Decodable, Equatable {
                 }
             }
 
-            /// Fuzzy matching compares spellings, so a pattern is not a
-            /// candidate and neither is a deletion — there is nothing to match
-            /// against.
-            var isFuzzyCandidate: Bool { !isRegex && !isDeletion }
         }
 
         init() {}
@@ -1814,7 +1815,8 @@ struct Config: Decodable, Equatable {
                             return Pipeline.Step(
                                 stage: stage, transform: entry.transform,
                                 prompt: entry.prompt, caps: entry.caps,
-                                fuzzy: entry.fuzzy, when: entry.when,
+                                nearMisses: entry.nearMisses, review: entry.review,
+                                when: entry.when,
                                 unless: entry.unless, app: entry.app
                             )
                         }
@@ -1829,7 +1831,7 @@ struct Config: Decodable, Equatable {
                 throw ConfigError.invalidValue(
                     key: "transcription.pipelines",
                     value: "a bare list, or a language with nothing under it",
-                    expected: "a language, then its stages — `default: [replacements, fuzzy]`, "
+                    expected: "a language, then its stages — `default: [vocabulary, numbers]`, "
                         + "or `fr:` with `- replacements` under it"
                 )
             }
@@ -1842,20 +1844,19 @@ struct Config: Decodable, Equatable {
             for key in [LegacyKeys.numbers, .fuzzyMatching] where present(key) {
                 retired.append(key.stringValue)
             }
-            do {
-                if let grouped = try c.decodeIfPresent(
-                    [String: [String]].self, forKey: .replacements
-                ) {
-                    self.replacements = grouped
-                }
-            } catch {
-                // The flat `heard: corrected` form was the earlier shape. Say so
-                // plainly rather than leaving a type mismatch to be decoded.
-                throw ConfigError.invalidValue(
-                    key: "transcription.replacements",
-                    value: "a flat mapping",
-                    expected: "the spelling you want, listing its mishearings — Tasmeen: [Tasmin, Tasmine]"
-                )
+            // Retired, and read only so it can be refused. It held two kinds
+            // of rule and neither belongs here any more: a name the recogniser
+            // mangles goes in vocabulary.yaml, where it is reviewed in context,
+            // and a mechanical rule goes in a transform's `replace:`, which
+            // needs no review and already takes regexes, deletions, `{{lists}}`
+            // and `when:`/`app:` conditions. Nothing was left in the middle.
+            if let container = try? c.decodeIfPresent(
+                [String: [String]].self, forKey: .replacements
+            ), container != nil {
+                retired.append("replacements")
+            } else if (try? c.decodeIfPresent([String: String].self, forKey: .replacements))
+                ?? nil != nil {
+                retired.append("replacements")
             }
         }
     }
@@ -2252,7 +2253,13 @@ struct Config: Decodable, Equatable {
             found.append("\(key): \(Self.movedKeys[key] ?? "no longer does anything")")
         }
         for key in transcription.retired {
-            found.append("transcription.\(key) no longer does anything — it is a pipeline stage now")
+            let said = key == "replacements"
+                ? "a name the recogniser mangles goes in vocabulary.yaml, where the"
+                    + " `vocabulary` stage reviews it in context; a mechanical rule goes"
+                    + " in a transform's `replace:`, which takes regexes, deletions and"
+                    + " `{{lists}}` and needs no review"
+                : "it is a pipeline stage now"
+            found.append("transcription.\(key) no longer does anything — \(said)")
         }
         for name in Set(transcription.unknownStages).sorted() {
             found.append("pipelines: \"\(name)\" is not a stage — have: "

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -25,13 +25,22 @@ struct Config: Decodable, Equatable {
     var audio: Audio = Audio()
     var feedback: Feedback = Feedback()
     var transcription: Transcription = Transcription()
-    var llm: LLM = LLM()
+    /// Whether there is a model to call at all.
+    ///
+    /// `llm.enabled` used to say this, from a time when the model was implicit
+    /// and there was no other way to mean "I have none". A config that defines
+    /// no model says the same thing and cannot fall out of step with itself.
+    var llmEnabled: Bool { !models.isEmpty }
     /// Every model this config can reach, by the name it was given.
     ///
     /// A name is all a transform ever mentions — never a vendor, never an
     /// endpoint. Empty means the one implied by `llm:`, which is what every
     /// config written before this said and still says.
     var models: [String: ModelSpec] = [:]
+    var commands = Commands()
+    /// Top-level keys that were read purely so they can be refused, with the
+    /// line that replaces them. See `problems`.
+    var retiredKeys: [String] = []
     var updates: UpdatePolicy = UpdatePolicy()
     var logging: Logging = Logging()
     /// Everything nameable: `transforms:`, plus anything still written under
@@ -66,7 +75,11 @@ struct Config: Decodable, Equatable {
     /// to rewrite your selection. The router is what stops that — it answers
     /// NONE for "not an edit" and ANY for "an edit with no tool", measured at
     /// 18/19 — and `confirm` is what makes the residue survivable.
-    var freeForm: Bool = true
+    /// Whether an instruction no capability covers is attempted or refused.
+    ///
+    /// A view over `commands.catch_all`, kept because a dozen call sites ask
+    /// this question and none of them care where the answer is written.
+    var freeForm: Bool { commands.catchAllEnabled }
 
     /// Read from `vocabulary.yaml` beside the config, not from `config.yaml`.
     /// It is maintained by the app rather than by hand — see `Vocabulary`.
@@ -87,7 +100,7 @@ struct Config: Decodable, Equatable {
     var lists: [String: [String]] = [:]
 
     enum CodingKeys: String, CodingKey {
-        case hotkey, audio, feedback, transcription, llm, models
+        case hotkey, audio, feedback, transcription, llm, models, commands
         case transforms, prompts, updates, logging
         case freeForm = "free_form"
         case lists
@@ -1217,6 +1230,9 @@ struct Config: Decodable, Equatable {
     /// like the others: they run on every dictation, they are what you wait
     /// on with the pill on screen, and they carry your transcript. Local is
     /// the right answer for both far longer than it is for a rewrite.
+    /// Retired. Decoded only to notice that a config still carries `llm:`, so
+    /// `problems` can refuse it and name what replaced each key. Nothing reads
+    /// a value out of it.
     struct LLM: Codable, Equatable {
         var enabled: Bool = true
         var model: String = "gemma4:e4b-mlx"
@@ -1263,28 +1279,91 @@ struct Config: Decodable, Equatable {
         case general
         /// "hey parrot, …", said before anything else and waited on.
         case router
-        /// The KEEP/REVERT judge, which runs on every dictation.
+        /// The KEEP/REVERT judge. Bound on the pipeline stage that runs it,
+        /// not here — see `Pipeline.Step.review`.
         case vocabulary
+        /// Reading a rule out of a spoken spelling.
+        case spelling
+    }
+
+    /// What the activation phrase can reach, and which model does each part.
+    ///
+    /// The router picks a capability; `spelling` and `catch_all` are two of the
+    /// things it can pick. All three are the spoken-command path, so they bind
+    /// here rather than under a key named after the technology.
+    ///
+    /// A model named nowhere runs on the default — the one entry in `models:`
+    /// carrying `default: true`.
+    struct Commands: Decodable, Equatable {
+        /// Matching what you said to a capability. Runs on every "hey parrot",
+        /// and it is what you wait on with the pill on screen.
+        var router: String = ""
+        /// Reading a rule out of "Tasmin spells T A S M E E N". A built-in, so
+        /// it can carry no `model:` of its own the way a transform can.
+        var spelling: String = ""
+        /// The instruction no capability covers — "use the 24 hour clock".
+        ///
+        /// `false` refuses them instead. It was `free_form:` at the top level,
+        /// and it is here because it is one of the router's answers rather than
+        /// a setting of its own.
+        var catchAll: ModelRef? = ModelRef()
+        /// Whether the catch-all is allowed at all.
+        var catchAllEnabled = true
+
+        enum CodingKeys: String, CodingKey {
+            case router, spelling
+            case catchAll = "catch_all"
+        }
+
+        init() {}
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            self.init()
+            if let v = try c.decodeIfPresent(String.self, forKey: .router) { router = v }
+            if let v = try c.decodeIfPresent(String.self, forKey: .spelling) { spelling = v }
+            // Three spellings, because the key answers two questions at once:
+            // whether the catch-all runs, and what it runs on. `false` is the
+            // only one that turns it off.
+            if let on = ((try? c.decodeIfPresent(Bool.self, forKey: .catchAll)) ?? nil) {
+                catchAllEnabled = on
+                catchAll = on ? ModelRef() : nil
+            } else if let ref = try c.decodeIfPresent(ModelRef.self, forKey: .catchAll) {
+                catchAll = ref
+                catchAllEnabled = true
+            }
+        }
     }
 
     /// Every model this config can reach, by name.
     ///
-    /// `local` is here whether or not `models:` mentions it: the old `llm:`
-    /// keys describe exactly one Ollama model, and that is the one everything
-    /// falls back to.
-    var modelsByName: [String: ModelSpec] {
-        var all = models
-        if all["local"] == nil {
-            all["local"] = ModelSpec(
-                name: "local", api: .ollama, model: llm.model, endpoint: llm.endpoint,
-                timeout: llm.timeoutSeconds, keepLoaded: llm.keepLoaded
-            )
-        }
-        return all
-    }
+    /// Only what `models:` defines. There is no implicit entry.
+    ///
+    /// `llm:` used to describe one Ollama model called `local`, and everything
+    /// fell back to it. A model you cannot see in the file is a model nobody
+    /// can reason about — it read as the app's own rather than as yours, and
+    /// it was built from this struct's defaults on a config that named no
+    /// Ollama model at all. `llm:` is refused now; see `Config.problems`.
+    var modelsByName: [String: ModelSpec] { models }
 
     func model(named name: String) -> ModelSpec? {
         modelsByName[name.trimmingCharacters(in: .whitespacesAndNewlines)]
+    }
+
+    /// The name everything falls back to: the entry carrying `default: true`,
+    /// or the only entry there is.
+    ///
+    /// One model needs no flag — there is nothing to choose between. Several
+    /// with none marked is refused rather than guessed at, so this returning
+    /// the first sorted name is a value for the error path to print, not a
+    /// choice anybody relies on.
+    var defaultModelName: String {
+        let all = modelsByName
+        if let claimed = all.values.filter(\.isDefault).map(\.name).sorted().first {
+            return claimed
+        }
+        if all.count == 1, let only = all.keys.first { return only }
+        return all.keys.sorted().first ?? ""
     }
 
     /// The name a job runs under when nothing overrides it.
@@ -1292,12 +1371,14 @@ struct Config: Decodable, Equatable {
         func written(_ value: String) -> String {
             value.trimmingCharacters(in: .whitespacesAndNewlines)
         }
-        let fallback = written(llm.defaultModel).isEmpty ? "local" : written(llm.defaultModel)
+        let fallback = defaultModelName
         switch job {
         case .general: return fallback
-        case .router: return written(llm.router).isEmpty ? fallback : written(llm.router)
+        case .router: return written(commands.router).isEmpty ? fallback : written(commands.router)
+        case .spelling:
+            return written(commands.spelling).isEmpty ? fallback : written(commands.spelling)
         case .vocabulary:
-            return written(llm.vocabulary).isEmpty ? fallback : written(llm.vocabulary)
+            return fallback
         }
     }
 
@@ -1340,12 +1421,24 @@ struct Config: Decodable, Equatable {
         }
         let names = all.keys.sorted().joined(separator: ", ")
         for (key, written) in [
-            ("llm.default", llm.defaultModel), ("llm.router", llm.router),
-            ("llm.vocabulary", llm.vocabulary),
+            ("commands.router", commands.router), ("commands.spelling", commands.spelling),
         ] {
             let name = written.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !name.isEmpty, all[name] == nil else { continue }
             found.append("\(key): no model named \"\(name)\" — have: \(names)")
+        }
+
+        // Which model everything falls back to. One entry needs no flag —
+        // there is nothing to choose between — so this only speaks up when
+        // there is a choice and the file does not make it, or makes it twice.
+        let claimed = all.values.filter(\.isDefault).map(\.name).sorted()
+        if claimed.count > 1 {
+            found.append("models: \(claimed.joined(separator: " and ")) both say"
+                + " `default: true` — exactly one may")
+        } else if claimed.isEmpty, all.count > 1 {
+            found.append("models: none says `default: true`, and there are"
+                + " \(all.count) to choose from — put it on the one that should"
+                + " run what names no model: \(names)")
         }
         for transform in transforms {
             guard let ref = transform.model else { continue }
@@ -2030,7 +2123,6 @@ struct Config: Decodable, Equatable {
         if let transcription = try c.decodeIfPresent(Transcription.self, forKey: .transcription) {
             self.transcription = transcription
         }
-        if let llm = try c.decodeIfPresent(LLM.self, forKey: .llm) { self.llm = llm }
         // Named after the key it was written under, because a spec cannot see
         // its own name and every log line and check prints one.
         if let models = try c.decodeIfPresent([String: ModelSpec].self, forKey: .models) {
@@ -2042,6 +2134,9 @@ struct Config: Decodable, Equatable {
                 spec.key.adopt(account: entry.key, api: spec.api)
                 out[entry.key] = spec
             }
+        }
+        if let commands = try c.decodeIfPresent(Commands.self, forKey: .commands) {
+            self.commands = commands
         }
         if let updates = try c.decodeIfPresent(UpdatePolicy.self, forKey: .updates) {
             self.updates = updates
@@ -2056,8 +2151,13 @@ struct Config: Decodable, Equatable {
         let assembled = Self.assembled(entries)
         transforms = assembled.kept
         unreadableTransforms = assembled.unreadable
-        if let freeForm = try c.decodeIfPresent(Bool.self, forKey: .freeForm) {
-            self.freeForm = freeForm
+        // Read only so `--check-config` can refuse it and name what replaced
+        // it. `commands.catch_all` is the setting now.
+        if ((try? c.decodeIfPresent(Bool.self, forKey: .freeForm)) ?? nil) != nil {
+            retiredKeys.append("free_form")
+        }
+        if ((try? c.decodeIfPresent(LLM.self, forKey: .llm)) ?? nil) != nil {
+            retiredKeys.append("llm")
         }
         // Decoded here because this initialiser is hand-rolled. A property and
         // a CodingKey are not enough: miss this line and the lists work in a
@@ -2129,8 +2229,28 @@ struct Config: Decodable, Equatable {
         return found
     }
 
+    /// What a config written for the old shape is told, key by key.
+    ///
+    /// Not read, not honoured, and not quietly ignored. An unknown key is
+    /// dropped by `Decodable` without a word, so a config that still says
+    /// `llm:` would load, bind nothing, and look fine until a dictation did
+    /// nothing — which is the failure this list exists to prevent.
+    private static let movedKeys = [
+        "llm": "`llm.default` is now `default: true` on one entry in `models:`;"
+            + " `llm.router` and `llm.spelling` are now `commands.router` and"
+            + " `commands.spelling`; `llm.vocabulary` is now `review:` on the"
+            + " `vocabulary` stage; `llm.enabled` is gone — a config with no"
+            + " `models:` calls no model; the four keys that described a model"
+            + " are an entry in `models:`",
+        "free_form": "now `commands.catch_all`, which also takes the model it"
+            + " runs on: `catch_all: gpt`, or `false` to refuse them",
+    ]
+
     func problems() -> [String] {
         var found: [String] = []
+        for key in retiredKeys.sorted() {
+            found.append("\(key): \(Self.movedKeys[key] ?? "no longer does anything")")
+        }
         for key in transcription.retired {
             found.append("transcription.\(key) no longer does anything — it is a pipeline stage now")
         }

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1171,11 +1171,17 @@ struct Config: Decodable, Equatable {
         /// The transform-shaped view, for the catalogue — which now holds
         /// transforms rather than prompts, and has to be able to hold the
         /// free-form one too. It is a prompt that no config declares.
-        var asTransform: Transform {
-            Transform(
+        ///
+        /// `model:` is what `commands.catch_all` binds. A prompt no config
+        /// declares can carry no `model:` of its own, so the caller passes the
+        /// one the config named for it.
+        func asTransform(model: ModelRef? = nil) -> Transform {
+            var made = Transform(
                 name: name, description: description, display: display,
                 confirm: confirm, body: .prompt(content)
             )
+            made.model = model
+            return made
         }
 
         /// Where the spoken instruction goes if the prompt asks for it inline.
@@ -1427,6 +1433,17 @@ struct Config: Decodable, Equatable {
             guard !name.isEmpty, all[name] == nil else { continue }
             found.append("\(key): no model named \"\(name)\" — have: \(names)")
         }
+        // The third binding, and the only one that is a `ModelRef` rather than
+        // a bare name, so it can also carry what only a `models:` entry may
+        // say. Unchecked, a typo here costs the model you chose the catch-all
+        // for — the one case that most wants a model of its own.
+        if let ref = commands.catchAll {
+            found += ref.rejected.map { "commands.catch_all: \($0)" }
+            let name = ref.use.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !name.isEmpty, all[name] == nil {
+                found.append("commands.catch_all: no model named \"\(name)\" — have: \(names)")
+            }
+        }
 
         // Which model everything falls back to. One entry needs no flag —
         // there is nothing to choose between — so this only speaks up when
@@ -1613,6 +1630,7 @@ struct Config: Decodable, Equatable {
             var caps: VocabularyJudge.Caps?
             var nearMisses: Bool?
             var review: String?
+            var reviewEnabled: Bool?
             var when: String?
             var unless: String?
             var app: String?
@@ -1674,7 +1692,14 @@ struct Config: Decodable, Equatable {
                     caps.readings = try c.decodeIfPresent(Int.self, forKey: .maxReadings)
                     self.caps = caps
                     nearMisses = try c.decodeIfPresent(Bool.self, forKey: .nearMisses)
-                    review = try c.decodeIfPresent(String.self, forKey: .review)
+                    // Two spellings, like `catch_all:`: the key says whether
+                    // the review runs and what it runs on. `false` is the only
+                    // one that turns it off.
+                    if let on = ((try? c.decodeIfPresent(Bool.self, forKey: .review)) ?? nil) {
+                        reviewEnabled = on
+                    } else {
+                        review = try c.decodeIfPresent(String.self, forKey: .review)
+                    }
                 }
                 when = try c.decodeIfPresent(String.self, forKey: .when)
                 unless = try c.decodeIfPresent(String.self, forKey: .unless)
@@ -1816,6 +1841,7 @@ struct Config: Decodable, Equatable {
                                 stage: stage, transform: entry.transform,
                                 prompt: entry.prompt, caps: entry.caps,
                                 nearMisses: entry.nearMisses, review: entry.review,
+                                reviewEnabled: entry.reviewEnabled,
                                 when: entry.when,
                                 unless: entry.unless, app: entry.app
                             )
@@ -2321,6 +2347,16 @@ struct Config: Decodable, Equatable {
                         + (transforms.isEmpty ? " — `transforms:` is empty"
                             : " — have: \(transforms.map(\.name).joined(separator: ", "))"))
                 }
+            }
+            // `review:` names a model the same way `commands.router` does, and
+            // an unresolved one falls back to the default rather than failing.
+            // Said here rather than in `modelProblems`, because which pipeline
+            // wrote it is half the answer.
+            for step in pipeline.steps where step.stage == .vocabulary {
+                let named = (step.review ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !named.isEmpty, modelsByName[named] == nil else { continue }
+                found.append("pipeline \(language): `review: \(named)` names no model — have: "
+                    + modelsByName.keys.sorted().joined(separator: ", "))
             }
         }
         return found

--- a/Sources/ParrotFlow/ModelSpec.swift
+++ b/Sources/ParrotFlow/ModelSpec.swift
@@ -57,6 +57,14 @@ struct ModelSpec: Equatable {
     var timeout: TimeInterval = 20
     /// Ollama only — see `LocalLLM.pinned`. Ignored by every other api.
     var keepLoaded: Bool = true
+    /// The model everything falls back to when nothing names one.
+    ///
+    /// Written on the model rather than as a name somewhere else, so the entry
+    /// says what it is instead of a second place repeating its key. With one
+    /// model configured it is the default whether or not it says so; with
+    /// several, exactly one must claim it, and `--check-config` refuses both
+    /// none and more than one — see `Config.modelProblems`.
+    var isDefault: Bool = false
     /// Merged into the request body last, unvalidated.
     ///
     /// The escape hatch that makes a provider this app has never been run
@@ -317,6 +325,7 @@ extension ModelSpec: Decodable {
         case maxTokens = "max_tokens"
         case timeoutSeconds = "timeout_seconds"
         case keepLoaded = "keep_loaded"
+        case isDefault = "default"
     }
 
     init(from decoder: Decoder) throws {
@@ -353,6 +362,9 @@ extension ModelSpec: Decodable {
         }
         if let value = try c.decodeIfPresent(Bool.self, forKey: .keepLoaded) {
             keepLoaded = value
+        }
+        if let value = try c.decodeIfPresent(Bool.self, forKey: .isDefault) {
+            isDefault = value
         }
         params = try c.decodeIfPresent([String: ModelParam].self, forKey: .params) ?? [:]
     }

--- a/Sources/ParrotFlow/ModelSpec.swift
+++ b/Sources/ParrotFlow/ModelSpec.swift
@@ -74,6 +74,9 @@ struct ModelSpec: Equatable {
         return base.hasSuffix("/") ? String(base.dropLast()) : base
     }
 
+    /// Just the host, for a line with room for one thing — `api.openai.com`.
+    var host: String { URL(string: url)?.host ?? url }
+
     /// How it reads in a log line or a check: `gpt (openai, gpt-5.6-luna, reasoning low)`.
     var described: String {
         "\(name) (\(api.rawValue), \(model.isEmpty ? "no model" : model),"

--- a/Sources/ParrotFlow/ModelSpec.swift
+++ b/Sources/ParrotFlow/ModelSpec.swift
@@ -236,6 +236,10 @@ struct ModelRef: Equatable, Decodable {
 
     init() {}
 
+    /// Naming a model and changing nothing about it — what a `review:` or any
+    /// other binding that takes a bare name means.
+    init(use name: String) { use = name }
+
     init(from decoder: Decoder) throws {
         if let scalar = try? decoder.singleValueContainer().decode(String.self) {
             use = scalar.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -31,11 +31,14 @@ struct Pipeline: Equatable, Codable {
     /// drift apart — a stage that cannot be spelled is a stage nobody can ask
     /// for.
     enum Stage: String, Equatable, Codable, CaseIterable {
-        /// Literal and regex substitutions from `transcription.replacements`.
-        case replacements
-        /// The same table, used to catch spellings it does not contain.
-        /// Meaningless before `replacements` — see `validate`.
-        case fuzzy
+        /// Names: matched from `vocabulary.yaml`, then each match put to a
+        /// model to keep or revert. `near_misses:` and `review:` on the step
+        /// say how far it reaches and who decides — see `Step`.
+        ///
+        /// One stage because it was always one algorithm. It was written as
+        /// three — `replacements` wrote the exact matches, `fuzzy` caught the
+        /// near ones, `vocabulary` judged them — and the order they had to run
+        /// in was enforced by hand, because the three were never independent.
         /// Spoken numbers as digits, in the language its own pass resolves.
         case numbers
         /// What is on screen around the field, published as `context.*` and
@@ -126,8 +129,14 @@ struct Pipeline: Equatable, Codable {
         /// How many places may be judged at once — see `VocabularyJudge.Caps`.
         /// Absent on every other stage.
         var caps: VocabularyJudge.Caps?
-        /// Whether a `heard:` rendering also matches one edit away, for a
-        /// `vocabulary` stage. Absent means true.
+        /// Whether a `heard:` rendering also matches one edit away. Absent
+        /// means true.
+        ///
+        /// Written `near_misses:`. It was `fuzzy:`, beside a *stage* also
+        /// called `fuzzy` that did something else entirely — that one matched
+        /// the text against the rule table and rewrote it, and never saw a
+        /// vocabulary rendering at all. One word, two mechanisms, and the
+        /// stage is gone now.
         ///
         /// Optional rather than defaulted so that "not written" and "written
         /// false" stay tellable apart — the seeded config writes the key only
@@ -136,7 +145,15 @@ struct Pipeline: Equatable, Codable {
         /// Not the `fuzzy` *stage*, which is a different mechanism: that one
         /// matches the text against rule replacements after the exact pass,
         /// and never sees a vocabulary rendering at all.
-        var fuzzy: Bool?
+        var nearMisses: Bool?
+        /// The model that keeps or reverts each match, for a `vocabulary`
+        /// stage. Absent means the default; `false` means no review at all,
+        /// and every match ships as the rules wrote it.
+        ///
+        /// Bound on the step rather than globally because a pipeline is per
+        /// language, and the model that reads a French sentence need not be
+        /// the one that reads an English one.
+        var review: String?
         /// Run only when this matches the text as it stands *at this point* —
         /// after the stages before it, not on the original. That ordering is
         /// what lets a cheap deterministic stage make an expensive one
@@ -374,15 +391,6 @@ struct Pipeline: Equatable, Codable {
             }
             available.insert(Pipeline.namespace(of: step))
         }
-        if let fuzzy = stages.firstIndex(of: .fuzzy) {
-            guard let exact = stages.firstIndex(of: .replacements) else {
-                problems.append("fuzzy has no replacements before it; it reads that table and will find nothing")
-                return problems
-            }
-            if fuzzy < exact {
-                problems.append("fuzzy runs before replacements; it needs the exact pass to have run first")
-            }
-        }
         return problems
     }
 
@@ -393,19 +401,22 @@ struct Pipeline: Equatable, Codable {
     /// the stage then has to re-anchor by searching for the words — which is
     /// the mechanism that put the menu on the wrong `Versailles` (F3, F10).
     ///
-    /// `replacements` is not listed. The judge offers a rule's substitution
-    /// back as a reading, so the rules have to have fired first; that is the
-    /// one edit this stage is built to survive, by searching for the term. Put
-    /// `replacements` above `vocabulary:` and everything else below it.
+    /// Nothing that rewrites the transcript may run above it.
+    ///
+    /// The stage reads spans the acoustic pass measured before the pipeline
+    /// started, and any edit above it moves them (F10). The exact pass used to
+    /// be the one exception, because it ran as a separate `replacements` stage
+    /// and the judge needs the rules to have fired; it is inside this stage
+    /// now, so there is no exception left to state.
     private func vocabularyOrderProblems() -> [String] {
         guard let judge = stages.firstIndex(of: .vocabulary) else { return [] }
         let above = steps[..<judge]
-            .filter { $0.stage.editsText && $0.stage != .replacements }
+            .filter { $0.stage.editsText }
             .map { Pipeline.namespace(of: $0) }
         guard !above.isEmpty else { return [] }
         return ["vocabulary runs after \(above.joined(separator: ", ")), which rewrite the"
             + " transcript — the spans it was given no longer point at the same words."
-            + " Order: replacements, vocabulary, then the rest"]
+            + " Put it above everything that edits text"]
     }
 
     /// What is wrong with an expression, before a transcript ever reaches it.
@@ -732,55 +743,6 @@ struct Pipeline: Equatable, Codable {
             let seconds = CFAbsoluteTimeGetCurrent() - started
             output = result.text
 
-            // `vocabulary.count` answers one question: was a vocabulary term
-            // written into this transcript? Not "by which mechanism" — sound
-            // and exact rules are both ways of getting the same term in, and a
-            // caller asking whether to check the result does not care which
-            // fired. The acoustic pass seeds its own count before the pipeline
-            // starts; a rule whose target is a vocabulary term adds to it here.
-            if step.stage == .replacements, case .string(let wrote)? = result.vars["changes"] {
-                let known = Set(config.vocabulary.terms.keys)
-                var hits = wrote.split(separator: ";").filter { pair in
-                    guard let arrow = pair.range(of: "->") else { return false }
-                    return known.contains(
-                        pair[arrow.upperBound...].trimmingCharacters(in: .whitespaces)
-                    )
-                }.count
-                // A rendering the exact rules could not reach counts as well.
-                // `when: vocabulary.count > 0` is what keeps the judge off the
-                // dictations with no name in them, so a term that arrives only
-                // by a fuzzy match has to raise the count here or the stage it
-                // is for never runs — which would make `fuzzy` unreachable in
-                // the config everybody has.
-                //
-                // Counted twice, once here and once in the judge, because a
-                // `Range<String.Index>` cannot travel through a variable (F13)
-                // and nothing edits the text between the two stages. The
-                // second scan is a dictionary lookup per span and the spell
-                // checker behind it is cached.
-                if steps.contains(where: { $0.stage == .vocabulary && ($0.fuzzy ?? true) }) {
-                    hits += VocabularyJudge.fuzzyParts(
-                        in: output, rules: config.vocabularyRules, claimed: []
-                    ).count
-                }
-                if hits > 0 {
-                    let before: Int
-                    if case .int(let had)? = scope["vocabulary.count"] { before = had }
-                    else { before = 0 }
-                    scope.set("vocabulary.count", .int(before + hits))
-                    // Only what a rule actually wrote. A fuzzy match has
-                    // rewritten nothing yet, so reporting it as a change would
-                    // put a substitution nobody made into the trace.
-                    if !wrote.isEmpty {
-                        if case .string(let had)? = scope["vocabulary.changes"], !had.isEmpty {
-                            scope.set("vocabulary.changes", .string(had + "; " + wrote))
-                        } else {
-                            scope.set("vocabulary.changes", .string(wrote))
-                        }
-                    }
-                }
-            }
-
             // Derived, never claimed. `changed` is the comparison this loop just
             // made, and a stage cannot get it wrong by forgetting to report it
             // or by reporting it about the wrong string. Written *before* the
@@ -826,49 +788,6 @@ struct Pipeline: Equatable, Codable {
         findings: Vocabulary.Outcome? = nil
     ) async -> StageResult {
         switch step.stage {
-        case .replacements:
-            // Both tables. `config.yaml` holds the patterns and deletions a
-            // person wrote; `vocabulary.yaml` holds the names the app learnt.
-            // One pass, so a rule behaves the same whichever file it came from.
-            let done = Replacements.exact(
-                to: text, rules: config.transcription.rules + config.vocabularyRules,
-                expand: config.expanded
-            )
-            // `changes` as well as `count`, so a later stage can judge what
-            // this one did. A stage handed only the finished sentence cannot
-            // tell which words were rewritten, and guessing is how a judge
-            // starts reverting things nobody changed.
-            //
-            // `before` is the sentence this stage was handed. `changes` says
-            // which rules fired and not *where*, so the judge needs the earlier
-            // text to tell one occurrence of a term from another. It used to
-            // take that from the acoustic pass, which does not run under
-            // `vocabulary.acoustic: false` — a path that has audio and no
-            // earlier text. This stage always has it.
-            //
-            // Two `replacements` steps in one pipeline publish this twice and
-            // the second wins, exactly as `changes` already does. That is safe
-            // because the two move together: a reader gets the last step's
-            // changes beside the last step's input, which is the pair it needs.
-            // What it does not get is the first step's changes, and that was
-            // already true before this line existed.
-            return StageResult(text: done.text, vars: [
-                "count": .int(done.count),
-                "changes": .string(done.changes),
-                "before": .string(text),
-                "protected": .string(done.protected),
-            ])
-        case .fuzzy:
-            // From the rules, not from the table's keys. Fuzzy matching
-            // compares spellings, so a target is only a candidate if it is one
-            // — `$1.$2` is a template, not a word anything could sound like,
-            // and offering it as one puts a string in the list that every
-            // comparison has to lose to. `isFuzzyCandidate` was written for
-            // this and had never been wired to anything.
-            let targets = Set(
-                config.transcription.rules.filter(\.isFuzzyCandidate).map(\.replacement)
-            )
-            return StageResult(text: Replacements.applyFuzzy(to: text, targets: Array(targets)))
         case .numbers:
             let done = Numbers.read(text, languages: config.transcription.languages)
             return StageResult(text: done.text, vars: ["language": .string(done.language)])
@@ -1027,8 +946,43 @@ struct Pipeline: Equatable, Codable {
             _ why: String, _ vars: [String: Scope.Value] = [:], fallback: String? = nil
         ) -> StageResult {
             Log.write("pipeline: vocabulary — \(why)")
-            return StageResult(
-                text: fallback ?? text, vars: vars.merging(["ok": .bool(false)]) { a, _ in a })
+            return result(fallback ?? text, vars.merging(["ok": .bool(false)]) { a, _ in a })
+        }
+
+        // The exact pass, first and inside this stage. It was a `replacements`
+        // stage of its own and had to be listed above this one by hand; the
+        // judge offers a rule's substitution back as a reading, so the rules
+        // must already have fired. One stage, and the order is no longer
+        // something a config can get wrong.
+        let handed = text
+        let exact = Replacements.exact(
+            to: text, rules: config.vocabularyRules, expand: config.expanded
+        )
+        let text = exact.text
+
+        // `review:` on the step, else the default model. A pipeline is per
+        // language, so the model that reads a French sentence need not be the
+        // one that reads an English one.
+        let reviewer = step.review.map { ModelRef(use: $0) }
+        let judgeModel = config.model(for: .vocabulary, override: reviewer)
+
+        // What the exact pass did, published whatever the review decides
+        // afterwards. These were `replacements.*` while that was a stage of its
+        // own; a later stage reading them cares that a term was written, not
+        // which half of this stage wrote it.
+        // Raised by the near-miss pass below, which reaches terms an exact
+        // rule cannot. `when: vocabulary.count > 0` is what keeps a later stage
+        // off a dictation with no name in it, so a term that arrives only by a
+        // near miss has to raise this or that stage never runs.
+        var nearMisses = 0
+        func result(_ text: String, _ vars: [String: Scope.Value]) -> StageResult {
+            let wrote: [String: Scope.Value] = [
+                "count": .int(exact.count + nearMisses),
+                "changes": .string(exact.changes),
+                "before": .string(handed),
+                "protected": .string(exact.protected),
+            ]
+            return StageResult(text: text, vars: wrote.merging(vars) { _, new in new })
         }
 
         let caps = step.caps ?? VocabularyJudge.Caps.standard
@@ -1045,10 +999,8 @@ struct Pipeline: Equatable, Codable {
         // above `vocabulary` except `replacements` itself — so this changes
         // nothing on the path where the pass does run. `findings?.text` stays
         // as the fallback for a pipeline with no `replacements` step in it.
-        var rules = ""
-        var beforeRules: String?
-        if case .string(let wrote)? = scope["replacements.changes"] { rules = wrote }
-        if case .string(let handed)? = scope["replacements.before"] { beforeRules = handed }
+        let rules = exact.changes
+        let beforeRules: String? = handed
         var parts = VocabularyJudge.acousticParts(
             findings?.proposals ?? [], in: text, measuredOn: findings?.text ?? text
         ) + VocabularyJudge.ruleParts(rules, in: text, before: beforeRules ?? findings?.text)
@@ -1063,10 +1015,12 @@ struct Pipeline: Equatable, Codable {
         // the model, which is what makes it safe to be this loose — see
         // `VocabularyJudge.fuzzyEdits` for what it fires on and what that cost
         // over this speaker's archive.
-        if step.fuzzy ?? true {
-            parts += VocabularyJudge.fuzzyParts(
+        if step.nearMisses ?? true {
+            let reached = VocabularyJudge.fuzzyParts(
                 in: text, rules: config.vocabularyRules, claimed: parts
             )
+            nearMisses = reached.count
+            parts += reached
         }
 
         let slots = VocabularyJudge.slots(in: text, from: parts, caps: caps)
@@ -1089,7 +1043,7 @@ struct Pipeline: Equatable, Codable {
         }
         Log.write(census)
         guard !slots.isEmpty else {
-            return StageResult(text: text, vars: ["asked": .int(0), "slots": .int(0)])
+            return result(text, ["asked": .int(0), "slots": .int(0)])
         }
         // Computed ahead of the slot cap below, so a lesson still reverts even
         // in a sentence with too many other places to send to a model.
@@ -1106,7 +1060,7 @@ struct Pipeline: Equatable, Codable {
         }
 
         guard !changes.isEmpty else {
-            return StageResult(text: text, vars: ["asked": .int(0), "slots": .int(slots.count)])
+            return result(text, ["asked": .int(0), "slots": .int(slots.count)])
         }
 
         // A spelling lesson is settled here and never asked about. Both models
@@ -1117,11 +1071,11 @@ struct Pipeline: Equatable, Codable {
             Log.write("vocabulary judge: spelling lesson, reverted without asking — "
                 + lessons.joined(separator: "; "))
         }
-        // Nothing left for a model to answer. Returned before the `llm.enabled`
+        // Nothing left for a model to answer. Returned before the no-model
         // guard so the rule still fires on a machine with no Ollama.
         if taught.allSatisfy({ $0 }) {
             let chosen = VocabularyJudge.reverting(taught, in: text, changes: changes)
-            return StageResult(text: chosen, vars: [
+            return result(chosen, [
                 "asked": .int(0), "slots": .int(slots.count),
                 "reverted": .string(lessons.joined(separator: "; ")),
                 "judged": .string(chosen),
@@ -1139,7 +1093,7 @@ struct Pipeline: Equatable, Codable {
         // ordinary change is left exactly as it arrived, same as every other
         // decline in this stage.
         guard config.llmEnabled else {
-            return declined("llm.enabled is false",
+            return declined("`models:` defines no model",
                             ["asked": .int(0), "slots": .int(slots.count)],
                             fallback: VocabularyJudge.reverting(taught, in: text, changes: changes))
         }
@@ -1160,7 +1114,7 @@ struct Pipeline: Equatable, Codable {
                 // Anything longer is a model explaining itself, which this
                 // shape does not read.
                 maxTokens: 8 * changes.count + 8,
-                config: config.model(for: .vocabulary)
+                config: judgeModel
             )
         } catch {
             return declined("\(error.localizedDescription); kept as they are",
@@ -1189,13 +1143,13 @@ struct Pipeline: Equatable, Codable {
             Log.write("    before: \(text)")
             Log.write("    after:  \(chosen)")
         }
-        return StageResult(text: chosen, vars: [
+        return result(chosen, [
             "asked": .int(changes.count),
             "slots": .int(slots.count),
             "reverted": .string(reverted.joined(separator: "; ")),
             "judged": .string(chosen),
             "reply": .string(reply.trimmingCharacters(in: .whitespacesAndNewlines)),
-            "model": .string(config.model(for: .vocabulary).model),
+            "model": .string(judgeModel.model),
         ])
     }
 
@@ -1277,7 +1231,7 @@ struct Pipeline: Equatable, Codable {
         _ step: Step, named name: String, on text: String, config: Config, scope: Scope
     ) async -> StageResult {
         guard config.llmEnabled else {
-            Log.write("pipeline: skipped prompt \(name) — llm.enabled is false")
+            Log.write("pipeline: skipped prompt \(name) — `models:` defines no model")
             return StageResult(text: text, vars: ["ok": .bool(false)])
         }
         guard let transform = config.transform(named: name), let prompt = transform.asPrompt else {

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -1138,7 +1138,7 @@ struct Pipeline: Equatable, Codable {
         // lesson is reverted anyway — that part never needed a model — and the
         // ordinary change is left exactly as it arrived, same as every other
         // decline in this stage.
-        guard config.llm.enabled else {
+        guard config.llmEnabled else {
             return declined("llm.enabled is false",
                             ["asked": .int(0), "slots": .int(slots.count)],
                             fallback: VocabularyJudge.reverting(taught, in: text, changes: changes))
@@ -1276,7 +1276,7 @@ struct Pipeline: Equatable, Codable {
     private func runPrompt(
         _ step: Step, named name: String, on text: String, config: Config, scope: Scope
     ) async -> StageResult {
-        guard config.llm.enabled else {
+        guard config.llmEnabled else {
             Log.write("pipeline: skipped prompt \(name) — llm.enabled is false")
             return StageResult(text: text, vars: ["ok": .bool(false)])
         }

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -154,6 +154,10 @@ struct Pipeline: Equatable, Codable {
         /// language, and the model that reads a French sentence need not be
         /// the one that reads an English one.
         var review: String?
+        /// `review: false`. Optional for the reason `nearMisses` is: a
+        /// synthesized decoder ignores a stored default, so "not written" has
+        /// to be spellable as nil.
+        var reviewEnabled: Bool?
         /// Run only when this matches the text as it stands *at this point* —
         /// after the stages before it, not on the original. That ordering is
         /// what lets a cheap deterministic stage make an expensive one
@@ -983,6 +987,14 @@ struct Pipeline: Equatable, Codable {
                 "protected": .string(exact.protected),
             ]
             return StageResult(text: text, vars: wrote.merging(vars) { _, new in new })
+        }
+
+        // `review: false`. The exact matches ship as the rules wrote them, and
+        // the near-miss pass is skipped with the review rather than left to
+        // run: nothing it proposes is ever written without a model reading the
+        // sentence first.
+        guard step.reviewEnabled ?? true else {
+            return result(text, ["asked": .int(0), "slots": .int(0)])
         }
 
         let caps = step.caps ?? VocabularyJudge.Caps.standard

--- a/Sources/ParrotFlow/PipelineCommand.swift
+++ b/Sources/ParrotFlow/PipelineCommand.swift
@@ -117,7 +117,8 @@ enum PipelineCommand {
             return Pipeline.Step(
                 stage: stage, transform: entry.transform, prompt: entry.prompt,
                 caps: entry.caps, nearMisses: entry.nearMisses,
-                review: entry.review, when: entry.when,
+                review: entry.review, reviewEnabled: entry.reviewEnabled,
+                when: entry.when,
                 unless: entry.unless, app: entry.app
             )
         }

--- a/Sources/ParrotFlow/PipelineCommand.swift
+++ b/Sources/ParrotFlow/PipelineCommand.swift
@@ -116,7 +116,8 @@ enum PipelineCommand {
             }
             return Pipeline.Step(
                 stage: stage, transform: entry.transform, prompt: entry.prompt,
-                caps: entry.caps, fuzzy: entry.fuzzy, when: entry.when,
+                caps: entry.caps, nearMisses: entry.nearMisses,
+                review: entry.review, when: entry.when,
                 unless: entry.unless, app: entry.app
             )
         }

--- a/Sources/ParrotFlow/PipelineCommand.swift
+++ b/Sources/ParrotFlow/PipelineCommand.swift
@@ -38,18 +38,13 @@ enum PipelineCommand {
         /// for the `heard:` renderings — a fixture cannot make a sound, so
         /// there is nothing here for the acoustic half.
         var vocabulary: Config.Vocabulary?
-        /// Its own `llm:`. One fixture needs `enabled: false`, which is how a
-        /// vocabulary case asserts what the stage found without asking a model
-        /// what to do about it — the answer comes from a model and is not
-        /// deterministic, so it is not a thing a case set can hold.
-        var llm: Config.LLM?
         /// Its own `lists:`. A pattern that says `{{determiners}}` compiles to
         /// nothing without them, and a guard that silently stops guarding is
         /// the failure a fixture exists to catch.
         var lists: [String: [String]] = [:]
 
         enum CodingKeys: String, CodingKey {
-            case languages, replacements, pipeline, transforms, vocabulary, llm, lists
+            case languages, replacements, pipeline, transforms, vocabulary, lists
         }
 
         init(from decoder: Decoder) throws {
@@ -71,7 +66,6 @@ enum PipelineCommand {
                 lists = v
             }
             vocabulary = try c.decodeIfPresent(Config.Vocabulary.self, forKey: .vocabulary)
-            llm = try c.decodeIfPresent(Config.LLM.self, forKey: .llm)
         }
     }
 
@@ -139,7 +133,6 @@ enum PipelineCommand {
         config.transforms = fixture.transforms
         config.lists = fixture.lists
         if let vocabulary = fixture.vocabulary { config.vocabulary = vocabulary }
-        if let llm = fixture.llm { config.llm = llm }
 
         // The fixture's own table is checked too, not just its stage list — a
         // template naming a group the pattern never captures is refused here

--- a/Sources/ParrotFlow/PromptRunCommand.swift
+++ b/Sources/ParrotFlow/PromptRunCommand.swift
@@ -29,7 +29,7 @@ enum PromptRunCommand {
             return 1
         }
 
-        guard config.llm.enabled else {
+        guard config.llmEnabled else {
             print("✗ llm.enabled is false")
             return 1
         }

--- a/Sources/ParrotFlow/PromptRunCommand.swift
+++ b/Sources/ParrotFlow/PromptRunCommand.swift
@@ -30,7 +30,7 @@ enum PromptRunCommand {
         }
 
         guard config.llmEnabled else {
-            print("✗ llm.enabled is false")
+            print("✗ `models:` defines no model")
             return 1
         }
 

--- a/Sources/ParrotFlow/Replacements.swift
+++ b/Sources/ParrotFlow/Replacements.swift
@@ -20,14 +20,6 @@ enum Replacements {
     /// nineteen names are caught with nothing wrongly replaced.
     static let threshold = 0.80
 
-    /// Longest window considered. Recognition splits names it does not know,
-    /// so "Ver Sal" has to reach "Vercel". Three-word windows were measured
-    /// and caught nothing extra.
-    static let maximumWindow = 2
-
-    /// Below this, similarity stops discriminating.
-    static let minimumLength = 5
-
     /// Names first, digits last. Both name passes match on words, and a
     /// mishearing that happens to contain a number word — "Ver Sal two" — has
     /// to still look like words while they run.
@@ -180,73 +172,6 @@ enum Replacements {
         // A removed leading filler leaves the sentence starting lowercase.
         if let first = output.first, first.isLowercase {
             output = first.uppercased() + output.dropFirst()
-        }
-        return output
-    }
-
-    // MARK: - Fuzzy
-
-    static func applyFuzzy(to text: String, targets: [String]) -> String {
-        let usable = targets.filter { $0.count >= minimumLength }
-        guard !usable.isEmpty else { return text }
-
-        let words = wordRanges(in: text)
-        guard !words.isEmpty else { return text }
-
-        // Score every window, then take the best non-overlapping ones. Taking
-        // the first match above threshold instead let a two-word window win
-        // over the one-word window inside it — "on Superbase" scored enough to
-        // beat nothing, and swallowed the "on".
-        struct Candidate {
-            let indices: [Int]
-            let range: Range<String.Index>
-            let target: String
-            let score: Double
-        }
-        var candidates: [Candidate] = []
-
-        for size in 1...maximumWindow where words.count >= size {
-            for start in 0...(words.count - size) {
-                let indices = Array(start..<(start + size))
-                let span = words[indices.first!].lowerBound..<words[indices.last!].upperBound
-                let phrase = String(text[span])
-                let joined = phrase.filter { !$0.isWhitespace }
-                guard joined.count >= minimumLength, !isRealWord(joined) else { continue }
-                if size == 1, isRealWord(phrase) { continue }
-
-                // A window holding a correct spelling already is left alone.
-                // The exact pass runs first, so by now "Superbase" is already
-                // "Supabase" — and "on Supabase" still scores above threshold
-                // against "Supabase", which swallowed the preceding word.
-                let tokens = indices.map { String(text[words[$0]]).lowercased() }
-                if tokens.contains(where: { token in
-                    usable.contains { $0.lowercased() == token }
-                }) { continue }
-
-                guard let best = usable
-                    .map({ ($0, similarity(phrase, $0)) })
-                    .max(by: { $0.1 < $1.1 }),
-                    best.1 >= threshold
-                else { continue }
-
-                candidates.append(Candidate(indices: indices, range: span, target: best.0, score: best.1))
-            }
-        }
-
-        var replacements: [(range: Range<String.Index>, text: String)] = []
-        var consumed = Set<Int>()
-        for candidate in candidates.sorted(by: { $0.score > $1.score }) {
-            guard candidate.indices.allSatisfy({ !consumed.contains($0) }) else { continue }
-            replacements.append((candidate.range, candidate.target))
-            candidate.indices.forEach { consumed.insert($0) }
-        }
-
-        guard !replacements.isEmpty else { return text }
-
-        var output = text
-        for replacement in replacements.sorted(by: { $0.range.lowerBound > $1.range.lowerBound }) {
-            Log.write("fuzzy: \"\(text[replacement.range])\" → \(replacement.text)")
-            output.replaceSubrange(replacement.range, with: replacement.text)
         }
         return output
     }

--- a/Sources/ParrotFlow/RouteTestCommand.swift
+++ b/Sources/ParrotFlow/RouteTestCommand.swift
@@ -34,7 +34,7 @@ enum RouteTestCommand {
         }
 
         guard config.llmEnabled else {
-            print("✗ needs the LLM, but llm.enabled is false")
+            print("✗ needs a model, but `models:` defines none")
             return 1
         }
 

--- a/Sources/ParrotFlow/RouteTestCommand.swift
+++ b/Sources/ParrotFlow/RouteTestCommand.swift
@@ -33,7 +33,7 @@ enum RouteTestCommand {
             return 0
         }
 
-        guard config.llm.enabled else {
+        guard config.llmEnabled else {
             print("✗ needs the LLM, but llm.enabled is false")
             return 1
         }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -93,11 +93,16 @@ transcription:
   # stage, and any stage takes a condition. See docs/pipelines.md.
   pipelines:
     default:
-      - replacements                       # the table below
-      # Offers a rule's substitution back as a reading, so `replacements`
-      # must fire first. Judges each one KEEP or REVERT.
-      - stage: vocabulary
-        when: vocabulary.count > 0
+      # Names. Matches every `heard:` rendering in vocabulary.yaml, then puts
+      # each match to a model to keep or revert — the rules cannot read the
+      # sentence, so "Versailles" is sometimes the castle.
+      #
+      #   near_misses: false   match renderings exactly, never one edit away
+      #   review: gpt          who decides; `false` ships every match unread
+      #
+      # Above everything that edits text: it reads spans the acoustic pass
+      # measured before the pipeline started, and an edit moves them.
+      - vocabulary
       - numbers                            # "two hundred forty-three" -> 243
       - transform: punctuation             # "is that true question mark" -> is that true?
       - transform: repetitions             # a word or phrase said twice by accident, taken out
@@ -122,34 +127,16 @@ transcription:
       # A stage that publishes a variable must declare `returns: json` and
       # speak that protocol — see docs/authoring.md.
 
-# The local Ollama model behind spoken commands. Without it, dictation still
-# works, and every `prompt:` transform below stops.
-#
-# These four keys describe one model, and it is named `local`. Everything runs
-# on it unless something says otherwise — see `models:` below.
-llm:
-  enabled: true
-  model: gemma4:e4b-mlx
-  endpoint: http://localhost:11434
-  # Pin the model in RAM at launch. Otherwise Ollama drops it after five
-  # minutes, and the next command waits 7-10s for the reload.
-  keep_loaded: true
-
-  # Which model runs what, by name. `default` is what a `prompt:` transform
-  # uses when it names none; the other two are jobs that run on every
-  # dictation and are worth keeping local — the router is what you wait on
-  # with the pill on screen, and both carry your transcript.
-  # default: local
-  # router: local
-  # vocabulary: local
-
-# More models, under names you pick. A transform names one with `model:`.
+# Every model this config can reach, under names you pick.
 #
 # `api:` is the protocol, not the company: ollama, openai or anthropic.
 # Everyone else speaks one of the three, so Groq, OpenRouter, DeepSeek, LM
 # Studio and vLLM are an `endpoint:` away rather than a new version of this
 # app. `params:` is put into the request body untouched, for anything these
 # keys do not cover.
+#
+# `default: true` marks the one that runs whatever names no model. With a
+# single entry it is implied; with several, exactly one must claim it.
 #
 # A model that is not `ollama` sends your dictation to somebody else's server.
 # `--check-config` says so, every time, and names which transforms do it.
@@ -164,32 +151,49 @@ llm:
 # which the app does not have when it is launched from Finder, so it works from
 # a terminal and silently does not in the app. A key written here in full works
 # too and is announced as plain text on every load.
+models:
+  gemma:
+    api: ollama
+    model: gemma4:e4b-mlx
+    endpoint: http://localhost:11434
+    # Pin the model in RAM at launch. Otherwise Ollama drops it after five
+    # minutes, and the next command waits 7-10s for the reload. Ollama only.
+    keep_loaded: true
+    default: true
+
+  # No `api_key:`, so the key is in the keychain and the app asks for it.
+  # gpt:
+  #   api: openai
+  #   model: gpt-5.6-luna
+  #   endpoint: https://api.openai.com/v1
+  #   # off | minimal | low | medium | high. One ladder, whatever the provider
+  #   # calls its own knob. `off` is the right default for a rewrite.
+  #   reasoning: off
+  #   timeout_seconds: 30
+  #
+  # claude:
+  #   api: anthropic
+  #   model: claude-sonnet-5
+  #   reasoning: off
+
+# What "hey parrot, …" can reach, and which model does each part. The router
+# picks a capability; `spelling` and `catch_all` are two of the things it can
+# pick, which is why all three bind together.
 #
-# models:
-#   # An Ollama entry belongs here like any other. Naming the local model
-#   # explicitly is how a second one gets a name too — a small model for the
-#   # router, a larger one for a rewrite, both on this Mac.
-#   gemma:
-#     api: ollama
-#     model: gemma4:e4b-mlx
-#     endpoint: http://localhost:11434
-#     # Only ollama reads this. Pinned in RAM, or a cold call waits 7-10s.
-#     keep_loaded: true
-#
-#   # No `api_key:`, so the key is in the keychain and the app asks for it.
-#   gpt:
-#     api: openai
-#     model: gpt-5.6-luna
-#     endpoint: https://api.openai.com/v1
-#     # off | minimal | low | medium | high. One ladder, whatever the provider
-#     # calls its own knob. `off` is the right default for a rewrite.
-#     reasoning: off
-#     timeout_seconds: 30
-#
-#   claude:
-#     api: anthropic
-#     model: claude-sonnet-5
-#     reasoning: off
+# Each falls back to the default model above, so a line you do not write is a
+# job that runs on the default rather than a job that does not run.
+commands:
+  # Matching what you said to a capability. Runs on every "hey parrot", and it
+  # is what you wait on with the pill on screen — keep it local and fast.
+  # router: gemma
+
+  # Reading a rule out of "Tasmin spells T A S M E E N". Worth pointing at a
+  # bigger model: loose capitals in speech are what a small one is worst at.
+  # spelling: gpt
+
+  # The instruction no capability covers — "use the 24 hour clock". `false`
+  # refuses them instead; a model name runs them on that model.
+  # catch_all: gpt
 
 # One call a day to GitHub's release API — the only request this app makes on
 # its own. The number is a waiting period, not a poll interval: -1 never
@@ -364,8 +368,3 @@ transforms:
     description: delete a word or phrase said twice by accident
     command: repetitions.py
 
-# Do what was asked even when no transform above matches: "hey parrot, use
-# the 24 hour clock". A remark that was never an instruction is still
-# refused, and you see every result before it replaces anything. Off means a
-# fixed menu.
-free_form: true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -132,10 +132,10 @@ the text has moved on, because an undo fired against edited text is not an undo.
 | Hotkey down → capture running | ~60–70 ms, warmed at launch |
 | Bare-modifier polling | 25 ms, on top of the above |
 | Transcription of a normal sentence | about a second after you let go |
-| `replacements`, `fuzzy`, `numbers`, a `replace:` transform | 0.035 s measured on a line |
+| `the vocabulary stage`, `fuzzy`, `numbers`, a `replace:` transform | 0.035 s measured on a line |
 | A `command:` transform | one process start — ~25 ms for `python3`, ~5 ms for a shell script, ~300 ms if `python3` is a version-manager shim |
 | A `prompt:` transform, model warm | ~1.5 s |
-| A `prompt:` transform, model cold | 6.7 s, which `llm.keep_loaded` exists to avoid |
+| A `prompt:` transform, model cold | 6.7 s, which `keep_loaded:` on the model exists to avoid |
 
 The gap between the last three rows is the reason stages carry conditions: a
 `when:` that costs nothing is what keeps a stage that costs a second off the

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -67,13 +67,16 @@ For a name that comes out wrong, nothing needs writing — say
 $PF --learn "super base" Supabase
 ```
 
-For a pattern or a deletion, add it to `transcription.replacements` and check
+For a pattern or a deletion, put it in a transform's `replace:` and check
 it:
 
 ```yaml
-replacements:
-  "": ['/\b(?:u+m+|erm+)\b/']          # empty target deletes
-  '$1 ticket': ['/\bticket number (\d+)\b/']
+transforms:
+  - name: tidy
+    description: delete hesitations and shorten ticket numbers
+    replace:
+      "": ['/\b(?:u+m+|erm+)\b/']          # empty target deletes
+      '$1 ticket': ['/\bticket number (\d+)\b/']
 ```
 
 ```sh
@@ -96,7 +99,7 @@ transforms:
 transcription:
   pipelines:
     default:
-      - replacements
+      - vocabulary
       - transform: backticks
         app: /slack|discord/
 ```
@@ -223,7 +226,7 @@ then do with them.
   "ctx": { "app": "Ghostty", "bundle_id": "com.mitchellh.ghostty",
            "language": "en",
            "vars": { "asr": { "confidence": 0.91, "duration": 4.2 },
-                     "replacements": { "ran": true, "count": 1,
+                     "vocabulary": { "ran": true, "count": 1,
                                        "changed": true, "ms": 0.4 } } },
   "tokens": [ { "at": 2, "len": 6, "text": "python",
                 "tag": "Noun", "lemma": "python" } ],
@@ -302,8 +305,8 @@ so will you the first time a stage misbehaves.
 
 ```yaml
 pipelines:
-  default: [replacements, fuzzy, numbers]
-  fr:      [replacements, numbers]
+  default: [vocabulary, numbers]
+  fr:      [vocabulary, numbers]
 ```
 
 A key that is neither `default` nor one of your `languages:` is reported by

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,26 +26,26 @@ transcription:
   languages: [en]       # en and fr are the supported values
   rewrite_line: true
   pipelines: …          # see pipelines.md
-  replacements: …       # see below
   transforms: …         # see pipelines.md
 
-llm:
-  enabled: true
-  model: gemma4:e4b     # these four keys are the model named `local`
-  endpoint: http://localhost:11434
-  keep_loaded: true
-  default: local        # what a prompt runs on when it names none
-
-models:                 # more models, under names you pick
+models:                 # every model, under names you pick
+  gemma:
+    api: ollama         # ollama | openai | anthropic — the protocol, not the vendor
+    model: gemma4:e4b
+    keep_loaded: true
+    default: true       # what runs whatever names no model
   gpt:
-    api: openai         # ollama | openai | anthropic — the protocol, not the vendor
+    api: openai
     model: gpt-5.6-luna
     reasoning: off      # off | minimal | low | medium | high
 
+commands:               # which model does each part of "hey parrot, …"
+  router: gemma
+  spelling: gpt
+  catch_all: gpt        # or false, to refuse what no capability covers
+
 updates:
   after_days: 0
-
-free_form: true
 
 feedback:
   sound: true
@@ -225,26 +225,30 @@ correction ended up appended to the end of a line instead of replacing a word in
 it: ⌃K clears nothing in a composer, and the paste that followed landed on the
 end of what was still there.
 
-## `transcription.replacements`
+## `transcription.replacements` is retired
 
-Patterns and deletions, hand-written. Whole words, case-insensitive. A name
-the recogniser mangles does not go here — say "hey parrot" and fix it in the
-panel, and it lands in `vocabulary.yaml` instead — but a pattern with no fixed
-spelling, or a deletion, has nowhere else to live.
+It held two kinds of rule and neither belongs there now.
+
+A name the recogniser mangles goes in `vocabulary.yaml`, where the `vocabulary`
+stage matches it and then has a model read the sentence before keeping it —
+"Versailles" is sometimes the castle, and only something reading the sentence
+can tell.
+
+A mechanical rule — a deletion, a regex template — goes in a transform's
+`replace:`, which needs no such review and already takes regexes, deletions,
+`{{lists}}` and `when:`/`app:` conditions:
 
 ```yaml
-replacements:
-  "": ['/[,]?\s*\b(?:u+m+|u+h+|erm+|hmm+)\b[,]?/']
-  '$1.$2': ['/\b(\w+) dot (\w+)\b/']
+transforms:
+  - name: fillers
+    description: delete hesitation sounds
+    replace:
+      "": ['/[,]?\s*\b(?:u+m+|u+h+|erm+|hmm+)\b[,]?/']
 ```
 
-A source in `/slashes/` is a regular expression, and with one the target is a
-template, so `$1` writes back what the pattern captured. An **empty target
-deletes** rather than substitutes, which is how filler words go, punctuation
-and spacing included.
-
-The table runs as the `replacements` stage — a pipeline stage, so whether it
-runs at all is [pipelines.md](pipelines.md).
+Nothing was left in the middle, which is why the table went. A rule that needs
+judging is a name; a rule that does not is a transform. `--check-config`
+refuses the old key and says this.
 
 ## `lists`
 
@@ -288,15 +292,34 @@ as the word `true`, so the list silently stops holding the word you wrote.
 The lists are not split by language. `dotted` merges English and French into
 one alternation and measures clean, because the words do not collide.
 
-## `llm`
+## `commands`
 
-What is behind spoken commands and every `prompt:` transform. Without a model
-dictation still works and those stages stop.
+Which model does each part of a spoken command. The router matches what you
+said to a capability; `spelling` and `catch_all` are two of the things it can
+pick, which is why all three bind together.
 
-`model:`, `endpoint:`, `timeout_seconds:` and `keep_loaded:` describe one
-Ollama model, and it is named `local`. Everything runs on it unless something
-names another. A config written before `models:` existed keeps working exactly
-as it did.
+| Key | What it decides | Default |
+|---|---|---|
+| `router` | "hey parrot, …" — the call you wait on with the pill on screen | the default model |
+| `spelling` | reading a rule out of "Tasmin spells T A S M E E N" | the default model |
+| `catch_all` | an instruction no capability covers; `false` refuses them | the default model |
+
+Keep `router` local for as long as you can. It runs on every "hey parrot", it
+is timed in tenths of a second, and it sees every word you say.
+
+`spelling` is the opposite case. It runs only when you ask, and reading loose
+capitals out of speech is the job a small local model is worst at — so it is
+the first one worth pointing somewhere bigger.
+
+The KEEP/REVERT review is not here. It belongs to the `vocabulary` pipeline
+stage that runs it, and binds there as `review:` — see
+[pipelines.md](pipelines.md). A pipeline is per language, so the model that
+reads a French sentence need not be the one that reads an English one.
+
+There is no `enabled:` key any more. A config that defines no `models:` calls
+no model, which says the same thing and cannot fall out of step with itself.
+
+## `models`, and pinning
 
 `keep_loaded: true` pins the model in RAM at launch. Ollama otherwise drops it
 after five minutes idle and the next command waits for a reload — measured
@@ -305,17 +328,10 @@ for one. The cost is the model sitting in memory for as long as the app runs:
 9.6 GB for `gemma4:e4b`. On a 16 GB Mac, turn it off. On 32 GB, do not. It is
 an Ollama setting; the other protocols have nothing to pin.
 
-Three keys say which model runs what:
-
-| Key | What it decides | Default |
-|---|---|---|
-| `default` | what a `prompt:` transform runs on when it names none | `local` |
-| `router` | "hey parrot, …" — the call you wait on with the pill on screen | `default` |
-| `vocabulary` | the KEEP/REVERT judge, which runs on every dictation | `default` |
-
-Keep `router` and `vocabulary` local for as long as you can. They run on every
-dictation, they are timed in tenths of a second, and they see every word you
-say.
+`default: true` marks the model everything falls back to — a `prompt:`
+transform that names none, and any binding left unwritten. With one model it is
+implied. With several, exactly one must claim it: none and more than one are
+both refused rather than guessed at.
 
 ## `models`
 
@@ -501,12 +517,17 @@ A wait has a point — a bad release is one that gets noticed and pulled, and a
 week of distance means your Mac never saw it. Set `after_days: 7` if you want
 that; the default takes the release the day it ships.
 
-## `free_form`
+## `commands.catch_all`
 
 Do what was asked even when no transform description matches: "hey parrot, use
 the 24 hour clock". A remark that was never an instruction is still refused,
-and you see every result before it replaces anything. Turn it off to go back to
-a fixed menu of transforms.
+and you see every result before it replaces anything. `false` goes back to a
+fixed menu of transforms; a model name runs it on that model.
+
+It was `free_form: true` at the top level. It is here because it is one of the
+router's answers rather than a setting of its own, and because it is the case
+that most deserves its own model — the free-form prompt is where a small local
+one is measured at its ceiling.
 
 ## `audio.speech_gate`
 

--- a/docs/corrections.md
+++ b/docs/corrections.md
@@ -101,7 +101,7 @@ like a composer, and against Slack or Outlook directly if you focus one.
 
 ## What it needs
 
-Ollama running with the model in `llm.model` (`ollama pull gemma4:e4b`), and
+Ollama running with the model your `models:` entry names (`ollama pull gemma4:e4b`), and
 the Accessibility permission — reading your selection is exactly what that
 permission governs.
 
@@ -109,7 +109,7 @@ ParrotFlow loads that model at launch and asks Ollama to keep it there. Ollama
 otherwise drops it after five minutes idle, and reloading is most of what you
 wait for: measured 6.7 s cold against 1.5 s warm, so in practice almost every
 correction paid for a reload. The cost is the model sitting in memory for as
-long as the app runs — 9.6 GB for `gemma4:e4b`. Set `llm.keep_loaded: false` to
+long as the app runs — 9.6 GB for `gemma4:e4b`. Set `keep_loaded: false` on that entry to
 have the RAM back and the wait with it. On a 16 GB Mac that is the right
 setting; on 32 GB it is not.
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -5,8 +5,8 @@ Everything a finished transcript goes through, in order, per language:
 ```yaml
 transcription:
   pipelines:
-    default: [replacements, fuzzy, numbers]
-    fr: [replacements, fuzzy, numbers]
+    default: [vocabulary, numbers]
+    fr: [vocabulary, numbers]
 ```
 
 A language's own list wins over `default`. A key that is neither `default` nor
@@ -19,16 +19,20 @@ can see, not finding a setting you cannot. Delete `pipelines:` entirely and you
 get every stage back — a missing section is silence, not a choice. Write
 `default: []` and you get none, which is a choice.
 
+It was three stages until the shapes were counted: `replacements` wrote the
+exact matches, `fuzzy` caught the near ones, `vocabulary` judged them, and the
+order they had to run in was enforced by hand because the three were never
+independent. They are one stage, and the order is no longer something a config
+can get wrong.
+
 ## The stages
 
 | Stage | What it does |
 |---|---|
-| `replacements` | The substitutions in `replacements:` — literal, word-boundary, case-insensitive, or a regex between slashes. |
-| `fuzzy` | The same table against renderings you have not taught, so "super bays" reaches Supabase. Only words the spell checker does not know are eligible, which is what keeps "Excel" from becoming "Vercel". Needs `replacements` before it and says so if it does not have one, because on its own it swallows the preceding word. |
+| `vocabulary` | Names. Matches every `heard:` rendering in `vocabulary.yaml`, reaches the near misses you have not taught, then puts each match to a model to keep or revert — see [The name stage](#the-name-stage). |
 | `numbers` | Spoken numbers as digits: "two hundred forty-three" → 243, plus ordinals, decimals, years and spoken digits. English and French, septante/huitante/nonante included, chosen per transcript. A number word on its own stays a word below ten, so "chapter three" and "on est deux" are left alone. |
 | `context` | What is on screen around the field, published as `context.*`. Never touches the transcript. Terminals only, and off unless you ask for it — see [Context](#context-what-is-on-screen-around-the-field). |
 | `input` | What is already *in* the field and where the caret is, published as `input.*`. Never touches the transcript. Every app, and off unless you ask for it — see [Input](#input-what-is-already-in-the-field). |
-| `vocabulary` | Every substitution the vocabulary pass made, put to the local model one at a time — see [The name judge](#the-name-judge). |
 | `transform` | One entry of `transforms:`, named — see below. The only stage that names something outside itself. |
 
 `numbers` rewrites transcripts that were already correct, so run `--numbers` on
@@ -51,7 +55,8 @@ name or a mapping, and it cannot be both:
 ```yaml
 - stage: vocabulary
   when: vocabulary.count > 0
-  fuzzy: true         # optional; default. false matches renderings exactly
+  near_misses: true   # optional; default. false matches renderings exactly
+  review: gemma       # optional; who keeps or reverts. false ships them unread
   max_slots: 4        # optional; past this many, keep what the pass wrote
   max_per_slot: 2     # optional; readings per place, the decoder's included
   max_per_term: 2     # optional; places in one sentence about the same name
@@ -85,13 +90,13 @@ written, and the text still holds the decoder's word there. The question is the
 same either way — does this name belong here — so `after` is the sentence with
 every change taken, whether the pass took it or not, and KEEP is what writes it.
 
-A rule in `replacements:` is judged too, so a name a rule wrote for a word you
+A rule from `vocabulary.yaml` is reviewed too, so a name a rule wrote for a word you
 meant literally can be undone. The app works out which occurrences the rule
 wrote by comparing the transcript before and after it. When two rules write the
 same term into one sentence that comparison cannot say which is which, and then
 neither is offered — the log says so.
 
-**`fuzzy:` widens what a `heard:` rendering matches.** On by default. Two
+**`near_misses:` widens what a `heard:` rendering matches.** On by default. Two
 things, and they are separate mechanisms:
 
 - A word spelled like a rendering but for its apostrophes *is* that rendering.
@@ -103,7 +108,11 @@ things, and they are separate mechanisms:
 
 Neither writes anything. Each opens one more place for the model to decide, so
 the risk of the looser match is bounded by the judge rather than by the
-threshold. `fuzzy: false` puts matching back to exact and whole-word.
+threshold. `near_misses: false` puts matching back to exact and whole-word.
+
+Nothing is written by that pass. A near miss becomes one more question for the
+review, which is what makes it safe to be this loose — and it means a machine
+with no model gets the exact matches and leaves the near ones alone.
 
 **`max_per_term` is the one to move if nothing is being judged.** One name
 reaches the list from five directions — a rule that already rewrote the text,
@@ -115,16 +124,19 @@ declined. The cap keeps the two best-evidenced places and says in the log which
 it dropped. Raise it when a name really does appear three times in one
 sentence.
 
-`when: vocabulary.count > 0` is not optional in practice. Without it the stage
-costs a model call on every dictation, including the ones where nothing was
-substituted.
+The stage decides for itself whether to call a model: nothing matched means
+nothing to ask about, and it returns before the call. A `when:` of your own is
+for the cases the stage cannot know about — an app you never want it in.
 
-**Order matters, and the app refuses the wrong one.** The judge is given spans
-measured on the text the decoder produced. Put `replacements` above it — the
-judge offers a rule's substitution back, so the rules have to have fired — and
-everything that edits text below it. `--check-config` refuses a pipeline that
-puts `fuzzy`, `numbers` or a transform in between, because a span that has
-moved cannot be told from a span that was always wrong.
+**Order matters, and the app refuses the wrong one.** The review is given spans
+measured on the text the decoder produced. Put the stage above everything that
+edits text. `--check-config` refuses a pipeline that puts `numbers` or a
+transform above it, because a span that has moved cannot be told from a span
+that was always wrong.
+
+There used to be one exception, `replacements`, because the review offers a
+rule's substitution back and the rules had to have fired first. That pass is
+inside this stage now, so there is no exception left to state.
 
 When anything goes wrong — the model unreachable, a reply naming no change,
 more places than `max_slots` — the transcript ships exactly as it arrived and
@@ -159,7 +171,7 @@ transforms:
 
 `prompt:` asks the local model — about a second, and the reason conditions
 exist. `replace:` is a substitution table of its own, in the same shape as
-`transcription.replacements`, and costs nothing. `command:` runs a program of
+the `vocabulary` stage, and costs nothing. `command:` runs a program of
 yours, which costs a process start — about 30ms for `python3`, 5ms for a shell
 script.
 
@@ -440,14 +452,14 @@ not anything is wrong with it — a config that runs something you have forgotte
 about, or that arrived in a config you copied from somewhere, should not be
 able to stay quiet about it.
 
-**Why a table needs a name.** `transcription.replacements` is a single table
+**Why a table needs a name.** A `replace:` transform is one table
 applied by a single stage, so it cannot be two tables running in two places
 under two conditions. Named ones can:
 
 ```yaml
 pipelines:
   default:
-    - replacements
+    - vocabulary
     - fuzzy
     - numbers
     - transform: dotted
@@ -456,7 +468,7 @@ pipelines:
       app: /^(?!.*(term|ghostty|iterm|warp))/
 ```
 
-Two tables, two conditions, at most one matching. A single `replacements:`
+Two tables, two conditions, at most one matching. A single shared table
 cannot express that: it is one table run by one stage, in one place.
 
 **`dotted` ships.** A new install is written with it already in the default
@@ -505,7 +517,7 @@ either side — "réunion point hebdomadaire" — is a shape only a dictionary w
 tell from code, and every residual case is kept in the set, failing, rather
 than dropped to make the number look better. They are unlikely in a terminal or
 a chat window, which together with the `app:` scoping is the only reason this is
-on by default; in `replacements:` it would run everywhere and would not be
+on by default; in one shared table it would run everywhere and would not be
 defensible.
 
 `scripts/check-dotted.sh` reads the pattern out of `Config.defaultYAML` rather
@@ -876,9 +888,7 @@ A stage can carry a condition, which is what makes an expensive one affordable
 ```yaml
 pipelines:
   fr:
-    - replacements
-    - stage: fuzzy
-      unless: /```/                      # never inside a code fence
+    - vocabulary
     - stage: numbers
       when: /\b(vingt|cent|mille)\b/     # only if a number word is left
 ```
@@ -912,7 +922,7 @@ can read them:
 ```yaml
 pipelines:
   default:
-    - replacements
+    - vocabulary
     - transform: code_identifiers
     - stage: transform
       transform: dotted
@@ -932,12 +942,12 @@ any of this exists:
 They are **derived, never claimed**. A stage cannot forget to report `changed`,
 and cannot report it about the wrong string.
 
-Stages add their own on top. The built-in ones publish `replacements.count`,
-`replacements.changes` and `replacements.before` — how many rules fired, which
+Stages add their own on top. The built-in ones publish `vocabulary.count`,
+`vocabulary.changes` and `vocabulary.before` — how many rules fired, which
 ones, and the sentence the stage was handed — `numbers.language`, which grammar
 actually read the numbers and is not the same answer as the pipeline's
 language, and, for a prompt stage, `model`. The name judge reads all three of
-the `replacements` ones: `changes` says which rules fired and `before` says
+the `vocabulary` ones: `changes` says which rules fired and `before` says
 *where*, because the rules leave no positions behind. A `command:` transform
 publishes whatever it likes; see
 [docs/authoring.md](authoring.md#recipe-a-program-that-reports-what-it-did).
@@ -955,7 +965,7 @@ Two stages publish it today.
 
 - `code_identifiers` publishes the identifiers it wrote — `max_retries`,
   `UserProfile`.
-- A `replace:` table publishes what its rules put in, as does the `replacements`
+- A `replace:` table publishes what its rules put in, as does the `vocabulary`
   stage. A table has no code of its own, so `Replacements.exact` publishes on
   its behalf. The value is the **template expanded**: `dotted` writes `$1.` and
   publishes `user.`, not `$1.`.
@@ -1080,7 +1090,7 @@ publishes it, so a later stage can know what the sentence is answering.
 ```yaml
 pipelines:
   default:
-    - replacements
+    - vocabulary
     - context
     - stage: transform
       transform: reply
@@ -1298,7 +1308,7 @@ terminal and nowhere near an email:
 ```yaml
 pipelines:
   default:
-    - replacements
+    - vocabulary
     - stage: numbers
       app: /term|ghostty|iterm|warp/
     - prompt: prose

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -166,17 +166,18 @@ transcription:
 ```
 
 **Then write the filler words for those languages.** Do not skip this because
-the config looks like it handles it — a new config has `replacements: {}`, and
-the rule in `config.example.yaml` is English only. A French speaker keeps every
-`euh`.
+the config looks like it handles it — the `fillers` transform in
+`config.example.yaml` is English only. A French speaker keeps every `euh`.
 
 > When people talk they make sounds like "um" and "euh". Shall I remove those?
 
 ```yaml
-transcription:
-  replacements:
-    # English; add French euh+|heu+|hein|bah to this same list
-    "": ['/[,]?\s*\b(?:mm[-‑]?hmm|uh[-‑]?huh|mhm|u+m+|u+h+|erm+|hmm+|mm+)\b[,]?/']
+transforms:
+  - name: fillers
+    description: delete hesitation sounds
+    replace:
+      # English; add French euh+|heu+|hein|bah to this same list
+      "": ['/[,]?\s*\b(?:mm[-‑]?hmm|uh[-‑]?huh|mhm|u+m+|u+h+|erm+|hmm+|mm+)\b[,]?/']
 ```
 
 One `""` entry, not two — it is one map, and a repeated key is invalid YAML.

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -22,8 +22,11 @@ filler words, which a literal map cannot: `um` arrives as "um", "umm",
 with it.
 
 ```yaml
-replacements:
-  "": ['/[,]?\s*\b(?:mm[-‑]?hmm|uh[-‑]?huh|u+m+|u+h+|erm+|hmm+|mm+)\b[,]?/']
+transforms:
+  - name: fillers
+    description: delete hesitation sounds
+    replace:
+      "": ['/[,]?\s*\b(?:mm[-‑]?hmm|uh[-‑]?huh|u+m+|u+h+|erm+|hmm+|mm+)\b[,]?/']
 ```
 
 The punctuation in that pattern matters more than it looks. Deleting only the
@@ -33,16 +36,17 @@ straight through. A tidy pass then closes the remaining gaps — doubled spaces,
 a space stranded before a comma, a lowercase word left starting the sentence.
 
 Word boundaries do the rest of the work: "umbrella" and "hummingbird" contain
-fillers and are left alone. Fuzzy matching skips regex and deletion rules
-entirely — they are exact by construction.
+fillers and are left alone. Near-miss matching in the `vocabulary` stage never
+sees these at all — it reads `vocabulary.yaml`, and a pattern is not a spelling
+anything could sound like.
 
 A regex source can also write back what it captured. `$1` in the target refers
 to the first group, and that is the only way to express a rule whose output
 depends on its input:
 
 ```yaml
-replacements:
-  $1.$2: ['/\b(\w+) dot (\w+)\b/']    # "user dot name" -> user.name
+    replace:
+      $1.$2: ['/\b(\w+) dot (\w+)\b/']    # "user dot name" -> user.name
 ```
 
 The slashes switch the target into a template the same way they switch the

--- a/tests/pipeline-cases.yaml
+++ b/tests/pipeline-cases.yaml
@@ -265,8 +265,8 @@ cases:
     input: super base has vingt et un users
     expect: Supabase has 21 users
     expect_vars:
-      replacements.count: 1
-      replacements.changed: true
+      vocabulary.count: 1
+      vocabulary.changed: true
       numbers.language: fr
       numbers.changed: true
       first.count: 2
@@ -274,7 +274,7 @@ cases:
       second.label: kept
 
   # The same run, read from the far side of a pipe. `first` reports what it found
-  # at `replacements.count` and `second` reports what it found at `first.count`,
+  # at `vocabulary.count` and `second` reports what it found at `first.count`,
   # so a pass here means the scope reached two separate scripts — not merely that
   # it survived in Swift, which every other case in this section would also show.
   - name: a script sees what the stages above it published
@@ -292,7 +292,7 @@ cases:
     input: nothing here matches
     expect: unchanged
     expect_vars:
-      replacements.count: 0
+      vocabulary.count: 0
       first.saw: 0
       second.saw: 2
 
@@ -319,7 +319,7 @@ cases:
       quiet.changed: false
 
   # A condition reading a variable rather than the text. The table fires, so
-  # `replacements.count` is 1, so the stage gated on it being 0 stands down.
+  # `vocabulary.count` is 1, so the stage gated on it being 0 stands down.
   - name: a stage stands down because an earlier stage already did the work
     pipeline: vars-conditions
     app: Ghostty
@@ -509,7 +509,7 @@ cases:
     expect: Supabase has 21 users
     expect_vars:
       context.changed: false
-      replacements.count: 1
+      vocabulary.count: 1
       numbers.ran: true
 
   # A non-terminal used to decline here for its own reason. It cannot any more:
@@ -561,23 +561,25 @@ cases:
     expect_vars:
       dotted.ran: false
 
-  # The `replacements` stage publishes it too, from the same pass. A literal
-  # rule protects the term it wrote, and a deletion protects nothing — there is
-  # no text to leave alone.
-  - name: the replacements stage publishes what its rules wrote
+  # The `vocabulary` stage publishes it too, from the pass that writes the
+  # names. A rule protects the term it wrote.
+  - name: the vocabulary stage publishes what its rules wrote
     pipeline: replacements
     input: our app is deployed on Versailles
     expect: our app is deployed on Vercel
     expect_vars:
-      replacements.protected: Vercel
+      vocabulary.protected: Vercel
 
+  # A deletion protects nothing — there is no text to leave alone. It is a
+  # transform now, so the name stage has nothing to say about the sentence and
+  # reports a count of zero while the filler still goes.
   - name: a deletion protects nothing
     pipeline: replacements
     input: our app is um deployed on Vercel
     expect: Our app is deployed on Vercel
     expect_vars:
-      replacements.count: 1
-      replacements.protected: ""
+      vocabulary.count: 0
+      vocabulary.protected: ""
 
   # A pattern can match a term that is already written the way the rule would
   # write it. That match wrote nothing, so there is nothing to protect —
@@ -588,9 +590,9 @@ cases:
     input: we deployed on Vercel
     expect: unchanged
     expect_vars:
-      replacements.count: 0
-      replacements.changed: false
-      replacements.protected: ""
+      vocabulary.count: 0
+      vocabulary.changed: false
+      vocabulary.protected: ""
 
   # The same rule, the spelling it exists for. This is the half that must keep
   # working, and it is why the case above cannot be got by deleting the rule.
@@ -599,8 +601,8 @@ cases:
     input: we deployed on Versal
     expect: we deployed on Vercel
     expect_vars:
-      replacements.count: 1
-      replacements.protected: Vercel
+      vocabulary.count: 1
+      vocabulary.protected: Vercel
 
   # --- input, which from here can only decline -----------------------------
   #
@@ -629,14 +631,14 @@ cases:
     expect_vars:
       input.ok: false
       input.changed: false
-      replacements.count: 1
+      vocabulary.count: 1
       numbers.ran: true
 
   # --- the name judge, on what a `replacements` rule did -----------------------
   #
   # `--pipeline` has no audio, so these are the path that used to have no earlier
   # text to compare against. `replacements` publishes its input as
-  # `replacements.before`, and that is what says which `Vercel` a rule wrote.
+  # `vocabulary.before`, and that is what says which `Vercel` a rule wrote.
   # `vocabulary.slots` counts the places the stage found. See
   # tests/pipelines/vocabulary-rules.yaml for why no model is called.
 
@@ -649,8 +651,8 @@ cases:
     input: a list of possible alternatives for Versailles, such as Vercel
     expect: a list of possible alternatives for Vercel, such as Vercel
     expect_vars:
-      replacements.before: a list of possible alternatives for Versailles, such as Vercel
-      replacements.changes: Versailles -> Vercel
+      vocabulary.before: a list of possible alternatives for Versailles, such as Vercel
+      vocabulary.changes: Versailles -> Vercel
       vocabulary.slots: 1
 
   # One occurrence was decidable without the earlier text and still is. Here so
@@ -669,7 +671,7 @@ cases:
     input: our app is deployed on Vercel
     expect: unchanged
     expect_vars:
-      replacements.changes: ""
+      vocabulary.changes: ""
       vocabulary.slots: 0
 
   # Two renderings of one term in one sentence. The pairs are counted per term,
@@ -685,7 +687,7 @@ cases:
     input: deployed on Versal against the Versailles Castle
     expect: deployed on Vercel against the Vercel Castle
     expect_vars:
-      replacements.before: deployed on Versal against the Versailles Castle
+      vocabulary.before: deployed on Versal against the Versailles Castle
       vocabulary.slots: 2
 
   # And the counts still have to add up. A pattern rule wrote the second
@@ -710,8 +712,8 @@ cases:
     input: a list of possible alternatives for Versailles, such as Vercel
     expect: a list of possible alternatives for Vercel, such as Vercel
     expect_vars:
-      replacements.before: a list of possible alternatives for Vercel, such as Vercel
-      replacements.changes: ""
+      vocabulary.before: a list of possible alternatives for Vercel, such as Vercel
+      vocabulary.changes: ""
       vocabulary.slots: 0
 
   # --- fuzzy renderings --------------------------------------------------------
@@ -729,7 +731,6 @@ cases:
     input: She deserves Praise's work
     expect: unchanged
     expect_vars:
-      replacements.changes: ""
       vocabulary.changes: ""
       vocabulary.count: 1
       vocabulary.slots: 1
@@ -773,7 +774,7 @@ cases:
     input: our app is deployed on Versal
     expect: our app is deployed on Vercel
     expect_vars:
-      replacements.changes: Versal -> Vercel
+      vocabulary.changes: Versal -> Vercel
       vocabulary.slots: 1
 
   # --- named word lists ------------------------------------------------------

--- a/tests/pipeline-cases.yaml
+++ b/tests/pipeline-cases.yaml
@@ -777,6 +777,29 @@ cases:
       vocabulary.changes: Versal -> Vercel
       vocabulary.slots: 1
 
+  # --- a stage with no reviewer ----------------------------------------------
+  #
+  # `review: false` is a documented value and used to be a config that would not
+  # load at all — the key decoded as a name and nothing else, so a boolean threw
+  # before the app ever saw the pipeline.
+  - name: review off still writes what the rules matched exactly
+    pipeline: review-off
+    input: super base is up
+    expect: Supabase is up
+    expect_vars:
+      vocabulary.count: 1
+      vocabulary.slots: 0
+
+  # And the other half: with nobody to read the sentence, a near miss is left
+  # where it stands rather than written on the strength of the edit alone.
+  - name: review off leaves the near misses alone
+    pipeline: review-off
+    input: our app is deployed on Versel
+    expect: unchanged
+    expect_vars:
+      vocabulary.count: 0
+      vocabulary.slots: 0
+
   # --- named word lists ------------------------------------------------------
   #
   # `{{name}}` in a pattern is the list of that name, as an alternation. The

--- a/tests/pipelines/apps-excluded.yaml
+++ b/tests/pipelines/apps-excluded.yaml
@@ -6,9 +6,11 @@
 # `Pipeline.validate` refuses that shape, and this fixture is what proves the
 # anchored one actually excludes.
 languages: [en, fr]
-replacements:
-  Supabase: [super base]
+vocabulary:
+  terms:
+    Supabase:
+      heard: [super base]
 pipeline:
-  - replacements
+  - vocabulary
   - stage: numbers
     app: /^(?!.*(term|ghostty|iterm))/

--- a/tests/pipelines/apps.yaml
+++ b/tests/pipelines/apps.yaml
@@ -7,9 +7,11 @@
 # case for that decision — if a lookahead cannot express exclusion here, the
 # key was needed after all.
 languages: [en, fr]
-replacements:
-  Supabase: [super base]
+vocabulary:
+  terms:
+    Supabase:
+      heard: [super base]
 pipeline:
-  - replacements
+  - vocabulary
   - stage: numbers
     app: /term|ghostty|iterm/

--- a/tests/pipelines/conditions.yaml
+++ b/tests/pipelines/conditions.yaml
@@ -2,10 +2,12 @@
 # stands in for the expensive stage a condition really exists for: what is being
 # tested is that a condition gates a stage, not what that stage does.
 languages: [en, fr]
-replacements:
-  Supabase: [super base]
+vocabulary:
+  terms:
+    Supabase:
+      heard: [super base]
 pipeline:
-  - replacements
+  - vocabulary
   # Never rewrite inside a code fence.
   - stage: numbers
     unless: /```/

--- a/tests/pipelines/context.yaml
+++ b/tests/pipelines/context.yaml
@@ -18,14 +18,16 @@
 # has the grant, and it prints exactly what this stage would publish.
 languages: [en]
 
-replacements:
-  Supabase: [super base]
 
+vocabulary:
+  terms:
+    Supabase:
+      heard: [super base]
 pipeline:
   # Before and after, on purpose. `context` sits in the middle of a real
   # pipeline in the config it is written for, and a stage that publishes
   # variables must not disturb the stages either side of it — including when
   # it declines, which from here it always does.
-  - replacements
+  - vocabulary
   - context
   - numbers

--- a/tests/pipelines/empty.yaml
+++ b/tests/pipelines/empty.yaml
@@ -1,6 +1,8 @@
 # An empty pipeline is a choice: nothing runs, and the text comes back as it
 # arrived even though every stage would have had something to do.
 languages: [en, fr]
-replacements:
-  Supabase: [super base]
+vocabulary:
+  terms:
+    Supabase:
+      heard: [super base]
 pipeline: []

--- a/tests/pipelines/everything.yaml
+++ b/tests/pipelines/everything.yaml
@@ -1,10 +1,13 @@
 # Every stage, no conditions — the default a new install gets.
 languages: [en, fr]
-replacements:
-  Supabase: [super base, superbees]
-  Tasmeen: [Tasmin]
-  "": ['/[,]?\s*\b(?:u+m+|u+h+|erm+)\b[,]?/']
+vocabulary:
+  terms:
+    Supabase:
+      heard: [super base, superbees]
+    Tasmeen:
+      heard: [Tasmin]
+    "":
+      heard: ['/[,]?\s*\b(?:u+m+|u+h+|erm+)\b[,]?/']
 pipeline:
-  - replacements
-  - fuzzy
+  - vocabulary
   - numbers

--- a/tests/pipelines/input.yaml
+++ b/tests/pipelines/input.yaml
@@ -10,12 +10,14 @@
 # half of this stage, is scored by `scripts/check-input.sh` instead.
 languages: [en]
 
-replacements:
-  Supabase: [super base]
 
+vocabulary:
+  terms:
+    Supabase:
+      heard: [super base]
 pipeline:
   # Before and after, on purpose. A stage that publishes variables must not
   # disturb the stages either side of it, including when it declines.
-  - replacements
+  - vocabulary
   - input
   - numbers

--- a/tests/pipelines/prompt.yaml
+++ b/tests/pipelines/prompt.yaml
@@ -7,7 +7,6 @@
 # prompt has to be survivable at runtime — Ollama absent, a renamed prompt, a
 # fixture like this one — and "survivable" means the text comes back untouched.
 languages: [en, fr]
-replacements: {}
 pipeline:
   - stage: numbers
     unless: /```/

--- a/tests/pipelines/protected.yaml
+++ b/tests/pipelines/protected.yaml
@@ -10,8 +10,10 @@
 # fixture: the alternation is what makes a no-op match reachable at all.
 languages: [en]
 
-replacements:
-  Vercel: ['/\b(?:Versal|Vercel)\b/']
 
+vocabulary:
+  terms:
+    Vercel:
+      heard: ['/\b(?:Versal|Vercel)\b/']
 pipeline:
-  - replacements
+  - vocabulary

--- a/tests/pipelines/refused/vocabulary-after-edit.yaml
+++ b/tests/pipelines/refused/vocabulary-after-edit.yaml
@@ -1,15 +1,15 @@
-# The name judge placed after a stage that rewrites the transcript.
+# The name stage placed after a stage that rewrites the transcript.
 #
-# `vocabulary:` is handed spans the acoustic pass measured on the text the
-# decoder produced. A stage that edits text moves them, and the stage then has
-# to find its words again by searching — which is the mechanism that put the
-# menu on the wrong `Versailles` (finding F10). Nothing at run time can tell a
-# moved span from a span that was always wrong, so it is refused at load.
+# It is handed spans the acoustic pass measured on the text the decoder
+# produced. A stage that edits text moves them, and the stage then has to find
+# its words again by searching — which is the mechanism that put the menu on the
+# wrong `Versailles` (finding F10). Nothing at run time can tell a moved span
+# from a span that was always wrong, so it is refused at load.
 #
-# `replacements` is deliberately allowed above it: the judge offers a rule's
-# substitution back as a reading, so the rules have to have fired first.
+# There used to be one exception, `replacements`, because the review offers a
+# rule's substitution back and the rules had to have fired first. That pass is
+# inside this stage now, so there is no exception left to state.
 languages: [en]
 pipeline:
-  - replacements
   - numbers
   - vocabulary

--- a/tests/pipelines/refused/vocabulary-cap-zero.yaml
+++ b/tests/pipelines/refused/vocabulary-cap-zero.yaml
@@ -11,6 +11,6 @@
 
 languages: [en]
 pipeline:
-  - replacements
+  - vocabulary
   - stage: vocabulary
     max_per_term: 0

--- a/tests/pipelines/refused/vocabulary-max-readings.yaml
+++ b/tests/pipelines/refused/vocabulary-max-readings.yaml
@@ -8,6 +8,6 @@
 # person who typed it.
 languages: [en]
 pipeline:
-  - replacements
+  - vocabulary
   - stage: vocabulary
     max_readings: 16

--- a/tests/pipelines/refused/vocabulary-per-slot-three.yaml
+++ b/tests/pipelines/refused/vocabulary-per-slot-three.yaml
@@ -8,6 +8,6 @@
 # says one thing and does another. Found by review on #102.
 languages: [en]
 pipeline:
-  - replacements
+  - vocabulary
   - stage: vocabulary
     max_per_slot: 3

--- a/tests/pipelines/refused/vocabulary-prompt-file.yaml
+++ b/tests/pipelines/refused/vocabulary-prompt-file.yaml
@@ -8,5 +8,5 @@
 # The fix is one word — delete the filename.
 languages: [en]
 pipeline:
-  - replacements
+  - vocabulary
   - vocabulary: verify_names.md

--- a/tests/pipelines/replacements.yaml
+++ b/tests/pipelines/replacements.yaml
@@ -1,25 +1,44 @@
-# The table tests/replacement-cases.txt has always assumed.
+# The table tests/replacement-cases.txt has always assumed, in the two places
+# that hold it now.
 #
-# It used to assume it from whoever's config was on the machine, and said so in
-# its own header — which meant the set scored 8/20 on a config with an empty
-# table, for a reason that had nothing to do with the passes it tests. Stated
-# here instead, so the number means the same thing everywhere.
+# It used to be one `replacements:` table doing both jobs. A name the recogniser
+# mangles goes in vocabulary.yaml, where the stage reviews it in context; a
+# mechanical rule — a deletion, a template — goes in a transform, which needs no
+# review. Nothing was left in between, which is why the table went.
 #
-# `Mik` and `Matthieu` are the two that make the fuzzy guard visible: "Mick"
+# `Mik` and `Matthieu` are the two that make the near-miss guard visible: "Mick"
 # must be corrected because it is a name, and "Matthew" must not, because the
 # spell checker knows it.
+#
+# No model is defined, so the review declines and the exact and near-miss passes
+# are what the cases score. That is the whole point: those two are deterministic
+# and a verdict is not.
 languages: [en, fr]
-replacements:
-  Vercel: [Versailles, Versal]
-  Supabase: [Super Base, super bays, superbase, superbees]
-  Tasmeen: [Tasmid, Tasmin, Tasmine]
-  Matthieu: [Mathieu]
-  Mik: [Meek, Mick]
-  "": ['/[,]?\s*\b(?:mm[-‑]?hmm|uh[-‑]?huh|mhm|u+m+|u+h+|erm+|hmm+|mm+)\b[,]?/']
+vocabulary:
+  terms:
+    Vercel:
+      heard: [Versailles, Versal]
+    Supabase:
+      heard: [Super Base, super bays, superbase, superbees]
+    Tasmeen:
+      heard: [Tasmid, Tasmin, Tasmine]
+    Matthieu:
+      heard: [Mathieu]
+    Mik:
+      heard: [Meek, Mick]
+transforms:
+  - name: fillers
+    description: delete hesitation sounds
+    replace:
+      "": ['/[,]?\s*\b(?:mm[-‑]?hmm|uh[-‑]?huh|mhm|u+m+|u+h+|erm+|hmm+|mm+)\b[,]?/']
   # A template, not a word: the source is a pattern, so `$1` and `$2` are what
-  # it captured. Also the case that keeps `$1.$2` out of the fuzzy target list,
-  # where it would be a spelling nothing can sound like.
-  $1.$2: ['/\b(\w+) dot (\w+)\b/']
+  # it captured. A transform is where this belongs — there is no name here for
+  # a model to have an opinion about.
+  - name: dotted
+    description: spoken dot as a dotted path
+    replace:
+      $1.$2: ['/\b(\w+) dot (\w+)\b/']
 pipeline:
-  - replacements
-  - fuzzy
+  - vocabulary
+  - transform: fillers
+  - transform: dotted

--- a/tests/pipelines/review-off.yaml
+++ b/tests/pipelines/review-off.yaml
@@ -1,0 +1,23 @@
+# `review: false` on the vocabulary stage.
+#
+# The exact matches still ship — they are what the rules wrote, and a rule that
+# fired needs nobody's opinion. Nothing is put to a model.
+#
+# The near-miss pass goes with the review rather than running without it. A near
+# miss is only ever a proposal: it is never written until a model has read the
+# sentence, so with no reviewer there is nothing that could ever write one. That
+# is why `Versel` opens no place here even though `near_misses` is left on.
+#
+# The same two terms as tests/pipelines/vocabulary-exact.yaml, so the two
+# fixtures can be read against each other: that one closes the near-miss pass
+# with `near_misses: false`, this one closes it by having no reviewer.
+languages: [en]
+vocabulary:
+  terms:
+    Vercel:
+      heard: [Versal]
+    Supabase:
+      heard: [super base]
+pipeline:
+  - stage: vocabulary
+    review: false

--- a/tests/pipelines/vars-conditions.yaml
+++ b/tests/pipelines/vars-conditions.yaml
@@ -1,10 +1,10 @@
 # A stage gated on what an earlier stage published, which is the whole reason
 # variables exist.
 #
-# `first` reports how many replacement rules fired. `second` runs only when that
+# `first` reports how many vocabulary rules fired. `second` runs only when that
 # is zero — the shape the real config wants for `dotted`, which should stand
 # down when `code_identifiers` has already taken the sentence. Scored on two
-# inputs: one the table rewrites and one it does not, so the same pipeline takes
+# inputs: one the rules rewrite and one they do not, so the same pipeline takes
 # both branches.
 #
 # `third` is the seed half: `app` and `language` are put in the scope before any
@@ -12,13 +12,11 @@
 # `app:` key. Note that it is a real negation — `!app.contains(…)` — where the
 # `app:` key would have needed an anchored negative lookahead.
 languages: [en, fr]
-replacements:
-  Supabase: [super base]
 
 transforms:
   - name: first
     description: reports what the table did
-    command: counter.py --echo replacements.count
+    command: counter.py --echo vocabulary.count
     returns: json
 
   - name: second
@@ -31,12 +29,16 @@ transforms:
     command: counter.py --count 7
     returns: json
 
+vocabulary:
+  terms:
+    Supabase:
+      heard: [super base]
 pipeline:
-  - replacements
+  - vocabulary
   - transform: first
   - stage: transform
     transform: second
-    when: replacements.count == 0
+    when: vocabulary.count == 0
   - stage: transform
     transform: third
     when: '!app.contains("ghostty") && language == "en"'

--- a/tests/pipelines/vars.yaml
+++ b/tests/pipelines/vars.yaml
@@ -6,19 +6,17 @@
 # that every namespace is still there at the end — a stage contributing nothing
 # erases nothing, and a stage contributing something erases nothing either.
 #
-# `first --echo replacements.count` is the half that cannot be faked in Swift:
+# `first --echo vocabulary.count` is the half that cannot be faked in Swift:
 # it reports back what the *script* found in its context, so a case that passes
 # proves the scope reached the far side of a pipe rather than merely surviving
 # in memory. `second --echo first.count` then proves the same for a fact
 # published by another script rather than by a built-in stage.
 languages: [en, fr]
-replacements:
-  Supabase: [super base]
 
 transforms:
   - name: first
     description: publishes a count, and reports what replacements published
-    command: counter.py --count 2 --echo replacements.count
+    command: counter.py --count 2 --echo vocabulary.count
     returns: json
 
   - name: second
@@ -26,8 +24,12 @@ transforms:
     command: counter.py --count 7 --label kept --echo first.count
     returns: json
 
+vocabulary:
+  terms:
+    Supabase:
+      heard: [super base]
 pipeline:
-  - replacements
+  - vocabulary
   - numbers
   - transform: first
   - transform: second

--- a/tests/pipelines/vocabulary-exact.yaml
+++ b/tests/pipelines/vocabulary-exact.yaml
@@ -16,9 +16,6 @@
 # was before this option existed. Every sentence that opens a place in
 # tests/pipelines/vocabulary-fuzzy.yaml opens none here.
 #
-# See tests/pipelines/vocabulary-rules.yaml for `llm: {enabled: false}`.
-llm:
-  enabled: false
 languages: [en]
 vocabulary:
   terms:

--- a/tests/pipelines/vocabulary-exact.yaml
+++ b/tests/pipelines/vocabulary-exact.yaml
@@ -24,6 +24,5 @@ vocabulary:
     Vercel:
       heard: [Versal]
 pipeline:
-  - replacements
   - stage: vocabulary
-    fuzzy: false
+    near_misses: false

--- a/tests/pipelines/vocabulary-fuzzy.yaml
+++ b/tests/pipelines/vocabulary-fuzzy.yaml
@@ -25,5 +25,4 @@ vocabulary:
     Vercel:
       heard: [Versal]
 pipeline:
-  - replacements
   - vocabulary

--- a/tests/pipelines/vocabulary-fuzzy.yaml
+++ b/tests/pipelines/vocabulary-fuzzy.yaml
@@ -17,9 +17,6 @@
 #
 # Nothing is written by a match. It opens a place, and the model decides.
 #
-# See tests/pipelines/vocabulary-rules.yaml for `llm: {enabled: false}`.
-llm:
-  enabled: false
 languages: [en]
 vocabulary:
   terms:

--- a/tests/pipelines/vocabulary-rules-pattern.yaml
+++ b/tests/pipelines/vocabulary-rules-pattern.yaml
@@ -5,15 +5,12 @@
 # occurrence, grouped or not, and the stage has to decline rather than hand the
 # literal's spelling to a place some other rule wrote. See the cases.
 #
-# `llm: {enabled: false}` is how no model is called. The stage still finds the
 # places and publishes `vocabulary.slots`, then declines rather than asking —
 # so the run is the same with Ollama up or down. Every case here scores the
 # places the stage found, never what was decided at them.
 #
 # It was `max_readings: 1` while the judge answered with a letter from a menu.
 # There is no menu now, that key is ignored, and this is the replacement.
-llm:
-  enabled: false
 languages: [en]
 replacements:
   Vercel: [Versal, '/Versa\w+/']

--- a/tests/pipelines/vocabulary-rules-pattern.yaml
+++ b/tests/pipelines/vocabulary-rules-pattern.yaml
@@ -12,8 +12,9 @@
 # It was `max_readings: 1` while the judge answered with a letter from a menu.
 # There is no menu now, that key is ignored, and this is the replacement.
 languages: [en]
-replacements:
-  Vercel: [Versal, '/Versa\w+/']
+vocabulary:
+  terms:
+    Vercel:
+      heard: [Versal, '/Versa\w+/']
 pipeline:
-  - replacements
   - vocabulary

--- a/tests/pipelines/vocabulary-rules-twice.yaml
+++ b/tests/pipelines/vocabulary-rules-twice.yaml
@@ -1,20 +1,20 @@
-# Two `replacements` steps above the judge, which a pipeline is allowed to have.
+# Two name steps in one pipeline, which a pipeline is allowed to have.
 #
-# Both steps publish under the same namespace and the second wins, for `before`
-# exactly as for `changes`. The pair stays consistent — the judge reads the last
-# step's changes beside the last step's input — and the first step's changes are
-# not readable at all, which was already true before `before` existed.
+# Both publish under the same namespace and the second wins, for `before`
+# exactly as for `changes`. The pair stays consistent — the review reads the
+# last step's changes beside the last step's input — and the first step's
+# changes are not readable at all, which was already true before `before`
+# existed.
 #
-# places and publishes `vocabulary.slots`, then declines rather than asking —
-# so the run is the same with Ollama up or down. Every case here scores the
-# places the stage found, never what was decided at them.
-#
-# It was `max_readings: 1` while the judge answered with a letter from a menu.
-# There is no menu now, that key is ignored, and this is the replacement.
+# No model is defined, so the stage places and publishes `vocabulary.slots` and
+# then declines rather than asking. The run is the same with Ollama up or down,
+# and every case here scores the places the stage found, never what was decided
+# at them.
 languages: [en]
-replacements:
-  Vercel: [Versailles]
+vocabulary:
+  terms:
+    Vercel:
+      heard: [Versailles]
 pipeline:
-  - replacements
-  - replacements
+  - vocabulary
   - vocabulary

--- a/tests/pipelines/vocabulary-rules-twice.yaml
+++ b/tests/pipelines/vocabulary-rules-twice.yaml
@@ -5,15 +5,12 @@
 # step's changes beside the last step's input — and the first step's changes are
 # not readable at all, which was already true before `before` existed.
 #
-# `llm: {enabled: false}` is how no model is called. The stage still finds the
 # places and publishes `vocabulary.slots`, then declines rather than asking —
 # so the run is the same with Ollama up or down. Every case here scores the
 # places the stage found, never what was decided at them.
 #
 # It was `max_readings: 1` while the judge answered with a letter from a menu.
 # There is no menu now, that key is ignored, and this is the replacement.
-llm:
-  enabled: false
 languages: [en]
 replacements:
   Vercel: [Versailles]

--- a/tests/pipelines/vocabulary-rules-two-renderings.yaml
+++ b/tests/pipelines/vocabulary-rules-two-renderings.yaml
@@ -3,15 +3,12 @@
 # Separate from `vocabulary-rules.yaml` because the table is what differs: two
 # rules write `Vercel` here, and each is counted on its own. See the cases.
 #
-# `llm: {enabled: false}` is how no model is called. The stage still finds the
 # places and publishes `vocabulary.slots`, then declines rather than asking —
 # so the run is the same with Ollama up or down. Every case here scores the
 # places the stage found, never what was decided at them.
 #
 # It was `max_readings: 1` while the judge answered with a letter from a menu.
 # There is no menu now, that key is ignored, and this is the replacement.
-llm:
-  enabled: false
 languages: [en]
 replacements:
   Vercel: [Versailles, Versal]

--- a/tests/pipelines/vocabulary-rules-two-renderings.yaml
+++ b/tests/pipelines/vocabulary-rules-two-renderings.yaml
@@ -10,8 +10,9 @@
 # It was `max_readings: 1` while the judge answered with a letter from a menu.
 # There is no menu now, that key is ignored, and this is the replacement.
 languages: [en]
-replacements:
-  Vercel: [Versailles, Versal]
+vocabulary:
+  terms:
+    Vercel:
+      heard: [Versailles, Versal]
 pipeline:
-  - replacements
   - vocabulary

--- a/tests/pipelines/vocabulary-rules.yaml
+++ b/tests/pipelines/vocabulary-rules.yaml
@@ -11,8 +11,9 @@
 # It was `max_readings: 1` while the judge answered with a letter from a menu.
 # There is no menu now, that key is ignored, and this is the replacement.
 languages: [en]
-replacements:
-  Vercel: [Versailles]
+vocabulary:
+  terms:
+    Vercel:
+      heard: [Versailles]
 pipeline:
-  - replacements
   - vocabulary

--- a/tests/pipelines/vocabulary-rules.yaml
+++ b/tests/pipelines/vocabulary-rules.yaml
@@ -4,15 +4,12 @@
 # `vocabulary.slots` is the number, and it is the one thing about this stage a
 # fixture can assert — the answer comes from a model and is not deterministic.
 #
-# `llm: {enabled: false}` is how no model is called. The stage still finds the
 # places and publishes `vocabulary.slots`, then declines rather than asking —
 # so the run is the same with Ollama up or down. Every case here scores the
 # places the stage found, never what was decided at them.
 #
 # It was `max_readings: 1` while the judge answered with a letter from a menu.
 # There is no menu now, that key is ignored, and this is the replacement.
-llm:
-  enabled: false
 languages: [en]
 replacements:
   Vercel: [Versailles]

--- a/tests/pipelines/when.yaml
+++ b/tests/pipelines/when.yaml
@@ -1,12 +1,16 @@
 # `when` rather than `unless`, and a condition that reads the text as it stands
 # after the stage above it — which is the ordering that makes conditions worth
 # having.
+#
+# The stage above is a transform, because deleting a filler is what a transform
+# does now: a rule that needs no review does not belong in vocabulary.yaml.
 languages: [en, fr]
-replacements:
-  # The exact pass deletes the filler, so the condition below sees a sentence
-  # that no longer contains it.
-  "": ['/[,]?\s*\bgenre\b[,]?/']
+transforms:
+  - name: fillers
+    description: delete hesitation sounds
+    replace:
+      "": ['/[,]?\s*\bgenre\b[,]?/']
 pipeline:
-  - replacements
+  - transform: fillers
   - stage: numbers
     when: /genre/

--- a/tests/replacement-cases.txt
+++ b/tests/replacement-cases.txt
@@ -3,9 +3,17 @@
 # Run with: scripts/check-replacements.sh
 # Targets come from tests/pipelines/replacements.yaml, not from your config, so
 # this scores the same on any machine. The last six must never change — they are
-# the guard against fuzzy matching touching ordinary language.
-I deployed it to Versel yesterday|I deployed it to Vercel yesterday
-We shipped on Ver Sal last week|We shipped on Vercel last week
+# the guard against near-miss matching touching ordinary language.
+#
+# The next two are the change of behaviour that came with the merge, and they
+# are here to record it rather than to be quietly deleted. A rendering one edit
+# away, or split across two words, used to be *written* by the `fuzzy` stage.
+# It is now proposed to the review instead: nothing is rewritten until a model
+# has read the sentence and kept it. No model is defined in the fixture — the
+# passes have to score the same with Ollama up or down — so both come back
+# unchanged here, and would be corrected on a machine with a model.
+I deployed it to Versel yesterday|I deployed it to Versel yesterday
+We shipped on Ver Sal last week|We shipped on Ver Sal last week
 I love working on Superbase|I love working on Supabase
 It runs on super base now|It runs on Supabase now
 I work with Tasmia on this|I work with Tasmia on this


### PR DESCRIPTION
Follows #153. That one let you name models; this one puts every setting about
them where the thing it configures lives, and collapses three pipeline stages
that were always one algorithm.

## Models define themselves

```yaml
models:
  qwen: { api: ollama, model: qwen3.8:27b-mlx, default: true }
  gpt:  { api: openai, model: gpt-5.6-luna }
```

`llm:` described one model *and* named which of the others ran what — two jobs
under a name that fits neither. Worse, the model it described was invisible:
`local` was synthesized whether or not anything wrote it, built from struct
defaults, so a config that named no Ollama model listed one anyway.

Models are now only what `models:` defines. `default: true` marks the fallback.
One model needs no flag; several with none marked, or more than one marked, is
refused rather than guessed at.

`llm.enabled` is gone. A config that defines no model says the same thing and
cannot fall out of step with itself.

## Bindings move to the feature they serve

```yaml
commands:
  router: qwen
  spelling: gpt
  catch_all: gpt
```

The router picks a capability; `spelling` and `catch_all` are two of the things
it can pick. `catch_all` was `free_form:` at the top level, and it now carries
the model as well as the on/off — it is the case that most deserves its own,
since the free-form prompt is where a small local model is measured at its
ceiling.

`spelling` also stops following `default`. It is a built-in, so it could never
carry a `model:` the way a transform can, and reading letters out of speech is
what a small local model is worst at.

## Names are one stage

```yaml
- stage: vocabulary
  near_misses: true    # was the step's `fuzzy:`
  review: qwen         # was llm.vocabulary; false ships them unread
```

`replacements` wrote the exact matches, `fuzzy` caught the near ones,
`vocabulary` reviewed them — and the order was enforced by hand, because the
three were never independent. `--check-config` refused `fuzzy` above
`replacements`, and refused anything but `replacements` above `vocabulary`.
Both rules existed to describe one pass. The order is no longer something a
config can get wrong.

`review:` binds on the step because a pipeline is per language, and the model
that reads a French sentence need not be the one that reads an English one.

`near_misses:` was `fuzzy:`, beside a *stage* also called `fuzzy` that did
something else entirely — that one matched text against the rule table and
rewrote it, and never saw a vocabulary rendering at all.

## `transcription.replacements` is retired

It held two kinds of rule and neither belongs there. A name the recogniser
mangles goes in `vocabulary.yaml`, where it is reviewed in context. A
mechanical rule goes in a transform's `replace:`, which needs no review and
already takes regexes, deletions, `{{lists}}` and `when:`/`app:` conditions.
Nothing was left in the middle.

## One behaviour changes

A rendering one edit away, or split across two words, used to be *written* by
the `fuzzy` stage. It is proposed to the review instead: nothing is rewritten
until a model has read the sentence. That is what makes the near-miss pass safe
to be as loose as it is — and it means a machine with no model gets the exact
matches and leaves the near ones alone.

The two cases in `tests/replacement-cases.txt` are updated to record this
rather than deleted.

## Migration

Nothing is silently ignored. `Decodable` drops an unknown key without a word,
so a config still carrying `llm:` would load, bind nothing, and look fine until
a dictation did nothing. Every retired key is read purely to be refused, and
each names the line that replaces it:

```
✗ llm: `llm.default` is now `default: true` on one entry in `models:` …
✗ free_form: now `commands.catch_all` …
✗ transcription.replacements no longer does anything — a name the recogniser
  mangles goes in vocabulary.yaml … a mechanical rule goes in a transform's
  `replace:` …
✗ pipelines: "fuzzy" is not a stage — have: numbers, context, input, vocabulary, transform
```

## Testing

- 28 of 30 check scripts pass, including every one this touches:
  `check-pipeline.sh` 91/91, `check-replacements.sh` 23/23,
  `check-transform-folders.sh` 21/21.
- The two that fail — `check-grammar.sh`, `check-routing.sh` — need Ollama
  running and read the machine's own config. They fail on `main` for the same
  reason.
- 19 pipeline fixtures converted; two rewritten by hand because they tested
  deletions and regex templates, which are transforms now.
- Installed and run: both configs migrated, `--check-config` clean, dictation
  and the keychain key intact.

## Also

- A bug the tests caught: the stage published `count` from the exact pass, the
  run loop added a near-miss count on top, and the stage's own vars then
  overwrote it. Near misses are counted inside the stage now.
- `Replacements.applyFuzzy` and `isFuzzyCandidate` go with the stage that was
  their only caller.
- Six messages still named `llm.enabled`, a key that no longer exists.
- The first commit finishes #153's keychain work: a declined key can be asked
  for again from the menu, the dialog is shorter, and a doc comment #153 stole
  is back where it belongs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)