### PR TITLE
refactor: fold the parallel state in the edit-by-voice branch back together

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -173,7 +173,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         /// Decided at the press because that is where the gesture is known, and
         /// carried here for the same reason everything else is — a second press
         /// landing mid-transcription must not be able to change what this one
-        /// was for. See `handleVoiceCommand(_:keyed:)` for what it buys.
+        /// was for. See `handleVoiceCommand(_:over:)` for what it buys.
         var keyed = false
         /// What was selected when this recording began.
         ///
@@ -195,6 +195,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         /// the instruction for it. Freezing the selection alone left this half
         /// of the same crossing open.
         var transcript: String?
+
+        /// What this press froze, as the command path wants it. `keyed` is
+        /// passed rather than read off `self.keyed` because the heard path
+        /// reaches here on a press that was not keyed and is still a command.
+        func frozenTarget(keyed: Bool) -> Target {
+            .frozen(selection: selection, fallback: transcript, keyed: keyed)
+        }
     }
 
     /// The words the offer on screen is about, and the field they went into.
@@ -215,8 +222,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// until the next dictation replaces it.
     private let reselect = SelectionWatch()
 
-    /// The last dictation a tap can summon an offer over: its words, and where
-    /// they went.
+    /// The last dictation a tap can summon an offer over.
+    ///
+    /// The same record the offer itself is raised over, kept past that offer so
+    /// a tap can raise another one from it. Its `dictation` is the run it came
+    /// from, which is never nil here.
     ///
     /// `offeredCorrection` is cleared by every ending, because it asserts that
     /// an offer is up and about these words. This asserts nothing of the sort —
@@ -231,10 +241,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// landing stays with the newer run — so a tap would have offered one
     /// dictation's words at another's field, and taking it would have rewritten
     /// there. One record, written once, cannot come apart that way.
-    private var lastDictated: (
-        run: Int, text: String, element: AXUIElement?,
-        owner: NSRunningApplication?, landing: Correction.Landing
-    )?
+    private var lastDictated: Correction?
 
     /// The focused element's text as it was at the press, for an app that gave
     /// no caret. What changed in it afterwards is where the words went.
@@ -826,26 +833,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         hotKeys.onAbort = { [weak self] in self?.cancelDictation(.notTheHotkey) }
         hotKeys.onTap = { [weak self] in self?.summonOffer() }
         do {
-            let binding = try hotKeys.register(
+            try hotKeys.register(
                 key: config.hotkey.key,
                 modifiers: config.hotkey.modifiers,
                 pressDelay: config.hotkey.pressDelaySeconds
             )
-            // The offer's "or hold …" row names this key, so it is read from
-            // what actually registered rather than from the config: a key the
-            // config asked for and macOS refused is not the key to tell
-            // somebody to hold. Set on every reload, because the hotkey is one
-            // of the things a reload can change.
-            pill.model.hotkey = binding.displayName
         } catch {
             hotkeyError = error.localizedDescription
             Log.write("hotkey registration FAILED: \(error.localizedDescription)")
-            // `register` unregisters before it tries, so a reload that fails
-            // leaves nothing bound. Cleared rather than left saying the old
-            // key: the row would be naming a key with no handler behind it,
-            // which is worse than the row being absent. Empty takes it off the
-            // pill — see `OfferContent.hold`.
-            pill.model.hotkey = ""
         }
 
         startKeepWarm()
@@ -2080,16 +2075,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// - **The preview.** Tap-then-hold has already named its target on the
     ///   pill and offered ⎋ for the whole time you were speaking, and "hey
     ///   parrot, undo" puts the substitution back afterwards — so a preview is
-    ///   a question that was answered twice before it was asked. It reaches
-    ///   `finishTransform` as `confirm: !keyed`, because that leaf's job is
-    ///   previewing and it should stay honest about it.
+    ///   a question that was answered twice before it was asked. That is
+    ///   `Target.confirms`, which the target carries down for itself.
     ///
     /// The saving is a model call in series. Heard costs a router round trip
     /// and then the transform's own; keyed costs one, or none.
-    private func handleVoiceCommand(
-        _ command: String, keyed: Bool = false,
-        over target: Target = .whateverIsSelected
-    ) {
+    ///
+    /// Read off the target rather than passed beside it, so the two cannot
+    /// disagree about which gesture this was.
+    private func handleVoiceCommand(_ command: String, over target: Target) {
+        let keyed = !target.confirms
         let catalogue = Catalogue(transforms: config.transforms)
 
         // Deterministic phrases first: no model needed, and they work when
@@ -2108,10 +2103,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             instruction: command, catalogue: catalogue, anywhere: keyed
         ) {
             Log.write("router: \"\(command)\" named \(capability.name) outright")
-            run(
-                capability, instruction: command,
-                progress: nil, confirm: !keyed, over: target
-            )
+            run(capability, instruction: command, progress: nil, over: target)
             return
         }
 
@@ -2132,7 +2124,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Log.write("keyed: \"\(command)\" → \(FreeForm.name), no router")
             runTransform(
                 FreeForm.prompt(for: command).asTransform(model: catchAll),
-                instruction: command, progress: nil, confirm: false, over: target
+                instruction: command, progress: nil, over: target
             )
             return
         }
@@ -2197,7 +2189,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     Log.write("routing failed: \(error.localizedDescription)")
                     self.endProgress(token: token)
                     let asked = self.askForKeyThenRetry(error) {
-                        self.handleVoiceCommand(command, keyed: keyed, over: target)
+                        self.handleVoiceCommand(command, over: target)
                     }
                     if !asked { self.flash(error.localizedDescription, tone: .failure) }
                 }
@@ -2212,8 +2204,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// down and nothing else.
     private func run(
         _ capability: Capability, instruction: String,
-        progress token: Int?, confirm: Bool = true,
-        over target: Target = .whateverIsSelected
+        progress token: Int?, over target: Target = .whateverIsSelected
     ) {
         switch capability {
         case .action(.vocabulary):
@@ -2223,8 +2214,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             interpretSpelling(instruction, progress: token, over: target)
         case .transform(let transform):
             runTransform(
-                transform, instruction: instruction,
-                progress: token, confirm: confirm, over: target
+                transform, instruction: instruction, progress: token, over: target
             )
         }
     }
@@ -2309,7 +2299,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // the model looking in the wrong sentence.
         let context: String?
         switch target {
-        case .frozen(_, let fallback): context = fallback
+        case .frozen(_, let fallback, _): context = fallback
         case .whateverIsSelected: context = lastTranscript
         }
         // From the transcript, never the command: the command is short and its
@@ -2369,7 +2359,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         /// which may also be nothing. A command reads neither slot and clears
         /// neither: by the time a decoder has answered, a newer press can own
         /// what is in them.
-        case frozen(selection: SelectionReader.Selection?, fallback: String?)
+        ///
+        /// `keyed` is how the words were declared to be an instruction — by a
+        /// keystroke, or by the wake phrase found inside a sentence. It rides
+        /// here rather than in a parameter of its own because the two always
+        /// travelled together and the only thing downstream asks of it is
+        /// `confirms`.
+        case frozen(
+            selection: SelectionReader.Selection?, fallback: String?, keyed: Bool
+        )
+
+        /// Whether a transform still previews before it writes.
+        ///
+        /// False for keyed alone. A preview is for a command whose target you
+        /// could have got wrong; tap-then-hold has already named its target on
+        /// the pill and offered ⎋ for the whole time you were speaking, and the
+        /// undo phrase survives the rewrite. Asking again after all that is a
+        /// second answer to a question answered twice.
+        var confirms: Bool {
+            if case .frozen(_, _, true) = self { return false }
+            return true
+        }
     }
 
     /// Runs a prompt over the selection, or over the last dictation.
@@ -2379,8 +2389,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// reading then returns nothing or something of ours.
     private func runTransform(
         _ transform: Config.Transform, instruction: String,
-        progress inherited: Int?, confirm: Bool = true,
-        over target: Target = .whateverIsSelected
+        progress inherited: Int?, over target: Target = .whateverIsSelected
     ) {
         // Never the clipboard. `read()` falls back to it for the correction
         // panel, where you see the words before anything happens and can
@@ -2398,7 +2407,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let selection: SelectionReader.Selection?
         let dictated: String?
         switch target {
-        case .frozen(let held, let fallback):
+        case .frozen(let held, let fallback, _):
             selection = held
             dictated = fallback
         case .whateverIsSelected:
@@ -2413,8 +2422,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Falling back to the last dictation is what makes "hey parrot, fix the
         // grammar" work immediately after speaking, with nothing selected.
-        let target = selection?.text ?? dictated ?? ""
-        guard !target.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        let text = selection?.text ?? dictated ?? ""
+        guard !text.isBlank else {
             endProgress(token: inherited)
             Log.write("transform: nothing selected and nothing dictated yet")
             flash("Select some text first, or dictate something", tone: .caution)
@@ -2424,10 +2433,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // The text itself, not just its length: a transform that worked on the
         // wrong thing is otherwise indistinguishable in the log from one that
         // worked on the right thing badly.
-        Log.write("transform: \(transform.name) over \(selection == nil ? "the last dictation" : "the selection") — \"\(target.prefix(80))\"")
+        Log.write("transform: \(transform.name) over \(selection == nil ? "the last dictation" : "the selection") — \"\(text.prefix(80))\"")
         runTransform(
-            transform, instruction: instruction, selection: selection, on: target,
-            confirm: confirm
+            transform, instruction: instruction, selection: selection, on: text,
+            confirm: target.confirms
         )
     }
 
@@ -2938,7 +2947,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Kept past the offer this is about to raise, so a tap can build another
         // one out of it once this has faded. Below the newer-run guard above,
         // and carrying the words as well as the field — see `lastDictated`.
-        lastDictated = (press.run, text, press.element, press.owner, landing)
+        let dictated = Correction(
+            original: text, element: press.element, owner: press.owner,
+            landing: landing, dictation: press.run
+        )
+        lastDictated = dictated
         watchForReselection()
 
         // The decoder's words matched back onto the sentence that came out of
@@ -2962,13 +2975,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
         if let warning = reading.warning { Log.write("offer: \(warning)") }
 
-        raiseOffer(
-            over: Correction(
-                original: text, element: press.element, owner: press.owner,
-                landing: landing, dictation: press.run
-            ),
-            run: press.run, headline: headline, reading: reading
-        )
+        raiseOffer(over: dictated, run: press.run, headline: headline, reading: reading)
 
         // Taken at the press, and only when that press found no caret. Matched
         // by run, so it is this dictation's own pane and nobody else's. A
@@ -3054,43 +3061,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// not that moment. Showing them again would also re-arm `holdReturn`,
     /// which exists for the Return already on its way down.
     private func summonOffer() {
-        // Nothing while a dictation is in the air. On `toggle` the key is what
-        // stops a recording, and a stop that came out short is a stop — the
-        // press was simply never delivered. Summoning there would answer a key
-        // meant for the microphone, and do it over the *previous* sentence.
-        guard !recorder.isRecording, runsInFlight <= 0 else { return }
-        // A tap while the offer is up is a tap at nothing. Raising a second one
-        // over the first would take the letters again and restart a clock the
-        // pointer may be deliberately holding.
-        guard !offerIsUp else { return }
-        guard config.feedback.correctOffer else { return }
+        guard canRaiseAnOffer else { return }
 
         // The selection wins, and it never goes stale: it is what you are
         // pointing at now. It is also the only target this can have in an app
         // ParrotFlow has never written a word into, which is the whole of why
         // the tap reaches further than the last dictation.
-        if let selection = SelectionReader.snapshot(),
-           !selection.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        if let selection = SelectionReader.snapshot(), !selection.text.isBlank {
             Log.write("summon: the offer, over the selection — \"\(selection.text.prefix(80))\"")
-            aim(at: selection)
-            raiseOffer(
-                over: Correction(
-                    original: selection.text, element: selection.element,
-                    owner: selection.owner, landing: .field,
-                    // Selecting part of what you just dictated and tapping is
-                    // still your dictation, so it still gets the panel — see
-                    // `dictationBehind`. Text nobody here wrote answers nil.
-                    dictation: dictationBehind(selection.text, in: selection.element),
-                    selection: selection
-                ),
-                run: pressRun, headline: .selection(selection.text),
-                reading: Confidence.Reading()
-            )
+            offerOverSelection(selection)
             return
         }
 
-        guard let last = lastDictated,
-              !last.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard let last = lastDictated, !last.original.isBlank else {
             Log.write("summon: nothing selected and nothing dictated yet")
             return
         }
@@ -3102,14 +3085,60 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Not re-aimed. The pill is already pointed where the words landed,
         // which is what "back where it was" means — and a fresh read would
         // answer where the caret is *now*, which is a different question.
+        raiseOffer(over: last, run: pressRun, headline: nil, reading: Confidence.Reading())
+    }
+
+    /// The three things that have to be true before any offer goes up, asked in
+    /// one place because both ways of raising one ask them.
+    ///
+    /// Nothing while a dictation is in the air. On `toggle` the key is what
+    /// stops a recording, and a stop that came out short is a stop — the press
+    /// was simply never delivered. Summoning there would answer a key meant for
+    /// the microphone, and do it over the *previous* sentence.
+    ///
+    /// Nothing over an offer already up. A tap there is a tap at nothing:
+    /// raising a second one would take the letters again and restart a clock
+    /// the pointer may be deliberately holding. For the reselect half it does
+    /// not cost a second selection, and the reason is an ordering worth
+    /// keeping: an outside click dismisses the offer on mouse *down* — see
+    /// `watchForOfferOutsideClick` — and `SelectionWatch` looks on mouse *up*.
+    /// So selecting different words takes the old offer down before the new one
+    /// is asked for. Move either monitor to the other edge and reselecting
+    /// while an offer is up stops answering.
+    private var canRaiseAnOffer: Bool {
+        !recorder.isRecording && runsInFlight <= 0 && !offerIsUp
+            && config.feedback.correctOffer
+    }
+
+    /// The offer over highlighted words, however they came to be highlighted:
+    /// tapped for, or noticed by `SelectionWatch`. There is no difference
+    /// between an offer you asked for and one that noticed — only in how it
+    /// arrived — so there is one path from here down.
+    private func offerOverSelection(_ selection: SelectionReader.Selection) {
+        aim(at: selection)
         raiseOffer(
             over: Correction(
-                original: last.text, element: last.element, owner: last.owner,
-                landing: last.landing, dictation: last.run
+                original: selection.text, element: selection.element,
+                owner: selection.owner, landing: .field,
+                // Selecting part of what you just dictated is still your
+                // dictation, so it still gets the panel — see
+                // `dictationBehind`. Text nobody here wrote answers nil.
+                dictation: dictationBehind(selection.text, in: selection.element),
+                selection: selection
             ),
-            run: pressRun, headline: nil, reading: Confidence.Reading()
+            run: pressRun, headline: .selection(selection.text, hotkey: holdKey),
+            reading: Confidence.Reading()
         )
     }
+
+    /// The key the offer's third row tells you to hold, as it is written on
+    /// screen — "Right ⌘", "⌃⌥Space".
+    ///
+    /// What actually registered rather than what the config asked for: a key
+    /// macOS refused is not the key to tell somebody to hold. Empty when
+    /// nothing is bound, which takes the row off — a row naming a dead key
+    /// sends somebody pressing it, and a row that is absent says nothing.
+    private var holdKey: String { hotKeys.binding?.displayName ?? "" }
 
     /// Offer again when the words are selected again.
     ///
@@ -3128,47 +3157,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// window.
     private func watchForReselection() {
         guard config.feedback.correctOffer else { reselect.stop(); return }
-        guard let last = lastDictated,
-              !last.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+        guard let last = lastDictated, !last.original.isBlank,
               case .field = last.landing, let element = last.element else {
             reselect.stop()
             return
         }
+        // The selection is the target, not the whole dictation: select three
+        // words out of a sentence and those three words are what you meant.
         reselect.onSelection = { [weak self] selection in
-            self?.offerOverReselected(selection)
+            guard let self, self.canRaiseAnOffer else { return }
+            self.offerOverSelection(selection)
         }
-        reselect.start(over: last.text, in: element)
-    }
-
-    /// The offer, over words that were dictated and have been selected again.
-    ///
-    /// The selection is the target, not the whole dictation: select three words
-    /// out of a sentence and those three words are what you meant. Everything
-    /// downstream is `summonOffer`'s, because there is no difference between an
-    /// offer you asked for and one that noticed — only in how it arrived.
-    private func offerOverReselected(_ selection: SelectionReader.Selection) {
-        // Never over a recording, never over an offer already up, and never
-        // while a decode this could be about is still in flight.
-        //
-        // Refusing while one is up does not cost you a second selection, and
-        // the reason is an ordering worth keeping: an outside click dismisses
-        // the offer on mouse *down* — see `watchForOfferOutsideClick` — and this
-        // looks on mouse *up*. So selecting different words takes the old offer
-        // down before the new one is asked for. Move either monitor to the other
-        // edge and reselecting while an offer is up stops answering.
-        guard !recorder.isRecording, runsInFlight <= 0, !offerIsUp else { return }
-        guard config.feedback.correctOffer else { return }
-        aim(at: selection)
-        raiseOffer(
-            over: Correction(
-                original: selection.text, element: selection.element,
-                owner: selection.owner, landing: .field,
-                dictation: dictationBehind(selection.text, in: selection.element),
-                selection: selection
-            ),
-            run: pressRun, headline: .selection(selection.text),
-            reading: Confidence.Reading()
-        )
+        reselect.start(over: last.original, in: element)
     }
 
     /// The dictation these words came from, or nil when nothing here wrote them.
@@ -3186,12 +3186,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// you just dictated, and it is exactly the kind of word somebody selects
     /// because they want it fixed.
     private func dictationBehind(_ text: String, in element: AXUIElement?) -> Int? {
-        let target = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard target.count >= SelectionWatch.floor,
+        let words = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard words.count >= SelectionWatch.floor,
               let last = lastDictated,
               let element, let field = last.element, CFEqual(element, field),
-              last.text.contains(target) else { return nil }
-        return last.run
+              last.original.contains(words) else { return nil }
+        return last.dictation
     }
 
     /// What the pill says the hold is for, or nil for the one that needs no
@@ -3725,7 +3725,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// a sentence nobody asked about. Every other path in this file carries its
     /// destination down the chain for the same reason.
     private struct Correction {
-        let original: String
+        /// `var` for `lastDictated` alone, where a rewrite relabels the record
+        /// in place. An offer's own copy is frozen the moment it is raised and
+        /// nothing writes to it — see `offeredCorrection`.
+        var original: String
         let element: AXUIElement?
         let owner: NSRunningApplication?
         /// Where the words went, so the correction can follow them.
@@ -3991,8 +3994,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // the same thing, the text matches while the record belongs to the
         // newer one. Relabelling it there would leave the older correction's
         // words pointing at the newer dictation's field.
-        guard let dictation, dictation == lastDictated?.run else { return }
-        lastDictated?.text = corrected
+        guard let dictation, dictation == lastDictated?.dictation else { return }
+        lastDictated?.original = corrected
         // And the watch follows them. Selecting a sentence you have just had
         // rewritten has to offer again — the words on screen are the new ones,
         // and the old ones are not in the field to be selected any more.
@@ -4010,7 +4013,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // is understood — the panel would then open over the newer selection.
         let selection: SelectionReader.Selection?
         switch target {
-        case .frozen(let held, _):
+        case .frozen(let held, _, _):
             selection = held
         case .whateverIsSelected:
             selection = selectionAtPress ?? (
@@ -4314,10 +4317,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 return
             }
             Log.write("command keyed: \"\(trimmed)\"")
-            handleVoiceCommand(
-                trimmed, keyed: true,
-                over: .frozen(selection: press.selection, fallback: press.transcript)
-            )
+            handleVoiceCommand(trimmed, over: press.frozenTarget(keyed: true))
             return
         }
 
@@ -4326,7 +4326,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if let command = commandAfterWakePhrase(trimmed) {
             Log.write("command heard: \"\(command)\"")
             dictationEnded(press.run)
-            handleVoiceCommand(command, over: .frozen(selection: press.selection, fallback: press.transcript))
+            handleVoiceCommand(command, over: press.frozenTarget(keyed: false))
             return
         }
 

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -112,10 +112,6 @@ enum PanelsCommand {
             model.state = state
             model.appIcon = icon
             model.level = level
-            // No hotkey is registered behind the sheet, so the selection offer
-            // is drawn against the shipped default — which is the one a reader
-            // should be checking that row against, and is not this machine's.
-            model.hotkey = "Right ⌘"
             return model
         }
 
@@ -128,8 +124,13 @@ enum PanelsCommand {
         // the plain one is the whole design — a pill that says which words is a
         // different surface from one that says there are some, and a row that
         // is only sometimes there gets looked at nowhere else.
+        //
+        // The key is the shipped default rather than this machine's: nothing is
+        // registered behind the sheet, and the default is what a reader should
+        // be checking that row against.
         let offerSelection = pill(.offer(
-            offerChips, .selection("things that turned out not to matter"),
+            offerChips,
+            .selection("things that turned out not to matter", hotkey: "Right ⌘"),
             Confidence.Reading()
         ))
         // Beside the plain one: the two endings must not look the same.
@@ -397,9 +398,7 @@ enum PanelsCommand {
     /// The window's size, not the capsule's — the glow needs the bleed around
     /// it or the sheet cuts the halo off square.
     private static func pillSize(_ model: PillModel) -> NSSize {
-        PillMetrics.panelSize(
-            for: model.state, hasIcon: model.appIcon != nil, hotkey: model.hotkey
-        )
+        PillMetrics.panelSize(for: model.state, hasIcon: model.appIcon != nil)
     }
 
     /// Something recognisable to sit in the pill's slot. Mail because that is

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -84,8 +84,14 @@ enum PillState: Equatable {
 enum Headline: Equatable {
     /// "Nowhere to type · ⌘V", and the rest of the endings nobody asked for.
     case landing(String)
-    /// The words this offer is about, shown as the field shows them.
-    case selection(String)
+    /// The words this offer is about, shown as the field shows them, and the
+    /// key the third row tells you to hold. Empty when nothing is bound, which
+    /// takes that row off — see `OfferContent.hold`.
+    ///
+    /// The key travels in the state rather than beside it so that a state is
+    /// enough to measure. The pill is sized before it is drawn, and a size that
+    /// needed a second value would be a size that can disagree with the view.
+    case selection(String, hotkey: String)
 
     /// Whether this is the three-row shape: the words, the chips, and the line
     /// about the key. Read by the metrics and by the view, so the two cannot
@@ -130,18 +136,6 @@ final class PillModel: ObservableObject {
     /// words are going, and a window with no caret in it is not somewhere they
     /// can go. See `Destination`.
     @Published var appIcon: NSImage?
-
-    /// The hotkey as it is written on screen — "Right ⌘", "⌃⌥Space".
-    ///
-    /// The selection offer tells you to hold it, and the key is configurable,
-    /// so the glyph cannot be a literal. It was `⌥` here while the shipped
-    /// default is `right_command`, which told everyone but this machine to hold
-    /// the wrong key.
-    ///
-    /// Here rather than in the state, for the reason the icon is: it changes
-    /// when the config is read, not when the pill changes what it is saying,
-    /// and a state change crossfades the whole surface.
-    @Published var hotkey: String = ""
 
     /// Which command the pointer is on, if any.
     ///
@@ -212,9 +206,7 @@ final class PillHUD {
     /// window — which in the middle of a morph is a width on its way somewhere
     /// rather than a width anything chose.
     private var wantedSize: NSSize {
-        PillMetrics.panelSize(
-            for: model.state, hasIcon: model.appIcon != nil, hotkey: model.hotkey
-        )
+        PillMetrics.panelSize(for: model.state, hasIcon: model.appIcon != nil)
     }
 
     /// One number for the whole surface: the rise, the morph and the fade.
@@ -924,12 +916,10 @@ enum PillMetrics {
     /// less there is to see.
     static let bleed: CGFloat = 52
 
-    static func panelSize(
-        for state: PillState, hasIcon: Bool, hotkey: String = ""
-    ) -> NSSize {
-        let width = width(for: state, hasIcon: hasIcon, hotkey: hotkey)
+    static func panelSize(for state: PillState, hasIcon: Bool) -> NSSize {
+        let width = width(for: state, hasIcon: hasIcon)
         return NSSize(width: width + bleed * 2,
-                      height: height(for: state, width: width, hotkey: hotkey) + bleed * 2)
+                      height: height(for: state, width: width) + bleed * 2)
     }
 
     /// The face the dictated sentence is set in — the same one the chips use.
@@ -1033,7 +1023,7 @@ enum PillMetrics {
     ///
     /// An offer with nothing to say about the decode is the height the pill has
     /// always been, so a dictation that went fine changes nothing.
-    static func height(for state: PillState, width: CGFloat, hotkey: String = "") -> CGFloat {
+    static func height(for state: PillState, width: CGFloat) -> CGFloat {
         guard case .offer(_, let headline, let reading) = state else { return height }
         // A selection offer is three rows: the words, the chips, and the line
         // about the key. Two of them are extra, and they are added whatever the
@@ -1042,7 +1032,7 @@ enum PillMetrics {
         // The words row always, and the hold row only when there is a key to
         // name — `OfferContent.hold` draws it on the same condition.
         var extra: CGFloat = 0
-        if headline?.isSelection == true {
+        if case .selection(_, let hotkey) = headline {
             extra = selectionRow + selectionGap
             if !hotkey.isEmpty { extra += selectionRow + selectionGap }
         }
@@ -1104,15 +1094,13 @@ enum PillMetrics {
     static let icon: CGFloat = 22
     static let meter: CGFloat = 66
 
-    static func width(
-        for state: PillState, hasIcon: Bool, hotkey: String = ""
-    ) -> CGFloat {
+    static func width(for state: PillState, hasIcon: Bool) -> CGFloat {
         switch state {
         case .recording(let label): return recording(hasIcon: hasIcon, label: label)
         case .working(let message): return text(message)
         case .notice(let message, _): return text(message)
         case .offer(let commands, let headline, let reading):
-            return offer(commands, headline: headline, reading: reading, hotkey: hotkey)
+            return offer(commands, headline: headline, reading: reading)
         }
     }
 
@@ -1160,7 +1148,7 @@ enum PillMetrics {
     /// paragraph and a pill as wide as one is a pill nobody can place.
     static func offer(
         _ commands: [OfferedCommand], headline: Headline? = nil,
-        reading: Confidence.Reading = Confidence.Reading(), hotkey: String = ""
+        reading: Confidence.Reading = Confidence.Reading()
     ) -> CGFloat {
         // A chip is its keycap, its words and 9pt of padding either side; then
         // 4pt between one chip and the next.
@@ -1172,7 +1160,7 @@ enum PillMetrics {
         let row = padding * 2 + lead + chips
             + CGFloat(max(commands.count - 1, 0)) * 4 + rowFit
         var widest = row
-        if case .selection(let words) = headline {
+        if case .selection(let words, let hotkey) = headline {
             widest = max(widest, min(
                 sentenceWidth,
                 padding * 2 + title(editLead) + gap + title(words) + selectionFit
@@ -1562,7 +1550,7 @@ private struct OfferContent: View {
     /// you have to read text off" — and it earns the exception by being a
     /// quotation mark rather than decoration.
     @ViewBuilder private var selection: some View {
-        if case .selection(let words) = headline {
+        if case .selection(let words, _) = headline {
             HStack(spacing: PillMetrics.gap - 4) {
                 Text(PillMetrics.editLead)
                     .font(.system(size: 12, weight: .medium, design: .rounded))
@@ -1599,10 +1587,10 @@ private struct OfferContent: View {
     /// budget for this row, so the surface is never sized for a line it does
     /// not draw.
     @ViewBuilder private var hold: some View {
-        if case .selection = headline, !model.hotkey.isEmpty {
+        if case .selection(_, let hotkey) = headline, !hotkey.isEmpty {
             HStack(spacing: 6) {
                 Text(PillMetrics.holdLead)
-                keycap(model.hotkey)
+                keycap(hotkey)
                 Text(PillMetrics.holdTail)
             }
             .font(.system(size: 12, weight: .medium, design: .rounded))

--- a/Sources/ParrotFlow/SelectionWatch.swift
+++ b/Sources/ParrotFlow/SelectionWatch.swift
@@ -148,3 +148,11 @@ final class SelectionWatch {
     /// `field` is what does the ruling out.
     static let floor = 2
 }
+
+extension String {
+    /// Nothing but whitespace, which every path that offers over text has to
+    /// rule out before it asks a model or raises a surface about it.
+    var isBlank: Bool {
+        trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+}


### PR DESCRIPTION
Six behaviour-preserving cuts over `feat/edit-by-voice`, all in code that branch added. Nothing changes on screen, in the log, or in what any gesture does. The point is the shape: three copies of the hotkey become one, two parameters that always agreed become one, a five-field tuple becomes the struct it already was, and two near-identical offer paths become one.

Code drops 30 lines net. The line count is not the win — the win is that four places that had to be kept in sync by hand no longer can drift.

Every check in `make test` passes, including `keyed`. Review `Target.confirms` and `canRaiseAnOffer` first: those two are where a mistake would be invisible.

<details>
<summary>The hotkey was stored in three places and only ever read in one</summary>

`hotKeys.binding?.displayName` is the live source. It was copied to `PillModel.hotkey` at registration, then threaded through `PillMetrics.panelSize`, `width`, `height` and `offer` as a defaulted `hotkey: String = ""` parameter, plus two call-site arguments.

Every one of those reads sat inside a `case .selection` branch. No other pill state consulted it. So it moves into the state: `Headline.selection(String, hotkey: String)`.

That deletes `PillModel.hotkey`, the four parameters, both call-site arguments, and the two `pill.model.hotkey = …` assignments in `AppDelegate.applyConfig`. `AppDelegate.holdKey` reads the binding at the moment the headline is built.

It also fixes a small inconsistency nobody had hit. The pill is measured before it is drawn. With the key outside the state, a config reload between raising an offer and re-measuring it could change the measurement of an offer already on screen. Frozen into the headline, the two cannot disagree.

</details>

<details>
<summary>`confirm:` was exactly `!keyed` at every call site</summary>

Two parameters travelled together through `handleVoiceCommand`, `run` and `runTransform`, and never disagreed:

| call site | `keyed` | `confirm` |
|---|---|---|
| `Router.local` named it outright | from the caller | `!keyed` |
| keyed catch-all | `true` | `false` |
| router `.matched` / `.anything` | unreachable when keyed | default `true` |
| offer chip, menu | `false` | default `true` |

`Target` now carries `keyed` and answers `confirms`. `handleVoiceCommand` reads `keyed` off the target instead of taking it beside one.

The leaf `runTransform(_:instruction:selection:on:confirm:)` and `finishTransform` keep the plain bool. By then the target is resolved to a `String` and there is nothing left to ask.

`Press.frozenTarget(keyed:)` replaces the two hand-built `.frozen(selection: press.selection, fallback: press.transcript)` constructions in `deliverTranscription`.

</details>

<details>
<summary>`lastDictated` was a `Correction` written as a tuple</summary>

It was `(run: Int, text: String, element: AXUIElement?, owner: NSRunningApplication?, landing: Correction.Landing)`. Both `showCorrectOffer` and `summonOffer` unpacked it field by field to build a `Correction` from it.

It is a `Correction?` now, with `dictation` holding the run. `showCorrectOffer` builds it once and hands the same value to both `lastDictated` and `raiseOffer`. `summonOffer`'s last-dictation branch is one line.

`Correction.original` becomes `var` so `noteRewritten` can relabel the record in place. Nothing writes to an offer's own copy — that one is frozen when the offer is raised.

</details>

<details>
<summary>`summonOffer` and `offerOverReselected` shared four guards and twelve lines</summary>

Both checked `!recorder.isRecording`, `runsInFlight <= 0`, `!offerIsUp` and `config.feedback.correctOffer`, in two separately-written lists. Both then ran the same `aim(at:)` plus `raiseOffer(over: Correction(… selection …))` block.

They are `canRaiseAnOffer` and `offerOverSelection(_:)` now. `offerOverReselected` is gone; `watchForReselection`'s callback checks the guard and calls the shared path.

The two guard lists were identical today. Nothing stopped the next edit from changing one and not the other.

</details>

<details>
<summary>`runTransform` shadowed its own parameter with a different type</summary>

```swift
private func runTransform(
    _ transform: Config.Transform, instruction: String,
    progress inherited: Int?, over target: Target = .whateverIsSelected
) {
    …
    let target = selection?.text ?? dictated ?? ""   // a String, not a Target
```

Legal Swift, and it compiled. But `target` meant three things in `AppDelegate.swift` — a `Target`, a `Correction`, and this `String`. The local is `text` now.

</details>

<details>
<summary>What this deliberately leaves alone</summary>

**The comments.** They are 51% of the added lines on `feat/edit-by-voice` (825 of 1618). Trimming them to the `CLAUDE.md` standard is worth roughly four times what this PR saves, but it is a reading job, not a mechanical one, and it belongs in its own review.

**`String.isBlank` at the older call sites.** Six `trimmingCharacters(in: .whitespacesAndNewlines).isEmpty` remain in `LLM.swift`, `LocalLLM.swift`, `Config.swift`, `Template.swift` and `Transcriber.swift`. Converting them would spread this diff into five files the branch never touched. Separate sweep.

**`SelectionWatch`'s copy of the last dictation.** It holds `haystack` and `field`, re-armed after every rewrite — a third copy of `lastDictated`. A closure reading the record live would delete `watchForReselection`. But `reselect.stop()` on press closes a real gap, and moving that check inside `look()` couples the watch to the recorder. Small saving, not-small risk.

**The `keyedAtPress` rule.** It reads `offerHeadline?.isSelection`, which is UI state deciding input semantics. `offeredCorrection?.target.selection != nil` says the same thing from the data. The existing comment argues for matching the headline on purpose, so it stays.

</details>

<details>
<summary>Review notes — where a mistake would hide</summary>

Mechanical and safe:

- every `.frozen(a, b)` → `.frozen(a, b, _)` pattern update
- `last.text` → `last.original`, `last.run` → `last.dictation`
- the `target` → `text` rename in `runTransform`

Worth reading closely:

- **`Target.confirms`.** The keyed catch-all must still reach `finishTransform` with `confirm: false`, and the router branches must still get `true`. The router branches are unreachable when keyed — `handleVoiceCommand` returns before them — which is what makes the derivation safe.
- **`canRaiseAnOffer`.** Same four conditions as both old guard lists, in one place.
- **`holdKey` on a failed registration.** `register` unregisters before it tries, so `hotKeys.binding` is nil and `holdKey` is `""`, which takes the hold row off. Same as the old explicit `pill.model.hotkey = ""`.

Not run: `check-grammar`, `check-routing`, `check-spelling` (need Ollama) and `check-inplace` (needs a screen). No prompt, no routing rule and no in-place write is touched by this diff.

</details>
