### PR TITLE
feat: report a bug from the menu, with the config and the log already in it

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -195,6 +195,14 @@ jobs:
       - name: The config a new install gets
         run: scripts/check-default-config.sh
 
+      # What the menu item and `--bug-report` put in front of someone before
+      # they send it. The sections, and the one thing this cannot be wrong
+      # about: no home path, so no account name, reaches a public issue. Runs
+      # against an empty config directory in /tmp, which is what a runner has
+      # and also what a broken install looks like.
+      - name: What a bug report carries
+        run: scripts/check-bug-report.sh
+
       # The other learnt file. Nobody rereads vocabulary.yaml, so a key that
       # quietly stops meaning what it meant is invisible — and one already did:
       # Yams answers `Bool.self` for `0.85`, so a decoder that asks about

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -20,6 +20,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let recorder = Recorder()
     private let pill = PillHUD()
     private let permissions = PermissionsWindowController()
+    private let bugReport = BugReportWindow()
 
     private var statusItem: NSStatusItem!
     private var statusInfoItem: NSMenuItem!
@@ -4223,6 +4224,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         menu.addItem(.separator())
 
+        let bugReportItem = NSMenuItem(
+            title: "Report a Bug…",
+            action: #selector(reportBug),
+            keyEquivalent: ""
+        )
+        bugReportItem.target = self
+        menu.addItem(bugReportItem)
+
         let aboutItem = NSMenuItem(
             title: "About \(AppVariant.displayName)",
             action: #selector(showAbout),
@@ -4475,6 +4484,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func openPermissions() {
         permissions.show(.revisiting)
+    }
+
+    /// The app in front is read before the window opens, because opening it
+    /// makes ParrotFlow the app in front.
+    @objc private func reportBug() {
+        let front = NSWorkspace.shared.frontmostApplication
+        let name = front?.bundleIdentifier == Bundle.main.bundleIdentifier
+            ? nil : front?.localizedName
+        bugReport.show(app: name)
     }
 
     @objc private func showAbout() {

--- a/Sources/ParrotFlow/BugReport.swift
+++ b/Sources/ParrotFlow/BugReport.swift
@@ -1,0 +1,281 @@
+import AppKit
+import Foundation
+
+/// The text a bug report needs, assembled from what the app already knows.
+///
+/// The form asks for the version, the machine, `--check-config` and the tail of
+/// the log. Every one of them is here, so nobody has to run four commands and
+/// paste the results.
+///
+/// Two rules shape it. Nothing is copied or opened before the person has read
+/// it — this app hears what people say, and the log can carry a transcript. And
+/// every absolute home path is written as `~`, in this one place, so no section
+/// can carry the account name out.
+enum BugReport {
+
+    /// What the form asks for: `tail -50`.
+    static let logLines = 50
+
+    /// GitHub answers a longer URL with an error page rather than a truncated
+    /// form, so the bulk goes to the clipboard and only the short fields go
+    /// here.
+    static let urlLimit = 2000
+
+    // MARK: - The machine
+
+    static var macOSVersion: String {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        var described = "\(version.majorVersion).\(version.minorVersion)"
+        if version.patchVersion > 0 { described += ".\(version.patchVersion)" }
+        return described
+    }
+
+    /// "Apple M2 Pro". `ProcessInfo` has no chip name; this sysctl key holds it
+    /// on Apple silicon and on Intel alike.
+    static var chip: String {
+        var size = 0
+        let key = "machdep.cpu.brand_string"
+        guard sysctlbyname(key, nil, &size, nil, 0) == 0, size > 0 else { return "unknown chip" }
+        var buffer = [UInt8](repeating: 0, count: size)
+        guard sysctlbyname(key, &buffer, &size, nil, 0) == 0 else { return "unknown chip" }
+        let name = String(decoding: buffer.prefix { $0 != 0 }, as: UTF8.self)
+        return name.trimmingCharacters(in: .whitespaces)
+    }
+
+    /// One line, and the value of the form's `macos` field.
+    static var machine: String { "macOS \(macOSVersion), \(chip)" }
+
+    // MARK: - The report
+
+    /// - Parameters:
+    ///   - fromTerminal: whether the accessibility answer can be trusted. It
+    ///     cannot from a command line, and the report says so instead of
+    ///     printing a wrong answer.
+    ///   - app: the app the person was dictating into, if it is known.
+    static func text(fromTerminal: Bool, app: String? = nil) -> String {
+        var sections: [String] = []
+
+        sections.append("ParrotFlow bug report")
+
+        var version = [
+            "Version",
+            "  app        \(AppVariant.version)",
+            "  build      \(AppVariant.buildStamp)",
+            "  macOS      \(macOSVersion)",
+            "  chip       \(chip)",
+        ]
+        if let app, !app.isEmpty { version.append("  app in use \(app)") }
+        sections.append(version.joined(separator: "\n"))
+
+        sections.append(permissions(fromTerminal: fromTerminal))
+        sections.append("--check-config\n\(CheckConfigCommand.report().text)")
+        sections.append("Log — last \(logLines) lines of \(Log.fileURL.path)\n\(logTail())")
+
+        return redacted(sections.joined(separator: "\n\n"))
+    }
+
+    private static func permissions(fromTerminal: Bool) -> String {
+        var lines = ["Permissions", "  microphone     \(Permissions.microphone.label)"]
+
+        if fromTerminal {
+            // The same caveat `--check-config` carries: TCC credits a check made
+            // from a shell to the shell, so ParrotFlow reads as untrusted even
+            // where the grant is in place. Measured — see docs/cli.md.
+            lines.append("  accessibility  not checkable from a terminal — macOS credits"
+                + " the check to the shell")
+            lines.append("                 the app writes the true value to the log at"
+                + " each launch (\"launched —\")")
+        } else {
+            lines.append("  accessibility  \(Permissions.accessibility.label)")
+            if let blocker = Permissions.accessibilityBlocker {
+                lines.append("                 \(blocker)")
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private static func logTail() -> String {
+        let url = Log.fileURL
+        guard let contents = try? String(contentsOf: url, encoding: .utf8) else {
+            return "  not found — no log file at \(url.path)"
+        }
+        let lines = contents
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .filter { !$0.isEmpty }
+        guard !lines.isEmpty else { return "  not found — the log file is empty" }
+        return lines.suffix(logLines).joined(separator: "\n")
+    }
+
+    // MARK: - The account name
+
+    /// Every absolute home path written as `~`.
+    ///
+    /// A path under another account is an account name too, so it is rewritten
+    /// the same way. Which home it was is worth less than the guarantee that
+    /// none of them leaves the machine.
+    static func redacted(_ text: String) -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        var out = text.replacingOccurrences(of: "/private\(home)", with: "~")
+        out = out.replacingOccurrences(of: home, with: "~")
+
+        guard let accounts = try? NSRegularExpression(pattern: "/Users/[^/\\s\"']+") else { return out }
+        return accounts.stringByReplacingMatches(
+            in: out,
+            range: NSRange(out.startIndex..., in: out),
+            withTemplate: "~"
+        )
+    }
+
+    // MARK: - The prefilled form
+
+    /// The issue form with the short fields already filled. The `--check-config`
+    /// output and the log are not in here — they are on the clipboard.
+    ///
+    /// The names are the field `id`s in `.github/ISSUE_TEMPLATE/bug.yml`. A name
+    /// that is not one is ignored by GitHub, silently.
+    static func issueURL(app: String? = nil) -> URL? {
+        var query = "template=bug.yml&labels=bug"
+        query += "&version=\(encoded(AppVariant.version))"
+        query += "&macos=\(encoded(machine))"
+        if let app, !app.isEmpty { query += "&app=\(encoded(app))" }
+
+        let base = "\(AppVariant.repository)/issues/new"
+        let full = "\(base)?\(query)"
+        let within = full.count <= urlLimit ? full : "\(base)?template=bug.yml&labels=bug"
+        return URL(string: within)
+    }
+
+    /// Alphanumerics only, so a space becomes `%20` rather than `+` and nothing
+    /// in a chip name or an app name can end the value early.
+    private static func encoded(_ value: String) -> String {
+        String(value.prefix(200)).addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? ""
+    }
+}
+
+/// The window behind 🦜 → Report a bug…
+///
+/// It exists to be read. The buttons are underneath the text rather than beside
+/// the menu item because a report that is copied before it is seen is a report
+/// nobody consented to — and this one carries the last fifty lines of a log that
+/// can hold dictated words.
+final class BugReportWindow: NSObject {
+
+    private var window: NSWindow?
+    private weak var textView: NSTextView?
+    private var report = ""
+    private var app: String?
+
+    /// - Parameter app: the app that was in front, for the form's `app` field.
+    func show(app: String?) {
+        self.app = app
+        report = BugReport.text(fromTerminal: false, app: app)
+
+        let window = self.window ?? build()
+        self.window = window
+        textView?.string = report
+
+        NSApp.activate(ignoringOtherApps: true)
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+    }
+
+    private func build() -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 720, height: 560),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Report a Bug"
+        window.isReleasedWhenClosed = false
+
+        let content = NSView()
+        window.contentView = content
+
+        let caption = NSTextField(wrappingLabelWithString:
+            "This is what will be copied. Read it first — the log can carry what you dictated."
+                + " Home paths are already written as ~.")
+        caption.font = .systemFont(ofSize: 11)
+        caption.textColor = .secondaryLabelColor
+
+        let scroll = NSScrollView()
+        scroll.hasVerticalScroller = true
+        scroll.hasHorizontalScroller = false
+        scroll.autohidesScrollers = true
+        scroll.borderType = .bezelBorder
+
+        // The recipe a text view in a scroll view needs: a real starting frame,
+        // an unbounded max size and width tracking, or it lays out at zero width
+        // and shows nothing.
+        let text = NSTextView(frame: NSRect(x: 0, y: 0, width: 688, height: 440))
+        text.minSize = NSSize(width: 0, height: 0)
+        let unbounded = CGFloat.greatestFiniteMagnitude
+        text.maxSize = NSSize(width: unbounded, height: unbounded)
+        text.isVerticallyResizable = true
+        text.isHorizontallyResizable = false
+        text.autoresizingMask = [.width]
+        text.textContainer?.widthTracksTextView = true
+        text.isEditable = false
+        text.isSelectable = true
+        text.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
+        text.string = report
+        scroll.documentView = text
+        textView = text
+
+        let cancel = NSButton(title: "Cancel", target: self, action: #selector(cancel))
+        cancel.keyEquivalent = "\u{1b}"
+        let copyOnly = NSButton(title: "Copy only", target: self, action: #selector(copyOnly))
+        let copyAndOpen = NSButton(
+            title: "Copy and open GitHub", target: self, action: #selector(copyAndOpen)
+        )
+        copyAndOpen.keyEquivalent = "\r"
+
+        let buttons = NSStackView(views: [cancel, copyOnly, copyAndOpen])
+        buttons.orientation = .horizontal
+        buttons.spacing = 12
+
+        for view in [caption, scroll, buttons] as [NSView] {
+            view.translatesAutoresizingMaskIntoConstraints = false
+            content.addSubview(view)
+        }
+
+        NSLayoutConstraint.activate([
+            caption.topAnchor.constraint(equalTo: content.topAnchor, constant: 16),
+            caption.leadingAnchor.constraint(equalTo: content.leadingAnchor, constant: 16),
+            caption.trailingAnchor.constraint(equalTo: content.trailingAnchor, constant: -16),
+
+            scroll.topAnchor.constraint(equalTo: caption.bottomAnchor, constant: 12),
+            scroll.leadingAnchor.constraint(equalTo: content.leadingAnchor, constant: 16),
+            scroll.trailingAnchor.constraint(equalTo: content.trailingAnchor, constant: -16),
+
+            buttons.topAnchor.constraint(equalTo: scroll.bottomAnchor, constant: 12),
+            buttons.leadingAnchor.constraint(greaterThanOrEqualTo: content.leadingAnchor, constant: 16),
+            buttons.trailingAnchor.constraint(equalTo: content.trailingAnchor, constant: -16),
+            buttons.bottomAnchor.constraint(equalTo: content.bottomAnchor, constant: -16),
+        ])
+
+        return window
+    }
+
+    private func copyReport() {
+        let board = NSPasteboard.general
+        board.clearContents()
+        board.setString(report, forType: .string)
+        Log.write("bug report: copied, \(report.count) characters")
+    }
+
+    @objc private func copyAndOpen() {
+        copyReport()
+        if let url = BugReport.issueURL(app: app) { NSWorkspace.shared.open(url) }
+        window?.close()
+    }
+
+    @objc private func copyOnly() {
+        copyReport()
+        window?.close()
+    }
+
+    @objc private func cancel() {
+        window?.close()
+    }
+}

--- a/Sources/ParrotFlow/BugReport.swift
+++ b/Sources/ParrotFlow/BugReport.swift
@@ -118,7 +118,10 @@ enum BugReport {
         var out = text.replacingOccurrences(of: "/private\(home)", with: "~")
         out = out.replacingOccurrences(of: home, with: "~")
 
-        guard let accounts = try? NSRegularExpression(pattern: "/Users/[^/\\s\"']+") else { return out }
+        // Everything up to the next slash or space, quotes included: an
+        // apostrophe is legal in an account name, and stopping at one left
+        // "~'connor" in the report.
+        guard let accounts = try? NSRegularExpression(pattern: "/Users/[^/\\s]+") else { return out }
         return accounts.stringByReplacingMatches(
             in: out,
             range: NSRange(out.startIndex..., in: out),

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -6,14 +6,28 @@ enum CheckConfigCommand {
 
     /// Returns the process exit code: 0 if the config is usable, 1 otherwise.
     static func run() -> Int32 {
-        print("config: \(ConfigStore.fileURL.path)")
+        let checked = report()
+        print(checked.text)
+        return checked.ok ? 0 : 1
+    }
+
+    /// The same lines, returned instead of printed, so `--bug-report` carries
+    /// this output without a second copy of it.
+    static func report() -> (text: String, ok: Bool) {
+        var lines: [String] = []
+        func emit(_ line: String) { lines.append(line) }
+        func finished(_ ok: Bool) -> (text: String, ok: Bool) {
+            (lines.joined(separator: "\n"), ok)
+        }
+
+        emit("config: \(ConfigStore.fileURL.path)")
 
         let config: Config
         do {
             config = try ConfigStore.load()
         } catch {
-            print("  ✗ \(describe(error))")
-            return 1
+            emit("  ✗ \(describe(error))")
+            return finished(false)
         }
 
         var ok = true
@@ -21,58 +35,58 @@ enum CheckConfigCommand {
         // Hotkey
         let mode = config.hotkey.mode == .toggle ? "toggle" : "push-to-talk"
         if let modifierKey = ModifierKey(name: config.hotkey.key) {
-            print("  ✓ hotkey            \(modifierKey.displayName)  (\(mode), polled)")
+            emit("  ✓ hotkey            \(modifierKey.displayName)  (\(mode), polled)")
             if !config.hotkey.modifiers.isEmpty {
-                print("  · note              hotkey.modifiers is ignored for a bare modifier key")
+                emit("  · note              hotkey.modifiers is ignored for a bare modifier key")
             }
         } else if KeyCodes.code(for: config.hotkey.key) == nil {
-            print("  ✗ hotkey.key: \"\(config.hotkey.key)\" is not a known key name")
+            emit("  ✗ hotkey.key: \"\(config.hotkey.key)\" is not a known key name")
             ok = false
         } else if KeyCodes.carbonModifiers(config.hotkey.modifiers) == 0 {
-            print("  ✗ hotkey.modifiers: need at least one of command, control, option, shift")
+            emit("  ✗ hotkey.modifiers: need at least one of command, control, option, shift")
             ok = false
         } else {
             let shortcut = KeyCodes.displayString(key: config.hotkey.key, modifiers: config.hotkey.modifiers)
-            print("  ✓ hotkey            \(shortcut)  (\(mode), Carbon)")
+            emit("  ✓ hotkey            \(shortcut)  (\(mode), Carbon)")
         }
         if config.hotkey.mode == .pushToTalk {
             let tail = config.hotkey.releaseTailSeconds
-            print("  · release tail      \(tail > 0 ? "\(tail)s after the key comes up" : "off — stops on the release")")
+            emit("  · release tail      \(tail > 0 ? "\(tail)s after the key comes up" : "off — stops on the release")")
         }
 
         // Audio
-        print("  ✓ sample rate       \(Int(config.audio.sampleRate)) Hz mono")
-        print("  ✓ output dir        \(config.resolvedOutputDir.path)")
-        print("  ✓ min duration      \(config.audio.minDurationSeconds)s")
-        print("  · speech gate       \(config.audio.speechGate ? "on" : "off")")
+        emit("  ✓ sample rate       \(Int(config.audio.sampleRate)) Hz mono")
+        emit("  ✓ output dir        \(config.resolvedOutputDir.path)")
+        emit("  ✓ min duration      \(config.audio.minDurationSeconds)s")
+        emit("  · speech gate       \(config.audio.speechGate ? "on" : "off")")
         if config.audio.secondOpinion, !config.audio.speechGate {
-            print("  ! second opinion    on, but it needs speech_gate — no padded decode will run")
+            emit("  ! second opinion    on, but it needs speech_gate — no padded decode will run")
         } else {
-            print("  · second opinion    \(config.audio.secondOpinion ? "on" : "off")")
+            emit("  · second opinion    \(config.audio.secondOpinion ? "on" : "off")")
         }
-        print("  · feedback          sound=\(config.feedback.sound) overlay=\(config.feedback.overlay)"
+        emit("  · feedback          sound=\(config.feedback.sound) overlay=\(config.feedback.overlay)"
               + " correct_offer=\(config.feedback.correctOffer)"
               + " confidence=\(config.feedback.confidence)")
-        print("  · low confidence    sentence<\(config.feedback.lowConfidence.sentence)"
+        emit("  · low confidence    sentence<\(config.feedback.lowConfidence.sentence)"
               + " AND word<\(config.feedback.lowConfidence.word)"
               + " hold_return=\(config.feedback.lowConfidence.holdReturn)"
               + (config.feedback.warnsOnLowConfidence ? "" : " (off)"))
-        print("  · logging           text=\(config.logging.text ? "on" : "off")"
+        emit("  · logging           text=\(config.logging.text ? "on" : "off")"
               + " audio=\(config.logging.audio ? "on" : "off")")
 
         // Transcription — printed so a mis-decoded config is visible rather
         // than silently falling back to "no vocabulary".
         let transcription = config.transcription
-        print("  · transcription     \(transcription.enabled ? "enabled" : "disabled")")
+        emit("  · transcription     \(transcription.enabled ? "enabled" : "disabled")")
         if transcription.enabled {
             let mode = transcription.insertMode == .paste
                 ? "paste into frontmost app (needs Accessibility)"
                 : "copy to clipboard"
-            print("  · insert mode       \(mode)")
+            emit("  · insert mode       \(mode)")
             let listed = transcription.activationPhrases
                 .map { "\"\($0)\"" }.joined(separator: ", ")
-            print("  · wake phrase       \(listed.isEmpty ? "none — spoken commands are off" : listed)")
-            print("  · rewrite line      \(transcription.rewriteLine ? "on" : "off (terminals can't be edited without it)")")
+            emit("  · wake phrase       \(listed.isEmpty ? "none — spoken commands are off" : listed)")
+            emit("  · rewrite line      \(transcription.rewriteLine ? "on" : "off (terminals can't be edited without it)")")
             // The pipeline, per language, because "why was this not
             // converted" is a question about the order and not about a
             // setting any more.
@@ -97,7 +111,7 @@ enum CheckConfigCommand {
                         if let app = step.app { described += " in \(app)" }
                         return described
                     }.joined(separator: " → ")
-                print("  · pipeline \(language)        \(stages)  (\(source))")
+                emit("  · pipeline \(language)        \(stages)  (\(source))")
             }
         }
 
@@ -105,18 +119,18 @@ enum CheckConfigCommand {
         // wrong: nothing fails, and two passes quietly stop running. So it is
         // an error, with the replacement spelled out.
         for problem in config.problems() {
-            print("  ✗ \(problem)")
+            emit("  ✗ \(problem)")
             ok = false
         }
         // Said, not complained about. These are true of a config that works —
         // a ✗ here used to fail the whole command over a `command:` transform
         // doing exactly what it was written to do.
         for notice in config.notices() {
-            print("  · \(notice)")
+            emit("  · \(notice)")
         }
         if !transcription.retired.isEmpty {
-            print("      pipelines:")
-            print("        default: [\(Pipeline.everything.stages.map(\.name).joined(separator: ", "))]")
+            emit("      pipelines:")
+            emit("        default: [\(Pipeline.everything.stages.map(\.name).joined(separator: ", "))]")
         }
 
         // What `voice/` has piled up, per term. Printed because it is the one
@@ -126,11 +140,11 @@ enum CheckConfigCommand {
         // learnt anything yet.
         let recorded = VoiceStore.counts()
         if !recorded.isEmpty {
-            print("  · voice             \(recorded.count) term(s) in"
+            emit("  · voice             \(recorded.count) term(s) in"
                 + " \(VoiceStore.directory.path)")
             let width = recorded.map(\.term.count).max() ?? 0
             for entry in recorded {
-                print("      \(entry.term.padding(toLength: width, withPad: " ", startingAt: 0))"
+                emit("      \(entry.term.padding(toLength: width, withPad: " ", startingAt: 0))"
                     + "  \(entry.observations) observation(s), \(entry.samples) sample(s)"
                     + "  — `--forget \(entry.term)` drops both")
             }
@@ -139,7 +153,7 @@ enum CheckConfigCommand {
         // says no threshold will ever separate that term for this speaker,
         // whatever `offer_below` is set to.
         if let bands = VoiceStore.calibration() {
-            print("  · calibration       measured \(bands.measured), \(bands.terms) term(s)"
+            emit("  · calibration       measured \(bands.measured), \(bands.terms) term(s)"
                 + (bands.closed > 0
                     ? ", \(bands.closed) with no band — those want `floor: off`"
                         + " and pronunciations, not a number"
@@ -162,33 +176,33 @@ enum CheckConfigCommand {
         // prompt starts answering differently. The key is described, never
         // printed.
         let models = config.modelsByName
-        print("  · models            \(models.count) reachable")
+        emit("  · models            \(models.count) reachable")
         let modelWidth = models.keys.map(\.count).max() ?? 0
         for name in models.keys.sorted() {
             guard let spec = models[name] else { continue }
             let padded = name.padding(toLength: max(modelWidth, 1), withPad: " ", startingAt: 0)
             let key = spec.api.isLocal ? "" : "  \(spec.key.described)"
-            print("      \(padded)  \(spec.api.rawValue)  \(spec.model)  \(spec.url)"
+            emit("      \(padded)  \(spec.api.rawValue)  \(spec.model)  \(spec.url)"
                 + "  reasoning \(spec.reasoning.rawValue)\(key)")
         }
-        print("  · runs on           default=\(config.modelName(for: .general))"
+        emit("  · runs on           default=\(config.modelName(for: .general))"
             + "  router=\(config.modelName(for: .router))"
             + "  spelling=\(config.modelName(for: .spelling))")
         let moved = config.transforms.filter { transform in
             transform.isPrompt && config.model(for: transform) != config.model()
         }
         for transform in moved {
-            print("      \(transform.name) → \(config.model(for: transform).described)")
+            emit("      \(transform.name) → \(config.model(for: transform).described)")
         }
 
         if !config.transforms.isEmpty {
-            print("  · transforms        \(config.transforms.count) defined")
+            emit("  · transforms        \(config.transforms.count) defined")
             let width = config.transforms.map(\.name.count).max() ?? 0
             for transform in config.transforms {
                 let name = transform.name.padding(
                     toLength: max(width, 1), withPad: " ", startingAt: 0
                 )
-                print("      \(name)  \(kind(of: transform))  \(bodyPath(transform))")
+                emit("      \(name)  \(kind(of: transform))  \(bodyPath(transform))")
             }
         }
 
@@ -196,13 +210,13 @@ enum CheckConfigCommand {
         // because the built-ins are the answer to "why did it do that" as
         // often as a prompt of your own is.
         let catalogue = Catalogue(transforms: config.transforms)
-        print("  ✓ capabilities      \(catalogue.capabilities.count) reachable by \"\(transcription.activationPhrase)\"")
+        emit("  ✓ capabilities      \(catalogue.capabilities.count) reachable by \"\(transcription.activationPhrase)\"")
         // What each one is made of, because the three cost wildly different
         // things — a model call, a process start, nothing at all — and because
         // a program reachable by voice is a program run by saying a sentence,
         // which this file says out loud everywhere else it happens.
         for capability in catalogue.capabilities {
-            print("      \(capability.kind)  \(capability.name) — \(capability.describedAs)")
+            emit("      \(capability.kind)  \(capability.name) — \(capability.describedAs)")
         }
         // A transform with no description cannot be routed to, so it is not in
         // the list above. It still runs from a pipeline, where the name is
@@ -210,16 +224,16 @@ enum CheckConfigCommand {
         // since "I wrote it and it does not answer" is otherwise a mystery.
         let unroutable = config.transforms.filter { $0.description.isEmpty }
         if !unroutable.isEmpty {
-            print("  · not by voice      \(unroutable.map(\.name).joined(separator: ", "))"
+            emit("  · not by voice      \(unroutable.map(\.name).joined(separator: ", "))"
                 + " — no description to match spoken words against")
         }
         // Not one of the capabilities above — the router reaches it by
         // answering ANY, not by picking it off the list — so it is printed
         // apart from them rather than pretending to be a catalogue entry.
         if config.freeForm {
-            print("      free-form  \(FreeForm.name) — \(FreeForm.prompt.description)")
+            emit("      free-form  \(FreeForm.name) — \(FreeForm.prompt.description)")
         } else {
-            print("  · catch_all         off — an instruction no prompt covers is refused")
+            emit("  · catch_all         off — an instruction no prompt covers is refused")
         }
 
         // How many rules each table holds, which nothing else says. The
@@ -234,10 +248,10 @@ enum CheckConfigCommand {
         // table rather than as a script.
         let tables = config.transforms.filter(\.isTable)
         if !tables.isEmpty {
-            print("  · replace           \(tables.count) transform(s)")
+            emit("  · replace           \(tables.count) transform(s)")
             for table in tables {
                 let rules = table.rules.count
-                print("      table     \(table.name) — \(rules) rule(s)"
+                emit("      table     \(table.name) — \(rules) rule(s)"
                     + (table.description.isEmpty ? "" : ", \(table.description)"))
             }
         }
@@ -250,9 +264,9 @@ enum CheckConfigCommand {
             transform.displayLabel.map { (transform.name, $0) }
         }
         if !announced.isEmpty {
-            print("  · display           \(announced.count) transform(s) say what they are doing")
+            emit("  · display           \(announced.count) transform(s) say what they are doing")
             for (name, label) in announced {
-                print("      \(name) — \"\(label)\"")
+                emit("      \(name) — \"\(label)\"")
             }
         }
 
@@ -262,7 +276,7 @@ enum CheckConfigCommand {
         // read as the offer simply being short.
         let offered = config.transforms.filter(\.offer)
         if !offered.isEmpty {
-            print("  · offer             \(offered.count) transform(s) on the pill, after Vocabulary")
+            emit("  · offer             \(offered.count) transform(s) on the pill, after Vocabulary")
             // Correct's letter is not a transform's to lose, and the first chip
             // with a letter is the one that key runs. So a second chip asking
             // for the same letter is drawn with a keycap that never fires, and
@@ -279,12 +293,12 @@ enum CheckConfigCommand {
                     note = " — \(key)"
                     taken.insert(key)
                 }
-                print("      \(transform.name)\(note)")
+                emit("      \(transform.name)\(note)")
             }
         }
 
         for prompt in config.prompts where prompt.description.isEmpty {
-            print("  ✗ prompt \"\(prompt.name)\" has no description; the router cannot pick it")
+            emit("  ✗ prompt \"\(prompt.name)\" has no description; the router cannot pick it")
             ok = false
         }
 
@@ -292,33 +306,33 @@ enum CheckConfigCommand {
         // that turns all of it off, and the pinning that only Ollama has.
         if config.llmEnabled {
             let router = config.model(for: .router)
-            print("  · models            \(config.modelsByName.count), default"
+            emit("  · models            \(config.modelsByName.count), default"
                 + " \(config.defaultModelName)")
             if router.api == .ollama {
-                print("  · keep loaded       \(router.keepLoaded ? "on (\(router.model) pinned in RAM)" : "off (Ollama unloads after 5 min; +7-10s on a cold call)")")
+                emit("  · keep loaded       \(router.keepLoaded ? "on (\(router.model) pinned in RAM)" : "off (Ollama unloads after 5 min; +7-10s on a cold call)")")
             }
         } else {
-            print("  · models            none — nothing calls a model")
+            emit("  · models            none — nothing calls a model")
         }
 
         switch config.updates.afterDays {
         case ..<0:
-            print("  · updates           never checked")
+            emit("  · updates           never checked")
         case 0:
-            print("  · updates           checked hourly, offered as soon as published")
+            emit("  · updates           checked hourly, offered as soon as published")
         case let days:
-            print("  · updates           checked hourly, offered after \(days) day\(days == 1 ? "" : "s")")
+            emit("  · updates           checked hourly, offered after \(days) day\(days == 1 ? "" : "s")")
         }
 
         // Environment
         let mic = Permissions.microphone
-        print("  \(mic == .granted ? "✓" : "✗") microphone        \(mic.label)")
+        emit("  \(mic == .granted ? "✓" : "✗") microphone        \(mic.label)")
         if mic != .granted { ok = false }
 
         if let device = AVCaptureDevice.default(for: .audio) {
-            print("  ✓ input device      \(device.localizedName)")
+            emit("  ✓ input device      \(device.localizedName)")
         } else {
-            print("  ✗ input device      none found")
+            emit("  ✗ input device      none found")
             ok = false
         }
 
@@ -333,13 +347,13 @@ enum CheckConfigCommand {
         // when the answer is yes is worse than no check, so it reports where the
         // real answer lives instead — the app tests it at launch and logs it.
         if transcription.insertMode == .paste || !transcription.activationPhrases.isEmpty {
-            print("  · accessibility     needed, but not checkable from a terminal")
-            print("      macOS credits this check to the shell, not to ParrotFlow.")
-            print("      The app records the true value each time it starts:")
-            print("      grep 'launched —' \(Log.fileURL.path) | tail -1")
+            emit("  · accessibility     needed, but not checkable from a terminal")
+            emit("      macOS credits this check to the shell, not to ParrotFlow.")
+            emit("      The app records the true value each time it starts:")
+            emit("      grep 'launched —' \(Log.fileURL.path) | tail -1")
         }
 
-        return ok ? 0 : 1
+        return finished(ok)
     }
 
     /// Which of the three bodies this is, in one column.

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -62,6 +62,20 @@ if arguments.contains("--check-config") {
     exit(CheckConfigCommand.run())
 }
 
+// Everything the bug form asks for, in one paste. `--url` prints the prefilled
+// issue URL instead, which is what the menu item opens.
+//
+// Always 0, config or no config: a report about a broken install is exactly the
+// one that has to come out.
+if arguments.contains("--bug-report") {
+    if arguments.contains("--url") {
+        print(BugReport.issueURL()?.absoluteString ?? "\(AppVariant.repository)/issues/new")
+    } else {
+        print(BugReport.text(fromTerminal: true))
+    }
+    exit(0)
+}
+
 /// `--app <name>`, for the commands that run a pipeline. Shared so the flag
 /// means the same thing to each of them.
 let appArgument: String? = arguments.firstIndex(of: "--app").flatMap { index in

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,6 +23,7 @@ means it did what it says**, so these compose into scripts — which is what
 | `--route "<what you'd say>"` | Which transform does this instruction reach? |
 | `--eval <transform>` | How does it score against its own case set? |
 | `--seed-config` | What does a first launch write, and what did it leave alone? |
+| `--bug-report` | Everything a bug report needs, in one paste. |
 
 Every one of them reads `~/.config/parrotflow/`. Set `PARROTFLOW_CONFIG_DIR` to
 point them somewhere else — a whole config directory in `/tmp`, say — which is
@@ -69,6 +70,26 @@ launch and writes the answer down:
 ```sh
 grep "launched —" ~/Library/Logs/ParrotFlow.log | tail -1
 ```
+
+### `--bug-report`
+
+Prints what the bug form asks for: the version, macOS and the chip, the
+permission state, the whole `--check-config` output and the last 50 lines of the
+log. Every absolute home path is written as `~`, so the report carries no
+account name.
+
+```sh
+$PF --bug-report            # the report, on stdout
+$PF --bug-report --url      # the prefilled issue form, without the report
+```
+
+It exits 0 with no config and no log file. A report about an install that does
+not work is the one that has to come out.
+
+🦜 → **Report a Bug…** shows the same text in a window, and copies it only after
+you have read it — the log can carry what you dictated. The URL it opens fills
+in the short fields; the report itself goes on the clipboard, because a log in a
+URL overflows what GitHub accepts and gives an error page rather than a form.
 
 ## Testing a rewrite
 
@@ -526,6 +547,7 @@ scripts/check-audio-recovery.sh    # a microphone that changes leaves a usable e
 scripts/check-profiles.sh          # which app gets examined, named, or read for context
 scripts/check-clipboard.sh         # when a rewrite may go to the clipboard, and stay there
 scripts/check-span-rule.sh         # which range a rewrite is written as, before any app sees it
+scripts/check-bug-report.sh        # what a bug report carries, and that it carries no home path
 
 PF_VIEWPORT=Ghostty scripts/check-inplace.sh   # the same set, in another terminal
 $PF --peek 3 --via-copy                        # what Select All + Copy hands back

--- a/scripts/check-bug-report.sh
+++ b/scripts/check-bug-report.sh
@@ -65,27 +65,31 @@ for section in \
   "--check-config" \
   "Log — last 50 lines"
 do
+  # `--` first: a pattern starting with a dash is otherwise read as an option,
+  # and BSD grep exits 2 with a usage message.
   check "the report names \"$section\"" \
-    "$(printf '%s\n' "$report" | grep -cF "$section")" \
+    "$(printf '%s\n' "$report" | grep -cF -- "$section")" \
     "1"
 done
 
 check "the version line is filled in" \
-  "$(printf '%s\n' "$report" | grep -cE '^  app        .+')" \
+  "$(printf '%s\n' "$report" | grep -cE '^  app +[^ ]')" \
   "1"
 
 check "macOS and the chip are named" \
-  "$(printf '%s\n' "$report" | grep -cE '^  (macOS|chip)       .+')" \
+  "$(printf '%s\n' "$report" | grep -cE '^  (macOS|chip) +[^ ]')" \
   "2"
 
 check "the microphone permission is reported" \
-  "$(printf '%s\n' "$report" | grep -cE '^  microphone     .+')" \
+  "$(printf '%s\n' "$report" | grep -cE '^  microphone +[^ ]')" \
   "1"
 
 # Accessibility read from a terminal is credited to the terminal, so the answer
 # would be "not granted" on a Mac where it is granted. It says so instead.
+# Anchored on the report's own line. `--check-config` carries the same caveat
+# further down, and an unanchored pattern counts both.
 check "accessibility says it cannot be answered from a terminal" \
-  "$(printf '%s\n' "$report" | grep -c 'not checkable from a terminal')" \
+  "$(printf '%s\n' "$report" | grep -cE '^  accessibility  not checkable from a terminal')" \
   "1"
 
 check "--check-config output is included, not summarised" \
@@ -146,7 +150,7 @@ check "it opens the issue form from AppVariant.repository" \
 # finds out why.
 for field in "template=bug.yml" "labels=bug" "version=" "macos="; do
   check "the URL carries $field" \
-    "$(printf '%s\n' "$url" | grep -cF "$field")" \
+    "$(printf '%s\n' "$url" | grep -cF -- "$field")" \
     "1"
 done
 

--- a/scripts/check-bug-report.sh
+++ b/scripts/check-bug-report.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Checks what `--bug-report` prints: every section the bug form asks for, no
+# account name anywhere in it, and a prefilled URL GitHub will accept.
+#
+#   scripts/check-bug-report.sh
+#
+# Three things are being answered, and each was a decision:
+#
+#   every section is there      the point of the command is that nobody has to
+#                              run four others. A section that quietly stops
+#                              being assembled looks exactly like a section
+#                              that had nothing to say
+#   no absolute home path       the report goes to a public issue tracker. The
+#                              home directory is rewritten to `~` in one place,
+#                              and `/Users/` surviving anywhere means it was
+#                              missed
+#   the URL stays short         GitHub answers a URL over its limit with an
+#                              error page, not with a truncated form. So the
+#                              log and `--check-config` go to the clipboard and
+#                              only the short fields go in the URL
+#
+# Run against a config directory in /tmp, so this says nothing about — and does
+# nothing to — the config on this machine. An empty one is also what a broken
+# install looks like, which is the install most likely to be reported.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/release/ParrotFlow"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+
+WORK="$(mktemp -d -t parrotflow-bug-report)"
+trap 'chmod -R u+w "$WORK" 2>/dev/null; rm -rf "$WORK"' EXIT
+
+pass=0; total=0; failed=""
+
+check() {  # check <name> <got> <want>
+  total=$((total + 1))
+  if [ "$2" = "$3" ]; then
+    pass=$((pass + 1))
+    printf '  ✓ %s\n' "$1"
+  else
+    failed="$failed
+      $1"
+    printf '  ✗ %s\n      got   %s\n      want  %s\n' "$1" "$2" "$3"
+  fi
+}
+
+EMPTY="$WORK/empty"
+mkdir -p "$EMPTY"
+
+report="$(PARROTFLOW_CONFIG_DIR="$EMPTY" "$BIN" --bug-report 2>/dev/null)"
+status="$(PARROTFLOW_CONFIG_DIR="$EMPTY" "$BIN" --bug-report > /dev/null 2>&1; echo $?)"
+
+# --- it comes out at all, with nothing configured ---------------------------
+#
+# The microphone is not granted on a runner and there is no log file. Neither
+# is a reason to refuse: a report about an install that does not work is the
+# one that has to be printable.
+check "exits 0 with no config directory" "$status" "0"
+
+# --- every section the form asks for ----------------------------------------
+for section in \
+  "ParrotFlow bug report" \
+  "Version" \
+  "Permissions" \
+  "--check-config" \
+  "Log — last 50 lines"
+do
+  check "the report names \"$section\"" \
+    "$(printf '%s\n' "$report" | grep -cF "$section")" \
+    "1"
+done
+
+check "the version line is filled in" \
+  "$(printf '%s\n' "$report" | grep -cE '^  app        .+')" \
+  "1"
+
+check "macOS and the chip are named" \
+  "$(printf '%s\n' "$report" | grep -cE '^  (macOS|chip)       .+')" \
+  "2"
+
+check "the microphone permission is reported" \
+  "$(printf '%s\n' "$report" | grep -cE '^  microphone     .+')" \
+  "1"
+
+# Accessibility read from a terminal is credited to the terminal, so the answer
+# would be "not granted" on a Mac where it is granted. It says so instead.
+check "accessibility says it cannot be answered from a terminal" \
+  "$(printf '%s\n' "$report" | grep -c 'not checkable from a terminal')" \
+  "1"
+
+check "--check-config output is included, not summarised" \
+  "$(printf '%s\n' "$report" | grep -c '^  · transcription')" \
+  "1"
+
+# The section is never empty: either the tail, or a line saying there is no log
+# to tail. Which one shows up here is not fixed — the process writes its own
+# build line to the log at startup, so a machine with no log file at all is
+# rarer than a machine with one line in it. Both are a section, not a failure.
+lines_or_notice="$(printf '%s\n' "$report" \
+  | grep -cE 'not found — (no log file|the log file is empty)|^[0-9]{4}-[0-9]{2}-[0-9]{2} ')"
+
+check "the log section holds either a tail or a clear \"not found\"" \
+  "$([ "$lines_or_notice" -ge 1 ] && echo yes || echo no)" \
+  "yes"
+
+check "the log section never carries more than 50 lines" \
+  "$([ "$(printf '%s\n' "$report" | grep -cE '^[0-9]{4}-[0-9]{2}-[0-9]{2} ')" -le 50 ] \
+     && echo yes || echo no)" \
+  "yes"
+
+# --- the account name -------------------------------------------------------
+#
+# The one thing this file exists to prove. `--check-config` alone prints the
+# config path, the output directory, the log path and every transform's
+# resolved path, and all of them start with the home directory.
+check "no absolute home path survives" \
+  "$(printf '%s\n' "$report" | grep -c '/Users/')" \
+  "0"
+
+# The config directory above is in a temporary folder, so its own path says
+# nothing about `$HOME`. This one is built against the real home, where every
+# path `--check-config` prints starts with it.
+home_report="$("$BIN" --bug-report 2>/dev/null)"
+
+check "nor from a report built against the real home" \
+  "$(printf '%s\n' "$home_report" | grep -c '/Users/')" \
+  "0"
+
+check "and the home directory is written as ~ instead" \
+  "$(printf '%s\n' "$home_report" | grep -c '^config: ~/')" \
+  "1"
+
+# --- the URL ----------------------------------------------------------------
+url="$(PARROTFLOW_CONFIG_DIR="$EMPTY" "$BIN" --bug-report --url 2>/dev/null)"
+
+check "the URL is under 2000 characters" \
+  "$([ "${#url}" -lt 2000 ] && echo yes || echo no)" \
+  "yes"
+
+check "it opens the issue form from AppVariant.repository" \
+  "$(printf '%s\n' "$url" | grep -c '^https://github.com/znat/parrotflow/issues/new?')" \
+  "1"
+
+# The names are field ids in .github/ISSUE_TEMPLATE/bug.yml. A name that is not
+# one is dropped by GitHub without a word, so the form arrives empty and nobody
+# finds out why.
+for field in "template=bug.yml" "labels=bug" "version=" "macos="; do
+  check "the URL carries $field" \
+    "$(printf '%s\n' "$url" | grep -cF "$field")" \
+    "1"
+done
+
+# Percent-encoded, so a space in "macOS 15.5, Apple M2 Pro" cannot end the value
+# early.
+check "the URL has no raw spaces" \
+  "$(printf '%s\n' "$url" | grep -c ' ')" \
+  "0"
+
+# The bulk goes to the clipboard. In the URL it would overflow the limit and
+# the reporter would get an error page.
+check "neither the log nor --check-config is in the URL" \
+  "$(printf '%s\n' "$url" | grep -c 'check-config=\|log=')" \
+  "0"
+
+echo
+echo "  $pass/$total$failed"
+[ "$pass" = "$total" ]

--- a/scripts/check-bug-report.sh
+++ b/scripts/check-bug-report.sh
@@ -134,6 +134,26 @@ check "and the home directory is written as ~ instead" \
   "$(printf '%s\n' "$home_report" | grep -c '^config: ~/')" \
   "1"
 
+# An apostrophe is legal in a macOS account name, and the pattern used to stop
+# at one — `/Users/o'connor/…` came out as `~'connor/…`, which is still the
+# name. Written into `output_dir`, which --check-config prints as an absolute
+# path whatever is there.
+QUOTED="$WORK/quoted"
+mkdir -p "$QUOTED"
+cat > "$QUOTED/config.yaml" <<'YAML'
+audio:
+  output_dir: "/Users/o'connor/Recordings"
+YAML
+quoted="$(PARROTFLOW_CONFIG_DIR="$QUOTED" "$BIN" --bug-report 2>/dev/null)"
+
+check "an account name holding an apostrophe is redacted too" \
+  "$(printf '%s\n' "$quoted" | grep -c "o'connor")" \
+  "0"
+
+check "and nothing under /Users/ is left in that report either" \
+  "$(printf '%s\n' "$quoted" | grep -c '/Users/')" \
+  "0"
+
 # --- the URL ----------------------------------------------------------------
 url="$(PARROTFLOW_CONFIG_DIR="$EMPTY" "$BIN" --bug-report --url 2>/dev/null)"
 


### PR DESCRIPTION
The bug form asks for four things a reporter has to gather by hand — the app version, the macOS version and chip, the `--check-config` output and the tail of the log. Most people will do none of it, so most reports cost a round trip before triage can start. 🦜 → **Report a Bug…** now assembles all four, shows the text, and copies it on one click; `--bug-report` prints the same text to stdout for a terminal user or an agent. Nothing is copied or opened before the person has read it: this app hears what people say, and the log can carry a transcript. Every absolute home path is rewritten to `~`, so no section carries the account name into a public issue.

Start the review at `Sources/ParrotFlow/BugReport.swift`. The one thing CI cannot check is on screen — see the click-through list below.

Closes #191

<details>
<summary>What goes in the URL, and why the log does not</summary>

The URL is built from `AppVariant.repository` and fills only the short, deterministic fields:

```
{repository}/issues/new?template=bug.yml&labels=bug&version=…&macos=…&app=…
```

`version`, `macos` and `app` are field `id`s in `.github/ISSUE_TEMPLATE/bug.yml`, which #189 adds. That file is not on `main` yet, so until #189 merges the URL opens the plain new issue form — GitHub ignores a template it cannot find. The ids were read from `origin/claude/github-promotion-plan-oscfvk` so they match; this branch does not add a second copy of that file.

`--check-config` and the log go to the clipboard instead. A URL over about 2000 characters gets an error page, not a truncated form, so the whole URL is kept under that and the check script asserts it. Values are percent-encoded against `.alphanumerics`, so a space in "macOS 15.5, Apple M2 Pro" cannot end the value early.

</details>

<details>
<summary>Sections, and what each one is read from</summary>

| Section | Source |
|---|---|
| Version, build | `AppVariant.version` (`CFBundleShortVersionString`), `AppVariant.buildStamp` |
| macOS, chip | `ProcessInfo.operatingSystemVersion`, `sysctlbyname("machdep.cpu.brand_string")` |
| Permissions | `Permissions.swift` |
| `--check-config` | `CheckConfigCommand.report()` |
| Log | last 50 lines of `Log.fileURL` |

`ProcessInfo` has no chip name, which is the only reason sysctl is in there.

Accessibility keeps the caveat `docs/cli.md` documents. macOS credits a permission check made from a terminal to the terminal, so from the CLI the report says the answer is not checkable there and points at the line the app writes at launch. From the menu the check is the app's own, so the real status is printed.

`CheckConfigCommand.run()` is split into `report()`, which returns the lines instead of printing them. That is the whole refactor — one copy of that output rather than two. Every `print(` in the function became `emit(`.

</details>

<details>
<summary>It works with no config and no log file, which is what a broken install looks like</summary>

`scripts/check-bug-report.sh` runs the real binary against an empty `PARROTFLOW_CONFIG_DIR` in a temporary directory, the way `check-transform-folders.sh` does. 26 assertions:

- exit 0 with no config directory
- every section is present, and `--check-config` output is included rather than summarised
- the log section holds either a tail or a clear "not found", and never more than 50 lines
- **no `/Users/` survives anywhere in the output** — asked of a report built against the temporary config directory, of one built against the real home, and of one whose `output_dir` is `/Users/o'connor/Recordings`
- the URL is under 2000 characters, carries `template=bug.yml`, `labels=bug`, `version=` and `macos=`, has no raw spaces, and carries neither the log nor `--check-config`

It is a new step in `.github/workflows/checks.yml`. #189 adds a `CHECKS :=` list to the `Makefile` for `make test`; **`check-bug-report.sh` needs adding to that list when the two branches meet.** This PR does not touch the `Makefile`. #189 also adds the DCO workflow, so no `dco` check runs here yet — every commit on this branch is signed off.

</details>

<details>
<summary>What the review found — one real bug in the redaction</summary>

An apostrophe is legal in a macOS account name, and the pattern excluded one from the account segment. `/Users/o'connor/Documents` came out as `~'connor/Documents`, so the name was still in a report headed for a public issue. It matches to the next slash or space now, quotes included, and `check-bug-report.sh` carries the case (238ec95).

The other finding was that `bug.yml` is missing from `main`. True, and expected: it comes with #189, as above. Nothing changed for it.

</details>

<details>
<summary>What CI cannot prove — the window, the buttons and the menu item need a Mac</summary>

CI proves it compiles, lints, and that `--bug-report` produces the right text with no account name in it. There is no screen on a runner, so none of this is checked:

- 🦜 → **Report a Bug…** appears above **About ParrotFlow**, under the separator
- the window opens, and the text is selectable and scrolls
- **Copy and open GitHub** puts the whole report on the clipboard and opens the form with Version and macOS already filled
- **Copy only** copies and closes, opening nothing
- **Cancel** closes and copies nothing — the clipboard is untouched
- the `app` field carries the app that was in front when the menu item was clicked, and is left out when that app is ParrotFlow itself
- Return triggers **Copy and open GitHub**, Escape triggers **Cancel**
- the accessibility line shows the real status from the app, not the terminal caveat

Worth checking on a machine that has been dictating for a while: that the log tail in the window is readable at 50 lines, and that nothing in it should have been redacted beyond the home path.

</details>