### PR TITLE
docs: say where a dictation's bullets and bold end up

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,10 +241,12 @@ transcription:
 you ask: hold `⌘` and say *"hey parrot, correct me"*, or press `S` on the pill
 after any dictation.
 
-A transform that returns Markdown — a bullet list, a bold word, a link — lands
-in Slack as real formatting rather than as `**stars**`. Other apps get plain
-text until they are measured, and plain text rides along beside the formatting
-either way, so nothing is ever lost to an app that does not take it. See
+A transform that returns a Markdown **list** lands in Slack as a real list,
+with the bold and the links inside it intact, rather than as `**stars**`. It
+takes block structure over more than one line: a lone `**bold**` in a sentence
+stays exactly as you said it, so an ordinary dictation is never reinterpreted.
+Other apps get plain text until they are measured, and plain text rides along
+either way, so nothing is lost to an app that does not take it. See
 [bullets, bold and links](docs/configuration.md#bullets-bold-and-links).
 
 ### More examples

--- a/README.md
+++ b/README.md
@@ -241,6 +241,12 @@ transcription:
 you ask: hold `⌘` and say *"hey parrot, correct me"*, or press `S` on the pill
 after any dictation.
 
+A transform that returns Markdown — a bullet list, a bold word, a link — lands
+in Slack as real formatting rather than as `**stars**`. Other apps get plain
+text until they are measured, and plain text rides along beside the formatting
+either way, so nothing is ever lost to an app that does not take it. See
+[bullets, bold and links](docs/configuration.md#bullets-bold-and-links).
+
 ### More examples
 
 Each with its own test cases, in [examples/transforms](examples/transforms):

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -94,7 +94,8 @@ transcription:
       # "read user dot name" -> read user.name, in code-ish windows only.
       - transform: dotted
         app: /term|ghostty|warp|kitty|alacritty|hyper|slack|discord/
-      # `backticks` does the same for chat, so pasted markup stays literal.
+      # `backticks` does the same for chat. Not enabled: its output is one
+      # line, and markup is only sent as rich text for block structure.
       - transform: code_identifiers
         app: /term|ghostty|warp|kitty|alacritty|hyper|code|cursor|zed|xcode|jetbrains|idea|pycharm|webstorm/
         when: /\b(?:function|method|variable|class|constant|type|struct|interface|enum|fonction|méthode|classe|constante)\b/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -257,7 +257,7 @@ If an app of yours takes formatting and is not on the list, it can be measured.
 Put the fixture on the clipboard and paste it in yourself:
 
 ```sh
-$PF --paste-probe all
+/Applications/ParrotFlow.app/Contents/MacOS/ParrotFlow --paste-probe all
 ```
 
 Then score seven things: bold, italic, code, bullet, nested bullet, numbered

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -217,6 +217,58 @@ that counts as moved and the transcript is copied. Not knowing is not the same
 as knowing it is fine, and a transcript on your clipboard is recoverable in a
 way that one typed into somebody else's window is not.
 
+## Bullets, bold and links
+
+A transcript that carries Markdown reaches an app that takes it as real
+formatting rather than as `**stars**`. Bold, italic, a code span, bullets with
+a real second level, numbered lists, and a link on the words it was written on.
+
+**Slack only, so far.** It is the one app measured. Every other app gets plain
+text, byte for byte as before. There is nothing to configure and nothing to
+turn on — the app is either measured or it is not, and an unmeasured one is
+never sent markup it might show as tags. Plain text also rides along beside
+every rich flavour, so an app that takes neither still gets the sentence.
+
+**Nothing turns speech into Markdown yet.** This is the delivery half. It
+carries what a transform already emits, so a prompt of yours that returns a
+bullet list lands as a bullet list. Dictating *"bullet point call the client"*
+does not, and that is separate work.
+
+### What counts as formatting
+
+Block structure — a list, a heading, a code block, a quote — spread over more
+than one line. Inline emphasis on its own never counts, and that is deliberate.
+Ordinary dictation parses as Markdown:
+
+| dictated | would have become |
+|---|---|
+| `use the __init__ method` | bold "init", underscores gone |
+| `multiply a*b*c and check the result` | `a`, italic `b`, `c` |
+| `1. Draft 2. Review` | a numbered list |
+
+Each loses characters you said, and `__init__` is a word a developer dictates.
+A transform that formats deliberately produces block structure over several
+lines; one dictated sentence cannot produce it by accident. The cost is that a
+one-line `Call **Dana** about it` stays plain.
+
+### Measuring your own app
+
+If an app of yours takes formatting and is not on the list, it can be measured.
+Put the fixture on the clipboard and paste it in yourself:
+
+```sh
+$PF --paste-probe all
+```
+
+Then score seven things: bold, italic, code, bullet, nested bullet, numbered
+list, and the link — twice, once for its words and once for the URL behind
+them. [cli.md](cli.md) has the flags,
+[proposals/formatted-paste.md](proposals/formatted-paste.md) has the table to
+fill and what promoting an app costs.
+
+Adding one is a line in `AppProfile.swift` today, so it needs a release. Making
+it a config setting is [#197](https://github.com/znat/parrotflow/issues/197).
+
 ## Escape stops a dictation
 
 Press ⎋ while recording, or while it is transcribing, and the dictation ends.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -248,7 +248,7 @@ Ordinary dictation parses as Markdown:
 | dictated | would have become |
 |---|---|
 | `use the __init__ method` | bold "init", underscores gone |
-| `multiply a*b*c and check the result` | `a`, italic `b`, `c` |
+| `multiply a*b*c and check the result` | an italic *b*, the asterisks gone |
 | `1. Draft 2. Review` | a numbered list |
 
 Each loses characters you said, and `__init__` is a word a developer dictates.
@@ -258,7 +258,7 @@ one-line `Call **Dana** about it` stays plain.
 
 ### Measuring your own app
 
-If an app of yours takes formatting and is not on the list, it can be measured.
+An app of yours that takes formatting and is not on the list can be measured.
 Put the fixture on the clipboard and paste it in yourself:
 
 ```sh

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -219,9 +219,14 @@ way that one typed into somebody else's window is not.
 
 ## Bullets, bold and links
 
-A transcript that carries Markdown reaches an app that takes it as real
-formatting rather than as `**stars**`. Bold, italic, a code span, bullets with
-a real second level, numbered lists, and a link on the words it was written on.
+A transcript that carries a Markdown **list, heading, code block or quote**,
+over more than one line, reaches an app that takes it as real formatting rather
+than as `**stars**`. Inside it, bold, italic, code spans, a real second level of
+bullets, numbered lists and links all survive.
+
+A single line never does, whatever is in it. `Call **Dana** about it` is pasted
+as you said it, markers and all. That is deliberate — see *What counts as
+formatting* below.
 
 **Slack only, so far.** It is the one app measured. Every other app gets plain
 text, byte for byte as before. There is nothing to configure and nothing to

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -554,17 +554,20 @@ not consume the word after the dot, so it has nowhere to put a closing backtick
 — the first attempt produced ``lis `config.`port``. It requires a letter to
 start, so `21.5` is left alone.
 
-**It is not in the shipped pipeline.** Slack's composer converts markdown as you
-type it and never re-reads text that arrives by paste, which is every way this
-app inserts text — so the backticks land in the message as characters. Tried on
-a real Slack, including with *Format messages with markup* enabled, and it did
-not render either way. A default that depends on a setting in another
-application, and does not work when that setting is on, is not a default: it
-puts noise in your messages and gives you nowhere to look.
+**It is not in the shipped pipeline.** Markdown *characters* arriving by paste
+are not rendered. Tried on a real Slack, including with *Format messages with
+markup* enabled, and the backticks landed in the message as characters either
+way. A default that depends on a setting in another application, and does not
+work when that setting is on, is not a default: it puts noise in your messages
+and gives you nowhere to look.
 
-Add the step if your chat app renders pasted markup. Getting this to work
-properly means putting rich text on the clipboard rather than markdown
-characters, which is a different feature.
+The other half of that has since been built. Slack does render **rich text**
+that arrives by paste, and the app now sends it — see
+[bullets, bold and links](configuration.md#bullets-bold-and-links). It does not
+rescue `backticks`: markup is only sent for block structure over more than one
+line, and a dotted path inside a sentence is one line, so it is still pasted
+with its backticks showing. Add the step if your chat app renders pasted
+markdown characters.
 
 ### `join`, which fits a clip to the box it lands in
 
@@ -717,10 +720,15 @@ your words, and it is not something a table can be taught.
 `email` puts the greeting on its own line with a blank line under it, breaks
 the body where the subject changes, and treats a name at the end as a
 signature. `slack` does almost none of that — no greeting, no sign-off, one
-paragraph — and is explicitly told to emit no markup at all, for the reason
-`backticks` is not in the shipped pipeline: Slack's composer does not render
-markdown that arrives by paste, so bold or bullets land in the message as
-characters.
+paragraph — and is explicitly told to emit no markup at all.
+
+**That instruction is older than the delivery path.** It was written because
+markup pasted into Slack showed as characters. A multi-line list now reaches
+Slack as a real list, with the bold and the links inside it — see
+[bullets, bold and links](configuration.md#bullets-bold-and-links) — so the
+reason no longer holds. Loosening it is a prompt change and needs scoring
+against its case set first; nothing has been changed here on the strength of
+the delivery path alone.
 
 Both are told twice not to write anything. That is the failure worth spending
 tokens on: a model handed a dictated email will gladly return a better one, in


### PR DESCRIPTION
#196 shipped the delivery path with nothing on the README and nothing in `configuration.md`. The only way to find out it existed was to read `AppProfile.swift`, so this writes it down.

Three places. A paragraph on the README where a transform's output is discussed, a section in `configuration.md` after `insert_mode`, and two corrections in `pipelines.md` where #196 falsified what the page says.

The thing to check is that it does not oversell. Slack is the one app measured, and nothing turns speech into Markdown yet — both are stated in the lead of the section rather than buried.

<details>
<summary>#196 falsified two statements in pipelines.md, one of which parked this as future work</summary>

The `backticks` section said Slack *"never re-reads text that arrives by paste"* and closed with:

> Getting this to work properly means putting rich text on the clipboard rather than markdown characters, which is a different feature.

That is #196. The `slack` transform section says the shipped prompt is *"explicitly told to emit no markup at all"* for the same, now-obsolete reason.

Both now say what is true: markdown **characters** still land as characters, rich text does not. `backticks` still should not ship, but for a new reason — markup is only sent for block structure over more than one line, and a dotted path inside a sentence is one line.

**The `slack` prompt is not changed.** Loosening "emit no markup" is a prompt change, and `AGENTS.md` is explicit that those are scored against their case set first. The page now records that the reason is obsolete and that changing it needs scoring. That is a decision, not a docs edit.

`config.example.yaml` is untouched. Its comment describes `backticks`' own single-line output, which is still pasted literally.

</details>

<details>
<summary>What it deliberately does not claim</summary>

Three limits, each said plainly rather than left for someone to discover:

- **Slack only.** Every other app gets plain text, byte for byte. There is nothing to configure and nothing to turn on.
- **Nothing turns speech into Markdown.** This is the delivery half. It carries what a transform already emits, so a prompt that returns a bullet list lands as one. Dictating *"bullet point call the client"* does not.
- **Adding an app needs a release.** It is a line in `AppProfile.swift` today. Making it a config setting is #197.

The README paragraph is four sentences and links to the section rather than repeating it. A front page that claimed formatted paste outright would be wrong today.

</details>

<details>
<summary>The gate is documented with the three dictations that made it necessary</summary>

`configuration.md` carries the table, so nobody widens the rule back without meeting the cases first:

| dictated | would have become |
|---|---|
| `use the __init__ method` | bold "init", underscores gone |
| `multiply a*b*c and check the result` | `a`, italic `b`, `c` |
| `1. Draft 2. Review` | a numbered list |

And what the rule costs, stated: a one-line `Call **Dana** about it` stays plain.

</details>

<details>
<summary>Checks run</summary>

Every relative link and every anchor in the touched files resolves, checked with a script over `README.md`, `docs/README.md`, `configuration.md`, `pipelines.md`, `cli.md`, `architecture.md` and `proposals/formatted-paste.md`.

The claims about behaviour are checked against the binary rather than read off the source:

```
✓ one line stays one line: "Call **Dana** about the invoice"
      clipboard reads "Call **Dana** about the invoice"
✓ a dictated list is written as one
      <p>Before Friday:</p><ul><li>call <strong>Dana</strong></li>…
```

```
check-default-config.sh   ✓ config.example.yaml is the one copy, parses, and its
                            pipeline names only real stages and transforms
```

Docs only. No Swift changed.

</details>
