### PR TITLE
fix: a bare-modifier hotkey ignores a press that belongs to a shortcut

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -736,8 +736,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         hotkeyError = nil
         hotKeys.onPress = { [weak self] in self?.handleHotKeyPress() }
         hotKeys.onRelease = { [weak self] in self?.handleHotKeyRelease() }
+        hotKeys.onAbort = { [weak self] in self?.cancelDictation(.notTheHotkey) }
         do {
-            try hotKeys.register(key: config.hotkey.key, modifiers: config.hotkey.modifiers)
+            try hotKeys.register(
+                key: config.hotkey.key,
+                modifiers: config.hotkey.modifiers,
+                pressDelay: config.hotkey.pressDelaySeconds
+            )
         } catch {
             hotkeyError = error.localizedDescription
             Log.write("hotkey registration FAILED: \(error.localizedDescription)")
@@ -1400,6 +1405,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Escape
 
+    private enum CancelReason {
+        case escape
+        /// The hotkey was the front half of a shortcut, and the dictation
+        /// started on its down edge has to go — see `ModifierKeyMonitor`.
+        case notTheHotkey
+    }
+
     /// Stop a dictation that is already under way.
     ///
     /// Escape is the one key everybody already presses to mean "not that". You
@@ -1418,7 +1430,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// flight is marked so its result is dropped when it lands: the model call
     /// is not interruptible, so this cannot make it stop sooner — it only makes
     /// sure nothing is written when it does.
-    private func cancelDictation() {
+    private func cancelDictation(_ reason: CancelReason = .escape) {
         let recording = recorder.isRecording
         // A run is in flight when one has been started and nothing has retired
         // it yet. `transcriptionRun` is bumped per dictation and already carries
@@ -1460,9 +1472,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // guards on idle itself, so a cancelled transcription that is still in
         // flight hands over nothing until it lands.
         stopWatchingForEscapeIfIdle()
-        if config.feedback.sound { NSSound(named: "Pop")?.play() }
-        Log.write("escape: cancelled while \(recording ? "recording" : "transcribing")")
-        flash(recording ? "Recording cancelled" : "Transcription cancelled", tone: .caution)
+        switch reason {
+        case .escape:
+            if config.feedback.sound { NSSound(named: "Pop")?.play() }
+            Log.write("escape: cancelled while \(recording ? "recording" : "transcribing")")
+            flash(recording ? "Recording cancelled" : "Transcription cancelled", tone: .caution)
+        case .notTheHotkey:
+            // Silent, and deliberately so. The user pressed ⌘S and is owed a
+            // save. A notice about a dictation they never started would be an
+            // apology for something they are not supposed to have seen.
+            Log.write("hotkey: dropped — the modifier was part of a shortcut")
+        }
         updateUI()
     }
 

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -235,6 +235,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// so it cannot be mistaken for a later one's.
     private var pressRun = 0
 
+    /// `transcriptionRun` as it stood when the current press arrived. It says
+    /// whether a transcription now in flight was started by this press or was
+    /// already running behind it, which is the difference between an abort
+    /// dropping its own dictation and an abort eating somebody else's words.
+    private var transcriptionRunAtPress = 0
+
     /// The newest press that has had the pill for an offer.
     ///
     /// Two things read it: the landing search, which only moves the pill while
@@ -1027,6 +1033,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Hotkey handling
 
     private func handleHotKeyPress() {
+        // Read before anything this press does, so an abort later can tell the
+        // transcription this press started from one that was already running.
+        transcriptionRunAtPress = transcriptionRun
         // Grab the selection now: by the time a transcript exists, a terminal
         // will very likely have dropped it. Timed out hard inside snapshot(),
         // because this is the main thread and recording must start regardless.
@@ -1435,7 +1444,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // A run is in flight when one has been started and nothing has retired
         // it yet. `transcriptionRun` is bumped per dictation and already carries
         // through the whole chain, so it is the identity to cancel against.
+        // An abort takes the dictation its own press started and nothing else.
+        // Push-to-talk does not wait for the previous transcript, so a
+        // transcription is routinely in flight from an earlier press while this
+        // one records — and those words were said on purpose. You pressed ⌘S;
+        // you are not asking for the sentence you finished a second ago to be
+        // thrown away. Escape still means the lot, which is what Escape is for.
+        let startedItsOwn = transcriptionRun > transcriptionRunAtPress
         let transcribing = transcriptionLabel != nil
+            && (reason == .escape || startedItsOwn)
         guard recording || transcribing else { return }
 
         if recording {

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -35,6 +35,16 @@ enum CheckConfigCommand {
             let shortcut = KeyCodes.displayString(key: config.hotkey.key, modifiers: config.hotkey.modifiers)
             print("  ✓ hotkey            \(shortcut)  (\(mode), Carbon)")
         }
+        if ModifierKey(name: config.hotkey.key) != nil {
+            let delay = config.hotkey.pressDelaySeconds
+            let held = delay > 0
+                ? "held alone for \(delay)s, or it is a shortcut"
+                : "off — starts on the down edge"
+            print("  · press delay       \(held)")
+            if delay > 0, Permissions.accessibility != .granted {
+                print("  · note              without Accessibility, only a second modifier is caught")
+            }
+        }
         if config.hotkey.mode == .pushToTalk {
             let tail = config.hotkey.releaseTailSeconds
             print("  · release tail      \(tail > 0 ? "\(tail)s after the key comes up" : "off — stops on the release")")

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1899,10 +1899,16 @@ struct Config: Decodable, Equatable {
         /// How long the mic stays open after the key comes up, in push-to-talk.
         /// The hand beats the mouth: the last syllable lands after the release.
         var releaseTailSeconds: Double = 0.3
+        /// How long a bare modifier must be held *alone* before it starts a
+        /// dictation. ⌘ is half of every shortcut and ⌥ types `#` on a French
+        /// layout, so the down edge alone does not mean dictation. Bare
+        /// modifiers only; 0 fires on the down edge as before.
+        var pressDelaySeconds: Double = 0.18
 
         enum CodingKeys: String, CodingKey {
             case key, modifiers, mode
             case releaseTailSeconds = "release_tail_seconds"
+            case pressDelaySeconds = "press_delay_seconds"
         }
 
         enum Mode: String, Codable, Equatable {
@@ -1942,6 +1948,16 @@ struct Config: Decodable, Equatable {
                     )
                 }
                 self.releaseTailSeconds = tail
+            }
+            if let delay = try c.decodeIfPresent(Double.self, forKey: .pressDelaySeconds) {
+                guard delay >= 0, delay <= 1 else {
+                    throw ConfigError.invalidValue(
+                        key: "hotkey.press_delay_seconds",
+                        value: String(delay),
+                        expected: "a delay between 0 and 1 second"
+                    )
+                }
+                self.pressDelaySeconds = delay
             }
         }
     }

--- a/Sources/ParrotFlow/HotKeyManager.swift
+++ b/Sources/ParrotFlow/HotKeyManager.swift
@@ -7,7 +7,8 @@ import Carbon.HIToolbox
 ///   `RegisterEventHotKey` — no Accessibility permission, and it swallows the
 ///   keystroke so the combo doesn't leak into the frontmost app.
 /// - A bare modifier (Right ⌥) can't be expressed that way, so it falls to
-///   `ModifierKeyMonitor`, which polls the global flag state.
+///   `ModifierKeyMonitor`, which polls the global flag state and holds the
+///   press back long enough to tell a dictation from a shortcut.
 ///
 /// Both are permission-free. Which one is in play is visible via `binding`.
 final class HotKeyManager {
@@ -50,6 +51,10 @@ final class HotKeyManager {
 
     var onPress: (() -> Void)?
     var onRelease: (() -> Void)?
+    /// A press already delivered turned out to be part of a shortcut — see
+    /// `ModifierKeyMonitor`. Never fires on the Carbon path: a combo is
+    /// unambiguous by construction.
+    var onAbort: (() -> Void)?
 
     private(set) var binding: Binding?
 
@@ -61,18 +66,21 @@ final class HotKeyManager {
     init() {
         modifierMonitor.onPress = { [weak self] in self?.onPress?() }
         modifierMonitor.onRelease = { [weak self] in self?.onRelease?() }
+        modifierMonitor.onAbort = { [weak self] in self?.onAbort?() }
     }
 
     // MARK: Lifecycle
 
     @discardableResult
-    func register(key: String, modifiers: [String]) throws -> Binding {
+    func register(
+        key: String, modifiers: [String], pressDelay: TimeInterval = 0
+    ) throws -> Binding {
         unregister()
 
         // A bare modifier wins over the combo path, and any `modifiers:` list
         // alongside it is meaningless — the key *is* the modifier.
         if let modifierKey = ModifierKey(name: key) {
-            modifierMonitor.start(key: modifierKey)
+            modifierMonitor.start(key: modifierKey, pressDelay: pressDelay)
             let binding = Binding.modifier(modifierKey)
             self.binding = binding
             return binding

--- a/Sources/ParrotFlow/ModifierKey.swift
+++ b/Sources/ParrotFlow/ModifierKey.swift
@@ -137,6 +137,12 @@ enum ModifierKey: String, CaseIterable {
 /// from the app in front. Monitors exist only while the key is down: an idle
 /// app is not watching the keyboard.
 ///
+/// The poll finds the down edge up to 25 ms late, and the monitors only exist
+/// from that moment, so a key typed inside those 25 ms is seen by neither. The
+/// third source covers exactly that gap: `secondsSinceLastEventType` says how
+/// long ago the last key or click was, and one more recent than the modifier's
+/// own `flagsChanged` came after it.
+///
 /// Polling rather than an event tap is still a deliberate trade: a cheap read
 /// every 25 ms, and no Input Monitoring grant, in exchange for not being able
 /// to swallow the keystroke. Nothing here wants to swallow one — the shortcut
@@ -239,6 +245,14 @@ final class ModifierKeyMonitor {
             deliverPress()
             return
         }
+        // The monitors above start here, which is up to one poll interval after
+        // the key physically went down. A `⌘S` typed faster than that lands in
+        // the gap and is never seen, so the delay would expire on silence and
+        // open the mic. Ask the event source about the gap instead.
+        if sawInputBeforeTheMonitors() {
+            somethingElseHappened()
+            return
+        }
         let timer = Timer(timeInterval: pressDelay, repeats: false) { [weak self] _ in
             self?.armTimer = nil
             self?.deliverPress()
@@ -282,6 +296,28 @@ final class ModifierKeyMonitor {
     }
 
     // MARK: Watching for everything that is not the key
+
+    /// Whether a key or a click landed between the modifier going down and the
+    /// poll noticing it.
+    ///
+    /// `secondsSinceLastEventType` timestamps the last event of a type without
+    /// reading any of them, so it costs no permission — the same trade as
+    /// `flagsState` above. The modifier's own down edge is a `flagsChanged`, so
+    /// anything with a *smaller* age than that arrived after it, which is the
+    /// definition of a shortcut.
+    ///
+    /// No scroll here, on purpose. Momentum cannot be told from a real scroll
+    /// through this API, and a trackpad flick keeps sending events for about a
+    /// second — so asking would abort every dictation started after scrolling a
+    /// page. The monitor half still catches scrolls, with the momentum filter.
+    private func sawInputBeforeTheMonitors() -> Bool {
+        func age(_ type: CGEventType) -> CFTimeInterval {
+            CGEventSource.secondsSinceLastEventType(.combinedSessionState, eventType: type)
+        }
+        let modifierWentDown = age(.flagsChanged)
+        let others: [CGEventType] = [.keyDown, .leftMouseDown, .rightMouseDown, .otherMouseDown]
+        return others.contains { age($0) < modifierWentDown }
+    }
 
     private func watchForOtherInput() {
         guard monitors.isEmpty else { return }

--- a/Sources/ParrotFlow/ModifierKey.swift
+++ b/Sources/ParrotFlow/ModifierKey.swift
@@ -44,6 +44,12 @@ enum ModifierKey: String, CaseIterable {
         CGEventSource.flagsState(.combinedSessionState).rawValue
     }
 
+    /// Every device-specific bit above, ORed together. Used to ask "is any
+    /// modifier other than this one down" — which is the cheap half of telling
+    /// a dictation apart from a shortcut, and the only half that needs no
+    /// permission.
+    static let allDeviceMasks: UInt64 = allCases.reduce(0) { $0 | $1.mask }
+
     var displayName: String {
         switch self {
         case .rightOption:  return "Right ⌥"
@@ -91,33 +97,102 @@ enum ModifierKey: String, CaseIterable {
     }
 }
 
-/// Edge-detects a single modifier key by polling the global flag state.
+/// Edge-detects a single modifier key, and refuses the edges that were part of
+/// somebody else's shortcut.
 ///
-/// Polling rather than an event tap is a deliberate trade: it costs a cheap
-/// read every 25 ms and gives up the ability to swallow the keystroke, in
-/// exchange for needing no permissions at all. A bare modifier types nothing on
-/// its own, so there is nothing to swallow.
+/// ## Why a bare modifier is never really bare
+///
+/// The first version of this assumed a modifier alone types nothing, so a
+/// press could be taken at face value. That is not true of any modifier on a
+/// Mac. ⌘ is half of every shortcut in every app. ⌥ is a live character key on
+/// most non-US layouts — on the French layout it is what types `#`, `{`, `|`
+/// and `~` — and everywhere it is ⌥← to jump a word and ⌥⌫ to delete one. So
+/// the down edge on its own says nothing about whether a dictation was meant.
+/// Taken at face value, every ⌘S opened the mic.
+///
+/// ## What tells them apart
+///
+/// Held alone, and nothing else touched. A shortcut is a modifier plus
+/// something; a dictation is a modifier and then silence on the keyboard.
+/// Waiting is what makes the difference visible, so the press is held back for
+/// `pressDelay` and only delivered if nothing else happened in that window.
+///
+/// The wait costs nothing at this end. `release_tail_seconds` exists because
+/// the hand beats the mouth on the way *up* — the key is released while the
+/// last syllable is still being said. There is no matching problem on the way
+/// down: nobody starts a word within 180 ms of pressing the key.
+///
+/// A shortcut can also be slow — a modifier held while you think, then a click
+/// — so the watch does not stop when the press is delivered. Something else
+/// arriving after that aborts the dictation instead of never starting it, and
+/// `onRelease` does not fire for a hold that was aborted.
+///
+/// ## What it watches
+///
+/// Two sources, because they cost different things. Another modifier is read
+/// straight out of the flags the poll already reads, so a ⌘⌥ chord is caught
+/// with no permission at all. Keys, clicks and scrolls need
+/// `NSEvent.addGlobalMonitorForEvents`, which needs Accessibility — already
+/// required by the app, and it observes without consuming, so nothing is taken
+/// from the app in front. Monitors exist only while the key is down: an idle
+/// app is not watching the keyboard.
+///
+/// Polling rather than an event tap is still a deliberate trade: a cheap read
+/// every 25 ms, and no Input Monitoring grant, in exchange for not being able
+/// to swallow the keystroke. Nothing here wants to swallow one — the shortcut
+/// is meant to work.
+///
+/// Secure Event Input — what a terminal turns on around a password prompt —
+/// hides keys from the monitor the same way it hides them from a tap, so the
+/// watch falls back to its modifier half there. Left as is: a modifier held
+/// alone is not what happens while somebody is typing a password.
 final class ModifierKeyMonitor {
     var onPress: (() -> Void)?
     var onRelease: (() -> Void)?
+    /// A press that was already delivered turned out to be a shortcut. Whoever
+    /// started a dictation on `onPress` has to drop it, silently: the user
+    /// pressed ⌘S and is owed a save, not a notice about dictation.
+    var onAbort: (() -> Void)?
 
     private var timer: Timer?
+    private var monitors: [Any] = []
+    private var armTimer: Timer?
+
+    private var key: ModifierKey?
+    private var pressDelay: TimeInterval = 0
+    /// The key is physically down.
     private var isDown = false
+    /// `onPress` has been delivered for the current hold.
+    private var pressDelivered = false
+    /// This hold has been ruled out. Stays set until the key comes up, so a
+    /// second key in the same shortcut cannot abort twice.
+    private var isSpent = false
 
     var isMonitoring: Bool { timer != nil }
 
-    func start(key: ModifierKey) {
+    /// `pressDelay` of 0 restores the old behaviour: the press fires on the
+    /// down edge, and only the abort path is left to catch a shortcut.
+    func start(key: ModifierKey, pressDelay: TimeInterval = 0) {
         stop()
+        self.key = key
+        self.pressDelay = pressDelay
         // Treat a key that is already held at registration time as "down", so a
-        // config reload mid-press doesn't fire a spurious edge.
+        // config reload mid-press doesn't fire a spurious edge. Spent as well:
+        // there is no way to know now what else has been pressed since it went
+        // down, and a dictation nobody asked for is worse than one that needs
+        // the key pressed again.
         isDown = key.isPressed
+        isSpent = isDown
+
+        // The flags half of the watch works regardless; the keys and clicks
+        // half does not, and its absence looks exactly like a shortcut that
+        // never came. Said once here rather than on every press.
+        if Permissions.accessibility != .granted {
+            Log.write("hotkey: accessibility is not granted; a shortcut cannot be told from a dictation")
+        }
 
         let timer = Timer(timeInterval: 0.025, repeats: true) { [weak self] _ in
-            guard let self else { return }
-            let down = key.isPressed
-            guard down != self.isDown else { return }
-            self.isDown = down
-            if down { self.onPress?() } else { self.onRelease?() }
+            self?.poll()
         }
         // .common so the key keeps working while a menu is open or a window is
         // being dragged — .default timers stall during those tracking loops.
@@ -128,8 +203,115 @@ final class ModifierKeyMonitor {
     func stop() {
         timer?.invalidate()
         timer = nil
+        endHold()
+        key = nil
         isDown = false
     }
 
     deinit { stop() }
+
+    // MARK: The poll
+
+    private func poll() {
+        guard let key else { return }
+        // One read, used for both questions below.
+        let flags = ModifierKey.currentFlags
+        let down = flags & key.mask == key.mask
+
+        if down != isDown {
+            isDown = down
+            if down { beginHold() } else { finishHold() }
+            return
+        }
+
+        // Held, and another modifier joined it: a chord, not a dictation.
+        if down, !isSpent, flags & ModifierKey.allDeviceMasks & ~key.mask != 0 {
+            somethingElseHappened()
+        }
+    }
+
+    private func beginHold() {
+        isSpent = false
+        pressDelivered = false
+        watchForOtherInput()
+
+        guard pressDelay > 0 else {
+            deliverPress()
+            return
+        }
+        let timer = Timer(timeInterval: pressDelay, repeats: false) { [weak self] _ in
+            self?.armTimer = nil
+            self?.deliverPress()
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        armTimer = timer
+    }
+
+    private func deliverPress() {
+        guard isDown, !isSpent, !pressDelivered else { return }
+        pressDelivered = true
+        onPress?()
+    }
+
+    private func finishHold() {
+        let wasPressed = pressDelivered
+        endHold()
+        if wasPressed { onRelease?() }
+    }
+
+    /// The one path out of a hold that was meant for something else. Delivered
+    /// as an abort only if a press went out for it — otherwise the press
+    /// simply never happens and there is nothing to tell anyone about.
+    private func somethingElseHappened() {
+        guard !isSpent else { return }
+        let wasPressed = pressDelivered
+        isSpent = true
+        pressDelivered = false
+        armTimer?.invalidate(); armTimer = nil
+        // Nothing more to learn from this hold, so the monitors go now rather
+        // than at the release.
+        removeMonitors()
+        if wasPressed { onAbort?() }
+    }
+
+    private func endHold() {
+        armTimer?.invalidate(); armTimer = nil
+        removeMonitors()
+        pressDelivered = false
+        isSpent = false
+    }
+
+    // MARK: Watching for everything that is not the key
+
+    private func watchForOtherInput() {
+        guard monitors.isEmpty else { return }
+        let mask: NSEvent.EventTypeMask = [
+            .keyDown, .leftMouseDown, .rightMouseDown, .otherMouseDown, .scrollWheel,
+        ]
+        let sawInput: (NSEvent) -> Void = { [weak self] event in
+            // A flick that ended before the key went down keeps sending scroll
+            // events for about a second afterwards. Coasting is not an action,
+            // and treating it as one would abort a dictation started right
+            // after scrolling a page.
+            guard event.type != .scrollWheel || event.momentumPhase.isEmpty else { return }
+            self?.somethingElseHappened()
+        }
+        // The global monitor sees events while another app is in front, which
+        // is every ordinary dictation. The local one sees them while a panel of
+        // ours is up. Neither consumes anything.
+        if let global = NSEvent.addGlobalMonitorForEvents(matching: mask, handler: sawInput) {
+            monitors.append(global)
+        }
+        if let local = NSEvent.addLocalMonitorForEvents(matching: mask, handler: { event in
+            sawInput(event)
+            return event
+        }) {
+            monitors.append(local)
+        }
+    }
+
+    private func removeMonitors() {
+        for monitor in monitors { NSEvent.removeMonitor(monitor) }
+        monitors = []
+    }
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -18,6 +18,12 @@ hotkey:
   # cut. push_to_talk only; 0 turns it off.
   release_tail_seconds: 0.3
 
+  # A bare modifier is still a real modifier: ⌘S saves, ⌥3 types # on a French
+  # layout. So it has to be held this long with nothing else pressed before it
+  # counts as dictation, and a key or click that arrives later drops the
+  # dictation it started. Bare modifiers only; 0 starts on the down edge.
+  press_delay_seconds: 0.18
+
 audio:
   # Where recordings and trace.jsonl go.
   output_dir: ~/Recordings/ParrotFlow

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,7 @@ hotkey:
   modifiers: []         # required for a character key, ignored for a modifier
   mode: push_to_talk    # or toggle
   release_tail_seconds: 0.3   # keep recording this long after you let go
+  press_delay_seconds: 0.18   # hold a bare modifier this long before it counts
 
 audio:
   output_dir: ~/Recordings/ParrotFlow
@@ -151,6 +152,31 @@ item says so. Pick another one.
 Keeps the mic open after you let go, because the hand is faster than the mouth
 and the last syllable lands after the key is up. Push-to-talk only. Raise it if
 endings still get clipped, `0` to stop the moment you release.
+
+### `press_delay_seconds`
+
+A bare modifier is never really bare. ⌘ is the front half of every shortcut in
+every app. ⌥ is a live character key on most non-US layouts — on the French
+layout it types `#`, `{`, `|` and `~` — and everywhere it is ⌥← to jump a word
+and ⌥⌫ to delete one. Taken at face value, every ⌘S opened the mic.
+
+So a bare modifier has to be held **alone** for this long before it starts a
+dictation, and anything else arriving while it is still down — a key, a click,
+a scroll, a second modifier — drops the dictation it started. That happens
+silently: you pressed ⌘S to save, and a notice about a dictation you never
+started would be an apology for something you were not supposed to see.
+
+The wait costs nothing. `release_tail_seconds` exists because the hand beats
+the mouth on the way *up*; there is no matching problem on the way down, since
+nobody starts a word within 180 ms of pressing the key. Raise it if a shortcut
+still slips through, `0` to start on the down edge as before.
+
+Bare modifiers only — a `⌃⌥Space`-style combo is unambiguous by construction
+and goes through Carbon, which swallows it.
+
+Keys and clicks are seen through a global event monitor, which needs
+Accessibility. Without it only the second-modifier check works, and the log
+says so at launch.
 
 ### Bare modifiers want push-to-talk
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -7,6 +7,12 @@ spoken corrections, because reading your selection is exactly what that
 permission governs. `insert_mode: clipboard` works without it: the transcript
 is copied and you press ⌘V.
 
+It is also what lets a bare-modifier hotkey tell ⌘S from a dictation. The app
+watches for a key or a click arriving while the modifier is held, which is a
+global event monitor and so is gated here. Without it, only a second modifier
+is caught — see `press_delay_seconds` in
+[configuration.md](configuration.md).
+
 **Input Monitoring** — required for the offer's own hotkeys (`V` for Vocabulary,
 and any `key:` on a transform with `offer: true`). The offer's chips sit in a
 window that never takes focus, so catching their letters before they land in


### PR DESCRIPTION
A bare modifier used as the hotkey started a dictation the instant it went down, so every ⌘S opened the mic. On a French layout ⌥ is a live character key, so ⌥3 — which types `#` — did the same. A bare modifier now has to be held alone for `hotkey.press_delay_seconds` (0.18 by default) before it counts as dictation, and a key, click, scroll or second modifier arriving while it is held drops the hold. If a dictation had already started, it is cancelled silently: you pressed ⌘S and are owed a save, not a notice.

Set `press_delay_seconds: 0` for the old behaviour. Combos are untouched — they go through `RegisterEventHotKey` and are unambiguous by construction.

Start the review at `ModifierKey.swift`, in `ModifierKeyMonitor`. The rest is wiring.

<details>
<summary>The old code said a bare modifier types nothing, and that is true of no modifier on a Mac</summary>

`ModifierKeyMonitor` polled the flag state and delivered `onPress` on the first tick the bit was set. The comment above it stated the assumption:

> A bare modifier types nothing on its own, so there is nothing to swallow.

The swallowing half is right — polling cannot consume a key, and this change does not try to. The typing half is wrong. ⌘ is the front half of every shortcut in every app. ⌥ types `#`, `{`, `|` and `~` on the French layout, and everywhere it is ⌥← to jump a word and ⌥⌫ to delete one.

The character always reached the app. What broke is that dictation started underneath it: the pill appeared, the mic opened, and the caret anchor was snapshotted mid-edit.

</details>

<details>
<summary>Two watches, because a shortcut can be fast or slow</summary>

A hold now has three states: begun, delivered, spent.

| Sequence | What happens |
|---|---|
| ⌥ down, `3` within 180 ms | press never delivered, nothing on screen |
| ⌥ down, held alone past 180 ms | press delivered, dictation starts |
| ⌥ down, held 400 ms, then a click | press delivered, then aborted and cancelled |
| ⌥ down, ⌘ joins | caught by the poll, no monitor involved |

Another modifier is read out of the flags the 25 ms poll already reads, so a ⌘⌥ chord costs no permission at all. Keys, clicks and scrolls come from `NSEvent.addGlobalMonitorForEvents` plus a local monitor, which needs Accessibility — already required by the app. Both observe without consuming. The monitors exist only while the key is down.

Momentum scroll is filtered out. A trackpad flick keeps sending scroll events for about a second, so without the filter a dictation started right after scrolling a page would abort.

`--check-config` prints the delay, and prints a note when Accessibility is missing:

```
  ✓ hotkey            Right ⌘  (push-to-talk, polled)
  · press delay       held alone for 0.18s, or it is a shortcut
  · release tail      0.3s after the key comes up
```

</details>

<details>
<summary>Why the delay is on the press and not, say, a double tap</summary>

**Double tap to arm** was the alternative. It needs no event monitor at all, and a real shortcut never produces two isolated press-release edges. It was rejected as the primary mechanism because it changes the gesture: push-to-talk becomes tap-tap-hold, which is a different thing to learn. It is still a reasonable `mode:` to add later, next to `toggle` and `push_to_talk`.

**Start the audio at t=0 and gate only the pill** was the other option, and it would have cost nothing in latency. It was rejected because the press does more than start the recorder: it snapshots focus and destination, dispatches the input-box capture, climbs the caret ladder, and calls `endTheOffer()`. That last one takes the offer off the screen, so an aborted ⌘S would have destroyed an offer that was still wanted.

The delay costs nothing at this end. `release_tail_seconds` exists because the hand beats the mouth on the way up — the key is released while the last syllable is still being said. There is no matching problem on the way down: nobody starts a word within 180 ms of pressing the key.

</details>

<details>
<summary>What this does not fix, and what it makes slightly worse</summary>

**Shift is still a bad key to bind.** `right_shift` is accepted and now behaves correctly, but Shift is pressed before every capital letter with a lead time that varies from 20 ms to half a second. Under the delay it is silent; over it you get a pill that appears and vanishes. Normal typing crosses that line often. The fix does not make Shift a usable hotkey.

**Secure Event Input hides the keys.** A terminal around a password prompt blocks the monitor the same way it blocks the `OfferKeys` tap, so the watch falls back to its modifier half there. Left as is: a modifier held alone is not what happens while somebody types a password.

**The poll still runs at 40 Hz.** This does not touch #182. It adds two `NSEvent` monitors while the key is held, which is new work, though only for the length of a hold.

**fn on a laptop is unconfirmed.** macOS sets the fn bit for arrow and function keys on its own. If that reaches `CGEventSource.flagsState`, `key: fn` could read as a press — the new keyDown watch should abort it inside the arm window, but I have not confirmed whether the bit is reported there at all. It does not affect any other binding.

</details>

<details>
<summary>What was verified, and what was not</summary>

- `swift build` clean. SwiftLint clean on the changed lines; the two remaining warnings in `Config.swift` and `CheckConfigCommand.swift` are pre-existing, confirmed against a stash.
- `--check-config` against three configs: default (`held alone for 0.18s`), `0` (`off — starts on the down edge`), and a combo key (line correctly absent).
- The range guard rejects `3` with `expected a delay between 0 and 1 second`.
- Installed as the dev build and exercised by hand. The abort path fires — `hotkey: dropped — the modifier was part of a shortcut` appears in `ParrotFlow-Dev.log`.

Not measured: how often 180 ms is the wrong threshold in real use. That wants a few days of typing, not a test.

</details>
