### PR TITLE
chore: keep GitHub's repository settings in settings/repo.yml

### DIFF
--- a/.github/workflows/repo-settings.yml
+++ b/.github/workflows/repo-settings.yml
@@ -1,0 +1,51 @@
+name: repo-settings
+
+# Whether GitHub's settings for this repository still match settings/repo.yml.
+# Once a week, and on demand.
+#
+# It never writes, and it could not if it wanted to. Changing repository
+# settings needs the `administration` permission, and the default GITHUB_TOKEN
+# has no such scope — `permissions:` cannot grant it either. Applying would
+# take a personal access token stored as a secret, which is a token with admin
+# on the repository sitting in CI. Writes stay on the maintainer's laptop:
+#
+#     make repo-settings          # dry run
+#     scripts/repo-settings.sh --apply
+#
+# So this job only ever reads, and drift fails the run rather than opening an
+# issue. A failed scheduled run already emails the owner, and an issue would
+# need `issues: write` plus code to find, reuse and close it — more moving
+# parts than the thing it reports.
+#
+# Private vulnerability reporting is the one setting this token cannot even
+# read. The script prints it as skipped and carries on, so it never fails the
+# run on its own.
+on:
+  schedule:
+    # Monday 07:17 UTC. Off the hour, because everything scheduled at :00 waits
+    # in the same queue.
+    - cron: "17 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # The settings file is YAML, and the script reads it with python3.
+      - name: Install pyyaml
+        run: |
+          python3 -m pip install --quiet pyyaml \
+            || python3 -m pip install --quiet --break-system-packages pyyaml
+
+      # `gh` is on the runner image already.
+      - name: Compare the live settings with settings/repo.yml
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/repo-settings.sh --check

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,15 @@ hooks:
 	@git config core.hooksPath .githooks
 	@echo "==> Commit subjects are now checked against Conventional Commits."
 
+.PHONY: repo-settings
+
+## Compare GitHub's own settings for the repository with settings/repo.yml.
+## Reads only. Writing them is `scripts/repo-settings.sh --apply`, kept out of
+## here on purpose: a target that changes the live repository is one you can
+## run by mistake.
+repo-settings:
+	@scripts/repo-settings.sh
+
 ## Rehearse the curl install against dist/. Leaves /Applications alone, but does
 ## quit a running release build — the installer will not leave two of them
 ## fighting over the hotkey.

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ Start from the question you have.
 | [architecture.md](architecture.md) | What each file is for, where the time goes, and what the app does not do. |
 | [transcription.md](transcription.md) | The speech model, its limits, and the stages that cover them. |
 | [distribution.md](distribution.md) | How the app ships, how it is signed, and how updates work. |
+| [repo-settings.md](repo-settings.md) | GitHub's own settings for the repository, kept in `settings/repo.yml` and applied from one script. |
 
 ---
 

--- a/docs/repo-settings.md
+++ b/docs/repo-settings.md
@@ -1,0 +1,61 @@
+# The repository's own settings
+
+GitHub's settings for this repository are in
+[`settings/repo.yml`](../settings/repo.yml): the description, the topics, which
+merge buttons exist, the labels, private vulnerability reporting. The file is
+the record. The live repository is meant to match it.
+
+Change one in the browser and the file is wrong. Change the file and nothing
+happens until someone applies it. So do it in this order.
+
+```sh
+$EDITOR settings/repo.yml
+make repo-settings                  # dry run: prints what would change
+scripts/repo-settings.sh --apply    # writes it
+```
+
+The dry run is the default everywhere. `--apply` is the only way the script
+writes anything.
+
+Needs the [`gh`](https://cli.github.com) CLI, logged in as someone with admin
+on the repository. A token without admin can still read most of it — the
+script prints what it cannot read as skipped and carries on.
+
+## Why a file and not the Settings page
+
+Two settings there are load-bearing, and both are invisible once set.
+
+**`squash_merge_commit_title: COMMIT_OR_PR_TITLE`** is what makes
+`.githooks/commit-msg` worth running. A single-commit pull request squashes to
+that commit's subject, which the hook already checked. Switch it to
+`PR_TITLE` and every squash takes the title instead, so the hook stops
+protecting anything. The comment at the top of
+[`.github/workflows/pr-title.yml`](../.github/workflows/pr-title.yml) is the
+long version.
+
+**`web_commit_signoff_required: true`** puts a `Signed-off-by` line on commits
+made through the web UI. Without it, the DCO check in
+`.github/workflows/dco.yml` fails any pull request that contains one.
+
+Neither shows up in a diff when someone flips it. The weekly check is what
+notices.
+
+## The weekly check
+
+[`.github/workflows/repo-settings.yml`](../.github/workflows/repo-settings.yml)
+runs `scripts/repo-settings.sh --check` every Monday, and on demand from the
+Actions tab. Drift fails the run.
+
+It never applies. Changing settings needs the `administration` permission, and
+the default `GITHUB_TOKEN` does not have it — that would take a personal access
+token with admin on the repository stored as a secret. Writes stay on the
+maintainer's laptop.
+
+## What the file does not cover
+
+| | |
+|---|---|
+| `homepage` | Empty on purpose. There is no site. The owner sets it in Settings → General when there is one. |
+| Discussion categories | **No API can create one.** Not REST, not GraphQL — there is no mutation for it. `has_discussions: true` turns Discussions on; the categories are made by hand in Settings → Discussions. |
+| Branch protection, Actions permissions, secrets | Untouched. The script only reads and writes what the file names. |
+| Deleting a label | Never. A label the file no longer names is left alone and reported, because deleting one strips it from every issue that carries it. |

--- a/scripts/repo-settings.sh
+++ b/scripts/repo-settings.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+# Whether GitHub's settings for this repository still match settings/repo.yml.
+#
+#   scripts/repo-settings.sh              # dry run: print the drift, write nothing
+#   scripts/repo-settings.sh --check      # the same, and exit 1 if anything differs
+#   scripts/repo-settings.sh --apply      # write the intended state, then re-read it
+#   scripts/repo-settings.sh --repo o/n   # act on another repository
+#
+# Dry run is the default, and --apply is the only way this writes anything. The
+# order matters more than it looks: settings/repo.yml is edited far more often
+# than it is applied, and a script that writes by default turns a typo into a
+# live repository change before anyone has read the diff.
+#
+# Exit codes:
+#   0  no drift, or drift printed by a dry run
+#   1  --check found drift, or --apply could not write something
+#
+# A setting this token cannot read or write is printed as a skip and the run
+# carries on. That is the normal case in CI: the default GITHUB_TOKEN has no
+# `administration` permission, so private vulnerability reporting reads 403.
+#
+# Needs `gh`, logged in as someone with admin on the repository, and python3
+# with pyyaml — the same pair the check scripts already use.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SETTINGS="$ROOT/settings/repo.yml"
+
+MODE=dry
+REPO=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --apply) MODE=apply ;;
+    --check) MODE=check ;;
+    --repo)  REPO="${2:-}"; shift ;;
+    -h|--help) sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+[ -f "$SETTINGS" ] || { echo "not found: $SETTINGS" >&2; exit 1; }
+command -v gh >/dev/null || { echo "gh is not installed: https://cli.github.com" >&2; exit 1; }
+command -v python3 >/dev/null || { echo "python3 is not installed" >&2; exit 1; }
+
+if [ -z "$REPO" ]; then
+  REPO="${GITHUB_REPOSITORY:-}"
+fi
+if [ -z "$REPO" ]; then
+  REPO="$(git -C "$ROOT" config --get remote.origin.url 2>/dev/null \
+          | sed -e 's#^git@github.com:#https://github.com/#' \
+                -e 's#^https://github.com/##' -e 's#\.git$##')"
+fi
+[ -n "$REPO" ] || { echo "cannot tell which repository this is; pass --repo owner/name" >&2; exit 1; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# The intended state, flattened to one line per thing. Tab separated, because a
+# label description has spaces in it and a topic never has a tab.
+python3 -c '
+import sys, yaml
+s = yaml.safe_load(open(sys.argv[1]))
+for k, v in (s.get("repository") or {}).items():
+    kind = "bool" if isinstance(v, bool) else "str"
+    print("\t".join(["repo", k, kind, ("true" if v else "false") if kind == "bool" else str(v)]))
+for t in s.get("topics") or []:
+    print("topic\t" + t)
+pvr = s.get("private_vulnerability_reporting")
+if pvr is not None:
+    print("pvr\t" + ("true" if pvr else "false"))
+for l in s.get("labels") or []:
+    print("\t".join(["label", l["name"], str(l["color"]).lstrip("#").lower(),
+                     l.get("description", "")]))
+' "$SETTINGS" > "$TMP/plan.tsv" || { echo "cannot read $SETTINGS" >&2; exit 1; }
+
+awk -F'\t' '$1=="repo"'          "$TMP/plan.tsv" > "$TMP/want-repo.tsv"
+awk -F'\t' '$1=="topic"{print $2}' "$TMP/plan.tsv" | sort > "$TMP/want-topics.txt"
+awk -F'\t' '$1=="label"'         "$TMP/plan.tsv" > "$TMP/want-labels.tsv"
+WANT_PVR="$(awk -F'\t' '$1=="pvr"{print $2}' "$TMP/plan.tsv")"
+
+drift=0; skipped=0; failed=0
+
+say_same()    { printf '  ✓ %-30s %s\n' "$1" "$2"; }
+say_differs() { drift=$((drift + 1)); printf '  ✗ %-30s %s → %s\n' "$1" "$2" "$3"; }
+say_skipped() { skipped=$((skipped + 1)); printf '  ⚠ %-30s skipped: %s\n' "$1" "$2"; }
+
+# Lines on stdin as one space separated line.
+oneline() { tr '\n' ' ' | sed 's/ *$//'; }
+
+# api <outfile> <gh api arguments…> — never aborts the run. On failure the
+# caller decides whether that is a skip or a failure to write.
+api() {
+  local out="$1"; shift
+  if gh api "$@" > "$out" 2> "$TMP/err"; then
+    return 0
+  fi
+  API_ERROR="$(grep -v '^$' "$TMP/err" | head -1)"
+  [ -n "$API_ERROR" ] || API_ERROR="gh api failed"
+  return 1
+}
+
+# The value of one key in a tab separated file.
+field_of() { awk -F'\t' -v k="$2" '$1==k {sub(/^[^\t]*\t/, ""); print; exit}' "$1"; }
+
+# ---------------------------------------------------------------- repository
+
+check_repository() {
+  printf '\n==> Repository\n'
+  if ! api "$TMP/repo.json" "repos/$REPO"; then
+    say_skipped "repository" "$API_ERROR"
+    return
+  fi
+  python3 -c '
+import json, sys
+d = json.load(open(sys.argv[1]))
+for k, v in d.items():
+    if isinstance(v, bool): v = "true" if v else "false"
+    elif v is None: v = ""
+    elif isinstance(v, (int, float, str)): v = str(v)
+    else: continue
+    print(k + "\t" + v.replace("\t", " ").replace("\n", " "))
+' "$TMP/repo.json" > "$TMP/live-repo.tsv"
+
+  : > "$TMP/changes.tsv"
+  local key kind want live
+  while IFS=$'\t' read -r _ key kind want; do
+    live="$(field_of "$TMP/live-repo.tsv" "$key")"
+    if [ "$live" = "$want" ]; then
+      say_same "$key" "$want"
+    else
+      say_differs "$key" "${live:-(unset)}" "$want"
+      printf '%s\t%s\t%s\n' "$key" "$kind" "$want" >> "$TMP/changes.tsv"
+    fi
+  done < "$TMP/want-repo.tsv"
+
+  [ "$MODE" = apply ] || return
+  [ -s "$TMP/changes.tsv" ] || return
+
+  python3 -c '
+import json, sys
+body = {}
+for line in open(sys.argv[1]):
+    k, kind, v = line.rstrip("\n").split("\t", 2)
+    body[k] = (v == "true") if kind == "bool" else v
+print(json.dumps(body))
+' "$TMP/changes.tsv" > "$TMP/body.json"
+
+  if api "$TMP/patched.json" --method PATCH "repos/$REPO" --input "$TMP/body.json"; then
+    printf '  → patched %s\n' "$(cut -f1 "$TMP/changes.tsv" | oneline)"
+  else
+    failed=$((failed + 1))
+    printf '  ⚠ could not patch the repository: %s\n' "$API_ERROR"
+  fi
+}
+
+# -------------------------------------------------------------------- topics
+
+check_topics() {
+  printf '\n==> Topics\n'
+  if ! api "$TMP/topics.json" "repos/$REPO/topics"; then
+    say_skipped "topics" "$API_ERROR"
+    return
+  fi
+  python3 -c '
+import json, sys
+for t in json.load(open(sys.argv[1]))["names"]: print(t)
+' "$TMP/topics.json" | sort > "$TMP/live-topics.txt"
+
+  local missing extra
+  missing="$(comm -23 "$TMP/want-topics.txt" "$TMP/live-topics.txt" | oneline)"
+  extra="$(comm -13 "$TMP/want-topics.txt" "$TMP/live-topics.txt" | oneline)"
+
+  if [ -z "$missing" ] && [ -z "$extra" ]; then
+    say_same "topics" "$(oneline < "$TMP/want-topics.txt")"
+    return
+  fi
+  drift=$((drift + 1))
+  [ -n "$missing" ] && printf '  ✗ %-30s missing: %s\n' "topics" "$missing"
+  # PUT replaces the whole list, so anything live and not in the file goes.
+  [ -n "$extra" ] && printf '  ✗ %-30s would be removed: %s\n' "topics" "$extra"
+
+  [ "$MODE" = apply ] || return
+  python3 -c '
+import json, sys
+print(json.dumps({"names": [l.strip() for l in open(sys.argv[1]) if l.strip()]}))
+' "$TMP/want-topics.txt" > "$TMP/topics-body.json"
+  if api "$TMP/topics-out.json" --method PUT "repos/$REPO/topics" --input "$TMP/topics-body.json"; then
+    printf '  → topics replaced\n'
+  else
+    failed=$((failed + 1))
+    printf '  ⚠ could not replace the topics: %s\n' "$API_ERROR"
+  fi
+}
+
+# ------------------------------------------ private vulnerability reporting
+
+check_pvr() {
+  [ -n "$WANT_PVR" ] || return 0
+  printf '\n==> Private vulnerability reporting\n'
+  # Reading this needs admin. A token without it is the normal CI case.
+  if ! api "$TMP/pvr.json" "repos/$REPO/private-vulnerability-reporting"; then
+    say_skipped "private_vulnerability_reporting" "$API_ERROR"
+    return
+  fi
+  local live
+  live="$(python3 -c '
+import json, sys
+print("true" if json.load(open(sys.argv[1]))["enabled"] else "false")
+' "$TMP/pvr.json")"
+
+  if [ "$live" = "$WANT_PVR" ]; then
+    say_same "private_vulnerability_reporting" "$live"
+    return
+  fi
+  say_differs "private_vulnerability_reporting" "$live" "$WANT_PVR"
+
+  [ "$MODE" = apply ] || return
+  local method=PUT
+  [ "$WANT_PVR" = true ] || method=DELETE
+  if api "$TMP/pvr-out" --method "$method" "repos/$REPO/private-vulnerability-reporting"; then
+    printf '  → %s\n' "$([ "$WANT_PVR" = true ] && echo enabled || echo disabled)"
+  else
+    failed=$((failed + 1))
+    printf '  ⚠ could not change it: %s\n' "$API_ERROR"
+  fi
+}
+
+# -------------------------------------------------------------------- labels
+
+check_labels() {
+  printf '\n==> Labels\n'
+  if ! api "$TMP/labels.json" --paginate "repos/$REPO/labels"; then
+    say_skipped "labels" "$API_ERROR"
+    return
+  fi
+  # --paginate concatenates one array per page, so read them as a stream.
+  python3 -c '
+import json, sys
+dec = json.JSONDecoder()
+text = open(sys.argv[1]).read().strip()
+i = 0
+while i < len(text):
+    page, end = dec.raw_decode(text, i)
+    for l in page:
+        print("\t".join([l["name"], (l.get("color") or "").lower(),
+                         (l.get("description") or "").replace("\t", " ")]))
+    i = end
+    while i < len(text) and text[i].isspace(): i += 1
+' "$TMP/labels.json" > "$TMP/live-labels.tsv"
+
+  local name color desc live live_color live_desc
+  while IFS=$'\t' read -r _ name color desc; do
+    live="$(awk -F'\t' -v k="$name" '$1==k {print; exit}' "$TMP/live-labels.tsv")"
+    if [ -z "$live" ]; then
+      drift=$((drift + 1))
+      printf '  ✗ %-30s missing\n' "$name"
+      [ "$MODE" = apply ] || continue
+      if api "$TMP/label-out.json" --method POST "repos/$REPO/labels" \
+           -f "name=$name" -f "color=$color" -f "description=$desc"; then
+        printf '  → created\n'
+      else
+        failed=$((failed + 1))
+        printf '  ⚠ could not create %s: %s\n' "$name" "$API_ERROR"
+      fi
+      continue
+    fi
+
+    live_color="$(printf '%s' "$live" | cut -f2)"
+    live_desc="$(printf '%s' "$live" | cut -f3)"
+    if [ "$live_color" = "$color" ] && [ "$live_desc" = "$desc" ]; then
+      say_same "$name" "#$color"
+      continue
+    fi
+    drift=$((drift + 1))
+    [ "$live_color" = "$color" ] || printf '  ✗ %-30s #%s → #%s\n' "$name" "$live_color" "$color"
+    [ "$live_desc" = "$desc" ]   || printf '  ✗ %-30s "%s" → "%s"\n' "$name" "$live_desc" "$desc"
+
+    [ "$MODE" = apply ] || continue
+    local path
+    path="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$name")"
+    if api "$TMP/label-out.json" --method PATCH "repos/$REPO/labels/$path" \
+         -f "color=$color" -f "description=$desc"; then
+      printf '  → updated\n'
+    else
+      failed=$((failed + 1))
+      printf '  ⚠ could not update %s: %s\n' "$name" "$API_ERROR"
+    fi
+  done < "$TMP/want-labels.tsv"
+
+  # Nothing is deleted here. A label removed from this file stays on the
+  # repository, because deleting one strips it from every issue that carries it.
+  local unlisted
+  cut -f1 "$TMP/live-labels.tsv" | sort > "$TMP/live-names.txt"
+  cut -f2 "$TMP/want-labels.tsv" | sort > "$TMP/want-names.txt"
+  unlisted="$(comm -13 "$TMP/want-names.txt" "$TMP/live-names.txt" | oneline)"
+  [ -n "$unlisted" ] && printf '    not in settings/repo.yml, left alone: %s\n' "$unlisted"
+  return 0
+}
+
+run_pass() {
+  drift=0; skipped=0
+  check_repository
+  check_topics
+  check_pvr
+  check_labels
+}
+
+printf '==> %s   (%s)\n' "$REPO" \
+  "$([ "$MODE" = apply ] && echo "applying settings/repo.yml" || echo "reading only, nothing is written")"
+run_pass
+
+if [ "$MODE" = apply ]; then
+  # Read it all back. This is the half that catches a field the API accepted
+  # and did not store, and it is what makes a second run a no-op.
+  printf '\n==> Reading it back\n'
+  MODE=verify
+  run_pass
+  printf '\n'
+  if [ "$drift" -gt 0 ]; then
+    printf '  %d setting(s) still differ after applying. Check them by hand in\n' "$drift"
+    printf '  Settings → General: the API accepts some fields it does not store.\n'
+  fi
+  [ "$skipped" -gt 0 ] && printf '  %d skipped — the token could not read them.\n' "$skipped"
+  if [ "$failed" -gt 0 ]; then
+    printf '  %d write(s) failed.\n' "$failed"
+    exit 1
+  fi
+  printf '  Done.\n'
+  exit 0
+fi
+
+printf '\n'
+if [ "$drift" -eq 0 ]; then
+  printf '  Everything matches settings/repo.yml.\n'
+else
+  printf '  %d setting(s) differ. Apply them with:\n\n      scripts/repo-settings.sh --apply\n' "$drift"
+fi
+[ "$skipped" -gt 0 ] && printf '  %d skipped — this token cannot read them. Not counted as drift.\n' "$skipped"
+
+[ "$MODE" = check ] && [ "$drift" -gt 0 ] && exit 1
+exit 0

--- a/scripts/repo-settings.sh
+++ b/scripts/repo-settings.sh
@@ -13,7 +13,9 @@
 #
 # Exit codes:
 #   0  no drift, or drift printed by a dry run
-#   1  --check found drift, or --apply could not write something
+#   1  --check found drift, or --apply could not write something, or --apply
+#      left drift behind — a write the API accepted and did not store reads
+#      back unchanged, and that has to be louder than a line of output
 #
 # A setting this token cannot read or write is printed as a skip and the run
 # carries on. That is the normal case in CI: the default GITHUB_TOKEN has no
@@ -248,9 +250,12 @@ while i < len(text):
     while i < len(text) and text[i].isspace(): i += 1
 ' "$TMP/labels.json" > "$TMP/live-labels.tsv"
 
-  local name color desc live live_color live_desc
+  # GitHub treats label names case-insensitively, so `bug` and `Bug` are the
+  # same label and creating the second one is a 422. Match that: find it
+  # regardless of case, then rename it to the case this file names.
+  local name color desc live live_name live_color live_desc
   while IFS=$'\t' read -r _ name color desc; do
-    live="$(awk -F'\t' -v k="$name" '$1==k {print; exit}' "$TMP/live-labels.tsv")"
+    live="$(awk -F'\t' -v k="$name" 'BEGIN{k=tolower(k)} tolower($1)==k {print; exit}' "$TMP/live-labels.tsv")"
     if [ -z "$live" ]; then
       drift=$((drift + 1))
       printf '  ✗ %-30s missing\n' "$name"
@@ -265,21 +270,25 @@ while i < len(text):
       continue
     fi
 
+    live_name="$(printf '%s' "$live" | cut -f1)"
     live_color="$(printf '%s' "$live" | cut -f2)"
     live_desc="$(printf '%s' "$live" | cut -f3)"
-    if [ "$live_color" = "$color" ] && [ "$live_desc" = "$desc" ]; then
+    if [ "$live_name" = "$name" ] && [ "$live_color" = "$color" ] && [ "$live_desc" = "$desc" ]; then
       say_same "$name" "#$color"
       continue
     fi
     drift=$((drift + 1))
+    [ "$live_name" = "$name" ]  || printf '  ✗ %-30s named "%s"\n' "$name" "$live_name"
     [ "$live_color" = "$color" ] || printf '  ✗ %-30s #%s → #%s\n' "$name" "$live_color" "$color"
     [ "$live_desc" = "$desc" ]   || printf '  ✗ %-30s "%s" → "%s"\n' "$name" "$live_desc" "$desc"
 
     [ "$MODE" = apply ] || continue
+    # Addressed by the name the repository has, renamed to the one this file
+    # has. new_name is a no-op when the two already agree.
     local path
-    path="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$name")"
+    path="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$live_name")"
     if api "$TMP/label-out.json" --method PATCH "repos/$REPO/labels/$path" \
-         -f "color=$color" -f "description=$desc"; then
+         -f "new_name=$name" -f "color=$color" -f "description=$desc"; then
       printf '  → updated\n'
     else
       failed=$((failed + 1))
@@ -290,8 +299,8 @@ while i < len(text):
   # Nothing is deleted here. A label removed from this file stays on the
   # repository, because deleting one strips it from every issue that carries it.
   local unlisted
-  cut -f1 "$TMP/live-labels.tsv" | sort > "$TMP/live-names.txt"
-  cut -f2 "$TMP/want-labels.tsv" | sort > "$TMP/want-names.txt"
+  cut -f1 "$TMP/live-labels.tsv" | tr '[:upper:]' '[:lower:]' | sort > "$TMP/live-names.txt"
+  cut -f2 "$TMP/want-labels.tsv" | tr '[:upper:]' '[:lower:]' | sort > "$TMP/want-names.txt"
   unlisted="$(comm -13 "$TMP/want-names.txt" "$TMP/live-names.txt" | oneline)"
   [ -n "$unlisted" ] && printf '    not in settings/repo.yml, left alone: %s\n' "$unlisted"
   return 0
@@ -321,8 +330,11 @@ if [ "$MODE" = apply ]; then
     printf '  Settings → General: the API accepts some fields it does not store.\n'
   fi
   [ "$skipped" -gt 0 ] && printf '  %d skipped — the token could not read them.\n' "$skipped"
-  if [ "$failed" -gt 0 ]; then
-    printf '  %d write(s) failed.\n' "$failed"
+  [ "$failed" -gt 0 ] && printf '  %d write(s) failed.\n' "$failed"
+  # Drift after the read-back is a failure, not a note. Exiting 0 there tells
+  # a scheduled run, and the person reading the last line, that a setting was
+  # applied when the repository says otherwise.
+  if [ "$drift" -gt 0 ] || [ "$failed" -gt 0 ]; then
     exit 1
   fi
   printf '  Done.\n'

--- a/scripts/repo-settings.sh
+++ b/scripts/repo-settings.sh
@@ -329,12 +329,13 @@ if [ "$MODE" = apply ]; then
     printf '  %d setting(s) still differ after applying. Check them by hand in\n' "$drift"
     printf '  Settings → General: the API accepts some fields it does not store.\n'
   fi
-  [ "$skipped" -gt 0 ] && printf '  %d skipped — the token could not read them.\n' "$skipped"
+  [ "$skipped" -gt 0 ] && printf '  %d skipped — could not read them back to confirm the write held.\n' "$skipped"
   [ "$failed" -gt 0 ] && printf '  %d write(s) failed.\n' "$failed"
-  # Drift after the read-back is a failure, not a note. Exiting 0 there tells
-  # a scheduled run, and the person reading the last line, that a setting was
-  # applied when the repository says otherwise.
-  if [ "$drift" -gt 0 ] || [ "$failed" -gt 0 ]; then
+  # Drift, a failed write, or a read-back that could not even be attempted are
+  # all a failure, not a note. Exiting 0 for any of them tells a scheduled run,
+  # and the person reading the last line, that a setting was confirmed applied
+  # when it was not.
+  if [ "$drift" -gt 0 ] || [ "$failed" -gt 0 ] || [ "$skipped" -gt 0 ]; then
     exit 1
   fi
   printf '  Done.\n'

--- a/settings/repo.yml
+++ b/settings/repo.yml
@@ -1,0 +1,152 @@
+# What GitHub's own settings for znat/parrotflow are supposed to be.
+#
+# This file is the record. `scripts/repo-settings.sh` reads it and compares it
+# with the live repository; `--apply` writes it back. Change a value here first,
+# then apply — a setting changed in the browser and not here is drift, and the
+# weekly check in .github/workflows/repo-settings.yml will say so.
+#
+# Most values below already match the live repository, so the first `--apply`
+# is close to a no-op. Three do not, on purpose: has_wiki, has_projects and
+# web_commit_signoff_required. Each says why underneath. Run the dry run first
+# and read them before applying.
+#
+# Only what is listed here is managed. Branch protection, Actions permissions
+# and secrets are untouched.
+
+repository:
+  # The live description, kept word for word — it is the README's one-liner
+  # trimmed, and the owner wrote it. Two places say what this app is, so change
+  # them together.
+  description: Local, fast and programmable dictation app
+
+  # Deliberately empty. There is no site yet. The owner sets this in
+  # Settings → General when there is one; do not invent a URL here.
+  homepage: ""
+
+  has_issues: true
+
+  # Already on — the owner enabled it. Recorded so it stays on.
+  #
+  # The issue templates send anything open-ended here: pipeline design, sharing
+  # a config, "how do I write this transform". See
+  # .github/ISSUE_TEMPLATE/config.yml, which links to /discussions.
+  #
+  # Discussion CATEGORIES cannot be created by any API — not REST, not GraphQL.
+  # There is no mutation for it. The owner creates them once, by hand, in
+  # Settings → Discussions. Nothing here can do it, so do not go looking.
+  has_discussions: true
+
+  # CHANGES THE LIVE SETTING: both are on today.
+  #
+  # The documentation is in docs/, in the same commit as the code it describes.
+  # A wiki is a second copy that drifts and no pull request touches. Turning it
+  # off hides the wiki; it does not delete it, and turning it back on returns
+  # whatever was there.
+  has_wiki: false
+  has_projects: false
+
+  # Squash only, and this is load-bearing rather than taste. release-please
+  # computes the version and the changelog from the commit subjects on main.
+  # One pull request has to arrive as one subject it can read. A merge commit
+  # or a rebase merge puts every branch commit on main, including the "wip"
+  # ones, and the changelog is then whatever was typed at 2am.
+  allow_squash_merge: true
+  allow_merge_commit: false
+  allow_rebase_merge: false
+
+  # COMMIT_OR_PR_TITLE is the whole reason .githooks/commit-msg is worth
+  # running. Read the comment at the top of .github/workflows/pr-title.yml: a
+  # single-commit pull request squashes to that commit's subject, which the
+  # hook already checked on the contributor's machine, and only the
+  # multi-commit case falls through to the workflow. Set this to PR_TITLE and
+  # the hook protects nothing — every squash takes the title instead, and the
+  # one check that runs before a commit exists stops mattering.
+  squash_merge_commit_title: COMMIT_OR_PR_TITLE
+
+  # The pull request body becomes the commit body. The alternative,
+  # COMMIT_MESSAGES, concatenates every commit on the branch.
+  squash_merge_commit_message: PR_BODY
+
+  # The branch is merged and gone; nothing reads it again.
+  delete_branch_on_merge: true
+
+  # Offers the "Update branch" button, so a stale branch can be brought up to
+  # main without a local checkout.
+  allow_update_branch: true
+
+  # Auto-merge off: one maintainer, who is the person clicking merge anyway.
+  allow_auto_merge: false
+
+  # CHANGES THE LIVE SETTING: off today.
+  #
+  # Makes GitHub add a Signed-off-by line to commits made through the web UI —
+  # editing a file on github.com, or the "Commit suggestion" button in a
+  # review. Without it those commits carry none and
+  # .github/workflows/dco.yml fails the pull request they land in.
+  web_commit_signoff_required: true
+
+# `PUT /repos/{owner}/{repo}/topics` REPLACES the whole list. This is the whole
+# list: a topic dropped from here is dropped from the repository on the next
+# apply.
+#
+# The first seven are live today and four of them are search terms rather than
+# description — someone looking for a way off Wispr Flow types those words.
+# Keep them. Lowercase, hyphens, 20 at most; GitHub rejects anything else.
+topics:
+  - dictation
+  - macos
+  - parakeet
+  - speech-to-text
+  - whisper
+  - wispr-flow
+  - wispr-flow-alternative
+  # Added: what the app is and what it runs on.
+  - swift
+  - voice-typing
+  - local-first
+  - ollama
+
+# SECURITY.md sends people to the advisory form. That form only exists when
+# this is on, so the link in SECURITY.md is dead without it.
+private_vulnerability_reporting: true
+
+# The issue templates apply `bug` and `question` — see the `labels:` line in
+# .github/ISSUE_TEMPLATE/bug.yml and question.yml. A template that applies a
+# label the repository does not have opens the issue with no label at all.
+#
+# The script creates a label that is missing and corrects the colour or the
+# description of one that exists. It never deletes a label this file does not
+# name: deleting a label strips it from every issue that carries it, and that
+# cannot be undone.
+labels:
+  - name: bug
+    color: d73a4a
+    description: A crash, a permission that fails, text that lands wrong.
+
+  - name: question
+    color: d876e3
+    description: Documented behaviour is unclear or looks wrong.
+
+  # The name has to be exactly "good first issue", spaces and all. GitHub's
+  # contribute page (/znat/parrotflow/contribute) and the "good first issues"
+  # search both match that literal string. "good-first-issue" is invisible to
+  # both.
+  #
+  # The description is the promise. An issue only gets this label if it names
+  # the file and the check to run, and if the answer is not "read the whole
+  # pipeline first".
+  - name: good first issue
+    color: 7057ff
+    description: Small, self-contained, names the file to change and the check to run.
+
+  - name: help wanted
+    color: 008672
+    description: The maintainer is not getting to this. Worth picking up.
+
+  - name: documentation
+    color: 0075ca
+    description: docs/, README, or a comment that says something untrue.
+
+  - name: enhancement
+    color: a2eeef
+    description: A capability that is not there yet.


### PR DESCRIPTION
The repository's own settings — description, topics, merge buttons, labels, private vulnerability reporting — now have a file that records them and says why each value is what it is: `settings/repo.yml`. `scripts/repo-settings.sh` compares that file with the live repository and, only with `--apply`, writes it back; the dry run is the default and `make repo-settings` runs it. A weekly workflow runs `--check` and fails on drift. Nothing changes on the live repository by merging this: the workflow only reads, and applying is a command the owner runs on their own laptop with `gh`.

Two values in the file are load-bearing and invisible in any diff when someone flips them. `squash_merge_commit_title: COMMIT_OR_PR_TITLE` is what makes `.githooks/commit-msg` worth running — see the comment at the top of `.github/workflows/pr-title.yml`. `web_commit_signoff_required: true` puts a `Signed-off-by` on commits made in the browser, which the DCO check needs.

Check three things first: the settings that differ from live on purpose, the topics list (a `PUT` replaces all of it), and the honest wording on the `good first issue` label.

<details>
<summary>Three settings differ from the live repository on purpose — the rest already match</summary>

| Setting | Live today | In the file | Why |
|---|---|---|---|
| `has_wiki` | `true` | `false` | The docs are in `docs/`, in the same commit as the code. A wiki is a second copy that drifts and no pull request touches. Turning it off hides a wiki, it does not delete it. |
| `has_projects` | `true` | `false` | Unused. |
| `web_commit_signoff_required` | `false` | `true` | A commit made through the web UI otherwise carries no `Signed-off-by`, and the DCO check fails the pull request it lands in. |

Everything else in `repository:` matches what the API reports today, so the first `--apply` is close to a no-op. The dry run prints all of this before anything is written.

The description is kept word for word as it is live (`Local, fast and programmable dictation app`) rather than replaced with the longer README line, so applying does not quietly rewrite something the owner wrote.

`topics:` keeps all seven live topics — including `whisper`, `wispr-flow` and `wispr-flow-alternative`, which are search terms — and adds `swift`, `voice-typing`, `local-first` and `ollama`. `PUT /repos/{owner}/{repo}/topics` replaces the whole list, so a topic dropped from the file is dropped from the repository. The file says that where the list is.

</details>

<details>
<summary>What could not be verified: docs.github.com is blocked here, and the script was never run against the real API</summary>

**The script has not been run against GitHub.** There is no `gh` CLI in this environment and no admin token. What was run:

- `bash -n` — clean.
- `shellcheck` 0.11.0 — clean, no warnings.
- Every YAML file parsed with python3 + pyyaml.
- The whole script end to end against a stub `gh` that serves canned JSON and applies writes to it. That covers: dry run writes nothing; `--check` exits 1 on drift and 0 when clean; `--apply` issues one `PATCH`, one `PUT /topics`, one label `PATCH` and four label `POST`s, then reads everything back; a second `--apply` issues zero writes; a 403 on private vulnerability reporting prints a skip line and does not abort or count as drift.

**`docs.github.com` is blocked by the egress proxy.** Instead of guessing, the endpoints and field names were checked against `github/rest-api-description` (`descriptions/api.github.com/dereferenced/api.github.com.deref.json`, `main`) — the machine-readable description that page is generated from. Confirmed there:

| Endpoint | Confirmed |
|---|---|
| `PATCH /repos/{owner}/{repo}` | `description`, `homepage`, `has_issues`, `has_wiki`, `has_projects`, `allow_squash_merge`, `allow_merge_commit`, `allow_rebase_merge`, `allow_auto_merge`, `delete_branch_on_merge`, `allow_update_branch`, `web_commit_signoff_required`, `squash_merge_commit_title` (`PR_TITLE` \| `COMMIT_OR_PR_TITLE`), `squash_merge_commit_message` (`PR_BODY` \| `COMMIT_MESSAGES` \| `BLANK`) |
| `PUT /repos/{owner}/{repo}/topics` | body `{"names": [...]}`, `names` required |
| `GET`/`PUT`/`DELETE /repos/{owner}/{repo}/private-vulnerability-reporting` | `GET` returns `{"enabled": bool}`; `PUT` and `DELETE` return 204 |
| `GET`/`POST /repos/{owner}/{repo}/labels`, `PATCH /repos/{owner}/{repo}/labels/{name}` | `name`, `color`, `description`; `new_name` on the update |

**One field is not confirmed: `has_discussions` on `PATCH /repos/{owner}/{repo}`.** It is in that description's `POST /user/repos` body and in the `GET` repository response, but not in the `PATCH` body schema. It is widely used and believed to work, and it could not be checked against the rendered docs. It costs nothing here: Discussions is already on, so the file only records it and the script has nothing to write. If a future `PATCH` did ignore the field, the read-back pass after `--apply` prints it as still differing rather than reporting success.

**Assumed, not checked:** `gh` is preinstalled on the `ubuntu-latest` runner image.

</details>

<details>
<summary>Only the owner can do these, and no API can do them for him</summary>

- **Run `scripts/repo-settings.sh --apply` once**, from a machine logged in to `gh` with admin on the repository. Until then the weekly check is red — that is it doing its job, not a bug.
- **`homepage` is empty on purpose.** No URL was invented. Settings → General, when there is a site.
- **Discussion categories cannot be created by any API** — not REST, not GraphQL; there is no mutation for it. `has_discussions: true` turns Discussions on and that is all any script can do. The categories are made by hand in Settings → Discussions. This is said in `settings/repo.yml` and in `docs/repo-settings.md` so nobody goes hunting for the endpoint.
- **Nothing is ever deleted.** A label the file no longer names is left alone and reported. Deleting a label strips it from every issue that carries it, and that cannot be undone.

</details>

<details>
<summary>Why drift fails the run instead of opening an issue</summary>

Both were on the table. Failing the run won because the job stays read-only: `permissions: contents: read`, no `issues: write`, and no code to find, reuse and close a tracking issue. A failed scheduled run already emails the owner. An issue would add three states to get right — open it, update it rather than open a second, close it when the drift is gone — for a repository with one maintainer who is also the only person who can fix the drift.

The job also cannot apply, by design. Changing repository settings needs the `administration` permission, and the default `GITHUB_TOKEN` cannot be granted it through `permissions:`. Applying from CI would mean storing a personal access token with admin on the repository as a secret. Writes stay on the maintainer's laptop. The workflow comment says this.

Private vulnerability reporting is the one setting the CI token cannot even read. It is printed as skipped and never fails the run on its own.

</details>

<details>
<summary>Review notes — where to start, and the overlap with the community-files branch</summary>

Read in this order: `settings/repo.yml` (it is the document — every non-obvious value has its reason under it), then `docs/repo-settings.md`, then the script.

The script is bash 3.2 compatible for macOS: no associative arrays, no `mapfile`, `set -uo pipefail` without `-e` so one failing API call cannot abort the run. It uses python3 with pyyaml to read the YAML and to shape JSON bodies, the same pair `scripts/check-*.sh` and `.github/workflows/checks.yml` already depend on.

`.PHONY: repo-settings` is on its own line rather than added to the block at the top of the Makefile. That is to avoid a textual conflict with the community-files branch, which edits that same line.

This branch is off `main` and does not touch `claude/github-promotion-plan-oscfvk`. It does refer to files that land there: `.github/workflows/dco.yml`, `.github/ISSUE_TEMPLATE/bug.yml` and `question.yml`, and `SECURITY.md`. Nothing breaks if this merges first — the references are in comments and prose, and the two links in `docs/repo-settings.md` point only at files already on `main`. The reasons simply read better once the other branch has merged.

</details>


---
_Generated by [Claude Code](https://claude.ai/code/session_01VRx4928MLWKGD7jPkgjSYL)_