### PR TITLE
fix: the prune reports what it did, not what it meant to do

### DIFF
--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -2658,7 +2658,17 @@ enum ConfigStore {
         let stillShipped = Set(shipped)
         for relative in installedExampleFiles() where !stillShipped.contains(relative) {
             var url = installedExamplesDirectory.appendingPathComponent(relative)
-            try? fm.removeItem(at: url)
+            do {
+                try fm.removeItem(at: url)
+            } catch {
+                // Said out loud, because the whole point of the prune is that a
+                // dropped example stops resolving. A failure that logged
+                // "removed" would report the opposite of what happened, and the
+                // stale `examples/...` path would go on working.
+                Log.write("config: could not remove transforms/examples/\(relative):"
+                    + " \(error.localizedDescription); it is stale and still resolves")
+                continue
+            }
             Log.write("config: removed transforms/examples/\(relative) (no longer shipped)")
             // A folder a removed example leaves empty — `retired/` once
             // `retired/retired.py` is gone — is cleaned up too, stopping at

--- a/Sources/ParrotFlow/SeedConfigCommand.swift
+++ b/Sources/ParrotFlow/SeedConfigCommand.swift
@@ -58,13 +58,25 @@ enum SeedConfigCommand {
             }
         }
 
-        for relative in stale {
+        // Read back rather than trusted: `stale` is what the refresh was going
+        // to remove, and this reports what it did remove. The two differ when a
+        // file cannot be deleted, and that is exactly the case worth printing —
+        // a stale example that survives goes on resolving.
+        let installedAfter = Set(ConfigStore.installedExampleFiles())
+        let removed = stale.filter { !installedAfter.contains($0) }
+        let kept = stale.filter { installedAfter.contains($0) }
+        for relative in removed {
             print("  · transforms/examples/\(relative) — removed, no longer shipped")
+        }
+        for relative in kept {
+            print("  ✗ transforms/examples/\(relative) — no longer shipped, and could not"
+                + " be removed; it still resolves")
         }
 
         print("")
         print("  \(written) example file(s) written, \(refreshed) refreshed"
-            + (stale.isEmpty ? "." : ", \(stale.count) removed."))
+            + (removed.isEmpty ? "" : ", \(removed.count) removed")
+            + (kept.isEmpty ? "." : ", \(kept.count) left behind."))
         print("  transforms/examples/ is the app's; edits there do not survive the next launch.")
         print("  transforms/<name>/ is yours — copy a file out of examples/ before editing it.")
         return 0

--- a/scripts/check-transform-folders.sh
+++ b/scripts/check-transform-folders.sh
@@ -355,6 +355,36 @@ check "and a command pointed at it no longer resolves — fails open" \
   "$("$BIN" --pipeline "$FRESH/retired.yaml" "keep it down" --quiet 2>/dev/null | tail -1)" \
   "keep it down"
 
+# --- a removal that fails says so, rather than claiming success --------------
+#
+# The prune exists so a dropped example stops resolving. A removal that fails
+# and reports "removed" says the opposite of what happened, and the stale path
+# goes on working while the log says it cannot. Read back from disk rather than
+# assumed, so the report cannot drift from the outcome.
+#
+# Skipped for root, which unlinks through a read-only directory anyway.
+if [ "$(id -u)" != "0" ]; then
+  mkdir -p "$FRESH/transforms/examples/stuck"
+  printf '#!/usr/bin/env python3\nprint("stuck")\n' > "$FRESH/transforms/examples/stuck/stuck.py"
+  chmod 500 "$FRESH/transforms/examples/stuck"
+  stuck_out="$(PARROTFLOW_CONFIG_DIR="$FRESH" "$BIN" --seed-config 2>/dev/null)"
+  chmod 700 "$FRESH/transforms/examples/stuck"
+
+  check "a stale file that cannot be removed is reported as left behind" \
+    "$(printf '%s\n' "$stuck_out" | grep -c 'stuck/stuck.py — no longer shipped, and could not be removed')" \
+    "1"
+
+  check "and it is not also reported as removed" \
+    "$(printf '%s\n' "$stuck_out" | grep -c 'stuck/stuck.py — removed')" \
+    "0"
+
+  check "and the file really is still there, so the report was true" \
+    "$([ -e "$FRESH/transforms/examples/stuck/stuck.py" ] && echo present || echo gone)" \
+    "present"
+
+  rm -rf "$FRESH/transforms/examples/stuck"
+fi
+
 # --- an older install's own folder is never touched --------------------------
 #
 # `transforms/punctuation/` is what a version before this one seeded, and a

--- a/scripts/check-transform-folders.sh
+++ b/scripts/check-transform-folders.sh
@@ -34,7 +34,7 @@ BIN="$ROOT/.build/release/ParrotFlow"
 [ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
 
 WORK="$(mktemp -d -t parrotflow-folders)"
-trap 'rm -rf "$WORK"' EXIT
+trap 'chmod -R u+w "$WORK" 2>/dev/null; rm -rf "$WORK"' EXIT
 
 pass=0; total=0; failed=""
 


### PR DESCRIPTION
Follow-up to #157. Greptile raised this after the merge, and it is real — I reproduced it against `main`.

## The fault

`Config.swift` removed a stale example with `try?` and then logged success unconditionally:

```swift
try? fm.removeItem(at: url)
Log.write("config: removed transforms/examples/\(relative) (no longer shipped)")
```

The prune exists so a dropped example stops resolving. A removal that fails and reports "removed" says the opposite of what happened, and the stale `examples/...` path goes on working while the log says it cannot.

`--seed-config` had the same fault independently: it computed the stale list *before* `createIfMissing()` ran, then printed every entry as removed.

## The fix

The error is caught and named, and the empty-folder cleanup below it is skipped for a file that is still there. `--seed-config` reads the directory back afterwards and reports what actually went, with survivors marked and counted apart.

Behaviour on a read-only folder, before and after:

```
before:  · transforms/examples/stuck/stuck.py — removed, no longer shipped
         0 example file(s) written, 15 refreshed, 1 removed.

after:   ✗ transforms/examples/stuck/stuck.py — no longer shipped, and could not
           be removed; it still resolves
         0 example file(s) written, 15 refreshed, 1 left behind.
```

The file is still on disk in both runs. Only the second says so.

## Checks

Three new cases in `check-transform-folders.sh` drive it with a read-only directory: the survivor is reported as left behind, is *not* also reported as removed, and really is still on disk. Skipped under root, which unlinks through a read-only directory anyway.

`check-transform-folders` 30/30 · `check-eval` pass · `check-default-config` pass · `check-dotted` pass · `--check-config` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)