### PR TITLE
feat: tapping the hotkey brings the offer back

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -197,7 +197,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// dictation's words at another's field, and taking it would have rewritten
     /// there. One record, written once, cannot come apart that way.
     private var lastDictated: (
-        text: String, element: AXUIElement?,
+        run: Int, text: String, element: AXUIElement?,
         owner: NSRunningApplication?, landing: Correction.Landing
     )?
 
@@ -2673,7 +2673,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Kept past the offer this is about to raise, so a tap can build another
         // one out of it once this has faded. Below the newer-run guard above,
         // and carrying the words as well as the field — see `lastDictated`.
-        lastDictated = (text, press.element, press.owner, landing)
+        lastDictated = (press.run, text, press.element, press.owner, landing)
 
         // The decoder's words matched back onto the sentence that came out of
         // the pipeline — see `Confidence.read`. Taken rather than copied: this
@@ -2698,7 +2698,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         raiseOffer(
             over: Correction(
-                original: text, element: press.element, owner: press.owner, landing: landing
+                original: text, element: press.element, owner: press.owner,
+                landing: landing, dictation: press.run
             ),
             run: press.run, headline: headline, reading: reading
         )
@@ -2825,7 +2826,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         raiseOffer(
             over: Correction(
                 original: last.text, element: last.element, owner: last.owner,
-                landing: last.landing
+                landing: last.landing, dictation: last.run
             ),
             run: pressRun, headline: nil, reading: Confidence.Reading()
         )
@@ -3349,6 +3350,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let owner: NSRunningApplication?
         /// Where the words went, so the correction can follow them.
         let landing: Landing
+        /// The dictation these words came from, or nil when they came from a
+        /// selection instead.
+        ///
+        /// Only `noteRewritten` reads it, and only to decide whether a rewrite
+        /// belongs to the record a tap would summon. Matching text is not proof
+        /// of that: say the same short sentence twice, take the first one's
+        /// offer after the second has landed, and the text matches while the
+        /// dictation is somebody else's.
+        var dictation: Int?
         /// The selection this offer was summoned over, when it was summoned
         /// over one rather than raised after a dictation.
         ///
@@ -3453,7 +3463,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 return false
             }
             Log.write("offer: the dictation went to the clipboard; \(what) went there too")
-            noteRewritten(original, as: corrected)
+            noteRewritten(original, as: corrected, from: target.dictation)
             flash("\(what) copied — ⌘V to paste", tone: .done)
             return false
         }
@@ -3479,7 +3489,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if let selection = target.selection {
             switch replaceSelected(with: corrected, in: selection, describedAs: what) {
             case .replaced:
-                noteRewritten(original, as: corrected)
+                noteRewritten(original, as: corrected, from: target.dictation)
                 applied(what)
                 return true
             case .failed, .notAttempted:
@@ -3521,7 +3531,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     dictated: original, in: now, describedAs: what
                 ) {
                 case .replaced:
-                    noteRewritten(original, as: corrected)
+                    noteRewritten(original, as: corrected, from: target.dictation)
                     applied(what)
                     return true
                 case .failed, .notAttempted:
@@ -3587,16 +3597,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     ///
     /// Only if this is still the sentence the app thinks it wrote last. A newer
     /// dictation has its own, and it is one slot.
-    private func noteRewritten(_ original: String, as corrected: String) {
+    private func noteRewritten(_ original: String, as corrected: String, from dictation: Int?) {
         guard lastTranscript?.trimmingCharacters(in: .whitespacesAndNewlines) == original
         else { return }
         lastTranscript = corrected
         // And the words a tap would summon over, which are the same words in
         // the same field. Left behind, a summon after a rewrite would offer the
         // sentence that is no longer on screen.
-        if lastDictated?.text.trimmingCharacters(in: .whitespacesAndNewlines) == original {
-            lastDictated?.text = corrected
-        }
+        //
+        // By run, not by text. The panel can be open for as long as it takes to
+        // think about a spelling and push-to-talk does not wait, so an older
+        // correction can finish after a newer dictation — and if the two said
+        // the same thing, the text matches while the record belongs to the
+        // newer one. Relabelling it there would leave the older correction's
+        // words pointing at the newer dictation's field.
+        guard let dictation, dictation == lastDictated?.run else { return }
+        lastDictated?.text = corrected
     }
 
     private func beginCorrection() {

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2779,15 +2779,38 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // pointer may be deliberately holding.
         guard !offerIsUp else { return }
         guard config.feedback.correctOffer else { return }
+
+        // The selection wins, and it never goes stale: it is what you are
+        // pointing at now. It is also the only target this can have in an app
+        // ParrotFlow has never written a word into, which is the whole of why
+        // the tap reaches further than the last dictation.
+        if let selection = SelectionReader.snapshot(),
+           !selection.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            Log.write("summon: the offer, over the selection — \"\(selection.text.prefix(80))\"")
+            aim(at: selection)
+            raiseOffer(
+                over: Correction(
+                    original: selection.text, element: selection.element,
+                    owner: selection.owner, landing: .field, selection: selection
+                ),
+                run: pressRun, headline: "the selection", reading: Confidence.Reading()
+            )
+            return
+        }
+
         guard let text = lastTranscript?.trimmingCharacters(in: .whitespacesAndNewlines),
               !text.isEmpty, let landing = lastDictationLanding else {
-            Log.write("summon: nothing has been dictated yet")
+            Log.write("summon: nothing selected and nothing dictated yet")
             return
         }
         Log.write("summon: the offer, over the last dictation")
         // `pressRun` rather than a number of its own: this offer is about that
         // dictation, and saying so is what lets a newer one take the pill off
         // it through the guard in `showCorrectOffer`.
+        //
+        // Not re-aimed. The pill is already pointed where the words landed,
+        // which is what "back where it was" means — and a fresh read would
+        // answer where the caret is *now*, which is a different question.
         raiseOffer(
             over: Correction(
                 original: text, element: landing.element, owner: landing.owner,
@@ -2795,6 +2818,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             ),
             run: pressRun, headline: nil, reading: Confidence.Reading()
         )
+    }
+
+    /// Put the pill under the selection instead of where the last dictation
+    /// left it.
+    ///
+    /// `CaretAnchor.read` already answers this and needed no new call: what it
+    /// asks the element for is the selected *range*, which is the caret only
+    /// when nothing is selected. A selection over several lines comes back as
+    /// one box around the whole of it, so the pill lands under its last line,
+    /// which is where it belongs.
+    ///
+    /// Left where it is when the read misses. `aim(at: nil)` means the bottom
+    /// of the screen, and a pill still near the words it is about beats one
+    /// parked away from them — Outlook answers `0+0` for a pane holding
+    /// hundreds of thousands of characters, and `trust` is what catches it.
+    private func aim(at selection: SelectionReader.Selection) {
+        guard let element = selection.element,
+              case .found(let anchor) = CaretAnchor.read(at: element) else {
+            Log.write("summon: no geometry for the selection; the pill stays where it was")
+            return
+        }
+        pill.aim(at: anchor)
     }
 
     /// Take the offer's letters and Escape for as long as the offer is up.
@@ -3293,6 +3338,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let owner: NSRunningApplication?
         /// Where the words went, so the correction can follow them.
         let landing: Landing
+        /// The selection this offer was summoned over, when it was summoned
+        /// over one rather than raised after a dictation.
+        ///
+        /// It is here for the range. `replace` otherwise finds the words by
+        /// their text and takes the last copy, which is the right answer for a
+        /// dictation — the newest thing written is the thing the offer is
+        /// about. A selection is not: the copy that matters is the one you
+        /// highlighted, and only the range says which that is. Carrying the
+        /// whole `Selection` rather than the range alone is what lets this hand
+        /// straight to `replaceSelected`, which already recovers a range that
+        /// has moved.
+        var selection: SelectionReader.Selection?
 
         /// The two places a dictation can end up.
         ///
@@ -3398,6 +3455,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             owner.activate()
             // Let it come forward before the keystroke is posted.
             Thread.sleep(forTimeInterval: 0.15)
+        }
+
+        // Summoned over a selection: the path that already knows how to write
+        // one back, range and all. The text search below would take the last
+        // copy of the words in the field, and for a selection the last copy is
+        // not the one you highlighted.
+        //
+        // A miss falls through to the clipboard rather than returning, the same
+        // as every other way of not reaching the field: the rewrite is done and
+        // it has to go somewhere.
+        if let selection = target.selection {
+            switch replaceSelected(with: corrected, in: selection, describedAs: what) {
+            case .replaced:
+                noteRewritten(original, as: corrected)
+                applied(what)
+                return true
+            case .failed, .notAttempted:
+                break
+            }
         }
 
         if config.transcription.insertMode == .paste, let aimed = target.element {

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -180,15 +180,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// ownership `offerPressRun` already asserts, carrying what it is about.
     private var offeredCorrection: (run: Int, target: Correction)?
 
-    /// Where the last dictation went, kept after its offer has gone.
+    /// The last dictation a tap can summon an offer over: its words, and where
+    /// they went.
     ///
     /// `offeredCorrection` is cleared by every ending, because it asserts that
-    /// an offer is up and about these words. This asserts nothing of the sort:
-    /// it is the field half of what `lastTranscript` already remembers, and it
-    /// lives exactly as long — one slot, replaced by the next dictation and
-    /// never cleared. `summonOffer` builds a new offer out of the two.
-    private var lastDictationLanding: (
-        element: AXUIElement?, owner: NSRunningApplication?, landing: Correction.Landing
+    /// an offer is up and about these words. This asserts nothing of the sort —
+    /// one slot, replaced by the next dictation and never cleared.
+    ///
+    /// The words are held here rather than read from `lastTranscript` at the
+    /// tap, because the two are written at different moments and a superseded
+    /// run can separate them. `lastTranscript` is set for every transcription
+    /// that finishes; this is set below the guard that refuses an offer to a
+    /// run a newer one has already overtaken. Dictate twice with the first
+    /// still decoding, and the older finish overwrites the transcript while the
+    /// landing stays with the newer run — so a tap would have offered one
+    /// dictation's words at another's field, and taking it would have rewritten
+    /// there. One record, written once, cannot come apart that way.
+    private var lastDictated: (
+        text: String, element: AXUIElement?,
+        owner: NSRunningApplication?, landing: Correction.Landing
     )?
 
     /// The focused element's text as it was at the press, for an app that gave
@@ -2660,9 +2670,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        // Kept past the offer this is about to raise, so a tap can build
-        // another one out of it once this has faded. See `lastDictationLanding`.
-        lastDictationLanding = (press.element, press.owner, landing)
+        // Kept past the offer this is about to raise, so a tap can build another
+        // one out of it once this has faded. Below the newer-run guard above,
+        // and carrying the words as well as the field — see `lastDictated`.
+        lastDictated = (text, press.element, press.owner, landing)
 
         // The decoder's words matched back onto the sentence that came out of
         // the pipeline — see `Confidence.read`. Taken rather than copied: this
@@ -2798,8 +2809,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        guard let text = lastTranscript?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !text.isEmpty, let landing = lastDictationLanding else {
+        guard let last = lastDictated,
+              !last.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             Log.write("summon: nothing selected and nothing dictated yet")
             return
         }
@@ -2813,8 +2824,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // answer where the caret is *now*, which is a different question.
         raiseOffer(
             over: Correction(
-                original: text, element: landing.element, owner: landing.owner,
-                landing: landing.landing
+                original: last.text, element: last.element, owner: last.owner,
+                landing: last.landing
             ),
             run: pressRun, headline: nil, reading: Confidence.Reading()
         )
@@ -3476,7 +3487,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
-        if config.transcription.insertMode == .paste, let aimed = target.element {
+        // Only when this offer was not about a selection. `replaceSelected`
+        // returns `.notAttempted` precisely when the field holds several copies
+        // of the words and nothing says which was meant — and the search below
+        // takes the last copy, which is the guess it just declined to make. A
+        // highlighted earlier copy would be left alone while a later one was
+        // rewritten. So a selection that could not be written falls to the
+        // clipboard, which is what the comment above always claimed.
+        if target.selection == nil,
+           config.transcription.insertMode == .paste, let aimed = target.element {
             let now = SelectionReader.focusedElement()
             if let now, CFEqual(now, aimed), !SelectionReader.isOurs(now) {
                 // `fuzzy: false`: the words on screen are the ones we typed
@@ -3572,6 +3591,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard lastTranscript?.trimmingCharacters(in: .whitespacesAndNewlines) == original
         else { return }
         lastTranscript = corrected
+        // And the words a tap would summon over, which are the same words in
+        // the same field. Left behind, a summon after a rewrite would offer the
+        // sentence that is no longer on screen.
+        if lastDictated?.text.trimmingCharacters(in: .whitespacesAndNewlines) == original {
+            lastDictated?.text = corrected
+        }
     }
 
     private func beginCorrection() {

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -180,6 +180,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// ownership `offerPressRun` already asserts, carrying what it is about.
     private var offeredCorrection: (run: Int, target: Correction)?
 
+    /// Where the last dictation went, kept after its offer has gone.
+    ///
+    /// `offeredCorrection` is cleared by every ending, because it asserts that
+    /// an offer is up and about these words. This asserts nothing of the sort:
+    /// it is the field half of what `lastTranscript` already remembers, and it
+    /// lives exactly as long — one slot, replaced by the next dictation and
+    /// never cleared. `summonOffer` builds a new offer out of the two.
+    private var lastDictationLanding: (
+        element: AXUIElement?, owner: NSRunningApplication?, landing: Correction.Landing
+    )?
+
     /// The focused element's text as it was at the press, for an app that gave
     /// no caret. What changed in it afterwards is where the words went.
     ///
@@ -753,6 +764,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         hotKeys.onPress = { [weak self] in self?.handleHotKeyPress() }
         hotKeys.onRelease = { [weak self] in self?.handleHotKeyRelease() }
         hotKeys.onAbort = { [weak self] in self?.cancelDictation(.notTheHotkey) }
+        hotKeys.onTap = { [weak self] in self?.summonOffer() }
         do {
             try hotKeys.register(
                 key: config.hotkey.key,
@@ -2648,15 +2660,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        offerUntil = Date().addingTimeInterval(Self.offerSeconds)
-        // A new offer is never born held, whatever the last one ended as.
-        offerHeld = false
-        offerPressRun = press.run
-        // This dictation's own words and its own field, frozen with the offer.
-        offeredCorrection = (press.run, Correction(
-            original: text, element: press.element, owner: press.owner, landing: landing
-        ))
-        let commands = offerCommands
+        // Kept past the offer this is about to raise, so a tap can build
+        // another one out of it once this has faded. See `lastDictationLanding`.
+        lastDictationLanding = (press.element, press.owner, landing)
+
         // The decoder's words matched back onto the sentence that came out of
         // the pipeline — see `Confidence.read`. Taken rather than copied: this
         // press's dictation is over and nothing else can want them.
@@ -2677,6 +2684,47 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             )
         )
         if let warning = reading.warning { Log.write("offer: \(warning)") }
+
+        raiseOffer(
+            over: Correction(
+                original: text, element: press.element, owner: press.owner, landing: landing
+            ),
+            run: press.run, headline: headline, reading: reading
+        )
+
+        // Taken at the press, and only when that press found no caret. Matched
+        // by run, so it is this dictation's own pane and nobody else's. A
+        // remembered anchor is still a guess, and this is what replaces it with
+        // the answer.
+        //
+        // Dropped on every ending, not only the one that uses it. A pane
+        // belongs to one run and no later dictation can want it, so it is
+        // retired here as `dictationEnded` would retire it — leaving it for the
+        // sweep would be keeping a copy of somebody's screen for no reason.
+        let pane = screenAtPress.removeValue(forKey: press.run)?.text
+        // Nothing landed in a field on the clipboard endings, so the diff has
+        // nothing to find. Whatever it did find would be something else moving
+        // on screen.
+        if case .field = landing, let pane, let element = press.element {
+            findWhereTheWordsLanded(comparedWith: pane, in: element, for: press.run)
+        }
+    }
+
+    /// Put the offer on screen over one target, however it got there.
+    ///
+    /// Split out of `showCorrectOffer` so `summonOffer` can reach it. What
+    /// stayed behind there is everything a *dictation's* ending owes and
+    /// nothing else does: the microphone notice, the decoder's reading, and the
+    /// search for where the words landed.
+    private func raiseOffer(
+        over target: Correction, run: Int, headline: String?, reading: Confidence.Reading
+    ) {
+        offerUntil = Date().addingTimeInterval(Self.offerSeconds)
+        // A new offer is never born held, whatever the last one ended as.
+        offerHeld = false
+        offerPressRun = run
+        offeredCorrection = (run, target)
+        let commands = offerCommands
         offerHeadline = headline
         offerReading = reading
         let hold = config.feedback.lowConfidence.holdReturn
@@ -2707,23 +2755,46 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         offerOnScreen = commands
         watchTheOfferKeys()
         watchForOfferOutsideClick()
+    }
 
-        // Taken at the press, and only when that press found no caret. Matched
-        // by run, so it is this dictation's own pane and nobody else's. A
-        // remembered anchor is still a guess, and this is what replaces it with
-        // the answer.
-        //
-        // Dropped on every ending, not only the one that uses it. A pane
-        // belongs to one run and no later dictation can want it, so it is
-        // retired here as `dictationEnded` would retire it — leaving it for the
-        // sweep would be keeping a copy of somebody's screen for no reason.
-        let pane = screenAtPress.removeValue(forKey: press.run)?.text
-        // Nothing landed in a field on the clipboard endings, so the diff has
-        // nothing to find. Whatever it did find would be something else moving
-        // on screen.
-        if case .field = landing, let pane, let element = press.element {
-            findWhereTheWordsLanded(comparedWith: pane, in: element, for: press.run)
+    /// The offer asked for rather than offered: the hotkey tapped, not held.
+    ///
+    /// Over the last dictation, in the field it landed in. This is what stops
+    /// `offerSeconds` being a deadline — an offer you can call back does not
+    /// have to be kept on screen against the chance that you want it, so
+    /// nothing here lengthens it.
+    ///
+    /// No reading. The colours and the low-confidence warning are what the
+    /// decoder said about a sentence as it arrived, and a tap minutes later is
+    /// not that moment. Showing them again would also re-arm `holdReturn`,
+    /// which exists for the Return already on its way down.
+    private func summonOffer() {
+        // Nothing while a dictation is in the air. On `toggle` the key is what
+        // stops a recording, and a stop that came out short is a stop — the
+        // press was simply never delivered. Summoning there would answer a key
+        // meant for the microphone, and do it over the *previous* sentence.
+        guard !recorder.isRecording, runsInFlight <= 0 else { return }
+        // A tap while the offer is up is a tap at nothing. Raising a second one
+        // over the first would take the letters again and restart a clock the
+        // pointer may be deliberately holding.
+        guard !offerIsUp else { return }
+        guard config.feedback.correctOffer else { return }
+        guard let text = lastTranscript?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !text.isEmpty, let landing = lastDictationLanding else {
+            Log.write("summon: nothing has been dictated yet")
+            return
         }
+        Log.write("summon: the offer, over the last dictation")
+        // `pressRun` rather than a number of its own: this offer is about that
+        // dictation, and saying so is what lets a newer one take the pill off
+        // it through the guard in `showCorrectOffer`.
+        raiseOffer(
+            over: Correction(
+                original: text, element: landing.element, owner: landing.owner,
+                landing: landing.landing
+            ),
+            run: pressRun, headline: nil, reading: Confidence.Reading()
+        )
     }
 
     /// Take the offer's letters and Escape for as long as the offer is up.

--- a/Sources/ParrotFlow/HotKeyManager.swift
+++ b/Sources/ParrotFlow/HotKeyManager.swift
@@ -55,6 +55,12 @@ final class HotKeyManager {
     /// `ModifierKeyMonitor`. Never fires on the Carbon path: a combo is
     /// unambiguous by construction.
     var onAbort: (() -> Void)?
+    /// The key was tapped rather than held — see `ModifierKeyMonitor.onTap`.
+    ///
+    /// Bare modifiers only. Carbon delivers a press on the down edge and
+    /// swallows the keystroke, so there is no sub-threshold edge to claim: a
+    /// tap of `⌃⌥Space` is a dictation, and a short one.
+    var onTap: (() -> Void)?
 
     private(set) var binding: Binding?
 
@@ -67,6 +73,7 @@ final class HotKeyManager {
         modifierMonitor.onPress = { [weak self] in self?.onPress?() }
         modifierMonitor.onRelease = { [weak self] in self?.onRelease?() }
         modifierMonitor.onAbort = { [weak self] in self?.onAbort?() }
+        modifierMonitor.onTap = { [weak self] in self?.onTap?() }
     }
 
     // MARK: Lifecycle

--- a/Sources/ParrotFlow/ModifierKey.swift
+++ b/Sources/ParrotFlow/ModifierKey.swift
@@ -159,6 +159,18 @@ final class ModifierKeyMonitor {
     /// started a dictation on `onPress` has to drop it, silently: the user
     /// pressed ⌘S and is owed a save, not a notice about dictation.
     var onAbort: (() -> Void)?
+    /// The key went down and came back up inside `pressDelay`, with nothing
+    /// else touched.
+    ///
+    /// This edge already existed and already did nothing: a hold shorter than
+    /// the delay never delivers a press, so `onRelease` does not fire for it
+    /// either. Naming it costs the dictation path nothing, because a tap is
+    /// decided by the release rather than by waiting to see whether one is
+    /// coming.
+    ///
+    /// Never fires at `pressDelay` of 0 — there the press goes out on the down
+    /// edge, so every hold has delivered one by the time it ends.
+    var onTap: (() -> Void)?
 
     private var timer: Timer?
     private var monitors: [Any] = []
@@ -269,8 +281,12 @@ final class ModifierKeyMonitor {
 
     private func finishHold() {
         let wasPressed = pressDelivered
+        // `isSpent` is the whole of what keeps a shortcut out. ⌥P types π on a
+        // French layout and is over in well under the delay, but the P marks
+        // the hold, so it can never be read as a tap.
+        let wasTap = !wasPressed && !isSpent
         endHold()
-        if wasPressed { onRelease?() }
+        if wasPressed { onRelease?() } else if wasTap { onTap?() }
     }
 
     /// The one path out of a hold that was meant for something else. Delivered

--- a/Sources/ParrotFlow/WatchModifiersCommand.swift
+++ b/Sources/ParrotFlow/WatchModifiersCommand.swift
@@ -36,4 +36,45 @@ enum WatchModifiersCommand {
         print("✓ detected: \(everSaw.map(\.displayName).sorted().joined(separator: ", "))")
         return 0
     }
+
+    /// `--watch-taps <key> [seconds]` — the same key through the real
+    /// `ModifierKeyMonitor`, printing which edge each press came out as.
+    ///
+    /// A tap cannot be scored from a fixture: it is a length of time on a
+    /// physical key, and what makes it hard is that a shortcut looks like one
+    /// until the second key arrives. So this is the surface for it — press the
+    /// key alone and it says `tap`; press ⌘S and it says nothing at all, which
+    /// is the case worth checking.
+    static func taps(key name: String, seconds: Double, pressDelay: TimeInterval) -> Int32 {
+        guard let key = ModifierKey(name: name) else {
+            print("✗ \"\(name)\" is not a bare modifier — see docs/configuration.md")
+            return 1
+        }
+        print("Tap \(key.displayName), hold it, and try a shortcut with it (\(Int(seconds))s)")
+        print("press_delay is \(pressDelay)s — shorter than that is a tap.\n")
+
+        let monitor = ModifierKeyMonitor()
+        var counts: [String: Int] = [:]
+        func note(_ edge: String) {
+            counts[edge, default: 0] += 1
+            print("  \(edge)")
+        }
+        monitor.onPress = { note("press   — a dictation would start here") }
+        monitor.onRelease = { note("release — and end here") }
+        monitor.onAbort = { note("abort   — that was a shortcut") }
+        monitor.onTap = { note("tap     — the offer would be summoned") }
+        monitor.start(key: key, pressDelay: pressDelay)
+        RunLoop.current.run(until: Date().addingTimeInterval(seconds))
+        monitor.stop()
+
+        print("")
+        if counts.isEmpty {
+            print("✗ no edges at all — the flag state isn't reaching this process")
+            return 1
+        }
+        for edge in counts.keys.sorted() {
+            print("  \(counts[edge] ?? 0)× \(edge.split(separator: " ")[0])")
+        }
+        return 0
+    }
 }

--- a/Sources/ParrotFlow/WatchModifiersCommand.swift
+++ b/Sources/ParrotFlow/WatchModifiersCommand.swift
@@ -64,12 +64,38 @@ enum WatchModifiersCommand {
         monitor.onAbort = { note("abort   — that was a shortcut") }
         monitor.onTap = { note("tap     — the offer would be summoned") }
         monitor.start(key: key, pressDelay: pressDelay)
-        RunLoop.current.run(until: Date().addingTimeInterval(seconds))
+
+        // Pumped in slices so the key can be sampled alongside the monitor. An
+        // edge that never arrives has three causes and they need different
+        // answers — nothing was pressed, the flags never reached us, or every
+        // hold was somebody's shortcut — and a summary that cannot tell them
+        // apart sends you looking at the wrong one. Same cadence the monitor
+        // polls at, so a press cannot fall between two samples.
+        var samples = 0
+        var sawDown = 0
+        let deadline = Date().addingTimeInterval(seconds)
+        while Date() < deadline {
+            samples += 1
+            if key.isPressed { sawDown += 1 }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.025))
+        }
         monitor.stop()
 
         print("")
-        if counts.isEmpty {
-            print("✗ no edges at all — the flag state isn't reaching this process")
+        guard samples > 1 else {
+            print("✗ the run loop never pumped — no key could have been seen")
+            return 1
+        }
+        guard sawDown > 0 else {
+            print("✗ \(key.displayName) was never down in those \(Int(seconds))s")
+            print("  Either it was not pressed, or the flag state is not reaching this")
+            print("  process — `--watch-modifiers` says which.")
+            return 1
+        }
+        guard !counts.isEmpty else {
+            print("✗ \(key.displayName) went down \(sawDown) sample(s) and produced no edge")
+            print("  Every hold was ruled out as a shortcut: something else was pressed,")
+            print("  clicked or scrolled while it was held. See `press_delay_seconds`.")
             return 1
         }
         for edge in counts.keys.sorted() {

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -551,6 +551,19 @@ if let index = arguments.firstIndex(of: "--watch-modifiers") {
     exit(WatchModifiersCommand.run(seconds: seconds ?? 10))
 }
 
+if let index = arguments.firstIndex(of: "--watch-taps") {
+    // The configured key and delay by default, since what this answers is
+    // whether the gesture works on the hotkey you actually use.
+    let loaded = (try? ConfigStore.load()) ?? Config()
+    let key = arguments.indices.contains(index + 1) && !arguments[index + 1].hasPrefix("-")
+        ? arguments[index + 1]
+        : loaded.hotkey.key
+    let seconds = arguments.indices.contains(index + 2) ? Double(arguments[index + 2]) : nil
+    exit(WatchModifiersCommand.taps(
+        key: key, seconds: seconds ?? 10, pressDelay: loaded.hotkey.pressDelaySeconds
+    ))
+}
+
 let app = NSApplication.shared
 let delegate = AppDelegate()
 app.delegate = delegate

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -316,6 +316,7 @@ $ ParrotFlow --forget Praisy
 $PF --record 3           # record 3s and verify the file it produced
 $PF --transcribe a.wav   # transcribe a clip
 $PF --watch-modifiers    # print which modifier keys are physically down, live
+$PF --watch-taps         # tap, hold or shortcut — which edge each press comes out as
 $PF --audio-recovery     # what the recorder does when the microphone changes
 ```
 
@@ -326,6 +327,14 @@ A silent clip or a short file gets a non-zero exit.
 `--watch-modifiers` is the one to reach for if a bare-modifier hotkey seems
 dead — it shows whether the key is reaching the app at all, and whether left
 and right are distinguishable on your keyboard.
+
+`--watch-taps` runs the same key through the real monitor and names the edge
+each press came out as: `press`/`release` for a hold, `tap` for one shorter
+than `press_delay_seconds`, `abort` for a hold that turned out to be a
+shortcut. It reads your configured hotkey and delay unless you name another
+(`--watch-taps right_option 20`). A tap is a length of time on a physical key,
+so no fixture can score it — the case worth checking by hand is that ⌘S prints
+nothing at all.
 
 `--audio-recovery` is for the other kind of dead: the microphone changed —
 AirPods connected, a headset came out — and since then dictation records

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -184,6 +184,35 @@ On `toggle`, right ⌥ would start recording every time you used it to type an
 accented character. Hold-to-talk is the mode that makes sense for these; it's
 also why apps in this category gravitate to `fn` or a right-hand modifier.
 
+### Tap it to bring the offer back
+
+Hold the hotkey and you dictate. **Tap it** — shorter than
+`press_delay_seconds` — and the pill comes back with its commands on it.
+
+| What is selected | What the offer is about |
+|---|---|
+| A selection, anywhere | Those words, and the pill appears under them |
+| Nothing | The last dictation, and the pill stays where it was |
+
+The selection wins because it is what you are pointing at now, and it is the
+only target the tap can have in an app ParrotFlow has never written into:
+select a paragraph in Word, tap, and press a chip's letter.
+
+This is why the offer's six seconds are not a deadline. It is not kept on
+screen against the chance that you want it — you ask for it again.
+
+**Bare modifiers only.** A `⌃⌥Space`-style combo goes through Carbon, which
+delivers the press on the down edge and swallows the keystroke, so there is no
+short press left over to claim: a tap there is a dictation, and a brief one.
+At `press_delay_seconds: 0` there is no tap either, for the same reason.
+
+Nothing is summoned while a dictation is recording or still decoding. On
+`toggle` the key is what stops a recording, and a stop that came out short is
+still a stop.
+
+`--watch-taps` says which edge each press comes out as — see
+[cli.md](cli.md). The case worth checking by hand is that ⌘S prints nothing.
+
 ## `transcription.insert_mode`
 
 `paste` types the transcript into the app you are in and needs the


### PR DESCRIPTION
The offer's six seconds were a deadline. Miss them and the only way back to a command was "hey parrot", which is a wake phrase for an app you are already holding a key down for. Now a **tap** of the dictation hotkey brings the offer back: over the selection when there is one, over the last dictation when there is not. Holding is unchanged and still dictates.

A tap is a press shorter than `press_delay_seconds`, which defaults to 0.18. Bare modifiers only — the setting does not apply to a `⌃⌥Space`-style combo, and at `press_delay_seconds: 0` there is no tap either. Nothing is summoned while a dictation is recording or decoding.

Start the review at `ModifierKeyMonitor.finishHold` and at the `raiseOffer` / `showCorrectOffer` split in `AppDelegate`.

<details>
<summary>The gesture is free: that edge already existed and already did nothing</summary>

A hold shorter than `pressDelay` never delivers a press, so `onRelease` does not fire for it either. `finishHold` now names that edge instead of discarding it.

The dictation path is untouched, because a tap is decided by the release rather than by waiting to see whether one is coming. Nothing is held back and no delay is added.

`isSpent` is the whole of what keeps a shortcut out. Left ⌥P types π on a French layout, but the P marks the hold, so it can never come out as a tap. Same for ⌘S, a click, or a scroll — all of them spend the hold before it can end as one.

Carbon has no such edge. It delivers a combo on the down edge and swallows the keystroke, so there is nothing sub-threshold left to claim, and `HotKeyManager.onTap` is documented as bare-modifier only.

</details>

<details>
<summary>Why `showCorrectOffer` was split in two</summary>

It was doing two jobs. `raiseOffer` is the half that puts the pill up over a target. What stayed behind is everything a dictation's *ending* owes and nothing else does: the microphone notice, the decoder's reading, and the search for where the words landed.

A summoned offer carries no reading. The word colours and the low-confidence warning are what the decoder said about a sentence as it arrived, and a tap minutes later is not that moment. Showing them again would also re-arm `holdReturn`, which exists for the Return already on its way down.

`lastDictationLanding` is new: the field half of what `lastTranscript` already remembers. One slot, replaced by the next dictation, never cleared — `offeredCorrection` could not be reused because every ending clears it.

</details>

<details>
<summary>Over a selection the pill anchors under it, and needs no new accessibility call</summary>

`CaretAnchor.read` already answers this. What it asks the element for is the selected *range*, which is the caret only when nothing is selected. A selection several lines long comes back as one box around the whole of it, so the pill lands under its last line.

When the read misses, the pill stays where it was rather than falling to the bottom of the screen. Outlook answers `0+0` for a pane of several hundred thousand characters, and a pill still near the words beats one parked away from them.

Writing the result back goes through `replaceSelected`, so `Correction` carries the `Selection` it was summoned over. `replace` otherwise finds the words by their text and takes the last copy — right for a dictation, where the newest thing written is what the offer is about, and wrong for a selection, where the copy that matters is the one you highlighted and only the range says which. A miss falls through to the clipboard like every other way of not reaching the field.

</details>

<details>
<summary>A tap is a length of time on a key, so no fixture can score it — `--watch-taps` is how you check it by hand</summary>

`--watch-taps` runs the configured hotkey through the real `ModifierKeyMonitor` and names the edge each press comes out as: `press`/`release` for a hold, `tap` for one shorter than the delay, `abort` for a hold that turned out to be a shortcut.

The case worth checking is that ⌘S prints nothing at all.

It distinguishes its three failures, because they need different answers and one message for all of them sends you looking at the wrong one: the key was never pressed, the flag state is not reaching the process, or every hold was ruled out as a shortcut.

</details>

- [x] `make test` passes.
- [x] A prompt or pattern change is scored, and the numbers are above. — no prompt, table or pattern changed.
- [x] Every commit is signed off.
