### PR TITLE
fix(pill): open where the words are, not at the bottom of the screen

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1189,6 +1189,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         case .found(let found):
             anchorAtPress = found
         case .missed(let why):
+            // Rung 2.5, terminals only. There is no caret to read — Ghostty
+            // answers `0+0` always — but the input line is on screen, and that
+            // is where the words are about to go.
+            //
+            // Before rung 3, which a terminal cannot satisfy: it repaints
+            // between dictations, so the digest never matches.
+            if appAtPress.map({ AppProfile.of($0).readsPane }) == true,
+               case .found(let box) = CaretAnchor.inputBox(at: focusAtPress?.element) {
+                anchorAtPress = box
+                Log.write(String(
+                    format: "pill: no caret, so the input line it is — %.0f,%.0f %.0fx%.0f",
+                    box.rect.minX, box.rect.minY, box.rect.width, box.rect.height
+                ))
+            }
+
             // Rung 3: open where the last dictation into this same element
             // landed. Two things have to hold, and both exist because a
             // remembered anchor looks confident while it is stale.
@@ -1207,15 +1222,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // opens at the bottom of the screen and rung 4 moves it a moment
             // later: starting nowhere in particular beats starting somewhere
             // wrong.
-            if let last = lastLanding, let now = focusAtPress?.element,
-               CFEqual(last.element, now),
-               Date().timeIntervalSince(last.at) < 60,
-               CaretAnchor.paneDigest(of: now) == last.digest {
-                anchorAtPress = CaretAnchor.Found(
-                    rect: last.found.rect, text: last.found.text, source: .remembered
-                )
-            } else {
-                Log.write("pill: no caret — \(why); will look for the words afterwards")
+            if anchorAtPress == nil {
+                if let last = lastLanding, let now = focusAtPress?.element,
+                   CFEqual(last.element, now),
+                   Date().timeIntervalSince(last.at) < 60,
+                   CaretAnchor.paneDigest(of: now) == last.digest {
+                    anchorAtPress = CaretAnchor.Found(
+                        rect: last.found.rect, text: last.found.text, source: .remembered
+                    )
+                } else {
+                    Log.write("pill: no caret — \(why); will look for the words afterwards")
+                }
             }
 
             // Rung 4: no caret to aim at, so take the pane as it is now and

--- a/Sources/ParrotFlow/CaretAnchor.swift
+++ b/Sources/ParrotFlow/CaretAnchor.swift
@@ -90,6 +90,26 @@ enum CaretAnchor {
         case missed(String)
     }
 
+    /// One budget for a whole lookup, rather than one per request.
+    ///
+    /// `AXUIElementSetMessagingTimeout` caps a single request.
+    /// `inputBox` makes seven in a row, so seven 80ms caps is 560ms — spent
+    /// before the recorder has started, on words somebody is already saying.
+    /// Armed before each request with what is left, the lookup cannot outlast
+    /// the budget.
+    private struct Deadline {
+        private let at: Date
+        init(_ seconds: Float) { at = Date().addingTimeInterval(TimeInterval(seconds)) }
+
+        /// Puts what is left on the element. False when it is spent.
+        func arm(_ element: AXUIElement) -> Bool {
+            let left = Float(at.timeIntervalSinceNow)
+            guard left > 0.005 else { return false }
+            AXUIElementSetMessagingTimeout(element, left)
+            return true
+        }
+    }
+
     /// Short, because this runs inside the key-down handler.
     ///
     /// The one thing that handler may not do is delay the recording. The
@@ -216,18 +236,23 @@ enum CaretAnchor {
         }
         guard let element else { return .missed("nothing was focused") }
         guard !SelectionReader.isOurs(element) else { return .missed("our own window") }
-        AXUIElementSetMessagingTimeout(element, timeout)
 
-        guard let pane = frame(of: element).map(flipped) else { return .missed("no geometry") }
-        guard let screen = SelectionReader.visibleText(of: element, within: timeout) else {
-            return .missed("the terminal will not say what is on screen")
+        // Seven requests, one budget. See `Deadline`.
+        let deadline = Deadline(timeout)
+
+        guard let pane = frame(of: element, before: deadline).map(flipped) else {
+            return .missed("no geometry, or the budget ran out")
         }
+        guard deadline.arm(element),
+              let screen = SelectionReader.visibleText(of: element, within: nil)
+        else { return .missed("the terminal will not say what is on screen in time") }
+
         guard let index = SelectionReader.lastInputRowIndex(in: screen) else {
             return .missed("nothing on screen looks like an input line")
         }
-        guard let row = line(of: index, in: element), let grid = visibleGrid(of: element) else {
-            return .missed("it will not say how the grid is laid out")
-        }
+        guard let row = line(of: index, in: element, before: deadline),
+              let grid = visibleGrid(of: element, before: deadline)
+        else { return .missed("it will not say how the grid is laid out in time") }
         return rectangle(forRow: row, of: grid, in: pane, source: .landed)
     }
 
@@ -511,11 +536,15 @@ enum CaretAnchor {
     /// Measured, the refusal reads "the grid says row 1364 of 1365 at 1pt",
     /// which is the plausibility check below doing its job. It stays refusing:
     /// there is no viewport in that answer to be had.
-    private static func visibleGrid(of element: AXUIElement) -> (first: Int, rows: Int)? {
-        guard let visible = range(kAXVisibleCharacterRangeAttribute, of: element),
+    private static func visibleGrid(
+        of element: AXUIElement, before deadline: Deadline? = nil
+    ) -> (first: Int, rows: Int)? {
+        guard let visible = range(
+                  kAXVisibleCharacterRangeAttribute, of: element, before: deadline),
               visible.length > 0,
-              let first = line(of: visible.location, in: element),
-              let last = line(of: visible.location + visible.length - 1, in: element),
+              let first = line(of: visible.location, in: element, before: deadline),
+              let last = line(
+                  of: visible.location + visible.length - 1, in: element, before: deadline),
               last >= first
         else { return nil }
         return (first, last - first + 1)
@@ -540,9 +569,12 @@ enum CaretAnchor {
     }
 
     /// Which row of the grid an index sits on. Nil when the app will not say.
-    private static func line(of index: Int, in element: AXUIElement) -> Int? {
+    private static func line(
+        of index: Int, in element: AXUIElement, before deadline: Deadline? = nil
+    ) -> Int? {
         var out: CFTypeRef?
-        guard AXUIElementCopyParameterizedAttributeValue(
+        guard deadline?.arm(element) != false,
+              AXUIElementCopyParameterizedAttributeValue(
             element, kAXLineForIndexParameterizedAttribute as CFString,
             NSNumber(value: index), &out
         ) == .success, let value = out as? NSNumber else { return nil }
@@ -582,11 +614,14 @@ enum CaretAnchor {
     }
 
     /// Any attribute whose value is a range.
-    private static func range(_ attribute: String, of element: AXUIElement) -> CFRange? {
+    private static func range(
+        _ attribute: String, of element: AXUIElement, before deadline: Deadline? = nil
+    ) -> CFRange? {
         var value: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(
-            element, attribute as CFString, &value
-        ) == .success, let wrapped = value, CFGetTypeID(wrapped) == AXValueGetTypeID()
+        guard deadline?.arm(element) != false,
+              AXUIElementCopyAttributeValue(
+                  element, attribute as CFString, &value
+              ) == .success, let wrapped = value, CFGetTypeID(wrapped) == AXValueGetTypeID()
         else { return nil }
         var range = CFRange()
         guard AXValueGetValue(wrapped as! AXValue, .cfRange, &range) else { return nil }
@@ -613,13 +648,15 @@ enum CaretAnchor {
         return rect
     }
 
-    private static func frame(of element: AXUIElement) -> CGRect? {
+    private static func frame(of element: AXUIElement, before deadline: Deadline? = nil) -> CGRect? {
         var origin = CGPoint.zero
         var size = CGSize.zero
         var position: CFTypeRef?
         var extent: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(
+        guard deadline?.arm(element) != false,
+              AXUIElementCopyAttributeValue(
                   element, kAXPositionAttribute as CFString, &position) == .success,
+              deadline?.arm(element) != false,
               AXUIElementCopyAttributeValue(
                   element, kAXSizeAttribute as CFString, &extent) == .success,
               let positionValue = position, CFGetTypeID(positionValue) == AXValueGetTypeID(),

--- a/Sources/ParrotFlow/CaretAnchor.swift
+++ b/Sources/ParrotFlow/CaretAnchor.swift
@@ -145,6 +145,28 @@ enum CaretAnchor {
             ))
         }
 
+        // Chromium and Outlook both get past the line above without answering.
+        // `AXBoundsForRange` declines inside a contenteditable, and Outlook
+        // reports its selection as `0+0`, which `trust` refuses. A composer is
+        // far taller than the 120pt below, so nothing was left and the pill
+        // opened at the bottom of the screen.
+        //
+        // The markers a screen reader reads text through do answer. Measured
+        // 2026-08-28: a Gmail composer gave 1613,631 0x15 — no width, one line
+        // tall, which is a caret — where the text leaf beside it ran
+        // 1293,631 320x15, so 1293 plus 320 lands exactly at the end of what
+        // had been typed. On that same element `AXBoundsForRange` answered
+        // 0,1329 0x0. Outlook answered 826,964 with a height of 19.
+        //
+        // Slack answers the pair too and gives a 0x0 rect a screen away, so
+        // this is checked twice: a caret has a height and that answer has none,
+        // and a rect a screen away is not inside the pane.
+        if let rect = markerCaret(of: element), (4.0...100.0).contains(rect.height),
+           let pane, pane.insetBy(dx: -4, dy: -4).intersects(rect) {
+            let text = flipped(rect)
+            return .found(Found(rect: across(text, flipped(pane)), text: text, source: .caret))
+        }
+
         // The control's own rectangle, but only when it is small enough to be
         // one. A search box is 22pt tall and its box is as good as its caret; a
         // terminal's text view is 915pt tall and its box puts the pill under
@@ -156,6 +178,57 @@ enum CaretAnchor {
             return .found(Found(rect: box, text: box, source: .field))
         }
         return .missed(pane == nil ? "no geometry" : "no caret, and the pane is too big to stand in for one")
+    }
+
+    /// The caret's rectangle, asked for the way a screen reader asks.
+    ///
+    /// Two private attributes, which is what a text area answers when the
+    /// public range ones decline. See `read` for what each app said.
+    private static func markerCaret(of element: AXUIElement) -> CGRect? {
+        var marker: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            element, "AXSelectedTextMarkerRange" as CFString, &marker
+        ) == .success, let marker else { return nil }
+
+        var out: CFTypeRef?
+        guard AXUIElementCopyParameterizedAttributeValue(
+            element, "AXBoundsForTextMarkerRange" as CFString, marker, &out
+        ) == .success, let out, CFGetTypeID(out) == AXValueGetTypeID() else { return nil }
+
+        var rect = CGRect.zero
+        guard AXValueGetValue(out as! AXValue, .cgRect, &rect) else { return nil }
+        return rect
+    }
+
+    /// Where the input line is, for a terminal that will not say where its
+    /// caret is.
+    ///
+    /// Ghostty answers `AXSelectedTextRange` as `0+0` always, so `read` misses,
+    /// and a terminal repaints between dictations so the remembered rung is
+    /// refused too. The pill opened at the bottom of the screen and moved only
+    /// once the words had landed, which is the placement that reads as random.
+    ///
+    /// No caret is needed to find the line: it is the row inside the rules a
+    /// TUI draws, or the shell prompt when nothing drew any.
+    static func inputBox(at element: AXUIElement?) -> Outcome {
+        guard Permissions.accessibility == .granted else {
+            return .missed("accessibility is not granted")
+        }
+        guard let element else { return .missed("nothing was focused") }
+        guard !SelectionReader.isOurs(element) else { return .missed("our own window") }
+        AXUIElementSetMessagingTimeout(element, timeout)
+
+        guard let pane = frame(of: element).map(flipped) else { return .missed("no geometry") }
+        guard let screen = SelectionReader.visibleText(of: element, within: timeout) else {
+            return .missed("the terminal will not say what is on screen")
+        }
+        guard let index = SelectionReader.lastInputRowIndex(in: screen) else {
+            return .missed("nothing on screen looks like an input line")
+        }
+        guard let row = line(of: index, in: element), let grid = visibleGrid(of: element) else {
+            return .missed("it will not say how the grid is laid out")
+        }
+        return rectangle(forRow: row, of: grid, in: pane, source: .landed)
     }
 
     /// The bottom strip of an app's frontmost window, for apps that answer no
@@ -362,13 +435,26 @@ enum CaretAnchor {
               let grid = visibleGrid(of: element)
         else { return .missed("no bounds, and it will not say how the grid is laid out") }
 
-        // Checked, not trusted. A pitch is a line height and it has a range —
-        // 17.3pt was measured on Ghostty — and the row has to be one the pane
-        // is showing. Either failing means the grid was read wrong, and a grid
-        // read wrong is refused rather than used: the pill stays where it
-        // opened, and nowhere in particular beats somewhere wrong.
+        return rectangle(forRow: row, of: grid, in: pane, source: .landed)
+    }
+
+    /// A grid row as a rectangle on screen.
+    /// Checked, not trusted. A pitch is a line height and it has a range, and
+    /// the row has to be one the pane is showing. Either failing means the grid
+    /// was read wrong, and a grid read wrong is refused rather than used: the
+    /// pill stays where it opened, and nowhere in particular beats somewhere
+    /// wrong.
+    ///
+    /// The band is 12 to 34pt. Measured: 17.3 and 17.26 on Ghostty, both sound.
+    /// Against that, a pane carrying scrollback answered 109 rows where the
+    /// terminal was showing 54, which is 9pt, and 9pt put the anchor on the
+    /// window's bottom edge instead of the input box. A 6pt floor let that
+    /// through.
+    private static func rectangle(
+        forRow row: Int, of grid: (first: Int, rows: Int), in pane: NSRect, source: Source
+    ) -> Outcome {
         let pitch = pane.height / CGFloat(grid.rows)
-        guard (6.0...40.0).contains(pitch), (grid.first..<grid.first + grid.rows).contains(row)
+        guard (12.0...34.0).contains(pitch), (grid.first..<grid.first + grid.rows).contains(row)
         else {
             return .missed(String(
                 format: "the grid says row %d of %d at %.0fpt, which is not a line of text",
@@ -388,7 +474,7 @@ enum CaretAnchor {
             x: pane.minX, y: pane.maxY - CGFloat(row - grid.first + 1) * pitch,
             width: pane.width, height: pitch
         )
-        return .found(Found(rect: rect, text: rect, source: .landed))
+        return .found(Found(rect: rect, text: rect, source: source))
     }
 
     /// The rows the pane is showing: the first one, and how many.

--- a/Sources/ParrotFlow/SelectionReader.swift
+++ b/Sources/ParrotFlow/SelectionReader.swift
@@ -269,10 +269,10 @@ enum SelectionReader {
     /// wrapping and all, which is why callers match against text they already
     /// hold rather than trying to identify "the current line" within it.
     ///
-    /// `timeout` is for the one caller that runs inside the key-down handler,
-    /// where 500ms of waiting is 500ms the recording has not started.
-    static func visibleText(of element: AXUIElement, within timeout: Float = 0.5) -> String? {
-        AXUIElementSetMessagingTimeout(element, timeout)
+    /// Nil `timeout` leaves the element's own alone, for a caller that has
+    /// already put a budget on it. See `CaretAnchor.inputBox`.
+    static func visibleText(of element: AXUIElement, within timeout: Float? = 0.5) -> String? {
+        if let timeout { AXUIElementSetMessagingTimeout(element, timeout) }
         var value: CFTypeRef?
         guard AXUIElementCopyAttributeValue(
             element, kAXValueAttribute as CFString, &value

--- a/Sources/ParrotFlow/SelectionReader.swift
+++ b/Sources/ParrotFlow/SelectionReader.swift
@@ -201,6 +201,41 @@ enum SelectionReader {
             .joined(separator: " ")
     }
 
+    /// The UTF-16 index of the row being typed on.
+    ///
+    /// Inside the box a TUI drew, or the shell prompt when nothing drew one.
+    /// `CaretAnchor` turns it into a grid row, and a row into somewhere to open
+    /// the pill.
+    static func lastInputRowIndex(in screen: String) -> Int? {
+        let rows = screen.components(separatedBy: "\n")
+        guard let last = inputRowNumber(in: rows) else { return nil }
+        // +1 per row for the newline that separated it.
+        return rows[0..<last].reduce(0) { $0 + $1.utf16.count + 1 }
+    }
+
+    private static func inputRowNumber(in rows: [String]) -> Int? {
+        let borders = rows.indices.filter { isBorder(rows[$0]) }
+        if borders.count >= 2 {
+            let lower = borders[borders.count - 1]
+            let upper = borders[borders.count - 2]
+            if upper + 1 < lower {
+                // The last row inside the box with anything on it. A box is
+                // drawn its full height whatever is typed into it, so the
+                // bottom row is padding and anchoring there sits below the box.
+                return (upper + 1..<lower).last {
+                    !rows[$0].trimmingCharacters(in: .whitespaces).isEmpty
+                } ?? upper + 1
+            }
+        }
+        // No box, so a bare shell. By the prompt glyph rather than the last row
+        // with text on it, because a status bar sits below the shell and under
+        // tmux it is always the last thing on screen.
+        return rows.indices.reversed().first {
+            guard let first = rows[$0].drop(while: { $0 == " " }).first else { return false }
+            return "❯>$#%⏵".contains(first)
+        }
+    }
+
     /// A rule the TUI drew, rather than anything anyone typed.
     static func isBorder(_ row: String) -> Bool {
         let bare = row.trimmingCharacters(in: .whitespaces)
@@ -233,8 +268,11 @@ enum SelectionReader {
     /// An element's whole value. In a terminal this is the visible screen,
     /// wrapping and all, which is why callers match against text they already
     /// hold rather than trying to identify "the current line" within it.
-    static func visibleText(of element: AXUIElement) -> String? {
-        AXUIElementSetMessagingTimeout(element, 0.5)
+    ///
+    /// `timeout` is for the one caller that runs inside the key-down handler,
+    /// where 500ms of waiting is 500ms the recording has not started.
+    static func visibleText(of element: AXUIElement, within timeout: Float = 0.5) -> String? {
+        AXUIElementSetMessagingTimeout(element, timeout)
         var value: CFTypeRef?
         guard AXUIElementCopyAttributeValue(
             element, kAXValueAttribute as CFString, &value


### PR DESCRIPTION
The pill opened at the bottom of the screen in three places: a Gmail composer, an Outlook composer, and a terminal. It moved to the words only after they had landed, so the first position was not a position at all. This adds two rungs to the ladder in `CaretAnchor`. One asks for the caret the way a screen reader asks, which Gmail and Outlook answer. The other works the terminal input line out of the grid, with no caret at all.

Check the two guards on the marker rung first. The rect must have a plausible height, and it must land inside the pane. Slack answers the same attributes and returns a `0x0` rect a screen away, so both guards are needed and neither is redundant.

<details>
<summary>What each app answered, measured 2026-08-28</summary>

The public range attributes are unreliable in a large text area. That is the one cause behind all three apps.

**Gmail composer.** `AXSelectedTextMarkerRange` into `AXBoundsForTextMarkerRange` gave `1613,631 0x15`. No width and one line tall, which is a caret. The text leaf beside it ran `1293,631 320x15`, and 1293 + 320 = 1613, so the caret sits exactly at the end of the typed text. On the same element `AXBoundsForRange` answered `0,1329 0x0`, which is garbage.

**Outlook composer.** The same pair answered `826,964` at height 19. Outlook reports its selection as `0+0` however much text it holds — measured at 395,489 characters — so `trust()` refuses it and the first rung could never fire.

**Slack.** Answers the same pair and gives a `0x0` rect a screen away. This is why the marker route was written off before. Height separates the two cases: a caret has one, Slack's answer has none. The rect is also checked against the pane, because a rect a screen away is not inside it.

**Ghostty, bare fish prompt.** The new terminal rung gave `89,926 935x17`. The 17 is the line pitch and the row sits where a fresh prompt is.

</details>

<details>
<summary>A terminal needs no caret, because a terminal is a fixed grid</summary>

Ghostty answers `AXSelectedTextRange` as `0+0` always, so `read()` misses. It also repaints between dictations, so the digest guard on the remembered rung never matches. Both rungs above it were dead there.

But the input line is on screen. It is the last written row inside the rules a TUI draws, or the shell prompt when nothing drew any. `SelectionReader.lastInputRowIndex` finds that row in the pane text. `CaretAnchor.inputBox` turns it into a rectangle with the same grid arithmetic `landed` already had, factored out as `rectangle(forRow:of:in:source:)`.

It is wired into `AppDelegate.readTheAnchor` as a rung before the remembered one, gated on `AppProfile.of(owner).readsPane`. So it can only fire in a terminal.

</details>

<details>
<summary>The pitch band goes from 6-40pt to 12-34pt, because 9pt got through</summary>

The grid arithmetic is checked, not trusted. A pitch is a line height, so a pitch outside a plausible band means the grid was read wrong, and a grid read wrong is refused.

Measured sound: 17.3 and 17.26 on Ghostty.

Measured wrong: a pane carrying scrollback reported 109 rows where the terminal was showing 54. That works out at 9pt, and 9pt put the anchor on the window's bottom edge instead of the input line. The 6pt floor let it through. A 9pt line needs roughly a 7pt font, which nobody is running.

Refusing costs nothing. The pill opens where it always did, and the `landed` diff moves it once the words arrive.

</details>

<details>
<summary>What is not verified, so nobody reads more into this than is there</summary>

- **The TUI case has never been seen to fire correctly.** In a Claude Code terminal the new rung has only been shown to refuse safely, on a pane whose grid read is untrustworthy. No pane with a sound grid could be built under tmux to test the other half. The bare-shell case does fire and is measured.
- **Gmail was proven by a read-only accessibility probe**, not end to end with this build.
- **No harness score belongs on this PR.** `scripts/check-inplace.sh` scores the in-place editing path. This change touches no editing code — there is no `Surface.swift` change — so the harness does not exercise it.

</details>

<details>
<summary>Review notes: where to start and what is risky</summary>

Start at `CaretAnchor.read`. The new block sits between the trusted-selection rung and the small-control rung, so an app that already answered `AXBoundsForRange` is untouched.

`CaretAnchor.markerCaret` is the only new AX call. It reads two private attributes, type-checks the result before the cast, and returns nil on anything unexpected.

`rectangle(forRow:of:in:source:)` is a straight extraction out of `landed`. The only behaviour change inside it is the band.

`Deadline` is the second commit, and it is the part worth reading twice. `AXUIElementSetMessagingTimeout` caps one request, and `inputBox` makes seven: two for the frame, one for the screen, one for the row, three for the grid. At 80ms each that is 560ms in the worst case, spent before `startRecording`. One deadline is armed before each request with the time that is left, so the whole lookup is capped at 80ms. Spent, the rung refuses.

It is threaded through `frame`, `range`, `line` and `visibleGrid` as an optional argument. `landed` passes nothing and keeps its unhurried timeout. It runs after the dictation, off the main thread, with nothing waiting on it.

The risk is a fourth app that answers the markers with something that has a real height, lands in the pane, and is still not the caret. If one exists, it fails the way this bug failed: the pill opens somewhere wrong, and the `landed` diff corrects it once the words arrive.

</details>
