### PR TITLE
perf: the pill arrives when the microphone opens, not 180 ms later

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -423,6 +423,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if Permissions.microphone == .granted {
             recorder.warmUp()
         }
+        // The other half of the first press. The engine warms above; this is
+        // the pill's own window, which costs as much again.
+        pill.warm()
         recorder.onLevel = { [weak self] level in
             self?.pill.model.level = level
         }

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -248,8 +248,8 @@ final class PillHUD {
 
         // Land on the starting strength at once, cancelling whatever was
         // animating alpha. Usually nothing — the offer follows a pill already
-        // on screen — but raised from cold, `set` starts a fade to full and the
-        // two would pull opposite ways.
+        // on screen — but raised from cold, `set` has just put it at full, and
+        // this is what takes it down to the offer's own strength.
         if !panel.isVisible {
             model.onScreen = true
             panel.orderFrontRegardless()
@@ -447,11 +447,26 @@ final class PillHUD {
             }
         }
 
+        let arriving = !panel.isVisible
+
         // The words change with the frame, not after it: SwiftUI is told inside
         // the same turn that starts the AppKit animation, and both read
         // `PillHUD.motion`.
-        withAnimation(.easeInOut(duration: Self.motion)) {
-            model.state = state
+        //
+        // Except on arrival, where there is nothing to change *from*. The pill
+        // is raised at the moment the microphone starts recording, so a
+        // crossfade there is 180 ms of looking absent while it is already
+        // listening — on top of the ~200 ms the microphone itself took. The
+        // panel's own alpha is cut the same way in `fadeIn`; both halves of the
+        // entrance have to go, or the surviving one still paces it.
+        if arriving {
+            var instant = Transaction()
+            instant.disablesAnimations = true
+            withTransaction(instant) { model.state = state }
+        } else {
+            withAnimation(.easeInOut(duration: Self.motion)) {
+                model.state = state
+            }
         }
 
         // The pill ignores the mouse in every state but this one. It sits over
@@ -470,7 +485,7 @@ final class PillHUD {
 
         let size = wantedSize
 
-        if panel.isVisible {
+        if !arriving {
             morph(to: size)
         } else {
             panel.setContentSize(size)
@@ -516,15 +531,19 @@ final class PillHUD {
     /// through the whole recording and only climbed to where it belonged when
     /// the next state morphed it there. Nothing to animate is nothing to get
     /// wrong.
+    ///
+    /// And in without fading. It was a 180 ms ease-out, and it was the last
+    /// 180 ms of a wait that measured ~700 ms from the key going down: 183 ms
+    /// of `press_delay_seconds`, ~200 ms of the microphone opening, and then
+    /// this. The other two buy something — the delay keeps ⌘C out, and the pill
+    /// may not appear before the microphone is actually recording or people
+    /// talk into a promise. This one bought a nicety, and paid for it in the
+    /// only part of the wait where the app is already listening and not saying
+    /// so. `fadeOut` keeps its fade: an exit has no one waiting on it.
     private func fadeIn(_ panel: NSPanel) {
         model.onScreen = true
-        panel.alphaValue = 0
+        panel.alphaValue = 1
         panel.orderFrontRegardless()
-        NSAnimationContext.runAnimationGroup { context in
-            context.duration = Self.motion
-            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
-            panel.animator().alphaValue = 1
-        }
     }
 
     /// Out the same way: alpha only.
@@ -614,6 +633,21 @@ final class PillHUD {
             context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
             panel.animator().setFrame(frame, display: true)
         }
+    }
+
+    /// Builds the panel before anything is waiting on it.
+    ///
+    /// An NSPanel, an NSHostingView and the glass container, all on the main
+    /// thread. Measured at 219 ms on the first press of a launch, between the
+    /// key going down and the pill appearing. Every press after it cost 25 ms.
+    ///
+    /// `onScreen` goes false here because the default is true: a panel built
+    /// and not shown would otherwise draw the pill into a window nobody can
+    /// see. `fadeIn` sets it back when the pill is actually raised.
+    func warm() {
+        guard panel == nil else { return }
+        model.onScreen = false
+        build()
     }
 
     private func build() {


### PR DESCRIPTION
Pressing the hotkey and seeing the pill measured about 700 ms. The last 180 ms of that was the pill fading in over a microphone that was already recording. This removes that fade, and builds the pill's window at launch instead of on the first press. A press a minute after the last one now shows the pill in about 495 ms, a press a few seconds after in about 375 ms.

Nothing about the hotkey changes. `press_delay_seconds` still holds a bare modifier for 180 ms before it counts as dictation, and the pill still appears only once the microphone is actually recording.

Start the review at `PillHUD.fadeIn`. The thing worth checking is that a state change *after* the entrance still animates — the entrance is instant, the morph between states is not.

<details>
<summary>Where the 700 ms went — six presses, measured on the dev build</summary>

Timings in ms from the key going down, right command, before this change:

| step | a press a minute later | first press of a launch |
|---|---|---|
| `press_delay_seconds` | 183 | 185 |
| selection, destination, anchor | 5 | 28 |
| read the input formats | 30 | 91 |
| install the tap | 20 | 19 |
| open the microphone | 190 | 380 |
| raise the pill | 90 | 219 |
| fade in | 180 | 180 |
| **visible at** | **~700** | **~1100** |

Two of the three big costs are not removable.

`press_delay_seconds` is what keeps ⌘C out. A bare modifier is half of every shortcut, so the press is held back to see whether anything else arrives.

The microphone is 80–380 ms depending on how long since the last press — CoreAudio powers the device down when it sits idle, so warming it at launch does not hold. `Recorder.warmUp()` already does everything that can be done without running the engine, and running the engine is the orange microphone indicator staying on all day.

Raising the pill *before* the microphone was considered and rejected. It would have saved 240 ms on every press, and it would have meant the pill claiming to listen before the engine was running. People start talking when they see it, and the first words would be gone. It also breaks the abort path: a slow shortcut — a modifier held while you think, then C at 300 ms — is caught by `onAbort`, and today the pill is still behind the microphone at that moment so it never appears. Raised early, it would flash on screen and be torn away.

That leaves the fade.

</details>

<details>
<summary>Two animations had to go, not one</summary>

The panel's alpha faded over `PillHUD.motion`, and the SwiftUI content crossfaded over the same constant, both starting on the same frame. Cutting either one alone would have left the other pacing the entrance.

- `fadeIn` sets alpha to 1 and orders the panel front. No animation group.
- `set` computes `arriving` from `panel.isVisible` and, when arriving, applies the state inside a `Transaction` with `disablesAnimations`.

Everything after the entrance is unchanged. A state change on a pill already on screen still morphs over `PillHUD.motion`, and `fadeOut` keeps its fade — nothing waits on an exit.

</details>

<details>
<summary>`PillHUD.warm()` — 219 ms off the first press of a launch</summary>

An NSPanel, an NSHostingView and the glass container, all built on the main thread on the first `set()`. Measured at 219 ms on the first press and 25 ms on every press after.

`warm()` builds it at launch instead, beside the `recorder.warmUp()` that was already there. `model.onScreen` goes false so a panel that exists and is not shown does not draw the pill into a window nobody can see; `fadeIn` sets it back when the pill is actually raised.

This only helps the first press. It does not touch the delay or the abort path.

</details>

<details>
<summary>Before and after, at the same moment — the pill on screen</summary>

| gap since the last press | before | after |
|---|---|---|
| a few seconds | ~525 ms | ~375 ms |
| 20 seconds to a minute | ~700 ms | ~495 ms |
| first press of a launch | ~1100 ms | 787 ms |

After this, `press_delay_seconds` is the largest single item: 186 ms of a 406 ms mean. The floor is about 360 ms warm and 500 ms after a pause.

</details>

<details>
<summary>What this does not fix</summary>

The microphone still costs 80–380 ms before the pill can honestly appear, and it re-cools whenever the app sits idle. A press after lunch pays the full amount.

If the total still reads as slow, the only lever left is `press_delay_seconds` itself. `--watch-taps` is the tool for finding how low it goes before ⌘C starts opening the microphone.

</details>
