### PR TITLE
perf: the hidden pill stops redrawing, the settle loop stops re-folding

### DIFF
--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -76,6 +76,16 @@ struct OfferedCommand: Equatable {
 
 final class PillModel: ObservableObject {
     @Published var state: PillState = .recording
+
+    /// Whether the panel is on screen. False unmounts the surface.
+    ///
+    /// An ordered-out panel still commits its layers. The rim's angle animates
+    /// a conic gradient, which is rasterised on the CPU every frame — so an
+    /// offer left mounted under a hidden panel measured at 57% of a core with
+    /// nothing on screen. The state does not stop it: nothing clears `state`
+    /// on the way out, and `.offer` means a rim that turns.
+    @Published var onScreen = true
+
     @Published var level: Float = 0
     @Published var elapsed: TimeInterval = 0
     /// The icon of the app the text is going to land in — the one an `app:`
@@ -240,7 +250,10 @@ final class PillHUD {
         // animating alpha. Usually nothing — the offer follows a pill already
         // on screen — but raised from cold, `set` starts a fade to full and the
         // two would pull opposite ways.
-        if !panel.isVisible { panel.orderFrontRegardless() }
+        if !panel.isVisible {
+            model.onScreen = true
+            panel.orderFrontRegardless()
+        }
         NSAnimationContext.runAnimationGroup { context in
             context.duration = 0
             panel.animator().alphaValue = Self.offerAlpha
@@ -273,6 +286,7 @@ final class PillHUD {
             // as in `fadeOut`.
             self.near = nil
             panel.orderOut(nil)
+            self.model.onScreen = false
             // Back to full strength while off screen, or the next appearance
             // starts from a panel that is already invisible and stays that way.
             panel.alphaValue = 1
@@ -503,6 +517,7 @@ final class PillHUD {
     /// the next state morphed it there. Nothing to animate is nothing to get
     /// wrong.
     private func fadeIn(_ panel: NSPanel) {
+        model.onScreen = true
         panel.alphaValue = 0
         panel.orderFrontRegardless()
         NSAnimationContext.runAnimationGroup { context in
@@ -550,6 +565,7 @@ final class PillHUD {
                 panel.animator().alphaValue = 1
             }
             panel.orderOut(nil)
+            model.onScreen = false
             return
         }
         // Nothing is decaying past this line. A held decay is standing at a
@@ -574,6 +590,7 @@ final class PillHUD {
             // otherwise inherit a caret that has long since moved.
             self.near = nil
             panel.orderOut(nil)
+            self.model.onScreen = false
             // Back to full strength while off screen, or the next appearance
             // starts from a panel that is already invisible and stays that way.
             panel.alphaValue = 1
@@ -1057,6 +1074,11 @@ struct PillView: View {
     @EnvironmentObject private var model: PillModel
 
     var body: some View {
+        // Nothing at all while the panel is out. See `PillModel.onScreen`.
+        if model.onScreen { pill }
+    }
+
+    private var pill: some View {
         // The capsule is the window, whatever the contents would rather be.
         //
         // The window's width is animated by AppKit and the contents are laid

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -1499,26 +1499,44 @@ struct ToneDot: View {
     let tone: NoticeTone
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var step = 0
-
-    private let clock = Timer.publish(every: 0.6, on: .main, in: .common).autoconnect()
 
     var body: some View {
+        // The clock belongs to `WalkingDot`, which exists only while the dot is
+        // walking. Held here it was a stored property, so it ticked 1.67 times
+        // a second on every tone for the life of the view and `onReceive` threw
+        // the ticks away.
+        if tone == .thinking, !reduceMotion {
+            WalkingDot()
+        } else {
+            Self.dot(resting)
+        }
+    }
+
+    /// Thinking with the motion turned off is the first feather, held. Every
+    /// other tone is its own colour.
+    private var resting: Color {
+        tone == .thinking ? Parrot.wheel[0] : tone.color
+    }
+
+    static func dot(_ color: Color) -> some View {
         Circle()
             .fill(color)
             .frame(width: 9, height: 9)
             .shadow(color: color, radius: 4)
             .shadow(color: color.opacity(0.6), radius: 9)
-            .animation(.easeInOut(duration: 0.5), value: step)
-            .onReceive(clock) { _ in
-                guard tone == .thinking, !reduceMotion else { return }
-                step += 1
-            }
     }
+}
 
-    private var color: Color {
-        guard tone == .thinking else { return tone.color }
-        return Parrot.wheel[step % 4]
+/// The dot walking the plumage: the one tone that needs a clock.
+private struct WalkingDot: View {
+    @State private var step = 0
+
+    private let clock = Timer.publish(every: 0.6, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        ToneDot.dot(Parrot.wheel[step % 4])
+            .animation(.easeInOut(duration: 0.5), value: step)
+            .onReceive(clock) { _ in step += 1 }
     }
 }
 

--- a/Sources/ParrotFlow/Surface.swift
+++ b/Sources/ParrotFlow/Surface.swift
@@ -489,7 +489,7 @@ struct Surface {
 
         // 1. Set the range, then write the text into it. Disturbs nothing, and
         //    is what a native field accepts.
-        if select(nsRange), setSelectedText(replacement), landed(fragment) {
+        if select(nsRange), setSelectedText(replacement), landed(fragment, needle: folded(fragment.text)) {
             Log.write("surface: wrote \(nsRange.length) chars via the accessibility range")
             return .replaced(undo)
         }
@@ -648,8 +648,9 @@ struct Surface {
     /// back — pressing Cmd-Z then would undo whatever the person did before we
     /// arrived, which is a far worse outcome than the failed correction.
     private func repairedAfterStrayPaste() -> String {
+        let foldedContent = folded(content)
         guard let now = SelectionReader.visibleText(of: element),
-              folded(now) != folded(content) else {
+              folded(now) != foldedContent else {
             Log.write("surface: the paste changed nothing; leaving the field alone")
             return "this app would not let me edit it"
         }
@@ -660,7 +661,7 @@ struct Surface {
         let deadline = Date().addingTimeInterval(1.0)
         repeat {
             if let value = SelectionReader.visibleText(of: element),
-               folded(value) == folded(content) {
+               folded(value) == foldedContent {
                 Log.write("surface: the stray paste is undone; the text is as it was")
                 return "this app would not let me edit it"
             }
@@ -691,8 +692,9 @@ struct Surface {
         // that is busy laying the paste out, so a single read can eat most of
         // the old budget and only two or three ever happened.
         let deadline = Date().addingTimeInterval(2.5)
+        let needle = folded(fragment.text)
         repeat {
-            if landed(fragment) { return true }
+            if landed(fragment, needle: needle) { return true }
             Thread.sleep(forTimeInterval: 0.05)
         } while Date() < deadline
 
@@ -778,10 +780,9 @@ struct Surface {
         return text.range(of: needle, range: first.upperBound..<text.endIndex) == nil
     }
 
-    private func landed(_ fragment: Fragment) -> Bool {
+    private func landed(_ fragment: Fragment, needle: String) -> Bool {
         guard let value = SelectionReader.visibleText(of: element) else { return false }
         let text = folded(value)
-        let needle = folded(fragment.text)
         guard fragment.atStart else { return text.contains(needle) }
         // Leading whitespace on both sides, because a rich-text editor can put
         // a blank line above what it holds and that is not a failed write.
@@ -793,18 +794,36 @@ struct Surface {
     /// apostrophe curly as it arrives, so "they're" comes back as "they’re" — the
     /// edit landed, and a literal comparison would call it a refusal.
     private func folded(_ text: String) -> String {
-        text.replacingOccurrences(of: "\u{2019}", with: "'")
-            .replacingOccurrences(of: "\u{2018}", with: "'")
-            .replacingOccurrences(of: "\u{201C}", with: "\"")
-            .replacingOccurrences(of: "\u{201D}", with: "\"")
+        var result = String.UnicodeScalarView()
+        result.reserveCapacity(text.utf8.count)
+        let scalars = text.unicodeScalars
+        var index = scalars.startIndex
+        while index < scalars.endIndex {
+            let scalar = scalars[index]
+            index = scalars.index(after: index)
+            switch scalar {
+            case "\u{2019}", "\u{2018}":
+                result.append("'")
+            case "\u{201C}", "\u{201D}":
+                result.append("\"")
             // What a rich-text editor does to text on the way in. Outlook and
             // Mail put non-breaking spaces around pasted runs and keep carriage
             // returns in the value; both make a literal comparison fail on text
             // that is plainly correct on screen.
-            .replacingOccurrences(of: "\u{00A0}", with: " ")
-            .replacingOccurrences(of: "\u{202F}", with: " ")
-            .replacingOccurrences(of: "\r\n", with: "\n")
-            .replacingOccurrences(of: "\r", with: "\n")
+            case "\u{00A0}", "\u{202F}":
+                result.append(" ")
+            case "\r":
+                result.append("\n")
+                // A lone \r folds to \n same as \r\n does, so the \n that
+                // follows a \r must not also fold — otherwise \r\n becomes \n\n.
+                if index < scalars.endIndex, scalars[index] == "\n" {
+                    index = scalars.index(after: index)
+                }
+            default:
+                result.append(scalar)
+            }
+        }
+        return String(result)
     }
 
     private func select(_ range: NSRange) -> Bool {
@@ -861,10 +880,11 @@ struct Surface {
     private func confirmedSelection(matches expected: String, range: NSRange) -> Bool {
         var lastSeen = "nothing"
         let deadline = Date().addingTimeInterval(0.6)
+        let foldedExpected = folded(expected)
         repeat {
             if let selected = SelectionReader.selectedText(of: element), !selected.isEmpty {
                 if folded(selected).compare(
-                    folded(expected), options: .caseInsensitive
+                    foldedExpected, options: .caseInsensitive
                 ) == .orderedSame {
                     return true
                 }
@@ -892,7 +912,7 @@ struct Surface {
                         return true
                     }
                     if folded(said).compare(
-                        folded(expected), options: .caseInsensitive
+                        foldedExpected, options: .caseInsensitive
                     ) == .orderedSame {
                         return true
                     }
@@ -991,10 +1011,11 @@ struct Surface {
     /// that append as a clean retype for as long as this bug existed.
     private func box(reads expected: String) -> Bool {
         let deadline = Date().addingTimeInterval(1.5)
+        let foldedExpected = folded(expected)
         repeat {
             if let value = SelectionReader.visibleText(of: element),
                let box = SelectionReader.joinedInputBox(in: value),
-               folded(box) == folded(expected) {
+               folded(box) == foldedExpected {
                 return true
             }
             Thread.sleep(forTimeInterval: 0.05)


### PR DESCRIPTION
Three of the five things the 2026-08-22 audit found. None of them changes what the app does; each removes work whose result is thrown away.

The largest is the pill. Its SwiftUI surface stayed mounted after the panel was ordered out, so an offer that had come and gone went on being redrawn into a window nobody could see — 33% of a core in a reproduction, 57% on a machine that had been running four days. The other two are small and certain: `ToneDot` held a 0.6s timer that ticked on every tone and threw the ticks away, and four polling loops in `Surface.swift` re-folded a string that never changed between iterations.

What a reviewer should check is the pill's coming and going — it still appears, morphs, hides and comes back — and the `folded()` rewrite, which is the one change that could alter a comparison rather than just its cost.

Closes #183. Part of #180 — items 1 and 3 of the five.

<details>
<summary>Why an invisible pill kept a core busy</summary>

`sample` on the running app, 2718 samples over 5s, every one of them on the main thread inside the CoreAnimation commit:

```
CA::Transaction::commit()
 └ CA::Layer::display_if_needed
    └ -[CALayer _display] → CABackingStoreUpdate_
       └ ripc_DrawShading → rgba64_shade_conic_RGB   1572 samples (58%)
          └ atan2f                                    721 samples (27%)
```

`CGWindowListCopyWindowInfo` reported `onscreen=false` for every window of the process at the same moment.

Two things have to be true together.

**`state` is never cleared.** `PillModel.state` is written in one place, `PillHUD.set()`. Every hide path — `fadeOut()`, both of its branches, and the `runOut()` that ends a decay — calls `panel.orderOut(nil)` and stops there. The panel goes out and the view tree stays mounted with the last state still in it. If that state was `.offer`, `PillView.isOffer` is still true.

**An ordered-out panel still commits its layers.** `PlumageRim.spin()` and `OfferKeyCap.spin()` are `repeatForever` animations on a gradient's *angle*. An angle is not a layer property CoreAnimation can animate on the GPU, so SwiftUI re-renders and CoreGraphics re-rasterises the conic shading every frame — one `atan2f` per pixel. Nothing about the window being off screen stops that.

This answers the open question in #183: yes, AppKit still drives frames for an ordered-out window, and it is the expensive half. It only burns while the display is awake, which is why the process had 33 minutes of CPU rather than 55 hours.

</details>

<details>
<summary>Measured — 33% of a core, then 0.25%</summary>

**The pill.** `--panels offer 40` raises a real offer with the real `offerSeconds`, lets it decay, and then sits there. CPU sampled over 20s after the panel is out, both builds on the same machine minutes apart:

| build | CPU with nothing on screen |
|---|---|
| `origin/main` | 6.65s / 20s = **33% of a core** |
| this branch | 0.05s / 20s = **0.25%** |

33% here is lower than the 57% seen in the wild because this offer has no confidence rows, so there is a smaller layer to re-rasterise each frame.

**The tone dot.** `--panels notice 25` holds a `.done` notice on screen, the tone whose ticks were all discarded:

| build | CPU over 15s, notice on screen |
|---|---|
| `origin/main` | 0.05s = **0.33% of a core** |
| this branch | 0.00s = **0.0%** |

**The pill still works.** `--panels sequence` for 48s, polling `CGWindowListCopyWindowInfo` every 3s, shows the panel off screen at t=39s and on screen again at t=42s. That run cost 9.02s over 48s, which is the pill actually working: a live meter and a turning rim.

`Surface.folded()` is not on a path a `--panels` run exercises; its numbers are in the commit message (about 450 full scans of a 400 KB field down to about 50).

</details>

<details>
<summary>The one behaviour change in `folded()`, and how far it goes</summary>

`folded()` was eight chained `replacingOccurrences` calls, each walking and copying the whole string. It is now a single pass over unicode scalars. That is not a pure refactor: `replacingOccurrences` is grapheme-aware and will not match a scalar that is part of a larger cluster, and a scalar pass will.

Both versions were compiled side by side and run over 50,648 generated strings — every ordered triple of 24 pieces plus 40,000 random concatenations, covering `CR`, `LF`, `CRLF`, `CRLFCRLF`, `\n\r`, curly quotes, non-breaking and narrow no-break spaces, `é` as `e` plus a combining acute, tabs, an ellipsis and a zero-width space. **0 mismatches.**

They diverge in exactly one shape: a combining mark attached directly to a scalar that folds. `U+2019 U+0301` stays a curly quote under the old version and becomes `' U+0301` under the new one. The old behaviour was not the more correct one — `CR LF U+0301` folded to *two* newlines under the old version, because the `\r\n` search could not match a partial cluster and the later lone-`\r` pass then fired. The new version gives one.

That input does not occur in text anyone dictates into. It is left as it is: folding more, not less, is the right direction for a function that exists to make a comparison succeed, and a fold that fails only makes the settle loop time out and fall back.

</details>

<details>
<summary>Why the pill fix is a flag and not a new `PillState` case</summary>

Clearing `state` on the way out is the other obvious fix — add `.idle`, set it after `orderOut`, mount nothing for it. That is what #183 suggests.

`PillMetrics.width(for:)` is what rules it out. It is exhaustive over `PillState` and would need a width for `.idle`, and there is no such width: the panel is not sized when nothing is up. Any number returned there is invented to satisfy the compiler.

The two facts are separate. `state` is what is written on the pill. `onScreen` is whether the pill is up. Keeping them apart also means a state cannot be half-cleared: whatever the pill was last showing, `onScreen = false` takes all of it, including anything added later that animates.

`OfferKeyCap.spin()` has no stop condition of its own and does not need one — it only exists inside `OfferContent`, so the unmount takes it too.

</details>

<details>
<summary>Review notes — three commits, and the five lines that have to be right</summary>

Read it one commit at a time. Each is independent and each builds on its own.

**`perf: the pill stops drawing once it is off the screen`.** The property is `PillHUD.swift:87`. The gate is `PillHUD.swift:1077`, which splits the old `body` into a `body` that decides and a `pill` that draws — nothing inside it changed. The other five lines are the flag being set, and what to check is that they cover every way in and out:

- in: `fadeIn()` — every ordinary appearance
- in: `decay()` — an offer raised from cold, which does its own `orderFrontRegardless`
- out: `runOut()` — a decay that ran to the end
- out: `fadeOut()` — a decision cutting a moving decay
- out: `fadeOut()` — the ordinary fade

Those are all five `orderOut(nil)` and `orderFrontRegardless()` calls in the file.

One ordering point: `set()` writes `model.state` before it calls `fadeIn()`, so a pill raised from cold mounts once, already carrying its new state. There is no crossfade from the state the last pill left behind, which is right — it is coming from nothing.

**`perf: the tone dot's clock only runs while the dot is walking`.** The one thing to check is the resting colour. Thinking with Reduce Motion on used to draw `Parrot.wheel[step % 4]` with `step` stuck at 0; it now draws `Parrot.wheel[0]` through `resting`. Same colour, said directly.

**`perf: fold invariant strings once per poll loop, not once per tick`.** Cherry-picked from `claude/issue-180-analysis-1kskmx`, which had no PR of its own. The toggle above covers what was checked.

The release variant has the same pill bug. It reads near zero because its last state was a notice, and a notice's rim does not turn — only `.offer` and `.working` animate a gradient angle.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
