### PR TITLE
fix: mined pronunciation samples keep the edges of the word

### DIFF
--- a/scripts/mine-pronunciations.py
+++ b/scripts/mine-pronunciations.py
@@ -88,12 +88,20 @@ def bare(word):
     return re.sub(r"[^\w']", "", word).lower()
 
 
+PAD = 0.25
+
+
 def cut(wav, start, end, target):
-    """The span, padded a little — a word's edges are where it is least clear."""
+    """The span plus 0.25 s each side.
+
+    The decoder's word times land inside the word. Measured 2026-08-24 on 122
+    samples: 0.05 s of padding gave a phoneme matcher AUC 0.952, 0.25 s gave
+    0.999, and 7 of its 9 errors were clipped spans.
+    """
     with wave.open(str(CLIPS / wav), "rb") as src:
         rate, width, channels = src.getframerate(), src.getsampwidth(), src.getnchannels()
-        first = max(0, int((start - 0.05) * rate))
-        last = min(src.getnframes(), int((end + 0.05) * rate))
+        first = max(0, int((start - PAD) * rate))
+        last = min(src.getnframes(), int((end + PAD) * rate))
         src.setpos(first)
         frames = src.readframes(last - first)
     target.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
`scripts/mine-pronunciations.py --audio` cuts each sample 0.25 s wide on each side of the decoder's word times, instead of 0.05 s. The word times land inside the word, so the old cuts lost the edges of the name. Nothing in the app reads these samples yet; they feed the acoustic measurements. Existing files in `voice/samples/` are not re-cut.

<details>
<summary>Measurements: 0.05 s padding gives AUC 0.952, 0.25 s gives 0.999</summary>

Offline spike, 2026-08-24, on the 122 samples in `voice/samples/` and 651 negatives. Phoneme recogniser `wav2vec2-xlsr-53-espeak-cv-ft` with a keyword-filler Viterbi log ratio.

| positives | negatives | macro AUC | 1-of-11 identification |
| --- | --- | --- | --- |
| as cut (0.05 s) | as cut | 0.952 | 113/122 |
| +0.25 s | as cut | 0.999 | 120/122 |
| +0.25 s | +0.25 s | 0.999 | 120/122 |

7 of the 9 errors on the old cuts were clipped spans. `Matthieu/00-mathieu.wav` is 0.58 s and the recogniser hears only /m/.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DadPD4pzfX4EF5d9qagAMo
