### PR TITLE
feat: tap then hold the hotkey to speak an edit

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2031,8 +2031,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // own, which means the panel rather than anything the router could pick.
         if let local = VoiceCommand.local(from: command) {
             // Nothing on the pill is ours: no model was asked, so no
-            // "Thinking…" went up.
-            apply(local, command: command, progress: nil)
+            // "Thinking…" went up. The target still travels: this path opens
+            // the correction panel, which reads the selection slot, and a
+            // command that was decoded while a newer press filled that slot
+            // would open over the newer selection.
+            apply(local, command: command, progress: nil, over: target)
             return
         }
         if let capability = Router.local(instruction: command, catalogue: catalogue) {
@@ -2126,7 +2129,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         switch capability {
         case .action(.vocabulary):
             endProgress(token: token)
-            beginCorrection()
+            beginCorrection(over: target)
         case .action(.spelling):
             interpretSpelling(instruction, progress: token, over: target)
         case .transform(let transform):
@@ -2236,7 +2239,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     command: command, lastTranscript: context,
                     language: language, config: llmConfig
                 )
-                await MainActor.run { self?.apply(result, command: command, progress: token) }
+                await MainActor.run {
+                    self?.apply(result, command: command, progress: token, over: target)
+                }
             } catch {
                 await MainActor.run {
                     guard let self else { return }
@@ -2244,8 +2249,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     self.endProgress(token: token)
                     let asked = self.askForKeyThenRetry(error) {
                         // The message above is already down, so the retry
-                        // inherits nothing.
-                        self.interpretSpelling(command, progress: nil)
+                        // inherits nothing. The target is not nothing: a retry
+                        // happens after a key dialog, which is all the time a
+                        // newer dictation needs to land, and reading the slot
+                        // then would correct that one instead.
+                        self.interpretSpelling(command, progress: nil, over: target)
                     }
                     if !asked { self.flash(error.localizedDescription, tone: .failure) }
                 }
@@ -2733,13 +2741,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         lastTranscript = text
     }
 
-    private func apply(_ command: VoiceCommand, command spoken: String, progress token: Int?) {
+    private func apply(
+        _ command: VoiceCommand, command spoken: String, progress token: Int?,
+        over target: Target = .whateverIsSelected
+    ) {
         // Whatever happens next replaces it: a panel, or a flash of its own.
         endProgress(token: token)
 
         switch command {
         case .openCorrectionPanel:
-            beginCorrection()
+            beginCorrection(over: target)
         case .undo:
             performUndo()
         case .addRules(let rules):
@@ -3786,14 +3797,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         lastDictated?.text = corrected
     }
 
-    private func beginCorrection() {
+    private func beginCorrection(over target: Target = .whateverIsSelected) {
         // Reading the selection needs Accessibility; the panel does not. Open
         // it either way — typing both sides still beats editing YAML by hand,
         // and a panel that silently refuses to appear reads as a broken app.
-        let selection = selectionAtPress ?? (
-            Permissions.accessibility == .granted ? SelectionReader.read() : nil
-        )
-        selectionAtPress = nil
+        //
+        // A spoken command brings its own, frozen when its recording began. It
+        // does not read the slot: "hey parrot" is decoded like any other
+        // dictation, and a newer press can have filled that slot by the time it
+        // is understood — the panel would then open over the newer selection.
+        let selection: SelectionReader.Selection?
+        switch target {
+        case .frozen(let held, _):
+            selection = held
+        case .whateverIsSelected:
+            selection = selectionAtPress ?? (
+                Permissions.accessibility == .granted ? SelectionReader.read() : nil
+            )
+            selectionAtPress = nil
+        }
 
         Log.write("correction: selection = \(selection.map { "\"\($0.text)\"" } ?? "none")")
         pendingSelection = selection

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -168,6 +168,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         /// would be delivered with the terminal's answer, and the reverse puts
         /// markup in front of an app that shows the tags.
         let paste: AppProfile.Paste
+        /// Tap-then-hold: what is said is an instruction, not text.
+        ///
+        /// Decided at the press because that is where the gesture is known, and
+        /// carried here for the same reason everything else is — a second press
+        /// landing mid-transcription must not be able to change what this one
+        /// was for.
+        var isCommand = false
     }
 
     /// The words the offer on screen is about, and the field they went into.
@@ -179,6 +186,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// one dictation's words against another's field. This is the same
     /// ownership `offerPressRun` already asserts, carrying what it is about.
     private var offeredCorrection: (run: Int, target: Correction)?
+
+    /// The current press was tap-then-hold, so its words are an instruction.
+    private var commandAtPress = false
 
     /// The last dictation a tap can summon an offer over: its words, and where
     /// they went.
@@ -774,7 +784,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         DispatchQueue.main.async { [weak self] in self?.askForMissingKeys() }
 
         hotkeyError = nil
-        hotKeys.onPress = { [weak self] in self?.handleHotKeyPress() }
+        hotKeys.onPress = { [weak self] afterTap in self?.handleHotKeyPress(afterTap: afterTap) }
         hotKeys.onRelease = { [weak self] in self?.handleHotKeyRelease() }
         hotKeys.onAbort = { [weak self] in self?.cancelDictation(.notTheHotkey) }
         hotKeys.onTap = { [weak self] in self?.summonOffer() }
@@ -1067,7 +1077,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Hotkey handling
 
-    private func handleHotKeyPress() {
+    private func handleHotKeyPress(afterTap: Bool = false) {
+        // The gesture, kept for the `Press` built when the recording stops.
+        // Only for a press that starts a dictation: the second press of a
+        // toggle belongs to the one already running, and it did not ask for
+        // anything different.
+        if !recorder.isRecording { commandAtPress = afterTap }
         // Read before anything this press does, so an abort later can tell the
         // transcription this press started from one that was already running.
         transcriptionRunAtPress = transcriptionRun
@@ -1432,8 +1447,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         playFeedback("Tink")
         if config.feedback.overlay {
-            pill.aim(at: anchorAtPress)
-            pill.recording(icon: appIconAtPress)
+            // Under the selection when there is one and this is a command: the
+            // words are about those words, and the pill belongs with them.
+            if commandAtPress, let selection = selectionAtPress {
+                aim(at: selection)
+            } else {
+                pill.aim(at: anchorAtPress)
+            }
+            pill.recording(icon: appIconAtPress, label: recordingLabel)
         }
 
         let tick = Timer(timeInterval: 0.1, repeats: true) { [weak self] _ in
@@ -1741,7 +1762,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             run: pressRun, element: focus?.element, owner: focus?.owner, mic: micAtPress,
             // Plain when nobody was in front, which is the answer that cannot
             // lose a sentence.
-            paste: appAtPress.map { AppProfile.of($0).paste } ?? .plain
+            paste: appAtPress.map { AppProfile.of($0).paste } ?? .plain,
+            isCommand: commandAtPress
         )
         Task { [weak self] in
             // Whatever happens below — decoded, cancelled, or thrown — nothing
@@ -2856,6 +2878,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
     }
 
+    /// What the pill says the hold is for, or nil for the one that needs no
+    /// saying.
+    ///
+    /// A command hold looks exactly like a dictation from outside — same key,
+    /// same mic, same meter — and the difference is that the words are routed
+    /// instead of written down. That has to be readable *before* you speak, not
+    /// worked out afterwards from a sentence that never landed. Escape is live
+    /// the whole time, so a wrong answer here costs one keystroke.
+    private var recordingLabel: String? {
+        guard commandAtPress else { return nil }
+        return selectionAtPress == nil ? "say an edit" : "editing the selection"
+    }
+
     /// Put the pill under the selection instead of where the last dictation
     /// left it.
     ///
@@ -3929,6 +3964,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Newlines are still cut. A newline in a composer sends the message,
         // and no stage has a reason to ask for one at either end.
         let delivered = text.trimmingCharacters(in: .newlines)
+
+        // The gesture already said this is an instruction, so nothing is
+        // looked for in the words. That is the whole point of it: the phrase
+        // exists to mark a command inside an ordinary dictation, and there is
+        // nothing to mark when the key said so first.
+        if press.isCommand {
+            dictationEnded(press.run)
+            guard !trimmed.isEmpty else {
+                Log.write("command: nothing was said")
+                flash("Didn't catch that", tone: .caution)
+                updateUI()
+                return
+            }
+            Log.write("command spoken: \"\(trimmed)\"")
+            handleVoiceCommand(trimmed)
+            return
+        }
 
         // Heard as a command, or nothing at all: no words are going to land,
         // so there is nothing to compare a pane against.

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2010,7 +2010,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// declared by a key, so being wrong about it is a real possibility.
     private func handleVoiceCommand(
         _ command: String, confirm: Bool = true,
-        over frozen: SelectionReader.Selection? = nil
+        over target: Target = .whateverIsSelected
     ) {
         let catalogue = Catalogue(transforms: config.transforms)
 
@@ -2027,7 +2027,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Log.write("router: \"\(command)\" named \(capability.name) outright")
             run(
                 capability, instruction: command,
-                progress: nil, confirm: confirm, over: frozen
+                progress: nil, confirm: confirm, over: target
             )
             return
         }
@@ -2057,7 +2057,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         Log.write("router: \"\(command)\" → \(capability.name)")
                         self.run(
                             capability, instruction: command,
-                            progress: token, confirm: confirm, over: frozen
+                            progress: token, confirm: confirm, over: target
                         )
                     case .anything:
                         // An edit with no prompt behind it. The instruction is
@@ -2067,7 +2067,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         self.runTransform(
                             FreeForm.prompt(for: command).asTransform(model: catchAll),
                             instruction: command, progress: token,
-                            confirm: confirm, over: frozen
+                            confirm: confirm, over: target
                         )
                     case .none:
                         // Nothing fits. Deliberately not falling through to
@@ -2093,7 +2093,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     Log.write("routing failed: \(error.localizedDescription)")
                     self.endProgress(token: token)
                     let asked = self.askForKeyThenRetry(error) {
-                        self.handleVoiceCommand(command, confirm: confirm, over: frozen)
+                        self.handleVoiceCommand(command, confirm: confirm, over: target)
                     }
                     if !asked { self.flash(error.localizedDescription, tone: .failure) }
                 }
@@ -2109,7 +2109,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func run(
         _ capability: Capability, instruction: String,
         progress token: Int?, confirm: Bool = true,
-        over frozen: SelectionReader.Selection? = nil
+        over target: Target = .whateverIsSelected
     ) {
         switch capability {
         case .action(.vocabulary):
@@ -2120,7 +2120,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         case .transform(let transform):
             runTransform(
                 transform, instruction: instruction,
-                progress: token, confirm: confirm, over: frozen
+                progress: token, confirm: confirm, over: target
             )
         }
     }
@@ -2231,6 +2231,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Transforms
 
+    /// Where a transform's target comes from.
+    ///
+    /// Two cases rather than an optional selection, because the answer
+    /// "nothing was selected" and the answer "nobody said" are different and an
+    /// optional cannot hold both. Flattened into one, a command that began with
+    /// nothing selected fell through to the shared slot and picked up whatever
+    /// a newer press had put there — the same crossing `Press.selection` exists
+    /// to stop, surviving in the nil case.
+    private enum Target {
+        /// Read the selection now. The menu and the offer run while the slot is
+        /// still the press's own.
+        case whateverIsSelected
+        /// What a spoken command froze when its recording began, which may be
+        /// nothing. A command never reads the slot and never clears it: by the
+        /// time a decoder has answered, a newer press can own it.
+        case frozen(SelectionReader.Selection?)
+    }
+
     /// Runs a prompt over the selection, or over the last dictation.
     ///
     /// The selection is taken from the snapshot made when the hotkey went down,
@@ -2239,7 +2257,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func runTransform(
         _ transform: Config.Transform, instruction: String,
         progress inherited: Int?, confirm: Bool = true,
-        over frozen: SelectionReader.Selection? = nil
+        over target: Target = .whateverIsSelected
     ) {
         // Never the clipboard. `read()` falls back to it for the correction
         // panel, where you see the words before anything happens and can
@@ -2251,15 +2269,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // speaker meant sat in the last transcript, unused.
         //
         // A spoken command brings its own, frozen when its recording began —
-        // see `Press.selection`. It must not read the slot here: by the time a
-        // decoder has answered, a second press can have overwritten it, and the
-        // command would edit that press's selection instead of its own.
-        let selection = frozen ?? selectionAtPress ?? (
-            Permissions.accessibility == .granted
-                ? SelectionReader.read(fallbackTo: false)
-                : nil
-        )
-        selectionAtPress = nil
+        // see `Press.selection` and `Target`. It neither reads the slot nor
+        // clears it: by the time a decoder has answered, a newer press can own
+        // what is in there.
+        let selection: SelectionReader.Selection?
+        switch target {
+        case .frozen(let held):
+            selection = held
+        case .whateverIsSelected:
+            selection = selectionAtPress ?? (
+                Permissions.accessibility == .granted
+                    ? SelectionReader.read(fallbackTo: false)
+                    : nil
+            )
+            selectionAtPress = nil
+        }
 
         // Falling back to the last dictation is what makes "hey parrot, fix the
         // grammar" work immediately after speaking, with nothing selected.
@@ -4037,7 +4061,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 return
             }
             Log.write("command spoken: \"\(trimmed)\"")
-            handleVoiceCommand(trimmed, confirm: false, over: press.selection)
+            handleVoiceCommand(trimmed, confirm: false, over: .frozen(press.selection))
             return
         }
 
@@ -4046,7 +4070,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if let command = commandAfterWakePhrase(trimmed) {
             Log.write("command heard: \"\(command)\"")
             dictationEnded(press.run)
-            handleVoiceCommand(command, over: press.selection)
+            handleVoiceCommand(command, over: .frozen(press.selection))
             return
         }
 

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1985,7 +1985,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
     }
 
-    private func handleVoiceCommand(_ command: String) {
+    /// `confirm: false` applies a rewrite in place instead of previewing it.
+    ///
+    /// The gesture path passes it. Tap-then-hold has already named its target
+    /// on the pill and offered ⎋ for the whole time you were speaking, and
+    /// "hey parrot, undo" puts the substitution back afterwards — so a preview
+    /// is a question that was answered twice before it was asked. The wake
+    /// phrase does not pass it: that one is found in a sentence rather than
+    /// declared by a key, so being wrong about it is a real possibility.
+    private func handleVoiceCommand(_ command: String, confirm: Bool = true) {
         let catalogue = Catalogue(transforms: config.transforms)
 
         // Deterministic phrases first: no model needed, and they work when
@@ -1999,7 +2007,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         if let capability = Router.local(instruction: command, catalogue: catalogue) {
             Log.write("router: \"\(command)\" named \(capability.name) outright")
-            run(capability, instruction: command, progress: nil)
+            run(capability, instruction: command, progress: nil, confirm: confirm)
             return
         }
 
@@ -2026,7 +2034,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     switch decision {
                     case .matched(let capability):
                         Log.write("router: \"\(command)\" → \(capability.name)")
-                        self.run(capability, instruction: command, progress: token)
+                        self.run(
+                            capability, instruction: command,
+                            progress: token, confirm: confirm
+                        )
                     case .anything:
                         // An edit with no prompt behind it. The instruction is
                         // the whole specification, so it goes through unsplit,
@@ -2034,7 +2045,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         Log.write("router: \"\(command)\" → \(FreeForm.name)")
                         self.runTransform(
                             FreeForm.prompt(for: command).asTransform(model: catchAll),
-                            instruction: command, progress: token
+                            instruction: command, progress: token, confirm: confirm
                         )
                     case .none:
                         // Nothing fits. Deliberately not falling through to
@@ -2060,7 +2071,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     Log.write("routing failed: \(error.localizedDescription)")
                     self.endProgress(token: token)
                     let asked = self.askForKeyThenRetry(error) {
-                        self.handleVoiceCommand(command)
+                        self.handleVoiceCommand(command, confirm: confirm)
                     }
                     if !asked { self.flash(error.localizedDescription, tone: .failure) }
                 }
@@ -2073,7 +2084,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `progress` is the "Thinking…" the router put up, where a router ran, so
     /// whichever branch ends without putting its own message up takes that one
     /// down and nothing else.
-    private func run(_ capability: Capability, instruction: String, progress token: Int?) {
+    private func run(
+        _ capability: Capability, instruction: String,
+        progress token: Int?, confirm: Bool = true
+    ) {
         switch capability {
         case .action(.vocabulary):
             endProgress(token: token)
@@ -2081,7 +2095,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         case .action(.spelling):
             interpretSpelling(instruction, progress: token)
         case .transform(let transform):
-            runTransform(transform, instruction: instruction, progress: token)
+            runTransform(
+                transform, instruction: instruction, progress: token, confirm: confirm
+            )
         }
     }
 
@@ -2197,7 +2213,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// not read now — by the time this runs, our own panel may hold focus, and
     /// reading then returns nothing or something of ours.
     private func runTransform(
-        _ transform: Config.Transform, instruction: String, progress inherited: Int?
+        _ transform: Config.Transform, instruction: String,
+        progress inherited: Int?, confirm: Bool = true
     ) {
         // Never the clipboard. `read()` falls back to it for the correction
         // panel, where you see the words before anything happens and can
@@ -2228,7 +2245,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // wrong thing is otherwise indistinguishable in the log from one that
         // worked on the right thing badly.
         Log.write("transform: \(transform.name) over \(selection == nil ? "the last dictation" : "the selection") — \"\(target.prefix(80))\"")
-        runTransform(transform, instruction: instruction, selection: selection, on: target)
+        runTransform(
+            transform, instruction: instruction, selection: selection, on: target,
+            confirm: confirm
+        )
     }
 
     /// The run itself, over text already decided.
@@ -2242,7 +2262,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         _ transform: Config.Transform,
         instruction: String,
         selection: SelectionReader.Selection?,
-        on target: String
+        on target: String,
+        confirm: Bool = true
     ) {
         let token = beginProgress(transform.progressLabel)
 
@@ -2254,7 +2275,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 await MainActor.run {
                     self?.finishTransform(
                         transform: transform, selection: selection,
-                        before: target, after: result, progress: token
+                        before: target, after: result,
+                        progress: token, confirm: confirm
                     )
                 }
             } catch {
@@ -2265,7 +2287,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     let asked = self.askForKeyThenRetry(error) {
                         self.runTransform(
                             transform, instruction: instruction,
-                            selection: selection, on: target
+                            selection: selection, on: target, confirm: confirm
                         )
                     }
                     if !asked { self.flash(error.localizedDescription, tone: .failure) }
@@ -2279,7 +2301,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         selection: SelectionReader.Selection?,
         before: String,
         after: String,
-        progress token: Int?
+        progress token: Int?,
+        confirm: Bool = true
     ) {
         endProgress(token: token)
 
@@ -2303,7 +2326,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        guard transform.confirm else {
+        // `confirm: false` overrides the transform's own setting, the way the
+        // offer's chips already do. A preview is for a command whose target you
+        // could have got wrong; tap-then-hold has already shown you the target
+        // on the pill and given you ⎋ to take it back, and the undo phrase
+        // survives the rewrite. Asking again after all that is a second answer
+        // to a question already answered.
+        guard transform.confirm, confirm else {
             applyTransform(cleaned, to: selection, replacing: before, transform: transform)
             return
         }
@@ -3978,7 +4007,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 return
             }
             Log.write("command spoken: \"\(trimmed)\"")
-            handleVoiceCommand(trimmed)
+            handleVoiceCommand(trimmed, confirm: false)
             return
         }
 

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -186,6 +186,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         /// gesture whose pill reads "editing the selection" is the one thing it
         /// must not do.
         var selection: SelectionReader.Selection?
+        /// The dictation this command would fall back to, frozen with it.
+        ///
+        /// "Make it terse" with nothing selected means the sentence that was
+        /// there when you said it. `lastTranscript` is one slot like the
+        /// selection is, and a dictation finishing while the router thinks
+        /// replaces it — so the command rewrote a sentence that arrived after
+        /// the instruction for it. Freezing the selection alone left this half
+        /// of the same crossing open.
+        var transcript: String?
     }
 
     /// The words the offer on screen is about, and the field they went into.
@@ -1778,7 +1787,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // Still this press's: the recording has only just stopped and no
             // newer press can have landed. The gap this closes is the decode
             // that follows, not this moment.
-            selection: selectionAtPress
+            selection: selectionAtPress,
+            // The dictation before this one, which is what a command with
+            // nothing selected is about.
+            transcript: lastTranscript
         )
         Task { [weak self] in
             // Whatever happens below — decoded, cancelled, or thrown — nothing
@@ -2116,7 +2128,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             endProgress(token: token)
             beginCorrection()
         case .action(.spelling):
-            interpretSpelling(instruction, progress: token)
+            interpretSpelling(instruction, progress: token, over: target)
         case .transform(let transform):
             runTransform(
                 transform, instruction: instruction,
@@ -2186,7 +2198,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// The spelling extractor, which is a second model call rather than part of
     /// routing — it reads the last transcript and returns a rule, not a name.
-    private func interpretSpelling(_ command: String, progress inherited: Int?) {
+    private func interpretSpelling(
+        _ command: String, progress inherited: Int?,
+        over target: Target = .whateverIsSelected
+    ) {
         guard config.llmEnabled else {
             endProgress(token: inherited)
             flash("Didn't understand \"\(command)\" — enable llm in config for free-form commands", tone: .caution)
@@ -2195,7 +2210,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let token = beginProgress("Thinking…")
         let llmConfig = llmConfig()
-        let context = lastTranscript
+        // The dictation the spelling is about, frozen with the command that
+        // asked. This one reads the transcript for its whole job — "Tasmin
+        // spells T A S M E E N" finds the word in what you said before — so a
+        // newer dictation replacing it while the router thought would have sent
+        // the model looking in the wrong sentence.
+        let context: String?
+        switch target {
+        case .frozen(_, let fallback): context = fallback
+        case .whateverIsSelected: context = lastTranscript
+        }
         // From the transcript, never the command: the command is short and its
         // trigger word plus a run of loose capitals reads as English whatever
         // was actually said.
@@ -2243,10 +2267,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         /// Read the selection now. The menu and the offer run while the slot is
         /// still the press's own.
         case whateverIsSelected
-        /// What a spoken command froze when its recording began, which may be
-        /// nothing. A command never reads the slot and never clears it: by the
-        /// time a decoder has answered, a newer press can own it.
-        case frozen(SelectionReader.Selection?)
+        /// What a spoken command froze when its recording began: the
+        /// selection, which may be nothing, and the dictation to fall back to,
+        /// which may also be nothing. A command reads neither slot and clears
+        /// neither: by the time a decoder has answered, a newer press can own
+        /// what is in them.
+        case frozen(selection: SelectionReader.Selection?, fallback: String?)
     }
 
     /// Runs a prompt over the selection, or over the last dictation.
@@ -2273,9 +2299,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // clears it: by the time a decoder has answered, a newer press can own
         // what is in there.
         let selection: SelectionReader.Selection?
+        let dictated: String?
         switch target {
-        case .frozen(let held):
+        case .frozen(let held, let fallback):
             selection = held
+            dictated = fallback
         case .whateverIsSelected:
             selection = selectionAtPress ?? (
                 Permissions.accessibility == .granted
@@ -2283,11 +2311,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     : nil
             )
             selectionAtPress = nil
+            dictated = lastTranscript
         }
 
         // Falling back to the last dictation is what makes "hey parrot, fix the
         // grammar" work immediately after speaking, with nothing selected.
-        let target = selection?.text ?? lastTranscript ?? ""
+        let target = selection?.text ?? dictated ?? ""
         guard !target.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             endProgress(token: inherited)
             Log.write("transform: nothing selected and nothing dictated yet")
@@ -4061,7 +4090,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 return
             }
             Log.write("command spoken: \"\(trimmed)\"")
-            handleVoiceCommand(trimmed, confirm: false, over: .frozen(press.selection))
+            handleVoiceCommand(trimmed, confirm: false, over: .frozen(selection: press.selection, fallback: press.transcript))
             return
         }
 
@@ -4070,7 +4099,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if let command = commandAfterWakePhrase(trimmed) {
             Log.write("command heard: \"\(command)\"")
             dictationEnded(press.run)
-            handleVoiceCommand(command, over: .frozen(press.selection))
+            handleVoiceCommand(command, over: .frozen(selection: press.selection, fallback: press.transcript))
             return
         }
 

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -175,6 +175,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         /// landing mid-transcription must not be able to change what this one
         /// was for.
         var isCommand = false
+        /// What was selected when this recording began.
+        ///
+        /// Frozen for the reason every other field here is. `selectionAtPress`
+        /// is one slot that the next press overwrites, and a spoken command
+        /// reads its target *after* the decoder has run — so starting a second
+        /// dictation while a command is still decoding pointed that command at
+        /// the newer press's selection. "Make it bold" then applied to whatever
+        /// happened to be highlighted by the time it finished, which on a
+        /// gesture whose pill reads "editing the selection" is the one thing it
+        /// must not do.
+        var selection: SelectionReader.Selection?
     }
 
     /// The words the offer on screen is about, and the field they went into.
@@ -1763,7 +1774,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // Plain when nobody was in front, which is the answer that cannot
             // lose a sentence.
             paste: appAtPress.map { AppProfile.of($0).paste } ?? .plain,
-            isCommand: commandAtPress
+            isCommand: commandAtPress,
+            // Still this press's: the recording has only just stopped and no
+            // newer press can have landed. The gap this closes is the decode
+            // that follows, not this moment.
+            selection: selectionAtPress
         )
         Task { [weak self] in
             // Whatever happens below — decoded, cancelled, or thrown — nothing
@@ -1993,7 +2008,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// is a question that was answered twice before it was asked. The wake
     /// phrase does not pass it: that one is found in a sentence rather than
     /// declared by a key, so being wrong about it is a real possibility.
-    private func handleVoiceCommand(_ command: String, confirm: Bool = true) {
+    private func handleVoiceCommand(
+        _ command: String, confirm: Bool = true,
+        over frozen: SelectionReader.Selection? = nil
+    ) {
         let catalogue = Catalogue(transforms: config.transforms)
 
         // Deterministic phrases first: no model needed, and they work when
@@ -2007,7 +2025,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         if let capability = Router.local(instruction: command, catalogue: catalogue) {
             Log.write("router: \"\(command)\" named \(capability.name) outright")
-            run(capability, instruction: command, progress: nil, confirm: confirm)
+            run(
+                capability, instruction: command,
+                progress: nil, confirm: confirm, over: frozen
+            )
             return
         }
 
@@ -2036,7 +2057,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         Log.write("router: \"\(command)\" → \(capability.name)")
                         self.run(
                             capability, instruction: command,
-                            progress: token, confirm: confirm
+                            progress: token, confirm: confirm, over: frozen
                         )
                     case .anything:
                         // An edit with no prompt behind it. The instruction is
@@ -2045,7 +2066,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         Log.write("router: \"\(command)\" → \(FreeForm.name)")
                         self.runTransform(
                             FreeForm.prompt(for: command).asTransform(model: catchAll),
-                            instruction: command, progress: token, confirm: confirm
+                            instruction: command, progress: token,
+                            confirm: confirm, over: frozen
                         )
                     case .none:
                         // Nothing fits. Deliberately not falling through to
@@ -2071,7 +2093,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     Log.write("routing failed: \(error.localizedDescription)")
                     self.endProgress(token: token)
                     let asked = self.askForKeyThenRetry(error) {
-                        self.handleVoiceCommand(command, confirm: confirm)
+                        self.handleVoiceCommand(command, confirm: confirm, over: frozen)
                     }
                     if !asked { self.flash(error.localizedDescription, tone: .failure) }
                 }
@@ -2086,7 +2108,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// down and nothing else.
     private func run(
         _ capability: Capability, instruction: String,
-        progress token: Int?, confirm: Bool = true
+        progress token: Int?, confirm: Bool = true,
+        over frozen: SelectionReader.Selection? = nil
     ) {
         switch capability {
         case .action(.vocabulary):
@@ -2096,7 +2119,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             interpretSpelling(instruction, progress: token)
         case .transform(let transform):
             runTransform(
-                transform, instruction: instruction, progress: token, confirm: confirm
+                transform, instruction: instruction,
+                progress: token, confirm: confirm, over: frozen
             )
         }
     }
@@ -2214,7 +2238,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// reading then returns nothing or something of ours.
     private func runTransform(
         _ transform: Config.Transform, instruction: String,
-        progress inherited: Int?, confirm: Bool = true
+        progress inherited: Int?, confirm: Bool = true,
+        over frozen: SelectionReader.Selection? = nil
     ) {
         // Never the clipboard. `read()` falls back to it for the correction
         // panel, where you see the words before anything happens and can
@@ -2224,7 +2249,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // That is exactly what happened: "convert numbers to digits" ran over
         // a comment line copied minutes earlier, while the sentence the
         // speaker meant sat in the last transcript, unused.
-        let selection = selectionAtPress ?? (
+        //
+        // A spoken command brings its own, frozen when its recording began —
+        // see `Press.selection`. It must not read the slot here: by the time a
+        // decoder has answered, a second press can have overwritten it, and the
+        // command would edit that press's selection instead of its own.
+        let selection = frozen ?? selectionAtPress ?? (
             Permissions.accessibility == .granted
                 ? SelectionReader.read(fallbackTo: false)
                 : nil
@@ -4007,7 +4037,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 return
             }
             Log.write("command spoken: \"\(trimmed)\"")
-            handleVoiceCommand(trimmed, confirm: false)
+            handleVoiceCommand(trimmed, confirm: false, over: press.selection)
             return
         }
 
@@ -4016,7 +4046,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if let command = commandAfterWakePhrase(trimmed) {
             Log.write("command heard: \"\(command)\"")
             dictationEnded(press.run)
-            handleVoiceCommand(command)
+            handleVoiceCommand(command, over: press.selection)
             return
         }
 

--- a/Sources/ParrotFlow/HotKeyManager.swift
+++ b/Sources/ParrotFlow/HotKeyManager.swift
@@ -49,7 +49,10 @@ final class HotKeyManager {
         }
     }
 
-    var onPress: (() -> Void)?
+    /// The key is being held. `afterTap` says a tap led straight into this
+    /// hold — see `ModifierKeyMonitor.onPress`. Always false on the Carbon
+    /// path, which has no tap to lead with.
+    var onPress: ((_ afterTap: Bool) -> Void)?
     var onRelease: (() -> Void)?
     /// A press already delivered turned out to be part of a shortcut — see
     /// `ModifierKeyMonitor`. Never fires on the Carbon path: a combo is
@@ -70,7 +73,7 @@ final class HotKeyManager {
     private let signature: OSType = 0x50_46_4C_57  // 'PFLW'
 
     init() {
-        modifierMonitor.onPress = { [weak self] in self?.onPress?() }
+        modifierMonitor.onPress = { [weak self] afterTap in self?.onPress?(afterTap) }
         modifierMonitor.onRelease = { [weak self] in self?.onRelease?() }
         modifierMonitor.onAbort = { [weak self] in self?.onAbort?() }
         modifierMonitor.onTap = { [weak self] in self?.onTap?() }
@@ -153,7 +156,7 @@ final class HotKeyManager {
                 let kind = GetEventKind(event)
                 DispatchQueue.main.async {
                     if kind == UInt32(kEventHotKeyPressed) {
-                        manager.onPress?()
+                        manager.onPress?(false)
                     } else if kind == UInt32(kEventHotKeyReleased) {
                         manager.onRelease?()
                     }

--- a/Sources/ParrotFlow/ModifierKey.swift
+++ b/Sources/ParrotFlow/ModifierKey.swift
@@ -338,8 +338,18 @@ final class ModifierKeyMonitor {
         guard wasTap else { return }
         tappedAt = Self.physicalEdge()
         let timer = Timer(timeInterval: Self.tapGrace, repeats: false) { [weak self] _ in
-            self?.tapTimer = nil
-            self?.onTap?()
+            guard let self else { return }
+            self.tapTimer = nil
+            // The key is down again already. The poll has not caught up with a
+            // press made inside the window — it will, and `beginHold` will
+            // classify it from the physical edges as the tap-and-hold it is.
+            // Summoning the offer here as well would answer one gesture twice:
+            // the pill would arrive and then the microphone would open over it.
+            //
+            // Asked of the flags rather than of `isDown`, which is the poll's
+            // view and is exactly what has not caught up yet.
+            guard self.key?.isPressed != true else { return }
+            self.onTap?()
         }
         RunLoop.main.add(timer, forMode: .common)
         tapTimer = timer

--- a/Sources/ParrotFlow/ModifierKey.swift
+++ b/Sources/ParrotFlow/ModifierKey.swift
@@ -185,14 +185,14 @@ final class ModifierKeyMonitor {
     private var armTimer: Timer?
     /// A tap waiting to find out whether a hold is coming after it.
     private var tapTimer: Timer?
-    /// When the tap was released.
+    /// When the tap was physically released.
     ///
-    /// The grace window is measured from this and not from `tapTimer` being
-    /// alive. The down edge is found by a 25 ms poll, so a second press made at
-    /// 0.399 s can be *seen* at 0.415 s — after the 0.4 s timer has fired and
-    /// cleared itself. Read off the timer, that press starts a dictation; read
-    /// off the clock, it is the tap-and-hold it was. The poll's lag must not
-    /// decide which gesture somebody made.
+    /// The grace window is measured between this and the next physical press,
+    /// and both are corrected for the poll — see `physicalEdge()`. Neither the
+    /// timer's liveness nor the moment the poll noticed will do. A second press
+    /// made at 0.399 s is seen up to 25 ms later, so measured off the poll it
+    /// falls outside a 0.4 s window and starts an ordinary dictation. The
+    /// poll's lag must not decide which gesture somebody made.
     private var tappedAt: Date?
     /// This hold began inside `tapGrace` of a tap, so it is tap-then-hold.
     private var afterTap = false
@@ -284,12 +284,14 @@ final class ModifierKeyMonitor {
         isSpent = false
         pressDelivered = false
         // A tap inside the grace window is this gesture's first half, not a
-        // gesture of its own. Timed from the release rather than from the
-        // timer, so the poll's lag cannot reclassify it — see `tappedAt`. A
+        // gesture of its own. Both ends are physical times, so the poll's lag
+        // cannot reclassify a press made inside the window — see `tappedAt`. A
         // pending timer is cancelled rather than delivered either way:
         // summoning the pill and then opening the microphone over it is two
         // answers to one request.
-        afterTap = tappedAt.map { Date().timeIntervalSince($0) < Self.tapGrace } ?? false
+        afterTap = tappedAt.map {
+            Self.physicalEdge().timeIntervalSince($0) < Self.tapGrace
+        } ?? false
         tappedAt = nil
         tapTimer?.invalidate()
         tapTimer = nil
@@ -334,7 +336,7 @@ final class ModifierKeyMonitor {
         endHold()
         guard !wasPressed else { onRelease?(); return }
         guard wasTap else { return }
-        tappedAt = Date()
+        tappedAt = Self.physicalEdge()
         let timer = Timer(timeInterval: Self.tapGrace, repeats: false) { [weak self] _ in
             self?.tapTimer = nil
             self?.onTap?()
@@ -367,6 +369,26 @@ final class ModifierKeyMonitor {
     }
 
     // MARK: Watching for everything that is not the key
+
+    /// When the modifier edge the poll has just noticed actually happened.
+    ///
+    /// The poll runs every 25 ms, so `Date()` here is the moment it looked and
+    /// not the moment the key moved. `secondsSinceLastEventType` gives the age
+    /// of the last `flagsChanged`, which is that edge, and subtracting it
+    /// recovers the physical time. Same API and same reasoning as
+    /// `sawInputBeforeTheMonitors` below, which exists because this poll is
+    /// late in exactly this way.
+    ///
+    /// It costs no permission: the age of an event is not the event.
+    private static func physicalEdge() -> Date {
+        let age = CGEventSource.secondsSinceLastEventType(
+            .combinedSessionState, eventType: .flagsChanged
+        )
+        // A negative or absurd answer means no such event is on record; the
+        // poll's own clock is then the best available.
+        guard age.isFinite, age >= 0, age < 1 else { return Date() }
+        return Date().addingTimeInterval(-age)
+    }
 
     /// Whether a key or a click landed between the modifier going down and the
     /// poll noticing it.

--- a/Sources/ParrotFlow/ModifierKey.swift
+++ b/Sources/ParrotFlow/ModifierKey.swift
@@ -289,9 +289,7 @@ final class ModifierKeyMonitor {
         // pending timer is cancelled rather than delivered either way:
         // summoning the pill and then opening the microphone over it is two
         // answers to one request.
-        afterTap = tappedAt.map {
-            Self.physicalEdge().timeIntervalSince($0) < Self.tapGrace
-        } ?? false
+        afterTap = pressIsTheTapsSecondHalf()
         tappedAt = nil
         tapTimer?.invalidate()
         tapTimer = nil
@@ -340,15 +338,20 @@ final class ModifierKeyMonitor {
         let timer = Timer(timeInterval: Self.tapGrace, repeats: false) { [weak self] _ in
             guard let self else { return }
             self.tapTimer = nil
-            // The key is down again already. The poll has not caught up with a
-            // press made inside the window — it will, and `beginHold` will
-            // classify it from the physical edges as the tap-and-hold it is.
-            // Summoning the offer here as well would answer one gesture twice:
-            // the pill would arrive and then the microphone would open over it.
+            // A press the poll has not caught up with can already own this
+            // gesture. `beginHold` will classify it from the physical edges as
+            // tap-and-hold, and summoning the offer here as well would answer
+            // one gesture twice — the pill arriving and then the microphone
+            // opening over it.
             //
-            // Asked of the flags rather than of `isDown`, which is the poll's
-            // view and is exactly what has not caught up yet.
-            guard self.key?.isPressed != true else { return }
+            // Both halves of the test matter. A key that is down but whose
+            // press landed outside the window is an ordinary dictation, and the
+            // tap it followed still deserves its offer. Asked of the flags
+            // rather than of `isDown`, which is the poll's view and is exactly
+            // what has not caught up yet.
+            guard self.key?.isPressed != true || !self.pressIsTheTapsSecondHalf() else {
+                return
+            }
             self.onTap?()
         }
         RunLoop.main.add(timer, forMode: .common)
@@ -379,6 +382,25 @@ final class ModifierKeyMonitor {
     }
 
     // MARK: Watching for everything that is not the key
+
+    /// Whether the press being looked at now is the second half of the tap
+    /// just made.
+    ///
+    /// One rule, asked in two places, because two places decide the same thing
+    /// and disagreeing is what goes wrong. `beginHold` asks it to classify the
+    /// press; the grace timer asks it to find out whether a press is already
+    /// holding the gesture, and so whether summoning the offer would answer
+    /// that gesture a second time.
+    ///
+    /// Written as its own answer rather than inlined twice: the first attempt
+    /// had the timer ask the cheaper question "is the key down at all", which
+    /// suppressed the offer for a press that landed *outside* the window and
+    /// was going to start an ordinary dictation. The tap then vanished for no
+    /// reason anybody could see.
+    private func pressIsTheTapsSecondHalf() -> Bool {
+        guard let tapped = tappedAt else { return false }
+        return Self.physicalEdge().timeIntervalSince(tapped) < Self.tapGrace
+    }
 
     /// When the modifier edge the poll has just noticed actually happened.
     ///

--- a/Sources/ParrotFlow/ModifierKey.swift
+++ b/Sources/ParrotFlow/ModifierKey.swift
@@ -185,6 +185,15 @@ final class ModifierKeyMonitor {
     private var armTimer: Timer?
     /// A tap waiting to find out whether a hold is coming after it.
     private var tapTimer: Timer?
+    /// When the tap was released.
+    ///
+    /// The grace window is measured from this and not from `tapTimer` being
+    /// alive. The down edge is found by a 25 ms poll, so a second press made at
+    /// 0.399 s can be *seen* at 0.415 s — after the 0.4 s timer has fired and
+    /// cleared itself. Read off the timer, that press starts a dictation; read
+    /// off the clock, it is the tap-and-hold it was. The poll's lag must not
+    /// decide which gesture somebody made.
+    private var tappedAt: Date?
     /// This hold began inside `tapGrace` of a tap, so it is tap-then-hold.
     private var afterTap = false
 
@@ -243,6 +252,7 @@ final class ModifierKeyMonitor {
         timer = nil
         tapTimer?.invalidate()
         tapTimer = nil
+        tappedAt = nil
         endHold()
         key = nil
         isDown = false
@@ -273,11 +283,14 @@ final class ModifierKeyMonitor {
     private func beginHold() {
         isSpent = false
         pressDelivered = false
-        // A tap still waiting out its grace is this gesture's first half, not a
-        // gesture of its own. Cancelled rather than delivered: summoning the
-        // pill and then opening the microphone over it is two answers to one
-        // request.
-        afterTap = tapTimer != nil
+        // A tap inside the grace window is this gesture's first half, not a
+        // gesture of its own. Timed from the release rather than from the
+        // timer, so the poll's lag cannot reclassify it — see `tappedAt`. A
+        // pending timer is cancelled rather than delivered either way:
+        // summoning the pill and then opening the microphone over it is two
+        // answers to one request.
+        afterTap = tappedAt.map { Date().timeIntervalSince($0) < Self.tapGrace } ?? false
+        tappedAt = nil
         tapTimer?.invalidate()
         tapTimer = nil
         watchForOtherInput()
@@ -321,6 +334,7 @@ final class ModifierKeyMonitor {
         endHold()
         guard !wasPressed else { onRelease?(); return }
         guard wasTap else { return }
+        tappedAt = Date()
         let timer = Timer(timeInterval: Self.tapGrace, repeats: false) { [weak self] _ in
             self?.tapTimer = nil
             self?.onTap?()

--- a/Sources/ParrotFlow/ModifierKey.swift
+++ b/Sources/ParrotFlow/ModifierKey.swift
@@ -153,7 +153,11 @@ enum ModifierKey: String, CaseIterable {
 /// watch falls back to its modifier half there. Left as is: a modifier held
 /// alone is not what happens while somebody is typing a password.
 final class ModifierKeyMonitor {
-    var onPress: (() -> Void)?
+    /// The key is being held. `afterTap` is a hold that a tap led straight
+    /// into — tap, release, press again — which is a different request from a
+    /// plain hold and is delivered here rather than through a callback of its
+    /// own, so no caller can wire one and forget the other.
+    var onPress: ((_ afterTap: Bool) -> Void)?
     var onRelease: (() -> Void)?
     /// A press that was already delivered turned out to be a shortcut. Whoever
     /// started a dictation on `onPress` has to drop it, silently: the user
@@ -164,9 +168,13 @@ final class ModifierKeyMonitor {
     ///
     /// This edge already existed and already did nothing: a hold shorter than
     /// the delay never delivers a press, so `onRelease` does not fire for it
-    /// either. Naming it costs the dictation path nothing, because a tap is
-    /// decided by the release rather than by waiting to see whether one is
-    /// coming.
+    /// either. Naming it costs the *dictation* path nothing — that one is
+    /// untouched, because a hold is still delivered on its own timing.
+    ///
+    /// It costs the tap `tapGrace`. A tap is held back that long to see whether
+    /// a hold follows it, because tap-then-hold has to be told from a tap and
+    /// the only difference is what happens next. Nothing waits on a pill, so
+    /// this is the cheap side of the trade.
     ///
     /// Never fires at `pressDelay` of 0 — there the press goes out on the down
     /// edge, so every hold has delivered one by the time it ends.
@@ -175,6 +183,18 @@ final class ModifierKeyMonitor {
     private var timer: Timer?
     private var monitors: [Any] = []
     private var armTimer: Timer?
+    /// A tap waiting to find out whether a hold is coming after it.
+    private var tapTimer: Timer?
+    /// This hold began inside `tapGrace` of a tap, so it is tap-then-hold.
+    private var afterTap = false
+
+    /// How long a tap waits for a hold to follow it.
+    ///
+    /// Long enough to release the key and press it again deliberately, short
+    /// enough that a tap meant on its own does not feel ignored. It buys the
+    /// two gestures a shared prefix: the tap says "me", and what happens inside
+    /// this window says what.
+    static let tapGrace: TimeInterval = 0.4
 
     private var key: ModifierKey?
     private var pressDelay: TimeInterval = 0
@@ -221,6 +241,8 @@ final class ModifierKeyMonitor {
     func stop() {
         timer?.invalidate()
         timer = nil
+        tapTimer?.invalidate()
+        tapTimer = nil
         endHold()
         key = nil
         isDown = false
@@ -251,6 +273,13 @@ final class ModifierKeyMonitor {
     private func beginHold() {
         isSpent = false
         pressDelivered = false
+        // A tap still waiting out its grace is this gesture's first half, not a
+        // gesture of its own. Cancelled rather than delivered: summoning the
+        // pill and then opening the microphone over it is two answers to one
+        // request.
+        afterTap = tapTimer != nil
+        tapTimer?.invalidate()
+        tapTimer = nil
         watchForOtherInput()
 
         guard pressDelay > 0 else {
@@ -276,7 +305,7 @@ final class ModifierKeyMonitor {
     private func deliverPress() {
         guard isDown, !isSpent, !pressDelivered else { return }
         pressDelivered = true
-        onPress?()
+        onPress?(afterTap)
     }
 
     private func finishHold() {
@@ -284,9 +313,20 @@ final class ModifierKeyMonitor {
         // `isSpent` is the whole of what keeps a shortcut out. ⌥P types π on a
         // French layout and is over in well under the delay, but the P marks
         // the hold, so it can never be read as a tap.
-        let wasTap = !wasPressed && !isSpent
+        //
+        // A tap that followed a tap is not a second tap. Two of them in a row
+        // is somebody who meant to tap-and-hold and let go too early, and
+        // summoning twice for it would be answering a gesture nobody made.
+        let wasTap = !wasPressed && !isSpent && !afterTap
         endHold()
-        if wasPressed { onRelease?() } else if wasTap { onTap?() }
+        guard !wasPressed else { onRelease?(); return }
+        guard wasTap else { return }
+        let timer = Timer(timeInterval: Self.tapGrace, repeats: false) { [weak self] _ in
+            self?.tapTimer = nil
+            self?.onTap?()
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        tapTimer = timer
     }
 
     /// The one path out of a hold that was meant for something else. Delivered
@@ -306,6 +346,7 @@ final class ModifierKeyMonitor {
 
     private func endHold() {
         armTimer?.invalidate(); armTimer = nil
+        afterTap = false
         removeMonitors()
         pressDelivered = false
         isSpent = false

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -146,7 +146,7 @@ enum PanelsCommand {
             )
         ))
 
-        let overlay = pill(.recording, icon: sampleIcon(), level: 0.75)
+        let overlay = pill(.recording(nil), icon: sampleIcon(), level: 0.75)
 
         // The pill has two states now and the difference is the whole point of
         // the slot: with somewhere to type it holds that app's icon, with
@@ -154,7 +154,14 @@ enum PanelsCommand {
         // are told the words are going to the clipboard instead. Both are on
         // the sheet because "it looks wrong with no icon" is the kind of thing
         // that is obvious side by side and invisible a week apart.
-        let overlayBlind = pill(.recording, level: 0.75)
+        let overlayBlind = pill(.recording(nil), level: 0.75)
+
+        // And the third, which is not dictation at all: tap-then-hold, where
+        // what you say is routed instead of written down. The label is the only
+        // thing that says so, which is exactly why it belongs on this sheet.
+        let overlayCommand = pill(
+            .recording("editing the selection"), icon: sampleIcon(), level: 0.75
+        )
 
         // A row the spell check proposed, half filled in, and a row typed by
         // hand — the two shapes the panel exists for, side by side.
@@ -207,6 +214,8 @@ enum PanelsCommand {
              pillSize(overlay), .dark, true),
             (AnyView(PillView().environmentObject(overlayBlind)),
              pillSize(overlayBlind), .dark, true),
+            (AnyView(PillView().environmentObject(overlayCommand)),
+             pillSize(overlayCommand), .dark, true),
             // The one real window the app has, and the first thing anyone sees.
             // On the sheet for the same reason as the rest: it is looked at,
             // not asserted on, and two screens that drift apart are obvious

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -435,7 +435,7 @@ private struct Instrument: View {
     /// Mid-sentence, so the meter has something to show.
     private static let hearing: PillModel = {
         let model = PillModel()
-        model.state = .recording
+        model.state = .recording(nil)
         model.level = 0.62
         return model
     }()

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -42,7 +42,13 @@ enum NoticeTone: Equatable {
 /// state change animates.
 enum PillState: Equatable {
     /// The mic is hot. Width depends on whether there is an app icon to show.
-    case recording
+    ///
+    /// The label is what this recording is *for*, and it is nil for the one
+    /// that needs no explaining: dictation. Tap-then-hold sets it, because a
+    /// hold that routes what you say instead of writing it down looks exactly
+    /// like one that writes it down, and the difference has to be readable
+    /// before you speak rather than after.
+    case recording(String?)
     /// Work of no predictable length — decoding, a prompt, a download.
     case working(String)
     /// A sentence, for a few seconds.
@@ -75,7 +81,7 @@ struct OfferedCommand: Equatable {
 }
 
 final class PillModel: ObservableObject {
-    @Published var state: PillState = .recording
+    @Published var state: PillState = .recording(nil)
 
     /// Whether the panel is on screen. False unmounts the surface.
     ///
@@ -178,11 +184,11 @@ final class PillHUD {
 
     // MARK: - The states
 
-    func recording(icon: NSImage?) {
+    func recording(icon: NSImage?, label: String? = nil) {
         model.elapsed = 0
         model.level = 0
         model.appIcon = icon
-        set(.recording)
+        set(.recording(label))
     }
 
     /// Stays up until something replaces it or `hide()` is called.
@@ -653,7 +659,7 @@ final class PillHUD {
     private func build() {
         let hosting = NSHostingView(rootView: PillView().environmentObject(model))
         hosting.frame = NSRect(origin: .zero,
-                               size: PillMetrics.panelSize(for: .recording, hasIcon: false))
+                               size: PillMetrics.panelSize(for: .recording(nil), hasIcon: false))
         // The panel is what resizes; the view follows it. Done this way round
         // because a SwiftUI frame inside a fixed panel centres a narrow pill in
         // a wide transparent box and takes the shadow with it.
@@ -978,7 +984,7 @@ enum PillMetrics {
 
     static func width(for state: PillState, hasIcon: Bool) -> CGFloat {
         switch state {
-        case .recording: return recording(hasIcon: hasIcon)
+        case .recording(let label): return recording(hasIcon: hasIcon, label: label)
         case .working(let message): return text(message)
         case .notice(let message, _): return text(message)
         case .offer(let commands, let headline, let reading):
@@ -988,9 +994,11 @@ enum PillMetrics {
 
     /// 15 + 8 + 10 + 66 + 15, and the icon after the meter when there is one
     /// to show.
-    static func recording(hasIcon: Bool) -> CGFloat {
+    static func recording(hasIcon: Bool, label: String? = nil) -> CGFloat {
         let base = padding * 2 + dot + gap + meter
-        return hasIcon ? base + icon + tuck : base
+        let width = hasIcon ? base + icon + tuck : base
+        guard let label else { return width }
+        return width + gap + title(label)
     }
 
     /// Wide enough for the message, the dot in front of it and the padding —
@@ -1135,8 +1143,8 @@ struct PillView: View {
         GeometryReader { geo in
             ZStack {
                 switch model.state {
-                case .recording:
-                    RecordingContent(level: model.level, icon: model.appIcon)
+                case .recording(let label):
+                    RecordingContent(level: model.level, icon: model.appIcon, label: label)
                         .transition(.opacity)
                 case .working(let message):
                     MessageContent(message: message, tone: .thinking)
@@ -1223,6 +1231,8 @@ struct PillView: View {
 private struct RecordingContent: View {
     let level: Float
     let icon: NSImage?
+    /// What this recording is for, when it is not dictation.
+    var label: String?
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var pulse = false
@@ -1246,6 +1256,14 @@ private struct RecordingContent: View {
                     .interpolation(.high)
                     .frame(width: PillMetrics.icon, height: PillMetrics.icon)
                     .padding(.leading, PillMetrics.tuck)
+            }
+
+            if let label {
+                Text(label)
+                    .font(.system(size: 12, weight: .medium, design: .rounded))
+                    .foregroundStyle(Color(white: 0.88))
+                    .fixedSize()
+                    .padding(.leading, PillMetrics.gap)
             }
         }
         .padding(.horizontal, PillMetrics.padding)

--- a/Sources/ParrotFlow/WatchModifiersCommand.swift
+++ b/Sources/ParrotFlow/WatchModifiersCommand.swift
@@ -59,7 +59,11 @@ enum WatchModifiersCommand {
             counts[edge, default: 0] += 1
             print("  \(edge)")
         }
-        monitor.onPress = { note("press   — a dictation would start here") }
+        monitor.onPress = { afterTap in
+            note(afterTap
+                ? "tap+hold — what you say would be routed as a command"
+                : "press   — a dictation would start here")
+        }
         monitor.onRelease = { note("release — and end here") }
         monitor.onAbort = { note("abort   — that was a shortcut") }
         monitor.onTap = { note("tap     — the offer would be summoned") }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -208,6 +208,14 @@ transform and the catch-all besides — with no phrase to remember, because the
 key already said it was an instruction. The pill says **editing the selection**
 or **say an edit** while you hold, and ⎋ cancels.
 
+**It applies in place**, whatever the transform's `confirm:` says — the same
+rule a chip on the pill already follows. The target was named on the pill
+before you spoke, ⎋ was live the whole time you were speaking, and
+`"hey parrot, undo"` puts the substitution back. A preview after all three is
+a question that was answered before it was asked. `"hey parrot, …"` still
+previews: that command is *found* in a sentence rather than declared by a key,
+so being wrong about it is a real possibility.
+
 A bare tap waits 0.4s before the pill appears, because that is how long it
 takes to find out whether a hold is coming. Nothing waits on a pill; the
 dictation path is untouched.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -186,13 +186,31 @@ also why apps in this category gravitate to `fn` or a right-hand modifier.
 
 ### Tap it to bring the offer back
 
-Hold the hotkey and you dictate. **Tap it** — shorter than
-`press_delay_seconds` — and the pill comes back with its commands on it.
+One key, three lengths. The tap means "me"; what you do next says what.
 
-| What is selected | What the offer is about |
+| Gesture | What happens |
+|---|---|
+| **Hold** | Dictate. Unchanged. |
+| **Tap** | The pill comes back, with its commands on it |
+| **Tap, then hold** | Speak an instruction — any command, not just the chips |
+
+A tap is a press shorter than `press_delay_seconds`. Tap and hold again within
+0.4s and the hold is the second half of one gesture rather than a dictation.
+
+| What is selected | What the gesture is about |
 |---|---|
 | A selection, anywhere | Those words, and the pill appears under them |
 | Nothing | The last dictation, and the pill stays where it was |
+
+**Tap-then-hold speaks the whole catalogue.** The chips are a short list; what
+you say is routed the way `"hey parrot, …"` is routed, so it reaches every
+transform and the catch-all besides — with no phrase to remember, because the
+key already said it was an instruction. The pill says **editing the selection**
+or **say an edit** while you hold, and ⎋ cancels.
+
+A bare tap waits 0.4s before the pill appears, because that is how long it
+takes to find out whether a hold is coming. Nothing waits on a pill; the
+dictation path is untouched.
 
 The selection wins because it is what you are pointing at now, and it is the
 only target the tap can have in an app ParrotFlow has never written into:


### PR DESCRIPTION
Tap the hotkey, then hold it again within 0.4s, and what you say is routed as an instruction instead of being written down. It reaches every transform and the catch-all, with no wake phrase, because the key already said this was a command. The pill reads **editing the selection** or **say an edit** while you hold, and ⎋ cancels the whole time. The rewrite applies in place rather than opening the preview panel, whatever the transform's `confirm:` says.

Nothing about dictation changes. A plain hold still starts a dictation on its own timing, and `"hey parrot, …"` still previews.

Start a review at `ModifierKeyMonitor.finishHold` — the tap is now held back for `tapGrace` before it fires, and that is the only timing change in the file. Then `PillMetrics.recording(hasIcon:label:)`, where the label widens the capsule.

<details>
<summary>Why a tap now waits 0.4s, and why that costs the dictation path nothing</summary>

Tap-then-hold has to be told from a tap, and the only difference between them is what happens next. So a tap is held for `ModifierKeyMonitor.tapGrace` to see whether a hold follows.

Nothing waits on a pill, so that is the cheap side of the trade. The dictation path is untouched: a hold is still delivered on its own `pressDelay` timing, and `beginHold` cancels a pending tap rather than delivering it — summoning the pill and then opening the microphone over it is two answers to one request.

Two taps in a row summon once. The second is somebody who meant to tap-and-hold and let go too early, not a second request.

</details>

<details>
<summary>Why the pill has to say what the hold is for, before you speak</summary>

A command hold is the same key, the same microphone and the same meter as a dictation. The only difference is that the words are routed instead of written down, and that has to be readable before you speak — not worked out afterwards from a sentence that never landed.

`.recording` carries an optional label for this. Nil is dictation, which needs no explaining. `--panels` draws all three recording pills side by side, which is what that sheet is for: a state that is sometimes there is one nobody looks at otherwise.

</details>

<details>
<summary>Why it applies in place, and why the wake phrase still previews</summary>

A preview guards a command whose target you could have got wrong. This one names its target on the pill before you speak, keeps ⎋ live for as long as you are speaking, and leaves `"hey parrot, undo"` behind afterwards. Asking again after all three answers a question twice.

It is the rule the offer's chips already follow — `runOfferedTransform` takes no preview whatever the transform says, and for the same reason.

`"hey parrot, …"` is different and keeps its preview. That command is *found* inside a sentence by a fuzzy matcher at 0.55 a word against a 0.7 floor, because the phrase arrives clipped. `tests/wake-cases.txt` holds the sentences about parrots it must not fire on. Being wrong about it is a real possibility rather than a theoretical one.

</details>

<details>
<summary>Conflicts resolved against PR #211 and the four commits main gained</summary>

Both commits were cherry-picked and both conflicted.

`ModifierKey.swift`, `HotKeyManager.swift`, `PillHUD.swift`, `PanelsCommand.swift`, `WatchModifiersCommand.swift`, `PermissionsWindow.swift` and `docs/configuration.md` applied clean. Every conflict was in `AppDelegate.swift`.

One conflict on the first commit: it inserted `commandAtPress` where #211's review rewrote the doc comment below it, renaming `lastDictationLanding` to `lastDictated`. Kept #211's comment and record intact, put the new property above it.

Eight conflicts on the second, all the same shape. `f89fea8` turned `beginProgress`/`endProgress` into a token protocol, and this commit adds a `confirm:` parameter to the same four functions — `handleVoiceCommand`, `run(_:instruction:)`, `runTransform`, `finishTransform`. Both parameters survive on every one.

Checked afterwards rather than trusting the compiler: the keyed path passes `confirm: false` and the wake path does not, every retry closure carries `confirm` through, and the inherited progress token is still ended on the early-return path.

</details>

<details>
<summary>Four races found in review, and the one left standing</summary>

A spoken command reads its target after the decoder has answered, and the app holds one slot for each thing it might read. Start a second dictation while a command is still routing and the command picked up the newer press's state. Four of those, all fixed here:

| Slot | What went wrong |
|---|---|
| `selectionAtPress` | The command edited the newer press's selection |
| `selectionAtPress`, nil | "Nothing was selected" flattened into "nobody said", so it fell back to the slot anyway |
| `lastTranscript` | A command with nothing selected rewrote a sentence that arrived after the instruction for it |
| `lastTranscript`, spelling | "Tasmin spells T A S M E E N" looked for the word in the wrong sentence |

`Press` freezes the selection and the transcript when the recording stops, which is before the gap, and `Target` is a two-case enum so a frozen nothing cannot flatten back into a slot read. A command reads neither slot and clears neither.

The wake phrase had the first, third and fourth before this branch. They are fixed by the same change rather than left.

**Still standing:** `applyTransform` activates `focusAtPress?.owner` before pasting when there is no selection, and that is a shared slot read after the same gap — so a command finishing after a newer press can bring the wrong app forward. It decides where a rewrite is pasted rather than what gets rewritten, it predates this branch, and it is shared with the menu and offer paths. Not fixed here.

</details>

<details>
<summary>What this does not cover</summary>

Bare modifiers only. Carbon delivers a combo on the down edge and swallows the keystroke, so a `⌃⌥Space`-style hotkey has no short press left to claim — a tap there is a dictation, and a brief one. Same at `press_delay_seconds: 0`.

A tap is a length of time on a physical key, so no fixture can score one. `--watch-taps` names the edge each press comes out as, and the case worth checking by hand is that ⌘S prints nothing at all.

The instruction goes through the pipeline before it is routed, so a transform can rewrite it on the way. That is shared with the wake path and is not new here.

The tap grace is 0.4s and both ends of it are physical event times rather than poll times — the poll runs every 25 ms, so timing it from when the poll looked misclassified a press made at 0.399s. `physicalEdge()` subtracts the age of the last `flagsChanged`, the same API `sawInputBeforeTheMonitors` uses a few lines below and for the same reason.

</details>

- [x] `make test` passes.
- [x] Every commit is signed off.
