### PR TITLE
feat: a second decode, run beside the first, gets the skipped words back

### DIFF
--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -45,6 +45,11 @@ enum CheckConfigCommand {
         print("  ✓ output dir        \(config.resolvedOutputDir.path)")
         print("  ✓ min duration      \(config.audio.minDurationSeconds)s")
         print("  · speech gate       \(config.audio.speechGate ? "on" : "off")")
+        if config.audio.secondOpinion, !config.audio.speechGate {
+            print("  ! second opinion    on, but it needs speech_gate — no padded decode will run")
+        } else {
+            print("  · second opinion    \(config.audio.secondOpinion ? "on" : "off")")
+        }
         print("  · feedback          sound=\(config.feedback.sound) overlay=\(config.feedback.overlay)"
               + " correct_offer=\(config.feedback.correctOffer)"
               + " confidence=\(config.feedback.confidence)")

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1956,12 +1956,28 @@ struct Config: Decodable, Equatable {
         /// with no speech in them. On by default; turn it off if it ever
         /// swallows something real.
         var speechGate: Bool = true
+        /// Decode the clip a second time beside the first, with silence at
+        /// both ends, and keep that decode when it reaches further. Off by
+        /// default: it recovers a rare failure and costs a second decode.
+        ///
+        /// The failure is Parakeet skipping frames it never looks at. It
+        /// predicts a token and a skip of up to 4 frames of 80ms together, so
+        /// one prediction can pass over 320ms of audio. Nothing in the output
+        /// says so: timing gap, speech coverage, tokens per second, decoder
+        /// confidence and the longest unclaimed stretch of speech were all
+        /// measured, and all five put the broken clips inside the healthy
+        /// distribution. Padding moves the speech against the frame grid,
+        /// which is the only thing that finds it.
+        ///
+        /// Needs `speech_gate`, which is what reads the clip as samples.
+        var secondOpinion: Bool = false
 
         enum CodingKeys: String, CodingKey {
             case sampleRate = "sample_rate"
             case outputDir = "output_dir"
             case minDurationSeconds = "min_duration_seconds"
             case speechGate = "speech_gate"
+            case secondOpinion = "second_opinion"
         }
 
         init() {}
@@ -1985,6 +2001,9 @@ struct Config: Decodable, Equatable {
             }
             if let gate = try c.decodeIfPresent(Bool.self, forKey: .speechGate) {
                 self.speechGate = gate
+            }
+            if let second = try c.decodeIfPresent(Bool.self, forKey: .secondOpinion) {
+                self.secondOpinion = second
             }
         }
     }

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -175,6 +175,15 @@ actor Transcriber {
         let asr = AsrManager(models: models)
         var decoderState = await TdtDecoderState.make(decoderLayers: asr.decoderLayerCount)
 
+        // `audio.second_opinion`: the same clip decoded again with silence at
+        // both ends, started here so it runs beside the first pass instead of
+        // after it. Nothing below is allowed to depend on it — every arm can
+        // come back empty and the dictation is whatever the first pass said.
+        var opinions: [Task<(pad: Double, result: ASRResult)?, Never>] = []
+        if config.audio.secondOpinion, let gated {
+            opinions = Self.startSecondOpinions(gate: gated, models: models)
+        }
+
         // Above 15s that batch path still chunks — 14.88s windows on a 12.88s
         // stride — so the seam is only gone for clips that fit one window. A
         // long pause mid-dictation can leave a whole window holding nothing
@@ -238,21 +247,30 @@ actor Transcriber {
         if let gated, Self.decodedNothing(result, gate: gated) {
             let speech = Self.speechSeconds(gated)
             var recovered: (pad: Double, result: ASRResult)?
-            for pad in Self.silenceRetryPads where recovered == nil {
-                do {
-                    guard let retried = try await decodePadded(gated, pad: pad, asr: asr),
-                        !retried.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                    else { continue }
-                    recovered = (pad, retried)
-                } catch {
-                    // A retry that fails leaves the clip as the first pass
-                    // decoded it. Letting this throw would turn a lost
-                    // dictation — bad, and already the case — into a failed
-                    // one, which is worse and would be caused by the repair.
-                    Log.write(String(
-                        format: "padded retry at %.0fms: %@",
-                        pad * 1000, error.localizedDescription
-                    ))
+            if opinions.isEmpty {
+                for pad in Self.silenceRetryPads where recovered == nil {
+                    do {
+                        guard let retried = try await Self.decodePadded(gated, pad: pad, asr: asr),
+                            !retried.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                        else { continue }
+                        recovered = (pad, retried)
+                    } catch {
+                        // A retry that fails leaves the clip as the first pass
+                        // decoded it. Letting this throw would turn a lost
+                        // dictation — bad, and already the case — into a failed
+                        // one, which is worse and would be caused by the repair.
+                        Log.write(String(
+                            format: "padded retry at %.0fms: %@",
+                            pad * 1000, error.localizedDescription
+                        ))
+                    }
+                }
+            } else {
+                // The same pads, already decoded beside the first pass. Taken
+                // from there rather than decoded again, so a dictation costs
+                // at most one decode per arm however it ends up being repaired.
+                recovered = await Self.collect(opinions).first {
+                    !$0.result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 }
             }
             if let recovered {
@@ -267,6 +285,55 @@ actor Transcriber {
                     format: "decoder returned nothing for %.2fs of speech, "
                         + "and no padded retry returned anything either",
                     speech
+                ))
+            }
+        } else if !opinions.isEmpty {
+            // The first pass wrote something, so the padded arms have to beat
+            // it rather than replace it. Two guards, both already used by the
+            // long-pause retry above: an arm must reach further into the clip,
+            // and it must say everything the first pass said before it says
+            // anything new. The second is what stops a recovered ending being
+            // paid for with a silently rewritten opening. There is a third
+            // guard below, stricter than either.
+            let further = await Self.collect(opinions)
+                .filter { Self.lastWordEnd($0.result) > Self.lastWordEnd(result) }
+            // Ranked on what an arm recovered, not on how far it reached.
+            // Reach cannot separate two arms: `unpadTimings` clamps a word
+            // running past the end of the clip back to the clip's length, and
+            // on a short clip every arm lands there. On the three clips that
+            // lost their ending, both arms reported that same clamped end
+            // while the 1.0s arm returned "that's a good one" and "scorer"
+            // and the 0.5s arm stopped at "that's the same" and "score".
+            func mostRecovered(
+                _ arms: [(pad: Double, result: ASRResult)]
+            ) -> (pad: Double, result: ASRResult)? {
+                arms.max { Self.recovered($0.result) < Self.recovered($1.result) }
+            }
+            // `extends` is a prefix test, so it also passes an arm that says
+            // exactly what the first pass said. Taking one of those swaps a
+            // decode for an equivalent decode — same words, different token
+            // split and casing. Over 60 archived clips that was the only
+            // thing it ever did, on 2 of them: "RXV" for "RX V", and "red
+            // rock roadmap" for "Red Rock Roadmap". So an arm has to add
+            // words, not just reach a later timestamp.
+            let added = further.filter {
+                Self.extends(result, by: $0.result)
+                    && Self.recovered($0.result) > Self.recovered(result)
+            }
+            if let best = mostRecovered(added) {
+                Log.write(String(
+                    format: "second opinion: the first pass stopped at %.2fs, "
+                        + "%.0fms of silence either side reached %.2fs; taking it",
+                    Self.lastWordEnd(result), best.pad * 1000, Self.lastWordEnd(best.result)
+                ))
+                result = best.result
+            } else if let rejected = mostRecovered(
+                further.filter { !Self.extends(result, by: $0.result) }
+            ) {
+                Log.write(String(
+                    format: "second opinion: %.0fms of silence either side reached %.2fs, but it "
+                        + "rewrote text the first pass had already decoded; keeping the first pass",
+                    rejected.pad * 1000, Self.lastWordEnd(rejected.result)
                 ))
             }
         }
@@ -367,19 +434,63 @@ actor Transcriber {
     /// A fresh `TdtDecoderState` per pass: the state is per-clip, and handing
     /// the first pass's state to the second would decode the padded copy as a
     /// continuation of the clip it is a copy of.
-    private func decodePadded(
+    private nonisolated static func decodePadded(
         _ gate: SpeechGate, pad: Double, asr: AsrManager
     ) async throws -> ASRResult? {
-        guard let padded = Self.paddedWithSilence(gate, pad: pad) else { return nil }
+        guard let padded = paddedWithSilence(gate, pad: pad) else { return nil }
         var state = await TdtDecoderState.make(decoderLayers: asr.decoderLayerCount)
         let raw = try await asr.transcribe(padded, decoderState: &state)
-        return Self.unpadTimings(raw, by: pad, seconds: gate.seconds)
+        return unpadTimings(raw, by: pad, seconds: gate.seconds)
+    }
+
+    /// Starts one padded decode per rung of `silenceRetryPads`, running now.
+    ///
+    /// A manager per arm. `AsrManager` is an actor, so arms sharing one would
+    /// decode one after another and the whole point is that they do not.
+    /// `AsrModels` is a struct of references, so the arms share the ~1GB of
+    /// weights and cost about 12MB each.
+    ///
+    /// `nonisolated` so the tasks do not inherit `Transcriber`'s executor,
+    /// which would put them back in the same queue as the first pass.
+    private nonisolated static func startSecondOpinions(
+        gate: SpeechGate, models: AsrModels
+    ) -> [Task<(pad: Double, result: ASRResult)?, Never>] {
+        silenceRetryPads.map { pad in
+            Task {
+                do {
+                    guard let decoded = try await decodePadded(
+                        gate, pad: pad, asr: AsrManager(models: models)
+                    ) else { return nil }
+                    return (pad, decoded)
+                } catch {
+                    // An arm that fails is an arm that has nothing to say. It
+                    // must never turn a dictation the first pass completed
+                    // into a thrown one — the repair would be the cause.
+                    Log.write(String(
+                        format: "second opinion at %.0fms: %@",
+                        pad * 1000, error.localizedDescription
+                    ))
+                    return nil
+                }
+            }
+        }
+    }
+
+    /// Waits for every arm and keeps the ones that decoded, in ladder order.
+    private nonisolated static func collect(
+        _ opinions: [Task<(pad: Double, result: ASRResult)?, Never>]
+    ) async -> [(pad: Double, result: ASRResult)] {
+        var decoded: [(pad: Double, result: ASRResult)] = []
+        for opinion in opinions {
+            if let value = await opinion.value { decoded.append(value) }
+        }
+        return decoded
     }
 
     /// What the speech gate found: the clip's samples and its speech
     /// boundaries, kept rather than reduced to a yes/no. The decoder wants
     /// both — see `closeLongPauses`.
-    struct SpeechGate {
+    struct SpeechGate: Sendable {
         let samples: [Float]
         let segments: [(start: Double, end: Double)]
         /// False when the clip is not the 16 kHz mono the recorder writes, in
@@ -590,6 +701,12 @@ actor Transcriber {
 
     private nonisolated static func comparable(_ text: String) -> String {
         text.lowercased().filter { $0.isLetter || $0.isNumber }
+    }
+
+    /// How much a decode said, on the same letters-and-digits view `extends`
+    /// compares on, so a comma or a capital does not count as a word.
+    private nonisolated static func recovered(_ result: ASRResult) -> Int {
+        comparable(result.text).count
     }
 
     /// True when the decoder stopped well before the speech did — the symptom

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -29,6 +29,12 @@ audio:
   # room tone into a sentence.
   speech_gate: true
 
+  # Decode every clip a second time beside the first, with silence added at
+  # both ends, and keep that decode when it reaches further. Recovers the
+  # endings the recogniser skips over — about 2% of dictations — and costs
+  # about 100ms. Needs speech_gate. See docs/configuration.md.
+  second_opinion: false
+
 feedback:
   sound: true     # a click when recording starts and stops
   overlay: true   # the floating pill while you speak

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,7 @@ hotkey:
 audio:
   output_dir: ~/Recordings/ParrotFlow
   speech_gate: true     # skip clips with no speech in them
+  second_opinion: false # decode each clip twice and keep the longer decode
 
 transcription:
   insert_mode: paste    # or clipboard
@@ -561,6 +562,63 @@ one is measured at its ceiling.
 Skips clips with no speech in them, so a key pressed by accident costs nothing.
 Gated on speech being *present*, not on how much — a one-word dictation is a
 real one.
+
+## `audio.second_opinion`
+
+Decodes the clip a second time, with silence added at both ends, and keeps that
+decode when it reaches further into the audio than the first one did. Off by
+default.
+
+**What it fixes.** Parakeet predicts a token and a duration at every step — how
+many encoder frames to skip before it looks again. A frame is 80ms and the
+model may skip 4 of them, so one prediction can pass over 320ms of audio
+without examining it. Words inside a skipped span are never seen. They are not
+mis-heard; they are not looked at. The result is a dictation that quietly loses
+its ending, or loses words mid-sentence. Measured rate: 3 of 150 random live
+dictations, about 2%.
+
+**Why a second decode and not a check.** Nothing in the output says a span was
+skipped, because the decoder leaves no record of frames it never examined. Five
+signals were measured over the archive — the timing gap to the last speech, how
+much of the speech span the words cover, tokens per second, decoder confidence,
+and the longest stretch of detected speech with no word on it. All five put the
+broken clips inside the healthy distribution, and on the last one the broken
+clips score *better* than the median healthy clip. Padding the clip moves the
+speech against the frame grid, so a different set of frames gets skipped. That
+is the only thing that finds it.
+
+**When the second decode wins.** Three guards. It has to reach further into the
+clip than the first pass did, it has to say everything the first pass said in
+order before it says anything new, and it has to actually add words.
+
+The first two are shared with the long-pause retry. The second is what stops a
+recovered ending being paid for with a silently rewritten opening. It also
+refuses some genuinely good recoveries. That is the trade: nobody re-reads the
+part that was already right.
+
+The third guard is this setting's own. A decode that says the same words is
+still a different decode — a different token split, different casing — and
+swapping one in buys nothing. Over 60 archived clips it was the only thing the
+second opinion ever did, on 2 of them: "RXV" for "RX V", and "red rock roadmap"
+for "Red Rock Roadmap". With the guard in, those 60 clips come back identical
+with the setting on and off.
+
+Two pads are tried, so two decodes can clear all three guards. The one that
+recovered the most words wins. Reach cannot separate them — a word running past
+the end of the clip is clamped back to the clip's length, and on a short clip
+every decode lands there.
+
+**What it costs.** Two padded decodes — 0.5s and 1.0s of silence, the same
+ladder the empty-decode retry uses — run at the same time as the first pass,
+each on its own decoder. The model weights are shared, so the extra memory is
+about 12MB per decode, not another copy of the ~1GB model. Measured on a 1.86s
+clip, release build, 9 runs each: 138ms median for the first pass alone, 238ms
+median for all three together. One decode costs about 140ms, so running them
+one after another would cost roughly three times as much.
+
+Needs `speech_gate`, which is what reads the clip as samples. With the gate off
+this setting does nothing, and `--check-config` says so. Clips too long to fit
+one decoder window with the padding on are left to the first pass.
 
 ## The microphone
 


### PR DESCRIPTION
This was written to stack on #158. #158 merged while it was being verified,
so it is based on `main` instead and the diff is only this work. Everything
below was re-run on the rebased branch.

## What breaks

Parakeet TDT predicts a token **and** a duration at every step — how many
encoder frames to skip before it looks again. `durationBins = [0,1,2,3,4]`
and a frame is 80ms, so one prediction can pass over 320ms of audio
without examining it. Words inside a skipped span are never seen. They are
not mis-decoded. They are not looked at.

The result is a dictation that quietly loses its ending, or loses a phrase
mid-sentence. Measured rate: 3 of 150 random live dictations, about 2%.

## Why this is not detectable

Five signals were measured against the archive: the timing gap to the last
speech, how much of the speech span the words cover, tokens per second,
decoder confidence, and the longest stretch of detected speech with no word
on it. All five put the broken clips inside the healthy distribution, and on
the last one the broken clips score *better* than the median healthy clip.

The reason is structural. The decoder leaves no record of frames it never
examined. The only thing that finds the loss is decoding the clip again with
the speech moved against the frame grid.

## What this adds

`audio.second_opinion`, a bool, default `false`. On, the clip is also decoded
with 0.5s and 1.0s of silence at both ends — the existing `silenceRetryPads`
ladder — and the decode that says more is kept.

**Concurrency.** Both padded decodes start before the first pass and run
beside it. Each gets its own `AsrManager`: the type is an actor, so calls on
one instance serialise however they are issued. `AsrModels` is a struct of
references, so the arms share the ~1GB of weights and cost about 12MB each.
`startSecondOpinions` is `nonisolated` so its tasks do not inherit
`Transcriber`'s executor, which would put them back in the first pass's queue.

**Three guards.** An arm must reach further into the clip, it must say
everything the first pass said in order before it says anything new, and it
must add words.

The first two already existed for the long-pause retry. Neither is loosened.
`extends` still rejects a decode that rewrites the opening to recover the
ending, and still rejects some genuinely good recoveries.

The third guard is new to this PR and came out of the 60-clip sweep below.
`extends` is a prefix test, so it also passes an arm that says exactly what
the first pass said. Swapping one of those in changes only the token split
and the casing. On 60 archived clips that was the *only* thing the second
opinion ever did, on 2 of them: `RXV` for `RX V`, and `red rock roadmap` for
`Red Rock Roadmap`. With the guard in, those 60 clips are identical with the
setting on and off.

**No extra decodes.** The empty-decode retry from #158 consumes the arms that
are already running instead of decoding again, so a dictation is never decoded
more than `1 + arms` times.

**Failures are contained.** An arm that throws logs and returns nothing. A
dictation the first pass completed can never be turned into a thrown one by a
speculative decode.

## Verification

Everything below is `--transcribe <clip> --no-vocab` against a copy of the
real config with only `audio.second_opinion` changed.

**Off, no regression.** The three clips #158 recovers still come back, and the
control is unchanged.

| clip | off | on |
|---|---|---|
| `16-17-19-15632853` (control) | `How should I do that?` | `How should I do that?` |
| `16-17-24-76CC256D` | `I don't know.` | `I don't know.` |
| `16-17-27-5DE767C5` | `I don't know.` | `I don't know.` |
| `16-17-30-ED5CB958` | `I don't know.` | `I don't know.` |

**On, endings recovered.**

| clip | off | on |
|---|---|---|
| `2026-08-04T11-47-06` | `By the way,` | `By the way, that's a good one.` |
| `2026-08-11T13-47-50` | `As long as` | `As long as we have a` |
| `2026-08-06T11-51-25` | `The CTC score.` | `The CTC scorer.` |

The third is `extends` accepting a recovery because the old text is a prefix
of the new one, as expected.

**On, 60 archived clips spread across the whole recording set.** 0 of 60
changed. Before the third guard it was 2 of 60, both casing-only.

**Latency, release build, 1.86s clip, 9 runs each.** Decode section, from
before the first pass starts to after the arms are resolved:

```
off  125 132 134 134 138 141 144 178 213   median 138ms
on   223 233 233 237 238 238 241 242 252   median 238ms
```

One decode alone is about 140ms, so three run one after another would cost
roughly 410ms. A single run makes the overlap plain on its own: `firstpass
241ms decodesection 242ms` — the arms had finished before the first pass did.
End to end through the full pipeline the same clip goes from a 0.25s median to
a 0.36s median.

**Scripts.** `check-no-voice.sh` 5/5. `check-audio-recovery.sh` 14/14.
`check-default-config.sh` passes.

**Builds.** `swift build` and `swift build -c release` both clean. The only
warnings are the pre-existing `SendableClosureCaptures` ones in
`AppDelegate.swift`, which this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
