### PR TITLE
feat: the log shows the caret and the text either side of it

### DIFF
--- a/Sources/ParrotFlow/InputBox.swift
+++ b/Sources/ParrotFlow/InputBox.swift
@@ -90,12 +90,16 @@ enum InputBox {
 
         /// Whitespace as its escape, so the neighbourhood stays on one log
         /// line. A newline is the difference between two of `join`'s rules, so
-        /// it has to be visible rather than acted on.
+        /// it has to be visible rather than acted on. U+2028 and U+2029 are
+        /// escaped too: both render as a line break and neither is caught by
+        /// `\n`/`\r`.
         private func escaped(_ part: String) -> String {
             part.replacingOccurrences(of: "\\", with: "\\\\")
                 .replacingOccurrences(of: "\n", with: "\\n")
                 .replacingOccurrences(of: "\r", with: "\\r")
                 .replacingOccurrences(of: "\t", with: "\\t")
+                .replacingOccurrences(of: "\u{2028}", with: "\\u2028")
+                .replacingOccurrences(of: "\u{2029}", with: "\\u2029")
         }
     }
 

--- a/Sources/ParrotFlow/InputBox.swift
+++ b/Sources/ParrotFlow/InputBox.swift
@@ -57,6 +57,46 @@ enum InputBox {
             (before?.count ?? 0) + (selection?.count ?? 0)
                 + (after?.count ?? 0) + (text?.count ?? 0)
         }
+
+        /// The caret and the text either side of it, as one short escaped
+        /// string — nil on a surface that publishes no caret.
+        ///
+        /// This is what `join` decides from, and it was the one input to that
+        /// decision the log did not record. A leading space it added could be
+        /// traced to the rule that added it, but not to the neighbourhood the
+        /// rule read, so the two states that pick different rules — a stop
+        /// behind the caret, a newline behind it — looked identical in the log.
+        /// Twenty characters a side covers a sentence end, a newline, a bracket
+        /// and a hyphen, which is everything the rules look at.
+        ///
+        /// Both edges in one string with the caret marked, rather than two
+        /// fields. The decision is about what sits either side of one point.
+        var neighbourhood: String? {
+            guard let before, let after else { return nil }
+            let edge = 20
+            let middle: String
+            if let selection, !selection.isEmpty {
+                middle = "\u{27E6}" + escaped(String(selection.prefix(edge)))
+                    + (selection.count > edge ? "\u{2026}" : "") + "\u{27E7}"
+            } else {
+                middle = "\u{2038}"
+            }
+            return (before.count > edge ? "\u{2026}" : "")
+                + escaped(String(before.suffix(edge)))
+                + middle
+                + escaped(String(after.prefix(edge)))
+                + (after.count > edge ? "\u{2026}" : "")
+        }
+
+        /// Whitespace as its escape, so the neighbourhood stays on one log
+        /// line. A newline is the difference between two of `join`'s rules, so
+        /// it has to be visible rather than acted on.
+        private func escaped(_ part: String) -> String {
+            part.replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "\n", with: "\\n")
+                .replacingOccurrences(of: "\r", with: "\\r")
+                .replacingOccurrences(of: "\t", with: "\\t")
+        }
     }
 
     /// Why a read did not happen. Published as `input.declined`, because a box
@@ -163,6 +203,12 @@ enum InputBox {
                 capture.chars, capture.total, ms,
                 capture.before == nil ? "caret unknown"
                     : (capture.appending == true ? "appending" : "inserting")))
+            // Press time and pipeline time are the same snapshot, seconds
+            // apart. Anything typed between them is invisible to both, and a
+            // pipeline with no `input` stage still leaves the evidence here.
+            if let neighbourhood = capture.neighbourhood {
+                Log.write("    caret: \(neighbourhood)")
+            }
         case .failure(let why):
             Log.write(String(
                 format: "input: nothing captured at press (%@) in %.0fms", why.rawValue, ms))

--- a/Sources/ParrotFlow/InputTestCommand.swift
+++ b/Sources/ParrotFlow/InputTestCommand.swift
@@ -31,7 +31,15 @@ enum InputTestCommand {
         // would score a different string from the one the stage publishes.
         print("before ⟪\(cut.before)⟫")
         print("selection ⟪\(cut.selection)⟫")
-        print("after ⟪\(cut.after)⟫", terminator: "")
+        print("after ⟪\(cut.after)⟫")
+        // The one line that survives a newline: the blocks above print theirs
+        // raw, so a field with a break in it cannot be stated in the case file
+        // at all. This is what the log shows, escaped.
+        let capture = InputBox.Capture(
+            before: cut.before, selection: cut.selection, after: cut.after,
+            text: nil, appending: cut.appending,
+            total: text.count, truncated: cut.truncated)
+        print("caret ⟪\(capture.neighbourhood ?? "")⟫", terminator: "")
         return 0
     }
 }

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -917,6 +917,12 @@ struct Pipeline: Equatable, Codable {
                 : (capture.appending == true ? "appending" : "inserting")
             Log.write("pipeline: input read \(capture.chars) of \(capture.total) chars, "
                 + placement + (capture.truncated ? ", truncated" : ""))
+            // Directly above whatever `join` then logs, because the two lines
+            // only answer the question together: which rule fired, and what it
+            // read to pick that one.
+            if let neighbourhood = capture.neighbourhood {
+                Log.write("    caret: \(neighbourhood)")
+            }
             var vars: [String: Scope.Value] = [
                 "chars": .int(capture.chars),
                 "total": .int(capture.total),

--- a/scripts/check-input.sh
+++ b/scripts/check-input.sh
@@ -14,7 +14,7 @@ CASES="$ROOT/tests/input-cases.txt"
 [ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
 
 pass=0; total=0; failed=""
-while IFS='~' read -r field caret selected limit shape where before selection after; do
+while IFS='~' read -r field caret selected limit shape where before selection after neighbourhood; do
   case "$field" in \#*) continue;; esac
   caret="$(printf '%s' "$caret" | tr -d ' ')"
   [ -z "$caret" ] && continue
@@ -31,7 +31,8 @@ while IFS='~' read -r field caret selected limit shape where before selection af
 $(trim "$where")
 before $(trim "$before")
 selection $(trim "$selection")
-after $(trim "$after")"
+after $(trim "$after")
+caret $(trim "$neighbourhood")"
 
   got="$("$BIN" --input-test "$field" "$caret" "$selected" "$limit" 2>/dev/null)"
 

--- a/tests/input-cases.txt
+++ b/tests/input-cases.txt
@@ -14,46 +14,58 @@
 # The blocks are delimited with ⟪⟫ because they keep their own spaces. The
 # leading space on `after` is a real character.
 #
-# field ~ caret ~ selected ~ limit ~ whole|truncated ~ appending|inserting ~ before ~ selection ~ after
+# The last column is what the log prints: the two edges as one string, cut to
+# 20 characters a side, with the caret as ‸ and a selection as ⟦⟧. It is the
+# only column that can hold a newline, because the three blocks print theirs
+# raw and a break in one of them would split the line this file compares. So a
+# newline case cannot be stated here; `--input-test` shows it directly.
+#
+# field ~ caret ~ selected ~ limit ~ whole|truncated ~ appending|inserting ~ before ~ selection ~ after ~ caret
 
 # --- nothing to cut ---
-the quick brown fox ~ 9 ~ 0 ~ 100 ~ whole ~ inserting ~ ⟪the quick⟫ ~ ⟪⟫ ~ ⟪ brown fox⟫
-the quick brown fox ~ 0 ~ 0 ~ 100 ~ whole ~ inserting ~ ⟪⟫ ~ ⟪⟫ ~ ⟪the quick brown fox⟫
+the quick brown fox ~ 9 ~ 0 ~ 100 ~ whole ~ inserting ~ ⟪the quick⟫ ~ ⟪⟫ ~ ⟪ brown fox⟫ ~ ⟪the quick‸ brown fox⟫
+the quick brown fox ~ 0 ~ 0 ~ 100 ~ whole ~ inserting ~ ⟪⟫ ~ ⟪⟫ ~ ⟪the quick brown fox⟫ ~ ⟪‸the quick brown fox⟫
 
 # Appending: nothing after the caret and nothing selected. This is the case the
 # punctuation rules turn on, and the one an off-by-one silently breaks.
-the quick brown fox ~ 19 ~ 0 ~ 100 ~ whole ~ appending ~ ⟪the quick brown fox⟫ ~ ⟪⟫ ~ ⟪⟫
+the quick brown fox ~ 19 ~ 0 ~ 100 ~ whole ~ appending ~ ⟪the quick brown fox⟫ ~ ⟪⟫ ~ ⟪⟫ ~ ⟪the quick brown fox‸⟫
 
 # An empty field is a real answer, not a decline — dictating into an empty box
 # is the commonest case there is, and it is also appending.
- ~ 0 ~ 0 ~ 100 ~ whole ~ appending ~ ⟪⟫ ~ ⟪⟫ ~ ⟪⟫
+ ~ 0 ~ 0 ~ 100 ~ whole ~ appending ~ ⟪⟫ ~ ⟪⟫ ~ ⟪⟫ ~ ⟪‸⟫
 
 # --- a selection, which dictating over will replace ---
-the quick brown fox ~ 4 ~ 5 ~ 100 ~ whole ~ inserting ~ ⟪the ⟫ ~ ⟪quick⟫ ~ ⟪ brown fox⟫
+the quick brown fox ~ 4 ~ 5 ~ 100 ~ whole ~ inserting ~ ⟪the ⟫ ~ ⟪quick⟫ ~ ⟪ brown fox⟫ ~ ⟪the ⟦quick⟧ brown fox⟫
 
 # A selection reaching the end is not appending: there is something to replace,
 # so the sentence is not being joined to what precedes it.
-the quick brown fox ~ 10 ~ 9 ~ 100 ~ whole ~ inserting ~ ⟪the quick ⟫ ~ ⟪brown fox⟫ ~ ⟪⟫
+the quick brown fox ~ 10 ~ 9 ~ 100 ~ whole ~ inserting ~ ⟪the quick ⟫ ~ ⟪brown fox⟫ ~ ⟪⟫ ~ ⟪the quick ⟦brown fox⟧⟫
 
 # --- the budget, split per side ---
 # Each side gets half and keeps the end nearest the caret. A single window
 # centred on the caret would let a long tail crowd out the text immediately
 # before it, which is the half a dictated sentence is being joined to.
-abcdefghijklmnopqrstuvwxyz ~ 13 ~ 0 ~ 8 ~ truncated ~ inserting ~ ⟪jklm⟫ ~ ⟪⟫ ~ ⟪nopq⟫
+abcdefghijklmnopqrstuvwxyz ~ 13 ~ 0 ~ 8 ~ truncated ~ inserting ~ ⟪jklm⟫ ~ ⟪⟫ ~ ⟪nopq⟫ ~ ⟪jklm‸nopq⟫
 
 # Near an end the other side is not given the slack. Half is half, so a caret
 # at the top still discloses only half a budget of what follows it.
-abcdefghijklmnopqrstuvwxyz ~ 0 ~ 0 ~ 8 ~ truncated ~ inserting ~ ⟪⟫ ~ ⟪⟫ ~ ⟪abcd⟫
-abcdefghijklmnopqrstuvwxyz ~ 26 ~ 0 ~ 8 ~ truncated ~ appending ~ ⟪wxyz⟫ ~ ⟪⟫ ~ ⟪⟫
+abcdefghijklmnopqrstuvwxyz ~ 0 ~ 0 ~ 8 ~ truncated ~ inserting ~ ⟪⟫ ~ ⟪⟫ ~ ⟪abcd⟫ ~ ⟪‸abcd⟫
+abcdefghijklmnopqrstuvwxyz ~ 26 ~ 0 ~ 8 ~ truncated ~ appending ~ ⟪wxyz⟫ ~ ⟪⟫ ~ ⟪⟫ ~ ⟪wxyz‸⟫
 
 # A caret past the end of the field is clamped, not trusted: the value and the
 # selection are read in two calls and an edit can land between them.
-abcdefghijklmnopqrstuvwxyz ~ 99 ~ 0 ~ 8 ~ truncated ~ appending ~ ⟪wxyz⟫ ~ ⟪⟫ ~ ⟪⟫
+abcdefghijklmnopqrstuvwxyz ~ 99 ~ 0 ~ 8 ~ truncated ~ appending ~ ⟪wxyz⟫ ~ ⟪⟫ ~ ⟪⟫ ~ ⟪wxyz‸⟫
 
 # A field no larger than the budget is not truncated.
-abcdefgh ~ 4 ~ 0 ~ 8 ~ whole ~ inserting ~ ⟪abcd⟫ ~ ⟪⟫ ~ ⟪efgh⟫
+abcdefgh ~ 4 ~ 0 ~ 8 ~ whole ~ inserting ~ ⟪abcd⟫ ~ ⟪⟫ ~ ⟪efgh⟫ ~ ⟪abcd‸efgh⟫
 
 # The selection gets the whole budget rather than half of it. It is a third
 # block, not part of either side, and what is about to be replaced is worth
 # seeing in full where the sides are only context.
-abcdefghijklmnopqrstuvwxyz ~ 4 ~ 20 ~ 8 ~ truncated ~ inserting ~ ⟪abcd⟫ ~ ⟪efghijkl⟫ ~ ⟪yz⟫
+abcdefghijklmnopqrstuvwxyz ~ 4 ~ 20 ~ 8 ~ truncated ~ inserting ~ ⟪abcd⟫ ~ ⟪efghijkl⟫ ~ ⟪yz⟫ ~ ⟪abcd⟦efghijkl⟧yz⟫
+
+# The 20-character window the log shows, and the ellipsis that says a side was
+# cut to reach it. Its own budget, not `limit`: the blocks are capped for the
+# stage, and this is capped again to keep one log line readable.
+abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz ~ 26 ~ 0 ~ 100 ~ whole ~ inserting ~ ⟪abcdefghijklmnopqrstuvwxyz⟫ ~ ⟪⟫ ~ ⟪abcdefghijklmnopqrstuvwxyz⟫ ~ ⟪…ghijklmnopqrstuvwxyz‸abcdefghijklmnopqrst…⟫
+abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz ~ 10 ~ 25 ~ 100 ~ whole ~ inserting ~ ⟪abcdefghij⟫ ~ ⟪klmnopqrstuvwxyzabcdefghi⟫ ~ ⟪jklmnopqrstuvwxyz⟫ ~ ⟪abcdefghij⟦klmnopqrstuvwxyzabcd…⟧jklmnopqrstuvwxyz⟫


### PR DESCRIPTION
## Why

`join` picks one of five leading rules from what sits either side of the caret. That neighbourhood was the one input to the decision the log did not record.

A real case from yesterday: a dictation landed in Slack as `reviews.` newline `␣I know Matthieu…`. The log said which rule fired and what the transform returned, but not what it read, so the leading space could not be explained without replaying `join.py` by hand against a guessed box. `new sentence` and `line start` differ only by a newline, and the log showed neither.

## What

The `input` stage writes the two edges as one string — 20 characters a side, caret as `‸`, a selection as `⟦⟧`, whitespace escaped so it stays on one line. It sits directly above what the transform logs, so the two lines answer the question together.

```
caret ⟪…l help with reviews.‸\nI know Matthieu is⟫    -> new sentence, space added
caret ⟪… help with reviews.\n‸I know Matthieu is⟫     -> line start, no space
```

Also written at press time, because a pipeline with no `input` stage still leaves the evidence there. The two moments are the same snapshot, seconds apart — anything typed between them is invisible to both, which is itself worth seeing.

## Scored, not eyeballed

`--input-test` prints the same string as a sixth line. `tests/input-cases.txt` gains the column with hand-written expectations, plus two cases for the 20-character window and the ellipsis. **14/14.**

A newline case cannot be stated in that file: the three blocks print theirs raw, and a break splits the line the harness compares. The column is documented as the only one that can hold a newline, and the rendering is verified with `--input-test` directly.

## Checks

`check-input` 14/14 · `check-join` 46/46 · `check-dotted` 73/73 · `check-pipeline` 93/93 · `check-eval` 29/29 · `--check-config` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)