### PR TITLE
fix: the offer opens to its full width, with every chip inside the pill

### DIFF
--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -962,7 +962,8 @@ enum PillMetrics {
             total + 20 + (command.key.isEmpty ? 0 : keycap) + title(command.title)
         }
         let lead = headline.map { title($0) + gap } ?? 0
-        let row = padding * 2 + lead + chips + CGFloat(max(commands.count - 1, 0)) * 4
+        let row = padding * 2 + lead + chips
+            + CGFloat(max(commands.count - 1, 0)) * 4 + rowFit
         var widest = row
         if !reading.words.isEmpty {
             widest = max(widest, min(sentenceWidth, padding * 2 + sentenceRun(reading.words)))
@@ -978,11 +979,33 @@ enum PillMetrics {
     /// the 7pt between it and the words.
     static let keycap: CGFloat = 27
 
-    /// A chip's words at 13pt rounded. Per character, which is what everything
-    /// else on this surface measures text with.
+    /// A chip's words at 13pt rounded.
+    ///
+    /// Measured in the font they are set in, not counted at a flat rate per
+    /// character. A flat rate is generous for ordinary lowercase words and
+    /// short by a couple of points for capitals and digits, and the error is
+    /// per chip: a row of transform names that all run wide is a row that does
+    /// not fit the capsule counted for it. The chip titles come from the
+    /// config, so what they are made of is not this file's to assume.
+    ///
+    /// `chipFit` is the gap between what AppKit measures here and what SwiftUI
+    /// draws over there.
     static func title(_ words: String) -> CGFloat {
-        CGFloat(words.count) * 7.5
+        ceil((words as NSString).size(withAttributes: [.font: sentenceFont]).width) + chipFit
     }
+
+    /// What SwiftUI lays the chip row out at, over what the numbers above add
+    /// up to. Two text engines: AppKit measures a title here, SwiftUI draws it
+    /// there, and they disagree by up to 2pt per chip; the row comes out 4pt
+    /// wider than its parts whatever it holds. Both measured against the drawn
+    /// row over one to six chips, and titles of capitals, digits, accents and
+    /// the narrowest and widest letters there are.
+    ///
+    /// Generous rather than tight, because the chip title is `.fixedSize()`: a
+    /// capsule a point short does not shorten a chip, it hangs one over the
+    /// end of the pill.
+    static let chipFit: CGFloat = 2
+    static let rowFit: CGFloat = 4
 }
 
 // MARK: - View
@@ -1016,23 +1039,45 @@ struct PillView: View {
     @EnvironmentObject private var model: PillModel
 
     var body: some View {
-        ZStack {
-            switch model.state {
-            case .recording:
-                RecordingContent(level: model.level, icon: model.appIcon)
-                    .transition(.opacity)
-            case .working(let message):
-                MessageContent(message: message, tone: .thinking)
-                    .transition(.opacity)
-            case .notice(let message, let tone):
-                MessageContent(message: message, tone: tone)
-                    .transition(.opacity)
-            case .offer(let commands, let headline, let reading):
-                OfferContent(commands: commands, headline: headline, reading: reading)
-                    .transition(.opacity)
+        // The capsule is the window, whatever the contents would rather be.
+        //
+        // The window's width is animated by AppKit and the contents are laid
+        // out by SwiftUI, and for the length of a morph the two disagree: the
+        // new state's contents are at full size on the first frame while the
+        // window is still on its way there from the last state's width. A
+        // `maxWidth: .infinity` frame grows to whichever is larger, so the
+        // whole surface — capsule, rim and chips — was drawn wider than the
+        // window and cut off square by its edge. An offer with four chips
+        // arriving after a notice spilled onto the desktop for those 180ms,
+        // which is what an offer with a row of transforms on it does every
+        // time.
+        //
+        // `geo.size` is the window less its bleed, and a fixed frame at that
+        // size is the one thing that cannot grow past it. What does not fit is
+        // clipped to the capsule instead — so a morph reads as the pill opening
+        // with the chips arriving from under its rim, and the surface never
+        // leaves the window. The clip is inside `parrotSurface` and the bloom,
+        // which draw outside the shape on purpose.
+        GeometryReader { geo in
+            ZStack {
+                switch model.state {
+                case .recording:
+                    RecordingContent(level: model.level, icon: model.appIcon)
+                        .transition(.opacity)
+                case .working(let message):
+                    MessageContent(message: message, tone: .thinking)
+                        .transition(.opacity)
+                case .notice(let message, let tone):
+                    MessageContent(message: message, tone: tone)
+                        .transition(.opacity)
+                case .offer(let commands, let headline, let reading):
+                    OfferContent(commands: commands, headline: headline, reading: reading)
+                        .transition(.opacity)
+                }
             }
+            .frame(width: geo.size.width, height: geo.size.height)
+            .clipShape(Self.shape)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
         // The whole surface, not each chip: moving from one chip to the next
         // must not read as leaving the pill. What leaving costs is decided by
         // whoever raised the offer — see `PillModel.onHover`.

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -150,6 +150,15 @@ final class PillHUD {
     /// one dictation never inherits the aim of the last.
     private var near: CaretAnchor.Found?
 
+    /// The window the state on screen asks for, bleed included.
+    ///
+    /// The one answer to "how big is this pill", so nothing has to ask the
+    /// window — which in the middle of a morph is a width on its way somewhere
+    /// rather than a width anything chose.
+    private var wantedSize: NSSize {
+        PillMetrics.panelSize(for: model.state, hasIcon: model.appIcon != nil)
+    }
+
     /// One number for the whole surface: the rise, the morph and the fade.
     ///
     /// The panel frame animates in AppKit and the words crossfade in SwiftUI,
@@ -378,7 +387,16 @@ final class PillHUD {
         // one it will ever get arrives after the words land — which is after
         // the pill is on screen. Without this the answer would be found and
         // never used.
-        if let panel, panel.isVisible { morph(to: panel.frame.size) }
+        //
+        // The size comes from the state, not from `panel.frame`. That is the
+        // same answer at rest and the wrong one in the middle of a morph: an
+        // animating window reports the width it is passing through, so aiming a
+        // pill that was still growing set the width it had reached as the width
+        // to finish at. The offer stopped part way and stayed there, with the
+        // chips it could not fit clipped off. That is the ordinary case, not a
+        // rare one — an app with no caret at the press is aimed from a look
+        // that lands a few milliseconds after the offer goes up.
+        if let panel, panel.isVisible { morph(to: wantedSize) }
     }
 
     // MARK: - Coming and going
@@ -436,7 +454,7 @@ final class PillHUD {
             offerFor = nil
         }
 
-        let size = PillMetrics.panelSize(for: state, hasIcon: model.appIcon != nil)
+        let size = wantedSize
 
         if panel.isVisible {
             morph(to: size)


### PR DESCRIPTION
An offer with more than two or three chips came up with its end chips hanging outside the pill, cut off square, and often stayed that way — the capsule stopped part way through growing and the row it had to hold did not fit. Two separate causes, both in `PillHUD.swift`. Aiming the pill at the caret froze the morph at whatever width it had reached, and the pill's contents were free to draw wider than the window while it was still moving. Nothing about the offer's contents changes; this is where the surface is drawn and how wide it is counted.

Worth checking first: dictate into a terminal, which is the app that gives no caret at the press and so takes the late aim. The offer should open to its full width with every chip whole.

<details>
<summary>Why the pill stopped part way — an animating window reports the width it is passing through</summary>

`aim(at:)` re-anchored the panel with `morph(to: panel.frame.size)`. That is the right size at rest and the wrong one during a morph: `panel.frame` on a window being animated returns the interpolated frame, so a pill still growing into an offer was told to finish at whatever width it had got to. It stopped there and stayed.

This is the ordinary path, not a rare race. An app with no caret at the press is aimed from a look that runs after the words land — `AppDelegate.swift:3116` — which is a few milliseconds after the offer goes up.

`aim` now takes the size from the state, through the same `wantedSize` that `set` uses.

Measured with the four-chip offer from a real config, aim landing 60ms into the morph:

| `aim` uses | settled capsule |
|---|---|
| `panel.frame.size` | 342pt |
| the state's own size | 505pt |

</details>

<details>
<summary>Why the chips left the pill at all — a `maxWidth: .infinity` frame takes the larger of the two</summary>

The window's width is animated by AppKit and the contents are laid out by SwiftUI. `PillView` sized itself with `.frame(maxWidth: .infinity)`, which grows to the contents when the contents are wider than the proposal. So the whole surface — capsule, rim and chips — was drawn at the offer's full width inside a window still travelling up from the last state's width, and the window edge cut it off square. That is why the pill in that state has no rounded ends: what you see is a band the width of the window with the capsule's middle in it.

The contents now sit in a fixed frame the size of the window and are clipped to the capsule, so the morph reads as the pill opening with the chips arriving from under its rim. The clip is inside `parrotSurface` and the bloom, which draw outside the shape on purpose.

Traced on a real morph, offer after a notice:

    t=0.004  capsule=300   contents already 493 wide
    t=0.086  capsule=395
    t=0.186  capsule=534

With the shipped two chips the offer is narrower than the notice before it, so it shrinks and nothing ever spills. It takes a config with three or four offered transforms to see this.

</details>

<details>
<summary>Chip titles are measured now, not counted at 7.5pt a character</summary>

The flat rate is generous for ordinary lowercase words and short for capitals and digits, and the error is per chip. With the shipped two chips the counted capsule was 0.5pt clear of the row it had to hold. A config naming its transforms in capitals would have hung a chip over the end of a pill that had stopped moving — the permanent version of the same fault, with no animation involved.

`PillMetrics.title` now measures the string in the font it is set in. Two constants carry what measuring cannot: `chipFit` (2pt) for the disagreement between AppKit's measure and SwiftUI's layout, and `rowFit` (4pt) for the row coming out wider than its parts. Both checked against the drawn row over one to six chips and titles of capitals, digits, accents, `iiiiiiiiii` and `mmmmmmmmmm`. No set is short; slack runs 2–15pt. The four-chip pill is 29pt narrower than the old estimate made it.

</details>

<details>
<summary>What this does not do</summary>

The offer row still has no upper bound. Enough offered transforms and the pill will be wider than the screen; it is now clipped to its own capsule rather than spilling, but nothing wraps it to a second row or drops a chip.

</details>
