### PR TITLE
feat: a dictation keeps its bullets, bold and links when the app takes them

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -113,12 +113,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// without Accessibility — an app condition has no business needing a
     /// permission that gating a stage by app does not otherwise require.
     private var appAtPress: Pipeline.App?
-    /// Which pasteboard flavour that app is known to take, over and above the
-    /// plain text every paste carries. Plain when nobody was in front, which is
-    /// the answer that cannot lose a sentence.
-    private var pasteFlavour: AppProfile.Paste {
-        appAtPress.map { AppProfile.of($0).paste } ?? .plain
-    }
     /// The same app as a pid, for the window anchor. Kept from the press so the
     /// pill is measured against the app the words are aimed at.
     private var pidAtPress: pid_t?
@@ -165,6 +159,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         /// device in System Settings — and the notice is about the microphone
         /// that recorded these words. See `micAtPress`.
         let mic: Recorder.InputDevice?
+        /// Which pasteboard flavour the app this was aimed at takes, over and
+        /// above the plain text every paste carries.
+        ///
+        /// Frozen here rather than read from `appAtPress` at the end, for the
+        /// reason that field is read once: it only ever holds the newest press.
+        /// A Slack dictation still decoding while you press again in a terminal
+        /// would be delivered with the terminal's answer, and the reverse puts
+        /// markup in front of an app that shows the tags.
+        let paste: AppProfile.Paste
     }
 
     /// The words the offer on screen is about, and the field they went into.
@@ -1700,7 +1703,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // device. Taken here rather than read at the end for the same reason as
         // the rest: the default input can change while the decoder runs.
         let press = Press(
-            run: pressRun, element: focus?.element, owner: focus?.owner, mic: micAtPress
+            run: pressRun, element: focus?.element, owner: focus?.owner, mic: micAtPress,
+            // Plain when nobody was in front, which is the answer that cannot
+            // lose a sentence.
+            paste: appAtPress.map { AppProfile.of($0).paste } ?? .plain
         )
         Task { [weak self] in
             // Whatever happens below — decoded, cancelled, or thrown — nothing
@@ -2524,8 +2530,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             }
 
+            // From the selection this transform was aimed at, not from
+            // `appAtPress`: this runs after a model call, and that field holds
+            // the newest press by then. Without a selection there is nothing
+            // saying where the text is going, and plain is the answer that
+            // cannot lose it.
+            let paste = selection?.owner.map {
+                AppProfile.of(
+                    Pipeline.App(name: $0.localizedName ?? "", bundleID: $0.bundleIdentifier ?? "")
+                ).paste
+            } ?? .plain
             switch TextInserter.insert(
-                text, mode: config.transcription.insertMode, paste: pasteFlavour
+                text, mode: config.transcription.insertMode, paste: paste
             ) {
             case .pasted, .copied:
                 if config.feedback.sound { NSSound(named: "Morse")?.play() }
@@ -4069,7 +4085,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
            Permissions.accessibility == .granted {
             let now = SelectionReader.focusedElement()
             if now == nil || !CFEqual(now!, element) {
-                TextInserter.insert(text, mode: .clipboard, paste: pasteFlavour)
+                TextInserter.insert(text, mode: .clipboard, paste: press.paste)
                 // Not the paste sound — see the nowhere-to-type ending below.
                 if config.feedback.sound { NSSound(named: "Tink")?.play() }
                 Log.write(now == nil
@@ -4104,7 +4120,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // `.clipboardOnly` branch below.
         if config.transcription.insertMode == .paste,
            case .nowhere(let reason) = destination, reason != .noAccessibility {
-            TextInserter.insert(text, mode: .clipboard, paste: pasteFlavour)
+            TextInserter.insert(text, mode: .clipboard, paste: press.paste)
             // Not Morse: a sound that cannot be told from success is no sound.
             if config.feedback.sound { NSSound(named: "Tink")?.play() }
             Log.write("nothing to type into (\(reason.described)); copied instead")
@@ -4118,7 +4134,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         switch TextInserter.insert(
-            text, mode: config.transcription.insertMode, paste: pasteFlavour
+            text, mode: config.transcription.insertMode, paste: press.paste
         ) {
         case .pasted:
             if config.feedback.sound { NSSound(named: "Morse")?.play() }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -113,6 +113,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// without Accessibility — an app condition has no business needing a
     /// permission that gating a stage by app does not otherwise require.
     private var appAtPress: Pipeline.App?
+    /// Which pasteboard flavour that app is known to take, over and above the
+    /// plain text every paste carries. Plain when nobody was in front, which is
+    /// the answer that cannot lose a sentence.
+    private var pasteFlavour: AppProfile.Paste {
+        appAtPress.map { AppProfile.of($0).paste } ?? .plain
+    }
     /// The same app as a pid, for the window anchor. Kept from the press so the
     /// pill is measured against the app the words are aimed at.
     private var pidAtPress: pid_t?
@@ -2518,7 +2524,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             }
 
-            switch TextInserter.insert(text, mode: config.transcription.insertMode) {
+            switch TextInserter.insert(
+                text, mode: config.transcription.insertMode, paste: pasteFlavour
+            ) {
             case .pasted, .copied:
                 if config.feedback.sound { NSSound(named: "Morse")?.play() }
                 flash("\(transform.name) applied", tone: .done)
@@ -4061,7 +4069,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
            Permissions.accessibility == .granted {
             let now = SelectionReader.focusedElement()
             if now == nil || !CFEqual(now!, element) {
-                TextInserter.insert(text, mode: .clipboard)
+                TextInserter.insert(text, mode: .clipboard, paste: pasteFlavour)
                 // Not the paste sound — see the nowhere-to-type ending below.
                 if config.feedback.sound { NSSound(named: "Tink")?.play() }
                 Log.write(now == nil
@@ -4096,7 +4104,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // `.clipboardOnly` branch below.
         if config.transcription.insertMode == .paste,
            case .nowhere(let reason) = destination, reason != .noAccessibility {
-            TextInserter.insert(text, mode: .clipboard)
+            TextInserter.insert(text, mode: .clipboard, paste: pasteFlavour)
             // Not Morse: a sound that cannot be told from success is no sound.
             if config.feedback.sound { NSSound(named: "Tink")?.play() }
             Log.write("nothing to type into (\(reason.described)); copied instead")
@@ -4109,7 +4117,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        switch TextInserter.insert(text, mode: config.transcription.insertMode) {
+        switch TextInserter.insert(
+            text, mode: config.transcription.insertMode, paste: pasteFlavour
+        ) {
         case .pasted:
             if config.feedback.sound { NSSound(named: "Morse")?.play() }
             // The words are in the field and you are looking at them. This is

--- a/Sources/ParrotFlow/AppProfile.swift
+++ b/Sources/ParrotFlow/AppProfile.swift
@@ -24,25 +24,61 @@ struct AppProfile: Equatable {
         case window
     }
 
+    /// Which rich pasteboard flavour this app is known to take. Plain text
+    /// always rides along beside it, so this names only what goes on the item
+    /// as well.
+    enum Paste: String {
+        /// Plain text and nothing else. What an app gets until it is measured.
+        case plain
+        case html
+        case rtf
+
+        /// What `Markup.item` writes, over and above the plain fallback.
+        var flavours: [Markup.Flavour] {
+            switch self {
+            case .plain: return []
+            case .html: return [.html]
+            case .rtf: return [.rtf]
+            }
+        }
+    }
+
     var focus: Focus
     var anchor: Anchor
     /// Whether the visible text can be handed to the pipeline. See `Context`.
     var readsPane: Bool
+    var paste: Paste
 
-    static let ordinary = AppProfile(focus: .examine, anchor: .ladder, readsPane: false)
-    static let terminal = AppProfile(focus: .screen, anchor: .ladder, readsPane: true)
-    static let blind = AppProfile(focus: .blind, anchor: .window, readsPane: false)
+    static let ordinary = AppProfile(
+        focus: .examine, anchor: .ladder, readsPane: false, paste: .plain)
+    static let terminal = AppProfile(
+        focus: .screen, anchor: .ladder, readsPane: true, paste: .plain)
+    static let blind = AppProfile(
+        focus: .blind, anchor: .window, readsPane: false, paste: .plain)
 
     /// Terminals by bundle id or name, because one terminal is several bundles
     /// and anything built from source signs itself however the build did.
     /// Blind apps by bundle id alone: the list is one measured build each, and
     /// a name is something any app can claim.
+    /// A terminal and a blind app return before the paste lookup is reached, so
+    /// neither can be promoted out of plain text by adding a line to a set
+    /// below. That is deliberate: a terminal renders no markup and shows the
+    /// tags instead, and a blind app is one nothing about is known by asking.
     static func of(_ app: Pipeline.App) -> AppProfile {
         let bundle = app.bundleID.lowercased()
         let name = app.name.lowercased()
         if terminalBundleIDs.contains(bundle) || terminalNames.contains(name) { return .terminal }
         if blindBundleIDs.contains(bundle) { return .blind }
-        return .ordinary
+
+        var profile = AppProfile.ordinary
+        profile.paste = pasteFlavour(bundle: bundle, name: name)
+        return profile
+    }
+
+    private static func pasteFlavour(bundle: String, name: String) -> Paste {
+        if htmlBundleIDs.contains(bundle) || htmlNames.contains(name) { return .html }
+        if rtfBundleIDs.contains(bundle) || rtfNames.contains(name) { return .rtf }
+        return .plain
     }
 
     private static let terminalBundleIDs: Set<String> = [
@@ -63,4 +99,18 @@ struct AppProfile: Equatable {
     /// `AXEnhancedUserInterface`. Its name is "ChatGPT", so the bundle id is
     /// the only thing that identifies it.
     private static let blindBundleIDs: Set<String> = ["com.openai.codex"]
+
+    /// An app belongs in one of these only once the matrix in
+    /// docs/proposals/formatted-paste.md scores it, with `--paste-probe` and a
+    /// real window. Not measured means plain, which is the answer that cannot
+    /// lose a sentence.
+    ///
+    /// Measured 2026-08-24: Slack takes `public.html` whole — bold, italic, a
+    /// code span, bullets, a real second level, an ordered list, and a link on
+    /// its own words.
+    private static let htmlBundleIDs: Set<String> = ["com.tinyspeck.slackmacgap"]
+    private static let htmlNames: Set<String> = ["slack"]
+
+    private static let rtfBundleIDs: Set<String> = []
+    private static let rtfNames: Set<String> = []
 }

--- a/Sources/ParrotFlow/AppProfile.swift
+++ b/Sources/ParrotFlow/AppProfile.swift
@@ -60,6 +60,7 @@ struct AppProfile: Equatable {
     /// and anything built from source signs itself however the build did.
     /// Blind apps by bundle id alone: the list is one measured build each, and
     /// a name is something any app can claim.
+    ///
     /// A terminal and a blind app return before the paste lookup is reached, so
     /// neither can be promoted out of plain text by adding a line to a set
     /// below. That is deliberate: a terminal renders no markup and shows the
@@ -71,13 +72,13 @@ struct AppProfile: Equatable {
         if blindBundleIDs.contains(bundle) { return .blind }
 
         var profile = AppProfile.ordinary
-        profile.paste = pasteFlavour(bundle: bundle, name: name)
+        profile.paste = pasteFlavour(bundle: bundle)
         return profile
     }
 
-    private static func pasteFlavour(bundle: String, name: String) -> Paste {
-        if htmlBundleIDs.contains(bundle) || htmlNames.contains(name) { return .html }
-        if rtfBundleIDs.contains(bundle) || rtfNames.contains(name) { return .rtf }
+    private static func pasteFlavour(bundle: String) -> Paste {
+        if htmlBundleIDs.contains(bundle) { return .html }
+        if rtfBundleIDs.contains(bundle) { return .rtf }
         return .plain
     }
 
@@ -105,12 +106,15 @@ struct AppProfile: Equatable {
     /// real window. Not measured means plain, which is the answer that cannot
     /// lose a sentence.
     ///
+    /// Bundle id alone, for the reason `blindBundleIDs` is: each line is one
+    /// measured build, and a name is something any app can claim. Terminals are
+    /// the exception in this file because a terminal really is built from
+    /// source and signed however the build did. Slack is not.
+    ///
     /// Measured 2026-08-24: Slack takes `public.html` whole — bold, italic, a
     /// code span, bullets, a real second level, an ordered list, and a link on
     /// its own words.
     private static let htmlBundleIDs: Set<String> = ["com.tinyspeck.slackmacgap"]
-    private static let htmlNames: Set<String> = ["slack"]
 
     private static let rtfBundleIDs: Set<String> = []
-    private static let rtfNames: Set<String> = []
 }

--- a/Sources/ParrotFlow/ClipboardTestCommand.swift
+++ b/Sources/ParrotFlow/ClipboardTestCommand.swift
@@ -107,14 +107,36 @@ enum ClipboardTestCommand {
                   && pasteboard.string(forType: .string) == flat,
               quoted(pasteboard))
 
-        // And the case the whole path exists for. The fallback rides along, so
-        // an app that takes neither flavour still gets the sentence.
+        // Ordinary dictation the Markdown parser reads as formatting. Each of
+        // these lost characters the speaker said before `isPlain` asked for
+        // block structure over more than one line.
+        for spoken in [
+            "use the __init__ method",
+            "multiply a*b*c and check the result",
+            "1. Draft 2. Review",
+            formatted,
+        ] {
+            TextInserter.insert(spoken, mode: .clipboard, paste: .html)
+            check("one line stays one line: \"\(spoken)\"",
+                  pasteboard.data(forType: .html) == nil
+                      && pasteboard.string(forType: .string) == spoken,
+                  quoted(pasteboard))
+        }
+
+        // And the case the whole path exists for: block structure, over more
+        // than one line. The fallback rides along, so an app that takes neither
+        // flavour still gets the sentence.
+        let list = "Before Friday:\n\n- call **Dana**\n- reconcile the ledger"
+        TextInserter.insert(list, mode: .clipboard, paste: .html)
+        let listHTML = pasteboard.data(forType: .html).flatMap { String(data: $0, encoding: .utf8) }
+        check("a dictated list is written as one",
+              listHTML?.contains("<li>call <strong>Dana</strong></li>") == true,
+              listHTML ?? "no html")
+
         TextInserter.insert(formatted, mode: .clipboard, paste: .html)
-        let html = pasteboard.data(forType: .html).flatMap { String(data: $0, encoding: .utf8) }
-        check("a measured app gets the markup and the fallback",
-              html?.contains("<strong>Dana</strong>") == true
-                  && pasteboard.string(forType: .string) == flat,
-              html ?? "no html")
+        check("a measured app is not enough on its own",
+              pasteboard.data(forType: .html) == nil,
+              quoted(pasteboard))
 
         print(failures == 0 ? "\nall clipboard rules hold" : "\n\(failures) failed")
         return failures == 0 ? 0 : 1

--- a/Sources/ParrotFlow/ClipboardTestCommand.swift
+++ b/Sources/ParrotFlow/ClipboardTestCommand.swift
@@ -1,7 +1,7 @@
 import AppKit
 
-/// `--clipboard-test` — checks the two rules that decide whether this app may
-/// write to the clipboard, against the real `NSPasteboard`.
+/// `--clipboard-test` — checks when this app may write to the clipboard, and
+/// what it writes, against the real `NSPasteboard`.
 ///
 /// Both rules are arithmetic on `NSPasteboard.changeCount`, and both were wrong
 /// in a way that only showed up as lost work. An in-place edit that Slack
@@ -84,6 +84,37 @@ enum ClipboardTestCommand {
         check("the restore leaves a later write alone",
               pasteboard.string(forType: .string) == "the rewrite, left here by the refused edit",
               quoted(pasteboard))
+
+        // What goes on the clipboard, as well as when.
+        //
+        // Plain text is the floor and there are two ways down to it: an app
+        // nobody has measured, and a transcript with no formatting in it. Both
+        // must write the text itself rather than a rendering of it — stripping
+        // markers that were never there can still move whitespace, and a
+        // dictation has to arrive as it left.
+        let formatted = "Call **Dana** about the invoice"
+        let flat = "Call Dana about the invoice"
+
+        TextInserter.insert(formatted, mode: .clipboard, paste: .plain)
+        check("an unmeasured app gets plain text, verbatim",
+              pasteboard.data(forType: .html) == nil
+                  && pasteboard.string(forType: .string) == formatted,
+              quoted(pasteboard))
+
+        TextInserter.insert(flat, mode: .clipboard, paste: .html)
+        check("a transcript with no markup gets plain text, verbatim",
+              pasteboard.data(forType: .html) == nil
+                  && pasteboard.string(forType: .string) == flat,
+              quoted(pasteboard))
+
+        // And the case the whole path exists for. The fallback rides along, so
+        // an app that takes neither flavour still gets the sentence.
+        TextInserter.insert(formatted, mode: .clipboard, paste: .html)
+        let html = pasteboard.data(forType: .html).flatMap { String(data: $0, encoding: .utf8) }
+        check("a measured app gets the markup and the fallback",
+              html?.contains("<strong>Dana</strong>") == true
+                  && pasteboard.string(forType: .string) == flat,
+              html ?? "no html")
 
         print(failures == 0 ? "\nall clipboard rules hold" : "\n\(failures) failed")
         return failures == 0 ? 0 : 1

--- a/Sources/ParrotFlow/Markup.swift
+++ b/Sources/ParrotFlow/Markup.swift
@@ -197,8 +197,13 @@ struct Markup {
     /// AppKit's HTML importer writes a real `\listtable` and real `HYPERLINK`
     /// fields, which attributed text built by hand does not. Going through it
     /// also keeps the two rich flavours the same document, so a difference in
-    /// the target app is the target app. Measured at 400ms, and it needs no
-    /// `NSApplication`, so it runs in a command as happily as in the app.
+    /// the target app is the target app. It needs no `NSApplication`, so it
+    /// runs in a command as happily as in the app.
+    ///
+    /// Measured on the fixture: 637ms the first time in a process, then 2ms.
+    /// The cost is WebKit starting, not the document. Nothing reaches this yet
+    /// — no app is `.rtf` — but the first formatted paste of a session into one
+    /// would pay it, and the fix would be to import a byte of HTML at launch.
     func richText() -> Data? {
         guard
             let document = try? NSAttributedString(

--- a/Sources/ParrotFlow/Markup.swift
+++ b/Sources/ParrotFlow/Markup.swift
@@ -1,0 +1,335 @@
+import AppKit
+import Foundation
+
+/// A dictation that carries formatting, parsed once and rendered as many ways
+/// as the app in front of it will take.
+///
+/// Markdown is the wire format, and that is the decision the rest of this
+/// rests on. Every stage in the pipeline is a string in and a string out, so a
+/// transform that adds bullets is a transform that returns different text and
+/// nothing else has to learn a new type. Anything richer would have to be
+/// converted at each boundary or understood by every stage.
+///
+/// Parsed at the end, on the way to the pasteboard, and only when there is
+/// something to parse — see `isPlain`.
+struct Markup {
+
+    /// The Markdown exactly as it arrived. What `markdown` renders, and what a
+    /// transcript with no formatting in it must come back as, byte for byte.
+    let source: String
+
+    private let blocks: [Block]
+
+    static func parse(_ markdown: String) -> Markup {
+        Markup(source: markdown, blocks: Self.blocks(of: markdown))
+    }
+
+    /// True when the parser found nothing to format: no emphasis, no code, no
+    /// link, no list, no heading.
+    ///
+    /// The gate on the whole path. A transcript that reads as plain is written
+    /// as `source` and never as `plain`, because stripping markers that are not
+    /// there can still move whitespace, and a dictation has to arrive as it
+    /// left.
+    var isPlain: Bool {
+        blocks.allSatisfy { block in
+            Self.containers(block.kinds).isEmpty
+                && Self.marker(block.kinds) == nil
+                && Self.headerLevel(block.kinds) == nil
+                && !Self.isCodeBlock(block.kinds)
+                && block.pieces.allSatisfy {
+                    !$0.bold && !$0.italic && !$0.code && !$0.struck && $0.link == nil
+                }
+        }
+    }
+
+    // MARK: - Flavours
+
+    /// One pasteboard flavour: what it is called, which type it claims, and how
+    /// to render it.
+    ///
+    /// A registry rather than a switch, because two callers read it — the
+    /// probe that measures an app and the inserter that writes to it. A switch
+    /// in each is how you end up measuring one thing and shipping another.
+    struct Flavour {
+        let name: String
+        let type: NSPasteboard.PasteboardType
+        let render: (Markup) -> Data?
+
+        static let plain = Flavour(name: "plain", type: .string) { Data($0.plain.utf8) }
+        static let markdown = Flavour(name: "markdown", type: .string) { Data($0.source.utf8) }
+        static let html = Flavour(name: "html", type: .html) { Data($0.html.utf8) }
+        static let rtf = Flavour(name: "rtf", type: .rtf) { $0.richText() }
+
+        static let all: [Flavour] = [.plain, .markdown, .html, .rtf]
+
+        static subscript(name: String) -> Flavour? {
+            all.first { $0.name == name }
+        }
+    }
+
+    /// The item to put on the pasteboard.
+    ///
+    /// Plain text always rides along, because a rich flavour on its own is not
+    /// a shape anything puts on a real clipboard: a clipboard manager reads it
+    /// as empty, and a paste that lands as plain cannot be told from a paste
+    /// that did not land. `fallback: false` withholds it, which is a diagnostic
+    /// — `--paste-probe --bare` — and never a setting.
+    ///
+    /// A flavour that will not render is dropped and the rest still go. Losing
+    /// one costs the bold; there is no failure here worth losing the sentence
+    /// over.
+    func item(_ flavours: [Flavour], fallback: Bool = true) -> NSPasteboardItem {
+        let item = NSPasteboardItem()
+        var claimed: Set<NSPasteboard.PasteboardType> = []
+
+        for flavour in flavours {
+            guard !claimed.contains(flavour.type) else { continue }
+            guard let data = flavour.render(self) else {
+                Log.write("paste: \(flavour.name) would not render; dropped")
+                continue
+            }
+            item.setData(data, forType: flavour.type)
+            claimed.insert(flavour.type)
+        }
+
+        // `markdown` claims the plain-text type itself, and then there is no
+        // fallback left to add.
+        if fallback, !claimed.contains(.string) {
+            item.setString(plain, forType: .string)
+        }
+        return item
+    }
+
+    // MARK: - Rendering
+
+    var html: String {
+        var out = ""
+        var lists: [(tag: String, identity: Int, itemOpen: Bool)] = []
+
+        func close(to depth: Int) {
+            while lists.count > depth {
+                let level = lists.removeLast()
+                if level.itemOpen { out += "</li>" }
+                out += "</\(level.tag)>"
+            }
+        }
+
+        for block in blocks {
+            let path = Self.containers(block.kinds)
+            var common = 0
+            while common < min(path.count, lists.count),
+                lists[common].identity == path[common].identity {
+                common += 1
+            }
+            close(to: common)
+            for level in path[common...] {
+                out += "<\(level.tag)>"
+                lists.append((level.tag, level.identity, false))
+            }
+
+            let inner = Self.inline(block.pieces)
+            if Self.marker(block.kinds) != nil, !lists.isEmpty {
+                // A nested list opens inside its parent item, so the item is
+                // left open until a sibling or the close needs it shut.
+                if lists[lists.count - 1].itemOpen { out += "</li>" }
+                out += "<li>\(inner)"
+                lists[lists.count - 1].itemOpen = true
+            } else if let level = Self.headerLevel(block.kinds) {
+                out += "<h\(level)>\(inner)</h\(level)>"
+            } else if Self.isCodeBlock(block.kinds) {
+                out += "<pre><code>\(inner)</code></pre>"
+            } else {
+                out += "<p>\(inner)</p>"
+            }
+        }
+        close(to: 0)
+        return out
+    }
+
+    /// The best plain text this document can be: markers gone, bullets kept,
+    /// and a link's URL in brackets after the words it was written on.
+    ///
+    /// The URL is kept rather than dropped. It is the fallback every paste
+    /// carries, and a fallback that silently loses the address is worse than a
+    /// visible one.
+    var plain: String {
+        var lines: [String] = []
+        var previousRoot: Int?
+        var started = false
+
+        for block in blocks {
+            let text = block.pieces.map { piece -> String in
+                guard let link = piece.link else { return piece.text }
+                let url = link.absoluteString
+                return piece.text == url ? piece.text : "\(piece.text) (\(url))"
+            }.joined()
+
+            // A blank line between two blocks that are not items of the same
+            // list. Without the root check two lists in a row run together.
+            let path = Self.containers(block.kinds)
+            let root = path.first?.identity
+            if started, root == nil || root != previousRoot { lines.append("") }
+            started = true
+            previousRoot = root
+
+            if !path.isEmpty, let bullet = Self.marker(block.kinds) {
+                lines.append(String(repeating: "  ", count: path.count - 1) + bullet + " " + text)
+            } else {
+                lines.append(text)
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// RTF by way of the HTML, not from the Markdown a second time.
+    ///
+    /// AppKit's HTML importer writes a real `\listtable` and real `HYPERLINK`
+    /// fields, which attributed text built by hand does not. Going through it
+    /// also keeps the two rich flavours the same document, so a difference in
+    /// the target app is the target app. Measured at 400ms, and it needs no
+    /// `NSApplication`, so it runs in a command as happily as in the app.
+    func richText() -> Data? {
+        guard
+            let document = try? NSAttributedString(
+                data: Data(html.utf8),
+                options: [
+                    .documentType: NSAttributedString.DocumentType.html,
+                    .characterEncoding: String.Encoding.utf8.rawValue,
+                ],
+                documentAttributes: nil
+            )
+        else { return nil }
+        return document.rtf(
+            from: NSRange(location: 0, length: document.length),
+            documentAttributes: [:]
+        )
+    }
+
+    private static func inline(_ pieces: [Piece]) -> String {
+        pieces.map { piece in
+            var text = escaped(piece.text)
+            if piece.code { text = "<code>\(text)</code>" }
+            if piece.bold { text = "<strong>\(text)</strong>" }
+            if piece.italic { text = "<em>\(text)</em>" }
+            if piece.struck { text = "<s>\(text)</s>" }
+            if let link = piece.link {
+                text = "<a href=\"\(escaped(link.absoluteString))\">\(text)</a>"
+            }
+            return text
+        }.joined()
+    }
+
+    private static func escaped(_ text: String) -> String {
+        text.replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+    }
+
+    // MARK: - The Markdown, in blocks
+
+    private struct Piece {
+        let text: String
+        let bold: Bool
+        let italic: Bool
+        let code: Bool
+        let struck: Bool
+        let link: URL?
+    }
+
+    private struct Block {
+        let kinds: [PresentationIntent.IntentType]
+        var pieces: [Piece]
+    }
+
+    private static func blocks(of markdown: String) -> [Block] {
+        let options = AttributedString.MarkdownParsingOptions(
+            allowsExtendedAttributes: true,
+            interpretedSyntax: .full,
+            failurePolicy: .returnPartiallyParsedIfPossible
+        )
+        guard let parsed = try? AttributedString(markdown: markdown, options: options) else {
+            let piece = Piece(
+                text: markdown, bold: false, italic: false, code: false, struck: false, link: nil
+            )
+            return [Block(kinds: [], pieces: [piece])]
+        }
+
+        var blocks: [Block] = []
+        for run in parsed.runs {
+            let inline = run.inlinePresentationIntent ?? []
+            let piece = Piece(
+                text: String(parsed[run.range].characters),
+                bold: inline.contains(.stronglyEmphasized),
+                italic: inline.contains(.emphasized),
+                code: inline.contains(.code),
+                struck: inline.contains(.strikethrough),
+                link: run.link
+            )
+            let kinds = run.presentationIntent?.components ?? []
+            // Every block the parser finds gets its own identity, and the
+            // innermost one is this block's. It is the only thing that
+            // separates two bullets in a row.
+            if !blocks.isEmpty, blocks.last?.kinds.first?.identity == kinds.first?.identity {
+                blocks[blocks.count - 1].pieces.append(piece)
+            } else {
+                blocks.append(Block(kinds: kinds, pieces: [piece]))
+            }
+        }
+        return blocks
+    }
+
+    /// The lists and quotes a block sits inside, outermost first. Intents
+    /// arrive innermost first, which is the wrong end to open tags from.
+    private static func containers(
+        _ kinds: [PresentationIntent.IntentType]
+    ) -> [(tag: String, identity: Int)] {
+        kinds.reversed().compactMap { component -> (tag: String, identity: Int)? in
+            switch component.kind {
+            case .unorderedList: return ("ul", component.identity)
+            case .orderedList: return ("ol", component.identity)
+            case .blockQuote: return ("blockquote", component.identity)
+            default: return nil
+            }
+        }
+    }
+
+    /// The bullet or the number, or nil when this block is not a list item.
+    ///
+    /// The list that owns an item is the first list after it, not the first
+    /// list in the array — otherwise a bullet nested in a numbered list takes
+    /// the number.
+    private static func marker(_ kinds: [PresentationIntent.IntentType]) -> String? {
+        guard
+            let item = kinds.firstIndex(where: {
+                if case .listItem = $0.kind { return true }
+                return false
+            }),
+            case .listItem(let ordinal) = kinds[item].kind
+        else { return nil }
+
+        let owner = kinds[(item + 1)...].first {
+            switch $0.kind {
+            case .orderedList, .unorderedList: return true
+            default: return false
+            }
+        }
+        if case .orderedList = owner?.kind { return "\(ordinal)." }
+        return "•"
+    }
+
+    private static func headerLevel(_ kinds: [PresentationIntent.IntentType]) -> Int? {
+        for component in kinds {
+            if case .header(let level) = component.kind { return min(max(level, 1), 6) }
+        }
+        return nil
+    }
+
+    private static func isCodeBlock(_ kinds: [PresentationIntent.IntentType]) -> Bool {
+        kinds.contains {
+            if case .codeBlock = $0.kind { return true }
+            return false
+        }
+    }
+}

--- a/Sources/ParrotFlow/Markup.swift
+++ b/Sources/ParrotFlow/Markup.swift
@@ -24,22 +24,32 @@ struct Markup {
         Markup(source: markdown, blocks: Self.blocks(of: markdown))
     }
 
-    /// True when the parser found nothing to format: no emphasis, no code, no
-    /// link, no list, no heading.
+    /// True when this has to be written as the text itself rather than as
+    /// markup. The gate on the whole path, and deliberately hard to leave.
     ///
-    /// The gate on the whole path. A transcript that reads as plain is written
-    /// as `source` and never as `plain`, because stripping markers that are not
-    /// there can still move whitespace, and a dictation has to arrive as it
-    /// left.
+    /// Asking "does this parse as Markdown" is the wrong question, because
+    /// ordinary dictation does. Measured on plain sentences:
+    ///
+    ///     use the __init__ method   ->  use the <strong>init</strong> method
+    ///     multiply a*b*c            ->  multiply a<em>b</em>c
+    ///     1. Draft 2. Review        ->  <ol><li>Draft 2. Review</li></ol>
+    ///
+    /// Each one loses characters the speaker said, and `__init__` is a word a
+    /// developer dictates. So inline emphasis alone never counts. What counts
+    /// is block structure — a list, a heading, a code block, a quote — spread
+    /// over more than one line. A transform that formats deliberately produces
+    /// that; a single dictated sentence cannot produce it by accident.
+    ///
+    /// The real gate is a stage saying its output is Markdown, which none does
+    /// yet. This is the conservative half of that: refusing wrongly costs a
+    /// bold, letting through wrongly costs the characters.
     var isPlain: Bool {
-        blocks.allSatisfy { block in
-            Self.containers(block.kinds).isEmpty
-                && Self.marker(block.kinds) == nil
-                && Self.headerLevel(block.kinds) == nil
-                && !Self.isCodeBlock(block.kinds)
-                && block.pieces.allSatisfy {
-                    !$0.bold && !$0.italic && !$0.code && !$0.struck && $0.link == nil
-                }
+        guard source.contains("\n") else { return true }
+        return !blocks.contains { block in
+            !Self.containers(block.kinds).isEmpty
+                || Self.marker(block.kinds) != nil
+                || Self.headerLevel(block.kinds) != nil
+                || Self.isCodeBlock(block.kinds)
         }
     }
 

--- a/Sources/ParrotFlow/PasteProbeCommand.swift
+++ b/Sources/ParrotFlow/PasteProbeCommand.swift
@@ -1,0 +1,100 @@
+import AppKit
+import Foundation
+
+/// `--paste-probe` — puts one known formatted document on the clipboard in a
+/// chosen set of flavours, so you can paste it by hand and see what the target
+/// app does.
+///
+/// The question is which pasteboard flavour each app accepts, and nothing in
+/// this repository can answer it. A pasteboard item can carry `public.html`,
+/// `public.rtf` and plain text at once, and the receiving app picks. Slack,
+/// Outlook and a browser compose box each pick differently and each lose
+/// something different.
+///
+/// It renders through `Markup`, which is what `TextInserter` writes with. One
+/// registry, two callers: what you score here is what the app will get.
+///
+/// `all` first — it is the shape a shipping paste has, and an app that keeps
+/// everything under it is finished. A single flavour is the follow-up, for an
+/// app that scored badly, to find out which one to withhold.
+///
+/// Your clipboard is not put back. The payload has to survive for you to paste.
+enum PasteProbeCommand {
+
+    /// Seven things worth scoring, in one paste. Everything here is a feature
+    /// that some app somewhere drops: nesting flattens, ordered lists lose
+    /// their numbers, a link keeps its words and loses its URL.
+    private static let fixture = """
+        Ship the **billing fix** before Friday. Keep it *quiet* until it lands.
+
+        - Call [Dana](https://example.com/dana) about the July invoice
+        - Reconcile the ledger
+          - the July rows first
+          - then August
+        - Run `make reconcile` and post the diff
+
+        1. Draft
+        2. Review
+        3. Ship
+        """
+
+    private static let usage =
+        "usage: ParrotFlow --paste-probe <plain|markdown|html|rtf|all>"
+        + " [--file <fixture.md>] [--bare] [--show]"
+
+    static func run(flavour: String, file: String?, bare: Bool, show: Bool) -> Int32 {
+        let markdown: String
+        if let file {
+            guard let text = try? String(contentsOfFile: file, encoding: .utf8) else {
+                print("✗ cannot read \(file)")
+                return 2
+            }
+            markdown = text
+        } else {
+            markdown = fixture
+        }
+
+        let chosen: [Markup.Flavour]
+        switch flavour {
+        case "all": chosen = [.html, .rtf]
+        default:
+            guard let one = Markup.Flavour[flavour] else {
+                print(usage)
+                return 2
+            }
+            chosen = [one]
+        }
+
+        let markup = Markup.parse(markdown)
+        let item = markup.item(chosen, fallback: !bare)
+
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.writeObjects([item])
+
+        print("flavour   \(flavour)\(bare ? " --bare" : "")")
+        // Every type, including the `utf16-external-plain-text` AppKit adds
+        // behind a string. It is on the clipboard, so it is in the listing.
+        let width = item.types.map(\.rawValue.count).max() ?? 0
+        for type in item.types {
+            let bytes = item.data(forType: type)?.count ?? 0
+            let name = type.rawValue.padding(toLength: width + 2, withPad: " ", startingAt: 0)
+            print("wrote     \(name)\(bytes) bytes")
+        }
+        print("clipboard the fixture is on it now; what you had is gone")
+        if !item.types.contains(.string) {
+            print("          no plain text — a clipboard manager will read this as empty")
+        }
+        print("")
+        print("Paste with ⌘V and score seven things:")
+        print("  bold · italic · code · bullet · nested bullet · numbered list · link")
+        print("A link is two scores: the words it was written on, and the URL behind them.")
+
+        if show {
+            print("\n--- markdown ---\n\(markup.source)")
+            print("\n--- plain ---\n\(markup.plain)")
+            print("\n--- html ---\n\(markup.html)")
+        }
+        return 0
+    }
+}

--- a/Sources/ParrotFlow/PasteProbeCommand.swift
+++ b/Sources/ParrotFlow/PasteProbeCommand.swift
@@ -68,6 +68,14 @@ enum PasteProbeCommand {
         let markup = Markup.parse(markdown)
         let item = markup.item(chosen, fallback: !bare)
 
+        // Reachable only with `--bare`, and only if the one flavour asked for
+        // would not render. Without this the clipboard is cleared and the run
+        // still reports that the fixture is on it.
+        guard !item.types.isEmpty else {
+            print("✗ \(flavour) would not render, and --bare left nothing to fall back to")
+            return 1
+        }
+
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.writeObjects([item])
@@ -84,6 +92,12 @@ enum PasteProbeCommand {
         print("clipboard the fixture is on it now; what you had is gone")
         if !item.types.contains(.string) {
             print("          no plain text — a clipboard manager will read this as empty")
+        } else if bare, !chosen.contains(where: { $0.type == .string }) {
+            // Measured: setting `public.rtf` on an item makes AppKit derive the
+            // plain-text types from it. So `rtf --bare` is not bare, and "does
+            // this app take RTF with nothing to fall back to" cannot be asked.
+            // `html --bare` is bare — nothing is derived from `public.html`.
+            print("          plain text is there anyway — AppKit derives it from the RTF")
         }
         print("")
         print("Paste with ⌘V and score seven things:")

--- a/Sources/ParrotFlow/ProfileCommand.swift
+++ b/Sources/ParrotFlow/ProfileCommand.swift
@@ -13,6 +13,7 @@ enum ProfileCommand {
         print("focus      \(profile.focus.rawValue)")
         print("anchor     \(profile.anchor.rawValue)")
         print("readsPane  \(profile.readsPane)")
+        print("paste      \(profile.paste.rawValue)")
         return 0
     }
 }

--- a/Sources/ParrotFlow/TextInserter.swift
+++ b/Sources/ParrotFlow/TextInserter.swift
@@ -55,14 +55,18 @@ enum TextInserter {
     }
 
     @discardableResult
-    static func insert(_ text: String, mode: Config.Transcription.InsertMode = .paste) -> Outcome {
+    static func insert(
+        _ text: String,
+        mode: Config.Transcription.InsertMode = .paste,
+        paste: AppProfile.Paste = .plain
+    ) -> Outcome {
         guard !text.isEmpty else { return .pasted }
 
         let pasteboard = NSPasteboard.general
         let saved = snapshot(of: pasteboard)
 
         pasteboard.clearContents()
-        pasteboard.setString(text, forType: .string)
+        pasteboard.writeObjects([item(for: text, paste: paste)])
         let ours = pasteboard.changeCount
         ownChange = ours
 
@@ -83,6 +87,27 @@ enum TextInserter {
         }
 
         return .pasted
+    }
+
+    /// Plain text, unless the app in front is known to take more.
+    ///
+    /// Two ways out before anything is rendered: an app nobody has measured,
+    /// and a transcript with no formatting in it. Both write `text` itself
+    /// rather than a rendering of it, so a dictation that carries no markup
+    /// arrives byte for byte as it left. Stripping markers that were never
+    /// there can still move whitespace.
+    private static func item(for text: String, paste: AppProfile.Paste) -> NSPasteboardItem {
+        guard paste != .plain else { return verbatim(text) }
+        let markup = Markup.parse(text)
+        guard !markup.isPlain else { return verbatim(text) }
+        Log.write("paste: \(paste.rawValue) alongside plain text")
+        return markup.item(paste.flavours)
+    }
+
+    private static func verbatim(_ text: String) -> NSPasteboardItem {
+        let item = NSPasteboardItem()
+        item.setString(text, forType: .string)
+        return item
     }
 
     // MARK: - Keystroke

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -495,8 +495,16 @@ if let index = arguments.firstIndex(of: "--paste-probe") {
             + " [--file <fixture.md>] [--bare] [--show]")
         exit(2)
     }
-    let file = arguments.firstIndex(of: "--file").flatMap { found in
-        arguments.indices.contains(found + 1) ? arguments[found + 1] : nil
+    var file: String?
+    if let found = arguments.firstIndex(of: "--file") {
+        // Not defaulted back to the built-in fixture. You asked to measure your
+        // own document; measuring a different one and saying nothing is how a
+        // matrix gets filled with the wrong numbers.
+        guard arguments.indices.contains(found + 1) else {
+            print("✗ --file needs a path; without one this would score the built-in fixture")
+            exit(2)
+        }
+        file = arguments[found + 1]
     }
     exit(PasteProbeCommand.run(
         flavour: arguments[index + 1],

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -489,6 +489,23 @@ if arguments.contains("--clipboard-test") {
     exit(ClipboardTestCommand.run())
 }
 
+if let index = arguments.firstIndex(of: "--paste-probe") {
+    guard arguments.indices.contains(index + 1) else {
+        print("usage: ParrotFlow --paste-probe <plain|markdown|html|rtf|all>"
+            + " [--file <fixture.md>] [--bare] [--show]")
+        exit(2)
+    }
+    let file = arguments.firstIndex(of: "--file").flatMap { found in
+        arguments.indices.contains(found + 1) ? arguments[found + 1] : nil
+    }
+    exit(PasteProbeCommand.run(
+        flavour: arguments[index + 1],
+        file: file,
+        bare: arguments.contains("--bare"),
+        show: arguments.contains("--show")
+    ))
+}
+
 if arguments.contains("--span-rule") {
     exit(SpanRuleCommand.run())
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,8 @@
 | Config | `Config.swift` | Yams + a `DispatchSource` file watcher for live reload |
 | Permissions | `Permissions.swift` | `AVCaptureDevice` for mic, `AXIsProcessTrusted` for Accessibility |
 | Text insertion | `TextInserter.swift`, `SelectionReader.swift` | Paste-via-clipboard, then the pasteboard is put back |
+| Formatted paste | `Markup.swift` | Markdown in, `public.html` / `public.rtf` / plain out. Plain always rides along, and an unmeasured app gets nothing else — [proposals/formatted-paste.md](proposals/formatted-paste.md) |
+| What an app affords | `AppProfile.swift` | One entry per app: which focus rule, which pill anchor, whether the pane reads, which paste flavour. Scored by `scripts/check-profiles.sh` |
 | Editing in place | `Surface.swift` | The field as one string plus one span, and the ladder that substitutes a range of it — [below](#editing-text-that-is-already-there) |
 | Where the words go | `Destination.swift` | Asks the focused element whether it takes text, at the press — decides the pill's icon and whether the transcript is typed or copied |
 | Menu bar & wiring | `AppDelegate.swift` | |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -361,10 +361,16 @@ $PF --profile com.openai.codex ChatGPT
 $PF --profile com.mitchellh.ghostty Ghostty
 ```
 
-Prints the three things `AppProfile` decides from an app's identity: whether its
+Prints the four things `AppProfile` decides from an app's identity: whether its
 focused element can be believed (`examine`, `screen` or `blind`), where the pill
-opens (`ladder` or `window`), and whether the visible pane can be read as
-context.
+opens (`ladder` or `window`), whether the visible pane can be read as context,
+and which rich pasteboard flavour a paste into it may carry (`plain`, `html` or
+`rtf`).
+
+`paste` is `plain` until the app is measured — see
+[proposals/formatted-paste.md](proposals/formatted-paste.md) and `--paste-probe`
+below. A terminal and a blind app return before the lookup is reached, so
+neither can be promoted out of plain by adding a line to a set.
 
 The name is optional and matters only for terminals, which are matched on either
 half — one terminal ships under several bundle ids. Blind apps are matched on the
@@ -415,6 +421,7 @@ $PF --edit-test <needle> <replacement> --find <sentinel> [--after 3] [--literal]
 $PF --span-test <start> <length> <replacement> --find <sentinel> [--after 3]
 $PF --clipboard-test
 $PF --span-rule
+$PF --paste-probe <plain|markdown|html|rtf|all> [--file <fixture.md>] [--bare] [--show]
 ```
 
 `--peek` reads the surface the way the app would — the value, the selection, and
@@ -457,6 +464,35 @@ with the count already moved by its own paste — this checks that the fallback
 writes anyway, that it still refuses once somebody else has copied, and that the
 restore queued behind the paste does not land on the rewrite. Your clipboard is
 saved and put back.
+
+`--paste-probe` answers a different question: which pasteboard flavour each app
+accepts. It renders through `Markup`, which is what `TextInserter` writes with —
+one registry, two callers, so what you score here is what the app will get. A pasteboard item can carry `public.html`, `public.rtf` and plain text
+at once and the receiving app picks, so this puts one fixture on the clipboard
+in **one** flavour and stops. You press ⌘V yourself, which keeps the test about
+the flavour and not about the event tap.
+
+The fixture exercises seven things in one paste — bold, italic, code, bullet,
+nested bullet, numbered list, link — and a link counts twice: the words it was
+written on, and the URL behind them. `--file` swaps in your own Markdown,
+`--show` prints the plain text and the HTML it generated.
+
+Plain text rides along with every flavour, because a rich flavour alone is not
+a shape anything puts on a real clipboard — a clipboard manager reads it as
+empty, and a paste that lands as plain looks the same as a paste that did not
+land. `--bare` withholds it. That is the follow-up run, for when a cell renders
+as plain and the question becomes whether the app *could* have taken the rich
+flavour or only preferred not to.
+
+`all` puts HTML and RTF on one item, which is the shape a shipping paste would
+have. Run it only after the single-flavour runs have priced each one: it says
+what an app preferred, not what it can take.
+
+Unlike `--clipboard-test`, this does **not** put your clipboard back. The
+payload has to survive for you to paste it.
+
+The matrix it exists to fill is in
+[proposals/formatted-paste.md](proposals/formatted-paste.md).
 
 `--span-rule` needs nothing at all. It scores the range a rewrite is turned into
 before any app sees it: the smallest range is often one no paste can carry — an

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -466,27 +466,35 @@ restore queued behind the paste does not land on the rewrite. Your clipboard is
 saved and put back.
 
 `--paste-probe` answers a different question: which pasteboard flavour each app
-accepts. It renders through `Markup`, which is what `TextInserter` writes with —
-one registry, two callers, so what you score here is what the app will get. A pasteboard item can carry `public.html`, `public.rtf` and plain text
-at once and the receiving app picks, so this puts one fixture on the clipboard
-in **one** flavour and stops. You press ⌘V yourself, which keeps the test about
-the flavour and not about the event tap.
+accepts. A pasteboard item can carry `public.html`, `public.rtf` and plain text
+at once and the receiving app picks, and nothing in this repository can say
+which. So this puts one fixture on the clipboard and stops. You press ⌘V
+yourself, which keeps the test about the flavour and not about the event tap.
+
+It renders through `Markup`, which is what `TextInserter` writes with. One
+registry, two callers, so what you score here is what the app will get.
 
 The fixture exercises seven things in one paste — bold, italic, code, bullet,
 nested bullet, numbered list, link — and a link counts twice: the words it was
-written on, and the URL behind them. `--file` swaps in your own Markdown,
-`--show` prints the plain text and the HTML it generated.
+written on, and the URL behind them. `--file` swaps in your own Markdown and
+refuses to run without a path, rather than falling back to the fixture and
+scoring a document you did not ask for. `--show` prints the Markdown, the plain
+text and the HTML.
 
-Plain text rides along with every flavour, because a rich flavour alone is not
-a shape anything puts on a real clipboard — a clipboard manager reads it as
-empty, and a paste that lands as plain looks the same as a paste that did not
-land. `--bare` withholds it. That is the follow-up run, for when a cell renders
-as plain and the question becomes whether the app *could* have taken the rich
-flavour or only preferred not to.
+**Run `all` first.** It puts HTML and RTF on one item, which is the shape a
+shipping paste has, so an app that keeps everything under it is finished and
+needs no entry. A single flavour is the follow-up, for an app that scored badly,
+to find out which one to withhold.
 
-`all` puts HTML and RTF on one item, which is the shape a shipping paste would
-have. Run it only after the single-flavour runs have priced each one: it says
-what an app preferred, not what it can take.
+Plain text rides along with every flavour, because a rich flavour alone is not a
+shape anything puts on a real clipboard — a clipboard manager reads it as empty,
+and a paste that lands as plain looks the same as a paste that did not land.
+`--bare` withholds it, to ask whether an app *could* have taken the rich flavour
+or only preferred not to.
+
+`--bare` works for `html` and not for `rtf`. Setting `public.rtf` on an item
+makes AppKit derive the plain-text types from it, so RTF is never offered alone
+and that question cannot be asked of it. The command says which case it is in.
 
 Unlike `--clipboard-test`, this does **not** put your clipboard back. The
 payload has to survive for you to paste it.

--- a/docs/proposals/formatted-paste.md
+++ b/docs/proposals/formatted-paste.md
@@ -1,0 +1,210 @@
+# Proposal: bullets, bold, italic and links that survive the paste
+
+**Status.** Built, and measuring. The delivery path ships: `Markup.swift`
+renders, `AppProfile.paste` decides, `TextInserter` writes. The matrix below is
+what promotes an app out of plain text, and only Slack is in it so far.
+
+**Goal.** A dictated message arrives in Slack, Outlook or a compose box with
+its bullets, its bold, its italics and its links intact.
+
+---
+
+## Two problems, kept apart
+
+| | |
+|---|---|
+| **Producing the markup** | Speech is flat. Something has to turn "bullet point call the client" into `- Call the client`. That is a pipeline stage with its own case set. |
+| **Delivering the markup** | A pasteboard item can carry `public.html`, `public.rtf` and plain text at once. The receiving app picks. Each app picks differently and each loses something different. |
+
+Delivery goes first. It is the half that cannot be reasoned about, and a
+production stage is worthless until something can carry its output.
+
+---
+
+## What is built
+
+| | |
+|---|---|
+| `Markup.swift` | Markdown parsed once, rendered as `plain`, `markdown`, `html` or `rtf`. A `Flavour` registry, not a switch, because two callers read it. |
+| `AppProfile.paste` | One entry per app, beside `focus`, `anchor` and `readsPane`. `plain`, `html` or `rtf`. |
+| `TextInserter.insert(_:mode:paste:)` | Defaults to `.plain`, so the four in-place-edit callers in `Surface.swift` are unchanged and stay plain — an edit writes into a field's existing text, where markup would be wrong. |
+| `--paste-probe` | The measuring tool, rendering through the same `Markup`. |
+| `--profile` | Prints the flavour. `scripts/check-profiles.sh` scores it against `tests/profile-cases.yaml` in CI. |
+| `--clipboard-test` | Three new checks on the fail-open contract, below. |
+
+RTF goes through AppKit's HTML importer rather than being built by hand: that is
+what produces a real `\listtable` and real `HYPERLINK` fields. It also keeps the
+two rich flavours the same document, so a difference in the target app is the
+target app. Measured at 400ms, no `NSApplication` needed.
+
+### The contract, checked by `--clipboard-test`
+
+```
+✓ an unmeasured app gets plain text, verbatim
+✓ a transcript with no markup gets plain text, verbatim
+✓ a measured app gets the markup and the fallback
+```
+
+"Verbatim" is the load-bearing word. Both ways down to plain write the text
+itself and not a rendering of it, because stripping markers that were never
+there can still move whitespace.
+
+### Where it is deliberately not extensible
+
+`AppProfile.of` returns for a terminal and for a blind app **before** the paste
+lookup is reached. Neither can be promoted out of plain by adding a line to a
+set. A terminal renders no markup and would show the tags.
+
+---
+
+## The probe
+
+```sh
+$PF --paste-probe <plain|markdown|html|rtf|all> [--file <fixture.md>] [--bare] [--show]
+```
+
+It puts one fixture on the clipboard in one flavour and stops. You press ⌘V
+yourself. Pressing it yourself keeps the test about the flavour and not about
+the event tap.
+
+The fixture exercises seven things in one paste: **bold, italic, code, bullet,
+nested bullet, numbered list, link**. A link is two scores — the words it was
+written on, and the URL behind them.
+
+The flavours:
+
+| | |
+|---|---|
+| `plain` | Markers stripped, bullets kept as `•`, URL in brackets. The floor. If this is good enough, stop here. |
+| `markdown` | The source left as it is. Notion, Linear and Obsidian convert it themselves. Most apps do not. |
+| `html` | `public.html`, plus the plain fallback. |
+| `rtf` | `public.rtf`, plus the plain fallback. Built from the same HTML through AppKit's importer, so it carries a real `\listtable` and real `HYPERLINK` fields. |
+| `all` | HTML and RTF and plain on one item — the shape a shipping paste would have. |
+
+`--bare` withholds the plain fallback. **A rich flavour alone is not a shape
+anything puts on a real clipboard.** A clipboard manager reads it as empty, and
+a paste that lands as plain looks identical to a paste that did not land. So
+the fallback is the default and `--bare` is the follow-up: when a cell renders
+as plain, `--bare` says whether the app could have taken the rich flavour or
+only preferred not to.
+
+**Your clipboard is not put back.** The payload has to survive for you to paste
+it.
+
+---
+
+## Step 1 — `all`, into everything
+
+`all` is the shape a shipping paste has: HTML, RTF and plain on one item. Test
+it first. Every app that scores 7/7 here is finished and needs no config at all.
+
+Run the probe **once**, then paste into every app in the list before running it
+again. Flavour outside, apps inside — three probe runs, not thirty.
+
+```sh
+.build/debug/ParrotFlow --paste-probe all
+```
+
+Score each cell per feature, not pass/fail. A cell that keeps everything but
+flattens the nesting is a different decision from one that drops the link. A
+cell says what was lost; `all 7` means nothing was. A link is two scores — the
+words, and the URL behind them.
+
+The five that decide it, plus the safety check:
+
+| App | engine | `all` |
+|---|---|---|
+| Slack | Electron | |
+| Microsoft Outlook | native | |
+| Gmail compose (Chrome) | Blink `contenteditable` | |
+| Google Docs (Chrome) | its own clipboard layer | |
+| Notion | Electron | |
+| VS Code or Ghostty | plain text | |
+
+Then the rest, if the first six leave anything open:
+
+| App | engine | `all` |
+|---|---|---|
+| Microsoft Teams | Electron | |
+| Obsidian | Electron | |
+| Granola | Electron | |
+| Apple Mail | native | |
+| Apple Notes | native | |
+| Microsoft Word | native | |
+
+The editor row is not a feature check, it is a safety check. An editor and a
+terminal understand none of these flavours and must land on the plain fallback.
+If either one pastes `<p>Ship the` then rich paste is dangerous everywhere and
+the default has to stay plain.
+
+Google Docs is the one to expect trouble from. It does not read the pasteboard
+the way the others do — it has its own internal clipboard, and what it accepts
+from outside is narrower than what it produces.
+
+## Step 2 — diagnose only what failed
+
+For an app that scored badly, the question is whether it *could* do better with
+one flavour alone. That is three more runs, on that app only.
+
+```sh
+.build/debug/ParrotFlow --paste-probe html --bare   # HTML alone
+.build/debug/ParrotFlow --paste-probe rtf --bare    # RTF alone
+.build/debug/ParrotFlow --paste-probe markdown      # does it convert markup itself?
+```
+
+| App | `all` picked | `html --bare` | `rtf --bare` | `markdown` |
+|---|---|---|---|---|
+| | | | | |
+
+An app that does better with HTML alone than with `all` is reaching for RTF when
+both are offered. The fix is to withhold RTF for it.
+
+## Measured so far
+
+| App | flavour | result |
+|---|---|---|
+| Slack | `html` | **all 7** — bold, italic, code span, bullets, a real second level with `◦`, 1/2/3, "Dana" styled as a link. URL not yet confirmed. Slack's WYSIWYG composer was on. **Shipped as `.html`.** |
+
+Record the Slack "format messages with markup" setting alongside its row. It
+changes the answer, and without it the numbers do not reproduce.
+
+## What the matrix decides
+
+Two lines in `AppProfile.swift`, one per measured app:
+
+```swift
+private static let htmlBundleIDs: Set<String> = ["com.tinyspeck.slackmacgap"]
+private static let rtfBundleIDs: Set<String> = []
+```
+
+Not a `paste:` block in `config.yaml`. That was proposed and withdrawn: it would
+be a second per-app registry sitting beside `AppProfile`, which exists precisely
+so an app does not appear in several lists. Its own doc comment says so.
+
+A config override can come later, for an app nobody here has measured. It is not
+needed to ship this and is not built.
+
+Two rules that do not depend on the numbers:
+
+- **Default to plain.** An app with no proven row gets `public.utf8-plain-text`
+  and nothing else. A wrong flavour does not only lose the bold — in some apps
+  it loses the sentence. Fail open. **Built and checked.**
+- **Only pay the cost when there is something to format.** A transcript with no
+  Markdown markers takes today's path unchanged. `Markup.isPlain` is the gate.
+  **Built and checked.**
+
+---
+
+## Known hazards
+
+- `AttributedString(markdown:)` sets `inlinePresentationIntent`, not fonts. RTF
+  built straight from the parse comes out unstyled. Going through the HTML
+  importer avoids this — measured at 400ms, and it needs no `NSApplication`.
+- Slack's composer rewrites what it receives, and its behaviour depends on a
+  preference. See above.
+- The matrix is measured against app versions, and Slack ships weekly. If it
+  drifts, the next harness is: paste, select all, copy back, and inspect the
+  returned flavours for bold runs. That is scriptable. Do not build it until
+  the manual matrix proves it is needed.
+- ⌘⇧V pastes plain in most of these apps. It is the user's escape hatch and it
+  belongs in the docs.

--- a/docs/proposals/formatted-paste.md
+++ b/docs/proposals/formatted-paste.md
@@ -35,7 +35,12 @@ production stage is worthless until something can carry its output.
 RTF goes through AppKit's HTML importer rather than being built by hand: that is
 what produces a real `\listtable` and real `HYPERLINK` fields. It also keeps the
 two rich flavours the same document, so a difference in the target app is the
-target app. Measured at 400ms, no `NSApplication` needed.
+target app. No `NSApplication` needed, so it runs in a command too.
+
+Measured on the fixture: **637ms the first time in a process, then 2ms.** The
+cost is WebKit starting, not the document. Nothing reaches it yet — no app is
+`.rtf` — but the first formatted paste of a session into one would pay it. The
+fix, when an app is promoted, is to import a byte of HTML at launch.
 
 ### The gate: block structure, over more than one line
 

--- a/docs/proposals/formatted-paste.md
+++ b/docs/proposals/formatted-paste.md
@@ -127,6 +127,12 @@ the fallback is the default and `--bare` is the follow-up: when a cell renders
 as plain, `--bare` says whether the app could have taken the rich flavour or
 only preferred not to.
 
+**`--bare` works for `html` and not for `rtf`.** Measured: setting `public.rtf`
+on an item makes AppKit derive `public.utf8-plain-text` from it by itself. So
+"does this app take RTF with nothing to fall back to" is a question that cannot
+be asked, and RTF is never risky the way HTML-only is. Nothing is derived from
+`public.html`. The probe says which case it is in its own output.
+
 **Your clipboard is not put back.** The payload has to survive for you to paste
 it.
 

--- a/docs/proposals/formatted-paste.md
+++ b/docs/proposals/formatted-paste.md
@@ -37,15 +37,49 @@ what produces a real `\listtable` and real `HYPERLINK` fields. It also keeps the
 two rich flavours the same document, so a difference in the target app is the
 target app. Measured at 400ms, no `NSApplication` needed.
 
+### The gate: block structure, over more than one line
+
+Asking "does this parse as Markdown" is the wrong question, because ordinary
+dictation does. Measured on plain sentences, before the gate was tightened:
+
+| dictated | became |
+|---|---|
+| `use the __init__ method` | `use the <strong>init</strong> method` |
+| `multiply a*b*c and check the result` | `multiply a<em>b</em>c and …` |
+| `1. Draft 2. Review` | `<ol><li>Draft 2. Review</li></ol>` |
+| `see https://example.com/x for the details` | the URL autolinked |
+
+Each one loses characters the speaker said, and `__init__` is a word a
+developer dictates. So **inline emphasis alone never counts.** What counts is
+block structure — a list, a heading, a code block, a quote — spread over more
+than one line. A transform that formats deliberately produces that; a single
+dictated sentence cannot produce it by accident.
+
+The cost is that a one-line `Call **Dana** about it` stays plain. Nothing
+produces that today, and refusing wrongly costs a bold where letting through
+wrongly costs the characters.
+
+The real gate is a stage declaring its output as Markdown. This is the
+conservative half of it until one does.
+
+**Residual, not fixed.** Inside a genuine multi-line list, `__init__` is still
+read as bold. Once a stage produces the Markdown deliberately, escaping is that
+stage's job.
+
 ### The contract, checked by `--clipboard-test`
 
 ```
 ✓ an unmeasured app gets plain text, verbatim
 ✓ a transcript with no markup gets plain text, verbatim
-✓ a measured app gets the markup and the fallback
+✓ one line stays one line: "use the __init__ method"
+✓ one line stays one line: "multiply a*b*c and check the result"
+✓ one line stays one line: "1. Draft 2. Review"
+✓ one line stays one line: "Call **Dana** about the invoice"
+✓ a dictated list is written as one
+✓ a measured app is not enough on its own
 ```
 
-"Verbatim" is the load-bearing word. Both ways down to plain write the text
+"Verbatim" is the load-bearing word. Every way down to plain writes the text
 itself and not a rendering of it, because stripping markers that were never
 there can still move whitespace.
 

--- a/scripts/check-profiles.sh
+++ b/scripts/check-profiles.sh
@@ -5,7 +5,7 @@
 # This is the routing every dictation turns on, and it is the one part of the
 # destination path that can be checked without a screen, a microphone or a real
 # app in front: given a bundle id and a name, which focus rule, which pill
-# anchor, and whether the pane is readable.
+# anchor, whether the pane is readable, and which paste flavour it may carry.
 #
 # It cannot check the things underneath it — that Codex really does refuse
 # `AXManualAccessibility`, that VS Code really does take it, that a ⌘V really
@@ -43,7 +43,7 @@ for case in cases:
         if len(parts) == 2:
             got[parts[0]] = parts[1]
 
-    for field in ("focus", "anchor", "readsPane"):
+    for field in ("focus", "anchor", "readsPane", "paste"):
         want = str(case[field]).lower()
         if got.get(field, "").lower() != want:
             print(f"  ✗ {case['what']}")

--- a/tests/profile-cases.yaml
+++ b/tests/profile-cases.yaml
@@ -1,5 +1,6 @@
 # What `AppProfile.of` must make of an app: which focus rule, which pill anchor,
-# and whether the visible pane can be read as context.
+# whether the visible pane can be read as context, and which rich pasteboard
+# flavour a paste into it may carry.
 #
 # `bundle` and `name` are what `NSWorkspace` reports — the bundle identifier and
 # the localized name. Both are matched for terminals; only the bundle id is
@@ -9,6 +10,11 @@
 # app that could have been examined pastes without checking what has focus, and
 # `ordinary` on an app that answers nothing sends every dictation to the
 # clipboard.
+#
+# `paste` is `plain` until the matrix in docs/proposals/formatted-paste.md
+# scores the app with `--paste-probe` against a real window. A wrong one here
+# does not lose the sentence — plain text rides along with every flavour — but
+# it does put markup in front of an app that will show it as tags.
 
 - what: a terminal by bundle id
   bundle: com.mitchellh.ghostty
@@ -16,6 +22,7 @@
   focus: screen
   anchor: ladder
   readsPane: true
+  paste: plain
 
 - what: a terminal by name, built from source and signed however the build did
   bundle: com.example.somebodys-build
@@ -23,6 +30,7 @@
   focus: screen
   anchor: ladder
   readsPane: true
+  paste: plain
 
 - what: one terminal, several bundle ids
   bundle: dev.warp.warp-preview
@@ -30,6 +38,7 @@
   focus: screen
   anchor: ladder
   readsPane: true
+  paste: plain
 
 - what: Codex, which refuses both Chromium accessibility switches
   bundle: com.openai.codex
@@ -37,6 +46,7 @@
   focus: blind
   anchor: window
   readsPane: false
+  paste: plain
 
 # The hole this file exists for. `blind` was matched on the name "codex" as well
 # as the bundle id, so any app calling itself Codex skipped the focus check
@@ -48,6 +58,7 @@
   focus: examine
   anchor: ladder
   readsPane: false
+  paste: plain
 
 - what: VS Code, which takes the unlock and can then be examined
   bundle: com.microsoft.VSCode
@@ -55,13 +66,15 @@
   focus: examine
   anchor: ladder
   readsPane: false
+  paste: plain
 
-- what: Slack, which never needed anything
+- what: Slack, which never needed anything, and takes HTML whole
   bundle: com.tinyspeck.slackmacgap
   name: Slack
   focus: examine
   anchor: ladder
   readsPane: false
+  paste: html
 
 - what: an app nobody has classified
   bundle: com.apple.finder
@@ -69,6 +82,7 @@
   focus: examine
   anchor: ladder
   readsPane: false
+  paste: plain
 
 - what: matching ignores case
   bundle: COM.MITCHELLH.GHOSTTY
@@ -76,3 +90,4 @@
   focus: screen
   anchor: ladder
   readsPane: true
+  paste: plain

--- a/tests/profile-cases.yaml
+++ b/tests/profile-cases.yaml
@@ -76,6 +76,14 @@
   readsPane: false
   paste: html
 
+- what: an impostor calling itself Slack still gets plain text
+  bundle: com.example.whatever
+  name: Slack
+  focus: examine
+  anchor: ladder
+  readsPane: false
+  paste: plain
+
 - what: an app nobody has classified
   bundle: com.apple.finder
   name: Finder


### PR DESCRIPTION
A dictation that carries Markdown now reaches the app as formatting rather than as markers. Slack is the one app measured so far, and it takes `public.html` whole — bold, italic, a code span, bullets, a real second level, an ordered list, and a link on its own words.

Every other app gets plain text, byte for byte as before. There is no setting: an app is promoted out of plain only by being measured with `--paste-probe` against a real window, which is one line in a set in `AppProfile.swift`. Outlook, Gmail, Google Docs and Notion are not measured yet and stay plain.

Start the review at `Markup.isPlain`. It is the gate, and it is the part that was wrong first: `AttributedString(markdown:)` reads ordinary dictation as formatting, so "use the `__init__` method" came out as bold "init". The gate now asks for block structure over more than one line. `Markup.item` and `TextInserter.item(for:paste:)` decide what then lands on the clipboard, and the eight new `--clipboard-test` checks are the contract all three have to keep.

<details>
<summary>Ordinary dictation parses as Markdown, so the gate asks for more than that</summary>

Asking "does this parse as Markdown" is the wrong question. Measured on plain sentences, before the gate was tightened:

| dictated | became |
|---|---|
| `use the __init__ method` | `use the <strong>init</strong> method` |
| `multiply a*b*c and check the result` | `multiply a<em>b</em>c and …` |
| `1. Draft 2. Review` | `<ol><li>Draft 2. Review</li></ol>` |

Each loses characters the speaker said, and `__init__` is a word a developer dictates into Slack — the one app this enables.

So inline emphasis alone never counts. What counts is block structure — a list, a heading, a code block, a quote — over more than one line. A transform that formats deliberately produces that. A single dictated sentence cannot produce it by accident.

The cost is that a one-line `Call **Dana** about it` stays plain. Nothing produces that today, and refusing wrongly costs a bold where letting through wrongly costs the characters. The real gate is a stage declaring its output as Markdown; this is the conservative half until one does.

Residual, not fixed: inside a genuine multi-line list, `__init__` is still read as bold. Once a stage produces the Markdown deliberately, escaping is that stage's job.

</details>

<details>
<summary>Every route down to plain text writes the text verbatim, checked in CI</summary>

Plain text is the floor, and there are three routes to it: an app nobody has measured, a transcript with no block structure, and a rich flavour that will not render. All of them write `text` itself and never a rendering of it — round-tripping a flat sentence through the parser can move whitespace, and a dictation has to arrive as it left.

`--clipboard-test`, in `scripts/check-clipboard.sh`, which already runs in CI:

```
✓ an unmeasured app gets plain text, verbatim
✓ a transcript with no markup gets plain text, verbatim
✓ one line stays one line: "use the __init__ method"
✓ one line stays one line: "multiply a*b*c and check the result"
✓ one line stays one line: "1. Draft 2. Review"
✓ one line stays one line: "Call **Dana** about the invoice"
✓ a dictated list is written as one
✓ a measured app is not enough on its own
```

Plain text also rides along with every rich flavour, so an app that takes neither `public.html` nor `public.rtf` still gets the sentence.

</details>

<details>
<summary>One field on AppProfile, not a second per-app registry in config.yaml</summary>

The first design was a `paste:` block in `config.yaml` with its own `app:` regexes. It was withdrawn. `AppProfile` already exists to stop an app appearing in several lists, and says so in its own doc comment:

> What an app affords, decided from its identity rather than by asking it. One entry per app, instead of the same app appearing in a list in `Destination`, a branch in `CaretAnchor` and a special case in `AppDelegate`.

So `paste` is a fourth field beside `focus`, `anchor` and `readsPane`. That brings `--profile`, `tests/profile-cases.yaml` and `scripts/check-profiles.sh` with it, so a wrong flavour fails CI rather than someone's message.

Matched by bundle id alone, for the reason `blindBundleIDs` already is: each line is one measured build, and a name is something any app can claim. Terminals stay the exception in that file, because a terminal really is built from source and signed however the build did. There is a case for it — an app calling itself Slack still gets plain text.

A config override for an app nobody here has measured can come later. It is not needed to ship this and is not built.

</details>

<details>
<summary>A terminal cannot be promoted, and that is structural rather than a rule</summary>

`AppProfile.of` returns for a terminal and for a blind app **before** the paste lookup is reached. Adding a bundle id to `htmlBundleIDs` cannot reach them. A terminal renders no markup and would show the tags instead.

</details>

<details>
<summary>RTF is built from the HTML, which is what gets a real list table</summary>

Both rich flavours come from one HTML rendering. The RTF is that HTML through AppKit's importer, then exported.

Attributed text built by hand exports RTF with tab-indented paragraphs. Through the importer it carries a real `\listtable`, real `HYPERLINK` fields, and `◦` at the second level. On the fixture: `HYPERLINK=true listtable=true bold=true`, 3056 bytes, and no `NSApplication` needed, so it runs in a command as happily as in the app.

It also keeps the two rich flavours the same document, so a difference in a target app is the target app rather than two renderers disagreeing.

Timing, measured over eight runs in one process: **637ms the first, then 2ms.** The cost is WebKit starting, not the document. Nothing reaches it yet — no app is `.rtf` — but the first formatted paste of a session into one would pay it, and the fix would be to import a byte of HTML at launch. Flagged rather than built, because the path is unreachable until an app is promoted.

</details>

<details>
<summary>--paste-probe, and the matrix it exists to fill</summary>

```sh
$PF --paste-probe <plain|markdown|html|rtf|all> [--file <fixture.md>] [--bare] [--show]
```

It puts one fixture on the clipboard and stops. You press ⌘V yourself, which keeps the test about the flavour and not about the event tap. The fixture exercises seven things in one paste: bold, italic, code, bullet, nested bullet, numbered list, link — and a link counts twice, the words and the URL behind them.

It renders through the same `Markup` the app writes with. One registry, two callers, so what you score is what the app gets.

Plain text rides along by default. `--bare` withholds it, which is a diagnostic and never a setting: a rich flavour alone is not a shape anything puts on a real clipboard, a clipboard manager reads it as empty, and a paste that lands as plain cannot be told from a paste that did not land.

`--bare` works for `html` and not for `rtf`. Setting `public.rtf` on an item makes AppKit derive the plain-text types from it, so RTF is never offered alone and that question cannot be asked of it:

```
$ --paste-probe rtf --bare
wrote     public.rtf                        3056 bytes
wrote     public.utf16-external-plain-text  416 bytes
wrote     public.utf8-plain-text            207 bytes
          plain text is there anyway — AppKit derives it from the RTF
```

The command says which case it is in, so nobody fills a matrix cell on a conclusion the clipboard does not support.

The matrix is `docs/proposals/formatted-paste.md`. Run `all` first — it is the shape a shipping paste has, so an app that keeps everything under it is finished. Single flavours are the follow-up, for an app that scored badly, to find out which one to withhold.

</details>

<details>
<summary>What this does not do</summary>

- **Nothing produces Markdown from speech yet.** This is the delivery half. A stage that turns "bullet point call the client" into `- Call the client` is separate work with its own case set. Until then this only carries markup a transform or the speaker already put there.
- **Five of the six apps in the matrix are unmeasured**, so they are plain. Outlook, Gmail compose, Google Docs, Notion, and the editor safety row.
- **In-place edits stay plain.** The four callers in `Surface.swift` take the default `.plain`, which is correct — an edit writes into a field's existing text, where markup would be wrong.

</details>

<details>
<summary>Checks run</summary>

```
swift build -c release      Build complete
swiftlint                   no errors; no warnings in the changed files
scripts/check-*.sh          28 passed, 0 failed
```

That is every check that runs without Ollama or a real screen — the same set CI runs, plus the four it skips for a model. The two this change is about:

```
check-profiles.sh    ✓ every app is classified as the case file says (10 cases)
check-clipboard.sh   ✓ all clipboard rules hold (14 checks)
```

</details>
