### PR TITLE
fix: the caret walk checks the characters, not the numbers naming them

### DIFF
--- a/Sources/ParrotFlow/PeekCommand.swift
+++ b/Sources/ParrotFlow/PeekCommand.swift
@@ -132,6 +132,8 @@ enum PeekCommand {
         // apps it will work in — see `caretDescription`.
         report("caret     \(caretDescription(of: element))")
         report("field     \(fieldDescription(of: element))")
+        report("offsets   \(offsetDescription(of: element, value: value))")
+        if let value { reportLineRanges(of: element, value: value) }
 
         // What the write path will actually be handed. Everything above is raw
         // accessibility; this is the one coordinate space the app edits in, and
@@ -328,6 +330,119 @@ enum PeekCommand {
         var range = CFRange()
         guard AXValueGetValue(wrapped as! AXValue, .cfRange, &range) else { return "unreadable" }
         return "location \(range.location), length \(range.length)"
+    }
+
+    /// Whether the app's offsets address the same string as its own value.
+    ///
+    /// They do not always, and nothing else here would show it. Measured in a
+    /// Chromium contenteditable on 2026-08-20: a value of 96 characters over
+    /// three paragraphs, the caret at the very end, and the app reporting 94.
+    /// The same 34-character value in one text node reported 34. So the offsets
+    /// run short by the block boundaries above them — not by the newlines in
+    /// the value, which are equal in both — and no arithmetic on the value can
+    /// tell the two apart.
+    ///
+    /// `kAXStringForRange` is the way out if the app answers it: hand it an
+    /// offset and it hands back the characters there, which converts one space
+    /// to the other by measurement rather than by theory. This line says
+    /// whether it is advertised, and what it returns for the first ten
+    /// characters — where the value and the answer differ, the offsets are
+    /// shifted, and by how much the two strings differ.
+    /// What the app calls each of its lines, against what the value calls them.
+    ///
+    /// `kAXRangeForLine` answers in the app's own numbers, so it maps the two
+    /// spaces line by line without any probing. Whether that is usable depends
+    /// on one thing this prints and nothing else can tell you: whether the
+    /// app's idea of a line is the value's idea of a line. A soft-wrapped
+    /// paragraph is one line in the value and may be several to the app, and a
+    /// mapping built on the assumption that they agree would be wrong for every
+    /// message long enough to wrap.
+    private static func reportLineRanges(of element: AXUIElement, value: String) {
+        let text = value as NSString
+        var names: CFArray?
+        let advertised = AXUIElementCopyParameterizedAttributeNames(element, &names) == .success
+            ? ((names as? [String]) ?? []) : []
+        guard advertised.contains(kAXRangeForLineParameterizedAttribute as String) else {
+            report("lines     AXRangeForLine not advertised")
+            return
+        }
+
+        var starts: [Int] = [0]
+        text.enumerateSubstrings(in: NSRange(location: 0, length: text.length),
+                                 options: [.byLines, .substringNotRequired]) { _, _, enclosing, _ in
+            starts.append(enclosing.location + enclosing.length)
+        }
+        report("lines     (the app's range for each line, then what the value has there)")
+        for line in 0..<max(1, starts.count - 1) {
+            var answer: CFTypeRef?
+            let error = AXUIElementCopyParameterizedAttributeValue(
+                element, kAXRangeForLineParameterizedAttribute as CFString,
+                NSNumber(value: line), &answer
+            )
+            guard error == .success, let wrapped = answer,
+                  CFGetTypeID(wrapped) == AXValueGetTypeID() else {
+                report("  \(line)       answered \(error.rawValue)")
+                continue
+            }
+            var range = CFRange()
+            guard AXValueGetValue(wrapped as! AXValue, .cfRange, &range) else { continue }
+            let start = starts[line]
+            let end = line + 1 < starts.count ? starts[line + 1] : text.length
+            let here = text.substring(with: NSRange(location: start, length: max(0, end - start)))
+            report("  \(line)       app \(range.location)+\(range.length)"
+                + "   value \(start)+\(max(0, end - start))   \"\(preview(here))\"")
+        }
+    }
+
+    private static func offsetDescription(of element: AXUIElement, value: String?) -> String {
+        var names: CFArray?
+        let advertised = AXUIElementCopyParameterizedAttributeNames(element, &names) == .success
+            ? ((names as? [String]) ?? []) : []
+        let attribute = kAXStringForRangeParameterizedAttribute as String
+        guard advertised.contains(attribute) else {
+            return "AXStringForRange not advertised — offsets can only be measured by selecting"
+        }
+
+        // The start of the last line, where any drift has had every boundary
+        // above it to accumulate over. Asking at 0 proves nothing: the two
+        // spaces always agree before the first block boundary.
+        //
+        // Counted as UTF-16, not as characters. The accessibility range API is
+        // UTF-16 throughout, and `String.count` is grapheme clusters — one emoji
+        // above the last line and the two disagree, so this would ask about a
+        // different place than it prints.
+        guard let value, !value.isEmpty else {
+            return "AXStringForRange advertised, no value to ask about"
+        }
+        let text = value as NSString
+        let lastBreak = text.range(of: "\n", options: .backwards)
+        let start = lastBreak.location == NSNotFound ? 0 : lastBreak.location + 1
+        let length = min(12, text.length - start)
+        guard length > 0 else { return "AXStringForRange advertised, last line is empty" }
+
+        var range = CFRange(location: start, length: length)
+        guard let parameter = AXValueCreate(.cfRange, &range) else {
+            return "AXStringForRange advertised, but the range would not encode"
+        }
+        var answer: CFTypeRef?
+        let error = AXUIElementCopyParameterizedAttributeValue(
+            element, attribute as CFString, parameter, &answer
+        )
+        guard error == .success, let said = answer as? String else {
+            return "AXStringForRange advertised but answered \(error.rawValue) at \(start)+\(length)"
+        }
+        let here = text.substring(with: NSRange(location: start, length: length))
+        if said == here {
+            return "the app and its value agree at \(start)+\(length) — \"\(preview(said))\""
+        }
+        // How far out, said as a number rather than left to the reader. Where
+        // the answer turns up later in the value than it was asked for, that
+        // distance is how far the app's numbers and its own value have parted.
+        let found = text.range(of: said)
+        let drift = found.location == NSNotFound ? nil : found.location - start
+        return "asked \(start)+\(length), the app answered \"\(preview(said))\""
+            + " where the value has \"\(preview(here))\""
+            + (drift.map { " — the app's offsets run \($0) behind" } ?? "")
     }
 
     /// Where the caret is on screen, if the app will say.

--- a/Sources/ParrotFlow/SelectionReader.swift
+++ b/Sources/ParrotFlow/SelectionReader.swift
@@ -399,6 +399,29 @@ enum SelectionReader {
         return range
     }
 
+    /// The characters the app says are at one of *its* offsets.
+    ///
+    /// The only read that crosses between the two coordinate spaces an app can
+    /// have. `kAXValue` is one string and `kAXSelectedTextRange` is a number,
+    /// and nothing says the number addresses the string — in Chromium it does
+    /// not, and the gap grows by one for every block boundary above the offset.
+    /// This asks in the app's own numbers and answers in characters, so the two
+    /// can be lined up by comparison instead of by assumption.
+    ///
+    /// Nil when the app does not implement it, which is most of them. That is
+    /// not a failure: an app whose offsets already address its value has
+    /// nothing to translate.
+    static func string(of element: AXUIElement, at location: Int, length: Int) -> String? {
+        guard location >= 0, length > 0 else { return nil }
+        var range = CFRange(location: location, length: length)
+        guard let parameter = AXValueCreate(.cfRange, &range) else { return nil }
+        var answer: CFTypeRef?
+        guard AXUIElementCopyParameterizedAttributeValue(
+            element, kAXStringForRangeParameterizedAttribute as CFString, parameter, &answer
+        ) == .success else { return nil }
+        return answer as? String
+    }
+
     // MARK: - Synthetic copy
 
     private static func viaCopy() -> String? {

--- a/Sources/ParrotFlow/Surface.swift
+++ b/Sources/ParrotFlow/Surface.swift
@@ -582,12 +582,16 @@ struct Surface {
         }
 
         post(arrowLeft, times: target.length, flags: .maskShift)
-        let got = SelectionReader.selectedRange(of: element)
-        guard let selected = got,
-              selected.location == target.location, selected.length == target.length else {
-            let reported = got.map { "\($0.location)+\($0.length)" } ?? "nothing"
-            Log.write("surface: selected \(reported), wanted"
-                + " \(target.location)+\(target.length) — not typing")
+        // The characters, not the numbers naming them — the same standard step 2
+        // holds itself to, and for a reason step 2 measured. An app's offsets and
+        // its own value do not always address the same string: Slack reported
+        // exactly 62+25 for a selection holding the characters at 63, so a check
+        // on the numbers passed while the selection was one character out, and
+        // this pasted over the wrong 25 characters. `confirmedSelection` asks
+        // what is selected first and falls back to the numbers only where the app
+        // will not say, which is every Chromium contenteditable.
+        guard let text = Range(target, in: content).map({ String(content[$0]) }),
+              confirmedSelection(matches: text, range: target) else {
             return nil
         }
 

--- a/Sources/ParrotFlow/Surface.swift
+++ b/Sources/ParrotFlow/Surface.swift
@@ -829,14 +829,23 @@ struct Surface {
     /// whatever happened. The question has to be one the app answers out of its
     /// own state.
     ///
-    /// Two ways it can answer, because the surfaces that matter answer
-    /// differently. A native field hands back the selected *text*, which is the
-    /// stronger evidence and is tried first. Chromium hands back `""` for the
-    /// selected text of a contenteditable however the selection was made — by
-    /// hand, by us, at all — so insisting on text refuses every browser and
-    /// every Electron app on earth. What it does report honestly is the
-    /// *range*, and a range that reads back as the one we asked for, when the
-    /// one before it was different, is the app saying it moved the selection.
+    /// Three ways it can answer, in descending order of how much they prove.
+    ///
+    /// The selected *text* is the strongest and is tried first. A native field
+    /// gives it, and so does Slack — it named "est tunday morning works " for a
+    /// selection asked for one character earlier, which is the whole reason
+    /// this function exists. Chromium hands back `""` for a contenteditable
+    /// whose selection was set through the accessibility API, so insisting on
+    /// text alone would refuse every browser.
+    ///
+    /// Then the characters at the range, via `AXStringForRange`. Asked in the
+    /// app's own numbers, so it says what the app took those numbers to mean —
+    /// which is the question, because an app's offsets need not address its own
+    /// value and the same numbers can name different characters.
+    ///
+    /// Then the *range* alone, for an app that implements neither. A range that
+    /// reads back as the one asked for, when the one before it was different,
+    /// is the app saying it moved the selection — and nothing more than that.
     ///
     /// Neither answer is taken as proof that the write worked. They only decide
     /// whether pasting is safe to attempt; what happened afterwards is settled
@@ -861,14 +870,37 @@ struct Surface {
                 }
                 lastSeen = "\"\(selected.prefix(40))\""
             } else if let echoed = SelectionReader.selectedRange(of: element) {
-                // Chromium reports `""` for the selected text of a
-                // contenteditable however the selection was made — by hand, by
-                // us, at all — so insisting on text refuses every browser and
-                // every Electron app. The range it does report honestly.
+                // No selected text to check, so the range is all there is —
+                // and a range that reads back as the one asked for is weaker
+                // evidence than it looks. An app's offsets need not address its
+                // own value, so the same numbers can name different characters:
+                // Slack echoed 62+25 for a selection holding the characters at
+                // 63, and this said yes.
+                //
+                // `AXStringForRange` closes that without having to work out
+                // where the selection really is. It is asked in the app's own
+                // numbers — the same ones `select` passed it — so it answers
+                // with the characters the app took those numbers to mean. If
+                // they are not the ones intended, the selection is somewhere
+                // else, whatever the numbers say.
                 if echoed.location == range.location, echoed.length == range.length {
-                    return true
+                    guard let said = SelectionReader.string(
+                        of: element, at: range.location, length: range.length
+                    ) else {
+                        // Not implemented. The numbers are all there is, which
+                        // is where this stood before.
+                        return true
+                    }
+                    if folded(said).compare(
+                        folded(expected), options: .caseInsensitive
+                    ) == .orderedSame {
+                        return true
+                    }
+                    lastSeen = "\(echoed.location)+\(echoed.length), holding"
+                        + " \"\(said.prefix(40))\""
+                } else {
+                    lastSeen = "\(echoed.location)+\(echoed.length)"
                 }
-                lastSeen = "\(echoed.location)+\(echoed.length)"
             }
             Thread.sleep(forTimeInterval: 0.03)
         } while Date() < deadline

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -402,6 +402,25 @@ as offsets into it. That last block is the one that decides what a write does;
 when it and the raw accessibility lines above it disagree, the surface block is
 the one that matters.
 
+The `offsets` line says whether the two can disagree at all. An app's value is a
+string and its selected range is a number, and nothing guarantees the number
+indexes the string — Chromium's does not. Every block boundary appears in the
+value as `\n` and is skipped by the offsets, so a caret at the end of a
+three-paragraph message reports two characters early:
+
+```
+value     96 chars, 3 line(s)
+range     location 94, length 0
+offsets   asked 62+12, the app answered "es Tuesday m" where the value has "Does Tuesday" — the app's offsets run 2 behind
+  span    96+0 — ""
+```
+
+`range` is what the app said. `span` is what it meant, measured with
+`AXStringForRange` and corrected. When the two differ, everything aimed by
+arithmetic on the value — where a rewrite is written, what the `input` stage
+reports either side of the caret — was wrong by that much before the
+correction.
+
 `--edit-test` performs a real in-place edit after a delay, finding the text by
 searching for it. `--span-test` does the same to a character range given
 outright, which is how the app itself now works — a caller that knows which
@@ -495,6 +514,7 @@ scripts/check-context.sh           # what the context stage publishes for a scre
 scripts/check-input.sh             # where the input stage cuts a field, and the caret
 scripts/check-join.sh              # fitting a clip to the text either side of the caret
 scripts/check-span.sh              # a composer-shaped page, or Slack, or Outlook
+scripts/probe-offsets.sh           # measures whether an app's offsets index its own value
 scripts/check-vocabulary-config.sh # what vocabulary.yaml adds up to, old keys included
 scripts/check-possessive.sh        # whether a possessive survives a substitution
 scripts/check-verdicts.sh          # what the name judge reads out of a reply

--- a/scripts/probe-offsets.sh
+++ b/scripts/probe-offsets.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Measures whether an app's text offsets address its own accessibility value.
+#
+#   scripts/probe-offsets.sh
+#
+# A probe, not a check: it prints what the app says and scores nothing. There is
+# no right answer to assert yet, and #175 is why.
+#
+# The two are not the same thing. `kAXValue` is a string; `kAXSelectedTextRange`
+# is a number; nothing guarantees the number indexes the string. In a Chromium
+# contenteditable it does not — the value renders every block boundary as "\n"
+# and counts it, and the offsets skip it. A caret at the end of a
+# three-paragraph message is reported two characters early.
+#
+# What stopped this becoming a correction is the last two rows. Two carets that
+# the page places one character apart, either side of a line break, come back as
+# the same number: the position is not recoverable from the range, because the
+# information is not in it.
+#
+# The page is the oracle, not accessibility — it publishes the selection it set
+# in its own title, in value offsets, so every row can be checked against
+# something that owes nothing to the API under test. Carets included, which is
+# the part that matters: a caret selects no text, so without this two positions
+# either side of a break look identical in the title as well.
+#
+# Needs Chrome and the dev app built (`make app`). Chrome rather than Slack
+# because it is the same engine, it runs unattended, and it sends nothing to
+# anyone. macOS may ask once for permission to control Chrome.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/ParrotFlowDev.app/Contents/MacOS/ParrotFlow"
+[ -x "$BIN" ] || { echo "build the app first: make app"; exit 1; }
+command -v osascript >/dev/null || { echo "needs macOS"; exit 1; }
+
+# name | seed ("|" separates paragraphs) | "from,length" in value offsets, or "end"
+probe() {
+  local name="$1" seed="$2" at="${3:-}"
+  local enc url
+  enc="$(python3 -c 'import sys,urllib.parse; print(urllib.parse.quote(sys.argv[1]))' "$seed")"
+  url="file://$ROOT/tests/fixtures/paragraphs.html#$enc"
+  [ -n "$at" ] && url="$url&at=$at"
+
+  osascript >/dev/null 2>&1 <<'OSA'
+tell application "Google Chrome"
+  repeat with w in windows
+    set i to (count of tabs of w)
+    repeat while i > 0
+      if (URL of tab i of w as string) contains "/tests/fixtures/" then close tab i of w
+      set i to i - 1
+    end repeat
+  end repeat
+end tell
+OSA
+  osascript >/dev/null 2>&1 <<OSA
+tell application "Google Chrome"
+  activate
+  if (count of windows) = 0 then make new window
+  make new tab at end of tabs of front window with properties {URL:"$url"}
+  set active tab index of front window to (count of tabs of front window)
+end tell
+OSA
+
+  local title=""
+  for _ in $(seq 1 24); do
+    title="$(osascript -e 'tell application "Google Chrome" to get title of active tab of front window' 2>/dev/null)"
+    case "$title" in *"|AT|"*) break ;; esac
+    sleep 0.25
+  done
+  case "$title" in
+    *"|AT|"*) ;;
+    *) printf "  %-34s the page never published its selection\n" "$name"; return ;;
+  esac
+
+  local page peek value said
+  page="${title#*|AT|}"; page="${page%%|SAID|*}"
+  peek="$("$BIN" --peek 2 2>/dev/null)"
+  value="$(echo "$peek" | sed -n 's/^value *\([0-9]*\) chars, \([0-9]*\).*/\1 chars, \2 line(s)/p' | head -1)"
+  said="$(echo "$peek" | sed -n 's/^range *location \([0-9]*\), length \([0-9]*\)/\1+\2/p' | head -1)"
+  printf "  %-34s page %-8s app %-8s (%s)\n" "$name" "$page" "$said" "$value"
+}
+
+echo "what the page set, and what the app reports for it:"
+echo
+
+probe "one paragraph, caret at the end"    "One line only, no breaks at all."
+probe "two paragraphs, caret at the end"   "First line here.|Second line here."
+probe "three paragraphs, caret at the end" \
+  "Hey Mik, good to hear from you!|I'm taking off until Tuesday.|Does Tuesday morning work for you?"
+probe "a blank last line, caret on it"     "First line here.|Second line here.|"
+probe "a word on the third line"           \
+  "Hey Mik, good to hear from you!|I'm taking off until Tuesday.|Does Tuesday morning work for you?" "62,12"
+
+echo
+echo "the two that stopped a correction being written:"
+echo
+probe "caret at the end of line two"       \
+  "Hey Mik, good to hear from you!|I'm taking off until Tuesday.|Does Tuesday morning work for you?" "61,0"
+probe "caret at the start of line three"   \
+  "Hey Mik, good to hear from you!|I'm taking off until Tuesday.|Does Tuesday morning work for you?" "62,0"
+echo
+echo "  one number for two positions — see #175"

--- a/tests/fixtures/paragraphs.html
+++ b/tests/fixtures/paragraphs.html
@@ -1,0 +1,168 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>PFBOX|</title>
+<style>
+  body { font: 15px/1.5 -apple-system, sans-serif; margin: 0; padding: 40px; background: #1a1d21; color: #d1d2d3; }
+  h1 { font-size: 13px; font-weight: 600; color: #868686; margin: 0 0 12px; letter-spacing: .04em; text-transform: uppercase; }
+  #composer { min-height: 96px; padding: 12px 14px; border: 1px solid #565856; border-radius: 8px; background: #222529; outline: none; }
+  #composer p { margin: 0; color: inherit; font-size: inherit; }
+  p.note { color: #868686; font-size: 12px; margin: 14px 0 0; }
+</style>
+</head>
+<body>
+
+<!--
+  The same composer as composer.html, in the shape that breaks the offsets.
+
+  composer.html is one text node. This is one <p> per line, which is what Quill
+  builds and therefore what Slack's message box actually is. The distinction is
+  the whole point of this file: the accessibility *value* renders a block
+  boundary as "\n" and counts it as a character, and the question under test is
+  whether AXSelectedTextRange counts it too.
+
+  Measured in Slack on 2026-08-20, three times, and never with one line: an
+  offset the app reported was short by one for every line break above it. A
+  selection asked for at 62 came back holding the characters at 63, and a caret
+  the app called 95 was really at 96. So the app's numbers and the app's own
+  value do not address the same string, and every write aimed by arithmetic on
+  that value lands one character off per line.
+
+  Seeded from the URL fragment, with "|" between paragraphs:
+
+      file://…/paragraphs.html#one|two|three
+
+  The title publishes the box the same way — PFBOX|<contents>, newlines as "\n"
+  — so a harness can read the real text without asking accessibility anything.
+-->
+
+<h1>ParrotFlow paragraph fixture</h1>
+<div id="composer" contenteditable="true" spellcheck="false"></div>
+<p class="note">The title mirrors this box. <code>PFBOX|&lt;contents, \n per break&gt;</code></p>
+
+<script>
+  var composer = document.getElementById('composer');
+
+  function publish() {
+    document.title = 'PFBOX|' + composer.innerText
+      .replace(/ /g, ' ')
+      .replace(/\n+$/, '')
+      .replace(/\n/g, '\\n');
+  }
+
+  function seed() {
+    // The seed is everything before the first "&": the parameters after it are
+    // the harness talking to this page, not text to put in the box.
+    var text = decodeURIComponent(location.hash.slice(1).split('&')[0]);
+    composer.innerHTML = '';
+    text.split('|').forEach(function (line) {
+      var p = document.createElement('p');
+      // <br> for an empty line, which is what a real editor puts there, and it
+      // leaves the paragraph genuinely empty. A zero-width space was tried and
+      // hid a bug: it gives the line a character to probe with, so a caret on a
+      // blank line looked measurable when in the real thing it is not.
+      if (line.length) {
+        p.appendChild(document.createTextNode(line));
+      } else {
+        p.appendChild(document.createElement('br'));
+      }
+      composer.appendChild(p);
+    });
+    publish();
+    composer.focus();
+
+    // "#lines&at=12,7" puts the selection over exactly those characters of the
+    // value — offsets counted the way innerText counts them, with one "\n" per
+    // break. Without it the caret goes to the very end, where a composer leaves
+    // it after you type.
+    //
+    // This is the page telling the harness where the selection really is, in
+    // the one coordinate space that is not in question. Everything the app
+    // reports about that selection can then be checked rather than assumed.
+    var want = /(?:^|&)at=(\d+),(\d+)/.exec(location.hash);
+    var range = document.createRange();
+    if (want) {
+      place(range, +want[1], +want[2]);
+    } else {
+      range.selectNodeContents(composer);
+      range.collapse(false);
+    }
+    var selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+    report(selection);
+  }
+
+  /// Where the selection really is, in value offsets, published for the
+  /// harness to check against.
+  ///
+  /// A caret has no text, so `selection.toString()` is empty for one and says
+  /// nothing about where it is. Without this the two positions either side of a
+  /// line break look identical in the title, and an experiment about exactly
+  /// those two positions has no oracle at all.
+  function report(selection) {
+    var at = offsetOf(selection.anchorNode, selection.anchorOffset);
+    var to = offsetOf(selection.focusNode, selection.focusOffset);
+    document.title = document.title + '|AT|' + at + ',' + (to - at)
+      + '|SAID|' + selection.toString();
+  }
+
+  function offsetOf(node, within) {
+    var offset = 0;
+    var blocks = composer.getElementsByTagName('p');
+    for (var i = 0; i < blocks.length; i++) {
+      var text = blocks[i].firstChild;
+      var length = (text && text.nodeType === 3) ? text.nodeValue.length : 0;
+      if (node === text) { return offset + within; }
+      if (node === blocks[i]) { return offset + Math.min(within, length); }
+      offset += length + 1;   // the break between blocks
+    }
+    // The selection is anchored on the composer itself rather than on any
+    // paragraph, which is what a caret at the very end looks like. The loop has
+    // counted a break after the last block that innerText does not, so take it
+    // back off.
+    return Math.max(0, offset - 1);
+  }
+
+  /// Walk the paragraphs counting one "\n" per break, and set the range over
+  /// value offsets [from, from + length).
+  function place(range, from, length) {
+    var offset = 0, set = false;
+    var blocks = composer.getElementsByTagName('p');
+    for (var i = 0; i < blocks.length; i++) {
+      var node = blocks[i].firstChild;
+      var text = (node && node.nodeType === 3) ? node.nodeValue : '';
+      if (!set && from <= offset + text.length) {
+        range.setStart(node && node.nodeType === 3 ? node : blocks[i], node && node.nodeType === 3 ? from - offset : 0);
+        set = true;
+      }
+      if (set && from + length <= offset + text.length) {
+        range.setEnd(node && node.nodeType === 3 ? node : blocks[i], node && node.nodeType === 3 ? from + length - offset : 0);
+        return;
+      }
+      offset += text.length + 1;   // the break between blocks
+    }
+  }
+
+  composer.addEventListener('input', publish);
+  window.addEventListener('hashchange', seed);
+
+  // Same reason as composer.html: navigating by URL often leaves Chrome's focus
+  // in the omnibox, and a fixture that measures that is not measuring this.
+  // Taking focus back must not move the selection. `composer.focus()` on its
+  // own puts the caret wherever the browser likes, which silently rewrites the
+  // state a case has just set up — so the seed is re-run instead, which places
+  // it again. Clicking on the page while a case is measuring would otherwise
+  // change the answer and leave no trace of having done so.
+  window.addEventListener('focus', seed);
+  document.addEventListener('visibilitychange', function () {
+    if (!document.hidden) seed();
+  });
+
+  seed();
+  setTimeout(seed, 250);
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Step 3 of the write ladder confirmed that the app reported the range it was asked for, and never asked what characters that range held. Where an app's offsets do not address its own value those are different questions, and it pasted over whatever the numbers meant. That is the fix. The rest of the branch is the investigation that found it — a `--peek` diagnostic, a Chromium fixture, and a probe script — kept so the next attempt does not start from nothing.

**This PR is smaller than it was.** It carried an offset correction, which has been taken back out: two carets one character apart either side of a line break report the same number, so the position cannot be recovered. The measurements are in #175. Nothing here corrects an offset; the app reads what it always did.

<details>
<summary>The bug: a range check that never looked at the characters</summary>

```swift
guard let selected = got,
      selected.location == target.location, selected.length == target.length
```

Slack reported exactly `62+25` for a selection holding the characters at 63. The numbers matched, the check passed, and the paste went over the wrong 25 characters:

```
surface: asked to select 62+25, the app still reports "est tunday morning works "; not pasting
surface: walked the caret to 62+25; pasting
surface: the text has not appeared in the field
surface: the paste landed somewhere unintended; undoing it
```

Step 2 has always compared the characters — that is the line that refused. Step 3 now holds itself to the same standard via the same `confirmedSelection(matches:range:)`, which asks what is selected and falls back to the numbers only where the app will not say.

The read-back caught the bad paste and the undo worked, so the cost was the rewrite rather than the message. But the read-back is the last line of defence and this is the first.

</details>

<details>
<summary>Why the correction came out, having been written and measured</summary>

The premise was sound and is now verified: `AXSelectedTextRange` and `AXStringForRange` share one space, and it is not the value's. The page selected `Does Tuesday` at value offset 62; the app reported `location 60`.

The fix does not follow from it. Two carets the page places one character apart come back identical:

```
  caret at the end of line two       page 61,0     app 60+0
  caret at the start of line three   page 62,0     app 60+0
```

A block boundary collapses two value positions into one app position. Which side the caret is on is exactly what the `join` bug turns on, so a correction that cannot answer it does not fix the thing it was written for — and it was actively wrong: for a selection the page set to `62+12` it produced `61+13`.

Two models were tried and both are falsified by the table in #175. `AXRangeForLine` would have given an exact mapping; Chromium returns the whole text as line 0 and errors on line 1.

</details>

<details>
<summary>What is kept, and why it is worth keeping</summary>

`--peek` gains an `offsets` line — whether `AXStringForRange` agrees with the value — and a `lines` block for `AXRangeForLine`. On any app, in one command, that says whether its numbers and its value are the same string.

`tests/fixtures/paragraphs.html` is a contenteditable built from `<p>` blocks, the shape Slack's composer has, driven from the URL. It publishes the selection it set in its own title, in value offsets, so a measurement can be checked against something that owes nothing to the API being measured. Carets included — a caret selects no text, and without that the two positions either side of a break are indistinguishable in the oracle as well. That hole was in the first version of the experiment and it had to be closed before the conclusion above could be trusted.

`scripts/probe-offsets.sh` prints what the app reports for each case. A probe and not a check: there is no right answer to assert yet.

</details>

<details>
<summary>Greptile's two findings on the earlier version</summary>

Both were valid and both are resolved, one by fixing and one by removal.

**Grapheme counts passed to a UTF-16 API** in `PeekCommand` — fixed. It now works in `NSString` throughout, so an emoji above the last line no longer makes the diagnostic ask about a different place than it prints.

**`drift` returning nil on an empty paragraph** — the code it applied to is gone. It was a real defect and it reproduced: two text lines plus a blank line gave a span of 34 where the value ends at 35. Chasing it is what exposed the ambiguity that ended the whole approach, so the finding did its job twice.

</details>

<details>
<summary>What was measured</summary>

`check-span-rule` 6/6, `check-clipboard` 6/6, `check-replacements` 23/23, `check-pipeline` 93/93, `check-numbers` 97/97, `check-input` 14/14, `check-join` 46/46, `check-profiles` ✓, `check-wake` 24/24, `check-split` 14/14, `check-dotted` 73/73, `check-possessive` 35/35, `check-suggest` PASS, `check-no-voice` 5/5, `check-default-config` ✓. swiftlint clean, debug and release builds with no new warnings.

Not run: `check-inplace.sh` and `check-span.sh`, which need tmux, the installed app, the Accessibility grant and a real screen. The step 3 change is exercised by neither; it is supported by the Slack log above and by the measurement that Chromium reports `AXSelectedText` correctly, which is what the new check compares against.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
