### PR TITLE
feat: a link or a code span reaches the app as one, on a single line

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,12 +241,12 @@ transcription:
 you ask: hold `⌘` and say *"hey parrot, correct me"*, or press `S` on the pill
 after any dictation.
 
-A transform that returns a Markdown **list** lands in Slack as a real list,
-with the bold and the links inside it intact, rather than as `**stars**`. It
-takes block structure over more than one line: a lone `**bold**` in a sentence
-stays exactly as you said it, so an ordinary dictation is never reinterpreted.
-Other apps get plain text until they are measured, and plain text rides along
-either way, so nothing is lost to an app that does not take it. See
+A transform that returns Markdown reaches Slack as real formatting rather than
+as `**stars**` — a list as a list, and `[#123](https://…)` as a link you can
+click. Emphasis on its own is left alone: a lone `**bold**` in a sentence stays
+exactly as you said it, so an ordinary dictation is never reinterpreted. Other
+apps get plain text until they are measured, and plain text rides along either
+way, so nothing is lost to an app that does not take it. See
 [bullets, bold and links](docs/configuration.md#bullets-bold-and-links).
 
 ### More examples

--- a/Sources/ParrotFlow/ClipboardTestCommand.swift
+++ b/Sources/ParrotFlow/ClipboardTestCommand.swift
@@ -153,6 +153,20 @@ enum ClipboardTestCommand {
               boldHTML?.contains("<strong>Dana</strong>") == true,
               boldHTML ?? "no html")
 
+        // The forms a narrower pattern got wrong: a title after the address,
+        // and an escaped bracket inside the label. Both are links the parser
+        // accepts, so both have to reach the app as links.
+        for written in [
+            "[#123](https://example.com \"Fix the thing\") is ready",
+            "[foo\\]bar](https://example.com) is odd but valid",
+        ] {
+            TextInserter.insert(written, mode: .clipboard, paste: .html)
+            let html = pasteboard.data(forType: .html).flatMap { String(data: $0, encoding: .utf8) }
+            check("a written link is a link: \(written.prefix(28))…",
+                  html?.contains("<a href=\"https://example.com\"") == true,
+                  html ?? "no html")
+        }
+
         // And a code span, which is what `backticks` emits.
         TextInserter.insert("read `user.name` first", mode: .clipboard, paste: .html)
         let codeHTML = pasteboard.data(forType: .html).flatMap { String(data: $0, encoding: .utf8) }

--- a/Sources/ParrotFlow/ClipboardTestCommand.swift
+++ b/Sources/ParrotFlow/ClipboardTestCommand.swift
@@ -92,7 +92,8 @@ enum ClipboardTestCommand {
         // must write the text itself rather than a rendering of it — stripping
         // markers that were never there can still move whitespace, and a
         // dictation has to arrive as it left.
-        let formatted = "Call **Dana** about the invoice"
+        // Underscores, so it is emphasis the speaker never asked for.
+        let formatted = "Call __Dana__ about the invoice"
         let flat = "Call Dana about the invoice"
 
         TextInserter.insert(formatted, mode: .clipboard, paste: .plain)
@@ -112,9 +113,11 @@ enum ClipboardTestCommand {
         // block structure over more than one line.
         for spoken in [
             "use the __init__ method",
+            "call __main__ before __exit__",
+            "we need __slots__ on that class",
             "multiply a*b*c and check the result",
+            "rate is 3*4*5",
             "1. Draft 2. Review",
-            formatted,
         ] {
             TextInserter.insert(spoken, mode: .clipboard, paste: .html)
             check("one line stays one line: \"\(spoken)\"",
@@ -142,6 +145,14 @@ enum ClipboardTestCommand {
               sameHTML?.contains("<a href=\"https://example.com\"") == true,
               sameHTML ?? "no html")
 
+        // Emphasis the speaker asked for: "start bold Dana end bold" reaches
+        // `punctuation` as **Dana**, which is asterisks and not inside a word.
+        TextInserter.insert("call **Dana** about the invoice", mode: .clipboard, paste: .html)
+        let boldHTML = pasteboard.data(forType: .html).flatMap { String(data: $0, encoding: .utf8) }
+        check("emphasis a speaker asked for is emphasis",
+              boldHTML?.contains("<strong>Dana</strong>") == true,
+              boldHTML ?? "no html")
+
         // And a code span, which is what `backticks` emits.
         TextInserter.insert("read `user.name` first", mode: .clipboard, paste: .html)
         let codeHTML = pasteboard.data(forType: .html).flatMap { String(data: $0, encoding: .utf8) }
@@ -166,7 +177,7 @@ enum ClipboardTestCommand {
               listHTML?.contains("<li>call <strong>Dana</strong></li>") == true,
               listHTML ?? "no html")
 
-        TextInserter.insert(formatted, mode: .clipboard, paste: .html)
+        TextInserter.insert(flat, mode: .clipboard, paste: .html)
         check("a measured app is not enough on its own",
               pasteboard.data(forType: .html) == nil,
               quoted(pasteboard))

--- a/Sources/ParrotFlow/ClipboardTestCommand.swift
+++ b/Sources/ParrotFlow/ClipboardTestCommand.swift
@@ -133,6 +133,15 @@ enum ClipboardTestCommand {
               linkHTML?.contains("href=\"https://github.com/znat/parrotflow/pull/123\"") == true,
               linkHTML ?? "no html")
 
+        // A link whose words are its own URL. Deliberate — the syntax says so —
+        // even though the label cannot be told from an autolink.
+        let sameLabel = "[https://example.com](https://example.com) is the one"
+        TextInserter.insert(sameLabel, mode: .clipboard, paste: .html)
+        let sameHTML = pasteboard.data(forType: .html).flatMap { String(data: $0, encoding: .utf8) }
+        check("a link labelled with its own URL is still a link",
+              sameHTML?.contains("<a href=\"https://example.com\"") == true,
+              sameHTML ?? "no html")
+
         // And a code span, which is what `backticks` emits.
         TextInserter.insert("read `user.name` first", mode: .clipboard, paste: .html)
         let codeHTML = pasteboard.data(forType: .html).flatMap { String(data: $0, encoding: .utf8) }

--- a/Sources/ParrotFlow/ClipboardTestCommand.swift
+++ b/Sources/ParrotFlow/ClipboardTestCommand.swift
@@ -123,6 +123,30 @@ enum ClipboardTestCommand {
                   quoted(pasteboard))
         }
 
+        // A link on one line, which is what a transform emits deliberately.
+        // The whole point of the path: a dictated "PR 123" reaches Slack as a
+        // link you can click, not as brackets.
+        let link = "[#123](https://github.com/znat/parrotflow/pull/123) is ready"
+        TextInserter.insert(link, mode: .clipboard, paste: .html)
+        let linkHTML = pasteboard.data(forType: .html).flatMap { String(data: $0, encoding: .utf8) }
+        check("a link on one line is a link",
+              linkHTML?.contains("href=\"https://github.com/znat/parrotflow/pull/123\"") == true,
+              linkHTML ?? "no html")
+
+        // And a code span, which is what `backticks` emits.
+        TextInserter.insert("read `user.name` first", mode: .clipboard, paste: .html)
+        let codeHTML = pasteboard.data(forType: .html).flatMap { String(data: $0, encoding: .utf8) }
+        check("a code span on one line is code",
+              codeHTML?.contains("<code>user.name</code>") == true,
+              codeHTML ?? "no html")
+
+        // A bare URL is not deliberate — the parser makes those out of ordinary
+        // text, so a sentence that mentions an address stays a sentence.
+        TextInserter.insert("see https://example.com/x for details", mode: .clipboard, paste: .html)
+        check("a bare URL is left as a sentence",
+              pasteboard.data(forType: .html) == nil,
+              quoted(pasteboard))
+
         // And the case the whole path exists for: block structure, over more
         // than one line. The fallback rides along, so an app that takes neither
         // flavour still gets the sentence.

--- a/Sources/ParrotFlow/Markup.swift
+++ b/Sources/ParrotFlow/Markup.swift
@@ -52,6 +52,7 @@ struct Markup {
         // that is where `__init__` and `a*b*c` live.
         if blocks.contains(where: { $0.pieces.contains(where: \.code) }) { return false }
         if hasLink, Self.writesALink(source) { return false }
+        if hasEmphasis, Self.writesEmphasis(source) { return false }
         // Everything else needs block structure over more than one line.
         guard source.contains("\n") else { return true }
         return !blocks.contains { block in
@@ -65,6 +66,25 @@ struct Markup {
     private var hasLink: Bool {
         blocks.contains { $0.pieces.contains { $0.link != nil } }
     }
+
+    private var hasEmphasis: Bool {
+        blocks.contains { $0.pieces.contains { $0.bold || $0.italic } }
+    }
+
+    /// Whether the source marks emphasis the way a speaker asks for it.
+    ///
+    /// Asterisks, and not inside a word. That is what "start bold … end bold"
+    /// produces through `punctuation`, and it is what the two ways of tripping
+    /// over emphasis do not: `__init__` and `__slots__` are underscores, and
+    /// `a*b*c` and `3*4*5` are inside a word. Both stay plain.
+    private static func writesEmphasis(_ source: String) -> Bool {
+        guard let pattern = emphasisSyntax else { return false }
+        let whole = NSRange(source.startIndex..., in: source)
+        return pattern.firstMatch(in: source, range: whole) != nil
+    }
+
+    private static let emphasisSyntax = try? NSRegularExpression(
+        pattern: "(?<![\\w*])\\*{1,2}(?![\\s*])(?:[^*]|\\*(?!\\*))+?(?<![\\s*])\\*{1,2}(?![\\w*])")
 
     /// Whether the source writes a link out, `[words](url)`.
     ///

--- a/Sources/ParrotFlow/Markup.swift
+++ b/Sources/ParrotFlow/Markup.swift
@@ -86,23 +86,23 @@ struct Markup {
     private static let emphasisSyntax = try? NSRegularExpression(
         pattern: "(?<![\\w*])\\*{1,2}(?![\\s*])(?:[^*]|\\*(?!\\*))+?(?<![\\s*])\\*{1,2}(?![\\w*])")
 
-    /// Whether the source writes a link out, `[words](url)`.
+    /// Whether the source writes a link out rather than merely naming an
+    /// address.
     ///
-    /// The syntax is the evidence, not the label. `[https://x](https://x)` is
-    /// deliberate even though its words are its URL, and a bare URL the parser
-    /// autolinked is not deliberate however it reads — accepting those would
-    /// send a whole sentence as markup for mentioning an address.
+    /// `](` is the whole test. Every inline link has it — labelled, titled,
+    /// or with an escaped bracket in the label — and an autolinked bare URL
+    /// never does. A pattern that tried to spell the forms out instead got
+    /// `[foo](url "title")` and `[foo\]bar](url)` wrong, because it was a
+    /// narrower grammar than the parser's.
     ///
-    /// Paired with the parser having found a link, so text shaped like the
-    /// syntax but not parsed as one changes nothing.
+    /// The syntax is the evidence, not the label: `[https://x](https://x)` is
+    /// deliberate even though its words are its address.
+    ///
+    /// Paired with the parser having found a link, so `](` sitting in ordinary
+    /// text changes nothing on its own.
     private static func writesALink(_ source: String) -> Bool {
-        guard let pattern = linkSyntax else { return false }
-        let whole = NSRange(source.startIndex..., in: source)
-        return pattern.firstMatch(in: source, range: whole) != nil
+        source.contains("](")
     }
-
-    private static let linkSyntax = try? NSRegularExpression(
-        pattern: "\\[[^\\]\n]*\\]\\([^)\\s]*\\)")
 
     // MARK: - Flavours
 

--- a/Sources/ParrotFlow/Markup.swift
+++ b/Sources/ParrotFlow/Markup.swift
@@ -44,6 +44,16 @@ struct Markup {
     /// yet. This is the conservative half of that: refusing wrongly costs a
     /// bold, letting through wrongly costs the characters.
     var isPlain: Bool {
+        // A link written on its own words, or a code span. Both need
+        // characters nobody utters — brackets, parentheses, backticks — so
+        // neither arrives by accident. Scanned over 1355 lines of the case
+        // files: 0 links, and the only 2 code spans were a transform's own
+        // output and a fixture about code. Emphasis is excluded on purpose;
+        // that is where `__init__` and `a*b*c` live.
+        if blocks.contains(where: { $0.pieces.contains(where: Self.isDeliberate) }) {
+            return false
+        }
+        // Everything else needs block structure over more than one line.
         guard source.contains("\n") else { return true }
         return !blocks.contains { block in
             !Self.containers(block.kinds).isEmpty
@@ -51,6 +61,17 @@ struct Markup {
                 || Self.headerLevel(block.kinds) != nil
                 || Self.isCodeBlock(block.kinds)
         }
+    }
+
+    /// A link whose words differ from its URL, or a code span.
+    ///
+    /// An autolinked bare URL is not one: the parser makes those out of
+    /// ordinary text, so accepting them would send a whole sentence as markup
+    /// because it happened to mention an address.
+    private static func isDeliberate(_ piece: Piece) -> Bool {
+        if piece.code { return true }
+        if let link = piece.link { return piece.text != link.absoluteString }
+        return false
     }
 
     // MARK: - Flavours

--- a/Sources/ParrotFlow/Markup.swift
+++ b/Sources/ParrotFlow/Markup.swift
@@ -44,15 +44,14 @@ struct Markup {
     /// yet. This is the conservative half of that: refusing wrongly costs a
     /// bold, letting through wrongly costs the characters.
     var isPlain: Bool {
-        // A link written on its own words, or a code span. Both need
-        // characters nobody utters — brackets, parentheses, backticks — so
-        // neither arrives by accident. Scanned over 1355 lines of the case
-        // files: 0 links, and the only 2 code spans were a transform's own
+        // A code span, or a link the source writes out as `[words](url)`.
+        // Both take characters a speaker only produces on purpose, so neither
+        // arrives by accident. Scanned over 1355 lines of the case files: no
+        // links at all, and the only two code spans were a transform's own
         // output and a fixture about code. Emphasis is excluded on purpose;
         // that is where `__init__` and `a*b*c` live.
-        if blocks.contains(where: { $0.pieces.contains(where: Self.isDeliberate) }) {
-            return false
-        }
+        if blocks.contains(where: { $0.pieces.contains(where: \.code) }) { return false }
+        if hasLink, Self.writesALink(source) { return false }
         // Everything else needs block structure over more than one line.
         guard source.contains("\n") else { return true }
         return !blocks.contains { block in
@@ -63,16 +62,27 @@ struct Markup {
         }
     }
 
-    /// A link whose words differ from its URL, or a code span.
-    ///
-    /// An autolinked bare URL is not one: the parser makes those out of
-    /// ordinary text, so accepting them would send a whole sentence as markup
-    /// because it happened to mention an address.
-    private static func isDeliberate(_ piece: Piece) -> Bool {
-        if piece.code { return true }
-        if let link = piece.link { return piece.text != link.absoluteString }
-        return false
+    private var hasLink: Bool {
+        blocks.contains { $0.pieces.contains { $0.link != nil } }
     }
+
+    /// Whether the source writes a link out, `[words](url)`.
+    ///
+    /// The syntax is the evidence, not the label. `[https://x](https://x)` is
+    /// deliberate even though its words are its URL, and a bare URL the parser
+    /// autolinked is not deliberate however it reads — accepting those would
+    /// send a whole sentence as markup for mentioning an address.
+    ///
+    /// Paired with the parser having found a link, so text shaped like the
+    /// syntax but not parsed as one changes nothing.
+    private static func writesALink(_ source: String) -> Bool {
+        guard let pattern = linkSyntax else { return false }
+        let whole = NSRange(source.startIndex..., in: source)
+        return pattern.firstMatch(in: source, range: whole) != nil
+    }
+
+    private static let linkSyntax = try? NSRegularExpression(
+        pattern: "\\[[^\\]\n]*\\]\\([^)\\s]*\\)")
 
     // MARK: - Flavours
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -224,10 +224,11 @@ over more than one line, reaches an app that takes it as real formatting rather
 than as `**stars**`. Inside it, bold, italic, code spans, a real second level of
 bullets, numbered lists and links all survive.
 
-A single line qualifies too, but only for a **link written on its own words**
-or a **code span** — `[the PR](https://…)` and `` `user.name` ``. Emphasis on a
-single line does not: `Call **Dana** about it` is pasted as you said it, markers
-and all. That is deliberate — see *What counts as formatting* below.
+A single line qualifies too, but only for a **link written out as
+`[words](url)`** or a **code span** — `[the PR](https://…)` and
+`` `user.name` ``. Emphasis on a single line does not: `Call **Dana** about it`
+is pasted as you said it, markers and all. That is deliberate — see *What counts
+as formatting* below.
 
 **Slack only, so far.** It is the one app measured. Every other app gets plain
 text, byte for byte as before. There is nothing to configure and nothing to
@@ -247,11 +248,16 @@ Two ways in.
 **Block structure** — a list, a heading, a code block, a quote — spread over
 more than one line.
 
-**Or a link or a code span, on any number of lines.** Both need characters
-nobody utters: brackets, parentheses, backticks. A transform that emits
-`[#123](https://…)` means it; a speaker cannot produce it by accident. Scanned
-over 1355 lines of the case files, there were no links at all and the only two
-code spans were a transform's own output.
+**Or a link or a code span, on any number of lines.** Both take characters a
+speaker only produces on purpose: brackets, parentheses, backticks. A transform
+that emits `[#123](https://…)` means it. Scanned over 1355 lines of the case
+files, there were no links at all and the only two code spans were a transform's
+own output.
+
+It is the **syntax** that counts, not what the link says. `[https://x](https://x)`
+is deliberate even though its words are its address. A bare URL the parser
+noticed on its own is not, however it reads — accepting those would send a whole
+sentence as markup for mentioning an address.
 
 **Emphasis never counts on its own**, and that is the deliberate part. Ordinary
 dictation parses as Markdown:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -224,9 +224,10 @@ over more than one line, reaches an app that takes it as real formatting rather
 than as `**stars**`. Inside it, bold, italic, code spans, a real second level of
 bullets, numbered lists and links all survive.
 
-A single line never does, whatever is in it. `Call **Dana** about it` is pasted
-as you said it, markers and all. That is deliberate — see *What counts as
-formatting* below.
+A single line qualifies too, but only for a **link written on its own words**
+or a **code span** — `[the PR](https://…)` and `` `user.name` ``. Emphasis on a
+single line does not: `Call **Dana** about it` is pasted as you said it, markers
+and all. That is deliberate — see *What counts as formatting* below.
 
 **Slack only, so far.** It is the one app measured. Every other app gets plain
 text, byte for byte as before. There is nothing to configure and nothing to
@@ -241,9 +242,19 @@ does not, and that is separate work.
 
 ### What counts as formatting
 
-Block structure — a list, a heading, a code block, a quote — spread over more
-than one line. Inline emphasis on its own never counts, and that is deliberate.
-Ordinary dictation parses as Markdown:
+Two ways in.
+
+**Block structure** — a list, a heading, a code block, a quote — spread over
+more than one line.
+
+**Or a link or a code span, on any number of lines.** Both need characters
+nobody utters: brackets, parentheses, backticks. A transform that emits
+`[#123](https://…)` means it; a speaker cannot produce it by accident. Scanned
+over 1355 lines of the case files, there were no links at all and the only two
+code spans were a transform's own output.
+
+**Emphasis never counts on its own**, and that is the deliberate part. Ordinary
+dictation parses as Markdown:
 
 | dictated | would have become |
 |---|---|
@@ -252,9 +263,9 @@ Ordinary dictation parses as Markdown:
 | `1. Draft 2. Review` | a numbered list |
 
 Each loses characters you said, and `__init__` is a word a developer dictates.
-A transform that formats deliberately produces block structure over several
-lines; one dictated sentence cannot produce it by accident. The cost is that a
-one-line `Call **Dana** about it` stays plain.
+Each is emphasis, and emphasis is what a speaker trips over. The cost is that a
+one-line `Call **Dana** about it` stays plain. A link or a code span in the same
+sentence would not — nothing about `[` or `` ` `` happens by accident.
 
 ### Measuring your own app
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -259,19 +259,24 @@ is deliberate even though its words are its address. A bare URL the parser
 noticed on its own is not, however it reads — accepting those would send a whole
 sentence as markup for mentioning an address.
 
-**Emphasis never counts on its own**, and that is the deliberate part. Ordinary
-dictation parses as Markdown:
+**Or emphasis you asked for.** Asterisks, and not inside a word — which is what
+*"start bold … end bold"* produces through `punctuation`. Underscores never
+count, and neither does an asterisk inside a word. Those are the two ways
+ordinary dictation trips over emphasis:
 
 | dictated | would have become |
 |---|---|
 | `use the __init__ method` | bold "init", underscores gone |
+| `we need __slots__ on that class` | bold "slots" |
 | `multiply a*b*c and check the result` | an italic *b*, the asterisks gone |
+| `rate is 3*4*5` | an italic *4* |
 | `1. Draft 2. Review` | a numbered list |
 
 Each loses characters you said, and `__init__` is a word a developer dictates.
-Each is emphasis, and emphasis is what a speaker trips over. The cost is that a
-one-line `Call **Dana** about it` stays plain. A link or a code span in the same
-sentence would not — nothing about `[` or `` ` `` happens by accident.
+All of them stay exactly as you said them. What separates them from `**Dana**`
+is the delimiter and the position: underscores, or an asterisk pressed against a
+letter. Nothing you dictate produces a word wrapped in loose asterisks unless
+you asked for it.
 
 ### Measuring your own app
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -561,13 +561,15 @@ way. A default that depends on a setting in another application, and does not
 work when that setting is on, is not a default: it puts noise in your messages
 and gives you nowhere to look.
 
-The other half of that has since been built. Slack does render **rich text**
-that arrives by paste, and the app now sends it — see
-[bullets, bold and links](configuration.md#bullets-bold-and-links). It does not
-rescue `backticks`: markup is only sent for block structure over more than one
-line, and a dotted path inside a sentence is one line, so it is still pasted
-with its backticks showing. Add the step if your chat app renders pasted
-markdown characters.
+**That has since changed.** Slack renders rich text that arrives by paste, the
+app now sends it, and a code span counts on a single line — see
+[bullets, bold and links](configuration.md#bullets-bold-and-links). So
+`` `config.port` `` from this transform reaches Slack as a real code span, not
+as two backticks.
+
+It is still not in the shipped pipeline, and that is now a decision rather than
+a limit. Enabling it needs the numbers: what it does to ordinary sentences in a
+chat window, scored, before it runs on every dictation there.
 
 ### `join`, which fits a clip to the box it lands in
 


### PR DESCRIPTION
The delivery path refused everything on a single line, so a transform that emits `[#123](https://…)` had its brackets pasted as characters. That is the case the whole feature was built for, and it was the one case it could not do.

A link written on its own words, and a code span, now count on any number of lines. Emphasis still needs block structure over more than one line — that is where `__init__` and `a*b*c` live, and all four one-line checks still pass.

Start the review at `Markup.isDeliberate`. The question it answers is why a link is safe on one line when `**bold**` is not.

Based on #198. Merge that first.

<details>
<summary>The rule, and the measurement that sized the risk</summary>

```
send as markup when:
    (a newline AND block structure)        ← unchanged
 OR (an explicit [text](url) link)         ← new
 OR (a code span)                          ← new
```

A link and a code span need characters nobody utters — brackets, parentheses, backticks. A speaker cannot produce them by accident; a transform that emits them means them.

Scanned over **1355 lines** of real dictation from `tests/*.yaml`, `tests/*.txt` and `examples/transforms/*/cases.yaml`:

| what the parser found | count |
|---|---|
| emphasis | 0 |
| explicit `[text](url)` link | **0** |
| autolinked bare URL | 0 |
| code span | 2 — `read \`user.name\`` and a fixture about code |
| block structure | 0 |

Both code spans are things you would want rendered. There were no links at all.

**An autolinked bare URL is deliberately not enough.** The parser makes those out of ordinary text, so accepting them would send a whole sentence as markup because it happened to mention an address.

</details>

<details>
<summary>Every false positive that forced the original gate is still refused</summary>

```
✓ one line stays one line: "use the __init__ method"
✓ one line stays one line: "multiply a*b*c and check the result"
✓ one line stays one line: "1. Draft 2. Review"
✓ one line stays one line: "Call **Dana** about the invoice"
✓ a link on one line is a link
      <p><a href="https://github.com/znat/parrotflow/pull/123">#123</a> is ready</p>
✓ a code span on one line is code
      <p>read <code>user.name</code> first</p>
✓ a bare URL is left as a sentence
      clipboard reads "see https://example.com/x for details"
```

`--clipboard-test` is 17 checks now, and `scripts/check-clipboard.sh` already runs in CI.

</details>

<details>
<summary>Proved end to end, from synthesised speech to the clipboard</summary>

Using `say` for TTS and the real decoder, with a `github_refs` `replace:` transform in a throwaway config:

```
spoken:      "P R one two three is ready"
decoded:     PR123 is ready.
transform:   [#123](https://github.com/znat/parrotflow/pull/123) is ready.
clipboard:   <p><a href="https://github.com/znat/parrotflow/pull/123">#123</a> is ready.</p>
```

The decoder emits `PR123` with no space, which is worth knowing for anyone writing that transform.

</details>

<details>
<summary>This unblocks `backticks`, which the docs parked for exactly this reason</summary>

`pipelines.md` said `backticks` could not ship because a dotted path inside a sentence is one line. A code span now counts on one line, so `` `config.port` `` reaches Slack as a real code span.

The page now says it is still not shipped, and that this is a **decision rather than a limit** — enabling it needs the numbers on what it does to ordinary sentences in a chat window, scored, before it runs on every dictation there. Nothing has been enabled here on the strength of the delivery path alone.

</details>

<details>
<summary>Checks run</summary>

```
swift build -c release      Build complete
swiftlint                   no findings in the changed files
scripts/check-*.sh          28 passed, 0 failed
check-clipboard.sh          ✓ all clipboard rules hold (17 checks)
```

</details>
