### PR TITLE
docs: community files, a DCO check and a make test target

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,75 @@
+name: Something is broken
+description: A crash, a permission that fails, a dictation that never lands, a rewrite that mangles text.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Two commands answer most of this form. Run them and paste the output —
+        it is faster than a description, and it says what the app really uses.
+
+        ```sh
+        PF=/Applications/ParrotFlow.app/Contents/MacOS/ParrotFlow
+        $PF --check-config
+        tail -50 ~/Library/Logs/ParrotFlow.log
+        ```
+
+  - type: textarea
+    id: what-happens
+    attributes:
+      label: What happens
+      description: What you did, what you expected, what you got. If it is about text, give the sentence you said and the text that landed.
+      placeholder: |
+        I said "let's ship the P one today" in Slack.
+        Expected: let's ship the P1 today
+        Got: nothing was pasted.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: "`defaults read /Applications/ParrotFlow.app/Contents/Info.plist CFBundleShortVersionString`"
+      placeholder: "0.9.0"
+    validations:
+      required: true
+
+  - type: input
+    id: macos
+    attributes:
+      label: macOS and Mac
+      placeholder: "macOS 15.5, M2 Pro"
+    validations:
+      required: true
+
+  - type: input
+    id: app
+    attributes:
+      label: Which app you were dictating into
+      description: Pipelines and transforms can be gated per app, so this often decides which stages ran.
+      placeholder: "Slack, Terminal, Cursor…"
+
+  - type: textarea
+    id: check-config
+    attributes:
+      label: "`--check-config`"
+      description: The whole output. It names the pipeline, every transform and every resolved path.
+      render: text
+
+  - type: textarea
+    id: log
+    attributes:
+      label: Log
+      description: "`tail -50 ~/Library/Logs/ParrotFlow.log`, taken right after the failure."
+      render: text
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before you send it
+      options:
+        - label: I searched the open and closed issues.
+          required: true
+        - label: I removed anything private from the log and the config.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: How do I write this transform?
+    url: https://github.com/znat/parrotflow/discussions
+    about: Open questions, pipeline design, sharing a config. Discussions, not issues.
+  - name: Documentation
+    url: https://github.com/znat/parrotflow/blob/main/docs/README.md
+    about: Setup, configuration, pipelines, the command line, permissions.
+  - name: A security problem
+    url: https://github.com/znat/parrotflow/security/advisories/new
+    about: Report it privately. Do not open an issue.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,33 @@
+name: A question about documented behaviour
+description: The docs say one thing and the app does another, or a flag does not do what it says.
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Designing a pipeline, writing a transform, or sharing a config?** Ask in
+        [Discussions](https://github.com/znat/parrotflow/discussions) instead. Threads
+        there stay findable and other people answer them.
+
+        Use this template when a documented behaviour is unclear or looks wrong.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: The question
+      description: What you are trying to do, and what is unclear.
+    validations:
+      required: true
+
+  - type: input
+    id: doc
+    attributes:
+      label: Which page you read
+      placeholder: "docs/pipelines.md#variables"
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What you tried
+      description: The config, the command and its output. `--pipeline`, `--replace` and `--route` answer most of these without a microphone.
+      render: text

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+<!-- Title: Conventional Commits — `feat:` bumps the minor, `fix:` and `perf:`
+the patch, everything else releases nothing. It becomes the changelog line, so
+write it for someone who did not read the diff. Checked automatically. -->
+
+What this changes, and what a reviewer should check. Three to six sentences,
+plain text, no heading. If it is behind a setting, name the setting and its
+default here.
+
+<details>
+<summary>Replace this line with what the numbers say</summary>
+
+The case set, the score before, the score after. Delete this block if the
+change touches no prompt, table or pattern.
+
+</details>
+
+- [ ] `make test` passes.
+- [ ] A prompt or pattern change is scored, and the numbers are above.
+- [ ] Every commit is signed off — `git commit -s`. See [CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,74 @@
+name: dco
+
+# Every commit has to carry a Signed-off-by line matching its author. That line
+# is the contributor certifying the DCO in the repository root: the code is
+# theirs to give, under this project's license. It is one line at commit time
+# (`git commit -s`) and the only record of origin the project keeps.
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dco:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Every commit is signed off
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$REPO/pulls/$PR/commits" --paginate > commits.json
+
+          # Two kinds of commit are skipped, and both would otherwise fail every
+          # run. A merge commit (two parents) is written by git, not by a person.
+          # A bot commit — release-please cuts one on every release — has no
+          # human author to certify anything.
+          #
+          # The match is on the email, lowercased: a sign-off naming someone
+          # other than the author certifies nothing.
+          jq -r '
+            .[]
+            | . as $c
+            | select(($c.parents | length) < 2)
+            | select(($c.author.type // "User") != "Bot")
+            | select((($c.commit.author.name // "") | endswith("[bot]")) | not)
+            | (($c.commit.author.email // "") | ascii_downcase) as $author
+            | ([ $c.commit.message
+                 | split("\n")[]
+                 | capture("^[[:space:]]*signed-off-by:.*<(?<mail>[^>]+)>"; "i")
+                 | .mail
+                 | ascii_downcase ]) as $signoffs
+            | select(($signoffs | index($author)) == null)
+            | "  \($c.sha[0:8])  \($c.commit.message | split("\n")[0])"
+          ' commits.json > missing.txt
+
+          if [ ! -s missing.txt ]; then
+            echo "ok: every commit is signed off"
+            exit 0
+          fi
+
+          {
+            echo "These commits carry no Signed-off-by line for their author:"
+            echo
+            cat missing.txt
+            cat <<'EOF'
+
+          The sign-off certifies the DCO in the repository root — that the code
+          is yours to give, under this project's license. See CONTRIBUTING.md.
+
+          On the next commits:
+
+            git commit -s -m "fix: …"
+
+          On the ones above, in one go, then force-push the branch:
+
+            git rebase --signoff main
+          EOF
+          } >&2
+          exit 1

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -25,10 +25,10 @@ jobs:
           set -euo pipefail
           gh api "repos/$REPO/pulls/$PR/commits" --paginate > commits.json
 
-          # Two kinds of commit are skipped, and both would otherwise fail every
-          # run. A merge commit (two parents) is written by git, not by a person.
-          # A bot commit — release-please cuts one on every release — has no
-          # human author to certify anything.
+          # Two kinds of commit are skipped here, and both would otherwise fail
+          # every run. A merge commit (two parents) is written by git, not by a
+          # person. A bot commit — release-please cuts one on every release —
+          # has no human author to certify anything.
           #
           # The match is on the email, lowercased: a sign-off naming someone
           # other than the author certifies nothing.
@@ -45,8 +45,34 @@ jobs:
                  | .mail
                  | ascii_downcase ]) as $signoffs
             | select(($signoffs | index($author)) == null)
-            | "  \($c.sha[0:8])  \($c.commit.message | split("\n")[0])"
-          ' commits.json > missing.txt
+            | "\($c.sha)\t\($c.commit.message | split("\n")[0])"
+          ' commits.json > candidates.tsv
+
+          # The third skip, and it needs the API rather than the commit itself.
+          #
+          # A squash merge rewrites the author to whoever pressed the button,
+          # while the Signed-off-by lines inside the message stay as the person
+          # who wrote the code. So the commit a merged pull request leaves
+          # behind carries a sign-off that no longer matches its author, and it
+          # fails here — on a branch where the only fix is rewriting history
+          # that other people have already pulled. Seen on #189, when #188 was
+          # merged into the branch underneath it.
+          #
+          # That work was certified on its own pull request. So a commit
+          # another, already merged pull request introduced is not asked again.
+          # Only commits that already failed reach this loop, so the usual run
+          # makes no extra API call.
+          : > missing.txt
+          while IFS="$(printf '\t')" read -r sha subject; do
+            [ -n "$sha" ] || continue
+            if gh api "repos/$REPO/commits/$sha/pulls" 2>/dev/null \
+               | jq -e --argjson pr "$PR" \
+                   'any(.[]; .merged_at != null and .number != $pr)' >/dev/null; then
+              printf 'certified on its own pull request: %s  %s\n' "${sha:0:8}" "$subject"
+              continue
+            fi
+            printf '  %s  %s\n' "${sha:0:8}" "$subject" >> missing.txt
+          done < candidates.tsv
 
           if [ ! -s missing.txt ]; then
             echo "ok: every commit is signed off"

--- a/.github/workflows/repo-settings.yml
+++ b/.github/workflows/repo-settings.yml
@@ -1,0 +1,51 @@
+name: repo-settings
+
+# Whether GitHub's settings for this repository still match settings/repo.yml.
+# Once a week, and on demand.
+#
+# It never writes, and it could not if it wanted to. Changing repository
+# settings needs the `administration` permission, and the default GITHUB_TOKEN
+# has no such scope — `permissions:` cannot grant it either. Applying would
+# take a personal access token stored as a secret, which is a token with admin
+# on the repository sitting in CI. Writes stay on the maintainer's laptop:
+#
+#     make repo-settings          # dry run
+#     scripts/repo-settings.sh --apply
+#
+# So this job only ever reads, and drift fails the run rather than opening an
+# issue. A failed scheduled run already emails the owner, and an issue would
+# need `issues: write` plus code to find, reuse and close it — more moving
+# parts than the thing it reports.
+#
+# Private vulnerability reporting is the one setting this token cannot even
+# read. The script prints it as skipped and carries on, so it never fails the
+# run on its own.
+on:
+  schedule:
+    # Monday 07:17 UTC. Off the hour, because everything scheduled at :00 waits
+    # in the same queue.
+    - cron: "17 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # The settings file is YAML, and the script reads it with python3.
+      - name: Install pyyaml
+        run: |
+          python3 -m pip install --quiet pyyaml \
+            || python3 -m pip install --quiet --break-system-packages pyyaml
+
+      # `gh` is on the runner image already.
+      - name: Compare the live settings with settings/repo.yml
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/repo-settings.sh --check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing
+
+Thanks for being here. This page is short on purpose: it says where to start,
+how to check your change, and what a commit has to carry.
+
+## Where to start
+
+| You want to | Read |
+|---|---|
+| Build the app and run it | [docs/development.md](docs/development.md) |
+| Write or change a prompt, a table or a script | [docs/authoring.md](docs/authoring.md) |
+| Understand what a transcript goes through | [docs/pipelines.md](docs/pipelines.md) |
+| Point a coding agent at this repo | [AGENTS.md](AGENTS.md) |
+
+The best first contribution is a transform. One folder under
+`examples/transforms/`, with its cases next to it. It is small, it is testable,
+and it is what other people copy.
+
+## Build and test
+
+```sh
+git clone https://github.com/znat/parrotflow && cd parrotflow
+make dev-certificate    # once, so permissions survive rebuilds
+make hooks              # once, so commit subjects can cut releases
+make install            # builds and installs ParrotFlow Dev, a separate app
+make test               # every check that needs no model, mic or screen
+```
+
+Needs Apple silicon, macOS 14 or later, and the Xcode command line tools.
+
+`make test` runs the same scripts CI runs. It does not run the sets that need
+Ollama (`check-grammar`, `check-routing`, `check-spelling`) or a real screen
+(`check-inplace`). If you touched a prompt, run those too — on a machine with
+the model — and put the numbers in the pull request.
+
+**Never change a prompt or a pattern without scoring it.** Every rewrite has a
+case set and a runner. Get the number before, change one thing, get it after.
+The rule and the loop are in [AGENTS.md](AGENTS.md).
+
+## Commits
+
+**The subject decides the release.** Releases and the changelog are computed
+from merged subjects, so a subject with no type ships nothing:
+
+```
+feat:  a capability that was not there before   -> bumps the minor
+fix:   behaviour that was wrong is now right    -> bumps the patch
+perf:  same behaviour, measurably faster        -> bumps the patch
+docs: refactor: test: build: ci: chore:         -> no release
+```
+
+`make hooks` checks this at `git commit`. The pull request title is checked
+again on GitHub, because a squash merge takes its subject from the title.
+
+**Sign off every commit.** Add `-s`:
+
+```sh
+git commit -s -m "fix: a dictation the decoder returned nothing for is decoded again"
+```
+
+That appends one line, `Signed-off-by: Your Name <your@email>`. It means you
+certify the [DCO](DCO): the code is yours to give, under this project's
+license. A check on every pull request enforces it. Forgot it? Fix the whole
+branch with:
+
+```sh
+git rebase --signoff main
+```
+
+## Pull requests
+
+Keep it to one change. Say what a reviewer should check, and put the numbers in
+if you touched a rewrite. Long evidence goes in a `<details>` block, so the
+first screen stays readable.
+
+Questions that are not bugs belong in
+[Discussions](https://github.com/znat/parrotflow/discussions).

--- a/DCO
+++ b/DCO
@@ -1,0 +1,38 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,15 @@ hooks:
 	@git config core.hooksPath .githooks
 	@echo "==> Commit subjects are now checked against Conventional Commits."
 
+.PHONY: repo-settings
+
+## Compare GitHub's own settings for the repository with settings/repo.yml.
+## Reads only. Writing them is `scripts/repo-settings.sh --apply`, kept out of
+## here on purpose: a target that changes the live repository is one you can
+## run by mistake.
+repo-settings:
+	@scripts/repo-settings.sh
+
 ## Rehearse the curl install against dist/. Leaves /Applications alone, but does
 ## quit a running release build — the installer will not leave two of them
 ## fighting over the hotkey.

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ V := . scripts/variant.sh &&
 
 .PHONY: app run install uninstall uninstall-dev uninstall-release stop clean \
         reset-permissions logs dev-certificate release release-certificate \
-        try-install which hooks
+        try-install which hooks test
 
 ## Build the app bundle into .build/
 app:
@@ -79,6 +79,34 @@ release:
 ## Create the certificate release builds are signed with — run once, ever
 release-certificate:
 	@scripts/release-certificate.sh
+
+## Every check that runs without a model, a microphone or a screen — the same
+## scripts CI runs, in the same order. Keep this list and
+## .github/workflows/checks.yml in step.
+##
+## Not here, and not skippable if you touched a prompt: check-grammar,
+## check-routing and check-spelling need Ollama and gemma4:e4b, and
+## check-inplace needs a real screen, the Accessibility grant and tmux. Run
+## those by hand and put the numbers in the pull request.
+CHECKS := numbers replacements pipeline wake split dotted dates \
+          transform-folders eval audio-recovery possessive suggest input join \
+          profiles span-rule clipboard default-config vocabulary-config learn \
+          pinned-certificate no-voice
+
+test:
+	@swift build -c release
+	@if command -v swiftlint >/dev/null; then \
+	  swiftlint lint --quiet; \
+	else \
+	  echo "==> swiftlint is not installed, lint skipped"; \
+	fi
+	@failed=""; \
+	for c in $(CHECKS); do \
+	  printf '\n==> %s\n' "$$c"; \
+	  scripts/check-$$c.sh || failed="$$failed $$c"; \
+	done; \
+	if [ -n "$$failed" ]; then printf '\nFailed:%s\n' "$$failed"; exit 1; fi; \
+	printf '\nEvery check passed.\n'
 
 ## Point git at .githooks, so commit subjects are checked before they land.
 ## Once per clone: hooks are not cloned with the repository.

--- a/README.md
+++ b/README.md
@@ -272,6 +272,10 @@ Each with its own test cases, in [examples/transforms](examples/transforms):
 **[docs/README.md](docs/README.md)** — configuration, pipelines, transforms, the
 command line, permissions, architecture.
 
+**[CONTRIBUTING.md](CONTRIBUTING.md)** — build it, test it, send a change.
+Questions that are not bugs go to
+[Discussions](https://github.com/znat/parrotflow/discussions).
+
 ---
 
 ## License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Reporting a security problem
+
+ParrotFlow holds the microphone, the Accessibility grant and the keystroke
+path. A bug in any of those is worth reporting privately first.
+
+**Report it here:**
+[github.com/znat/parrotflow/security/advisories/new](https://github.com/znat/parrotflow/security/advisories/new).
+Please do not open a public issue.
+
+One maintainer, so: first reply within 72 hours, a fix or a plan within two
+weeks for anything that leaks audio, text or credentials. Only the latest
+release is patched.
+
+Useful in the report: what an attacker can reach, the steps, the version, and
+the config if it is part of the path. A `command:` transform runs code by
+design — that is config, not a vulnerability. A way to make the app run code
+its owner did not put in the config is one.

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ Start from the question you have.
 | [architecture.md](architecture.md) | What each file is for, where the time goes, and what the app does not do. |
 | [transcription.md](transcription.md) | The speech model, its limits, and the stages that cover them. |
 | [distribution.md](distribution.md) | How the app ships, how it is signed, and how updates work. |
+| [repo-settings.md](repo-settings.md) | GitHub's own settings for the repository, kept in `settings/repo.yml` and applied from one script. |
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ Start from the question you have.
 |---|---|
 | [authoring.md](authoring.md) | **Start here to write a prompt, a table or a script.** The procedure, and the measurement loop that scores it. |
 | [development.md](development.md) | Dev and released builds are separate apps. Building, the Makefile, and how to cut a release. |
+| [../CONTRIBUTING.md](../CONTRIBUTING.md) | Sending a change: `make test`, the commit subject rules, and the sign-off. |
 | [architecture.md](architecture.md) | What each file is for, where the time goes, and what the app does not do. |
 | [transcription.md](transcription.md) | The speech model, its limits, and the stages that cover them. |
 | [distribution.md](distribution.md) | How the app ships, how it is signed, and how updates work. |

--- a/docs/repo-settings.md
+++ b/docs/repo-settings.md
@@ -1,0 +1,61 @@
+# The repository's own settings
+
+GitHub's settings for this repository are in
+[`settings/repo.yml`](../settings/repo.yml): the description, the topics, which
+merge buttons exist, the labels, private vulnerability reporting. The file is
+the record. The live repository is meant to match it.
+
+Change one in the browser and the file is wrong. Change the file and nothing
+happens until someone applies it. So do it in this order.
+
+```sh
+$EDITOR settings/repo.yml
+make repo-settings                  # dry run: prints what would change
+scripts/repo-settings.sh --apply    # writes it
+```
+
+The dry run is the default everywhere. `--apply` is the only way the script
+writes anything.
+
+Needs the [`gh`](https://cli.github.com) CLI, logged in as someone with admin
+on the repository. A token without admin can still read most of it — the
+script prints what it cannot read as skipped and carries on.
+
+## Why a file and not the Settings page
+
+Two settings there are load-bearing, and both are invisible once set.
+
+**`squash_merge_commit_title: COMMIT_OR_PR_TITLE`** is what makes
+`.githooks/commit-msg` worth running. A single-commit pull request squashes to
+that commit's subject, which the hook already checked. Switch it to
+`PR_TITLE` and every squash takes the title instead, so the hook stops
+protecting anything. The comment at the top of
+[`.github/workflows/pr-title.yml`](../.github/workflows/pr-title.yml) is the
+long version.
+
+**`web_commit_signoff_required: true`** puts a `Signed-off-by` line on commits
+made through the web UI. Without it, the DCO check in
+`.github/workflows/dco.yml` fails any pull request that contains one.
+
+Neither shows up in a diff when someone flips it. The weekly check is what
+notices.
+
+## The weekly check
+
+[`.github/workflows/repo-settings.yml`](../.github/workflows/repo-settings.yml)
+runs `scripts/repo-settings.sh --check` every Monday, and on demand from the
+Actions tab. Drift fails the run.
+
+It never applies. Changing settings needs the `administration` permission, and
+the default `GITHUB_TOKEN` does not have it — that would take a personal access
+token with admin on the repository stored as a secret. Writes stay on the
+maintainer's laptop.
+
+## What the file does not cover
+
+| | |
+|---|---|
+| `homepage` | Empty on purpose. There is no site. The owner sets it in Settings → General when there is one. |
+| Discussion categories | **No API can create one.** Not REST, not GraphQL — there is no mutation for it. `has_discussions: true` turns Discussions on; the categories are made by hand in Settings → Discussions. |
+| Branch protection, Actions permissions, secrets | Untouched. The script only reads and writes what the file names. |
+| Deleting a label | Never. A label the file no longer names is left alone and reported, because deleting one strips it from every issue that carries it. |

--- a/scripts/repo-settings.sh
+++ b/scripts/repo-settings.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+# Whether GitHub's settings for this repository still match settings/repo.yml.
+#
+#   scripts/repo-settings.sh              # dry run: print the drift, write nothing
+#   scripts/repo-settings.sh --check      # the same, and exit 1 if anything differs
+#   scripts/repo-settings.sh --apply      # write the intended state, then re-read it
+#   scripts/repo-settings.sh --repo o/n   # act on another repository
+#
+# Dry run is the default, and --apply is the only way this writes anything. The
+# order matters more than it looks: settings/repo.yml is edited far more often
+# than it is applied, and a script that writes by default turns a typo into a
+# live repository change before anyone has read the diff.
+#
+# Exit codes:
+#   0  no drift, or drift printed by a dry run
+#   1  --check found drift, or --apply could not write something, or --apply
+#      left drift behind — a write the API accepted and did not store reads
+#      back unchanged, and that has to be louder than a line of output
+#
+# A setting this token cannot read or write is printed as a skip and the run
+# carries on. That is the normal case in CI: the default GITHUB_TOKEN has no
+# `administration` permission, so private vulnerability reporting reads 403.
+#
+# Needs `gh`, logged in as someone with admin on the repository, and python3
+# with pyyaml — the same pair the check scripts already use.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SETTINGS="$ROOT/settings/repo.yml"
+
+MODE=dry
+REPO=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --apply) MODE=apply ;;
+    --check) MODE=check ;;
+    --repo)  REPO="${2:-}"; shift ;;
+    -h|--help) sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+[ -f "$SETTINGS" ] || { echo "not found: $SETTINGS" >&2; exit 1; }
+command -v gh >/dev/null || { echo "gh is not installed: https://cli.github.com" >&2; exit 1; }
+command -v python3 >/dev/null || { echo "python3 is not installed" >&2; exit 1; }
+
+if [ -z "$REPO" ]; then
+  REPO="${GITHUB_REPOSITORY:-}"
+fi
+if [ -z "$REPO" ]; then
+  REPO="$(git -C "$ROOT" config --get remote.origin.url 2>/dev/null \
+          | sed -e 's#^git@github.com:#https://github.com/#' \
+                -e 's#^https://github.com/##' -e 's#\.git$##')"
+fi
+[ -n "$REPO" ] || { echo "cannot tell which repository this is; pass --repo owner/name" >&2; exit 1; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# The intended state, flattened to one line per thing. Tab separated, because a
+# label description has spaces in it and a topic never has a tab.
+python3 -c '
+import sys, yaml
+s = yaml.safe_load(open(sys.argv[1]))
+for k, v in (s.get("repository") or {}).items():
+    kind = "bool" if isinstance(v, bool) else "str"
+    print("\t".join(["repo", k, kind, ("true" if v else "false") if kind == "bool" else str(v)]))
+for t in s.get("topics") or []:
+    print("topic\t" + t)
+pvr = s.get("private_vulnerability_reporting")
+if pvr is not None:
+    print("pvr\t" + ("true" if pvr else "false"))
+for l in s.get("labels") or []:
+    print("\t".join(["label", l["name"], str(l["color"]).lstrip("#").lower(),
+                     l.get("description", "")]))
+' "$SETTINGS" > "$TMP/plan.tsv" || { echo "cannot read $SETTINGS" >&2; exit 1; }
+
+awk -F'\t' '$1=="repo"'          "$TMP/plan.tsv" > "$TMP/want-repo.tsv"
+awk -F'\t' '$1=="topic"{print $2}' "$TMP/plan.tsv" | sort > "$TMP/want-topics.txt"
+awk -F'\t' '$1=="label"'         "$TMP/plan.tsv" > "$TMP/want-labels.tsv"
+WANT_PVR="$(awk -F'\t' '$1=="pvr"{print $2}' "$TMP/plan.tsv")"
+
+drift=0; skipped=0; failed=0
+
+say_same()    { printf '  ✓ %-30s %s\n' "$1" "$2"; }
+say_differs() { drift=$((drift + 1)); printf '  ✗ %-30s %s → %s\n' "$1" "$2" "$3"; }
+say_skipped() { skipped=$((skipped + 1)); printf '  ⚠ %-30s skipped: %s\n' "$1" "$2"; }
+
+# Lines on stdin as one space separated line.
+oneline() { tr '\n' ' ' | sed 's/ *$//'; }
+
+# api <outfile> <gh api arguments…> — never aborts the run. On failure the
+# caller decides whether that is a skip or a failure to write.
+api() {
+  local out="$1"; shift
+  if gh api "$@" > "$out" 2> "$TMP/err"; then
+    return 0
+  fi
+  API_ERROR="$(grep -v '^$' "$TMP/err" | head -1)"
+  [ -n "$API_ERROR" ] || API_ERROR="gh api failed"
+  return 1
+}
+
+# The value of one key in a tab separated file.
+field_of() { awk -F'\t' -v k="$2" '$1==k {sub(/^[^\t]*\t/, ""); print; exit}' "$1"; }
+
+# ---------------------------------------------------------------- repository
+
+check_repository() {
+  printf '\n==> Repository\n'
+  if ! api "$TMP/repo.json" "repos/$REPO"; then
+    say_skipped "repository" "$API_ERROR"
+    return
+  fi
+  python3 -c '
+import json, sys
+d = json.load(open(sys.argv[1]))
+for k, v in d.items():
+    if isinstance(v, bool): v = "true" if v else "false"
+    elif v is None: v = ""
+    elif isinstance(v, (int, float, str)): v = str(v)
+    else: continue
+    print(k + "\t" + v.replace("\t", " ").replace("\n", " "))
+' "$TMP/repo.json" > "$TMP/live-repo.tsv"
+
+  : > "$TMP/changes.tsv"
+  local key kind want live
+  while IFS=$'\t' read -r _ key kind want; do
+    live="$(field_of "$TMP/live-repo.tsv" "$key")"
+    if [ "$live" = "$want" ]; then
+      say_same "$key" "$want"
+    else
+      say_differs "$key" "${live:-(unset)}" "$want"
+      printf '%s\t%s\t%s\n' "$key" "$kind" "$want" >> "$TMP/changes.tsv"
+    fi
+  done < "$TMP/want-repo.tsv"
+
+  [ "$MODE" = apply ] || return
+  [ -s "$TMP/changes.tsv" ] || return
+
+  python3 -c '
+import json, sys
+body = {}
+for line in open(sys.argv[1]):
+    k, kind, v = line.rstrip("\n").split("\t", 2)
+    body[k] = (v == "true") if kind == "bool" else v
+print(json.dumps(body))
+' "$TMP/changes.tsv" > "$TMP/body.json"
+
+  if api "$TMP/patched.json" --method PATCH "repos/$REPO" --input "$TMP/body.json"; then
+    printf '  → patched %s\n' "$(cut -f1 "$TMP/changes.tsv" | oneline)"
+  else
+    failed=$((failed + 1))
+    printf '  ⚠ could not patch the repository: %s\n' "$API_ERROR"
+  fi
+}
+
+# -------------------------------------------------------------------- topics
+
+check_topics() {
+  printf '\n==> Topics\n'
+  if ! api "$TMP/topics.json" "repos/$REPO/topics"; then
+    say_skipped "topics" "$API_ERROR"
+    return
+  fi
+  python3 -c '
+import json, sys
+for t in json.load(open(sys.argv[1]))["names"]: print(t)
+' "$TMP/topics.json" | sort > "$TMP/live-topics.txt"
+
+  local missing extra
+  missing="$(comm -23 "$TMP/want-topics.txt" "$TMP/live-topics.txt" | oneline)"
+  extra="$(comm -13 "$TMP/want-topics.txt" "$TMP/live-topics.txt" | oneline)"
+
+  if [ -z "$missing" ] && [ -z "$extra" ]; then
+    say_same "topics" "$(oneline < "$TMP/want-topics.txt")"
+    return
+  fi
+  drift=$((drift + 1))
+  [ -n "$missing" ] && printf '  ✗ %-30s missing: %s\n' "topics" "$missing"
+  # PUT replaces the whole list, so anything live and not in the file goes.
+  [ -n "$extra" ] && printf '  ✗ %-30s would be removed: %s\n' "topics" "$extra"
+
+  [ "$MODE" = apply ] || return
+  python3 -c '
+import json, sys
+print(json.dumps({"names": [l.strip() for l in open(sys.argv[1]) if l.strip()]}))
+' "$TMP/want-topics.txt" > "$TMP/topics-body.json"
+  if api "$TMP/topics-out.json" --method PUT "repos/$REPO/topics" --input "$TMP/topics-body.json"; then
+    printf '  → topics replaced\n'
+  else
+    failed=$((failed + 1))
+    printf '  ⚠ could not replace the topics: %s\n' "$API_ERROR"
+  fi
+}
+
+# ------------------------------------------ private vulnerability reporting
+
+check_pvr() {
+  [ -n "$WANT_PVR" ] || return 0
+  printf '\n==> Private vulnerability reporting\n'
+  # Reading this needs admin. A token without it is the normal CI case.
+  if ! api "$TMP/pvr.json" "repos/$REPO/private-vulnerability-reporting"; then
+    say_skipped "private_vulnerability_reporting" "$API_ERROR"
+    return
+  fi
+  local live
+  live="$(python3 -c '
+import json, sys
+print("true" if json.load(open(sys.argv[1]))["enabled"] else "false")
+' "$TMP/pvr.json")"
+
+  if [ "$live" = "$WANT_PVR" ]; then
+    say_same "private_vulnerability_reporting" "$live"
+    return
+  fi
+  say_differs "private_vulnerability_reporting" "$live" "$WANT_PVR"
+
+  [ "$MODE" = apply ] || return
+  local method=PUT
+  [ "$WANT_PVR" = true ] || method=DELETE
+  if api "$TMP/pvr-out" --method "$method" "repos/$REPO/private-vulnerability-reporting"; then
+    printf '  → %s\n' "$([ "$WANT_PVR" = true ] && echo enabled || echo disabled)"
+  else
+    failed=$((failed + 1))
+    printf '  ⚠ could not change it: %s\n' "$API_ERROR"
+  fi
+}
+
+# -------------------------------------------------------------------- labels
+
+check_labels() {
+  printf '\n==> Labels\n'
+  if ! api "$TMP/labels.json" --paginate "repos/$REPO/labels"; then
+    say_skipped "labels" "$API_ERROR"
+    return
+  fi
+  # --paginate concatenates one array per page, so read them as a stream.
+  python3 -c '
+import json, sys
+dec = json.JSONDecoder()
+text = open(sys.argv[1]).read().strip()
+i = 0
+while i < len(text):
+    page, end = dec.raw_decode(text, i)
+    for l in page:
+        print("\t".join([l["name"], (l.get("color") or "").lower(),
+                         (l.get("description") or "").replace("\t", " ")]))
+    i = end
+    while i < len(text) and text[i].isspace(): i += 1
+' "$TMP/labels.json" > "$TMP/live-labels.tsv"
+
+  # GitHub treats label names case-insensitively, so `bug` and `Bug` are the
+  # same label and creating the second one is a 422. Match that: find it
+  # regardless of case, then rename it to the case this file names.
+  local name color desc live live_name live_color live_desc
+  while IFS=$'\t' read -r _ name color desc; do
+    live="$(awk -F'\t' -v k="$name" 'BEGIN{k=tolower(k)} tolower($1)==k {print; exit}' "$TMP/live-labels.tsv")"
+    if [ -z "$live" ]; then
+      drift=$((drift + 1))
+      printf '  ✗ %-30s missing\n' "$name"
+      [ "$MODE" = apply ] || continue
+      if api "$TMP/label-out.json" --method POST "repos/$REPO/labels" \
+           -f "name=$name" -f "color=$color" -f "description=$desc"; then
+        printf '  → created\n'
+      else
+        failed=$((failed + 1))
+        printf '  ⚠ could not create %s: %s\n' "$name" "$API_ERROR"
+      fi
+      continue
+    fi
+
+    live_name="$(printf '%s' "$live" | cut -f1)"
+    live_color="$(printf '%s' "$live" | cut -f2)"
+    live_desc="$(printf '%s' "$live" | cut -f3)"
+    if [ "$live_name" = "$name" ] && [ "$live_color" = "$color" ] && [ "$live_desc" = "$desc" ]; then
+      say_same "$name" "#$color"
+      continue
+    fi
+    drift=$((drift + 1))
+    [ "$live_name" = "$name" ]  || printf '  ✗ %-30s named "%s"\n' "$name" "$live_name"
+    [ "$live_color" = "$color" ] || printf '  ✗ %-30s #%s → #%s\n' "$name" "$live_color" "$color"
+    [ "$live_desc" = "$desc" ]   || printf '  ✗ %-30s "%s" → "%s"\n' "$name" "$live_desc" "$desc"
+
+    [ "$MODE" = apply ] || continue
+    # Addressed by the name the repository has, renamed to the one this file
+    # has. new_name is a no-op when the two already agree.
+    local path
+    path="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$live_name")"
+    if api "$TMP/label-out.json" --method PATCH "repos/$REPO/labels/$path" \
+         -f "new_name=$name" -f "color=$color" -f "description=$desc"; then
+      printf '  → updated\n'
+    else
+      failed=$((failed + 1))
+      printf '  ⚠ could not update %s: %s\n' "$name" "$API_ERROR"
+    fi
+  done < "$TMP/want-labels.tsv"
+
+  # Nothing is deleted here. A label removed from this file stays on the
+  # repository, because deleting one strips it from every issue that carries it.
+  local unlisted
+  cut -f1 "$TMP/live-labels.tsv" | tr '[:upper:]' '[:lower:]' | sort > "$TMP/live-names.txt"
+  cut -f2 "$TMP/want-labels.tsv" | tr '[:upper:]' '[:lower:]' | sort > "$TMP/want-names.txt"
+  unlisted="$(comm -13 "$TMP/want-names.txt" "$TMP/live-names.txt" | oneline)"
+  [ -n "$unlisted" ] && printf '    not in settings/repo.yml, left alone: %s\n' "$unlisted"
+  return 0
+}
+
+run_pass() {
+  drift=0; skipped=0
+  check_repository
+  check_topics
+  check_pvr
+  check_labels
+}
+
+printf '==> %s   (%s)\n' "$REPO" \
+  "$([ "$MODE" = apply ] && echo "applying settings/repo.yml" || echo "reading only, nothing is written")"
+run_pass
+
+if [ "$MODE" = apply ]; then
+  # Read it all back. This is the half that catches a field the API accepted
+  # and did not store, and it is what makes a second run a no-op.
+  printf '\n==> Reading it back\n'
+  MODE=verify
+  run_pass
+  printf '\n'
+  if [ "$drift" -gt 0 ]; then
+    printf '  %d setting(s) still differ after applying. Check them by hand in\n' "$drift"
+    printf '  Settings → General: the API accepts some fields it does not store.\n'
+  fi
+  [ "$skipped" -gt 0 ] && printf '  %d skipped — could not read them back to confirm the write held.\n' "$skipped"
+  [ "$failed" -gt 0 ] && printf '  %d write(s) failed.\n' "$failed"
+  # Drift, a failed write, or a read-back that could not even be attempted are
+  # all a failure, not a note. Exiting 0 for any of them tells a scheduled run,
+  # and the person reading the last line, that a setting was confirmed applied
+  # when it was not.
+  if [ "$drift" -gt 0 ] || [ "$failed" -gt 0 ] || [ "$skipped" -gt 0 ]; then
+    exit 1
+  fi
+  printf '  Done.\n'
+  exit 0
+fi
+
+printf '\n'
+if [ "$drift" -eq 0 ]; then
+  printf '  Everything matches settings/repo.yml.\n'
+else
+  printf '  %d setting(s) differ. Apply them with:\n\n      scripts/repo-settings.sh --apply\n' "$drift"
+fi
+[ "$skipped" -gt 0 ] && printf '  %d skipped — this token cannot read them. Not counted as drift.\n' "$skipped"
+
+[ "$MODE" = check ] && [ "$drift" -gt 0 ] && exit 1
+exit 0

--- a/settings/repo.yml
+++ b/settings/repo.yml
@@ -1,0 +1,152 @@
+# What GitHub's own settings for znat/parrotflow are supposed to be.
+#
+# This file is the record. `scripts/repo-settings.sh` reads it and compares it
+# with the live repository; `--apply` writes it back. Change a value here first,
+# then apply — a setting changed in the browser and not here is drift, and the
+# weekly check in .github/workflows/repo-settings.yml will say so.
+#
+# Most values below already match the live repository, so the first `--apply`
+# is close to a no-op. Three do not, on purpose: has_wiki, has_projects and
+# web_commit_signoff_required. Each says why underneath. Run the dry run first
+# and read them before applying.
+#
+# Only what is listed here is managed. Branch protection, Actions permissions
+# and secrets are untouched.
+
+repository:
+  # The live description, kept word for word — it is the README's one-liner
+  # trimmed, and the owner wrote it. Two places say what this app is, so change
+  # them together.
+  description: Local, fast and programmable dictation app
+
+  # Deliberately empty. There is no site yet. The owner sets this in
+  # Settings → General when there is one; do not invent a URL here.
+  homepage: ""
+
+  has_issues: true
+
+  # Already on — the owner enabled it. Recorded so it stays on.
+  #
+  # The issue templates send anything open-ended here: pipeline design, sharing
+  # a config, "how do I write this transform". See
+  # .github/ISSUE_TEMPLATE/config.yml, which links to /discussions.
+  #
+  # Discussion CATEGORIES cannot be created by any API — not REST, not GraphQL.
+  # There is no mutation for it. The owner creates them once, by hand, in
+  # Settings → Discussions. Nothing here can do it, so do not go looking.
+  has_discussions: true
+
+  # CHANGES THE LIVE SETTING: both are on today.
+  #
+  # The documentation is in docs/, in the same commit as the code it describes.
+  # A wiki is a second copy that drifts and no pull request touches. Turning it
+  # off hides the wiki; it does not delete it, and turning it back on returns
+  # whatever was there.
+  has_wiki: false
+  has_projects: false
+
+  # Squash only, and this is load-bearing rather than taste. release-please
+  # computes the version and the changelog from the commit subjects on main.
+  # One pull request has to arrive as one subject it can read. A merge commit
+  # or a rebase merge puts every branch commit on main, including the "wip"
+  # ones, and the changelog is then whatever was typed at 2am.
+  allow_squash_merge: true
+  allow_merge_commit: false
+  allow_rebase_merge: false
+
+  # COMMIT_OR_PR_TITLE is the whole reason .githooks/commit-msg is worth
+  # running. Read the comment at the top of .github/workflows/pr-title.yml: a
+  # single-commit pull request squashes to that commit's subject, which the
+  # hook already checked on the contributor's machine, and only the
+  # multi-commit case falls through to the workflow. Set this to PR_TITLE and
+  # the hook protects nothing — every squash takes the title instead, and the
+  # one check that runs before a commit exists stops mattering.
+  squash_merge_commit_title: COMMIT_OR_PR_TITLE
+
+  # The pull request body becomes the commit body. The alternative,
+  # COMMIT_MESSAGES, concatenates every commit on the branch.
+  squash_merge_commit_message: PR_BODY
+
+  # The branch is merged and gone; nothing reads it again.
+  delete_branch_on_merge: true
+
+  # Offers the "Update branch" button, so a stale branch can be brought up to
+  # main without a local checkout.
+  allow_update_branch: true
+
+  # Auto-merge off: one maintainer, who is the person clicking merge anyway.
+  allow_auto_merge: false
+
+  # CHANGES THE LIVE SETTING: off today.
+  #
+  # Makes GitHub add a Signed-off-by line to commits made through the web UI —
+  # editing a file on github.com, or the "Commit suggestion" button in a
+  # review. Without it those commits carry none and
+  # .github/workflows/dco.yml fails the pull request they land in.
+  web_commit_signoff_required: true
+
+# `PUT /repos/{owner}/{repo}/topics` REPLACES the whole list. This is the whole
+# list: a topic dropped from here is dropped from the repository on the next
+# apply.
+#
+# The first seven are live today and four of them are search terms rather than
+# description — someone looking for a way off Wispr Flow types those words.
+# Keep them. Lowercase, hyphens, 20 at most; GitHub rejects anything else.
+topics:
+  - dictation
+  - macos
+  - parakeet
+  - speech-to-text
+  - whisper
+  - wispr-flow
+  - wispr-flow-alternative
+  # Added: what the app is and what it runs on.
+  - swift
+  - voice-typing
+  - local-first
+  - ollama
+
+# SECURITY.md sends people to the advisory form. That form only exists when
+# this is on, so the link in SECURITY.md is dead without it.
+private_vulnerability_reporting: true
+
+# The issue templates apply `bug` and `question` — see the `labels:` line in
+# .github/ISSUE_TEMPLATE/bug.yml and question.yml. A template that applies a
+# label the repository does not have opens the issue with no label at all.
+#
+# The script creates a label that is missing and corrects the colour or the
+# description of one that exists. It never deletes a label this file does not
+# name: deleting a label strips it from every issue that carries it, and that
+# cannot be undone.
+labels:
+  - name: bug
+    color: d73a4a
+    description: A crash, a permission that fails, text that lands wrong.
+
+  - name: question
+    color: d876e3
+    description: Documented behaviour is unclear or looks wrong.
+
+  # The name has to be exactly "good first issue", spaces and all. GitHub's
+  # contribute page (/znat/parrotflow/contribute) and the "good first issues"
+  # search both match that literal string. "good-first-issue" is invisible to
+  # both.
+  #
+  # The description is the promise. An issue only gets this label if it names
+  # the file and the check to run, and if the answer is not "read the whole
+  # pipeline first".
+  - name: good first issue
+    color: 7057ff
+    description: Small, self-contained, names the file to change and the check to run.
+
+  - name: help wanted
+    color: 008672
+    description: The maintainer is not getting to this. Worth picking up.
+
+  - name: documentation
+    color: 0075ca
+    description: docs/, README, or a comment that says something untrue.
+
+  - name: enhancement
+    color: a2eeef
+    description: A capability that is not there yet.


### PR DESCRIPTION
Phase 0 of `docs/proposals/promotion.md`, the GitHub half. A launch sends strangers here, and today there is no path for them: no way to file a usable bug, no statement of what a contribution certifies, and no single command that runs the tests. This adds the files that answer those three, plus `make test`. Nothing here changes the app.

Two settings are left that only the owner can change: the repository homepage field, and private vulnerability reporting — `SECURITY.md` links to the advisory form, and that form only exists when the setting is on. Discussions is already on.

<details>
<summary>What each file is for</summary>

| File | Why |
|---|---|
| `CONTRIBUTING.md` | Where to start, how to build, how to test, what a commit subject decides, and the sign-off. Points at `AGENTS.md` and `docs/`. |
| `.github/ISSUE_TEMPLATE/bug.yml` | Asks for `--check-config` and the log, because a bug report without them costs a round trip. Also asks which app was focused — pipelines are gated per app, so that often decides which stages ran. |
| `.github/ISSUE_TEMPLATE/question.yml` | Narrow on purpose: a documented behaviour that looks wrong. |
| `.github/ISSUE_TEMPLATE/config.yml` | Blank issues off. Open questions go to Discussions, security goes to a private advisory. |
| `.github/pull_request_template.md` | The lead, a `<details>` for the numbers, three checkboxes. |
| `DCO` + `.github/workflows/dco.yml` | Every commit carries a `Signed-off-by` matching its author. |
| `SECURITY.md` | A private channel for a bug in the microphone, Accessibility or keystroke path, and what counts as one. |
| `Makefile` | `make test`. |

</details>

<details>
<summary>The DCO check skips merge commits and bot commits, or release-please would go red every release</summary>

The check reads the pull request's commits through `gh api` and fails on any commit with no `Signed-off-by` line matching its author's email, lowercased.

Skipped:

- **Merge commits** (two parents). Written by git, not by a person.
- **Bot commits**, by `author.type == "Bot"` or an author name ending in `[bot]`. Without this, every release-please pull request fails.

Tested against a fixture of seven commits: it catches a missing sign-off and a sign-off naming a different email, and passes a merge commit, a bot commit found by type, a bot commit found by name, and a sign-off from an account whose email is not linked to GitHub.

</details>

<details>
<summary>make test runs the 22 checks that need no model, mic or screen — not run on this branch</summary>

The same scripts `.github/workflows/checks.yml` runs, in the same order, after `swift build -c release` and swiftlint. The Makefile comment says to keep the two lists in step.

Not included, and named in `CONTRIBUTING.md` as things to run by hand: `check-grammar`, `check-routing` and `check-spelling` need Ollama and gemma4:e4b; `check-inplace` needs a real screen and the Accessibility grant.

**This was not run.** It was written in a Linux container and the build is macOS-only. Run it once before merging.

</details>

<details>
<summary>The DCO text is from memory — worth one diff before merging</summary>

`developercertificate.org` is blocked by the egress proxy here, so the `DCO` file was written from knowledge rather than copied. The wording of the four clauses is standard and stable. The part most likely to be wrong is the address block under the copyright line. Compare it against the site once.

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRx4928MLWKGD7jPkgjSYL)_