### PR TITLE
feat: the pill is smaller and its chimes are quieter

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1405,7 +1405,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         watchForEscape()
 
-        if config.feedback.sound { NSSound(named: "Tink")?.play() }
+        playFeedback("Tink")
         if config.feedback.overlay {
             pill.aim(at: anchorAtPress)
             pill.recording(icon: appIconAtPress)
@@ -1501,7 +1501,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         stopWatchingForEscapeIfIdle()
         switch reason {
         case .escape:
-            if config.feedback.sound { NSSound(named: "Pop")?.play() }
+            playFeedback("Pop")
             Log.write("escape: cancelled while \(recording ? "recording" : "transcribing")")
             flash(recording ? "Recording cancelled" : "Transcription cancelled", tone: .caution)
         case .notTheHotkey:
@@ -1587,7 +1587,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         pushToTalkPoll?.invalidate(); pushToTalkPoll = nil
         releaseTail?.invalidate(); releaseTail = nil
         pill.hide()
-        if config.feedback.sound { NSSound(named: "Pop")?.play() }
+        playFeedback("Pop")
 
         // Transcription takes the watch over from here — it is the other half
         // of the dictation Escape can still stop. With transcription off there
@@ -2421,7 +2421,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// moment you can tell it went wrong is the moment you are looking at the
     /// text and not at the menu bar. It has to already be on screen.
     private func applied(_ what: String) {
-        if config.feedback.sound { NSSound(named: "Morse")?.play() }
+        playFeedback("Morse")
         flash("\(what) applied\(undoHint)", tone: .done)
     }
 
@@ -2463,7 +2463,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         case .replaced:
             Log.write("undo: put back \(quoted(record.before))")
             lastSubstitution = nil
-            if config.feedback.sound { NSSound(named: "Morse")?.play() }
+            playFeedback("Morse")
             flash("Undone", tone: .done)
         case .refused(let why):
             Log.write("undo: refused — \(why)")
@@ -2544,7 +2544,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 text, mode: config.transcription.insertMode, paste: paste
             ) {
             case .pasted, .copied:
-                if config.feedback.sound { NSSound(named: "Morse")?.play() }
+                playFeedback("Morse")
                 flash("\(transform.name) applied", tone: .done)
             case .clipboardOnly:
                 flash("\(transform.name) copied — grant Accessibility to paste", tone: .caution)
@@ -3558,7 +3558,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         pendingSelection = nil
         focusAtPress = nil
 
-        if config.feedback.sound { NSSound(named: "Morse")?.play() }
+        playFeedback("Morse")
         if landedOnClipboard {
             flash("Rule saved · \"\(rules.first?.corrected ?? "")\" copied — this app won't let me edit it", tone: .caution)
             return
@@ -3583,6 +3583,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let head = flat.prefix(limit / 2).trimmingCharacters(in: .whitespaces)
         let tail = flat.suffix(limit / 2 - 1).trimmingCharacters(in: .whitespaces)
         return "\"\(head)…\(tail)\""
+    }
+
+    /// Play one of the system sounds, if sounds are on, at the configured volume.
+    private func playFeedback(_ name: String) {
+        guard config.feedback.sound, let sound = NSSound(named: name) else { return }
+        sound.volume = config.feedback.soundVolume
+        sound.play()
     }
 
     /// Show a message on screen, and in the menu bar for as long as it lasts.
@@ -4087,7 +4094,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             if now == nil || !CFEqual(now!, element) {
                 TextInserter.insert(text, mode: .clipboard, paste: press.paste)
                 // Not the paste sound — see the nowhere-to-type ending below.
-                if config.feedback.sound { NSSound(named: "Tink")?.play() }
+                playFeedback("Tink")
                 Log.write(now == nil
                     ? "could not read what is focused; copied instead of pasting"
                     : "focus moved since the press; copied instead of pasting")
@@ -4122,7 +4129,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
            case .nowhere(let reason) = destination, reason != .noAccessibility {
             TextInserter.insert(text, mode: .clipboard, paste: press.paste)
             // Not Morse: a sound that cannot be told from success is no sound.
-            if config.feedback.sound { NSSound(named: "Tink")?.play() }
+            playFeedback("Tink")
             Log.write("nothing to type into (\(reason.described)); copied instead")
             setLabel("Nowhere to type — the transcription is on your clipboard", clearAfter: 4)
             // And on the pill: the menu bar row is inside a menu you must open.
@@ -4137,17 +4144,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             text, mode: config.transcription.insertMode, paste: press.paste
         ) {
         case .pasted:
-            if config.feedback.sound { NSSound(named: "Morse")?.play() }
+            playFeedback("Morse")
             // The words are in the field and you are looking at them. This is
             // the only second in which correcting one is free.
             showCorrectOffer(for: press, landing: .field)
         case .copied:
             // Deliberate clipboard mode — confirm it landed.
-            if config.feedback.sound { NSSound(named: "Morse")?.play() }
+            playFeedback("Morse")
             setLabel("Copied — ⌘V to paste", clearAfter: 4)
             showCorrectOffer(for: press, landing: .clipboardNow())
         case .clipboardOnly:
-            if config.feedback.sound { NSSound(named: "Morse")?.play() }
+            playFeedback("Morse")
             // Don't nag on every dictation — the text is safe on the clipboard.
             Log.write("Accessibility not granted; left transcript on the clipboard")
             setLabel("Copied — grant Accessibility to auto-paste", clearAfter: 4)

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -74,7 +74,8 @@ enum CheckConfigCommand {
         } else {
             emit("  · second opinion    \(config.audio.secondOpinion ? "on" : "off")")
         }
-        emit("  · feedback          sound=\(config.feedback.sound) overlay=\(config.feedback.overlay)"
+        emit("  · feedback          sound=\(config.feedback.sound)"
+              + " volume=\(config.feedback.soundVolume) overlay=\(config.feedback.overlay)"
               + " correct_offer=\(config.feedback.correctOffer)"
               + " confidence=\(config.feedback.confidence)")
         emit("  · low confidence    sentence<\(config.feedback.lowConfidence.sentence)"

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -2027,6 +2027,12 @@ struct Config: Decodable, Equatable {
     struct Feedback: Codable, Equatable {
         /// Play a short system sound on start/stop.
         var sound: Bool = true
+        /// How loud those sounds are, from 0 to 1, relative to system volume.
+        ///
+        /// The system sounds are mixed loud for alerts. Dictation plays them
+        /// several times a sentence, so full volume reads as shouting — hence
+        /// the low default. Values outside the range are clamped.
+        var soundVolume: Float = 0.3
         /// Show the floating recording pill near the bottom of the screen.
         var overlay: Bool = true
         /// After a dictation lands, offer to correct it for a few seconds.
@@ -2118,6 +2124,7 @@ struct Config: Decodable, Equatable {
 
         enum CodingKeys: String, CodingKey {
             case sound
+            case soundVolume = "sound_volume"
             case overlay
             case correctOffer = "correct_offer"
             case confidence
@@ -2130,6 +2137,9 @@ struct Config: Decodable, Equatable {
             let c = try decoder.container(keyedBy: CodingKeys.self)
             self.init()
             if let sound = try c.decodeIfPresent(Bool.self, forKey: .sound) { self.sound = sound }
+            if let volume = try c.decodeIfPresent(Float.self, forKey: .soundVolume) {
+                self.soundVolume = min(max(volume, 0), 1)
+            }
             if let overlay = try c.decodeIfPresent(Bool.self, forKey: .overlay) { self.overlay = overlay }
             if let offer = try c.decodeIfPresent(Bool.self, forKey: .correctOffer) {
                 self.correctOffer = offer

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -795,7 +795,7 @@ final class PillHUD {
 // MARK: - Metrics
 
 enum PillMetrics {
-    static let height: CGFloat = 46
+    static let height: CGFloat = 42
 
     /// Transparent margin between the capsule and the edge of the window.
     ///
@@ -834,9 +834,9 @@ enum PillMetrics {
     /// chips are measured at a flat rate per character; a line count off by one
     /// would clip the words instead of costing a few points of capsule.
     static let sentenceFont: NSFont = {
-        let plain = NSFont.systemFont(ofSize: 13, weight: .medium)
+        let plain = NSFont.systemFont(ofSize: 12, weight: .medium)
         guard let rounded = plain.fontDescriptor.withDesign(.rounded) else { return plain }
-        return NSFont(descriptor: rounded, size: 13) ?? plain
+        return NSFont(descriptor: rounded, size: 12) ?? plain
     }()
 
     /// One line of it, and the air above.
@@ -849,7 +849,7 @@ enum PillMetrics {
     /// already leaves. The chips sit in capsules of their own and carry their
     /// own margin with them; the sentence is bare text and read as crowded
     /// against the rim without this.
-    static let sentenceTop: CGFloat = 5
+    static let sentenceTop: CGFloat = 4
 
     /// Past this the sentence wraps rather than the pill growing sideways. The
     /// pill sits under the line you dictated into, and one wider than the window
@@ -863,7 +863,7 @@ enum PillMetrics {
     static let sentenceLines = 3
 
     /// The utterance score, set under the words.
-    static let readingFont: NSFont = .monospacedDigitSystemFont(ofSize: 15, weight: .semibold)
+    static let readingFont: NSFont = .monospacedDigitSystemFont(ofSize: 14, weight: .semibold)
     static let readingLine: CGFloat = ceil(
         NSLayoutManager().defaultLineHeight(for: readingFont)
     )
@@ -871,9 +871,9 @@ enum PillMetrics {
     /// The warning, above everything. One line, never wrapped: it names one
     /// word and one number, and a warning that wraps is a paragraph.
     static let warningFont: NSFont = {
-        let plain = NSFont.systemFont(ofSize: 13, weight: .bold)
+        let plain = NSFont.systemFont(ofSize: 12, weight: .bold)
         guard let rounded = plain.fontDescriptor.withDesign(.rounded) else { return plain }
-        return NSFont(descriptor: rounded, size: 13) ?? plain
+        return NSFont(descriptor: rounded, size: 12) ?? plain
     }()
     static let warningLine: CGFloat = ceil(
         NSLayoutManager().defaultLineHeight(for: warningFont)
@@ -928,19 +928,19 @@ enum PillMetrics {
         sentence.map(\.text).joined(separator: " ") as NSString
     }
 
-    static let padding: CGFloat = 17
-    static let gap: CGFloat = 11
+    static let padding: CGFloat = 15
+    static let gap: CGFloat = 10
     /// The gap on the meter's right, 2pt tighter than the one on its left.
     ///
-    /// Both were 11 and did not look it. The dot is small, round and spills a
-    /// little glow into its gap; the meter closes on its shortest, dimmest bar
-    /// and the icon has a hard edge — so the eye measures from the last bar it
-    /// can actually see to that edge, and reads that side as wider. Equal
-    /// numbers, unequal gaps. These two are equal to look at.
-    static let tuck: CGFloat = 9
-    static let dot: CGFloat = 9
-    static let icon: CGFloat = 24
-    static let meter: CGFloat = 72
+    /// Both were the same and did not look it. The dot is small, round and
+    /// spills a little glow into its gap; the meter closes on its shortest,
+    /// dimmest bar and the icon has a hard edge — so the eye measures from the
+    /// last bar it can actually see to that edge, and reads that side as wider.
+    /// Equal numbers, unequal gaps. These two are equal to look at.
+    static let tuck: CGFloat = 8
+    static let dot: CGFloat = 8
+    static let icon: CGFloat = 22
+    static let meter: CGFloat = 66
 
     static func width(for state: PillState, hasIcon: Bool) -> CGFloat {
         switch state {
@@ -952,7 +952,7 @@ enum PillMetrics {
         }
     }
 
-    /// 17 + 9 + 11 + 72 + 17, and the icon after the meter when there is one
+    /// 15 + 8 + 10 + 66 + 15, and the icon after the meter when there is one
     /// to show.
     static func recording(hasIcon: Bool) -> CGFloat {
         let base = padding * 2 + dot + gap + meter
@@ -963,13 +963,13 @@ enum PillMetrics {
     /// the text is one line and truncating it would lose the half that says
     /// what to do about it.
     static func text(_ message: String) -> CGFloat {
-        min(600, max(300, CGFloat(message.count) * 8 + 86))
+        min(540, max(270, CGFloat(message.count) * 7.5 + 78))
     }
 
     /// A row of chips, and no minimum.
     ///
     /// Unlike a message, which is a sentence you have to be able to read to the
-    /// end, this is a shape you learn after seeing it twice. Held to the 300pt
+    /// end, this is a shape you learn after seeing it twice. Held to the 270pt
     /// floor it would be a mostly empty pill, and an offer that looks like a
     /// notice reads as something having gone wrong.
     ///
@@ -991,10 +991,10 @@ enum PillMetrics {
         _ commands: [OfferedCommand], headline: String? = nil,
         reading: Confidence.Reading = Confidence.Reading()
     ) -> CGFloat {
-        // A chip is its keycap, its words and 10pt of padding either side; then
+        // A chip is its keycap, its words and 9pt of padding either side; then
         // 4pt between one chip and the next.
         let chips = commands.reduce(CGFloat(0)) { total, command in
-            total + 20 + (command.key.isEmpty ? 0 : keycap) + title(command.title)
+            total + 18 + (command.key.isEmpty ? 0 : keycap) + title(command.title)
         }
         let lead = headline.map { title($0) + gap } ?? 0
         let row = padding * 2 + lead + chips
@@ -1010,11 +1010,11 @@ enum PillMetrics {
         return widest
     }
 
-    /// The keycap on a chip: one character at 12pt bold, 5pt either side, and
-    /// the 7pt between it and the words.
-    static let keycap: CGFloat = 27
+    /// The keycap on a chip: one character at 11pt bold, 4pt either side, and
+    /// the 6pt between it and the words.
+    static let keycap: CGFloat = 24
 
-    /// A chip's words at 13pt rounded.
+    /// A chip's words at 12pt rounded.
     ///
     /// Measured in the font they are set in, not counted at a flat rate per
     /// character. A flat rate is generous for ordinary lowercase words and
@@ -1177,7 +1177,7 @@ struct PillView: View {
             : (Parrot.amber.opacity(0.24), Parrot.warned)
     }
 
-    /// A fixed radius, not a `Capsule`. At the 46pt the pill has always been the
+    /// A fixed radius, not a `Capsule`. At the pill's resting height the
     /// two are the same shape — but an offer carrying the dictated sentence is
     /// taller, and a capsule would round its ends to half of that. The glass
     /// behind it cannot follow: `ParrotGlass.backdrop` takes its corner radius
@@ -1203,7 +1203,7 @@ private struct RecordingContent: View {
                 .animation(.easeInOut(duration: 0.7).repeatForever(autoreverses: true), value: pulse)
 
             Meter(level: level)
-                .frame(width: PillMetrics.meter, height: 16)
+                .frame(width: PillMetrics.meter, height: 14)
                 .padding(.leading, PillMetrics.gap)
 
             if let icon {
@@ -1231,7 +1231,7 @@ private struct MessageContent: View {
             ToneDot(tone: tone)
 
             Text(message)
-                .font(.system(size: 13, weight: .medium, design: .rounded))
+                .font(.system(size: 12, weight: .medium, design: .rounded))
                 .lineLimit(1)
 
             Spacer(minLength: 0)
@@ -1299,7 +1299,7 @@ private struct OfferContent: View {
     /// gave its width to.
     private var words: some View {
         Confidence.sentence(reading.words)
-            .font(.system(size: 13, weight: .medium, design: .rounded))
+            .font(.system(size: 12, weight: .medium, design: .rounded))
             .multilineTextAlignment(.center)
             .lineLimit(PillMetrics.sentenceLines)
             .truncationMode(.tail)
@@ -1319,7 +1319,7 @@ private struct OfferContent: View {
         HStack(spacing: PillMetrics.gap) {
             ToneDot(tone: reading.stopped ? .failure : .caution)
             Text(text)
-                .font(.system(size: 13, weight: .bold, design: .rounded))
+                .font(.system(size: 12, weight: .bold, design: .rounded))
                 .foregroundStyle(Color(white: 0.97))
                 .lineLimit(1)
                 .fixedSize()
@@ -1336,7 +1336,7 @@ private struct OfferContent: View {
     /// by word.
     private func score(_ score: Float) -> some View {
         Text(verbatim: Confidence.overall(score))
-            .font(.system(size: 15, weight: .semibold, design: .monospaced))
+            .font(.system(size: 14, weight: .semibold, design: .monospaced))
             .foregroundStyle(Confidence.overallTint(score))
             .frame(maxWidth: .infinity, alignment: .center)
             .padding(.horizontal, PillMetrics.padding)
@@ -1346,7 +1346,7 @@ private struct OfferContent: View {
         HStack(spacing: 4) {
             if let headline {
                 Text(headline)
-                    .font(.system(size: 13, weight: .medium, design: .rounded))
+                    .font(.system(size: 12, weight: .medium, design: .rounded))
                     .foregroundStyle(NoticeTone.caution.color)
                     .lineLimit(1)
                     .fixedSize()
@@ -1378,12 +1378,12 @@ private struct OfferContent: View {
     /// they are the same claim — this is the one that will happen — so the eye
     /// learns the colour once.
     private func chip(_ command: OfferedCommand, lit: Bool) -> some View {
-        HStack(spacing: 7) {
+        HStack(spacing: 6) {
             if !command.key.isEmpty {
                 OfferKeyCap(key: command.key, lit: lit)
             }
             Text(command.title)
-                .font(.system(size: 13, weight: .medium, design: .rounded))
+                .font(.system(size: 12, weight: .medium, design: .rounded))
                 // One line whatever the capsule thinks. The width is measured
                 // in `PillMetrics.offer`, and without this the capsule would
                 // win the argument and wrap a name to two lines.
@@ -1391,8 +1391,8 @@ private struct OfferContent: View {
                 .fixedSize()
         }
         .foregroundStyle(lit ? Self.litText : Self.restingText)
-        .padding(.horizontal, 10)
-        .padding(.vertical, 5)
+        .padding(.horizontal, 9)
+        .padding(.vertical, 4)
         .background {
             Capsule()
                 .fill(lit ? Parrot.leaf.opacity(0.28) : Color.white.opacity(0.05))
@@ -1434,12 +1434,12 @@ private struct OfferKeyCap: View {
 
     var body: some View {
         Text(key)
-            .font(.system(size: 12, weight: .bold, design: .rounded))
+            .font(.system(size: 11, weight: .bold, design: .rounded))
             // A floor rather than a width: every letter draws in the same box,
             // so the chips do not step in and out by a point as the pointer
             // moves along them.
-            .frame(minWidth: 9)
-            .padding(.horizontal, 5)
+            .frame(minWidth: 8)
+            .padding(.horizontal, 4)
             .padding(.vertical, 2)
             .background {
                 RoundedRectangle(cornerRadius: Self.radius, style: .continuous)
@@ -1521,7 +1521,7 @@ struct ToneDot: View {
     static func dot(_ color: Color) -> some View {
         Circle()
             .fill(color)
-            .frame(width: 9, height: 9)
+            .frame(width: PillMetrics.dot, height: PillMetrics.dot)
             .shadow(color: color, radius: 4)
             .shadow(color: color.opacity(0.6), radius: 9)
     }
@@ -1573,6 +1573,6 @@ struct Meter: View {
         // again, which reads as a shape with a peak — something that has
         // already happened. Rising the whole way reads as something still
         // opening, which is what a microphone that is still listening is.
-        6 + CGFloat(index) / CGFloat(bars - 1) * 13
+        5 + CGFloat(index) / CGFloat(bars - 1) * 12
     }
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -37,6 +37,7 @@ audio:
 
 feedback:
   sound: true     # a click when recording starts and stops
+  sound_volume: 0.3  # 0 to 1, on top of system volume. 1.0 is the alert level.
   overlay: true   # the floating pill while you speak
   # After the words land, the pill offers what to do for 6s, the last 2 of
   # them fading. Click a chip to run it, or tap the hotkey for the panel.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -760,6 +760,12 @@ thing that costs you the words.
 that shows the mic is hot. Both on by default; the pill is the only thing on
 screen that says recording is happening, so turning it off is a real choice.
 
+`sound_volume` is how loud the chimes are, from 0 to 1, on top of system
+volume. Default 0.3. The macOS system sounds are mixed to be heard once, as an
+alert; dictation plays them several times a sentence, and at 1.0 that is a lot
+of chime for something you already know happened. Set it to 1.0 for the alert
+level. Values outside the range are clamped.
+
 **Where the pill appears.** Next to the place your words are about to go, so you
 can see where they are headed before you have said any of them. Where the app
 will not say where that is, it sits at the bottom of the screen instead. That is


### PR DESCRIPTION
Two changes to the pill, both cosmetic and both defaults.

The pill and everything on it step down one increment: 46pt tall to 42pt, the sentence and chips 13pt to 12, the score 15 to 14. The chimes get a volume, `feedback.sound_volume`, 0 to 1, and it defaults to `0.3` rather than full. Both apply with no config line, so anyone updating sees a smaller, quieter pill.

Check the offer pill first. Its width is measured in `PillMetrics` and drawn by SwiftUI, and the two only ever agree approximately, so a chip hanging over the end of the capsule is the failure this could cause.

<details>
<summary>Every number that moved, and the four that follow on their own</summary>

| | before | after |
|---|---|---|
| height | 46 | 42 |
| sentence and chip font | 13 | 12 |
| score font | 15 | 14 |
| keycap font | 12 | 11 |
| padding | 17 | 15 |
| gap / tuck | 11 / 9 | 10 / 8 |
| dot | 9 | 8 |
| icon | 24 | 22 |
| meter | 72 × 16 | 66 × 14 |
| keycap | 27 | 24 |
| chip padding | 10 / 5 | 9 / 4 |
| notice width | 300–600 | 270–540 |

The corner radius, the glass backdrop and the pill preview in
`PermissionsWindow` all derive from `PillMetrics.height`, so they followed
without being touched.

`ToneDot.dot` drew a 9pt circle from a literal, next to `PillMetrics.dot` which
was also 9. It reads the metric now, so the two cannot drift apart again.

</details>

<details>
<summary>Two numbers deliberately left alone, so nobody re-files them</summary>

`sentenceWidth` (640) is where the dictated sentence wraps instead of the pill
growing sideways. Its reason is the width of the window you dictated into, not
the pill's own scale, so scaling it down would be scaling it against its
purpose.

`bleed` (52) is the transparent margin the glow needs. It is sized to twice the
widest blur radius on the rim, which this change does not touch. Cutting it
would clip the halo square at the window edge.

</details>

<details>
<summary>Why 0.3, and why twelve call sites became one</summary>

macOS mixes Tink, Pop and Morse to be heard once, as an alert. Dictation plays
one of them on start, on stop, and again on every transform that lands — several
times a sentence. At full volume that is a lot of chime for something you can
already see happened.

`sound_volume` is clamped to 0 to 1 on decode, so a typo in the config cannot
produce a silent or a distorted pill.

Twelve places in `AppDelegate` each wrote
`if config.feedback.sound { NSSound(named: "Morse")?.play() }`. Applying a
volume to each of them would have been twelve chances to miss one, so they are
now `playFeedback(_:)` and the volume is set in the one place that plays a
sound.

</details>

<details>
<summary>How this was checked, and what is not covered</summary>

`ParrotFlow --panel-sheet out.png` renders every surface to one image, in light
and dark. Rendered before and after: the recording pill, the notices, the plain
offer, the offer with a headline, and the tall offer carrying a warning, a
two-line sentence and a score. Nothing clips, and the chips still sit inside
their capsule with room to spare.

There is no test target in the repository, so this is the check that exists.
`swift build` is clean apart from the Swift 6 concurrency warnings already on
`main`.

</details>
