### PR TITLE
feat: the offer shows the words it is about

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -840,6 +840,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         } catch {
             hotkeyError = error.localizedDescription
             Log.write("hotkey registration FAILED: \(error.localizedDescription)")
+            // `register` unregisters before it tries, so a reload that fails
+            // leaves nothing bound. Cleared rather than left saying the old
+            // key: the row would be naming a key with no handler behind it,
+            // which is worse than the row being absent. Empty takes it off the
+            // pill — see `OfferContent.hold`.
+            pill.model.hotkey = ""
         }
 
         startKeepWarm()

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -826,11 +826,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         hotKeys.onAbort = { [weak self] in self?.cancelDictation(.notTheHotkey) }
         hotKeys.onTap = { [weak self] in self?.summonOffer() }
         do {
-            try hotKeys.register(
+            let binding = try hotKeys.register(
                 key: config.hotkey.key,
                 modifiers: config.hotkey.modifiers,
                 pressDelay: config.hotkey.pressDelaySeconds
             )
+            // The offer's "or hold …" row names this key, so it is read from
+            // what actually registered rather than from the config: a key the
+            // config asked for and macOS refused is not the key to tell
+            // somebody to hold. Set on every reload, because the hotkey is one
+            // of the things a reload can change.
+            pill.model.hotkey = binding.displayName
         } catch {
             hotkeyError = error.localizedDescription
             Log.write("hotkey registration FAILED: \(error.localizedDescription)")

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -388,7 +388,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var offerOnScreen: [OfferedCommand]?
     /// The headline and the reading the offer went up with, so the pill can be
     /// drawn again without rebuilding what it is about. See `holdTheReturn`.
-    private var offerHeadline: String?
+    private var offerHeadline: Headline?
     private var offerReading = Confidence.Reading()
     /// Until when this offer's Return is held. Set when the offer goes up, so
     /// an offer whose keys arrive late — a second dictation was still running —
@@ -2870,7 +2870,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// off `self`, so an offer can never be moved by another dictation's press.
     /// `headline` is only passed for an ending nobody chose.
     private func showCorrectOffer(
-        for press: Press, landing: Correction.Landing, headline: String? = nil
+        for press: Press, landing: Correction.Landing, headline: Headline? = nil
     ) {
         // Beside the offer, not on it: its own window, so advice about the
         // microphone never costs you the chance to fix the sentence. Here
@@ -2966,7 +2966,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// nothing else does: the microphone notice, the decoder's reading, and the
     /// search for where the words landed.
     private func raiseOffer(
-        over target: Correction, run: Int, headline: String?, reading: Confidence.Reading
+        over target: Correction, run: Int, headline: Headline?, reading: Confidence.Reading
     ) {
         offerUntil = Date().addingTimeInterval(Self.offerSeconds)
         // A new offer is never born held, whatever the last one ended as.
@@ -3054,7 +3054,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     dictation: dictationBehind(selection.text, in: selection.element),
                     selection: selection
                 ),
-                run: pressRun, headline: "the selection", reading: Confidence.Reading()
+                run: pressRun, headline: .selection(selection.text),
+                reading: Confidence.Reading()
             )
             return
         }
@@ -3136,7 +3137,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 dictation: dictationBehind(selection.text, in: selection.element),
                 selection: selection
             ),
-            run: pressRun, headline: "the selection", reading: Confidence.Reading()
+            run: pressRun, headline: .selection(selection.text),
+            reading: Confidence.Reading()
         )
     }
 
@@ -4731,7 +4733,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     : "focus moved since the press; copied instead of pasting")
                 setLabel("Focus moved — the transcription is on your clipboard", clearAfter: 4)
                 showCorrectOffer(
-                    for: press, landing: .clipboardNow(), headline: "Focus moved · ⌘V"
+                    for: press, landing: .clipboardNow(), headline: .landing("Focus moved · ⌘V")
                 )
                 updateUI()
                 return
@@ -4765,7 +4767,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             setLabel("Nowhere to type — the transcription is on your clipboard", clearAfter: 4)
             // And on the pill: the menu bar row is inside a menu you must open.
             showCorrectOffer(
-                for: press, landing: .clipboardNow(), headline: "Nowhere to type · ⌘V"
+                for: press, landing: .clipboardNow(), headline: .landing("Nowhere to type · ⌘V")
             )
             updateUI()
             return

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1119,7 +1119,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Only for a press that starts a dictation: the second press of a
         // toggle belongs to the one already running, and it did not ask for
         // anything different.
-        if !recorder.isRecording { keyedAtPress = afterTap }
+        //
+        // A plain hold counts as keyed while an offer over a *selection* is up,
+        // and only then. There the pill is pointing at words and asking what to
+        // do about them, so a hold cannot mean "start a new dictation" — and
+        // the tap that summoned it already happened, so asking for another
+        // would be asking twice for the same thing. It is also what the third
+        // row of that pill promises, and a promise nothing honoured would be
+        // worse than no row.
+        //
+        // An offer over the last dictation is not that. It carries no such row,
+        // nothing on screen offers the gesture, and holding after a sentence
+        // lands is how the next one gets said. Matched against the headline
+        // rather than against `selectionAtPress` so the rule is the one the
+        // pill is drawing: the row appears exactly when this is true, and the
+        // two cannot drift apart.
+        if !recorder.isRecording {
+            keyedAtPress = afterTap || (offerIsUp && offerHeadline?.isSelection == true)
+        }
         // Read before anything this press does, so an abort later can tell the
         // transcription this press started from one that was already running.
         transcriptionRunAtPress = transcriptionRun
@@ -3424,6 +3441,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         offerHeld = false
         offeredCorrection = nil
         offerOnScreen = nil
+        // With the rest of what the offer was about. It decides whether a hold
+        // is an edit — see `handleHotKeyPress` — and a headline outliving its
+        // offer is one more slot that says something true about a surface that
+        // is no longer there.
+        offerHeadline = nil
         offerKeysExpiry?.cancel()
         offerKeysExpiry = nil
         offerKeys.stop()

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -119,8 +119,19 @@ enum PanelsCommand {
         let caution = pill(.notice("Grammar copied — this app won't let me edit it", .caution))
         let thinking = pill(.working("Thinking…"))
         let offer = pill(.offer(offerChips, nil, Confidence.Reading()))
+        // The offer over a selection: three rows, and the words themselves
+        // rather than a word for them. On the sheet because the difference from
+        // the plain one is the whole design — a pill that says which words is a
+        // different surface from one that says there are some, and a row that
+        // is only sometimes there gets looked at nowhere else.
+        let offerSelection = pill(.offer(
+            offerChips, .selection("things that turned out not to matter"),
+            Confidence.Reading()
+        ))
         // Beside the plain one: the two endings must not look the same.
-        let offerCopied = pill(.offer(offerChips, "Nowhere to type · ⌘V", Confidence.Reading()))
+        let offerCopied = pill(.offer(
+            offerChips, .landing("Nowhere to type · ⌘V"), Confidence.Reading()
+        ))
         // The warning on its own, which is what most people will ever see of
         // this: `feedback.confidence` is off by default and the thresholds are
         // not, so a shaky dictation raises one line and nothing else.
@@ -254,6 +265,8 @@ enum PanelsCommand {
             // comparison that matters: it has to not look like one.
             (AnyView(PillView().environmentObject(offer)),
              pillSize(offer), .dark, true),
+            (AnyView(PillView().environmentObject(offerSelection)),
+             pillSize(offerSelection), .dark, true),
             (AnyView(PillView().environmentObject(offerCopied)),
              pillSize(offerCopied), .dark, true),
             // The same offer with `feedback.confidence` on: two rows instead of

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -112,6 +112,10 @@ enum PanelsCommand {
             model.state = state
             model.appIcon = icon
             model.level = level
+            // No hotkey is registered behind the sheet, so the selection offer
+            // is drawn against the shipped default — which is the one a reader
+            // should be checking that row against, and is not this machine's.
+            model.hotkey = "Right ⌘"
             return model
         }
 

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -397,7 +397,9 @@ enum PanelsCommand {
     /// The window's size, not the capsule's — the glow needs the bleed around
     /// it or the sheet cuts the halo off square.
     private static func pillSize(_ model: PillModel) -> NSSize {
-        PillMetrics.panelSize(for: model.state, hasIcon: model.appIcon != nil)
+        PillMetrics.panelSize(
+            for: model.state, hasIcon: model.appIcon != nil, hotkey: model.hotkey
+        )
     }
 
     /// Something recognisable to sit in the pill's slot. Mail because that is

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -57,15 +57,49 @@ enum PillState: Equatable {
     /// one the pointer is on lives in the model, not here, so moving the
     /// highlight is not a state change and does not crossfade the whole pill.
     ///
-    /// The headline is where the words went. Nil when they went into the field
-    /// you were looking at, set for the endings nobody asked for.
+    /// The headline says either where the words went or which words they are —
+    /// see `Headline`. Nil for an offer that needs neither.
     ///
     /// The reading is what the decoder made of the dictation — the sentence
     /// word by word, its score for the whole utterance, and a warning when it
     /// is worth a second look. An empty one is the whole difference: it is what
     /// decides the pill's height, so nothing about this state changes shape for
     /// a dictation that went fine.
-    case offer([OfferedCommand], String?, Confidence.Reading)
+    case offer([OfferedCommand], Headline?, Confidence.Reading)
+}
+
+/// What an offer says above its chips.
+///
+/// Two things, and they are opposite enough to be worth telling apart in the
+/// type. A landing is about the *ending* — the words went somewhere you did not
+/// ask for, and you have to know that before the chips mean anything. A
+/// selection is about the *subject*, and it is drawn as the words themselves in
+/// the highlight they wear in the field, because the one question an offer over
+/// a selection has to answer is which words, and no description of them is as
+/// exact as showing them.
+///
+/// They are also measured differently — a landing widens the chip row it sits
+/// in front of, a selection is a row of its own — which is the other half of
+/// why one `String?` could not carry both.
+enum Headline: Equatable {
+    /// "Nowhere to type · ⌘V", and the rest of the endings nobody asked for.
+    case landing(String)
+    /// The words this offer is about, shown as the field shows them.
+    case selection(String)
+
+    var text: String {
+        switch self {
+        case .landing(let words), .selection(let words): return words
+        }
+    }
+
+    /// Whether this is the three-row shape: the words, the chips, and the line
+    /// about the key. Read by the metrics and by the view, so the two cannot
+    /// disagree about which shape they are describing.
+    var isSelection: Bool {
+        if case .selection = self { return true }
+        return false
+    }
 }
 
 /// A command on the offer, and the letter that runs it.
@@ -220,7 +254,7 @@ final class PillHUD {
     /// usable to the last frame. The keys and the chips work the whole way
     /// down; the fading only says how long is left.
     func offer(
-        _ commands: [OfferedCommand], headline: String? = nil,
+        _ commands: [OfferedCommand], headline: Headline? = nil,
         reading: Confidence.Reading = Confidence.Reading(), for duration: TimeInterval
     ) {
         model.selected = nil
@@ -906,6 +940,29 @@ enum PillMetrics {
     )
     static let sentenceGap: CGFloat = 4
 
+    /// Between the rows of an offer over a selection.
+    ///
+    /// Wider than `sentenceGap`, which sets the reading's lines — those are one
+    /// block of text and belong together. These three are three different
+    /// things: the words, what can be done to them, and the way out the chips
+    /// do not cover. At 4pt they read as a paragraph rather than as a list of
+    /// choices.
+    static let selectionGap: CGFloat = 8
+
+    /// What the two extra rows of a selection offer say.
+    ///
+    /// Here rather than in the view because the pill is measured before it is
+    /// drawn, and a string measured in one place and set in another is how a
+    /// chip ends up hanging over the end of a capsule. The view reads these.
+    static let editLead = "Edit"
+    static let holdLead = "or hold"
+    static let holdTail = "and say what to change"
+    /// The ⌥ keycap between the two halves of the hold line, and the gaps
+    /// either side of it.
+    static let holdKeycap: CGFloat = 20 + 12
+    /// The highlight's own padding, either side of the words.
+    static let selectionFit: CGFloat = 12
+
     /// Extra air above the sentence, on top of what centring the two rows
     /// already leaves. The chips sit in capsules of their own and carry their
     /// own margin with them; the sentence is bare text and read as crowded
@@ -945,10 +1002,16 @@ enum PillMetrics {
     /// An offer with nothing to say about the decode is the height the pill has
     /// always been, so a dictation that went fine changes nothing.
     static func height(for state: PillState, width: CGFloat) -> CGFloat {
-        guard case .offer(_, _, let reading) = state else { return height }
+        guard case .offer(_, let headline, let reading) = state else { return height }
+        // A selection offer is three rows: the words, the chips, and the line
+        // about the key. Two of them are extra, and they are added whatever the
+        // reading says — the two can appear together, on a dictation you
+        // selected part of after being warned about it.
+        let extra = headline?.isSelection == true ? (sentenceLine + selectionGap) * 2 : 0
         let rows = readingRows(reading, width: width)
-        guard !rows.isEmpty else { return height }
-        return height + sentenceTop + rows.reduce(0, +) + sentenceGap * CGFloat(rows.count)
+        guard !rows.isEmpty else { return height + extra }
+        return height + extra + sentenceTop
+            + rows.reduce(0, +) + sentenceGap * CGFloat(rows.count)
     }
 
     /// The height of each row the reading draws, top to bottom. The count is
@@ -1046,12 +1109,17 @@ enum PillMetrics {
     /// title is `.fixedSize()`, so a capsule a few points too narrow lets a
     /// chip hang over the end rather than shortening it.
     ///
-    /// A headline widens it and is meant to: then the sentence is on the
-    /// clipboard and looking like a notice is the point.
+    /// A landing headline widens it and is meant to: then the sentence is on
+    /// the clipboard and looking like a notice is the point.
     /// A sentence widens it too, up to `sentenceWidth`, and then wraps. So
     /// does a warning, which never wraps.
+    ///
+    /// A selection headline does neither. It is a row of its own, so it
+    /// competes with the chip row for the pill's width rather than adding to
+    /// it — and it is capped like the sentence, because a selection can be a
+    /// paragraph and a pill as wide as one is a pill nobody can place.
     static func offer(
-        _ commands: [OfferedCommand], headline: String? = nil,
+        _ commands: [OfferedCommand], headline: Headline? = nil,
         reading: Confidence.Reading = Confidence.Reading()
     ) -> CGFloat {
         // A chip is its keycap, its words and 9pt of padding either side; then
@@ -1059,10 +1127,21 @@ enum PillMetrics {
         let chips = commands.reduce(CGFloat(0)) { total, command in
             total + 18 + (command.key.isEmpty ? 0 : keycap) + title(command.title)
         }
-        let lead = headline.map { title($0) + gap } ?? 0
+        let lead: CGFloat
+        if case .landing(let words) = headline { lead = title(words) + gap } else { lead = 0 }
         let row = padding * 2 + lead + chips
             + CGFloat(max(commands.count - 1, 0)) * 4 + rowFit
         var widest = row
+        if case .selection(let words) = headline {
+            widest = max(widest, min(
+                sentenceWidth,
+                padding * 2 + title(editLead) + gap + title(words) + selectionFit
+            ))
+            widest = max(widest, min(
+                sentenceWidth,
+                padding * 2 + title(holdLead) + holdKeycap + title(holdTail)
+            ))
+        }
         if !reading.words.isEmpty {
             widest = max(widest, min(sentenceWidth, padding * 2 + sentenceRun(reading.words)))
         }
@@ -1327,7 +1406,7 @@ private struct MessageContent: View {
 private struct OfferContent: View {
     @EnvironmentObject private var model: PillModel
     let commands: [OfferedCommand]
-    let headline: String?
+    let headline: Headline?
     /// What the decoder made of the dictation. See `Confidence.Reading`.
     var reading = Confidence.Reading()
 
@@ -1344,13 +1423,18 @@ private struct OfferContent: View {
     private static let restingText = Color(white: 0.88)
 
     var body: some View {
-        VStack(alignment: .leading, spacing: PillMetrics.sentenceGap) {
+        VStack(
+            alignment: .leading,
+            spacing: centred ? PillMetrics.selectionGap : PillMetrics.sentenceGap
+        ) {
             if let warning = reading.warning { self.warning(warning) }
             if !reading.words.isEmpty {
                 words
                 if let overall = reading.overall { score(overall) }
             }
+            selection
             chips
+            hold
         }
         // The whole block is centred in the pill's height, so this lands as air
         // above the sentence rather than being split between the two rows.
@@ -1415,16 +1499,99 @@ private struct OfferContent: View {
             .padding(.horizontal, PillMetrics.padding)
     }
 
+    /// The words the offer is about, wearing the highlight they wear in the
+    /// field.
+    ///
+    /// Shown rather than described. "the selection" answered a question nobody
+    /// was asking — the doubt is never *whether* there is a selection, it is
+    /// which words are about to change, and the only exact answer to that is
+    /// the words. It also asks the accessibility layer for nothing, which is
+    /// why it survives where pointing at the span did not: web content will not
+    /// say where a span is, only where the box holding it is.
+    ///
+    /// The app's own blue, not a neutral fill. Those words are sitting in that
+    /// colour two lines above, so the pill says "these ones" by matching. This
+    /// is the one place colour goes inside a surface here — `parrotSurface`
+    /// keeps it on the rim, because "a surface washed in a feather is a surface
+    /// you have to read text off" — and it earns the exception by being a
+    /// quotation mark rather than decoration.
+    @ViewBuilder private var selection: some View {
+        if case .selection(let words) = headline {
+            HStack(spacing: PillMetrics.gap - 4) {
+                Text(PillMetrics.editLead)
+                    .font(.system(size: 12, weight: .medium, design: .rounded))
+                    .foregroundStyle(Color(white: 0.55))
+                Text(words)
+                    .font(.system(size: 12, weight: .medium, design: .rounded))
+                    .foregroundStyle(Self.quotedText)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 1)
+                    .background(
+                        RoundedRectangle(cornerRadius: 3, style: .continuous)
+                            .fill(Parrot.action.opacity(0.42))
+                    )
+            }
+            .padding(.horizontal, PillMetrics.padding)
+            .frame(maxWidth: .infinity, alignment: .center)
+        }
+    }
+
+    /// The other way out, under the chips.
+    ///
+    /// The chips are a short list; holding the key reaches every transform and
+    /// the catch-all besides. Said on the pill because this is the one surface
+    /// where the two are alternatives to each other — everywhere else the
+    /// gesture is something you either know or do not.
+    @ViewBuilder private var hold: some View {
+        if case .selection = headline {
+            HStack(spacing: 6) {
+                Text(PillMetrics.holdLead)
+                keycap("⌥")
+                Text(PillMetrics.holdTail)
+            }
+            .font(.system(size: 12, weight: .medium, design: .rounded))
+            .foregroundStyle(Color(white: 0.5))
+            .padding(.horizontal, PillMetrics.padding)
+            .frame(maxWidth: .infinity, alignment: .center)
+        }
+    }
+
+    /// The words on the highlight: the glass text, so they read the way the
+    /// dictated sentence does two rows up rather than as white on blue.
+    private static let quotedText = Color(red: 0.875, green: 0.941, blue: 0.906)
+
+    private func keycap(_ glyph: String) -> some View {
+        Text(glyph)
+            .font(.system(size: 11, weight: .bold, design: .rounded))
+            .foregroundStyle(Color(white: 0.72))
+            .frame(width: 20, height: 17)
+            .background(
+                RoundedRectangle(cornerRadius: 4, style: .continuous)
+                    .fill(Color.white.opacity(0.07))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4, style: .continuous)
+                            .strokeBorder(Color.white.opacity(0.12), lineWidth: 1)
+                    )
+            )
+    }
+
+    /// Whether this is the three-row shape, which is centred throughout.
+    private var centred: Bool { headline?.isSelection == true }
+
     private var chips: some View {
         HStack(spacing: 4) {
-            if let headline {
-                Text(headline)
+            if case .landing(let words) = headline {
+                Text(words)
                     .font(.system(size: 12, weight: .medium, design: .rounded))
                     .foregroundStyle(NoticeTone.caution.color)
                     .lineLimit(1)
                     .fixedSize()
                     .padding(.trailing, PillMetrics.gap - 4)
             }
+
+            if centred { Spacer(minLength: 0) }
 
             ForEach(Array(commands.enumerated()), id: \.offset) { index, command in
                 // A tap gesture rather than a `Button`. The pill is a
@@ -1444,7 +1611,10 @@ private struct OfferContent: View {
             Spacer(minLength: 0)
         }
         .padding(.horizontal, PillMetrics.padding)
-        .frame(maxWidth: .infinity, alignment: .leading)
+        // Centred under the words it is about, left where it is the only row.
+        // Three rows want one axis; one row is a thing you aim at, and a row of
+        // chips that moves as the pill grows is a row you have to find again.
+        .frame(maxWidth: .infinity, alignment: centred ? .center : .leading)
     }
 
     /// Lit carries the same leaf as a changed word and as the confirm button:

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -87,12 +87,6 @@ enum Headline: Equatable {
     /// The words this offer is about, shown as the field shows them.
     case selection(String)
 
-    var text: String {
-        switch self {
-        case .landing(let words), .selection(let words): return words
-        }
-    }
-
     /// Whether this is the three-row shape: the words, the chips, and the line
     /// about the key. Read by the metrics and by the view, so the two cannot
     /// disagree about which shape they are describing.

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -131,6 +131,18 @@ final class PillModel: ObservableObject {
     /// can go. See `Destination`.
     @Published var appIcon: NSImage?
 
+    /// The hotkey as it is written on screen — "Right ⌘", "⌃⌥Space".
+    ///
+    /// The selection offer tells you to hold it, and the key is configurable,
+    /// so the glyph cannot be a literal. It was `⌥` here while the shipped
+    /// default is `right_command`, which told everyone but this machine to hold
+    /// the wrong key.
+    ///
+    /// Here rather than in the state, for the reason the icon is: it changes
+    /// when the config is read, not when the pill changes what it is saying,
+    /// and a state change crossfades the whole surface.
+    @Published var hotkey: String = ""
+
     /// Which command the pointer is on, if any.
     ///
     /// Nil when it is on none, which is how the offer arrives. This is only
@@ -1558,7 +1570,7 @@ private struct OfferContent: View {
         if case .selection = headline {
             HStack(spacing: 6) {
                 Text(PillMetrics.holdLead)
-                keycap("⌥")
+                keycap(model.hotkey.isEmpty ? "⌥" : model.hotkey)
                 Text(PillMetrics.holdTail)
             }
             .font(.system(size: 12, weight: .medium, design: .rounded))
@@ -1572,11 +1584,18 @@ private struct OfferContent: View {
     /// dictated sentence does two rows up rather than as white on blue.
     private static let quotedText = Color(red: 0.875, green: 0.941, blue: 0.906)
 
+    /// Sized to what it holds, with a floor. The hotkey is configurable and
+    /// its name is anything from "fn" to "⌃⌥Space", so a fixed width either
+    /// clips the long ones or leaves the short ones swimming. The floor and the
+    /// padding are the same numbers `PillMetrics.holdKeycapWidth` measures, or
+    /// the capsule is sized for a cap it does not draw.
     private func keycap(_ glyph: String) -> some View {
         Text(glyph)
             .font(.system(size: 11, weight: .bold, design: .rounded))
             .foregroundStyle(Color(white: 0.72))
-            .frame(width: 20, height: PillMetrics.holdKeycapHeight)
+            .fixedSize()
+            .padding(.horizontal, 2)
+            .frame(minWidth: 20, minHeight: PillMetrics.holdKeycapHeight)
             .background(
                 RoundedRectangle(cornerRadius: 4, style: .continuous)
                     .fill(Color.white.opacity(0.07))

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -212,7 +212,9 @@ final class PillHUD {
     /// window — which in the middle of a morph is a width on its way somewhere
     /// rather than a width anything chose.
     private var wantedSize: NSSize {
-        PillMetrics.panelSize(for: model.state, hasIcon: model.appIcon != nil)
+        PillMetrics.panelSize(
+            for: model.state, hasIcon: model.appIcon != nil, hotkey: model.hotkey
+        )
     }
 
     /// One number for the whole surface: the rise, the morph and the fade.
@@ -922,10 +924,12 @@ enum PillMetrics {
     /// less there is to see.
     static let bleed: CGFloat = 52
 
-    static func panelSize(for state: PillState, hasIcon: Bool) -> NSSize {
-        let width = width(for: state, hasIcon: hasIcon)
+    static func panelSize(
+        for state: PillState, hasIcon: Bool, hotkey: String = ""
+    ) -> NSSize {
+        let width = width(for: state, hasIcon: hasIcon, hotkey: hotkey)
         return NSSize(width: width + bleed * 2,
-                      height: height(for: state, width: width) + bleed * 2)
+                      height: height(for: state, width: width, hotkey: hotkey) + bleed * 2)
     }
 
     /// The face the dictated sentence is set in — the same one the chips use.
@@ -963,9 +967,15 @@ enum PillMetrics {
     static let editLead = "Edit"
     static let holdLead = "or hold"
     static let holdTail = "and say what to change"
-    /// The ⌥ keycap between the two halves of the hold line, and the gaps
-    /// either side of it.
-    static let holdKeycap: CGFloat = 20 + 12
+    /// The keycap between the two halves of the hold line, and the gaps either
+    /// side of it.
+    ///
+    /// Measured from the name it will hold, because the hotkey is configurable
+    /// and "Right ⌘" is not the width of "⌥". A fixed box is what let the glyph
+    /// be a literal in the first place.
+    static func holdKeycapWidth(_ hotkey: String) -> CGFloat {
+        max(20, title(hotkey) + 4) + 12
+    }
     /// Its box, which is taller than a line of the text beside it.
     static let holdKeycapHeight: CGFloat = 17
     /// The highlight's own padding, either side of the words.
@@ -1023,13 +1033,19 @@ enum PillMetrics {
     ///
     /// An offer with nothing to say about the decode is the height the pill has
     /// always been, so a dictation that went fine changes nothing.
-    static func height(for state: PillState, width: CGFloat) -> CGFloat {
+    static func height(for state: PillState, width: CGFloat, hotkey: String = "") -> CGFloat {
         guard case .offer(_, let headline, let reading) = state else { return height }
         // A selection offer is three rows: the words, the chips, and the line
         // about the key. Two of them are extra, and they are added whatever the
         // reading says — the two can appear together, on a dictation you
         // selected part of after being warned about it.
-        let extra = headline?.isSelection == true ? (selectionRow + selectionGap) * 2 : 0
+        // The words row always, and the hold row only when there is a key to
+        // name — `OfferContent.hold` draws it on the same condition.
+        var extra: CGFloat = 0
+        if headline?.isSelection == true {
+            extra = selectionRow + selectionGap
+            if !hotkey.isEmpty { extra += selectionRow + selectionGap }
+        }
         let rows = readingRows(reading, width: width)
         guard !rows.isEmpty else { return height + extra }
         return height + extra + sentenceTop
@@ -1088,13 +1104,15 @@ enum PillMetrics {
     static let icon: CGFloat = 22
     static let meter: CGFloat = 66
 
-    static func width(for state: PillState, hasIcon: Bool) -> CGFloat {
+    static func width(
+        for state: PillState, hasIcon: Bool, hotkey: String = ""
+    ) -> CGFloat {
         switch state {
         case .recording(let label): return recording(hasIcon: hasIcon, label: label)
         case .working(let message): return text(message)
         case .notice(let message, _): return text(message)
         case .offer(let commands, let headline, let reading):
-            return offer(commands, headline: headline, reading: reading)
+            return offer(commands, headline: headline, reading: reading, hotkey: hotkey)
         }
     }
 
@@ -1142,7 +1160,7 @@ enum PillMetrics {
     /// paragraph and a pill as wide as one is a pill nobody can place.
     static func offer(
         _ commands: [OfferedCommand], headline: Headline? = nil,
-        reading: Confidence.Reading = Confidence.Reading()
+        reading: Confidence.Reading = Confidence.Reading(), hotkey: String = ""
     ) -> CGFloat {
         // A chip is its keycap, its words and 9pt of padding either side; then
         // 4pt between one chip and the next.
@@ -1159,10 +1177,16 @@ enum PillMetrics {
                 sentenceWidth,
                 padding * 2 + title(editLead) + gap + title(words) + selectionFit
             ))
-            widest = max(widest, min(
-                sentenceWidth,
-                padding * 2 + title(holdLead) + holdKeycap + title(holdTail)
-            ))
+            // Only when there is a key to name. `OfferContent.hold` draws the
+            // row on the same condition, so the two agree about whether it is
+            // there to be measured.
+            if !hotkey.isEmpty {
+                widest = max(widest, min(
+                    sentenceWidth,
+                    padding * 2 + title(holdLead)
+                        + holdKeycapWidth(hotkey) + title(holdTail)
+                ))
+            }
         }
         if !reading.words.isEmpty {
             widest = max(widest, min(sentenceWidth, padding * 2 + sentenceRun(reading.words)))

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -960,8 +960,24 @@ enum PillMetrics {
     /// The ⌥ keycap between the two halves of the hold line, and the gaps
     /// either side of it.
     static let holdKeycap: CGFloat = 20 + 12
+    /// Its box, which is taller than a line of the text beside it.
+    static let holdKeycapHeight: CGFloat = 17
     /// The highlight's own padding, either side of the words.
     static let selectionFit: CGFloat = 12
+    /// The vertical padding inside the highlight, top and bottom.
+    static let selectionPadding: CGFloat = 1
+
+    /// How tall each of the two extra rows is.
+    ///
+    /// Not `sentenceLine`. The words row is that plus its highlight's padding,
+    /// and the hold row is as tall as the keycap in it — both 17 against a
+    /// 15pt line. Budgeting a bare line made the pill 4pt shorter than its own
+    /// contents, which the capsule's slack around a 26pt chip row hid: it
+    /// looked right and was wrong, and a longer selection or a different system
+    /// font would have shown it.
+    static let selectionRow: CGFloat = max(
+        sentenceLine + selectionPadding * 2, holdKeycapHeight
+    )
 
     /// Extra air above the sentence, on top of what centring the two rows
     /// already leaves. The chips sit in capsules of their own and carry their
@@ -1007,7 +1023,7 @@ enum PillMetrics {
         // about the key. Two of them are extra, and they are added whatever the
         // reading says — the two can appear together, on a dictation you
         // selected part of after being warned about it.
-        let extra = headline?.isSelection == true ? (sentenceLine + selectionGap) * 2 : 0
+        let extra = headline?.isSelection == true ? (selectionRow + selectionGap) * 2 : 0
         let rows = readingRows(reading, width: width)
         guard !rows.isEmpty else { return height + extra }
         return height + extra + sentenceTop
@@ -1527,7 +1543,7 @@ private struct OfferContent: View {
                     .lineLimit(1)
                     .truncationMode(.tail)
                     .padding(.horizontal, 5)
-                    .padding(.vertical, 1)
+                    .padding(.vertical, PillMetrics.selectionPadding)
                     .background(
                         RoundedRectangle(cornerRadius: 3, style: .continuous)
                             .fill(Parrot.action.opacity(0.42))
@@ -1566,7 +1582,7 @@ private struct OfferContent: View {
         Text(glyph)
             .font(.system(size: 11, weight: .bold, design: .rounded))
             .foregroundStyle(Color(white: 0.72))
-            .frame(width: 20, height: 17)
+            .frame(width: 20, height: PillMetrics.holdKeycapHeight)
             .background(
                 RoundedRectangle(cornerRadius: 4, style: .continuous)
                     .fill(Color.white.opacity(0.07))

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -1590,11 +1590,19 @@ private struct OfferContent: View {
     /// the catch-all besides. Said on the pill because this is the one surface
     /// where the two are alternatives to each other — everywhere else the
     /// gesture is something you either know or do not.
+    /// Only when a hotkey is bound. `register` unregisters before it tries, so
+    /// a reload that fails leaves nothing to hold — and a fallback glyph there
+    /// would name Option, which is not bound either. A row that is absent says
+    /// nothing; a row naming a dead key sends somebody pressing it.
+    ///
+    /// `PillMetrics.offer` and `height(for:)` ask the same question before they
+    /// budget for this row, so the surface is never sized for a line it does
+    /// not draw.
     @ViewBuilder private var hold: some View {
-        if case .selection = headline {
+        if case .selection = headline, !model.hotkey.isEmpty {
             HStack(spacing: 6) {
                 Text(PillMetrics.holdLead)
-                keycap(model.hotkey.isEmpty ? "⌥" : model.hotkey)
+                keycap(model.hotkey)
                 Text(PillMetrics.holdTail)
             }
             .font(.system(size: 12, weight: .medium, design: .rounded))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -248,6 +248,25 @@ select a paragraph in Word, tap, and press a chip's letter.
 This is why the offer's six seconds are not a deadline. It is not kept on
 screen against the chance that you want it — you ask for it again.
 
+**Over a selection the pill says which words**, in the highlight they wear in
+the field, with the chips under them and one line under those:
+
+    Edit  ▏things that turned out not to matter▕
+       V Vocabulary    F Fix grammar    S Terse
+        or hold ⌥ and say what to change
+
+Shown rather than described. The doubt is never whether there is a selection —
+it is which words are about to change, and no wording is as exact as the words.
+
+**Holding while _that_ pill is up speaks the edit**, with no tap first. There a
+hold cannot mean "start a new dictation": the pill is on screen pointing at
+words and asking what to do about them, and talking over it would be answering
+a question with a different sentence.
+
+Only that pill. The offer after a plain dictation carries no such row and
+nothing on screen offers the gesture, so holding there starts the next
+sentence, exactly as it always has.
+
 **Select what it just wrote and the pill comes back on its own**, with no key
 at all. All or part of it — select three words out of a sentence you dictated
 and those three words are the target.


### PR DESCRIPTION
The offer over a selection now shows the words it is about, in the highlight they wear in the field, instead of saying "the selection". The chips sit under them, and one line under those says the key reaches what the chips do not. Holding the hotkey while that pill is up speaks an edit, which is what the new row promises — and only that pill, because the offer after a plain dictation carries no such row.

A reviewer should check two things. `Headline` is now a type with two cases, and the two are measured differently: a landing widens the chip row it sits in front of, a selection is a row of its own that competes with the chip row for the pill's width. And the hold condition matches against the headline rather than against `selectionAtPress`, so the row appears exactly when a hold means an edit.

The highlight is the only place colour goes inside a surface in this app, which is deliberate and argued below.

<details>
<summary>Why the words replaced "the selection" — and why the notch did not</summary>

"the selection" answered a question nobody was asking. The doubt is never *whether* there is a selection; it is which words are about to change.

The first attempt at that question was a notch on the pill's top edge, pointing at the span. It was built and reverted. Chromium answers nothing about where a span is — not `AXBoundsForRange` inside a contenteditable, and not the marker pair VoiceOver reads web content through — so in Slack the pill fell back to the composer's whole box, 638pt of it, and pointed at the middle. `CaretAnchor` records that finding so nobody pays for it twice.

Showing the words asks the accessibility layer for nothing. That is why it survives where pointing at them did not.

</details>

<details>
<summary>The blue is a quotation mark, not decoration — the one exception to the rim rule</summary>

`parrotSurface` is explicit that colour lives on the edge and nowhere else: "a surface washed in a feather is a surface you have to read text off." These surfaces appear over documents, terminals and dark editors without knowing which, so a dark ground is the one background that stays legible.

The highlight breaks that rule on purpose. The words being quoted are sitting in `Parrot.action` two lines above, inside the field, and the pill is saying "these ones" by matching. A neutral fill would be a box around some text; the field's own colour is a pointer. The text on it is the glass colour, so it reads the way the dictated sentence does a row up rather than as white on blue.

It is one span of one row, on one state of the pill. Nothing else inside a surface takes colour.

</details>

<details>
<summary>Why `Headline` is a type, and what breaks if it is one string</summary>

A landing (`Nowhere to type · ⌘V`) and a selection were both `String?`. They are opposite things:

| | About | Drawn | Measured |
|---|---|---|---|
| `landing` | the ending — the words went somewhere you did not ask for | in front of the chips | widens the chip row |
| `selection` | the subject — which words are about to change | its own row above the chips | competes with the chip row for the width |

You need a landing before the chips mean anything. A selection is what the chips are *for*. Carried as one string, the width calculation had no way to tell which arithmetic to do, and the view had no way to tell where to draw it.

Both extra rows are measured from constants in `PillMetrics` (`editLead`, `holdLead`, `holdTail`, `holdKeycap`, `selectionFit`) rather than from strings in the view. The pill is sized before it is drawn, and a string measured in one place and set in another is how a chip ends up hanging over the end of a capsule. Both rows are capped at `sentenceWidth`, because a selection can be a paragraph and a pill as wide as one cannot be placed.

</details>

<details>
<summary>The hold fix, and the stale slot it closes</summary>

The third row promises that holding the key speaks an edit. Nothing honoured it.

A plain hold now counts as keyed while an offer over a selection is up. There a hold cannot mean "start a new dictation" — the pill is pointing at words and asking what to do about them, and talking over it would answer a question with a different sentence. The tap that summoned the offer already happened, so requiring another before the hold would be asking twice for the same thing.

Only that pill. The offer after a plain dictation has no such row, nothing on screen offers the gesture, and holding after a sentence lands is how the next one gets said.

It matches against `offerHeadline`, not against `selectionAtPress`, so the condition is literally the one that decides whether the row is drawn — the two cannot drift apart.

`endTheOffer` now clears `offerHeadline` with the rest of the offer's state. It was set and never cleared, and it now decides whether a hold is an edit. A headline outliving its offer is one more slot saying something true about a surface that is no longer there, which is the shape that produced seven findings across #211 and #212.

</details>

<details>
<summary>The height was 4pt short, and rendering correctly is what hid it</summary>

The first version budgeted a bare `sentenceLine` for each extra row. Neither row is one line: the words row is a line plus its highlight's vertical padding, and the hold row is as tall as the keycap in it. Both are 17pt against a 15pt line, so the pill was 4pt shorter than its own contents.

It rendered correctly anyway, because the capsule's base height has slack around a 26pt chip row and absorbed the shortfall. A longer selection, a larger system font, or one more row would have shown it. Found by adding the row heights up rather than by looking.

`selectionRow` is now that height, derived from the same constants the view sets — `selectionPadding` and `holdKeycapHeight` are read by both, so the drawing and the measuring cannot disagree.

</details>

<details>
<summary>Rows are 8pt apart, and chips centre only in the three-row shape</summary>

`sentenceGap` is 4pt and sets the reading's lines. Those are one block of text and belong together. These three rows are three different things — the words, what can be done to them, and the way out the chips do not cover — and at 4pt they read as a paragraph instead of a list of choices. `selectionGap` is 8.

Chips centre only when there are three rows. One row is a thing you aim at, and a row of chips that moves as the pill grows is a row you have to find again.

`--panel-sheet` draws the selection offer beside the plain one and the clipboard one. A row that is only sometimes there gets looked at nowhere else. The rendered sheet was checked before this was pushed.

</details>

- [x] `make test` passes.
- [x] Every commit is signed off.
