### PR TITLE
feat: a command path may share a script under transforms/, and examples install as one tree

### DIFF
--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -2531,50 +2531,42 @@ enum ConfigStore {
         directory.appendingPathComponent("transforms", isDirectory: true)
     }
 
-    /// Transforms seeded on first launch, script-only: (folder name, script
-    /// filename). Each folder is copied whole from `exampleTransformsDirectory`
-    /// — the script, plus the `cases.yaml` beside it.
-    static let seededTransforms: [(name: String, script: String)] = [
-        ("code_identifiers", "code_identifiers.py"),
-        ("punctuation", "punctuation.py"),
-        ("repetitions", "repetitions.py"),
-    ]
-
-    /// The folder a seeded transform owns.
-    static func seededTransformFolder(_ name: String) -> URL {
-        transformsDirectory.appendingPathComponent(name, isDirectory: true)
-    }
-
-    /// Where a seeded transform's program lives — in its folder, which is
-    /// what makes `command: <script>` resolve.
-    static func seededTransformScript(_ name: String, _ script: String) -> URL {
-        seededTransformFolder(name).appendingPathComponent(script)
-    }
-
-    /// Every file a seeded transform's example folder holds, by name.
+    /// `<config>/transforms/examples/` — every shipped example, in one
+    /// folder, refreshed from `exampleTransformsDirectory` on every launch.
     ///
-    /// Read rather than listed, so a transform that grows a data file is
-    /// seeded with it. `punctuation` owns `en.py` and `fr.py`, and a
-    /// script seeded without its data does nothing on every transcript.
-    static func seededTransformFiles(_ name: String) -> [String] {
-        let source = exampleTransformsDirectory.appendingPathComponent(name, isDirectory: true)
-        let found = try? FileManager.default.contentsOfDirectory(
-            at: source, includingPropertiesForKeys: nil)
-        return (found ?? [])
-            .filter { !$0.hasDirectoryPath && !$0.lastPathComponent.hasPrefix(".") }
-            .map(\.lastPathComponent)
-            .sorted()
+    /// This folder is the app's, not yours: unlike `transforms/<name>/`,
+    /// which is written once and never touched again, this one is
+    /// overwritten every time `createIfMissing()` runs, so the shipped
+    /// examples never go stale. That is what buys one copy of a script
+    /// instead of a copy per transform that uses it —
+    /// `command: examples/punctuation/punctuation.py` reads the file here,
+    /// and every config that points a `command:` at it shares the same one.
+    /// Edit a file in here and the edit is gone at the next launch; copy it
+    /// into `transforms/<name>/` first if you want to keep changes to it.
+    static var installedExamplesDirectory: URL {
+        transformsDirectory.appendingPathComponent("examples", isDirectory: true)
     }
 
-    /// Is the file a user owns still the copy that ships?
+    /// Every file under `exampleTransformsDirectory`, as paths relative to
+    /// it — `code_identifiers/code_identifiers.py`,
+    /// `punctuation/cases.yaml`, and so on.
     ///
-    /// Byte for byte, which answers both "you edited it" and "it is the one
-    /// from an older version" at once, and cannot tell them apart. Neither can
-    /// anything else, which is why this reports rather than overwrites.
-    static func differsFromShipped(_ file: URL, _ shipped: URL) -> Bool {
-        let fm = FileManager.default
-        guard fm.fileExists(atPath: shipped.path) else { return false }
-        return !fm.contentsEqual(atPath: file.path, andPath: shipped.path)
+    /// Walked rather than named one by one, so a folder that gains a file,
+    /// or the tree that gains a folder, is picked up without a list here to
+    /// keep in sync with `examples/transforms/`.
+    static func exampleTransformFiles() -> [String] {
+        let source = exampleTransformsDirectory
+        guard let enumerator = FileManager.default.enumerator(
+            at: source, includingPropertiesForKeys: [.isDirectoryKey]
+        ) else { return [] }
+        var files: [String] = []
+        for case let url as URL in enumerator {
+            let isDirectory = (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory
+                ?? false
+            guard !isDirectory, !url.lastPathComponent.hasPrefix(".") else { continue }
+            files.append(String(url.path.dropFirst(source.path.count + 1)))
+        }
+        return files.sorted()
     }
 
     /// `examples/transforms/` — the one copy of every shipped example, seeded
@@ -2603,46 +2595,37 @@ enum ConfigStore {
             .appendingPathComponent("examples/transforms", isDirectory: true)
     }
 
-    /// Creates the config file, and the one transform it ships with, if they
-    /// are not there yet.
+    /// Creates the config file, and refreshes the shipped examples, if they
+    /// are not there yet — or, for the examples, whether they are or not.
     ///
-    /// A folder rather than two loose files, because that is the layout the
-    /// app reads and a shipped example that does not demonstrate it teaches
-    /// the wrong thing. The case set goes in with the script: a transform that
-    /// arrives with its own set is the whole argument of docs/authoring.md
-    /// made concrete, and `--eval code_identifiers` finds it by convention.
+    /// **`transforms/examples/` is the app's**, refreshed from
+    /// `exampleTransformsDirectory` on every call — every launch, and every
+    /// `--seed-config`. That is the point: an improvement to
+    /// `code_identifiers.py` reaches every config that points a `command:`
+    /// at it, from one copy, instead of a copy per transform that a person
+    /// has to notice is stale and re-seed by hand.
     ///
-    /// Copied from `exampleTransformsDirectory`, not written from a string —
-    /// one real file instead of two hand-synced copies. Nothing here is ever
-    /// overwritten: once it exists it is yours, and an update that reverted
-    /// your stop lists would be the app taking back what it gave you.
+    /// **`transforms/<name>/` is still yours**, and this never writes it. An
+    /// install from before this folder existed already has its own
+    /// `transforms/punctuation/punctuation.py`, and `command: punctuation.py`
+    /// still finds it by the bare-name rule — nothing here moves it, reads
+    /// it, or copies over it.
     static func createIfMissing() throws {
         let fm = FileManager.default
-        for (name, script) in seededTransforms {
-            let folder = seededTransformFolder(name)
-            let source = exampleTransformsDirectory.appendingPathComponent(name, isDirectory: true)
-            for filename in seededTransformFiles(name) {
-                let destination = folder.appendingPathComponent(filename)
-                let shipped = source.appendingPathComponent(filename)
-                guard !fm.fileExists(atPath: destination.path) else {
-                    // Never overwritten, so the most an upgrade can do is say
-                    // so. `--seed-config` prints the same thing with the path
-                    // of the copy that ships.
-                    if differsFromShipped(destination, shipped) {
-                        Log.write("config: transforms/\(name)/\(filename) is yours, "
-                                  + "and not the copy that ships now")
-                    }
-                    continue
-                }
-                try fm.createDirectory(at: folder, withIntermediateDirectories: true)
-                try fm.copyItem(at: shipped, to: destination)
-                if filename == script {
-                    // A shebang does nothing without this.
-                    try fm.setAttributes([.posixPermissions: 0o755],
-                                         ofItemAtPath: destination.path)
-                }
-                Log.write("config: wrote transforms/\(name)/\(filename)")
+        let source = exampleTransformsDirectory
+        for relative in exampleTransformFiles() {
+            let shipped = source.appendingPathComponent(relative)
+            let destination = installedExamplesDirectory.appendingPathComponent(relative)
+            let isNew = !fm.fileExists(atPath: destination.path)
+            try fm.createDirectory(
+                at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
+            if !isNew { try fm.removeItem(at: destination) }
+            try fm.copyItem(at: shipped, to: destination)
+            if destination.pathExtension == "py" {
+                // A shebang does nothing without this.
+                try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: destination.path)
             }
+            if isNew { Log.write("config: wrote transforms/examples/\(relative)") }
         }
         // The vocabulary, empty but explained. Written so the file exists to
         // be found and read — a person who never dictates a mangled word

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -2543,6 +2543,9 @@ enum ConfigStore {
     /// and every config that points a `command:` at it shares the same one.
     /// Edit a file in here and the edit is gone at the next launch; copy it
     /// into `transforms/<name>/` first if you want to keep changes to it.
+    /// A file a later version stops shipping is removed from here too, so a
+    /// deleted or renamed example does not go on resolving through an
+    /// `examples/...` path after the app that shipped it is gone.
     static var installedExamplesDirectory: URL {
         transformsDirectory.appendingPathComponent("examples", isDirectory: true)
     }
@@ -2555,16 +2558,34 @@ enum ConfigStore {
     /// or the tree that gains a folder, is picked up without a list here to
     /// keep in sync with `examples/transforms/`.
     static func exampleTransformFiles() -> [String] {
-        let source = exampleTransformsDirectory
-        guard let enumerator = FileManager.default.enumerator(
-            at: source, includingPropertiesForKeys: [.isDirectoryKey]
-        ) else { return [] }
+        filesUnder(exampleTransformsDirectory)
+    }
+
+    /// The same walk, over what is actually installed at
+    /// `installedExamplesDirectory` — which, right before a refresh, may
+    /// still include files an older version shipped and this one does not.
+    static func installedExampleFiles() -> [String] {
+        filesUnder(installedExamplesDirectory)
+    }
+
+    private static func filesUnder(_ root: URL) -> [String] {
+        // `enumerator(atPath:)`, not `enumerator(at:)` — it hands back paths
+        // already relative to `root`, so there is no absolute prefix to
+        // strip. Stripping one was fragile: under `/tmp` or `/var/folders`,
+        // the enumerator resolves the ancestor symlink and reports
+        // `/private/…`, while `root` does not, and the two disagreed on
+        // length.
+        guard let enumerator = FileManager.default.enumerator(atPath: root.path)
+        else { return [] }
         var files: [String] = []
-        for case let url as URL in enumerator {
-            let isDirectory = (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory
-                ?? false
-            guard !isDirectory, !url.lastPathComponent.hasPrefix(".") else { continue }
-            files.append(String(url.path.dropFirst(source.path.count + 1)))
+        for case let relative as String in enumerator {
+            var isDirectory: ObjCBool = false
+            let exists = FileManager.default.fileExists(
+                atPath: root.appendingPathComponent(relative).path, isDirectory: &isDirectory)
+            guard exists, !isDirectory.boolValue,
+                  !(relative as NSString).lastPathComponent.hasPrefix(".")
+            else { continue }
+            files.append(relative)
         }
         return files.sorted()
     }
@@ -2610,22 +2631,45 @@ enum ConfigStore {
     /// `transforms/punctuation/punctuation.py`, and `command: punctuation.py`
     /// still finds it by the bare-name rule — nothing here moves it, reads
     /// it, or copies over it.
+    ///
+    /// **A file this version no longer ships is removed from
+    /// `transforms/examples/`.** Without that, an example an earlier version
+    /// installed but this one dropped or renamed would keep sitting there,
+    /// still resolvable through its old `examples/...` path, working when it
+    /// should instead be reported as missing.
     static func createIfMissing() throws {
         let fm = FileManager.default
         let source = exampleTransformsDirectory
-        for relative in exampleTransformFiles() {
-            let shipped = source.appendingPathComponent(relative)
+        let shipped = exampleTransformFiles()
+        for relative in shipped {
+            let shippedFile = source.appendingPathComponent(relative)
             let destination = installedExamplesDirectory.appendingPathComponent(relative)
             let isNew = !fm.fileExists(atPath: destination.path)
             try fm.createDirectory(
                 at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
             if !isNew { try fm.removeItem(at: destination) }
-            try fm.copyItem(at: shipped, to: destination)
+            try fm.copyItem(at: shippedFile, to: destination)
             if destination.pathExtension == "py" {
                 // A shebang does nothing without this.
                 try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: destination.path)
             }
             if isNew { Log.write("config: wrote transforms/examples/\(relative)") }
+        }
+        let stillShipped = Set(shipped)
+        for relative in installedExampleFiles() where !stillShipped.contains(relative) {
+            var url = installedExamplesDirectory.appendingPathComponent(relative)
+            try? fm.removeItem(at: url)
+            Log.write("config: removed transforms/examples/\(relative) (no longer shipped)")
+            // A folder a removed example leaves empty — `retired/` once
+            // `retired/retired.py` is gone — is cleaned up too, stopping at
+            // the first one that still has something else in it, and never
+            // above `installedExamplesDirectory` itself.
+            url.deleteLastPathComponent()
+            while url.path != installedExamplesDirectory.path,
+                  (try? fm.contentsOfDirectory(atPath: url.path))?.isEmpty == true {
+                try? fm.removeItem(at: url)
+                url.deleteLastPathComponent()
+            }
         }
         // The vocabulary, empty but explained. Written so the file exists to
         // be found and read — a person who never dictates a mangled word

--- a/Sources/ParrotFlow/EvalCommand.swift
+++ b/Sources/ParrotFlow/EvalCommand.swift
@@ -162,11 +162,13 @@ enum EvalCommand {
             // `--cases` wins over the transform's own `tests:`, which wins over
             // the `cases.yaml` every folder has by convention.
             let wanted = override ?? transform.tests ?? "cases.yaml"
-            guard let found = transform.folder?.resolve(wanted) else {
+            guard let found = transform.folder?.resolve(wanted)
+                ?? sharedCases(wanted, transform: transform)
+            else {
                 let folder = transform.folder?.url?.path ?? ConfigStore.directory.path
                 print("✗ no \(wanted) for \"\(transform.name)\""
                     + " — expected it in \(short(folder))")
-                print("    a transform's case set lives in its own folder;"
+                print("    a transform's case set lives beside its script;"
                     + " see docs/authoring.md")
                 return nil
             }
@@ -200,6 +202,22 @@ enum EvalCommand {
         // transform called `lists` or `asr` would file its variables where the
         // runner has already put something, and score against its own damage.
         return (file, set, transform)
+    }
+
+    /// `cases.yaml` beside a shared `command:`, for a transform whose own
+    /// folder is not where its script lives — `command: examples/punctuation/
+    /// punctuation.py` reads from `transforms/examples/punctuation/`, and its
+    /// case set is right there next to the script, not in `transforms/
+    /// punctuation/`.
+    private static func sharedCases(
+        _ wanted: String, transform: Config.Transform
+    ) -> TransformFolder.Resolved? {
+        guard let folder = transform.folder, case .command(let command) = transform.body,
+              let script = folder.resolve(command)
+        else { return nil }
+        let candidate = script.url.deletingLastPathComponent().appendingPathComponent(wanted)
+        guard FileManager.default.fileExists(atPath: candidate.path) else { return nil }
+        return TransformFolder.Resolved(url: candidate)
     }
 
     // MARK: - Running

--- a/Sources/ParrotFlow/EvalCommand.swift
+++ b/Sources/ParrotFlow/EvalCommand.swift
@@ -161,9 +161,14 @@ enum EvalCommand {
             }
             // `--cases` wins over the transform's own `tests:`, which wins over
             // the `cases.yaml` every folder has by convention.
-            let wanted = override ?? transform.tests ?? "cases.yaml"
+            let explicit = override ?? transform.tests
+            let wanted = explicit ?? "cases.yaml"
+            // The shared-script fallback is only for the by-convention name.
+            // A file named explicitly, by `--cases` or by `tests:`, says
+            // where it lives; missing it there is a miss to report, not a
+            // reason to go looking beside a shared script instead.
             guard let found = transform.folder?.resolve(wanted)
-                ?? sharedCases(wanted, transform: transform)
+                ?? (explicit == nil ? sharedCases(wanted, transform: transform) : nil)
             else {
                 let folder = transform.folder?.url?.path ?? ConfigStore.directory.path
                 print("✗ no \(wanted) for \"\(transform.name)\""
@@ -209,6 +214,11 @@ enum EvalCommand {
     /// punctuation.py` reads from `transforms/examples/punctuation/`, and its
     /// case set is right there next to the script, not in `transforms/
     /// punctuation/`.
+    ///
+    /// Only called for the by-convention `cases.yaml`, never for a name given
+    /// explicitly by `--cases` or `tests:` — an explicit name says where the
+    /// file lives, so not finding it there is a miss to report, not a reason
+    /// to look elsewhere.
     private static func sharedCases(
         _ wanted: String, transform: Config.Transform
     ) -> TransformFolder.Resolved? {

--- a/Sources/ParrotFlow/SeedConfigCommand.swift
+++ b/Sources/ParrotFlow/SeedConfigCommand.swift
@@ -9,8 +9,10 @@ import Foundation
 ///
 /// `config.yaml` and `vocabulary.yaml` are written once and never touched
 /// again. `transforms/examples/` is refreshed every time this runs, the same
-/// as every launch — that folder is the app's, not yours. Point it somewhere
-/// else with `PARROTFLOW_CONFIG_DIR` to see the full result.
+/// as every launch — that folder is the app's, not yours. A file it no
+/// longer ships is removed from there too, so an example an older version
+/// installed does not go on resolving after this one drops it. Point it
+/// somewhere else with `PARROTFLOW_CONFIG_DIR` to see the full result.
 enum SeedConfigCommand {
 
     static func run() -> Int32 {
@@ -19,10 +21,9 @@ enum SeedConfigCommand {
 
         let fm = FileManager.default
         let relatives = ConfigStore.exampleTransformFiles()
-        let before = Set(relatives.filter {
-            fm.fileExists(atPath: ConfigStore.installedExamplesDirectory
-                .appendingPathComponent($0).path)
-        })
+        let installedBefore = Set(ConfigStore.installedExampleFiles())
+        let before = Set(relatives).intersection(installedBefore)
+        let stale = installedBefore.subtracting(relatives).sorted()
         let configExisted = fm.fileExists(atPath: ConfigStore.fileURL.path)
         let vocabularyExisted = fm.fileExists(atPath: ConfigStore.vocabularyURL.path)
 
@@ -57,8 +58,13 @@ enum SeedConfigCommand {
             }
         }
 
+        for relative in stale {
+            print("  · transforms/examples/\(relative) — removed, no longer shipped")
+        }
+
         print("")
-        print("  \(written) example file(s) written, \(refreshed) refreshed.")
+        print("  \(written) example file(s) written, \(refreshed) refreshed"
+            + (stale.isEmpty ? "." : ", \(stale.count) removed."))
         print("  transforms/examples/ is the app's; edits there do not survive the next launch.")
         print("  transforms/<name>/ is yours — copy a file out of examples/ before editing it.")
         return 0

--- a/Sources/ParrotFlow/SeedConfigCommand.swift
+++ b/Sources/ParrotFlow/SeedConfigCommand.swift
@@ -4,37 +4,27 @@ import Foundation
 ///
 /// The app does this at startup and has always done it silently, which left
 /// "what does a new install actually get" as a question you could only answer
-/// by deleting your own config. It is now a folder rather than two loose files,
-/// so the answer is worth being able to see, and worth a check script being
-/// able to assert.
+/// by deleting your own config. It is now worth being able to see, and worth
+/// a check script being able to assert.
 ///
-/// Nothing is ever overwritten — that is `createIfMissing`'s whole contract —
-/// so running this against a config you already have is safe and does nothing.
-/// It does say when a file you own is no longer the copy that ships, which is
-/// the only thing an upgrade can honestly do about a file that is yours.
-/// Point it somewhere else with `PARROTFLOW_CONFIG_DIR` to see the full result.
+/// `config.yaml` and `vocabulary.yaml` are written once and never touched
+/// again. `transforms/examples/` is refreshed every time this runs, the same
+/// as every launch — that folder is the app's, not yours. Point it somewhere
+/// else with `PARROTFLOW_CONFIG_DIR` to see the full result.
 enum SeedConfigCommand {
 
     static func run() -> Int32 {
         let directory = ConfigStore.directory
         print("config: \(directory.path)")
 
-        // Each seeded file, paired with the copy that ships now. `config.yaml`
-        // has no pair: it is written once from a template and then edited, so
-        // "differs" would be true for everyone and mean nothing.
-        var watched: [(file: URL, shipped: URL?)] = [(ConfigStore.fileURL, nil)]
-        for (name, _) in ConfigStore.seededTransforms {
-            let folder = ConfigStore.seededTransformFolder(name)
-            let source = ConfigStore.exampleTransformsDirectory
-                .appendingPathComponent(name, isDirectory: true)
-            for filename in ConfigStore.seededTransformFiles(name) {
-                watched.append((folder.appendingPathComponent(filename),
-                                source.appendingPathComponent(filename)))
-            }
-        }
-
         let fm = FileManager.default
-        let before = Set(watched.map(\.file).filter { fm.fileExists(atPath: $0.path) }.map(\.path))
+        let relatives = ConfigStore.exampleTransformFiles()
+        let before = Set(relatives.filter {
+            fm.fileExists(atPath: ConfigStore.installedExamplesDirectory
+                .appendingPathComponent($0).path)
+        })
+        let configExisted = fm.fileExists(atPath: ConfigStore.fileURL.path)
+        let vocabularyExisted = fm.fileExists(atPath: ConfigStore.vocabularyURL.path)
 
         do {
             try ConfigStore.createIfMissing()
@@ -43,29 +33,34 @@ enum SeedConfigCommand {
             return 1
         }
 
-        var differing = 0
-        for (file, shipped) in watched {
-            let relative = file.path.hasPrefix(directory.path + "/")
-                ? String(file.path.dropFirst(directory.path.count + 1)) : file.path
-            if before.contains(file.path) {
-                if let shipped, ConfigStore.differsFromShipped(file, shipped) {
-                    print("  · \(relative) — yours, and not the copy that ships now")
-                    differing += 1
-                } else {
-                    print("  · \(relative) — already there, left alone")
-                }
-            } else if fm.fileExists(atPath: file.path) {
-                print("  ✓ \(relative) — written")
+        if configExisted {
+            print("  · config.yaml — already there, left alone")
+        } else {
+            print("  ✓ config.yaml — written")
+        }
+        if vocabularyExisted {
+            print("  · vocabulary.yaml — already there, left alone")
+        } else {
+            print("  ✓ vocabulary.yaml — written")
+        }
+
+        var written = 0
+        var refreshed = 0
+        for relative in relatives {
+            let label = "transforms/examples/\(relative)"
+            if before.contains(relative) {
+                print("  · \(label) — refreshed")
+                refreshed += 1
+            } else {
+                print("  ✓ \(label) — written")
+                written += 1
             }
         }
 
-        if differing > 0 {
-            print("")
-            let noun = differing == 1 ? "file is" : "files are"
-            print("  \(differing) \(noun) yours, and older or edited. Nothing was overwritten.")
-            print("  The copies that ship are in \(ConfigStore.exampleTransformsDirectory.path)")
-            print("  Diff against them, or move yours aside and run this again.")
-        }
+        print("")
+        print("  \(written) example file(s) written, \(refreshed) refreshed.")
+        print("  transforms/examples/ is the app's; edits there do not survive the next launch.")
+        print("  transforms/<name>/ is yours — copy a file out of examples/ before editing it.")
         return 0
     }
 }

--- a/Sources/ParrotFlow/TransformFolder.swift
+++ b/Sources/ParrotFlow/TransformFolder.swift
@@ -22,6 +22,15 @@ import Foundation
 /// paid for a population of nobody — the layout arrived before anyone had
 /// installed the app. A config that still points outside its folder is now
 /// told so once, by `--check-config`, and moving the file is the whole fix.
+///
+/// What that invariant is really about is the *bare name*: `punctuation.py`
+/// resolves in the folder or nowhere, so the spelling written every day cannot
+/// mean two files. A path with a directory in it —
+/// `examples/punctuation/punctuation.py` — may name a file elsewhere under
+/// `transforms/`, which is how the shipped examples are read from one copy
+/// rather than copied per transform. It is still one answer per spelling, and
+/// the working directory does not move: a shared script runs in the folder of
+/// whichever transform called it, so it locates its own data from `__file__`.
 struct TransformFolder: Equatable {
     /// The directory of the file that declared the transform — where
     /// `config.yaml` is, or where a `--pipeline` fixture is.
@@ -92,22 +101,48 @@ struct TransformFolder: Equatable {
         let inFolder = url.appendingPathComponent(expanded).standardizedFileURL
         if fm.fileExists(atPath: inFolder.path) { return Resolved(url: inFolder) }
 
+        // A folder shared between transforms, resolved against `transforms/`
+        // rather than against any one transform's own folder —
+        // `examples/punctuation/punctuation.py`. The shipped examples are the
+        // case that wants it: one copy of a script, read by whoever names it,
+        // instead of a copy per transform that names it.
+        //
+        // **Only for a path with a slash in it.** A bare `punctuation.py` still
+        // means your own folder and nothing else, which is the invariant the
+        // note above is defending: the common spelling can never resolve in two
+        // places, so the two can never disagree. A path that reaches sideways
+        // says so by having a directory in it.
+        if expanded.contains("/") {
+            let shared = transformsDirectory
+                .appendingPathComponent(expanded).standardizedFileURL
+            if fm.fileExists(atPath: shared.path), shared.isInside(transformsDirectory) {
+                return Resolved(url: shared)
+            }
+        }
+
         // `transforms/slack_mentions/slack_mentions.py` spells out what
         // `slack_mentions.py` does, and people write both, so both name the
         // same file. Resolved against the config directory and then **required
-        // to land inside the folder** — which is what keeps this from being a
-        // second place to look. Nothing outside the folder can be reached this
-        // way, so there are still never two directories that could disagree.
+        // to land inside the folder**, so this is not a second place to look:
+        // the only paths it adds are longer spellings of the folder above.
         let spelledOut = configDirectory.appendingPathComponent(expanded).standardizedFileURL
-        guard fm.fileExists(atPath: spelledOut.path), contains(spelledOut) else { return nil }
+        guard fm.fileExists(atPath: spelledOut.path), spelledOut.isInside(url) else { return nil }
         return Resolved(url: spelledOut)
     }
 
-    /// Whether a path is inside the folder, compared as resolved absolute
-    /// paths rather than by matching what was written.
-    private func contains(_ candidate: URL) -> Bool {
-        guard let url else { return false }
-        let folder = url.path.hasSuffix("/") ? url.path : url.path + "/"
-        return candidate.path.hasPrefix(folder)
+    /// `<config>/transforms` — where every transform's folder sits.
+    private var transformsDirectory: URL {
+        configDirectory
+            .appendingPathComponent("transforms", isDirectory: true)
+            .standardizedFileURL
+    }
+}
+
+private extension URL {
+    /// Whether this path sits inside `directory`, compared as resolved
+    /// absolute paths rather than by matching what was written.
+    func isInside(_ directory: URL) -> Bool {
+        let folder = directory.path.hasSuffix("/") ? directory.path : directory.path + "/"
+        return path.hasPrefix(folder)
     }
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -343,17 +343,18 @@ transforms:
       '`$1`': ['/\b([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)+)/']
 
   # A program, not a table — casing words is not something a substitution
-  # can express. Written to transforms/code_identifiers/ on first launch.
+  # can express. `examples/code_identifiers/` is transforms/examples/, kept
+  # current by the app; copy it to transforms/code_identifiers/ to edit it.
   - name: code_identifiers
     description: spoken names as identifiers
     display: Formatting identifiers
-    command: code_identifiers.py
+    command: examples/code_identifiers/code_identifiers.py
 
   # A spoken mark replaces whatever punctuation the decoder already guessed
   # next to it: "we could find. exclamation point" -> "we could find!".
   - name: punctuation
     description: spoken marks as punctuation
-    command: punctuation.py
+    command: examples/punctuation/punctuation.py
     # The script needs its context, and `returns: json` is what sends it: the
     # language, which picks `<lang>.py`, and `lists.talked_about`. It reports
     # `applied` — the marks it wrote — and `declined`, which names the guard
@@ -366,5 +367,5 @@ transforms:
   # start, and it deletes nothing when it finds nothing.
   - name: repetitions
     description: delete a word or phrase said twice by accident
-    command: repetitions.py
+    command: examples/repetitions/repetitions.py
 

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -291,12 +291,13 @@ else:
 That branch is worth keeping. Every harness in `scripts/` pipes plain text, and
 so will you the first time a stage misbehaves.
 
-> **Upgrading an existing transform.** A transform folder is written on first
-> launch and **never overwritten**, so adding `returns: json` to a config whose
-> script predates it means the script prints bare text, the app cannot read it,
-> and the stage silently stops doing anything. Edit the script first, then the
-> config. `--pipeline <fixture> "<text>" --vars` is how you check, before it
-> matters.
+> **Upgrading an existing transform.** A transform folder you own —
+> `transforms/<name>/` — is never overwritten, so adding `returns: json` to a
+> config whose script predates it means the script prints bare text, the app
+> cannot read it, and the stage silently stops doing anything. Edit the script
+> first, then the config. `--pipeline <fixture> "<text>" --vars` is how you
+> check, before it matters. `transforms/examples/` is different: it is
+> refreshed on every launch, so the shipped scripts there are always current.
 
 ## Recipe: a language
 
@@ -376,9 +377,9 @@ to a built-in stage or to the router have nowhere else to be and stay in
 | `tests/` | `spelling` (62), `french` (45), `numbers` (97), `routing` (45), `wake` (25), `split` (14), `generic`, `dates`, `inplace`, `pipeline`, `replacement` |
 
 Each has a runner in `scripts/`; the transform sets can also be scored with
-`--eval`. `examples/transforms/` is what a first launch copies into
-`~/.config/parrotflow/transforms/` — one file, not a mirror of one, so there
-is nothing to keep in sync. See `Config.exampleTransformsDirectory`.
+`--eval`. `examples/transforms/` is copied whole into
+`~/.config/parrotflow/transforms/examples/`, refreshed on every launch — one
+tree, not files kept in sync by hand. See `Config.exampleTransformsDirectory`.
 
 ## Before you call it done
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -112,10 +112,13 @@ its own data files from `__file__` rather than by bare relative name.
 
 `transforms/examples/` is the app's folder: refreshed from the copy that ships
 every time ParrotFlow starts, so an edit made there does not survive the next
-launch. `transforms/<name>/` is yours: nothing here ever writes it, and
-nothing in it is ever overwritten. To change a shipped example, copy its
-folder from `transforms/examples/` into `transforms/<name>/` and point
-`command:` at the bare name there.
+launch. The refresh also removes a file this version no longer ships, so an
+example a past version installed and this one dropped or renamed stops
+resolving through its old `examples/...` path instead of quietly going stale.
+`transforms/<name>/` is yours: nothing here ever writes it, and nothing in it
+is ever overwritten. To change a shipped example, copy its folder from
+`transforms/examples/` into `transforms/<name>/` and point `command:` at the
+bare name there.
 
 Beyond that there is no flat alternative to fall back to: a `command:` that
 names neither a file under `transforms/` nor anything the shell can find on

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,7 +66,7 @@ logging:
 | Recordings | `~/Recordings/ParrotFlow` — empty unless `logging.audio: true` |
 | Trace | `~/Recordings/ParrotFlow/trace.jsonl` |
 | Log | `~/Library/Logs/ParrotFlow.log` — off with `logging.text: false` |
-| The example transform | `~/.config/parrotflow/transforms/code_identifiers/`, written on first launch and never overwritten |
+| The shipped examples | `~/.config/parrotflow/transforms/examples/` — refreshed from the app on every launch, not yours to edit in place |
 
 The menu bar item shows the current state and offers *Open Recordings
 Folder* — the wavs, if `logging.audio` is on, and `trace.jsonl` — *Settings*,
@@ -84,10 +84,14 @@ inside, so it can be written, scored and handed to someone else as one thing:
 ~/.config/parrotflow/
   config.yaml
   transforms/
-    code_identifiers/
-      code_identifiers.py    # the entry point, named after the transform
-      cases.yaml             # what --eval scores it against
-    slack_mentions/
+    examples/                # every shipped example — the app's, refreshed
+      code_identifiers/      # on every launch, not yours to edit in place
+        code_identifiers.py
+        cases.yaml
+      punctuation/
+        punctuation.py
+        cases.yaml
+    slack_mentions/          # yours
       slack_mentions.py
       cases.yaml
       roster.json            # data the transform owns
@@ -98,12 +102,26 @@ working directory its command runs in** — which is what pays for the extra
 directory. A script can open `roster.json` as a bare relative path, so the
 folder is self-contained: copy it to another machine and it works.
 
-That folder is the only place a transform's files are looked for. There is no
-flat alternative to fall back to: a `command:` that names neither a file in its
-folder nor anything the shell can find on `PATH` is reported by
-`--check-config` as a fault, rather than failing quietly once per transcript.
-Writing the path out in full — `transforms/slack/slack.md` — names the same
-file, because people write both.
+A bare name is only ever looked for in that folder. A path with a directory in
+it — `command: examples/punctuation/punctuation.py` — may also name a file
+elsewhere under `transforms/`, which is how the config that ships points every
+transform that uses a shipped example at the one copy in `transforms/examples/`
+instead of a copy per transform. The working directory still does not move: a
+shared script runs in the folder of whichever transform called it, so it reads
+its own data files from `__file__` rather than by bare relative name.
+
+`transforms/examples/` is the app's folder: refreshed from the copy that ships
+every time ParrotFlow starts, so an edit made there does not survive the next
+launch. `transforms/<name>/` is yours: nothing here ever writes it, and
+nothing in it is ever overwritten. To change a shipped example, copy its
+folder from `transforms/examples/` into `transforms/<name>/` and point
+`command:` at the bare name there.
+
+Beyond that there is no flat alternative to fall back to: a `command:` that
+names neither a file under `transforms/` nor anything the shell can find on
+`PATH` is reported by `--check-config` as a fault, rather than failing quietly
+once per transcript. Writing the path out in full — `transforms/slack/slack.md`
+— names the same file, because people write both.
 
 The dev build keeps its own copies of all of these; see
 [development.md](development.md).

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -404,7 +404,9 @@ examples/code_identifiers/code_identifiers.py` — the shared copy in
 launch. The stop lists in it decide where a name ends, which is a judgement
 about how you speak rather than a fact, and they are meant to be edited — but
 that folder is the app's, not yours, and an edit there does not survive the
-next launch.
+next launch. The refresh also drops a file this version stops shipping, so
+renaming or retiring an example does not leave a stale copy still resolving
+under its old path.
 
 **To make it yours, copy it out.** `transforms/examples/code_identifiers/` to
 `transforms/code_identifiers/`, and `command:` from

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -339,21 +339,38 @@ the log and `--check-config` name that case as itself rather than as "command
 not found", which would send you looking for a file that is sitting right where
 you put it.
 
-A relative path is looked for in the transform's own folder, and nowhere else:
+A bare name is looked for in the transform's own folder, and nowhere else:
 `command: code_identifiers.py` on a transform named `code_identifiers` is
 `transforms/code_identifiers/code_identifiers.py`. Writing it out in full names
 the same file. **The folder is the working directory**, so a script reads its
 neighbours by bare relative name.
 
-One place to look, deliberately. An earlier draft searched the config directory
-too, so a script left beside `config.yaml` kept running; two directories that
-can disagree turned out to cost more than they bought, because *which* one a
-command runs in stops being answerable once the command names files in both. A
-program that is in neither the folder nor on `PATH` is a fault `--check-config`
-names, and moving the file is the whole fix.
-Beside `config.yaml` is tried second, which is where a script written before
-folders existed still sits; it runs, and `--check-config` says where to move it.
-Writing the path out in full — `command:
+A path *with a directory in it* may also name a file elsewhere under
+`transforms/`, which is how two transforms share one script:
+
+```yaml
+transforms:
+  - name: punctuation
+    command: examples/punctuation/punctuation.py   # transforms/examples/…
+```
+
+The rule is the slash. `punctuation.py` can only ever mean your own folder, so
+the spelling you write every day cannot resolve in two places. `examples/…`
+says out loud that it reaches sideways, and it still cannot leave
+`transforms/`.
+
+The working directory does not move: a shared script runs in the folder of
+whichever transform called it, not in its own. So a shared script finds its own
+data files from `__file__` rather than by bare relative name — a private one
+still uses the bare name, and both keep working when you copy the folder.
+
+One place per spelling, deliberately. An earlier draft searched the config
+directory too, so a script left beside `config.yaml` kept running; two
+directories that can disagree turned out to cost more than they bought, because
+*which* one a command runs in stops being answerable once the command names
+files in both. A program that is in neither the folder, nor under
+`transforms/`, nor on `PATH` is a fault `--check-config` names, and moving the
+file is the whole fix. Writing the path out in full — `command:
 transforms/code_identifiers/code_identifiers.py` — names the same file and is
 not reported. A bare name that is not a file in either place — `sed`, `python3`
 — is left to the shell to find on PATH, so a command can be a one-liner with
@@ -381,24 +398,22 @@ sentence — snake_case for python and rust, camelCase for typescript and go,
 PascalCase for a class or a type, SCREAMING_SNAKE for a constant, camelCase
 when no language was said.
 
-A copy is written to `~/.config/parrotflow/code_identifiers.py` on first launch and
-never overwritten afterwards: once it exists it is yours. The stop lists in it
-decide where a name ends, which is a judgement about how you speak rather than
-a fact, and they are meant to be edited.
+The config that ships points at it as `command:
+examples/code_identifiers/code_identifiers.py` — the shared copy in
+`~/.config/parrotflow/transforms/examples/`, refreshed from the app on every
+launch. The stop lists in it decide where a name ends, which is a judgement
+about how you speak rather than a fact, and they are meant to be edited — but
+that folder is the app's, not yours, and an edit there does not survive the
+next launch.
 
-**So an upgrade never changes a shipped transform you already have.** It only
-adds files that are not there — a new data file next to a script you own, say.
-It does say which of your files is no longer the copy that ships, in the log at
-startup and in `ParrotFlow --seed-config`:
-
-```
-  · transforms/punctuation/punctuation.py — yours, and not the copy that ships now
-```
-
-Byte for byte, so "you edited it" and "it is from an older version" look the
-same and nothing can tell them apart. To take the new one, move yours aside and
-run `--seed-config` again. That is the whole upgrade path, and it is manual on
-purpose: the alternative is an update reverting your stop lists.
+**To make it yours, copy it out.** `transforms/examples/code_identifiers/` to
+`transforms/code_identifiers/`, and `command:` from
+`examples/code_identifiers/code_identifiers.py` down to the bare
+`code_identifiers.py`. From then on it is a transform like any other you
+wrote: nothing here ever writes `transforms/code_identifiers/`, reads it, or
+reports on it, while `transforms/examples/code_identifiers/code_identifiers.py`
+— still pointed at by anyone who has not copied it out — keeps refreshing
+underneath it, from the log at startup and from `ParrotFlow --seed-config`.
 
 It is gated twice, and both gates are in the config where you can see them:
 `app:` to editors and terminals, and `when:` to a sentence containing a kind

--- a/scripts/check-transform-folders.sh
+++ b/scripts/check-transform-folders.sh
@@ -321,6 +321,40 @@ check "and the refresh is reported" \
   "$(printf '%s\n' "$refreshed_out" | grep -c 'transforms/examples/punctuation/punctuation.py — refreshed')" \
   "1"
 
+# --- a file the shipped tree drops is pruned, not left stale -----------------
+#
+# An example a past version installed and this one no longer ships must not
+# keep resolving through an `examples/...` path forever. `retired` is not a
+# folder `examples/transforms/` has, so the next refresh has nothing to copy
+# there and removes what is left over from before.
+mkdir -p "$FRESH/transforms/examples/retired"
+printf '#!/usr/bin/env python3\nprint("gone")\n' > "$FRESH/transforms/examples/retired/retired.py"
+pruned_out="$(PARROTFLOW_CONFIG_DIR="$FRESH" "$BIN" --seed-config 2>/dev/null)"
+
+check "a file the app no longer ships is removed from transforms/examples/" \
+  "$([ -e "$FRESH/transforms/examples/retired/retired.py" ] && echo present || echo gone)" \
+  "gone"
+
+check "and the removal is reported" \
+  "$(printf '%s\n' "$pruned_out" | grep -c 'transforms/examples/retired/retired.py — removed, no longer shipped')" \
+  "1"
+
+# It stops resolving too. Written into `$FRESH` itself, not `$WORK` — a
+# `--pipeline` fixture resolves `command:` against its own directory, and
+# `transforms/examples/` was just pruned under `$FRESH`.
+cat > "$FRESH/retired.yaml" <<YAML
+transforms:
+  - name: retired_user
+    description: points at a file the app no longer ships
+    command: examples/retired/retired.py
+pipeline:
+  - transform: retired_user
+YAML
+
+check "and a command pointed at it no longer resolves — fails open" \
+  "$("$BIN" --pipeline "$FRESH/retired.yaml" "keep it down" --quiet 2>/dev/null | tail -1)" \
+  "keep it down"
+
 # --- an older install's own folder is never touched --------------------------
 #
 # `transforms/punctuation/` is what a version before this one seeded, and a

--- a/scripts/check-transform-folders.sh
+++ b/scripts/check-transform-folders.sh
@@ -5,18 +5,24 @@
 #   scripts/check-transform-folders.sh
 #
 # A transform named X owns `transforms/X/` beside the config that declared it,
-# and that is the only place its files are looked for. Three things follow, and
+# and a bare name is looked for there and nowhere else. Four things follow, and
 # each of them was a decision:
 #
-#   one place to look          `command: shout.py` is in the folder or it is
+#   one place per spelling      `command: shout.py` is in the folder or it is
 #                              nowhere — there is no second directory that
 #                              could disagree about which file runs
 #   either spelling            `transforms/X/shout.py` names the same file,
 #                              because people write both. It is accepted only
 #                              when it lands inside the folder
+#   a path may reach            `examples/shout/shout.py`, a directory in the
+#   sideways under transforms/  path, may name a file elsewhere under
+#                              `transforms/` — the shipped examples share one
+#                              copy this way instead of one per transform
 #   the folder is the          so a script opens a sibling data file by a bare
 #   working directory          relative path, and the whole transform is one
-#                              directory you can copy to another machine
+#                              directory you can copy to another machine —
+#                              even a shared script, which finds its own
+#                              sibling from `__file__` instead
 #
 # Everything is built in a temporary directory and run through `--pipeline`,
 # which carries its own `transforms:` and resolves relative paths against the
@@ -118,6 +124,50 @@ check "a command outside its folder is reported, not silently left to the shell"
 check "and that is a fault, so --check-config exits 1" \
   "$(PARROTFLOW_CONFIG_DIR="$WORK/outside" "$BIN" --check-config > /dev/null 2>&1; echo $?)" \
   "1"
+
+# --- a path with a slash may reach a shared script under transforms/ --------
+#
+# `command: examples/shared/shared.py` is not this transform's own folder —
+# `transforms/shared_user/` — so it is resolved against `transforms/` itself,
+# which is how the shipped examples are read from one copy rather than a copy
+# per transform. The working directory does not move: it is still
+# `transforms/shared_user/`, which is why the script reads its own sibling
+# file from `__file__` instead of by bare name.
+mkdir -p "$WORK/transforms/examples/shared"
+cat > "$WORK/transforms/examples/shared/shared.py" <<'PY'
+#!/usr/bin/env python3
+import pathlib, sys
+here = pathlib.Path(__file__).resolve().parent
+suffix = (here / "suffix.txt").read_text().strip()
+print(sys.stdin.read().strip().upper() + suffix)
+PY
+chmod +x "$WORK/transforms/examples/shared/shared.py"
+printf '?\n' > "$WORK/transforms/examples/shared/suffix.txt"
+
+fixture shared.yaml '  - name: shared_user
+    description: shares a script under transforms/examples
+    command: examples/shared/shared.py' shared_user
+
+check "a slash path reaches a script shared under transforms/" \
+  "$("$BIN" --pipeline "$WORK/shared.yaml" "keep it down" --quiet 2>/dev/null | tail -1)" \
+  "KEEP IT DOWN?"
+
+# A bare name still means the transform's own folder and nothing else — the
+# whole point of the rule is that `loose.py` can never mean two things.
+# `transforms/loose.py`, sitting loose in `transforms/` rather than in any
+# transform's own folder, is nowhere this ever looks, so the shell is left to
+# find it and cannot: the pipeline fails open and hands the transcript back
+# untouched.
+printf '#!/usr/bin/env python3\nprint("nope")\n' > "$WORK/transforms/loose.py"
+chmod +x "$WORK/transforms/loose.py"
+
+fixture loose.yaml '  - name: loose_user
+    description: a bare name cannot reach sideways
+    command: loose.py' loose_user
+
+check "a bare name loose in transforms/ does not resolve — fails open" \
+  "$("$BIN" --pipeline "$WORK/loose.yaml" "keep it down" --quiet 2>/dev/null | tail -1)" \
+  "keep it down"
 
 # --- a transform named after something the runner already publishes ---------
 #
@@ -227,46 +277,68 @@ FRESH="$WORK/fresh"
 mkdir -p "$FRESH"
 seeded="$(PARROTFLOW_CONFIG_DIR="$FRESH" "$BIN" --seed-config 2>/dev/null)"
 
-check "a first launch writes the transform as a folder" \
+# What is expected is read from `examples/transforms/` itself rather than
+# spelled out here, so a folder gaining a file — or the tree gaining a
+# folder — does not make this check stale.
+expected_examples="$(cd "$ROOT/examples/transforms" && find . -type f | sed 's|^\./|transforms/examples/|')"
+expected="$(printf 'config.yaml\nvocabulary.yaml\n%s\n' "$expected_examples" | sort | tr '\n' ' ')"
+
+check "a first launch copies the whole examples/ tree" \
   "$(cd "$FRESH" && find . -type f | sed 's|^\./||' | sort | tr '\n' ' ')" \
-  "config.yaml transforms/code_identifiers/cases.yaml transforms/code_identifiers/code_identifiers.py transforms/punctuation/cases.yaml transforms/punctuation/en.py transforms/punctuation/fr.py transforms/punctuation/punctuation.py transforms/repetitions/cases.yaml transforms/repetitions/repetitions.py vocabulary.yaml "
+  "$expected"
 
 check "the seeded script is executable" \
-  "$([ -x "$FRESH/transforms/code_identifiers/code_identifiers.py" ] && echo yes || echo no)" \
+  "$([ -x "$FRESH/transforms/examples/code_identifiers/code_identifiers.py" ] && echo yes || echo no)" \
   "yes"
 
-check "the seeded config resolves its command into the folder" \
+check "the seeded config resolves its command through transforms/examples/" \
   "$(PARROTFLOW_CONFIG_DIR="$FRESH" "$BIN" --check-config 2>/dev/null \
-     | grep -c 'transforms/code_identifiers/code_identifiers.py')" \
+     | grep -c 'transforms/examples/code_identifiers/code_identifiers.py')" \
   "1"
 
 check "a seeded config is clean" \
   "$(PARROTFLOW_CONFIG_DIR="$FRESH" "$BIN" --check-config > /dev/null 2>&1; echo $?)" \
   "0"
 
-check "seeding twice writes nothing the second time" \
+check "seeding twice writes no new file the second time" \
   "$(PARROTFLOW_CONFIG_DIR="$FRESH" "$BIN" --seed-config 2>/dev/null | grep -c '✓')" \
   "0"
 
-# --- a file you own that is no longer the shipped one -----------------------
+# --- transforms/examples/ is refreshed, not preserved ------------------------
 #
-# Nothing is ever overwritten, so the most an upgrade can do is say which of
-# your files is older or edited. An older install with the previous script is
-# exactly this: the file is there, and it is not what ships.
-echo "# edited" >> "$FRESH/transforms/punctuation/punctuation.py"
-stale="$(PARROTFLOW_CONFIG_DIR="$FRESH" "$BIN" --seed-config 2>/dev/null)"
+# It is the app's folder, not yours: an edit there does not survive the next
+# `--seed-config`, the same as it would not survive the next launch. That is
+# what buys one copy of a script instead of a copy per transform that a
+# person has to notice has gone stale.
+echo "# edited" >> "$FRESH/transforms/examples/punctuation/punctuation.py"
+refreshed_out="$(PARROTFLOW_CONFIG_DIR="$FRESH" "$BIN" --seed-config 2>/dev/null)"
 
-check "a file that differs from the shipped copy is named" \
-  "$(printf '%s\n' "$stale" | grep -c 'transforms/punctuation/punctuation.py — yours, and not the copy that ships now')" \
+check "an edit under transforms/examples/ does not survive a refresh" \
+  "$(grep -c '# edited' "$FRESH/transforms/examples/punctuation/punctuation.py")" \
+  "0"
+
+check "and the refresh is reported" \
+  "$(printf '%s\n' "$refreshed_out" | grep -c 'transforms/examples/punctuation/punctuation.py — refreshed')" \
   "1"
 
-check "and it is still not overwritten" \
-  "$(tail -n 1 "$FRESH/transforms/punctuation/punctuation.py")" \
-  "# edited"
+# --- an older install's own folder is never touched --------------------------
+#
+# `transforms/punctuation/` is what a version before this one seeded, and a
+# config that still says `command: punctuation.py` finds it through the
+# bare-name rule. Nothing here writes it, reads it, or reports on it.
+mkdir -p "$FRESH/transforms/punctuation"
+printf '#!/usr/bin/env python3\nprint("mine")\n' > "$FRESH/transforms/punctuation/punctuation.py"
+chmod +x "$FRESH/transforms/punctuation/punctuation.py"
+own_out="$(PARROTFLOW_CONFIG_DIR="$FRESH" "$BIN" --seed-config 2>/dev/null)"
 
-check "a file you did not touch is not named" \
-  "$(printf '%s\n' "$stale" | grep -c 'transforms/punctuation/en.py — already there, left alone')" \
-  "1"
+check "an old install's own transforms/<name>/ is not mentioned" \
+  "$(printf '%s\n' "$own_out" | grep -c 'transforms/punctuation/punctuation.py')" \
+  "0"
+
+check "and it is left exactly as it was" \
+  "$(cat "$FRESH/transforms/punctuation/punctuation.py")" \
+  "#!/usr/bin/env python3
+print(\"mine\")"
 
 echo
 echo "  $pass/$total$failed"


### PR DESCRIPTION
## Summary

- A `command:` path with a slash in it, like `examples/punctuation/punctuation.py`, now resolves against `<config>/transforms/` and may name a file outside the transform's own folder, as long as it stays under `transforms/`. A bare name — `punctuation.py` — still resolves only in the transform's own folder or nowhere: the spelling written every day can never mean two files. The working directory does not move, so a shared script finds its own sibling data from `__file__` rather than by bare relative name.
- The app now copies the whole `examples/transforms/` tree — every file, whatever is there — into `<config>/transforms/examples/`, refreshed from the app on every launch. `transforms/examples/` is app-owned; `transforms/<name>/` is still yours and is never touched. An older install's `transforms/punctuation/punctuation.py` keeps working through the bare-name rule.
- `config.example.yaml` points its three shipped transforms (`code_identifiers`, `punctuation`, `repetitions`) at the shared copies: `command: examples/code_identifiers/code_identifiers.py`, and so on.

## `--eval`

`--eval <name>` looks for `cases.yaml` in the transform's own folder by convention. Since a fresh install no longer seeds `transforms/<name>/`, that folder does not exist for a transform whose `command:` points at a shared example, and the bare-name lookup would fail. I added a fallback in `EvalCommand.locate`: when the transform's own folder has no `cases.yaml`, it looks beside the transform's resolved `command:` script instead — so `--eval code_identifiers` finds `transforms/examples/code_identifiers/cases.yaml`. Verified this against a freshly seeded config: `--eval code_identifiers` scores 88% as before. An old install with its own `transforms/<name>/cases.yaml` still takes priority, since the own-folder lookup is tried first.

## Docs

- `docs/pipelines.md`: replaced the "bare name only" paragraph with the shared-path rule, and reworded the "one place to look" paragraph — including removing a stale, self-contradicting sentence about a fallback to beside `config.yaml` that the current code does not implement. Rewrote the `code_identifiers, which ships` section to describe copying an example out of `transforms/examples/` to make it yours.
- `docs/configuration.md`: updated the "where things live" table and the "a folder per transform" section for the new layout.
- `docs/authoring.md`: updated two references to the old "written on first launch, never overwritten" seeding.
- `docs/setup.md`: checked, no reference to the old seeding found.

## Not in the original brief

- `scripts/check-transform-folders.sh` tested the old per-name seeding in detail (exact file listing, "yours, and not the copy that ships now" diffing). I updated it to match the new behavior — added cases for the shared slash-path resolving and a bare name in `transforms/` failing open, replaced the seeded-file listing with one computed from `examples/transforms/` instead of hardcoded, and replaced the "diffs from shipped" test with one confirming an edit under `transforms/examples/` does not survive a refresh, plus a new case confirming an old install's own `transforms/<name>/` is left untouched. All 24/24 pass.

## Test plan

- [x] `swift build -c release` completes (pre-existing `SendableClosureCaptures` warnings in AppDelegate.swift only)
- [x] `.build/release/ParrotFlow --check-config` against a freshly seeded config: exit 0, no fault, resolves `command:` through `transforms/examples/`
- [x] `bash scripts/check-input.sh` — 12/12
- [x] `bash scripts/check-dotted.sh` — 73/73 (+3 known-unfixable)
- [x] `bash scripts/check-grammar.sh` — 16/17 (pre-existing, unrelated to this change)
- [x] `bash scripts/check-transform-folders.sh` — 24/24 (updated for this change)
- [x] `bash scripts/check-default-config.sh`, `check-eval.sh`, `check-pipeline.sh`, `check-join.sh` — all pass
- [x] Manual fixture: `command: examples/punctuation/punctuation.py` resolves and the script finds a sibling data file via `__file__`
- [x] Manual fixture: a bare `loose.py` sitting directly in `transforms/` does not resolve — `/bin/sh: loose.py: command not found`, and the pipeline fails open (transcript unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)