### PR TITLE
fix: say on screen when an offered transform changes nothing

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3008,7 +3008,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         transform, over: target, clipboardWhenChosen: clipboardWhenChosen
                     )
                 }
-                if !asked { self.setLabel(error.localizedDescription, clearAfter: 7) }
+                if !asked { self.flash(error.localizedDescription, tone: .failure) }
             }
         }
     }
@@ -3017,9 +3017,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// write.
     ///
     /// Every refusal here leaves the sentence exactly as it is — in the field or
-    /// on the clipboard — and says so in the menu bar. The pill is not used: it
-    /// sits over the words, and a notice there would cover the thing the message
-    /// is about.
+    /// on the clipboard — and says so on screen.
+    ///
+    /// On screen, not only in the menu bar. The menu bar was the whole of it,
+    /// on the argument that the pill sits over the words and a notice there
+    /// would cover the thing the message is about. True, and beside the point:
+    /// you are looking at the sentence, not at the menu bar, so an outcome
+    /// reported there alone is an outcome nobody sees. "Fix grammar: nothing to
+    /// change" arrived twice on 2026-08-20 and read both times as the app
+    /// having quietly died. Every *failure* in this flow already used the pill,
+    /// so the one shape that looked like nothing happening was the one that
+    /// said nothing.
+    ///
+    /// Covering the sentence for a moment costs a moment. Not saying anything
+    /// costs a retry, and the belief that the feature is broken.
     private func finishOfferedTransform(
         _ transform: Config.Transform, over target: Correction, before: String, after: String,
         clipboardWhenChosen: Int
@@ -3029,14 +3040,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let cleaned = after.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !cleaned.isEmpty else {
             Log.write("offer: \(transform.name) returned nothing")
-            setLabel("\(transform.name) returned nothing", clearAfter: 7)
+            flash("\(transform.name) returned nothing", tone: .caution)
             return
         }
         // Saying so beats replacing text with itself and calling it done, which
         // looks identical to the prompt having silently failed.
         guard cleaned != before else {
             Log.write("offer: \(transform.name) changed nothing")
-            setLabel("\(transform.name): nothing to change", clearAfter: 7)
+            flash("\(transform.name): nothing to change", tone: .plain)
             return
         }
 


### PR DESCRIPTION
Take an offer and the transform returns nothing, changes nothing, or fails, and the app said so in the menu bar and nowhere else. You are looking at the sentence when you take an offer, so all three read as the app having quietly died. They flash on screen now.

Reviewers: three lines in `finishOfferedTransform` and `runOfferedTransform`. The tones are copied from the selection path, which already reported the same three outcomes this way — the offer path was the one that did not.

<details>
<summary>What it looked like — a working transform reported as a crash</summary>

```
19:16:02  offer: taken; running "Fix grammar"
19:16:02  offer: Fix grammar over "Do you want to ping me on Tuesday? It's usually not too busy, so we should find "
19:16:03  offer: Fix grammar changed nothing
```

The sentence was already correct, so the model returned it unchanged. Right answer. But the pill showed "Thinking…", vanished, and the only report was a menu-bar title — so it was reported to me as "the grammar check just stopped and didn't do anything but didn't return an error either".

It happened twice on 2026-08-20. The other was at 16:48:40.

| | pill | menu bar |
|---|---|---|
| every failure in `replace` | yes | 4s |
| `returned nothing`, `nothing to change`, and the transform error | **no** | 7s |

So the three outcomes that look most like nothing happening were the three that said nothing.

</details>

<details>
<summary>The argument for the menu bar, and why it loses</summary>

The comment on `finishOfferedTransform` made a real point:

> The pill is not used: it sits over the words, and a notice there would cover the thing the message is about.

That is true. It is also beside the point — covering the sentence costs a moment, and saying nothing costs a retry plus the belief that the feature is broken. The comment is rewritten rather than deleted, so the trade-off stays on the record with the reason it went the other way.

Consistency settles the tones rather than my judgement: `runTransform` already flashes `returned nothing` as `.caution` and `nothing to change` as `.plain` for the selection path. The offer path now matches.

</details>

<details>
<summary>What was measured</summary>

`check-span-rule` 6/6, `check-clipboard` 6/6, `check-replacements` 23/23, `check-pipeline` 93/93, `check-numbers` 97/97, `check-input` 14/14, `check-join` 46/46, `check-profiles` ✓, `check-wake` 24/24, `check-split` 14/14, `check-dotted` 73/73, `check-possessive` 35/35, `check-suggest` PASS, `check-no-voice` 5/5, `check-default-config` ✓. swiftlint clean, release build with no new warnings.

Not measured: what the pill looks like when it fires. This changes which surface a message goes to, and no check covers that — `$PF --panels notice` and `--panels caution` render them if you want to look.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
