### PR TITLE
feat: the offer holds at full strength before it fades, and its keys shimmer

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -343,19 +343,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// See `holdTheOffer`.
     private var offerHeld = false
 
-    /// How long the offer stays up.
+    /// How long the offer stays up: the pill's own hold plus its fade.
     ///
-    /// Long enough to read the sentence, decide it is wrong and reach for a
-    /// key, which three seconds was not. It can afford to be this long because
-    /// it does not sit there at full strength: it thins out the whole way — see
-    /// `PillHUD.offer` — and the pointer stops that clock and gives the nine
-    /// seconds back in full. A fade this generous would be clutter after every
-    /// dictation if reading it did not put it back.
+    /// Read from `PillHUD` rather than chosen here, because the keys and the
+    /// pill have to end together. A number of its own would mean letters still
+    /// being taken from the app you are typing in after the surface offering
+    /// them has gone — or the other way round, a chip on screen whose key does
+    /// nothing.
+    ///
+    /// The pointer stops that clock and gives all of it back — see
+    /// `holdTheOffer`.
     ///
     /// Not private: `--panels offer` previews the offer for as long as the app
     /// gives it, and a preview with a number of its own is a preview of
     /// something else.
-    static let offerSeconds: TimeInterval = 9
+    static let offerSeconds: TimeInterval = PillHUD.offerLife
 
     /// What the offer offers: Correct, then every transform that asked for a
     /// place on it with `offer: true`.
@@ -2587,7 +2589,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // dismissing the offer. The chips stay clickable meanwhile, and
         // `stopWatchingForEscapeIfIdle` calls back here the moment that
         // dictation is over — so an offer still on screen then gets its keys
-        // for whatever is left of its nine seconds.
+        // for whatever is left of its `offerSeconds`.
         guard !recorder.isRecording, runsInFlight <= 0 else {
             Log.write("offer keys: a dictation is still running; the keys wait for it")
             return
@@ -2724,7 +2726,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// would hold the offer open until the next dictation, with the letters it
     /// takes from every app. So the hold is checked once every `offerSeconds`,
     /// and a pointer that has gone without saying so is treated as one that
-    /// said so: the offer gets its nine seconds and runs out normally.
+    /// said so: the offer gets its `offerSeconds` back and runs out normally.
     private func offerDeadlinePassed() {
         guard offerHeld else { endTheOffer(); return }
         if pill.pointerIsOver {
@@ -2742,7 +2744,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// were reaching for it would be arguing about whether you had finished,
     /// and a pointer can rest for longer than any number chosen here. So while
     /// it is inside the offer has no deadline at all, and leaving starts a
-    /// whole new nine seconds.
+    /// whole new `offerSeconds`.
     ///
     /// Three clocks have to move together, or the pill and the keys disagree:
     /// the pill's own fade, this deadline, and the tap's expiry. The tap's is

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -261,7 +261,7 @@ enum CheckConfigCommand {
             // Correct's letter is not a transform's to lose, and the first chip
             // with a letter is the one that key runs. So a second chip asking
             // for the same letter is drawn with a keycap that never fires, and
-            // that is invisible on a pill that fades out in nine seconds.
+            // that is invisible on a pill that fades out in a few seconds.
             var taken: Set<String> = ["C"]
             for transform in offered {
                 let key = transform.offerKey

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -2011,7 +2011,7 @@ struct Config: Decodable, Equatable {
         ///
         /// Off by default, and it is the one thing on the pill that is about the
         /// app rather than about your words: it puts the whole sentence back on
-        /// screen for nine seconds, which is a lot of pill for something you can
+        /// screen for the length of the offer, which is a lot of pill for something you can
         /// already read where it landed. Worth turning on while you are learning
         /// what your own dictation is weak at — see `Confidence` for what the
         /// colours are anchored to, and why they cannot be anchored to anything

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -407,9 +407,9 @@ enum PanelsCommand {
             pill.working("Thinking…")
         case "offer":
             // The real call rather than a bare `set`. The offer is the one
-            // state that arrives below full strength and thins out, so a
-            // preview holding it at full would be a picture of a pill that
-            // never appears. It gets the duration the app gives it.
+            // state that holds and then thins out, so a preview that only held
+            // would be a picture of a pill that never leaves. It gets the
+            // duration the app gives it.
             pill.offer(offerChips, for: AppDelegate.offerSeconds)
             // The one state that takes the mouse, so the one worth being able
             // to hover. Nothing runs — this is the surface, not the app — but

--- a/Sources/ParrotFlow/ParrotStyle.swift
+++ b/Sources/ParrotFlow/ParrotStyle.swift
@@ -82,9 +82,15 @@ extension View {
     /// ground is the one background that stays legible over all of them, and
     /// the rim carries the identity without asking anything of the text.
     ///
-    /// `alive` is for work of unknown length. The rim turns and brightens, which
-    /// is the only motion any of these surfaces make — it means the app is busy,
-    /// so nothing else may borrow it for decoration.
+    /// `alive` is for work of unknown length. The rim turns fast and brightens,
+    /// and the glow drifts with it. That combination means the app is busy, and
+    /// nothing else may borrow it.
+    ///
+    /// `turning` is the rim alone, at a third of the speed and at its resting
+    /// weight. The offer uses it: a surface asking to be answered before it
+    /// goes should be the one thing on screen that moves. It is not the busy
+    /// signal, because the weight, the brightness and the drifting glow are
+    /// what make that one — see `PlumageRim.spin`.
     ///
     /// `glass` gives the surface a thickness: a lighter scrim, a sheen down the
     /// face, and the rim's inner hairline weighted to the top so the edge reads
@@ -116,8 +122,9 @@ extension View {
     /// the translucent ones already take their colour from what is behind
     /// them, and a wash on top of that is paint on a window.
     func parrotSurface<S: InsettableShape>(
-        _ shape: S, alive: Bool = false, glass: Bool = false, solid: Bool = false,
-        scrim: Double? = nil, wash: Color? = nil, wheel: [Color] = Parrot.wheel
+        _ shape: S, alive: Bool = false, turning: Bool = false, glass: Bool = false,
+        solid: Bool = false, scrim: Double? = nil, wash: Color? = nil,
+        wheel: [Color] = Parrot.wheel
     ) -> some View {
         background {
             if solid {
@@ -174,7 +181,9 @@ extension View {
         }
         // The lit edge is the rim's own inner hairline, weighted to the top —
         // not a line of its own. See `PlumageRim`.
-        .overlay { PlumageRim(shape: shape, alive: alive, glass: glass, wheel: wheel) }
+        .overlay {
+            PlumageRim(shape: shape, alive: alive, turning: turning, glass: glass, wheel: wheel)
+        }
     }
 }
 
@@ -182,6 +191,8 @@ extension View {
 struct PlumageRim<S: InsettableShape>: View {
     let shape: S
     var alive: Bool = false
+    /// Turn without saying the app is busy. See `spin`.
+    var turning: Bool = false
     /// Weight the inner hairline toward the top, so it reads as light on the
     /// edge. See the hairline below.
     var glass: Bool = false
@@ -212,6 +223,7 @@ struct PlumageRim<S: InsettableShape>: View {
             }
             .animation(.easeInOut(duration: 0.35), value: alive)
             .onChange(of: alive) { _, _ in spin() }
+            .onChange(of: turning) { _, _ in spin() }
             .onAppear { spin() }
     }
 
@@ -229,15 +241,32 @@ struct PlumageRim<S: InsettableShape>: View {
         )
     }
 
+    /// One turn of the feathers, at the speed the surface asked for.
+    ///
+    /// Busy is 1.8s. `turning` is `slowTurn`, which is slow enough that you
+    /// see the colours move rather than a rim spinning — and the bloom behind
+    /// it stays still either way, which is the other half of why the two do
+    /// not read alike. That stillness is also what keeps this affordable: a
+    /// drifting bloom is four Gaussian blurs re-rendered every frame, measured
+    /// at 40% of a core. See `PlumageBloom.spin`.
+    ///
+    /// The rim alone measured at about 11% of a core on the offer pill, for
+    /// the five seconds the offer is up. The pill standing still is 0-3%.
     private func spin() {
-        guard alive, !reduceMotion else {
+        guard alive || turning, !reduceMotion else {
             withAnimation(.default) { angle = -90 }
             return
         }
-        withAnimation(.linear(duration: 1.8).repeatForever(autoreverses: false)) {
+        withAnimation(
+            .linear(duration: alive ? 1.8 : Self.slowTurn).repeatForever(autoreverses: false)
+        ) {
             angle = 270
         }
     }
+
+    /// One trip round a rim that is not saying anything is happening.
+    /// Computed rather than stored: this type is generic over its shape.
+    static var slowTurn: TimeInterval { 6 }
 }
 
 // MARK: - Fields
@@ -531,10 +560,10 @@ struct PlumageBloom<S: InsettableShape>: View {
     /// expensive is not a decoration, it is a fan.
     ///
     /// Still, the reason to stop it is the rule that was already written on
-    /// `PlumageRim`: motion on these surfaces means the app is working, and
-    /// nothing may borrow it to look nice. A glow that drifts while nothing is
-    /// happening says something is happening. At rest the bloom is simply
-    /// there — lit, uneven, and still.
+    /// `PlumageRim`: a glow that drifts while nothing is happening says
+    /// something is happening. At rest the bloom is simply there — lit,
+    /// uneven, and still. The offer turns its rim slowly and the bloom stays
+    /// out of it, which is what keeps "busy" a signal of its own.
     private func spin() {
         guard alive, !reduceMotion else {
             withAnimation(.easeInOut(duration: 0.4)) { outer = -90; inner = 90 }

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -125,13 +125,14 @@ final class PillHUD {
     private var isDecaying = false
     /// How long the offer on screen was given, so the pointer can give it again.
     private var offerFor: TimeInterval?
-    /// A decay the pointer has stopped, as against one still running.
+    /// A decay standing still, as against one whose alpha is moving.
     ///
-    /// The two end differently. A stopped one sits at `offerAlpha`, which is a
-    /// real strength, so it can fade out the way every other state does. A
-    /// running one has already told AppKit to finish at zero, so a fade laid
-    /// over it has nothing left to move and it is cut instead.
-    private var decayIsHeld = false
+    /// True through the hold, and again once the pointer stops the fade. The
+    /// two end differently. A still one sits at `offerAlpha`, which is a real
+    /// strength, so it can fade out the way every other state does. A moving
+    /// one has already told AppKit to finish at zero, so a fade laid over it
+    /// has nothing left to move and it is cut instead.
+    private var decayIsStill = false
     /// Which decay is the live one.
     ///
     /// Replacing an animation makes the one it replaced call its completion
@@ -141,6 +142,8 @@ final class PillHUD {
     /// was the pointer dismissing the offer it was there to hold open. The
     /// handler checks this number as well, and a stale one does nothing.
     private var decayRun = 0
+    /// The offer's fade, waiting out the hold. See `decay(over:)`.
+    private var pendingDecayFade: DispatchWorkItem?
 
     /// Where this dictation's words are going, set at the press by `aim(at:)`.
     /// Every state reads it while the pill is up, and `fadeOut` clears it, so
@@ -185,14 +188,12 @@ final class PillHUD {
     ///
     /// This is the one state that leaves by going quiet rather than by
     /// disappearing. Every other one holds full strength and then goes. This
-    /// one starts below full and thins the whole way out, for two reasons. It
-    /// is the only state nobody asked for — it arrives after a dictation you
-    /// had already finished — so it should announce itself less than a notice
-    /// does. And it is the only state with a deadline you might want to beat: a
-    /// hard cut gives you the time and then nothing, while a decay says how
-    /// long is left without a clock on screen, and stays usable to the last
-    /// frame. The keys and the chips work the whole way down; the fading only
-    /// says how long is left.
+    /// one stands at full strength for `PillHUD.offerHold` and then thins out
+    /// over `PillHUD.offerFade`, because it is the only state with a deadline
+    /// you might want to beat: a hard cut gives you the time and then nothing,
+    /// while a fade says how long is left without a clock on screen, and stays
+    /// usable to the last frame. The keys and the chips work the whole way
+    /// down; the fading only says how long is left.
     func offer(
         _ commands: [OfferedCommand], headline: String? = nil,
         reading: Confidence.Reading = Confidence.Reading(), for duration: TimeInterval
@@ -203,18 +204,26 @@ final class PillHUD {
         decay(over: duration)
     }
 
-    /// From `Self.offerAlpha` to nothing, over `duration`, then gone.
+    /// Hold at `Self.offerAlpha` for what is left after the fade, then run
+    /// out over `Self.offerFade`, then gone.
     ///
-    /// Linear on purpose. An eased fade spends most of its time near the ends
-    /// and crosses the middle quickly, which reads as the surface being yanked
-    /// away at the halfway mark. A straight ramp is the one shape that says
-    /// "this is running out" at a steady rate — a clock without a clock.
+    /// The hold comes first because the offer is read before it is answered.
+    /// A surface that starts thinning on the frame it appears is one you read
+    /// against the clock; one that stands still first is one you read, and
+    /// only then decide about.
+    ///
+    /// The fade is linear on purpose. An eased fade spends most of its time
+    /// near the ends and crosses the middle quickly, which reads as the
+    /// surface being yanked away at the halfway mark. A straight ramp is the
+    /// one shape that says "this is running out" at a steady rate — a clock
+    /// without a clock.
     private func decay(over duration: TimeInterval) {
         guard let panel else { return }
         pendingDismiss?.cancel(); pendingDismiss = nil
+        pendingDecayFade?.cancel(); pendingDecayFade = nil
         isFading = false
         isDecaying = true
-        decayIsHeld = false
+        decayIsStill = true
         decayRun += 1
         let run = decayRun
 
@@ -227,14 +236,30 @@ final class PillHUD {
             context.duration = 0
             panel.animator().alphaValue = Self.offerAlpha
         }
+
+        let fade = min(Self.offerFade, duration)
+        let hold = max(0, duration - fade)
+        let start = DispatchWorkItem { [weak self] in
+            self?.runOut(panel, over: fade, run: run)
+        }
+        pendingDecayFade = start
+        DispatchQueue.main.asyncAfter(deadline: .now() + hold, execute: start)
+    }
+
+    /// The second half of the decay: the alpha finally moves.
+    private func runOut(_ panel: NSPanel, over fade: TimeInterval, run: Int) {
+        // `decayRun` and not `isDecaying` alone: see the property.
+        guard isDecaying, decayRun == run else { return }
+        pendingDecayFade = nil
+        decayIsStill = false
         NSAnimationContext.runAnimationGroup { context in
-            context.duration = duration
+            context.duration = fade
             context.timingFunction = CAMediaTimingFunction(name: .linear)
             panel.animator().alphaValue = 0
         } completionHandler: { [weak self] in
-            // `decayRun` and not `isDecaying` alone: see the property.
             guard let self, self.isDecaying, self.decayRun == run else { return }
             self.isDecaying = false
+            self.decayIsStill = false
             // The aim belonged to the dictation that has just ended, the same
             // as in `fadeOut`.
             self.near = nil
@@ -253,9 +278,9 @@ final class PillHUD {
     /// A surface that went on thinning while you were reaching for it would be
     /// arguing with you about whether you had finished.
     ///
-    /// This is also why the decay can be as long as it is. Nine seconds of
-    /// clutter would be too much to put on screen after every dictation if
-    /// reading it did not put it back.
+    /// This is also why the offer can stand at full strength the way it does.
+    /// Clutter that bright would be too much to put on screen after every
+    /// dictation if reading it did not put the whole clock back.
     func hovering(_ inside: Bool) {
         // `isVisible` as well as the flag: a decay that finished a moment ago
         // has taken the panel out, and nothing about the pointer should bring
@@ -266,8 +291,9 @@ final class PillHUD {
             // animation below replaces it, and a replaced animation calls its
             // handler at once.
             decayRun += 1
+            pendingDecayFade?.cancel(); pendingDecayFade = nil
             isDecaying = true
-            decayIsHeld = true
+            decayIsStill = true
             NSAnimationContext.runAnimationGroup { context in
                 context.duration = 0
                 panel.animator().alphaValue = Self.offerAlpha
@@ -277,9 +303,20 @@ final class PillHUD {
         }
     }
 
-    /// Where the offer starts. Below full, because it is the one surface that
-    /// appears without being asked for.
-    static let offerAlpha: CGFloat = 0.92
+    /// Where the offer starts, and stands through the hold: full strength.
+    ///
+    /// It was 0.92 — quieter than the other states, because it is the one
+    /// surface that appears without being asked for. That made the chips on it
+    /// hard to read at the moment they are meant to be read, and the fade
+    /// already says the offer is optional.
+    static let offerAlpha: CGFloat = 1
+
+    /// How long the offer stands still before it starts running out.
+    static let offerHold: TimeInterval = 3
+    /// How long it takes to go, once it starts.
+    static let offerFade: TimeInterval = 2
+    /// The whole of the offer's life, hold and fade.
+    static let offerLife: TimeInterval = offerHold + offerFade
 
     /// The pill's own visible capsule right now — what a click has to land
     /// inside of to count as a click on the pill rather than a click past it.
@@ -365,9 +402,10 @@ final class PillHUD {
         if isFading || isDecaying {
             isFading = false
             isDecaying = false
-            decayIsHeld = false
+            decayIsStill = false
             // The decay's handler is now a stale one. See `decayRun`.
             decayRun += 1
+            pendingDecayFade?.cancel(); pendingDecayFade = nil
             // Zero-length rather than a plain assignment: that is what stops
             // the animation underneath, which would otherwise go on pulling
             // the alpha down under the state that has just replaced it.
@@ -472,16 +510,18 @@ final class PillHUD {
         // here, and a dismissal that took another few seconds to show would
         // read as the key not working.
         //
-        // A running decay is cut, because its alpha is already on its way to
-        // zero and a fade laid over that has nothing left to move. A decay the
-        // pointer is holding is not: it is stopped at `offerAlpha`, so it goes
-        // out the way every other state does. Clicking a chip is the common
+        // A moving decay is cut, because its alpha is already on its way to
+        // zero and a fade laid over that has nothing left to move. A decay
+        // standing still is not — in its hold, or stopped there by the pointer
+        // — because it sits at `offerAlpha`, so it goes out the way every
+        // other state does. Clicking a chip is the common
         // path and the pointer is on the pill by definition, so that is the
         // one that must not blink out. The stale handler is seen off the same
         // way as in `set`.
-        if isDecaying, !decayIsHeld {
+        if isDecaying, !decayIsStill {
             isDecaying = false
             decayRun += 1
+            pendingDecayFade?.cancel(); pendingDecayFade = nil
             near = nil
             // A zero-length animation is how the running one is stopped, and
             // it leaves the panel at full strength for the next appearance.
@@ -498,8 +538,9 @@ final class PillHUD {
         // real alpha, so it leaves as an ordinary fade — and either way the
         // flags and the handler are seen off before that fade starts.
         isDecaying = false
-        decayIsHeld = false
+        decayIsStill = false
         decayRun += 1
+        pendingDecayFade?.cancel(); pendingDecayFade = nil
 
         isFading = true
         NSAnimationContext.runAnimationGroup { context in
@@ -782,7 +823,7 @@ enum PillMetrics {
 
     /// Three lines holds about 240 characters, which is the 99th percentile of
     /// the dictations in this machine's archive. Past that it truncates: the
-    /// pill is on screen for nine seconds and a paragraph of it would cover the
+    /// pill is on screen for seconds and a paragraph of it would cover the
     /// words it is about.
     static let sentenceLines = 3
 
@@ -1000,8 +1041,11 @@ struct PillView: View {
         // said. The line says it, but the line is on a pill you have already
         // learned to ignore: the surface changing colour is what gets looked
         // at, and it is the same signal the caution notices use.
+        // The offer turns its rim slowly, on its own: it is the one state with
+        // a deadline, and the only one you are meant to answer. Slow, and with
+        // the glow behind it left still, so it does not read as the busy rim.
         .parrotSurface(
-            Self.shape, alive: isWorking, solid: true,
+            Self.shape, alive: isWorking, turning: isOffer, solid: true,
             wash: warning?.wash, wheel: warning?.wheel ?? Parrot.wheel
         )
         // Under the capsule, so it is the capsule's shape and not the glow's.
@@ -1024,6 +1068,11 @@ struct PillView: View {
 
     private var isWorking: Bool {
         if case .working = model.state { return true }
+        return false
+    }
+
+    private var isOffer: Bool {
+        if case .offer = model.state { return true }
         return false
     }
 
@@ -1127,6 +1176,14 @@ private struct OfferContent: View {
     /// The lit chip's lettering: leaf lightened almost to white, so the words
     /// stay readable over a fill of the same colour.
     private static let litText = Color(red: 0.89, green: 0.96, blue: 0.93)
+
+    /// Every other chip's lettering.
+    ///
+    /// `.secondary` was what this used to be, and on a dark capsule that is
+    /// grey: the commands read as unavailable, which is the one thing they are
+    /// not. Not white either — white is where the lit chip goes, and there
+    /// would be nothing left for the pointer to say.
+    private static let restingText = Color(white: 0.88)
 
     var body: some View {
         VStack(alignment: .leading, spacing: PillMetrics.sentenceGap) {
@@ -1238,18 +1295,7 @@ private struct OfferContent: View {
     private func chip(_ command: OfferedCommand, lit: Bool) -> some View {
         HStack(spacing: 7) {
             if !command.key.isEmpty {
-                Text(command.key)
-                    .font(.system(size: 11, weight: .bold, design: .rounded))
-                    // A floor rather than a width: every letter draws in the
-                    // same box, so the chips do not step in and out by a point
-                    // as the pointer moves along them.
-                    .frame(minWidth: 9)
-                    .padding(.horizontal, 5)
-                    .padding(.vertical, 2)
-                    .background {
-                        RoundedRectangle(cornerRadius: 4, style: .continuous)
-                            .fill(Color.white.opacity(lit ? 0.2 : 0.12))
-                    }
+                OfferKeyCap(key: command.key, lit: lit)
             }
             Text(command.title)
                 .font(.system(size: 13, weight: .medium, design: .rounded))
@@ -1259,7 +1305,7 @@ private struct OfferContent: View {
                 .lineLimit(1)
                 .fixedSize()
         }
-        .foregroundStyle(lit ? Self.litText : .secondary)
+        .foregroundStyle(lit ? Self.litText : Self.restingText)
         .padding(.horizontal, 10)
         .padding(.vertical, 5)
         .background {
@@ -1270,6 +1316,84 @@ private struct OfferContent: View {
                         lit ? Parrot.leaf.opacity(0.62) : .clear, lineWidth: 1
                     )
                 }
+        }
+    }
+}
+
+/// The letter you can press, in a box with a light going round it.
+///
+/// The key is the only thing on the offer that is not obvious: the chips look
+/// like things to click, and a click is what people did — the letters were
+/// read as decoration and the offer timed out with the keyboard unused. A
+/// still border did not fix that, because everything else on the pill is still
+/// too. Movement is what the eye finds on a surface it is not looking at.
+///
+/// Slow and dim on purpose. One turn takes `turnSeconds`, so at a glance it is
+/// a border and only a border; what it does is make you glance.
+private struct OfferKeyCap: View {
+    let key: String
+    let lit: Bool
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var angle: Double = -90
+
+    /// One trip round the border. Long enough that the light never reads as a
+    /// spinner, short enough to be seen inside the offer's hold. It does not
+    /// divide into the rim's `PlumageRim.slowTurn`, so the two never fall into
+    /// step.
+    private static let turnSeconds: TimeInterval = 3.4
+    private static let radius: CGFloat = 4
+
+    /// The border when the light is elsewhere.
+    private var base: Double { lit ? 0.28 : 0.18 }
+
+    var body: some View {
+        Text(key)
+            .font(.system(size: 11, weight: .bold, design: .rounded))
+            // A floor rather than a width: every letter draws in the same box,
+            // so the chips do not step in and out by a point as the pointer
+            // moves along them.
+            .frame(minWidth: 9)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background {
+                RoundedRectangle(cornerRadius: Self.radius, style: .continuous)
+                    .fill(Color.white.opacity(lit ? 0.2 : 0.12))
+            }
+            .overlay { sheen }
+    }
+
+
+    /// A bright arc travelling round the box, over the resting border.
+    ///
+    /// The angle is animated, the same way `PlumageRim` turns the feathers —
+    /// the gradient is the border rather than something masked into it. The
+    /// arc is short and the rest of the ring is the resting white, so a still
+    /// frame is a border and only the movement is new.
+    private var sheen: some View {
+        RoundedRectangle(cornerRadius: Self.radius, style: .continuous)
+            .strokeBorder(
+                AngularGradient(
+                    stops: [
+                        .init(color: .white.opacity(base), location: 0),
+                        .init(color: .white.opacity(lit ? 0.95 : 0.8), location: 0.1),
+                        .init(color: .white.opacity(base), location: 0.26),
+                        .init(color: .white.opacity(base), location: 1),
+                    ],
+                    center: .center, angle: .degrees(angle)
+                ),
+                lineWidth: 1
+            )
+            // `initial: true` covers what `onAppear` did; the view stays alive
+            // across offers, so a Reduce Motion toggle mid-session needs the
+            // same call again, not just on the first appearance.
+            .onChange(of: reduceMotion, initial: true) { _, _ in spin() }
+    }
+
+    private func spin() {
+        guard !reduceMotion else { return }
+        withAnimation(.linear(duration: Self.turnSeconds).repeatForever(autoreverses: false)) {
+            angle = 270
         }
     }
 }

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -1391,7 +1391,10 @@ private struct OfferKeyCap: View {
     }
 
     private func spin() {
-        guard !reduceMotion else { return }
+        guard !reduceMotion else {
+            withAnimation(.default) { angle = -90 }
+            return
+        }
         withAnimation(.linear(duration: Self.turnSeconds).repeatForever(autoreverses: false)) {
             angle = 270
         }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -443,8 +443,9 @@ resizes the panel, *Got it* dismisses it. The sheet draws it both ways.
 one to print which was chosen. Every other state lets clicks through, so the
 pill is never a hole in your screen while you are dictating.
 
-It is also the one state that fades. It arrives just below full strength and
-thins out over nine seconds, the same as in the app, so it leaves on its own.
+It is also the one state that fades. It stands at full strength for three
+seconds and thins out over the next two, the same as in the app, so it leaves
+on its own.
 Put the pointer on it and the fading stops, which is both what the app does and
 how you keep it on screen for as long as you want to look at it.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -637,13 +637,13 @@ dictation's — the result is not written over it, and the menu bar says so.
 | `↩` | Dismisses, and reaches the app underneath untouched |
 | the dictation hotkey | Starts the next dictation, exactly as before |
 
-It fades rather than vanishing. It arrives just below full strength and thins
-out over nine seconds, and then it is gone. The keys, the click, and the chips
-work the whole way down — the fading only says how long is left. Putting the
-pointer on the pill stops the clock, and taking it off starts the nine seconds
-again. Any of the endings above takes the pill at once.
+It fades rather than vanishing. It stands at full strength for three seconds,
+thins out over the next two, and then it is gone. The keys, the click, and the
+chips work the whole way down — the fading only says how long is left. Putting
+the pointer on the pill stops the clock, and taking it off starts the five
+seconds again. Any of the endings above takes the pill at once.
 
-**The letters are taken from every app for those nine seconds.** The pill
+**The letters are taken from every app for those five seconds.** The pill
 never holds keyboard focus, so it swallows a chip's own letter system-wide or
 it does not get it at all. Only that bare letter runs a command — a letter
 with a modifier on it is somebody else's shortcut and is left alone, `⌘C`

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -299,7 +299,7 @@ the first chip with that letter wins.
 
 `--check-config` prints what is on the pill and the letter each chip carries.
 A chip that is missing, or a `key:` that was cut, is otherwise invisible: the
-pill fades out over nine seconds and a short offer looks like a normal one.
+pill fades out after a few seconds and a short offer looks like a normal one.
 
 Only the shipped `grammar` asks for a place. Everything else in
 config.example.yaml is left off.


### PR DESCRIPTION
The offer pill is the surface you are meant to answer, and it was the hardest
one to read. It arrived below full strength, thinned from the first frame, and
its chips were drawn in the grey macOS uses for things you cannot click.

**It holds, then it fades.** Full opacity for three seconds, then two seconds of
linear fade. Five seconds in all, against nine of continuous thinning. The
pointer still stops the clock and gives all five back on leaving.

**The chips are readable.** White 0.88 at rest instead of `.secondary`. The lit
chip keeps its leaf tint, so the pointer still says something.

**The keys move.** Each key cap has a border with a light travelling round it,
one turn every 3.4s. The pill's own plumage rim turns while the offer is up, one
turn every 6s, at its resting weight — not the 1.8s and the extra weight that
mean the app is busy. The bloom behind it stays still, which is the other half
of keeping "busy" a signal of its own.

## Two things worth a reviewer's eye

`AppDelegate.offerSeconds` now reads `PillHUD.offerLife` rather than carrying a
`9` of its own. The pill's fade, the offer deadline and the key tap have to end
together: a number in two places is letters still being taken from the app you
are typing in after the surface offering them has gone.

`decayIsHeld` became `decayIsStill`, and it is now true through the hold as well
as while the pointer holds the offer open. `fadeOut` reads it to decide between
an ordinary fade and an instant cut. Pressing a key during the hold gets the
fade; only a decay whose alpha is already moving is cut.

## Cost

Measured with `--panels offer`, `ps %cpu` over the five seconds the pill is up:

| | CPU |
|---|---|
| pill standing still | 0-3% |
| key shimmer only | ~9% |
| shimmer + turning rim | ~20% |

For comparison, the bloom's own drift — cut long ago, and still cut — was 40% of
a core for the whole of every dictation. This is a fifth of that, for five
seconds.

## Checked

`swift build` clean. `--panel-sheet` renders every surface; the offer's chips
and key borders were read off it. The motion itself was checked by eye with
`--panels offer 12` — this shell has no screen-recording grant, so there is no
capture of it in the PR.
