### PR TITLE
feat: selecting what it just wrote brings the offer back

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3119,6 +3119,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func offerOverReselected(_ selection: SelectionReader.Selection) {
         // Never over a recording, never over an offer already up, and never
         // while a decode this could be about is still in flight.
+        //
+        // Refusing while one is up does not cost you a second selection, and
+        // the reason is an ordering worth keeping: an outside click dismisses
+        // the offer on mouse *down* — see `watchForOfferOutsideClick` — and this
+        // looks on mouse *up*. So selecting different words takes the old offer
+        // down before the new one is asked for. Move either monitor to the other
+        // edge and reselecting while an offer is up stops answering.
         guard !recorder.isRecording, runsInFlight <= 0, !offerIsUp else { return }
         guard config.feedback.correctOffer else { return }
         aim(at: selection)
@@ -3185,7 +3192,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func aim(at selection: SelectionReader.Selection) {
         guard let element = selection.element,
               case .found(let anchor) = CaretAnchor.read(at: element) else {
-            Log.write("summon: no geometry for the selection; the pill stays where it was")
+            Log.write("pill: no geometry for the selection; it stays where it was")
             return
         }
         pill.aim(at: anchor)

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -210,6 +210,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// The current press was tap-then-hold, so its words are an instruction.
     private var keyedAtPress = false
 
+    /// Watches for the last dictation being selected again — see
+    /// `SelectionWatch`. Running from the moment there is something to select
+    /// until the next dictation replaces it.
+    private let reselect = SelectionWatch()
+
     /// The last dictation a tap can summon an offer over: its words, and where
     /// they went.
     ///
@@ -435,8 +440,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     ///
     /// Read fresh each time rather than stored, so a config reloaded between
     /// two dictations changes what the next offer says.
-    private var offerCommands: [OfferedCommand] {
-        [OfferedCommand(title: "Vocabulary", key: "V")]
+    /// `teaching` puts `Vocabulary` in front, and it is left out for words
+    /// nothing here dictated.
+    ///
+    /// The panel behind that chip maps what was HEARD to what it should be, and
+    /// over a selection in somebody else's email there is no hearing — nothing
+    /// listened to it. A rule taught from a typo somebody else typed would fire
+    /// on *your* future dictations, correcting a mistake the decoder never made.
+    ///
+    /// Before the hotkey could summon an offer over an arbitrary selection this
+    /// could not arise: the panel only ever opened over a dictation. Leaving the
+    /// chip off is the whole of the fix, and it is what the `add a word` panel
+    /// mode was going to be for.
+    private func offerCommands(teaching: Bool) -> [OfferedCommand] {
+        (teaching ? [OfferedCommand(title: "Vocabulary", key: "V")] : [])
             + config.transforms.filter(\.offer).map {
                 OfferedCommand(title: $0.name, key: $0.offerKey)
             }
@@ -1152,6 +1169,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if startsDictation {
             anchorAtPress = nil
             pressRun += 1
+            // The words it is watching for are about to be replaced. Stopped
+            // here rather than when the new ones land, so the gap in between
+            // cannot offer over a sentence that is already history.
+            reselect.stop()
             readTheAnchor()
         }
 
@@ -2889,6 +2910,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // one out of it once this has faded. Below the newer-run guard above,
         // and carrying the words as well as the field — see `lastDictated`.
         lastDictated = (press.run, text, press.element, press.owner, landing)
+        watchForReselection()
 
         // The decoder's words matched back onto the sentence that came out of
         // the pipeline — see `Confidence.read`. Taken rather than copied: this
@@ -2951,7 +2973,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         offerHeld = false
         offerPressRun = run
         offeredCorrection = (run, target)
-        let commands = offerCommands
+        // Frozen with the offer rather than asked again when a chip is pressed.
+        // `lastDictated` is one slot and push-to-talk does not wait, so the same
+        // question a few seconds later can be about a different sentence.
+        let teaching = target.dictation != nil
+        let commands = offerCommands(teaching: teaching)
         offerHeadline = headline
         offerReading = reading
         let hold = config.feedback.lowConfidence.holdReturn
@@ -2964,10 +2990,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // under the pointer, and the click would run whatever took the slot.
         pill.model.onPick = { [weak self] index in
             guard let self, self.offerIsUp, commands.indices.contains(index) else { return }
-            // Index 0 is Vocabulary, which is not a transform and cannot be
-            // one: a config free to name a transform "Vocabulary" must not be
-            // able to take that slot over.
-            self.runOfferedCommand(index == 0 ? nil : commands[index].title)
+            // Index 0 is Vocabulary *when it is there* — it is not a transform
+            // and cannot be one, so a config free to name a transform
+            // "Vocabulary" must not be able to take that slot over. Matched by
+            // position rather than by title for exactly that reason, which means
+            // an offer without it has to say so or the first transform would be
+            // run as the panel.
+            self.runOfferedCommand(teaching && index == 0 ? nil : commands[index].title)
         }
         // The highlight is the pointer's mark and does not outlive it. Leaving
         // the pill gives it up, so a chip is never lit for a command that is
@@ -3018,7 +3047,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             raiseOffer(
                 over: Correction(
                     original: selection.text, element: selection.element,
-                    owner: selection.owner, landing: .field, selection: selection
+                    owner: selection.owner, landing: .field,
+                    // Selecting part of what you just dictated and tapping is
+                    // still your dictation, so it still gets the panel — see
+                    // `dictationBehind`. Text nobody here wrote answers nil.
+                    dictation: dictationBehind(selection.text, in: selection.element),
+                    selection: selection
                 ),
                 run: pressRun, headline: "the selection", reading: Confidence.Reading()
             )
@@ -3045,6 +3079,81 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             ),
             run: pressRun, headline: nil, reading: Confidence.Reading()
         )
+    }
+
+    /// Offer again when the words are selected again.
+    ///
+    /// The other half of `summonOffer`. A tap is how you ask for the offer;
+    /// this is how it arrives without being asked, and it is bounded to the one
+    /// case where appearing uninvited is right — you selected text ParrotFlow
+    /// wrote, which is a deliberate act aimed at words it already knows about.
+    ///
+    /// Re-armed after every rewrite, so a sentence corrected and then selected
+    /// again still answers with the words that are on screen rather than the
+    /// ones that were.
+    ///
+    /// The field is what the watch judges by, so no field means no watch. A
+    /// dictation that ended on the clipboard left nothing on screen to select,
+    /// and one whose element was never captured cannot be told from any other
+    /// window.
+    private func watchForReselection() {
+        guard config.feedback.correctOffer else { reselect.stop(); return }
+        guard let last = lastDictated,
+              !last.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              case .field = last.landing, let element = last.element else {
+            reselect.stop()
+            return
+        }
+        reselect.onSelection = { [weak self] selection in
+            self?.offerOverReselected(selection)
+        }
+        reselect.start(over: last.text, in: element)
+    }
+
+    /// The offer, over words that were dictated and have been selected again.
+    ///
+    /// The selection is the target, not the whole dictation: select three words
+    /// out of a sentence and those three words are what you meant. Everything
+    /// downstream is `summonOffer`'s, because there is no difference between an
+    /// offer you asked for and one that noticed — only in how it arrived.
+    private func offerOverReselected(_ selection: SelectionReader.Selection) {
+        // Never over a recording, never over an offer already up, and never
+        // while a decode this could be about is still in flight.
+        guard !recorder.isRecording, runsInFlight <= 0, !offerIsUp else { return }
+        guard config.feedback.correctOffer else { return }
+        aim(at: selection)
+        raiseOffer(
+            over: Correction(
+                original: selection.text, element: selection.element,
+                owner: selection.owner, landing: .field,
+                dictation: dictationBehind(selection.text, in: selection.element),
+                selection: selection
+            ),
+            run: pressRun, headline: "the selection", reading: Confidence.Reading()
+        )
+    }
+
+    /// The dictation these words came from, or nil when nothing here wrote them.
+    ///
+    /// Asked at the moment an offer is raised and frozen onto it, never read
+    /// later: `lastDictated` is one slot and push-to-talk does not wait, so the
+    /// answer a second from now can belong to a different sentence.
+    ///
+    /// `contains` rather than equality — select three words out of something you
+    /// dictated and it is still your dictation, and the part you selected is the
+    /// part you meant. What keeps that from being true of everything is the
+    /// field, not the length, which is the same judgement `SelectionWatch`
+    /// makes. "know" is four characters and sits inside half of everything
+    /// anybody says; "know" in the box those words were written into is the word
+    /// you just dictated, and it is exactly the kind of word somebody selects
+    /// because they want it fixed.
+    private func dictationBehind(_ text: String, in element: AXUIElement?) -> Int? {
+        let target = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard target.count >= SelectionWatch.floor,
+              let last = lastDictated,
+              let element, let field = last.element, CFEqual(element, field),
+              last.text.contains(target) else { return nil }
+        return last.run
     }
 
     /// What the pill says the hold is for, or nil for the one that needs no
@@ -3841,6 +3950,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // words pointing at the newer dictation's field.
         guard let dictation, dictation == lastDictated?.run else { return }
         lastDictated?.text = corrected
+        // And the watch follows them. Selecting a sentence you have just had
+        // rewritten has to offer again — the words on screen are the new ones,
+        // and the old ones are not in the field to be selected any more.
+        watchForReselection()
     }
 
     private func beginCorrection(over target: Target = .whateverIsSelected) {

--- a/Sources/ParrotFlow/CaretAnchor.swift
+++ b/Sources/ParrotFlow/CaretAnchor.swift
@@ -145,6 +145,19 @@ enum CaretAnchor {
             ))
         }
 
+        // Chromium never gets past the line above. `AXBoundsForRange` declines
+        // inside a contenteditable — its offsets address a reconstruction rather
+        // than the render tree, the same fact `Surface` works around when it
+        // edits one — and the marker pair VoiceOver reads web content through,
+        // `AXSelectedTextMarkerRange` into `AXBoundsForTextMarkerRange`, was
+        // tried here and answered nothing on Slack's composer either. They may
+        // sit on the web area above the focused text area; reaching that is a
+        // tree walk, which this file has taken out once already.
+        //
+        // Written down because it has now been paid for twice: in web content
+        // there is no way to ask where a *span* is, only where the box holding
+        // it is, which is the line below.
+
         // The control's own rectangle, but only when it is small enough to be
         // one. A search box is 22pt tall and its box is as good as its caret; a
         // terminal's text view is 915pt tall and its box puts the pill under

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -497,6 +497,7 @@ final class PillHUD {
             panel.setContentSize(size)
             panel.setFrameOrigin(anchor(size))
             fadeIn(panel)
+            logFrame("raised")
         }
 
         guard let duration else { return }
@@ -633,6 +634,7 @@ final class PillHUD {
         guard let panel else { return }
         let frame = NSRect(origin: anchor(size), size: size)
         guard frame != panel.frame else { return }
+        defer { logFrame("moved") }
 
         NSAnimationContext.runAnimationGroup { context in
             context.duration = Self.motion
@@ -654,6 +656,25 @@ final class PillHUD {
         guard panel == nil else { return }
         model.onScreen = false
         build()
+    }
+
+    /// Where the window actually ended up.
+    ///
+    /// Every other line in this file is about what was *asked for* — the
+    /// anchor, the state, the keys — and a pill nobody can see has usually been
+    /// asked for perfectly and put somewhere off the screen it belongs on. That
+    /// is what this exists to tell apart, and it is how a pill that was raised,
+    /// keyed and invisible was tracked down once already.
+    private func logFrame(_ what: String) {
+        guard let panel else { return }
+        let capsule = panel.frame.insetBy(dx: PillMetrics.bleed, dy: PillMetrics.bleed)
+        let screen = NSScreen.screens.firstIndex { $0.frame.intersects(panel.frame) }
+        Log.write(String(
+            format: "pill: %@ at %.0f,%.0f %.0fx%.0f on screen %@%@",
+            what, capsule.minX, capsule.minY, capsule.width, capsule.height,
+            screen.map(String.init) ?? "none",
+            model.onScreen ? "" : " — but the surface is unmounted"
+        ))
     }
 
     private func build() {

--- a/Sources/ParrotFlow/SelectionWatch.swift
+++ b/Sources/ParrotFlow/SelectionWatch.swift
@@ -1,0 +1,150 @@
+import AppKit
+import ApplicationServices
+
+/// Notices when you select words ParrotFlow just wrote, so the offer can come
+/// back without being asked for.
+///
+/// ## Why this is events and not an observer
+///
+/// The obvious build is an `AXObserver` on the field, listening for
+/// `kAXSelectedTextChangedNotification`. It is also the only thing in this app
+/// that would need one — observer lifetimes, per-app registration, teardown on
+/// a window that closed while nobody was looking.
+///
+/// None of that is necessary, because a selection cannot appear on its own. It
+/// is made by dragging the mouse, by holding shift and pressing an arrow, or by
+/// ⌘A — and every one of those is an event `NSEvent` already hands out. So the
+/// question is asked at the three moments the answer can have changed, and
+/// never in between. An idle app is watching nothing.
+///
+/// ## Why the read is cheap
+///
+/// `kAXSelectedTextAttribute` returns the selected substring and nothing else.
+/// The expensive read in this app is `AXValue` — Outlook's message pane
+/// measured 395,489 characters, and `CaretAnchor` is careful about it for that
+/// reason. This is not that read. What comes back is what you highlighted.
+///
+/// ## What it refuses
+///
+/// It fires for one thing: a selection that is part of what ParrotFlow last
+/// wrote. Anything else is somebody selecting text to copy it, delete it, drag
+/// it or type over it, which is most of what selecting is for — and a surface
+/// that appeared every time would be wrong far more often than right.
+///
+/// It also never fires twice for the same words. Dismiss the offer and the
+/// selection is usually still sitting there, so the next arrow key would put it
+/// straight back up. `offered` is what stops that: the pill returns when you
+/// select something, not while you have something selected.
+final class SelectionWatch {
+
+    /// A selection worth offering on: the words, and the field they are in.
+    var onSelection: ((SelectionReader.Selection) -> Void)?
+
+    /// What the selection has to be part of. Nil stops the watch answering —
+    /// it is set from `lastTranscript`, which is empty until something is said.
+    private var haystack: String?
+    /// The field the last dictation landed in.
+    ///
+    /// This is what makes a short selection safe. "know" is four characters and
+    /// is inside half the sentences anybody dictates, but "know" *in the box
+    /// those words were written into* is the word you just said — so the
+    /// question is asked about the field rather than about the length.
+    private var field: AXUIElement?
+    private var monitors: [Any] = []
+    /// The last selection handed out, so it is not handed out again.
+    private var offered: String?
+    /// A drag ends in one event; shift-arrow makes one per keypress. Reading on
+    /// every one is cheap but pointless, and the second read of a growing
+    /// selection is a different string, so `offered` would not stop it.
+    private var lastLook = Date.distantPast
+
+    var isRunning: Bool { !monitors.isEmpty }
+
+    /// Watch for selections inside `text`.
+    ///
+    /// Called again with the new transcript every time one is written — a
+    /// rewrite changes what the words are, and the offer has to follow them.
+    func start(over text: String, in element: AXUIElement?) {
+        haystack = text
+        field = element
+        offered = nil
+        guard monitors.isEmpty else { return }
+        guard Permissions.accessibility == .granted else {
+            Log.write("reselect: accessibility is not granted; selections cannot be seen")
+            return
+        }
+
+        // Mouse up rather than down: the drag is over and the selection is
+        // final. Key up for the same reason, and it covers shift-arrow, ⌘A and
+        // shift-click's keyboard half in one mask.
+        let mask: NSEvent.EventTypeMask = [.leftMouseUp, .keyUp]
+        let look: (NSEvent) -> Void = { [weak self] _ in self?.look() }
+        if let global = NSEvent.addGlobalMonitorForEvents(matching: mask, handler: look) {
+            monitors.append(global)
+        }
+        // The local one is not for our own windows — it is for the moment our
+        // panel has focus and the selection behind it is still the one being
+        // talked about. Passing the event straight back leaves it untouched.
+        if let local = NSEvent.addLocalMonitorForEvents(matching: mask, handler: { event in
+            look(event)
+            return event
+        }) {
+            monitors.append(local)
+        }
+    }
+
+    func stop() {
+        for monitor in monitors { NSEvent.removeMonitor(monitor) }
+        monitors = []
+        haystack = nil
+        field = nil
+        offered = nil
+    }
+
+    deinit { stop() }
+
+    /// The whole of the work, at the three moments a selection can have changed.
+    private func look() {
+        guard let haystack else { return }
+        // 40ms, which is under the fastest key repeat and over the cost of one
+        // small accessibility read. Held down, an arrow key would otherwise ask
+        // this on every repeat while the selection is still growing.
+        guard Date().timeIntervalSince(lastLook) > 0.04 else { return }
+        lastLook = Date()
+
+        // `offered` survives exactly as long as the selection it was about. Let
+        // go of those words — click away, select something else — and the same
+        // words chosen again are a new request, not the old one still standing.
+        //
+        // It was cleared only when the watch restarted, which meant selecting a
+        // term, clicking off it, and selecting it again did nothing at all. The
+        // rule it was written for is narrower than that: the pill must not come
+        // back while a selection it has already answered is still sitting there.
+        guard let selection = SelectionReader.snapshot(),
+              let field, let element = selection.element, CFEqual(field, element)
+        else {
+            offered = nil
+            return
+        }
+        // In the field the words were written into. Everything else this could
+        // check — how long the selection is, how unusual — is a proxy for this
+        // one question, and a bad one: a floor high enough to rule out "the"
+        // ruled out "know", which is a word somebody selects precisely because
+        // they want it fixed.
+        let text = selection.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard text.count >= Self.floor, haystack.contains(text) else {
+            offered = nil
+            return
+        }
+        guard text != offered else { return }
+
+        offered = text
+        Log.write("reselect: \"\(text.prefix(60))\" is part of the last dictation")
+        onSelection?(selection)
+    }
+
+    /// One letter is somebody part-way through a selection, or fixing a typo
+    /// by hand. Two is a word. Nothing above this is ruled out by length —
+    /// `field` is what does the ruling out.
+    static let floor = 2
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -248,6 +248,27 @@ select a paragraph in Word, tap, and press a chip's letter.
 This is why the offer's six seconds are not a deadline. It is not kept on
 screen against the chance that you want it — you ask for it again.
 
+**Select what it just wrote and the pill comes back on its own**, with no key
+at all. All or part of it — select three words out of a sentence you dictated
+and those three words are the target.
+
+Only for words ParrotFlow wrote, in the field it wrote them into, and only
+while they are still the last thing it wrote. Every other selection gets
+nothing, because selecting text is mostly how you copy it, delete it or type
+over it, and a surface that appeared each time would be wrong far more often
+than right. It never appears twice for the same words either: the pill returns
+when you *select* something, not while you have something selected.
+
+It costs no polling. A selection is made by a drag, a shift-arrow or ⌘A, so the
+question is asked at those three moments and never in between.
+
+**`Vocabulary` is left off the pill for words nothing here dictated.** The
+panel behind it maps what was *heard* to what it should be, and there is no
+hearing behind a paragraph somebody else typed — a rule taught from their typo
+would fire on your own future dictations, correcting a mistake the decoder
+never made. Every other chip is a rewrite and applies to any text, so they
+stay.
+
 **Bare modifiers only.** A `⌃⌥Space`-style combo goes through Carbon, which
 delivers the press on the down edge and swallows the keystroke, so there is no
 short press left over to claim: a tap there is a dictation, and a brief one.


### PR DESCRIPTION
After a dictation, selecting the words it just wrote brings the offer back on
its own — no key at all, all or part of the sentence, and the part you selected
is what the chips act on. It only answers a selection inside the field that
dictation landed in, and only while those words are still the last thing
ParrotFlow wrote; every other selection gets nothing. This also closes a hazard
the hotkey tap opened: `Vocabulary` is now left off the pill for words nothing
here dictated.

Start the review at `SelectionWatch.swift` — it is the whole feature and it is
150 lines. Then `dictationBehind` in `AppDelegate.swift`, which is the one
predicate both halves ask.

<details>
<summary>Why this needs no AXObserver, and no polling</summary>

The obvious build is an `AXObserver` on the field listening for
`kAXSelectedTextChangedNotification`. It would be the only one in the app —
observer lifetimes, per-app registration, teardown on a window that closed
while nobody was looking.

None of it is necessary. A selection cannot appear on its own. It is made by
dragging the mouse, by holding shift and pressing an arrow, or by ⌘A, and every
one of those is an event `NSEvent` already hands out. So the question is asked
at those three moments and never in between. An idle app is watching nothing,
and the monitors exist only while there is something to select.

The read is cheap for a second reason. `kAXSelectedTextAttribute` returns the
selected substring and nothing else. The expensive read in this app is
`AXValue` — the one `CaretAnchor` is careful about after Outlook reported a
message pane of 395,489 characters. This is not that read.

</details>

<details>
<summary>It is judged by the field, not by how long the selection is</summary>

A length floor guards the right risk with the wrong instrument.

The risk is a selected "the" — a word inside every sentence anybody has ever
dictated, which would put the offer up over text with no connection to the last
one. But a floor high enough to rule that out also rules out "know", and "know"
is exactly the kind of word somebody selects because they want it fixed.

The question is which field. "know" in the box those words were written into is
the word you just said. So the watch holds the element the dictation landed in
and compares against it, and the floor drops to 2 — one character is somebody
part-way through a drag.

No field, no watch. A dictation that ended on the clipboard left nothing on
screen to reselect, and one whose element was never captured cannot be told
from any other window.

</details>

<details>
<summary>Why Vocabulary comes off the pill, and why the other chips do not</summary>

The panel behind that chip maps what was HEARD to what it should be. Over a
paragraph somebody else typed there is no hearing — nothing listened to it. A
rule taught from their typo is written to `vocabulary.yaml` and fires on *your*
future dictations, correcting a mistake the decoder never made.

Before the hotkey could summon an offer over an arbitrary selection this could
not arise: the panel only ever opened over a dictation. Leaving the chip off is
the whole of the fix.

Every other chip is a rewrite — grammar, terse, a `command:` script — and those
apply to any text, so they stay.

One consequence worth checking in review: the chip row can no longer be read by
position alone. Index 0 is Vocabulary *when it is there*, matched that way so a
config free to name a transform "Vocabulary" cannot take the slot over. An offer
without it has to say so, or the first transform would be run as the panel.

</details>

<details>
<summary>Where the shared-slot bug could have come back, and what stops it</summary>

Review on #211 and #212 found seven instances of one class: the app held one
mutable slot per thing it might read, and a second dictation started mid-flight
stole it. This feature reads state after a gap by construction, so it is the
same shape.

`dictationBehind` is asked once, at the moment an offer is raised, and the
answer is frozen onto the `Correction`. It is never asked again when a chip is
pressed. `lastDictated` is one slot and push-to-talk does not wait, so the same
question a few seconds later can be about a different sentence.

The watch itself is armed where the dictation record is written — below the
guard that refuses an offer to a superseded run — and stopped at the top of the
next press that starts a dictation, so the gap in between cannot offer over a
sentence that is already history.

</details>

<details>
<summary>Two things kept from the notch, which was built and taken out again</summary>

Both were paid for by that work and neither should be paid for twice.

`PillHUD.logFrame` says where the window actually landed. Every other line in
that file records what was *asked for* — the anchor, the state, the keys — and
a pill nobody can see has usually been asked for perfectly and put somewhere
off the screen it belongs on. Telling those apart is how a pill that was
raised, keyed and invisible got tracked down.

`CaretAnchor` now records why web content stops at the control's own box.
`AXBoundsForRange` declines inside a contenteditable, and the marker pair
VoiceOver reads web content through — `AXSelectedTextMarkerRange` into
`AXBoundsForTextMarkerRange` — answered nothing on Slack's composer either. In
web content there is no way to ask where a *span* is, only where the box
holding it is.

</details>

<details>
<summary>What this does not do</summary>

It does not watch for selections in an app ParrotFlow has not written into.
Reaching those still takes a tap, which is what #211 added.

It does not survive the next dictation. The watch is one record deep on
purpose — the offer is about what was last written, and reappearing over older
text is the same mistake made later.

</details>

- [x] `make test` passes.
- [x] No prompt, table or pattern changed, so there is nothing to score.
- [x] Every commit is signed off.
