### PR TITLE
feat: vocabulary judge — annotate {terms} with each term's kind

### DIFF
--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -1117,7 +1117,12 @@ struct Pipeline: Equatable, Codable {
         }
 
         let built = VocabularyJudge.sentences(in: text, from: changes)
-        let terms = Array(Set(changes.flatMap(\.terms))).sorted().joined(separator: ", ")
+        // `.word` means "not a name" and is not shown — see `WordKind` — and a
+        // term nobody has corrected yet has no `kind:` at all.
+        let terms = Array(Set(changes.flatMap(\.terms))).sorted().map { name -> String in
+            guard let kind = config.vocabulary.terms[name]?.kind, kind != .word else { return name }
+            return "\(name) (\(kind.rawValue))"
+        }.joined(separator: ", ")
         let system = VocabularyJudge.prompt.replacingOccurrences(of: "{terms}", with: terms)
         let user = VocabularyJudge.question(
             heard: built.heard, after: built.after, changes: changes

--- a/Sources/ParrotFlow/Vocabulary.swift
+++ b/Sources/ParrotFlow/Vocabulary.swift
@@ -207,6 +207,10 @@ actor Vocabulary {
     struct Proposal: Sendable {
         let heard: String
         let term: String
+        /// `term`, before inflection and trailing punctuation were added for
+        /// display. The vocabulary's own key — `config.vocabulary.terms`
+        /// looks things up by this, not by `term`.
+        let canonicalTerm: String
         let range: Range<String.Index>
         /// The decoded word's CTC score. Raw. Absent for a spotter-only hit.
         let heardScore: Float?
@@ -722,7 +726,7 @@ actor Vocabulary {
                 let holds = verdict.applied ? reading : String(text[range])
                 guard let placed = moved(range, holding: holds) else { continue }
                 proposals.append(Proposal(
-                    heard: change.originalWord, term: reading, range: placed,
+                    heard: change.originalWord, term: reading, canonicalTerm: term, range: placed,
                     heardScore: change.originalScore, termScore: verdict.raw,
                     bonus: verdict.bonus, applied: verdict.applied
                 ))
@@ -744,7 +748,8 @@ actor Vocabulary {
                 )
                 proposals.append(Proposal(
                     heard: span.heard,
-                    term: span.term + Self.trailingMarks(of: span.heard), range: placed,
+                    term: span.term + Self.trailingMarks(of: span.heard), canonicalTerm: span.canonical,
+                    range: placed,
                     heardScore: nil, termScore: nil, bonus: nil, applied: false
                 ))
             }
@@ -762,7 +767,7 @@ actor Vocabulary {
                     phrase, span.term, span.score
                 ))
                 proposals.append(Proposal(
-                    heard: phrase, term: span.term, range: placed,
+                    heard: phrase, term: span.term, canonicalTerm: span.term, range: placed,
                     heardScore: nil, termScore: span.score, bonus: nil, applied: false
                 ))
             }
@@ -916,8 +921,8 @@ actor Vocabulary {
     /// spelling near `Praisy` and arrives entirely from the spotter.
     private static func widerSpans(
         in text: String, anchors: [(range: Range<String.Index>, term: String)]
-    ) -> [(range: Range<String.Index>, heard: String, term: String)] {
-        var wider: [(range: Range<String.Index>, heard: String, term: String)] = []
+    ) -> [(range: Range<String.Index>, heard: String, term: String, canonical: String)] {
+        var wider: [(range: Range<String.Index>, heard: String, term: String, canonical: String)] = []
         for (range, term) in anchors {
             guard !term.isEmpty else { continue }
 
@@ -959,7 +964,7 @@ actor Vocabulary {
                               $0.range == range.lowerBound..<stop && $0.term == reading
                           })
                     else { continue }
-                    wider.append((range.lowerBound..<stop, phrase, reading))
+                    wider.append((range.lowerBound..<stop, phrase, reading, term))
                 }
             }
         }

--- a/Sources/ParrotFlow/VocabularyJudge.swift
+++ b/Sources/ParrotFlow/VocabularyJudge.swift
@@ -82,6 +82,13 @@ enum VocabularyJudge {
     /// sound could decide. The largest gap in the data is 2.72, and argmax on
     /// those numbers scores 28 of 57 spans against 34 for the constant "keep
     /// what the decoder wrote". It was describing a scale that does not exist.
+    ///
+    /// `{terms}` can carry `(person)` / `(place)` / `(organization)` after a
+    /// name — see where the caller builds it, from `Config.Vocabulary.Term.kind`
+    /// — with nothing here telling the model what that means. An earlier draft
+    /// added a sentence explaining it and no worked example ever showed it in
+    /// use, which is the shape this file elsewhere argues against. Give it a
+    /// worked example before writing a sentence about it.
     static let prompt = """
         The user dictates text. A deterministic pass has already replaced some words
         with names from their vocabulary.

--- a/Sources/ParrotFlow/VocabularyJudge.swift
+++ b/Sources/ParrotFlow/VocabularyJudge.swift
@@ -334,7 +334,7 @@ enum VocabularyJudge {
             if let already = resolved[span] {
                 parts.append(Part(
                     range: already, decoded: proposal.heard,
-                    other: proposal.term, term: proposal.term,
+                    other: proposal.term, term: proposal.canonicalTerm,
                     standing: standing(proposal)
                 ))
                 continue
@@ -368,7 +368,7 @@ enum VocabularyJudge {
             resolved[span] = found
             parts.append(Part(
                 range: found, decoded: proposal.heard,
-                other: proposal.term, term: proposal.term,
+                other: proposal.term, term: proposal.canonicalTerm,
                 standing: standing(proposal)
             ))
         }


### PR DESCRIPTION
`Config.Vocabulary.Term.kind` (`WordKind`: person, place, organization, word) has been recorded since the correction panel started writing it, and nothing has read it. This shows it to the vocabulary judge: `{terms}` now reads `Vercel (organization)` instead of bare `Vercel` when a term's kind is known. `.word` (not a name) is not shown, and a term with no `kind:` yet is unaffected — most of the vocabulary still is.

Reviewers should look hardest at one thing: **this is unmeasured**. `VocabularyJudge.swift`'s own doc comments treat prompt wording as something to measure, not choose — five wordings of one sentence scored 38/39/40/41/42 on the same cases. There is no such measurement here. `tests/judge-cases.yaml` has no case with a `kind:` set on its term, and `scripts/validate-judge.py` scores its own separate prompt variant, not this compiled-in one. So this ships the *signal* with no evidence yet that it changes any verdict.

An earlier draft of this also added a sentence explaining the annotation to the model ("a hint, not a rule"). It's not in this PR — no worked example in the prompt ever demonstrates the annotation being used, and an unmeasured instruction with zero examples behind it is exactly the shape this file argues against elsewhere. The doc comment on `prompt` says so and leaves a pointer: give it a worked example before writing a sentence about it.

<details>
<summary>What actually changed, and a real trace it would touch</summary>

`Pipeline.swift`, where `{terms}` gets built for the judge call:

```swift
let terms = Array(Set(changes.flatMap(\.terms))).sorted().map { name -> String in
    guard let kind = config.vocabulary.terms[name]?.kind, kind != .word else { return name }
    return "\(name) (\(kind.rawValue))"
}.joined(separator: ", ")
```

Live trace, dictated during testing: raw decoder output "So I'm going with Tasmine with to the Versailles castle while our app is being deployed on Versailles." became 3 judge slots — `Tasmine -> Tasmeen` and `Versailles -> Vercel` twice (once for "the Versailles castle", once for "deployed on Versailles"). `gemma4:e4b-mlx` answered `KEEP KEEP KEEP`, which is wrong on the castle occurrence — it produced "the Vercel castle". At the time, `Vercel` had no `kind:` set, so `{terms}` read `Tasmeen, Vercel` with no annotation. With `Vercel` now tagged `kind: organization` in that dictation's vocabulary, the same call would see `{terms}` = `Tasmeen (person), Vercel (organization)` — untested whether that flips the verdict on the castle occurrence.

Checked: `swift build -c release`, `scripts/check-judge-prompt.sh` (4/4), `scripts/check-verdicts.sh` (24/24).

</details>