### PR TITLE
fix: an offered rewrite lands in the field, or on the clipboard

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -176,6 +176,19 @@ jobs:
       - name: What ParrotFlow makes of an app
         run: scripts/check-profiles.sh
 
+      # Which range a rewrite is written as. Pure string work — the surface half
+      # of the same question is check-span.sh, which needs a real app and does
+      # not run here. Three of the six cases are dictations that were silently
+      # lost in Slack.
+      - name: Which range a rewrite becomes
+        run: scripts/check-span-rule.sh
+
+      # When a rewrite the field refused may go to the clipboard, and stay
+      # there. Uses the real NSPasteboard, because what is under test is which
+      # calls move its change count. No window and no accessibility.
+      - name: The clipboard rules
+        run: scripts/check-clipboard.sh
+
       # Not a validation set: it checks that the file a new install is written
       # with still teaches everything config.example.yaml documents. That has
       # drifted twice, both times silently.

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2270,7 +2270,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             if updated != before { applied += 1 }
         }
 
-        guard applied > 0, let change = Surface.minimalSpan(from: surface.content, to: updated) else {
+        guard applied > 0, let change = Surface.writableSpan(from: surface.content, to: updated) else {
             Log.write("in-place: nothing on the line matches \(edits.map(\.find))")
             return .notAttempted
         }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3318,18 +3318,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// what was on the clipboard. Anything copied since moves it, and then the
     /// clipboard is somebody's work rather than ours to overwrite.
     ///
-    /// The look and the write sit next to each other with nothing between them
-    /// — no logging, no message — because there is nothing stronger to have.
-    /// `NSPasteboard` offers no compare-and-write: `declareTypes(owner:)` names
-    /// an owner for callbacks and stops no other process from writing. Any check
-    /// is a look followed by a write, and the gap can only be made small. It is
-    /// two calls here, and the messages are left to the caller so they cannot
-    /// get in between.
+    /// Or the clipboard this app itself last wrote, which a refused in-place
+    /// edit reaches here having moved — see `TextInserter.clipboardIsOurs`.
+    ///
+    /// On the writing path the look and the write sit next to each other with
+    /// nothing between them — no message — because there is nothing stronger to
+    /// have. `NSPasteboard` offers no compare-and-write: `declareTypes(owner:)`
+    /// names an owner for callbacks and stops no other process from writing. Any
+    /// check is a look followed by a write, and the gap can only be made small.
+    /// It is two calls here, and the messages are left to the caller so they
+    /// cannot get in between. Only the refusal logs, and by then nothing is
+    /// going to be written.
     ///
     /// Returns false when it did not write.
     private func copyOverOurOwn(_ text: String, unlessChangedFrom change: Int) -> Bool {
         let pasteboard = NSPasteboard.general
-        guard pasteboard.changeCount == change else { return false }
+        guard TextInserter.clipboardIsOurs(unchangedFrom: change) else {
+            Log.write("clipboard: at \(pasteboard.changeCount), not \(change) and not"
+                + " our own \(TextInserter.ownChange); left alone")
+            return false
+        }
         pasteboard.clearContents()
         pasteboard.setString(text, forType: .string)
         return true

--- a/Sources/ParrotFlow/ClipboardTestCommand.swift
+++ b/Sources/ParrotFlow/ClipboardTestCommand.swift
@@ -1,0 +1,97 @@
+import AppKit
+
+/// `--clipboard-test` — checks the two rules that decide whether this app may
+/// write to the clipboard, against the real `NSPasteboard`.
+///
+/// Both rules are arithmetic on `NSPasteboard.changeCount`, and both were wrong
+/// in a way that only showed up as lost work. An in-place edit that Slack
+/// refuses falls back to leaving the rewrite on the clipboard, and the ladder it
+/// just came down pastes, so the count has moved and this app is what moved it:
+/// the fallback used to read that as "the user copied something" and drop the
+/// rewrite. The repair for that then walks into the second rule, because the
+/// paste has a restore queued behind it that would put the pre-paste contents
+/// straight back over the rewrite.
+///
+/// A real pasteboard rather than a fake one. What is being tested is which
+/// writes move the count and by how much — `clearContents` does, `setString`
+/// does not — and a fake that answers that question is a restatement of the
+/// assumption rather than a check on it.
+///
+/// The user's own clipboard is put back at the end.
+enum ClipboardTestCommand {
+
+    static func run() -> Int32 {
+        let pasteboard = NSPasteboard.general
+        // Handed back at the end. This walks over the real clipboard, and the
+        // count it is asked to match is read at that moment, so the restore is
+        // unconditional — the point here is to leave nothing behind.
+        let usersOwn = TextInserter.snapshot(of: pasteboard)
+        defer {
+            TextInserter.putBack(usersOwn, to: pasteboard, ifStillAt: pasteboard.changeCount)
+        }
+
+        var failures = 0
+        func check(_ name: String, _ passed: Bool, _ detail: String = "") {
+            print("\(passed ? "✓" : "✗") \(name)\(detail.isEmpty ? "" : "  — \(detail)")")
+            if !passed { failures += 1 }
+        }
+
+        // An untouched clipboard is writable. The case that always worked.
+        write("what the user copied", to: pasteboard)
+        let chosen = pasteboard.changeCount
+        check("untouched since you chose", TextInserter.clipboardIsOurs(unchangedFrom: chosen))
+
+        // Somebody else copied. The case the rule exists for.
+        write("something the user copied while the model was thinking", to: pasteboard)
+        check("refused after somebody else copies",
+              !TextInserter.clipboardIsOurs(unchangedFrom: chosen))
+
+        // The ladder borrowed the clipboard to paste with, and the edit was
+        // refused. `.clipboard` moves the count exactly as the paste branch does
+        // and stops short of posting ⌘V into whatever window is in front.
+        let borrowed = pasteboard.changeCount
+        TextInserter.insert("the rewrite the model produced", mode: .clipboard)
+        check("writable after our own paste borrowed it",
+              TextInserter.clipboardIsOurs(unchangedFrom: borrowed),
+              "count \(borrowed) → \(pasteboard.changeCount)")
+
+        // …but only until somebody else copies over the paste.
+        write("something the user copied after the paste", to: pasteboard)
+        check("refused when somebody copies over our paste",
+              !TextInserter.clipboardIsOurs(unchangedFrom: borrowed))
+
+        // The restore, when nothing has happened since the paste: it puts the
+        // borrowed clipboard back.
+        write("what the user copied", to: pasteboard)
+        let before = TextInserter.snapshot(of: pasteboard)
+        write("the paste payload", to: pasteboard)
+        TextInserter.putBack(before, to: pasteboard, ifStillAt: pasteboard.changeCount)
+        check("the restore puts back what the paste borrowed",
+              pasteboard.string(forType: .string) == "what the user copied",
+              quoted(pasteboard))
+
+        // The restore, when the refused edit has since left the rewrite there.
+        // This is the one that costs the rewrite when it is wrong.
+        write("what the user copied", to: pasteboard)
+        let borrowedAgain = TextInserter.snapshot(of: pasteboard)
+        write("the paste payload", to: pasteboard)
+        let paste = pasteboard.changeCount
+        write("the rewrite, left here by the refused edit", to: pasteboard)
+        TextInserter.putBack(borrowedAgain, to: pasteboard, ifStillAt: paste)
+        check("the restore leaves a later write alone",
+              pasteboard.string(forType: .string) == "the rewrite, left here by the refused edit",
+              quoted(pasteboard))
+
+        print(failures == 0 ? "\nall clipboard rules hold" : "\n\(failures) failed")
+        return failures == 0 ? 0 : 1
+    }
+
+    private static func write(_ text: String, to pasteboard: NSPasteboard) {
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+    }
+
+    private static func quoted(_ pasteboard: NSPasteboard) -> String {
+        "clipboard reads \"\(pasteboard.string(forType: .string) ?? "")\""
+    }
+}

--- a/Sources/ParrotFlow/ClipboardTestCommand.swift
+++ b/Sources/ParrotFlow/ClipboardTestCommand.swift
@@ -22,13 +22,16 @@ enum ClipboardTestCommand {
 
     static func run() -> Int32 {
         let pasteboard = NSPasteboard.general
-        // Handed back at the end. This walks over the real clipboard, and the
-        // count it is asked to match is read at that moment, so the restore is
-        // unconditional — the point here is to leave nothing behind.
-        let usersOwn = TextInserter.snapshot(of: pasteboard)
-        defer {
-            TextInserter.putBack(usersOwn, to: pasteboard, ifStillAt: pasteboard.changeCount)
-        }
+        // Handed back at the end, every item of it.
+        //
+        // Not `TextInserter.snapshot`, which keeps the first item and drops the
+        // rest. That is a fair trade where it lives: it runs because you asked
+        // for a dictation, and it is putting back what its own paste borrowed.
+        // Here nothing was asked for — this is a check script — and copying
+        // four files in Finder is four items, so the same trade would take
+        // three of them without saying so.
+        let usersOwn = everything(on: pasteboard)
+        defer { putEverythingBack(usersOwn, to: pasteboard) }
 
         var failures = 0
         func check(_ name: String, _ passed: Bool, _ detail: String = "") {
@@ -84,6 +87,29 @@ enum ClipboardTestCommand {
 
         print(failures == 0 ? "\nall clipboard rules hold" : "\n\(failures) failed")
         return failures == 0 ? 0 : 1
+    }
+
+    /// Every item on the clipboard, copied out of it.
+    ///
+    /// Copied, not referenced: `pasteboardItems` hands back the pasteboard's
+    /// own items, and `clearContents` empties them. Reading the data afterwards
+    /// gives nil, so a restore built on them puts back nothing.
+    private static func everything(on pasteboard: NSPasteboard) -> [NSPasteboardItem] {
+        (pasteboard.pasteboardItems ?? []).map { source in
+            let copy = NSPasteboardItem()
+            for type in source.types {
+                if let data = source.data(forType: type) {
+                    copy.setData(data, forType: type)
+                }
+            }
+            return copy
+        }
+    }
+
+    private static func putEverythingBack(_ items: [NSPasteboardItem], to pasteboard: NSPasteboard) {
+        pasteboard.clearContents()
+        guard !items.isEmpty else { return }
+        pasteboard.writeObjects(items)
     }
 
     private static func write(_ text: String, to pasteboard: NSPasteboard) {

--- a/Sources/ParrotFlow/EditTestCommand.swift
+++ b/Sources/ParrotFlow/EditTestCommand.swift
@@ -97,7 +97,7 @@ enum EditTestCommand {
                 [(heard: needle, corrected: replacement)], to: updated
             )
         }
-        guard let change = Surface.minimalSpan(from: surface.content, to: updated) else {
+        guard let change = Surface.writableSpan(from: surface.content, to: updated) else {
             report("✗ \"\(needle)\" is not in the content — nothing to replace")
             return 2
         }

--- a/Sources/ParrotFlow/SpanRuleCommand.swift
+++ b/Sources/ParrotFlow/SpanRuleCommand.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// `--span-rule` — scores `Surface.writableSpan` on before/after pairs.
+///
+/// The other half of `scripts/check-span.sh`. That one starts from a range that
+/// is already known and asks whether a real app writes exactly those characters.
+/// This asks the question before it: given a sentence and its rewrite, which
+/// range should be handed over at all.
+///
+/// Pure, so it needs no app, no window and no accessibility. It is also where
+/// the answer was wrong three times in one afternoon, each time in a way that
+/// only showed up as a rewrite quietly not happening.
+enum SpanRuleCommand {
+
+    /// `before`, `after`, and the whole of what should be written: the
+    /// characters the span covers, and what they become.
+    private static let cases: [(name: String, before: String, after: String,
+                                covers: String, becomes: String)] = [
+        // 2026-08-20, Slack. The minimal answer is nothing-becomes-"do ", and
+        // Slack drops the trailing space off the paste: "one doyou".
+        ("a word inserted between two words",
+         "In the categories above, which one you recommend?",
+         "In the categories above, which one do you recommend?",
+         "y", "do y"),
+
+        // 2026-08-20, Slack. Minimally nothing-becomes-",", which asks to paste
+        // at a caret — and an empty selection confirms itself wherever the caret
+        // is, so there is nothing for step 2 of the ladder to check.
+        ("a comma inserted mid-sentence",
+         "I don't know whether the dictation will be clearly understood in a car though.",
+         "I don't know whether the dictation will be clearly understood in a car, though.",
+         " t", ", t"),
+
+        // 2026-08-20, Slack. Minimally "'ll t I"-becomes-nothing, and
+        // `TextInserter.insert("")` returns without writing anything, so the
+        // ladder cannot tell this from an app that refused the edit.
+        ("a stutter deleted from the front",
+         "I'll t I told you I will tell you when my dictation app is ready to test.",
+         "I told you I will tell you when my dictation app is ready to test.",
+         "I'll t I t", "I t"),
+
+        // A letter added inside a word. Minimally nothing-becomes-"r", and one
+        // character either side is all it takes to make that writable.
+        ("a letter added inside a word",
+         "PFCHK Jery is on vacation", "PFCHK Jerry is on vacation",
+         "y", "ry"),
+
+        // A whole sentence rewritten. Nothing to grow.
+        ("the ends differ",
+         "sixty euros", "60 EUR",
+         "sixty euros", "60 EUR"),
+
+        // Growth runs off the end of the line and has to turn round.
+        ("the edit is at the very end",
+         "ask him on Monday", "ask him on Monday.",
+         "y", "y."),
+    ]
+
+    static func run() -> Int32 {
+        var failures = 0
+        for one in cases {
+            guard let (range, replacement) = Surface.writableSpan(
+                from: one.before, to: one.after
+            ) else {
+                print("✗ \(one.name)  — no span at all")
+                failures += 1
+                continue
+            }
+            let covers = String(one.before[range])
+            let rebuilt = one.before.replacingCharacters(in: range, with: replacement)
+
+            var wrong: [String] = []
+            if covers != one.covers || replacement != one.becomes {
+                wrong.append("\"\(covers)\" → \"\(replacement)\","
+                    + " wanted \"\(one.covers)\" → \"\(one.becomes)\"")
+            }
+            // The rules the span has to satisfy, checked rather than assumed:
+            // the expectations above are one reading of them and could be
+            // written down wrong.
+            if rebuilt != one.after { wrong.append("rebuilds as \"\(rebuilt)\"") }
+            if range.isEmpty { wrong.append("covers no characters") }
+            if replacement.isEmpty { wrong.append("nothing to paste") }
+            if replacement.first?.isWhitespace == true { wrong.append("starts on whitespace") }
+            if replacement.last?.isWhitespace == true { wrong.append("ends on whitespace") }
+
+            print("\(wrong.isEmpty ? "✓" : "✗") \(one.name)"
+                + (wrong.isEmpty ? "" : "  — \(wrong.joined(separator: "; "))"))
+            if !wrong.isEmpty { failures += 1 }
+        }
+
+        print(failures == 0
+            ? "\n\(cases.count)/\(cases.count)"
+            : "\n\(cases.count - failures)/\(cases.count)")
+        return failures == 0 ? 0 : 1
+    }
+}

--- a/Sources/ParrotFlow/Surface.swift
+++ b/Sources/ParrotFlow/Surface.swift
@@ -262,6 +262,86 @@ struct Surface {
         return (start..<end, String(after[afterStart..<afterEnd]))
     }
 
+    /// `minimalSpan`, grown until it is a span a paste can carry.
+    ///
+    /// The minimal answer is often not writable. Three real dictations, all in
+    /// Slack, all on 2026-08-20:
+    ///
+    ///   "one you" → "one do you"      nothing, at one point, becomes "do "
+    ///   "car though" → "car, though"  nothing, at one point, becomes ","
+    ///   "I'll t I told" → "I told"    "'ll t I" becomes nothing
+    ///
+    /// Each one fails, and for its own reason. `TextInserter.insert("")` does
+    /// nothing at all, so the third never writes and the ladder cannot tell
+    /// that from a write the app refused. Slack drops a trailing space off a
+    /// paste, so the first lands as "one doyou". And the first two both ask to
+    /// paste at a caret rather than over a selection, which is the one thing
+    /// step 2 of the ladder cannot check: `confirmedSelection` over an empty
+    /// range confirms that nothing is selected, which is true wherever the
+    /// caret happens to be.
+    ///
+    /// So the span grows until three things hold. It covers at least one real
+    /// character, so the app has to say in its own words which characters are
+    /// selected before anything is written. The replacement is not empty, so
+    /// there is something to paste. And neither end of the replacement is
+    /// whitespace, so an editor entitled to tidy the whitespace it is handed
+    /// has nothing of ours to tidy.
+    ///
+    /// It grows outward over text the two strings agree on, so the result is
+    /// the same edit written differently: "insert `do ` before `you`" becomes
+    /// "replace `y` with `do y`". One character at a time, and it stops as soon
+    /// as the three hold — a bigger span is more to paste and more to put back
+    /// if the paste goes wrong.
+    static func writableSpan(
+        from before: String, to after: String
+    ) -> (range: Range<String.Index>, replacement: String)? {
+        guard let (span, minimal) = minimalSpan(from: before, to: after) else { return nil }
+
+        var start = span.lowerBound
+        var end = span.upperBound
+        var replacement = minimal
+
+        // The characters outside the span are the ones both strings share, so
+        // taking one from `before` is taking the same one from `after`.
+        func growForwards() {
+            replacement.append(before[end])
+            end = before.index(after: end)
+        }
+        func growBackwards() {
+            start = before.index(before: start)
+            replacement.insert(before[start], at: replacement.startIndex)
+        }
+
+        while true {
+            // Which side is wrong decides which way to grow, and a leading
+            // space is only ever fixed by growing backwards. Growing the other
+            // way instead is how this ate a whole line the first time it ran.
+            //
+            // Whitespace against the edge of the line is not a hazard: there is
+            // nothing out there for an editor to join it to.
+            let leading = replacement.first?.isWhitespace == true && start > before.startIndex
+            let trailing = replacement.last?.isWhitespace == true && end < before.endIndex
+
+            if leading {
+                growBackwards()
+            } else if trailing || replacement.isEmpty || start == end {
+                if end < before.endIndex {
+                    growForwards()
+                } else if start > before.startIndex {
+                    growBackwards()
+                } else {
+                    // A line with nothing left to grow into. A caller that
+                    // writes this is no worse off than it was.
+                    break
+                }
+            } else {
+                break
+            }
+        }
+
+        return (start..<end, replacement)
+    }
+
     /// The range holding `needle`, nearest the end.
     ///
     /// Last rather than first: the word being corrected was dictated a moment
@@ -374,7 +454,7 @@ struct Surface {
         guard surface.folded(surface.content) == surface.folded(record.after) else {
             return .refused("the text has changed since; leaving it alone")
         }
-        guard let edit = minimalSpan(from: record.after, to: record.before) else {
+        guard let edit = writableSpan(from: record.after, to: record.before) else {
             return .refused("there is nothing to put back")
         }
         // Located against `record.after`, which we have just confirmed is what

--- a/Sources/ParrotFlow/Surface.swift
+++ b/Sources/ParrotFlow/Surface.swift
@@ -503,6 +503,10 @@ struct Surface {
             Log.write("surface: the range write was ignored; pasting over a confirmed selection")
             TextInserter.insert(replacement, mode: .paste)
             if settled(on: fragment) {
+                // Said out loud, like the branch above. Without it a success
+                // here is an absence of failure lines, and reading the log for
+                // "did the edit land" means knowing which lines are missing.
+                Log.write("surface: pasted \(nsRange.length) chars over the selection")
                 return .replaced(undo)
             }
             return .refused(repairedAfterStrayPaste())

--- a/Sources/ParrotFlow/TextInserter.swift
+++ b/Sources/ParrotFlow/TextInserter.swift
@@ -22,6 +22,38 @@ enum TextInserter {
         var isInserted: Bool { self == .pasted }
     }
 
+    /// `NSPasteboard.changeCount` as this app last left it.
+    ///
+    /// The count only ever goes up, so this matches only while the thing on the
+    /// clipboard is still the thing this app put there. That is what makes it
+    /// safe to read as "nobody else has been here since" — which is the whole
+    /// of `clipboardIsOurs` below.
+    ///
+    /// Not set by `putBack`: what that restores is the user's own clipboard
+    /// from before the paste, and it is not this app's to overwrite.
+    ///
+    /// -1 until this app writes something, because "never" has to match nothing.
+    /// Starting it at the count as it stands would claim whatever the user had
+    /// copied before this app ran as ours to write over.
+    private(set) static var ownChange = -1
+
+    /// True while the clipboard is this app's to write over: untouched since
+    /// `change`, or still holding what this app itself put there.
+    ///
+    /// The second half is what makes a refused in-place edit able to fall back
+    /// to the clipboard at all. The edit ladder pastes — that is the branch that
+    /// carries every Electron app — and a paste borrows the clipboard, so by the
+    /// time the fallback runs the count has moved and this app is the one that
+    /// moved it. Measured in Slack, twice on 2026-08-20: the rewrite was
+    /// dropped and the message blamed the user's clipboard.
+    ///
+    /// It is still a real check. The count only goes up, so `ownChange` matches
+    /// only while this app's write is the last one there was.
+    static func clipboardIsOurs(unchangedFrom change: Int) -> Bool {
+        let now = NSPasteboard.general.changeCount
+        return now == change || now == ownChange
+    }
+
     @discardableResult
     static func insert(_ text: String, mode: Config.Transcription.InsertMode = .paste) -> Outcome {
         guard !text.isEmpty else { return .pasted }
@@ -31,6 +63,8 @@ enum TextInserter {
 
         pasteboard.clearContents()
         pasteboard.setString(text, forType: .string)
+        let ours = pasteboard.changeCount
+        ownChange = ours
 
         guard mode == .paste else { return .copied }
 
@@ -45,7 +79,7 @@ enum TextInserter {
         // Restoring immediately races the paste: the target app reads the
         // pasteboard asynchronously after receiving the keystroke.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
-            restore(saved, to: pasteboard)
+            putBack(saved, to: pasteboard, ifStillAt: ours)
         }
 
         return .pasted
@@ -72,12 +106,12 @@ enum TextInserter {
 
     // MARK: - Pasteboard preservation
 
-    private struct Item {
+    struct Item {
         let type: NSPasteboard.PasteboardType
         let data: Data
     }
 
-    private static func snapshot(of pasteboard: NSPasteboard) -> [Item] {
+    static func snapshot(of pasteboard: NSPasteboard) -> [Item] {
         guard let items = pasteboard.pasteboardItems else { return [] }
         // Only the first item — restoring a full multi-item pasteboard is rarely
         // what anyone needs, and this keeps the copy cheap.
@@ -85,6 +119,26 @@ enum TextInserter {
         return first.types.compactMap { type in
             first.data(forType: type).map { Item(type: type, data: $0) }
         }
+    }
+
+    /// Puts back what `insert` borrowed — but only while the paste is still the
+    /// newest thing on the clipboard.
+    ///
+    /// The 0.4s wait is long on the scale of what happens in it. An in-place
+    /// edit runs on the main actor from end to end, so this cannot even start
+    /// until that returns, and by then a refused edit has fallen through to the
+    /// clipboard and left the rewrite there. Putting the pre-paste contents
+    /// over that would throw the rewrite away.
+    ///
+    /// Anything newer also means there is nothing of ours left to take back:
+    /// the payload this was meant to clear is already gone, so the restore has
+    /// no work to do and only damage to cause.
+    static func putBack(_ items: [Item], to pasteboard: NSPasteboard, ifStillAt ours: Int) {
+        guard pasteboard.changeCount == ours else {
+            Log.write("clipboard: written since the paste; the old contents stay put")
+            return
+        }
+        restore(items, to: pasteboard)
     }
 
     private static func restore(_ items: [Item], to pasteboard: NSPasteboard) {

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -475,6 +475,10 @@ if arguments.contains("--clipboard-test") {
     exit(ClipboardTestCommand.run())
 }
 
+if arguments.contains("--span-rule") {
+    exit(SpanRuleCommand.run())
+}
+
 if let index = arguments.firstIndex(of: "--panel-sheet") {
     guard arguments.indices.contains(index + 1) else {
         print("usage: ParrotFlow --panel-sheet <out.png>")

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -471,6 +471,10 @@ if let index = arguments.firstIndex(of: "--edit-test") {
     ))
 }
 
+if arguments.contains("--clipboard-test") {
+    exit(ClipboardTestCommand.run())
+}
+
 if let index = arguments.firstIndex(of: "--panel-sheet") {
     guard arguments.indices.contains(index + 1) else {
         print("usage: ParrotFlow --panel-sheet <out.png>")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -392,6 +392,7 @@ accessibility grant, so it is not faked here — see
 $PF --peek 3 [--find <sentinel>]
 $PF --edit-test <needle> <replacement> --find <sentinel> [--after 3] [--literal]
 $PF --span-test <start> <length> <replacement> --find <sentinel> [--after 3]
+$PF --clipboard-test
 ```
 
 `--peek` reads the surface the way the app would — the value, the selection, and
@@ -408,6 +409,13 @@ characters it wants changed says so, and nothing searches for anything.
 `--find <sentinel>` is **required** for both: without it these write into
 whatever happens to be in front, which during a test run is as likely to be a
 real window as the scratch one you meant.
+
+`--clipboard-test` needs neither a window nor a sentinel. A paste borrows the
+clipboard, so an in-place edit that gets refused arrives at its own fallback
+with the count already moved by its own paste — this checks that the fallback
+writes anyway, that it still refuses once somebody else has copied, and that the
+restore queued behind the paste does not land on the rewrite. Your clipboard is
+saved and put back.
 
 ## Looking at the floating surfaces
 
@@ -489,6 +497,7 @@ scripts/check-suggest.sh           # which words the correction panel proposes
 scripts/check-no-voice.sh          # nothing in git is one person's voice
 scripts/check-audio-recovery.sh    # a microphone that changes leaves a usable engine
 scripts/check-profiles.sh          # which app gets examined, named, or read for context
+scripts/check-clipboard.sh         # when a rewrite may go to the clipboard, and stay there
 
 PF_VIEWPORT=Ghostty scripts/check-inplace.sh   # the same set, in another terminal
 $PF --peek 3 --via-copy                        # what Select All + Copy hands back

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -393,6 +393,7 @@ $PF --peek 3 [--find <sentinel>]
 $PF --edit-test <needle> <replacement> --find <sentinel> [--after 3] [--literal]
 $PF --span-test <start> <length> <replacement> --find <sentinel> [--after 3]
 $PF --clipboard-test
+$PF --span-rule
 ```
 
 `--peek` reads the surface the way the app would — the value, the selection, and
@@ -416,6 +417,12 @@ with the count already moved by its own paste — this checks that the fallback
 writes anyway, that it still refuses once somebody else has copied, and that the
 restore queued behind the paste does not land on the rewrite. Your clipboard is
 saved and put back.
+
+`--span-rule` needs nothing at all. It scores the range a rewrite is turned into
+before any app sees it: the smallest range is often one no paste can carry — an
+insertion is a caret with nothing selected, a deletion pastes an empty string,
+and a trailing space is Slack's to trim — so the span grows until it covers a
+real character and neither end of the replacement is whitespace.
 
 ## Looking at the floating surfaces
 
@@ -498,6 +505,7 @@ scripts/check-no-voice.sh          # nothing in git is one person's voice
 scripts/check-audio-recovery.sh    # a microphone that changes leaves a usable engine
 scripts/check-profiles.sh          # which app gets examined, named, or read for context
 scripts/check-clipboard.sh         # when a rewrite may go to the clipboard, and stay there
+scripts/check-span-rule.sh         # which range a rewrite is written as, before any app sees it
 
 PF_VIEWPORT=Ghostty scripts/check-inplace.sh   # the same set, in another terminal
 $PF --peek 3 --via-copy                        # what Select All + Copy hands back

--- a/scripts/check-clipboard.sh
+++ b/scripts/check-clipboard.sh
@@ -17,7 +17,7 @@
 # Your own clipboard is saved and put back.
 set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$ROOT" || exit 1
+BIN="$ROOT/.build/release/ParrotFlow"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
 
-swift build >/dev/null || exit 1
-exec ./.build/debug/ParrotFlow --clipboard-test 2>/dev/null
+exec "$BIN" --clipboard-test 2>/dev/null

--- a/scripts/check-clipboard.sh
+++ b/scripts/check-clipboard.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Checks the rules that decide whether this app may write to the clipboard.
+#
+#   scripts/check-clipboard.sh
+#
+# No app bundle, no accessibility, no window: it builds with swift and runs the
+# rules against the real NSPasteboard. Real, because what is being tested is
+# which calls move NSPasteboard.changeCount — clearContents does, setString does
+# not — and a fake that answers that is the assumption restated.
+#
+# Both rules are about the same collision. A refused in-place edit leaves the
+# rewrite on the clipboard, and the ladder it just came down pastes, so the
+# count has moved and this app is what moved it. One rule has to see that and
+# still write; the other has to see it and not put the pre-paste contents back
+# over the rewrite 0.4s later.
+#
+# Your own clipboard is saved and put back.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT" || exit 1
+
+swift build >/dev/null || exit 1
+exec ./.build/debug/ParrotFlow --clipboard-test 2>/dev/null

--- a/scripts/check-span-rule.sh
+++ b/scripts/check-span-rule.sh
@@ -15,7 +15,7 @@
 # three are cases in here.
 set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$ROOT" || exit 1
+BIN="$ROOT/.build/release/ParrotFlow"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
 
-swift build >/dev/null || exit 1
-exec ./.build/debug/ParrotFlow --span-rule 2>/dev/null
+exec "$BIN" --span-rule 2>/dev/null

--- a/scripts/check-span-rule.sh
+++ b/scripts/check-span-rule.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Scores which range a rewrite should be written as — Surface.writableSpan.
+#
+#   scripts/check-span-rule.sh
+#
+# The half of the story that comes before scripts/check-span.sh. That one hands
+# a real app a range that is already known and asks whether exactly those
+# characters change. This asks what the range should be: a sentence and its
+# rewrite go in, a range and a replacement come out.
+#
+# Pure, so it needs no app, no window and no accessibility grant. It is also
+# where the answer was wrong three times in one afternoon — a paste with a
+# trailing space that Slack trimmed, a paste at a caret that nothing could
+# confirm, and an empty paste that wrote nothing while reporting success. All
+# three are cases in here.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT" || exit 1
+
+swift build >/dev/null || exit 1
+exec ./.build/debug/ParrotFlow --span-rule 2>/dev/null


### PR DESCRIPTION
A grammar fix taken in Slack was reverted and then thrown away. Two independent bugs did it. The range the app asked to write was one no paste can carry, so Slack mangled the edit and the read-back correctly undid it; then the fallback that should have left the rewrite on the clipboard refused, because the edit ladder's own paste had moved the clipboard and the guard read that as somebody else copying. Both are fixed, and the same dictation now lands in Slack instead of being lost.

Reviewers should start with `Surface.writableSpan` — it decides what every in-place edit writes, in every app, so it is the change with reach. The clipboard half is narrow. Two new check sets run in CI.

<details>
<summary>Three dictations, three ways for the same function to produce an unwritable range</summary>

`Surface.minimalSpan` returns the smallest range that turns the sentence into its rewrite. Smallest is usually not writable. All three of these are real, all in Slack, all on 2026-08-20:

| dictation | minimal span | why it cannot be written |
|---|---|---|
| `one you` → `one do you` | nothing at one point → `"do "` | Slack's composer trims the trailing space off the paste. The line read `one doyou`. |
| `car though` → `car, though` | nothing at one point → `","` | asks to paste at a caret, and `confirmedSelection` over an empty range confirms that nothing is selected — true wherever the caret is |
| `I'll t I told` → `I told` | `"'ll t I"` → `""` | `TextInserter.insert("")` returns without writing, so nothing happened and the ladder could not tell that from an app refusing the edit |

The first two are the ones a person notices, because the read-back catches the damage and undoes it. The third is silent.

`Surface.writableSpan` grows the span outward over text both versions agree on, until three things hold: it covers at least one real character, the replacement is not empty, and neither end of the replacement is whitespace. `"insert `do ` before `you`"` becomes `"replace `y` with `do y`"` — the same edit, with nothing for an editor to tidy and a selection the app has to name before anything is written.

`minimalSpan` is unchanged. The three call sites that write ask for a writable span instead.

One thing worth a second look: growth direction is decided by which side is wrong. A leading space is only ever fixed by growing backwards. My first version grew forwards only, ran to the end of the line and swallowed it — `scripts/check-span-rule.sh` caught that, and the case is still in the set.

</details>

<details>
<summary>The clipboard guard could never pass after the ladder had pasted</summary>

When an in-place edit is refused, `AppDelegate.copyOverOurOwn` leaves the rewrite on the clipboard — but only if `NSPasteboard.changeCount` still matches the value recorded when the command was taken. The point of that check is not to overwrite something you copied while the model was thinking.

Step 2 of the edit ladder pastes, and a paste borrows the clipboard. Measured: `clearContents()` moves the count by one, `setString` by none, and `TextInserter` calls `clearContents` twice — once to borrow, once to restore. So by the time the fallback ran the count had always moved, and this app was what moved it. The rewrite was dropped and the message said "the clipboard has changed".

`TextInserter.ownChange` now records the count this app leaves behind, and `clipboardIsOurs(unchangedFrom:)` accepts either. It stays a real check: the count only goes up, so `ownChange` matches only while our write is the last one there was. It starts at `-1`, not at the count on launch — otherwise "we have never written" would claim whatever you had copied before ParrotFlow started.

Fixing that alone would have made things worse. The paste queues a restore 0.4s behind it, and an in-place edit holds the main actor for longer than that — 2.5s of read-back polling, plus up to 1s of undo. So the restore lands after the fallback has written the rewrite, and would put the pre-paste contents straight over it. `TextInserter.putBack` now restores only while our own paste is still the newest thing there. That also covers the direct `clearContents` + `setString` fallbacks in `runTransform` and `saveCorrections`, which had the same exposure.

</details>

<details>
<summary>Two new check sets, both in CI, and what they cover</summary>

`scripts/check-span-rule.sh` — 6/6. Pure: no model, no window, no accessibility. Three of the six cases are the dictations in the table above. It also checks the invariants directly rather than trusting the expected values, which is what caught my growth-direction bug.

`scripts/check-clipboard.sh` — 6/6. Runs against the real `NSPasteboard`, because what is under test is which calls move the change count; a fake that answers that question is the assumption restated. Your clipboard is saved and put back.

On the code before this PR, the clipboard set fails exactly twice:

```
✗ writable after our own paste borrowed it       — count 518 → 519
✗ the restore leaves a later write alone         — clipboard reads "what the user copied"
```

That second line is the rewrite being destroyed.

Also run locally: `check-replacements` 23/23, `check-pipeline` 93/93, `check-no-voice` 5/5, `check-default-config` ✓, swiftlint clean, debug and release builds with no new warnings.

</details>

<details>
<summary>Verified in Slack, and what the log says now</summary>

Same dictation, before and after. Before:

```
surface: the range write was ignored; pasting over a confirmed selection
surface: the text has not appeared in the field
surface: the paste landed somewhere unintended; undoing it
surface: the stray paste is undone; the text is as it was
in-place: refused — this app would not let me edit it
offer: the field refused Fix grammar and the clipboard has been used since; left both alone
```

With the clipboard fix only — the edit still fails, but the rewrite survives:

```
in-place: refused — this app would not let me edit it
offer: left Fix grammar on the clipboard
clipboard: written since the paste; the old contents stay put
```

With the span fix, the edit lands:

```
surface: the range write was ignored; pasting over a confirmed selection
surface: pasted 1 chars over the selection
```

That last line is new. Step 1 of the ladder logged its success and step 2 did not, so a landed edit used to be an absence of failure lines — reading the log for "did this work" meant knowing which lines should have been there.

</details>

<details>
<summary>What this does not fix</summary>

Slack still refuses step 1 of the ladder, the accessibility range write. It always did, and that is expected for Electron: the write reports `.success` and changes nothing. The edit now succeeds at step 2 instead. Nothing here makes step 1 work in Chromium or Electron, and nothing tries to.

`scripts/check-inplace.sh` and `check-span.sh` were not run. They need tmux, the installed app, the Accessibility grant and a real screen, and they score against a terminal rather than against Slack. The Slack evidence above is by hand.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
