### PR TITLE
feat: the pill shows the speech model downloading, with the percentage

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,19 +29,24 @@ max_retries; in Mail, pressing S drops a spoken correction.">
 
 ## Install
 
-ParrotFlow requires Apple silicon and macOS 14 or later.
+ParrotFlow requires Apple silicon and macOS 14 or later. Both routes install the
+same app. Take Homebrew if you already use it — upgrading and removing go
+through `brew`. Otherwise run the script.
 
-```sh
-curl -fsSL https://raw.githubusercontent.com/znat/parrotflow/main/scripts/install.sh | sh
-```
-
-Or with Homebrew:
+**Homebrew**
 
 ```sh
 brew install znat/tap/parrotflow
 ```
 
-Either way this also downloads Parakeet, the speech model, about 1.2 GB.
+**Script**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/znat/parrotflow/main/scripts/install.sh | sh
+```
+
+Neither one downloads the speech model. ParrotFlow fetches Parakeet itself the
+first time it launches, about 470 MB, and says how far along it is.
 Releases are signed with a Developer ID and notarized by Apple.
 
 Spoken commands and the vocabulary check need a language model as well, and that part is optional. Run one on your own Mac with [Ollama](https://ollama.com/download) (e.g. [Gemma4](https://ollama.com/library/gemma4:e4b-mlx)), or use a hosted one (e.g. OpenAI).

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ curl -fsSL https://raw.githubusercontent.com/znat/parrotflow/main/scripts/instal
 
 Neither one downloads the speech model. ParrotFlow fetches Parakeet itself the
 first time it launches, about 470 MB, and says how far along it is.
-Releases are signed with a Developer ID and notarized by Apple.
 
 Spoken commands and the vocabulary check need a language model as well, and that part is optional. Run one on your own Mac with [Ollama](https://ollama.com/download) (e.g. [Gemma4](https://ollama.com/library/gemma4:e4b-mlx)), or use a hosted one (e.g. OpenAI).
 

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1676,7 +1676,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // A dictation into a mail window spends a second in the `email` prompt
         // with nothing on screen at all, which reads as the app having dropped
         // it. Same pair the spoken-command path has used all along.
-        beginProgress("Transcribing…")
+        // "Transcribing…" is a lie while the model is still arriving, and the
+        // first dictation after an install is exactly when that happens: the
+        // download is 469 MB and the pill would sit on one word for all of it.
+        // Say what is actually happening, with the figure.
+        if case .downloading(let what) = transcriberStatus {
+            pillShowsDownload = true
+            beginProgress("Downloading \(what)")
+        } else {
+            beginProgress("Transcribing…")
+        }
 
         let config = self.config
         // Taken at the press, not here: a transcript arrives seconds later and
@@ -3608,6 +3617,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func endProgress() {
+        pillShowsDownload = false
         pill.hide()
         setLabel(nil)
     }
@@ -4168,11 +4178,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// dictation may have put up in the meantime.
     private var transcriberLabelToken: Int?
 
+    /// The transcriber's last reported status, mirrored here because this runs
+    /// on the main thread and the actor's own copy cannot be read without an
+    /// await — which a key release has no time for.
+    private var transcriberStatus: Transcriber.Status = .idle
+
+    /// Set while the pill is showing the model download instead of the
+    /// dictation. Two jobs: a new percentage replaces the text in place rather
+    /// than putting up a second pill, and `.ready` knows the pill is owed back
+    /// to "Transcribing…".
+    private var pillShowsDownload = false
+
     private func handleTranscriberStatus(_ status: Transcriber.Status) {
+        transcriberStatus = status
         switch status {
         case .downloading(let what):
             setLabel("Downloading \(what)")
             transcriberLabelToken = labelToken
+            // `what` already carries the percentage, so this is the live
+            // figure. Only while the pill is this download's: a dictation that
+            // started before the model was ready is waiting on exactly this,
+            // and "Transcribing…" over a 469 MB fetch reads as a hang.
+            if pillShowsDownload { pill.working("Downloading \(what)") }
             // `what` reads like "speech model 43%" — the number, if this is
             // the one download that carries one, is the only part worth a
             // second field for; the rest is already the sentence above.
@@ -4183,6 +4210,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         case .loading:
             setLabel("Loading speech model…")
             transcriberLabelToken = labelToken
+            if pillShowsDownload { pill.working("Loading speech model…") }
             permissions.model.speechModel = .preparing(percent: nil)
         case .failed(let message):
             setLabel("Model error: \(message)")
@@ -4195,6 +4223,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         case .ready, .idle:
             if transcriberLabelToken == labelToken { setLabel(nil) }
             transcriberLabelToken = nil
+            // The dictation that was waiting on the model gets the pill back.
+            // `endProgress` clears the flag, so it is still set only while one
+            // is genuinely in flight.
+            if pillShowsDownload {
+                pillShowsDownload = false
+                pill.working("Transcribing…")
+            }
             permissions.model.speechModel = .ready
         }
     }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1488,7 +1488,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         if transcribing {
             cancelledThroughRun = transcriptionRun
-            endProgress()
+            endProgress(for: transcriptionRun)
         }
 
         stopWatchingForEscape()
@@ -1771,7 +1771,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     // screen — the bug this is meant to fix, one press later.
                     // The text is delivered either way: `destination` was
                     // captured at the press for exactly that reason.
-                    if self.transcriptionRun == run { self.endProgress() }
+                    if self.transcriptionRun == run { self.endProgress(for: run) }
                     // Escape, while this was decoding. The decoder cannot be
                     // stopped part-way, so the text exists — it simply goes
                     // nowhere. Logged, because a dictation that vanishes with
@@ -1793,7 +1793,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             } catch {
                 await MainActor.run {
                     guard let self else { return }
-                    if self.transcriptionRun == run { self.endProgress() }
+                    if self.transcriptionRun == run { self.endProgress(for: run) }
                     self.runsInFlight -= 1
                     self.stopWatchingForEscapeIfIdle()
                     // Cancelled or failed, nothing is going to be written.
@@ -3616,8 +3616,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         setLabel(message)
     }
 
-    private func endProgress() {
-        pillDownloadRun = nil
+    /// `run` is the dictation this ends, where there is one. Only that run may
+    /// give up its claim on the download pill. Push-to-talk leaves an older
+    /// dictation running a transform while a newer one waits on a model — the
+    /// vocabulary model is fetched mid-dictation at `Transcriber.swift:356` —
+    /// and clearing the claim from the older one would cost the newer one the
+    /// pill it gets back at `.ready`.
+    private func endProgress(for run: Int? = nil) {
+        if pillDownloadRun == run { pillDownloadRun = nil }
         pill.hide()
         setLabel(nil)
     }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1678,10 +1678,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // it. Same pair the spoken-command path has used all along.
         // "Transcribing…" is a lie while the model is still arriving, and the
         // first dictation after an install is exactly when that happens: the
-        // download is 469 MB and the pill would sit on one word for all of it.
-        // Say what is actually happening, with the figure.
+        // download is about 470 MB and the pill would sit on one word for all
+        // of it. Say what is actually happening, with the figure.
         if case .downloading(let what) = transcriberStatus {
-            pillShowsDownload = true
+            pillDownloadRun = run
             beginProgress("Downloading \(what)")
         } else {
             beginProgress("Transcribing…")
@@ -3617,7 +3617,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func endProgress() {
-        pillShowsDownload = false
+        pillDownloadRun = nil
         pill.hide()
         setLabel(nil)
     }
@@ -4178,16 +4178,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// dictation may have put up in the meantime.
     private var transcriberLabelToken: Int?
 
-    /// The transcriber's last reported status, mirrored here because this runs
-    /// on the main thread and the actor's own copy cannot be read without an
-    /// await — which a key release has no time for.
+    /// The transcriber's last reported status, mirrored here because the
+    /// actor's own copy cannot be read without an await, and a key release has
+    /// no time for one. Both sides are the main queue — `onStatusChange` hops
+    /// there before it lands — so it needs no lock.
     private var transcriberStatus: Transcriber.Status = .idle
 
-    /// Set while the pill is showing the model download instead of the
-    /// dictation. Two jobs: a new percentage replaces the text in place rather
-    /// than putting up a second pill, and `.ready` knows the pill is owed back
-    /// to "Transcribing…".
-    private var pillShowsDownload = false
+    /// The `transcriptionRun` whose pill is showing the model download instead
+    /// of the dictation, if any.
+    ///
+    /// A run and not a flag, for the reason every other late arrival in this
+    /// file carries one. Push-to-talk does not wait, so two dictations sit on
+    /// the same download, and the older one's `.ready` would otherwise take the
+    /// pill from the newer one that has since put its own message up.
+    private var pillDownloadRun: Int?
+
+    /// The `transcriptionRun == run` test the rest of the chain makes, asked of
+    /// the pill: the run that put the download up is still the newest one.
+    private var ownsDownloadPill: Bool { pillDownloadRun == transcriptionRun }
 
     private func handleTranscriberStatus(_ status: Transcriber.Status) {
         transcriberStatus = status
@@ -4195,11 +4203,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         case .downloading(let what):
             setLabel("Downloading \(what)")
             transcriberLabelToken = labelToken
-            // `what` already carries the percentage, so this is the live
-            // figure. Only while the pill is this download's: a dictation that
-            // started before the model was ready is waiting on exactly this,
-            // and "Transcribing…" over a 469 MB fetch reads as a hang.
-            if pillShowsDownload { pill.working("Downloading \(what)") }
+            // `what` already carries the percentage, so replacing the text in
+            // place is what makes the number climb. Only for the dictation that
+            // put the download up: it is waiting on exactly this, and
+            // "Transcribing…" over a 470 MB fetch reads as a hang.
+            if ownsDownloadPill { pill.working("Downloading \(what)") }
             // `what` reads like "speech model 43%" — the number, if this is
             // the one download that carries one, is the only part worth a
             // second field for; the rest is already the sentence above.
@@ -4210,11 +4218,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         case .loading:
             setLabel("Loading speech model…")
             transcriberLabelToken = labelToken
-            if pillShowsDownload { pill.working("Loading speech model…") }
+            if ownsDownloadPill { pill.working("Loading speech model…") }
             permissions.model.speechModel = .preparing(percent: nil)
         case .failed(let message):
             setLabel("Model error: \(message)")
             transcriberLabelToken = labelToken
+            // The pill is left to the dictation. `.loading` is the same wait
+            // continuing, so it says so; a failure is the wait ending, and the
+            // run waiting on the model gets it as a thrown error whose catch
+            // already hides the pill and puts up the alert. Two endings on
+            // screen for one failure is worse than one.
             // Not surfaced as "preparing" forever: the permissions window
             // isn't the place a transcription failure gets diagnosed, and a
             // stuck "downloading" badge there would outlive the one place
@@ -4223,13 +4236,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         case .ready, .idle:
             if transcriberLabelToken == labelToken { setLabel(nil) }
             transcriberLabelToken = nil
-            // The dictation that was waiting on the model gets the pill back.
-            // `endProgress` clears the flag, so it is still set only while one
-            // is genuinely in flight.
-            if pillShowsDownload {
-                pillShowsDownload = false
-                pill.working("Transcribing…")
-            }
+            // The dictation that was waiting on the model gets its pill back.
+            if ownsDownloadPill { pill.working("Transcribing…") }
+            pillDownloadRun = nil
             permissions.model.speechModel = .ready
         }
     }

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1983,7 +1983,7 @@ struct Config: Decodable, Equatable {
         /// which is the only thing that finds it.
         ///
         /// Needs `speech_gate`, which is what reads the clip as samples.
-        var secondOpinion: Bool = false
+        var secondOpinion: Bool = true
 
         enum CodingKeys: String, CodingKey {
             case sampleRate = "sample_rate"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -31,9 +31,11 @@ audio:
   # Skip clips with no speech, so a stray keypress does not decode room tone.
   speech_gate: true
 
-  # Decode each clip again with silence padding, keep it if it reaches
-  # further. Recovers dropped endings (~2%) for ~100ms. Needs speech_gate.
-  second_opinion: false
+  # Decode each clip again with silence padding, and keep that decode if it
+  # reaches further. About 2% of dictations silently lose words, and this is
+  # what gets them back. Every dictation pays ~100ms for it: set this to
+  # false to keep the 100ms. Needs speech_gate.
+  second_opinion: true
 
 feedback:
   sound: true     # a click when recording starts and stops

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,7 @@ hotkey:
 audio:
   output_dir: ~/Recordings/ParrotFlow
   speech_gate: true     # skip clips with no speech in them
-  second_opinion: false # decode each clip twice and keep the longer decode
+  second_opinion: true  # decode each clip twice and keep the longer decode
 
 transcription:
   insert_mode: paste    # or clipboard
@@ -671,8 +671,10 @@ real one.
 ## `audio.second_opinion`
 
 Decodes the clip a second time, with silence added at both ends, and keeps that
-decode when it reaches further into the audio than the first one did. Off by
-default.
+decode when it reaches further into the audio than the first one did. On by
+default: every dictation pays about 100ms so that the ~2% that lose words stop
+losing them. Set it to `false` to keep the 100ms. A config written from an
+older template carries `second_opinion: false` explicitly and keeps it.
 
 **What it fixes.** Parakeet predicts a token and a duration at every step — how
 many encoder frames to skip before it looks again. A frame is 80ms and the

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -170,7 +170,7 @@ Launch — no Dock icon, a 🦜 appears in the menu bar
         ▼
   ├─ Microphone       [Grant]   ← system prompt, required
   ├─ Accessibility    [Grant]   ← System Settings, required to type text
-  └─ Speech model     [1.2 GB, downloading… 34%]
+  └─ Speech model     [470 MB, downloading… 34%]
         │
         ▼
 "Hold Right ⌘ and talk"  ← the one thing they need to know
@@ -208,7 +208,7 @@ Notes on getting this right:
   launch and logs the result; that log line is the reliable read.
 - **The model download must not block.** Recording should work immediately;
   transcription unlocks when the download finishes. Resumable, cancellable,
-  with a real progress figure — a silent 1.2 GB fetch reads as a hang.
+  with a real progress figure — a silent 470 MB fetch reads as a hang.
 - **Ship a fallback.** If Apple's `SpeechTranscriber` proves good enough, offer
   it as the zero-download default and make Parakeet the opt-in upgrade.
 - **First run after install is the only chance.** Someone evaluating a dictation

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -28,7 +28,7 @@ Say which download you are on. A silent 10 GB download looks like a hang.
 | What | Size | When | Needed for |
 | --- | --- | --- | --- |
 | The app | 3 MB | Step 2 | everything |
-| Parakeet, the speech model | 1.2 GB | Step 3, automatic | dictation |
+| Parakeet, the speech model | 470 MB | Step 3, automatic | dictation |
 | Gemma, the language model | 10 GB | Step 5, optional | voice commands |
 
 Dictation works after Step 3. Everything after is extra.
@@ -145,8 +145,8 @@ say -o /tmp/pf-check.wav --data-format=LEI16@16000 --channels=1 "Testing one two
 
 The first run downloads that model — tell them first:
 
-> Downloading the speech model now. It is called Parakeet, about 1.2 GB, and it
-> runs on your Mac. A few minutes.
+> Downloading the speech model now. It is called Parakeet, about 470 MB, and it
+> runs on your Mac. A minute or two.
 
 `Testing 123.` is a correct result; what matters is that text came back. If this
 fails, stop and fix it — nothing after this step can work.

--- a/scripts/bump-cask.sh
+++ b/scripts/bump-cask.sh
@@ -90,33 +90,30 @@ cask "parrotflow" do
     "~/Library/Preferences/com.parrotflow.app.plist",
   ]
 
-  caveats <<~EOS
-    ParrotFlow asks for two permissions the first time it runs:
+  # A block, not a plain string, so Formatter can be interpolated. Homebrew
+  # strips the escapes when the output is not a terminal, so a piped install
+  # log stays readable.
+  caveats do
+    <<~EOS
+      #{Formatter.headline("Hold Right Command and talk.")}
 
-      Microphone     a system prompt
-      Accessibility  System Settings > Privacy & Security > Accessibility
+      Your first dictation will have to wait for the speech model to download: about 470 MB, once.
 
-    Upgrading from 0.9.0 or earlier: this release is signed with a different
-    certificate, and macOS ties both permissions to the one that signed the
-    app. You will be asked again. If Accessibility already lists ParrotFlow as
-    ticked but the app says it is not granted, remove it from that list and add
-    it back — the entry belongs to the old certificate.
+      #{Formatter.headline("Add a language model — recommended")}
 
-    The speech model downloads on first launch, about 470 MB. Recording works
-    straight away. Transcription starts when the download finishes.
+      It unlocks spoken commands and the vocabulary check. Dictation keeps working
+      while it downloads, so there is no reason to wait:
 
-    Then hold Right Command and talk. That much needs nothing else.
+        #{Formatter.identifier("brew install ollama && brew services start ollama")}
+        #{Formatter.identifier("ollama pull gemma4:e4b-mlx")}
 
-    Spoken commands and the vocabulary check need a language model too. That
-    part is optional, and it runs on your own Mac:
+      For harder formatting, a transform can name a hosted model instead using the OpenAI or Anthropic API protocols.
+      See docs/configuration.md.
 
-      brew install ollama && brew services start ollama
-      ollama pull gemma4:e4b-mlx
-
-    Ollama 0.22.0 or later — older builds cannot run gemma4 e-series models.
-    The model needs 9.6 GB of RAM while loaded. A hosted model works instead;
-    see docs/configuration.md.
-  EOS
+      Or hand the setup to your coding agent: docs/setup.md is written for one to
+      execute.
+    EOS
+  end
 end
 EOF
 

--- a/scripts/bump-cask.sh
+++ b/scripts/bump-cask.sh
@@ -102,10 +102,20 @@ cask "parrotflow" do
     ticked but the app says it is not granted, remove it from that list and add
     it back — the entry belongs to the old certificate.
 
-    The speech model downloads on first launch, about 460 MB. Recording works
+    The speech model downloads on first launch, about 470 MB. Recording works
     straight away. Transcription starts when the download finishes.
 
-    Then hold Right Command and talk.
+    Then hold Right Command and talk. That much needs nothing else.
+
+    Spoken commands and the vocabulary check need a language model too. That
+    part is optional, and it runs on your own Mac:
+
+      brew install ollama && brew services start ollama
+      ollama pull gemma4:e4b-mlx
+
+    Ollama 0.22.0 or later — older builds cannot run gemma4 e-series models.
+    The model needs 9.6 GB of RAM while loaded. A hosted model works instead;
+    see docs/configuration.md.
   EOS
 end
 EOF

--- a/scripts/bump-cask.sh
+++ b/scripts/bump-cask.sh
@@ -75,7 +75,7 @@ cask "parrotflow" do
 
   zap trash: [
     "~/.config/parrotflow",
-    # The speech models, about 1.2 GB of them.
+    # The speech models, about 470 MB of them.
     "~/Library/Application Support/FluidAudio",
     "~/Library/Logs/ParrotFlow.log",
     "~/Library/Preferences/com.parrotflow.app.plist",

--- a/scripts/bump-cask.sh
+++ b/scripts/bump-cask.sh
@@ -73,6 +73,15 @@ cask "parrotflow" do
 
   app "ParrotFlow.app"
 
+  # Launched with LaunchServices, not by running the binary. TCC credits a
+  # permission to the responsible process, and a binary exec'd from a shell is
+  # credited to the terminal — the app then holds grants it cannot use. `open`
+  # makes the app responsible for itself. scripts/install.sh ends the same way,
+  # for the same reason. See docs/distribution.md.
+  postflight do
+    system_command "/usr/bin/open", args: ["--background", appdir/"ParrotFlow.app"]
+  end
+
   zap trash: [
     "~/.config/parrotflow",
     # The speech models, about 470 MB of them.
@@ -80,6 +89,24 @@ cask "parrotflow" do
     "~/Library/Logs/ParrotFlow.log",
     "~/Library/Preferences/com.parrotflow.app.plist",
   ]
+
+  caveats <<~EOS
+    ParrotFlow asks for two permissions the first time it runs:
+
+      Microphone     a system prompt
+      Accessibility  System Settings > Privacy & Security > Accessibility
+
+    Upgrading from 0.9.0 or earlier: this release is signed with a different
+    certificate, and macOS ties both permissions to the one that signed the
+    app. You will be asked again. If Accessibility already lists ParrotFlow as
+    ticked but the app says it is not granted, remove it from that list and add
+    it back — the entry belongs to the old certificate.
+
+    The speech model downloads on first launch, about 460 MB. Recording works
+    straight away. Transcription starts when the download finishes.
+
+    Then hold Right Command and talk.
+  EOS
 end
 EOF
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -214,7 +214,7 @@ EOF
 MODELS="$HOME/Library/Application Support/FluidAudio/Models"
 if ! ls -d "$MODELS"/parakeet-* >/dev/null 2>&1; then
     printf '    The speech model is not on this Mac yet. Your first dictation\n'
-    printf '    downloads it: about 1.2 GB, a few minutes, once. That wait is\n'
+    printf '    downloads it: about 470 MB, a minute or two, once. That wait is\n'
     printf '    normal and only happens the first time.\n\n'
 fi
 


### PR DESCRIPTION
On a fresh install the pill said "Transcribing…" for the length of the speech model download, which reads as a hang. It now says "Downloading speech model 43%" and the number climbs in place, then hands the pill back to "Transcribing…" once the model is ready. Separately, `audio.second_opinion` now defaults to `true`: every dictation gets about 100ms slower so that roughly 2% of them stop losing words. That default reaches new installs and configs that omit the key only — an existing `config.yaml` carries `second_opinion: false` explicitly and keeps it, so nobody's current install changes. The docs also stop saying the speech model is 1.2 GB; it measures 469 MB on disk.

Start the review at `pillDownloadRun` in `AppDelegate.swift`. It replaces a bare flag, because push-to-talk runs two dictations at once and the older one's `.ready` could take the pill from the newer one.

One thing to decide at merge: there are two `feat:` commits here. A rebase or a merge commit puts both in the changelog. A squash collapses them into the PR title, and the `second_opinion` default would ship with no line of its own.

<details>
<summary>A bare flag let one dictation's `.ready` take the pill from another</summary>

`3e8cf1b` used `pillShowsDownload: Bool`. Every other late arrival in `AppDelegate.swift` carries a run instead, and the reason is written into the file several times over: push-to-talk does not wait for the previous transcript, so two dictations are routinely in flight.

The sequence that breaks a flag:

| step | flag | what happens |
|---|---|---|
| dictation A starts mid-download | `true` | pill: "Downloading speech model 12%" |
| dictation B starts mid-download | `true` | pill: "Downloading speech model 13%" |
| B ends first | `false` | `endProgress()` clears the flag while A is still waiting |
| model arrives | `false` | A gets no pill back at all |

And in the other direction, a stale `true` left by any path that ends a dictation without `endProgress()` would let an unrelated later download — the vocabulary model, fetched mid-dictation at `Transcriber.swift:356` — write over whatever the pill was showing.

`pillDownloadRun: Int?` holds the `transcriptionRun` that put the download up, and `ownsDownloadPill` is the same `pillDownloadRun == transcriptionRun` test the rest of the chain makes. A stale value stops matching the moment a newer press lands, so it cannot hijack anything.

On the two other checks asked for: `Transcriber.Status` is `Equatable` at `Transcriber.swift:18`, though the pattern match here does not need it. The mirror needs no lock — `onStatusChange` hops to `DispatchQueue.main.async` at `AppDelegate.swift:87`, and `transcribe()` runs on the main queue too, so both sides are the same queue.

</details>

<details>
<summary>`.failed` is left off the pill on purpose, and `Transcriber` never emits it anyway</summary>

`.loading` keeps the pill because it is the same wait continuing — the model is still on its way and the pill should keep saying so. A failure is the wait ending, and the run waiting on the model already learns about it as a thrown error: `transcribe()`'s catch calls `endProgress()` and then `presentAlert`. Putting a second ending on the pill would mean two of them on screen for one failure.

Reachability is a second reason and not the main one. Grepping `setStatus` in `Transcriber.swift` finds `.downloading` and `.ready` and nothing else — neither `.failed` nor `.loading` is ever produced today. Both cases are already in the switch for the menu bar label, so the pill line for `.loading` matches what that case already does; a pill line for `.failed` would be code with no way to run and no reason to.

</details>

<details>
<summary>1.2 GB was never measured — the same repo comes to 469 MB, twice</summary>

Measured under `~/Library/Application Support/FluidAudio/Models`:

```
469M  parakeet-tdt-0.6b-v3
461M  parakeet-tdt-0.6b-v3.moved-2026-08-26   (an earlier download of the same repo)
1.0M  silero-vad
```

The bulk is `Encoder.mlmodelc` at 433 MB, then `Decoder.mlmodelc` at 23 MB and `JointDecisionv3.mlmodelc` at 12 MB.

The two readings the figure could have meant were both checked and neither rescues it. Transferred bytes are not larger: FluidAudio fetches compiled `.mlmodelc` directories from Hugging Face, not an archive that expands, so what crosses the wire is the same set of files. An older revision is not it either — `git log -S parakeet-tdt-0.6b-v2` finds nothing, and `Repo.parakeetV3` is the only model id the app has ever used. 1.2 GB looks like an estimate that was written down once and copied forward.

Corrected at `README.md`, `docs/setup.md` (x2), `docs/distribution.md` (x2), `scripts/install.sh` and `scripts/bump-cask.sh`. The README install section also now reads as two equal routes with a line saying which to take, and attributes the download to the first launch rather than to either installer — neither the script nor the cask fetches the model.

</details>

<details>
<summary>The second opinion was verified against all three configs, not just the Swift default</summary>

Both places that set the value had to change or the switch does nothing. `Config.swift:1986` is the default when the key is absent; `config.example.yaml:36` is what a new install is seeded with, so the Swift default would never be reached by a normal install.

Checked with the real binary, using `PARROTFLOW_CONFIG_DIR`:

| config | `--check-config` says |
|---|---|
| key absent | `· second opinion    on` |
| `second_opinion: false` written out | `· second opinion    off` |
| the new `config.example.yaml` | `· second opinion    on` |

`audio.speech_gate` still defaults to `true` at `Config.swift:1971`, so this genuinely takes effect rather than sitting behind a gate that is off.

Nothing else asserts the old default. `second_opinion` and `secondOpinion` across `Sources/`, `docs/`, `scripts/`, `tests/` and `examples/` reach only `Config.swift`, `Transcriber.swift:183`, `CheckConfigCommand.swift` (which prints the live value, it does not assert one) and the two doc sites updated here. No `scripts/check-*.sh` reads it, and `second_opinion` is not one of the four lines `Config.defaultYAML` substitutes per variant.

On migrating existing users: this leaves them alone, and that looks right. The value in their file is one they can read and change, and flipping a latency default under someone who has an explicit setting is worse than leaving it. `docs/configuration.md` now says so in the `audio.second_opinion` section. It is worth one line in the release notes, because someone who has had the app since before this will not get the fix and will have no way to know from the changelog alone.

`feat:` and not `feat!:` — nothing that works today stops working, no key is renamed or removed, and no existing config is read differently.

</details>

<details>
<summary>Three things this leaves alone</summary>

**A download that starts after the pill is already up does not reach it.** The status is read once, at the key release. The vocabulary model is fetched mid-dictation at `Transcriber.swift:356`, and a dictation that started before it will sit on "Transcribing…" through it. Making `.downloading` claim a pill it did not put up would fight the pipeline stage labels at `AppDelegate.swift:1755`, which are already the truth for the run that owns them.

**"Downloading speech model" is shown for a load from disk too.** `Transcriber.swift:70` sets `.downloading("speech model")` before `AsrModels.downloadAndLoad`, which also covers loading a model already on disk. `.loading` exists for exactly that and is never emitted. The window is short and the launch warm-up usually closes it before the first press, but it is a small lie. Pre-existing — the menu bar label has always had it.

**"downloads 11 GB" at `docs/distribution.md:185` is left as it is, and it is probably wrong too.** With Parakeet at 470 MB the total is 3 MB + 470 MB + Gemma. `ollama list` on this machine puts `gemma4:e4b-mlx` at 8.8 GB, not the 10 GB `docs/setup.md:32` states, which makes the total about 9.3 GB. Not changed here for two reasons: the Gemma figure is the dominant term and is stated in a second place, so fixing one without the other splits them; and `ollama list` reports manifest size, which is not necessarily on-disk size. Worth its own pass with a real measurement.

</details>

<details>
<summary>Review notes — four commits, and where the risk is</summary>

| commit | what |
|---|---|
| `3e8cf1b` | the pill shows the download (yours, unchanged) |
| `cc10ed0` | the pill is keyed to `transcriptionRun` instead of a flag |
| `69c5a1b` | the 470 MB figure, and the README install section |
| `8542a36` | `second_opinion` defaults to on |

The only risky part is `cc10ed0`. Everything else is a number, a comment or a one-word default.

`make test` passes — every check, and `swiftlint` flags nothing. `swift build -c release` is clean; the two warnings it prints are pre-existing and in code this branch does not touch (`AppDelegate.swift:3916`, `Config.swift:1878`).

</details>
