### PR TITLE
feat: a command started by the hotkey skips the router

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ release-certificate:
 ## check-routing and check-spelling need Ollama and gemma4:e4b, and
 ## check-inplace needs a real screen, the Accessibility grant and tmux. Run
 ## those by hand and put the numbers in the pull request.
-CHECKS := numbers replacements pipeline pipeline-config wake split dotted dates \
+CHECKS := numbers replacements pipeline pipeline-config wake split dotted dates keyed \
           transform-folders eval audio-recovery possessive suggest input join \
           profiles span-rule clipboard default-config vocabulary-config learn \
           signing-identity no-voice

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2642,14 +2642,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         NSRange(range, in: text).location
     }
 
-    /// The toast after a substitution, and the phrase that takes it back.
+    /// The chime after a substitution, and nothing on screen.
     ///
-    /// Said every time rather than only when something looks wrong, because the
-    /// moment you can tell it went wrong is the moment you are looking at the
-    /// text and not at the menu bar. It has to already be on screen.
+    /// It used to say "<name> applied" with the undo phrase after it. Two
+    /// things retired that. The text is the confirmation — a rewrite lands
+    /// where you are already looking, and the pill sits under it — so the
+    /// notice was telling you what you had just watched happen. And the
+    /// catch-all is called `anything`, a name written for the log and for
+    /// `--check-config`, which made the message read "anything applied".
+    ///
+    /// The failures still speak. Nothing changed, the app refused the edit,
+    /// the words went to the clipboard instead: those are the cases you cannot
+    /// see, and every one of them still puts a line on the pill.
     private func applied(_ what: String) {
+        Log.write("applied: \(what)\(undoHint)")
         playFeedback("Morse")
-        flash("\(what) applied\(undoHint)", tone: .done)
     }
 
     /// `· "Hey parrot, undo"` — empty when there is no phrase to say it with.

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -168,13 +168,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         /// would be delivered with the terminal's answer, and the reverse puts
         /// markup in front of an app that shows the tags.
         let paste: AppProfile.Paste
-        /// Tap-then-hold: what is said is an instruction, not text.
+        /// Tap-then-hold: a key said this would be an instruction, not text.
         ///
         /// Decided at the press because that is where the gesture is known, and
         /// carried here for the same reason everything else is — a second press
         /// landing mid-transcription must not be able to change what this one
-        /// was for.
-        var isCommand = false
+        /// was for. See `handleVoiceCommand(_:keyed:)` for what it buys.
+        var keyed = false
         /// What was selected when this recording began.
         ///
         /// Frozen for the reason every other field here is. `selectionAtPress`
@@ -208,7 +208,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var offeredCorrection: (run: Int, target: Correction)?
 
     /// The current press was tap-then-hold, so its words are an instruction.
-    private var commandAtPress = false
+    private var keyedAtPress = false
 
     /// The last dictation a tap can summon an offer over: its words, and where
     /// they went.
@@ -1102,7 +1102,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Only for a press that starts a dictation: the second press of a
         // toggle belongs to the one already running, and it did not ask for
         // anything different.
-        if !recorder.isRecording { commandAtPress = afterTap }
+        if !recorder.isRecording { keyedAtPress = afterTap }
         // Read before anything this press does, so an abort later can tell the
         // transcription this press started from one that was already running.
         transcriptionRunAtPress = transcriptionRun
@@ -1469,7 +1469,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if config.feedback.overlay {
             // Under the selection when there is one and this is a command: the
             // words are about those words, and the pill belongs with them.
-            if commandAtPress, let selection = selectionAtPress {
+            if keyedAtPress, let selection = selectionAtPress {
                 aim(at: selection)
             } else {
                 pill.aim(at: anchorAtPress)
@@ -1783,7 +1783,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // Plain when nobody was in front, which is the answer that cannot
             // lose a sentence.
             paste: appAtPress.map { AppProfile.of($0).paste } ?? .plain,
-            isCommand: commandAtPress,
+            keyed: keyedAtPress,
             // Still this press's: the recording has only just stopped and no
             // newer press can have landed. The gap this closes is the decode
             // that follows, not this moment.
@@ -2012,16 +2012,32 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
     }
 
-    /// `confirm: false` applies a rewrite in place instead of previewing it.
+    /// `keyed` — a keystroke said this was an instruction, before a word of it
+    /// was spoken.
     ///
-    /// The gesture path passes it. Tap-then-hold has already named its target
-    /// on the pill and offered ⎋ for the whole time you were speaking, and
-    /// "hey parrot, undo" puts the substitution back afterwards — so a preview
-    /// is a question that was answered twice before it was asked. The wake
-    /// phrase does not pass it: that one is found in a sentence rather than
-    /// declared by a key, so being wrong about it is a real possibility.
+    /// The alternative is *heard*: the phrase was found inside a sentence by a
+    /// fuzzy matcher, which fires at 0.55 a word against a 0.7 floor because
+    /// "hey parrot" arrives clipped. It can be wrong, and `tests/wake-cases.txt`
+    /// holds the sentences about parrots it must not fire on. Everything the
+    /// two paths do differently follows from that one difference.
+    ///
+    /// Keyed skips two things, and both are insurance against that doubt:
+    ///
+    /// - **The router.** It answers two questions, and the first is "was this
+    ///   an edit at all". A key has already answered it. What is left is
+    ///   "which tool", which the name match answers for free or the catch-all
+    ///   answers by taking the whole instruction as its specification.
+    /// - **The preview.** Tap-then-hold has already named its target on the
+    ///   pill and offered ⎋ for the whole time you were speaking, and "hey
+    ///   parrot, undo" puts the substitution back afterwards — so a preview is
+    ///   a question that was answered twice before it was asked. It reaches
+    ///   `finishTransform` as `confirm: !keyed`, because that leaf's job is
+    ///   previewing and it should stay honest about it.
+    ///
+    /// The saving is a model call in series. Heard costs a router round trip
+    /// and then the transform's own; keyed costs one, or none.
     private func handleVoiceCommand(
-        _ command: String, confirm: Bool = true,
+        _ command: String, keyed: Bool = false,
         over target: Target = .whateverIsSelected
     ) {
         let catalogue = Catalogue(transforms: config.transforms)
@@ -2038,11 +2054,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             apply(local, command: command, progress: nil, over: target)
             return
         }
-        if let capability = Router.local(instruction: command, catalogue: catalogue) {
+        if let capability = Router.local(
+            instruction: command, catalogue: catalogue, anywhere: keyed
+        ) {
             Log.write("router: \"\(command)\" named \(capability.name) outright")
             run(
                 capability, instruction: command,
-                progress: nil, confirm: confirm, over: target
+                progress: nil, confirm: !keyed, over: target
+            )
+            return
+        }
+
+        // Keyed and named nothing: the catch-all, with no router in between.
+        //
+        // This is the change that makes the gesture worth using. Asking a model
+        // which tool you meant, and then asking a model to do the work, is two
+        // waits where the first one usually reports what the second was going
+        // to do anyway. The name match above is what keeps the other bodies
+        // reachable — a script and a table are not prompts, and the catch-all
+        // is, so it can stand in for a prompt and for nothing else.
+        if keyed {
+            guard let catchAll = config.commands.catchAll, config.freeForm else {
+                Log.write("keyed: \"\(command)\" named nothing and the catch-all is off")
+                flash("No transform called \"\(command)\"", tone: .caution)
+                return
+            }
+            Log.write("keyed: \"\(command)\" → \(FreeForm.name), no router")
+            runTransform(
+                FreeForm.prompt(for: command).asTransform(model: catchAll),
+                instruction: command, progress: nil, confirm: false, over: target
             )
             return
         }
@@ -2072,7 +2112,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         Log.write("router: \"\(command)\" → \(capability.name)")
                         self.run(
                             capability, instruction: command,
-                            progress: token, confirm: confirm, over: target
+                            progress: token, over: target
                         )
                     case .anything:
                         // An edit with no prompt behind it. The instruction is
@@ -2081,8 +2121,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         Log.write("router: \"\(command)\" → \(FreeForm.name)")
                         self.runTransform(
                             FreeForm.prompt(for: command).asTransform(model: catchAll),
-                            instruction: command, progress: token,
-                            confirm: confirm, over: target
+                            instruction: command, progress: token, over: target
                         )
                     case .none:
                         // Nothing fits. Deliberately not falling through to
@@ -2108,7 +2147,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     Log.write("routing failed: \(error.localizedDescription)")
                     self.endProgress(token: token)
                     let asked = self.askForKeyThenRetry(error) {
-                        self.handleVoiceCommand(command, confirm: confirm, over: target)
+                        self.handleVoiceCommand(command, keyed: keyed, over: target)
                     }
                     if !asked { self.flash(error.localizedDescription, tone: .failure) }
                 }
@@ -3010,7 +3049,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// worked out afterwards from a sentence that never landed. Escape is live
     /// the whole time, so a wrong answer here costs one keystroke.
     private var recordingLabel: String? {
-        guard commandAtPress else { return nil }
+        guard keyedAtPress else { return nil }
         return selectionAtPress == nil ? "say an edit" : "editing the selection"
     }
 
@@ -4103,7 +4142,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // looked for in the words. That is the whole point of it: the phrase
         // exists to mark a command inside an ordinary dictation, and there is
         // nothing to mark when the key said so first.
-        if press.isCommand {
+        if press.keyed {
             dictationEnded(press.run)
             guard !trimmed.isEmpty else {
                 Log.write("command: nothing was said")
@@ -4111,8 +4150,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 updateUI()
                 return
             }
-            Log.write("command spoken: \"\(trimmed)\"")
-            handleVoiceCommand(trimmed, confirm: false, over: .frozen(selection: press.selection, fallback: press.transcript))
+            Log.write("command keyed: \"\(trimmed)\"")
+            handleVoiceCommand(
+                trimmed, keyed: true,
+                over: .frozen(selection: press.selection, fallback: press.transcript)
+            )
             return
         }
 

--- a/Sources/ParrotFlow/AppProfile.swift
+++ b/Sources/ParrotFlow/AppProfile.swift
@@ -1,4 +1,4 @@
-import Foundation
+import AppKit
 
 /// What an app affords, decided from its identity rather than by asking it.
 ///
@@ -65,6 +65,16 @@ struct AppProfile: Equatable {
     /// neither can be promoted out of plain text by adding a line to a set
     /// below. That is deliberate: a terminal renders no markup and shows the
     /// tags instead, and a blind app is one nothing about is known by asking.
+    /// From a running application, which is what every accessibility path has
+    /// in hand. Nil is the ordinary profile: an app nobody could name takes
+    /// plain text, which is the answer that cannot corrupt anything.
+    static func of(_ app: NSRunningApplication?) -> AppProfile {
+        guard let app else { return .ordinary }
+        return of(Pipeline.App(
+            name: app.localizedName ?? "", bundleID: app.bundleIdentifier ?? ""
+        ))
+    }
+
     static func of(_ app: Pipeline.App) -> AppProfile {
         let bundle = app.bundleID.lowercased()
         let name = app.name.lowercased()

--- a/Sources/ParrotFlow/Capability.swift
+++ b/Sources/ParrotFlow/Capability.swift
@@ -56,6 +56,15 @@ enum Capability: Equatable {
         }
     }
 
+    /// Every way of naming this out loud: its own name, and whatever `say:`
+    /// adds. Only `Router.local` reads them — see `Config.Transform.say`.
+    var spokenNames: [String] {
+        switch self {
+        case .action(let action): return [action.rawValue]
+        case .transform(let transform): return [transform.name] + transform.say
+        }
+    }
+
     /// Which of the three bodies it is, for anything printing the catalogue.
     /// The router never sees this: what a tool is made of is not a reason to
     /// pick it, and putting it in the listing would be one more thing for the

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -671,12 +671,14 @@ struct Config: Decodable, Equatable {
         var offer = false
         /// `key: f` — the letter shown on its chip.
         var offerKey = ""
+        /// `say: [slack handles, handles]` — what to call it out loud.
+        var say: [String] = []
         /// `model: gpt`, or `model: { use: gpt, reasoning: low }`.
         var model: ModelRef?
 
         enum CodingKeys: String, CodingKey {
             case name, description, display, confirm, prompt, content, replace, command
-            case tests, returns, offer, model
+            case tests, returns, offer, model, say
             case offerKey = "key"
             case timeout = "timeout_seconds"
         }
@@ -753,6 +755,16 @@ struct Config: Decodable, Equatable {
             // keycap holds one character; a key is printed in capitals whatever
             // the config wrote it as.
             offerKey = String(try trimmed(.offerKey).prefix(1)).uppercased()
+            // One string or a list, because most transforms want one alias and
+            // writing `say: bullets` should not be an error.
+            let spoken: [String]
+            if let one = ((try? c.decodeIfPresent(String.self, forKey: .say)) ?? nil) {
+                spoken = [one]
+            } else {
+                spoken = ((try? c.decodeIfPresent([String].self, forKey: .say)) ?? nil) ?? []
+            }
+            say = spoken.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
 
             // A body written either way. The mapping is tried first and only
             // succeeds on `{ path: <string> }`, so nothing that decoded before
@@ -923,7 +935,7 @@ struct Config: Decodable, Equatable {
                 display: entry.display,
                 folder: entry.folder, timeout: entry.timeout,
                 confirm: entry.confirm, returnsJSON: entry.returnsJSON,
-                offer: entry.offer, offerKey: entry.offerKey,
+                offer: entry.offer, offerKey: entry.offerKey, say: entry.say,
                 body: body, source: entry.source,
                 tests: entry.tests, model: entry.model
             ))
@@ -1007,6 +1019,15 @@ struct Config: Decodable, Equatable {
         /// The letter shown on that chip. Empty when the config named none; the
         /// chip is still there and still clickable.
         var offerKey: String = ""
+        /// What to call this out loud, besides its name.
+        ///
+        /// A name is written for a config file — `slack_handles`, `code_identifiers` — and nobody says an underscore. An alias is what you would actually
+        /// ask for, and it is the difference between a script the keyed path
+        /// can reach without a model and one it cannot reach at all.
+        ///
+        /// Only the keyed path reads these. `"hey parrot"` goes to the router,
+        /// where a `description` is the thing written to be matched against.
+        var say: [String] = []
         var body: Body
         /// Where the body was read from, when it was read from a file at all —
         /// `prompt: { path: slack.md }`. Nil for an inline body, and nil for a

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -757,13 +757,22 @@ struct Config: Decodable, Equatable {
             offerKey = String(try trimmed(.offerKey).prefix(1)).uppercased()
             // One string or a list, because most transforms want one alias and
             // writing `say: bullets` should not be an error.
-            let spoken: [String]
-            if let one = ((try? c.decodeIfPresent(String.self, forKey: .say)) ?? nil) {
-                spoken = [one]
-            } else {
-                spoken = ((try? c.decodeIfPresent([String].self, forKey: .say)) ?? nil) ?? []
+            //
+            // Absent and unreadable are told apart. Both used to answer with an
+            // empty list, so `say: 42` left the transform in the catalogue with
+            // no alias — and the only symptom was that the words you had put
+            // there stopped reaching it, which is a routing bug to chase rather
+            // than a config line to fix. `--check-config` names it now.
+            if c.contains(.say) {
+                if let one = try? c.decode(String.self, forKey: .say) {
+                    say = [one]
+                } else if let listed = try? c.decode([String].self, forKey: .say) {
+                    say = listed
+                } else {
+                    unreadable = "has a `say:` that is neither a word nor a list of words"
+                }
             }
-            say = spoken.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            say = say.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
                 .filter { !$0.isEmpty }
 
             // A body written either way. The mapping is tried first and only

--- a/Sources/ParrotFlow/Markup.swift
+++ b/Sources/ParrotFlow/Markup.swift
@@ -214,14 +214,32 @@ struct Markup {
     /// The URL is kept rather than dropped. It is the fallback every paste
     /// carries, and a fallback that silently loses the address is worse than a
     /// visible one.
-    var plain: String {
+    var plain: String { flattened(keepingLinkURLs: true) }
+
+    /// The text a rich editor puts on screen for this document.
+    ///
+    /// The same as `plain` but for a labelled link, which displays as its words
+    /// alone: the address is in the anchor, not in the line. `plain` appends it
+    /// because that flavour is the fallback and a fallback that loses the
+    /// address is worse than a visible one — the opposite call, made for the
+    /// opposite reason.
+    ///
+    /// Only a read-back wants this. `Surface` verifies every write by reading
+    /// the field back, and it has to look for what will be *there*: told to
+    /// paste `[Alex](https://example.com)` into an app that takes HTML, it
+    /// would otherwise go looking for "Alex (https://example.com)" and find
+    /// "Alex". A read-back that fails runs the stray-paste repair, so that is a
+    /// correct edit one step from being undone.
+    var displayed: String { flattened(keepingLinkURLs: false) }
+
+    private func flattened(keepingLinkURLs: Bool) -> String {
         var lines: [String] = []
         var previousRoot: Int?
         var started = false
 
         for block in blocks {
             let text = block.pieces.map { piece -> String in
-                guard let link = piece.link else { return piece.text }
+                guard let link = piece.link, keepingLinkURLs else { return piece.text }
                 let url = link.absoluteString
                 return piece.text == url ? piece.text : "\(piece.text) (\(url))"
             }.joined()

--- a/Sources/ParrotFlow/RouteTestCommand.swift
+++ b/Sources/ParrotFlow/RouteTestCommand.swift
@@ -6,9 +6,15 @@ import Foundation
 /// The routing decision is otherwise only observable by speaking and watching
 /// what happens, which conflates "routed wrong" with "the prompt is bad". This
 /// separates them, and it is what `scripts/check-routing.sh` drives.
+///
+/// `--keyed` scores the other path — tap-and-hold, where a key said this was
+/// an instruction. There is no model router at all: a name anywhere in the
+/// sentence wins, and everything else is the catch-all. It answers a different
+/// question from the default, so it has a set of its own —
+/// `scripts/check-keyed.sh`.
 enum RouteTestCommand {
 
-    static func run(text: String, quiet: Bool = false) -> Int32 {
+    static func run(text: String, quiet: Bool = false, keyed: Bool = false) -> Int32 {
         let config: Config
         do { config = try ConfigStore.load() } catch {
             print("✗ config: \(CheckConfigCommand.describe(error))")
@@ -28,8 +34,21 @@ enum RouteTestCommand {
             print("instruction: \"\(instruction)\"")
         }
 
-        if let match = Router.local(instruction: instruction, catalogue: catalogue) {
+        if let match = Router.local(
+            instruction: instruction, catalogue: catalogue, anywhere: keyed
+        ) {
             print(quiet ? match.name : "→ \(match.name)  (named outright, no model)")
+            return 0
+        }
+
+        // Keyed: no router, so the answer is already known. Named nothing means
+        // the catch-all, and the only way to get NONE is to have turned it off.
+        if keyed {
+            guard config.freeForm else {
+                print(quiet ? "NONE" : "→ NONE  (named nothing, and the catch-all is off)")
+                return 0
+            }
+            print(quiet ? "ANY" : "→ ANY  (named nothing, straight to the catch-all — no model)")
             return 0
         }
 

--- a/Sources/ParrotFlow/Router.swift
+++ b/Sources/ParrotFlow/Router.swift
@@ -34,10 +34,20 @@ enum Router {
     /// Worth having twice over: it removes a round trip from the commands you
     /// use most, and it is the only path that works when Ollama is not running.
     ///
-    /// Only the opening words are considered. "bullets" and "bullets but keep
-    /// the headings" both name `bullets`; "I was thinking about bullets"
-    /// should not, and does not, because the match is anchored at the start.
-    static func local(instruction: String, catalogue: Catalogue) -> Capability? {
+    /// Anchored by default: "bullets" and "bullets but keep the headings" both
+    /// name `bullets`, while "I was thinking about bullets" does not, because
+    /// the match starts where the sentence does. That is right for a command
+    /// *heard* inside a sentence, which might not have been a command at all.
+    ///
+    /// `anywhere` lifts the anchor, for a command declared by a key. There the
+    /// whole utterance is the instruction — you held the key down to say it —
+    /// so a name in the middle of it is still a name, and "use our slack
+    /// handles" has to reach `slack_handles` or it reaches a model that cannot
+    /// run a script. The risk the anchor was guarding against does not exist on
+    /// that path: there is no sentence for a name to be buried in by accident.
+    static func local(
+        instruction: String, catalogue: Catalogue, anywhere: Bool = false
+    ) -> Capability? {
         let words = instruction.lowercased()
             .components(separatedBy: CharacterSet.alphanumerics.inverted)
             .filter { !$0.isEmpty }
@@ -45,16 +55,25 @@ enum Router {
 
         var best: (capability: Capability, score: Double)?
         for capability in catalogue.capabilities {
-            let target = capability.name.lowercased()
-            // A capability's name may be more than one word, so try the same
-            // number of leading words as the name has, and one either side.
-            let nameWords = target.components(separatedBy: CharacterSet.alphanumerics.inverted)
-                .filter { !$0.isEmpty }.count
-            for count in 1...max(1, min(nameWords + 1, words.count)) {
-                let candidate = words.prefix(count).joined(separator: " ")
-                let score = VoiceCommand.similarity(candidate, target)
-                if score >= nameThreshold, score > (best?.score ?? 0) {
-                    best = (capability, score)
+            for spoken in capability.spokenNames {
+                // Underscores are how a config spells a space. Nobody says one,
+                // so `slack_handles` is compared as "slack handles".
+                let target = spoken.lowercased()
+                    .components(separatedBy: CharacterSet.alphanumerics.inverted)
+                    .filter { !$0.isEmpty }
+                guard !target.isEmpty else { continue }
+                let name = target.joined(separator: " ")
+                // A capability's name may be more than one word, so try the same
+                // number of words as the name has, and one either side.
+                let starts = anywhere ? Array(words.indices) : [0]
+                for from in starts {
+                    for count in 1...max(1, min(target.count + 1, words.count - from)) {
+                        let candidate = words[from..<(from + count)].joined(separator: " ")
+                        let score = VoiceCommand.similarity(candidate, name)
+                        if score >= nameThreshold, score > (best?.score ?? 0) {
+                            best = (capability, score)
+                        }
+                    }
                 }
             }
         }

--- a/Sources/ParrotFlow/Surface.swift
+++ b/Sources/ParrotFlow/Surface.swift
@@ -56,6 +56,19 @@ struct Surface {
 
     var selectedText: String? { span.map { String(content[$0]) } }
 
+    /// The pasteboard flavours this app takes, over and above plain text.
+    ///
+    /// A rewrite is written the same way a dictation is, because it is the same
+    /// text going into the same field. Without this it went in plain, so a
+    /// transform that answered `**Alex**` put four asterisks into Slack where a
+    /// dictation of the same words arrives bold. Nothing said so: a paste that
+    /// lands is a paste that worked, and the markers look like the model's
+    /// fault rather than the paste's.
+    ///
+    /// A terminal answers `.plain` here, which is what `writeScreen` needs and
+    /// gets by not asking.
+    var paste: AppProfile.Paste { AppProfile.of(owner).paste }
+
     // MARK: - Reading
 
     /// What is in front, read once.
@@ -131,11 +144,7 @@ struct Surface {
         }
 
         let front = app ?? NSWorkspace.shared.frontmostApplication
-        let isTerminal = front.map {
-            AppProfile.of(Pipeline.App(
-                name: $0.localizedName ?? "", bundleID: $0.bundleIdentifier ?? ""
-            )).focus == .screen
-        } ?? false
+        let isTerminal = AppProfile.of(front).focus == .screen
 
         if isTerminal {
             return screen(element: element, owner: front, value: value, dictated: dictated)
@@ -501,7 +510,7 @@ struct Surface {
         if select(nsRange),
            confirmedSelection(matches: String(content[range]), range: nsRange) {
             Log.write("surface: the range write was ignored; pasting over a confirmed selection")
-            TextInserter.insert(replacement, mode: .paste)
+            TextInserter.insert(replacement, mode: .paste, paste: paste)
             if settled(on: fragment) {
                 // Said out loud, like the branch above. Without it a success
                 // here is an absence of failure lines, and reading the log for
@@ -596,7 +605,7 @@ struct Surface {
         }
 
         Log.write("surface: walked the caret to \(target.location)+\(target.length); pasting")
-        TextInserter.insert(replacement, mode: .paste)
+        TextInserter.insert(replacement, mode: .paste, paste: paste)
         if settled(on: fragment) { return .replaced(undo) }
         return .refused(repairedAfterStrayPaste())
     }

--- a/Sources/ParrotFlow/Surface.swift
+++ b/Sources/ParrotFlow/Surface.swift
@@ -69,6 +69,24 @@ struct Surface {
     /// gets by not asking.
     var paste: AppProfile.Paste { AppProfile.of(owner).paste }
 
+    /// What the field will show once `replacement` has been pasted.
+    ///
+    /// Not the same string when the app takes a rich flavour: `**Alex**` goes
+    /// onto the pasteboard as markup and arrives as bold Alex, with the markers
+    /// gone. Every write here is verified by reading the field back, so the
+    /// check has to look for what will be *there* rather than for what was
+    /// sent. Measured the moment the flavour was carried into a rewrite: a
+    /// bold that applied correctly reported "this app won't let me edit it",
+    /// because the read-back went looking for two asterisks Slack had consumed.
+    ///
+    /// Only the paste renders. `setSelectedText` writes the string literally,
+    /// so that branch still reads back the markers it put there.
+    func asShown(_ replacement: String) -> String {
+        guard paste != .plain else { return replacement }
+        let markup = Markup.parse(replacement)
+        return markup.isPlain ? replacement : markup.plain
+    }
+
     // MARK: - Reading
 
     /// What is in front, read once.
@@ -495,6 +513,15 @@ struct Surface {
         // value should read afterwards, and the fragment is widened against it
         // until it names one place there.
         let fragment = self.fragment(around: range, replacement: replacement, in: updated)
+        // The same check for the branches that paste, against what a paste
+        // actually leaves in the field. Identical to `fragment` whenever the
+        // app takes plain text or the replacement carries no markup, which is
+        // most of the time — see `asShown`.
+        let shown = asShown(replacement)
+        let pasted = shown == replacement ? fragment : self.fragment(
+            around: range, replacement: shown,
+            in: content.replacingCharacters(in: range, with: shown)
+        )
 
         // 1. Set the range, then write the text into it. Disturbs nothing, and
         //    is what a native field accepts.
@@ -511,7 +538,7 @@ struct Surface {
            confirmedSelection(matches: String(content[range]), range: nsRange) {
             Log.write("surface: the range write was ignored; pasting over a confirmed selection")
             TextInserter.insert(replacement, mode: .paste, paste: paste)
-            if settled(on: fragment) {
+            if settled(on: pasted) {
                 // Said out loud, like the branch above. Without it a success
                 // here is an absence of failure lines, and reading the log for
                 // "did the edit land" means knowing which lines are missing.
@@ -535,7 +562,7 @@ struct Surface {
         //    it is to where the span starts, and every step of that walk can be
         //    checked against the app's own account before anything is typed.
         if let outcome = writeByWalkingTheCaret(
-            nsRange, replacement: replacement, fragment: fragment, undo: undo
+            nsRange, replacement: replacement, fragment: pasted, undo: undo
         ) {
             return outcome
         }

--- a/Sources/ParrotFlow/Surface.swift
+++ b/Sources/ParrotFlow/Surface.swift
@@ -81,10 +81,17 @@ struct Surface {
     ///
     /// Only the paste renders. `setSelectedText` writes the string literally,
     /// so that branch still reads back the markers it put there.
+    ///
+    /// `displayed` and not `plain`. They differ on one thing — a labelled link,
+    /// which `plain` writes as `words (url)` because that flavour is the
+    /// clipboard fallback and losing the address there is worse than showing
+    /// it. On screen the address is in the anchor and the line reads "words",
+    /// so a read-back against `plain` would reject a link that pasted
+    /// correctly and the repair would undo it.
     func asShown(_ replacement: String) -> String {
         guard paste != .plain else { return replacement }
         let markup = Markup.parse(replacement)
-        return markup.isPlain ? replacement : markup.plain
+        return markup.isPlain ? replacement : markup.displayed
     }
 
     // MARK: - Reading

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -262,11 +262,12 @@ if let index = arguments.firstIndex(of: "--command") {
 
 if let index = arguments.firstIndex(of: "--route") {
     guard arguments.indices.contains(index + 1) else {
-        print("usage: ParrotFlow --route \"hey parrot, make that a bullet list\" [--quiet]")
+        print("usage: ParrotFlow --route \"hey parrot, make that a bullet list\" [--quiet] [--keyed]")
         exit(2)
     }
     exit(RouteTestCommand.run(
-        text: arguments[index + 1], quiet: arguments.contains("--quiet")
+        text: arguments[index + 1], quiet: arguments.contains("--quiet"),
+        keyed: arguments.contains("--keyed")
     ))
 }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -254,6 +254,12 @@ $PF --learn <heard> <corrected>
 matches your words against each transform's `description`, so this is how you
 find out that a description is too vague before a user does.
 
+`--route "…" --keyed` scores the other path: tap-and-hold, where a key said
+this was an instruction and there is no router at all. A name anywhere in the
+sentence wins, `say:` aliases included; everything else is `ANY`. No model, so
+it answers instantly. `scripts/check-keyed.sh` drives it against
+`tests/keyed-cases.yaml`, which supplies its own catalogue.
+
 `--prompt` runs one named transform against text you supply, with the
 instruction that would have been spoken. `--command` runs the whole
 wake-phrase path: is this a command at all, is it a correction, which words in

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -855,6 +855,12 @@ vim and less all work this way, and the pill follows your words there. A pane
 sitting at an ordinary shell prompt keeps everything you have run in it, and the
 pill goes to the bottom of the screen.
 
+A rewrite that lands says nothing. The text is the confirmation — it changes
+where you are already looking, with the pill sitting under it — so a notice
+would be describing what you just watched happen. A chime plays and the log
+records it. Every way of *not* landing still speaks: nothing to change, the app
+refused the edit, the words went to the clipboard instead.
+
 `correct_offer` is what the pill does after a dictation. It stays where it
 is and names what can be done to the words, one chip per command:
 `Vocabulary` first, then every transform with `offer: true` — see

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -208,6 +208,27 @@ transform and the catch-all besides — with no phrase to remember, because the
 key already said it was an instruction. The pill says **editing the selection**
 or **say an edit** while you hold, and ⎋ cancels.
 
+**And no router.** A key said this was an instruction, so the question the
+router exists to answer — *was that even an edit?* — is already answered.
+What is left is which tool, and that is decided without a model:
+
+1. Does the sentence contain the name of one of your transforms, or one of the
+   words its `say:` lists? Then run it. No model call at all.
+2. Otherwise the catch-all takes the whole sentence as its specification. One
+   model call.
+
+Never two waits in a row. Often none. `"hey parrot, …"` keeps the router,
+because that one is *found* in a sentence and really does have to guess.
+
+Step 1 is not an optimisation, it is what keeps the rest of your catalogue
+reachable. The catch-all is a prompt. A `command:` script and a `replace:`
+table are not, so nothing can stand in for them — "flag this" sent to the
+catch-all does not file your text, it rewords it. `say:` is how a tool named
+`slack_handles` gets reached by someone saying "use our slack handles".
+
+`scripts/check-keyed.sh` scores this against `tests/keyed-cases.yaml`, with no
+model and in about a second.
+
 **It applies in place**, whatever the transform's `confirm:` says — the same
 rule a chip on the pill already follows. The target was named on the pill
 before you spoke, ⎋ was live the whole time you were speaking, and

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -297,6 +297,29 @@ entry costs the others room, so a transform joins it only by asking. Put a
 chip on what you reach for without thinking. Leave it off anything you would
 only ever ask for out loud — that is what the wake phrase is for.
 
+### `say` — what to call it out loud
+
+```yaml
+  - name: slack_handles
+    description: turn names into slack handles
+    say: [slack handles, handles]
+    command: slack_handles.py
+```
+
+A name is written for a config file. Nobody says an underscore, and nobody
+calls a script `code_identifiers` when asking for it. `say:` is the words you
+would actually use, and one string is as good as a list.
+
+Only the tap-and-hold path reads them, and there it decides whether a tool is
+reachable at all. That path has no router: a name anywhere in what you said
+wins, and everything else goes to the catch-all. The catch-all is a prompt, so
+it can stand in for another prompt and for nothing else — a script or a
+`replace:` table that is never named is a tool you cannot reach. See
+[configuration.md](configuration.md#tap-it-to-bring-the-offer-back).
+
+`"hey parrot, …"` ignores `say:`. That path asks a model, and `description:`
+is the field written to be matched against.
+
 `key:` is one letter, drawn as a keycap and shown in capitals whatever you
 write. More than one character is cut to the first. A transform with `offer:
 true` and no `key:` still gets a chip, without a keycap on it — clickable, and

--- a/scripts/check-keyed.sh
+++ b/scripts/check-keyed.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Scores the keyed path against tests/keyed-cases.yaml.
+#
+#   scripts/check-keyed.sh
+#
+# Tap-and-hold: a key said this was an instruction, so there is no router in
+# the path. A name anywhere in the sentence wins; everything else is the
+# catch-all. That is the whole decision, and it costs no model call — this runs
+# in under a second, unlike check-routing.sh, which is a round trip per case.
+#
+# The catalogue is written here rather than read from your config. A set that
+# inherits whichever transforms happen to be on the machine only means
+# something on that machine, and what is being scored is a matcher against a
+# list — the list is half the question. Same argument as
+# tests/routing-cases.yaml makes for itself.
+#
+# What a failure costs is not symmetrical, so read the two groups at the end.
+# A name that misses does not degrade to a slightly worse rewrite: the
+# catch-all is a prompt, and most of these tools are not. "flag this" sent to
+# ANY does not file your text, it rewords it.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/release/ParrotFlow"
+CASES="$ROOT/tests/keyed-cases.yaml"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+
+WORK="$(mktemp -d -t parrotflow-keyed)"
+trap 'rm -rf "$WORK"' EXIT
+
+cat > "$WORK/config.yaml" <<'YAML'
+transcription:
+  languages: [en]
+models:
+  local:
+    api: ollama
+    model: gemma4:e4b
+    default: true
+transforms:
+  - name: bullets
+    description: turn the text into a bullet list
+    prompt: "Rewrite as bullets."
+  - name: terse
+    description: make the text shorter
+    prompt: "Shorten."
+  - name: slack_handles
+    description: turn names into slack handles
+    say: [slack handles, handles]
+    command: 'true'
+  - name: flag
+    description: save this dictation to look at later
+    say: [flag this, save this for later]
+    command: 'true'
+  - name: punctuation
+    description: fix spoken punctuation
+    command: 'true'
+  - name: repetitions
+    description: drop repeated words
+    command: 'true'
+  - name: dotted
+    description: spoken dotted paths as code
+    replace:
+      "$1.": ['/(\w+) dot (?=\w)/']
+YAML
+
+pass=0; total=0; missed=""; forced=""
+
+route() { PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --route "$1" --keyed --quiet 2>/dev/null | tail -1; }
+
+while IFS='|' read -r instruction want; do
+  [ -z "$instruction" ] && continue
+  total=$((total + 1))
+  got="$(route "$instruction")"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1))
+    printf '  ✓ %-46s %s\n' "$instruction" "$got"
+  else
+    printf '  ✗ %-46s got %s, want %s\n' "$instruction" "$got" "$want"
+    # A name that fell through to the catch-all is the expensive failure: the
+    # tool it named is a script or a table, and a prompt cannot stand in for
+    # one. The other direction only costs a rewrite that was not asked for.
+    if [ "$got" = "ANY" ]; then
+      missed="$missed
+      $instruction → wanted $want"
+    else
+      forced="$forced
+      $instruction → $got, wanted $want"
+    fi
+  fi
+done < <(
+  awk '
+    /^  - instruction: / { sub(/^  - instruction: /, ""); ins = $0; next }
+    /^    expect: /      { sub(/^    expect: /, ""); if (ins != "") print ins "|" $0; ins = "" }
+  ' "$CASES"
+)
+
+printf '\n  %d/%d\n' "$pass" "$total"
+[ -n "$missed" ] && printf '\n  named a tool and did not reach it (a script did not run):%s\n' "$missed"
+[ -n "$forced" ] && printf '\n  reached the wrong tool:%s\n' "$forced"
+[ "$pass" = "$total" ] || exit 1

--- a/tests/keyed-cases.yaml
+++ b/tests/keyed-cases.yaml
@@ -1,0 +1,96 @@
+# The keyed path: tap-and-hold, where a key said this was an instruction.
+#
+# Run with scripts/check-keyed.sh, which supplies its own catalogue — see
+# below. Unlike tests/routing-cases.yaml this needs no model and takes no time:
+# the whole point of the path is that there is no router in it.
+#
+# Two answers only. A name anywhere in the sentence wins; everything else is
+# the catch-all. There is no NONE, because a key was held down to say this —
+# "that was not a command" is a verdict the gesture has already ruled out.
+#
+# What is being scored is one thing: does a name reach the tool that owns it.
+# It matters because most tools are not prompts. A script and a substitution
+# table cannot be stood in for by the catch-all, which is a prompt, so a name
+# that misses does not degrade — it runs the wrong kind of thing entirely.
+# "flag this" going to ANY does not file your text, it rewords it.
+#
+# The catalogue is fixed in the script rather than read from your config, for
+# the reason routing-cases.yaml gives: a set that inherits whichever transforms
+# happen to be on the machine only means something on that machine.
+#
+#   bullets      prompt   — the one the catch-all could stand in for
+#   terse        prompt
+#   slack_handles command  say: [slack handles, handles]
+#   flag         command  say: [flag this, save this for later]
+#   punctuation  command
+#   repetitions  command
+#   dotted       replace
+
+cases:
+  # --- the bare name, which worked before this and still has to ------------
+  - instruction: bullets
+    expect: bullets
+  - instruction: terse
+    expect: terse
+  - instruction: punctuation
+    expect: punctuation
+
+  # --- a name at the front, with the rest of the request behind it ---------
+  - instruction: bullets but keep the headings
+    expect: bullets
+  - instruction: punctuation on that last paragraph
+    expect: punctuation
+
+  # --- a name in the middle, which is what `anywhere` adds ----------------
+  # The anchored match was written for "hey parrot", where the words around a
+  # name might not be a command at all. Held down on a key they always are.
+  - instruction: use our slack handles
+    expect: slack_handles
+  - instruction: clean up the repetitions
+    expect: repetitions
+  - instruction: fix the punctuation
+    expect: punctuation
+  - instruction: can you make that bullets
+    expect: bullets
+
+  # --- an underscore is how a config spells a space -----------------------
+  - instruction: slack handles please
+    expect: slack_handles
+
+  # --- `say:`, for a tool whose name is not what you would call it --------
+  - instruction: handles
+    expect: slack_handles
+  - instruction: save this for later
+    expect: flag
+  - instruction: flag this
+    expect: flag
+
+  # --- misheard, because every one of these arrived through a decoder -----
+  - instruction: fix the punctuation marks
+    expect: punctuation
+  - instruction: terce
+    expect: terse
+
+  # --- the catch-all, which is the other half of the design ---------------
+  # These name nothing and must not be forced onto the nearest tool. One model
+  # call, and the instruction is the whole specification.
+  - instruction: make this three bullet points
+    expect: bullets
+  - instruction: shorten it
+    expect: ANY
+  - instruction: use the 24 hour clock
+    expect: ANY
+  - instruction: sort that list alphabetically
+    expect: ANY
+  - instruction: make sure the amounts are formatted as money
+    expect: ANY
+  - instruction: rewrite this so my manager will read it
+    expect: ANY
+
+  # --- a name that is also an ordinary word -------------------------------
+  # `dotted` is a table for spoken paths. "join the dotted line" is prose about
+  # a dotted line, and there is no tool called join in this catalogue — so the
+  # risk is `dotted` eating it. It may: a keyed instruction is a command, and
+  # the speaker did say the word. Recorded rather than argued with.
+  - instruction: dotted
+    expect: dotted


### PR DESCRIPTION
A command started by tap-and-hold no longer asks a model which tool you meant. It cost two model calls in series: a router decided, then the tool ran, and the first usually reported what the second was about to do anyway. Now a transform name anywhere in what you said runs that transform with no model at all, and anything else goes straight to the catch-all — one call, never two. `"hey parrot, …"` keeps the router and is unchanged.

Transforms gain an optional `say:` list, off by default: the words you would use out loud for a tool whose name is written for a config file. `say: [slack handles, handles]` on `slack_handles`, one string or a list. Only the keyed path reads it.

Start the review at `Router.local(instruction:catalogue:anywhere:)` and at the keyed branch of `handleVoiceCommand`. The thing worth checking is that `"hey parrot"` still goes through `Router.route` — the anchor is lifted only for `anywhere: true`.

<details>

<summary>Why the router is safe to skip here and not on the wake phrase</summary>

The router answers two questions, and the first is "was this an edit at all".

That question exists because the wake phrase is *found* inside a sentence by a fuzzy matcher — 0.55 per word against a 0.7 floor, because "hey parrot" arrives clipped as "parrot" or misheard as "hey parrots". `tests/wake-cases.txt` holds the sentences about parrots it must not fire on. A keystroke cannot be misread that way, so the keyed path was paying for an answer it already had.

`keyed` is the name for that distinction, beside the `command heard:` the wake path already logs. Heard means it might be wrong. Keyed means it cannot be.

It also replaces the `confirm:` flag added in #212. No preview and no router both follow from the same fact, so one parameter carries it: `finishTransform` still receives `confirm: !keyed`, because that leaf's job is previewing and it should stay honest about it.

</details>

<details>

<summary>The name match is not an optimisation — without it, scripts become unreachable</summary>

The catch-all is a `prompt:`. Most transforms are not: on a working config, eleven of thirteen are `command:` scripts and `replace:` tables. A prompt cannot stand in for either.

So "flag this" sent to the catch-all does not file your text, it rewords it. The name step is what keeps those tools reachable, and it does three things to get there:

- **Lifts the anchor.** A key means the whole utterance is the instruction, so a name in the middle of it is still a name. "use our slack handles" reaches `slack_handles`. The wake path keeps the anchor, because there the words around a name might not be a command at all.
- **Normalises the separators.** Nobody says an underscore, so `slack_handles` is compared as "slack handles".
- **Reads `say:`.** For the tools whose names are not what you would call them.

</details>

<details>

<summary>Measurements — 22/22 keyed, and the heard path is unchanged at 2 of 54</summary>

New set, `tests/keyed-cases.yaml`, run by `scripts/check-keyed.sh`:

```
22/22
```

No model call, about a second for the whole set, so it is cheap enough to run on every change. The script ships its own catalogue rather than reading your config, for the reason `tests/routing-cases.yaml` gives for doing the same: a set that inherits whichever transforms happen to be on the machine only means something on that machine.

The set is two answers only. There is no `NONE`, because a key was held down to say this — "that was not a command" is a verdict the gesture has already ruled out. What it scores is one thing: does a name reach the tool that owns it. It covers the bare name, a name at the front, a name in the middle, an underscored name, `say:` aliases, two misheard spellings, six that must reach the catch-all, and one name that is also an ordinary word.

`Router.local` is shared with the wake path, and this change touches how it normalises separators, so the heard path was measured before and after:

| | model-free routing cases |
|---|---|
| before | 2 of 54 |
| after | 2 of 54 |

The same two cases, `terse` and `spelling`. `scripts/check-routing.sh` itself is a round trip per case against a live model and is not run here.

`make test` passes.

</details>

<details>

<summary>Three fixes ride along, and two of them are one bug</summary>

**`Surface.replace` pasted plain text whatever the app took.** A rewrite answering `**Alex**` put four asterisks into Slack, where a dictation of the same words arrives bold. Dictation had always passed the app's paste flavour; a rewrite is the same text going into the same field and was the one write that never asked. Terminals are unaffected — `writeScreen` retypes the input line and never asks for a flavour.

**Fixing that broke the read-back.** Every write in `Surface` verifies itself by reading the field back, and the needle was built from the string that was *sent*. That was the same string until the flavour started being carried: `**Alex**` now arrives as bold Alex with the markers consumed, so the check went looking for asterisks the app had eaten. It reported "this app won't let me edit it" on a rewrite that had landed correctly, and `settled` returning false runs the stray-paste repair — the correct edit was one step from being undone. Two needles now: `setSelectedText` writes literally and still checks for markers, the paste branches check the plain rendering.

**A rewrite that worked said "anything applied".** The catch-all is named `anything`, a name written for the log and for `--check-config`. Once a spoken instruction could reach it without a router, that name was on screen after every free-form edit. The success flash is gone — the text is the confirmation, it changes where you are already looking with the pill under it — and the chime and the log line stay. Every way of *not* landing still speaks: nothing to change, the app refused the edit, the words went to the clipboard instead.

</details>

<details>

<summary>Review notes — where the conflict was, and what a compiler could not check</summary>

The first commit conflicted in `AppDelegate.swift` and was resolved by hand. `handleVoiceCommand` had been given a `progress:` parameter by #211 and an `over target:` parameter by #212, and this commit adds `keyed:` to the same function and the same call sites. All three survive on each.

A compile does not catch a dropped parameter that has a default, so the keyed path was checked by hand at every branch:

| branch | passes |
|---|---|
| `VoiceCommand.local` | `progress: nil, over: target` |
| `Router.local` hit | `progress: nil, confirm: !keyed, over: target` |
| keyed, named nothing | `progress: nil, confirm: false, over: target` |
| router matched | `progress: token, over: target` — `confirm` takes its default of `true`, and this branch is unreachable when keyed |
| router `.anything` | `progress: token, over: target` — same |
| the retry closure | `keyed: keyed, over: target` |

Seven `PressTiming.mark()` calls were dropped from the cherry-picked commit. `Sources/ParrotFlow/PressTiming.swift` has never been committed to this repository, so those lines would not have compiled here — they only built on the machine where the spike was written, which had the file untracked in its working tree. The instrumentation is not part of this change.

</details>
