### PR TITLE
feat: tap the hotkey to edit what you just said, or what you have selected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ release-certificate:
 ## check-routing and check-spelling need Ollama and gemma4:e4b, and
 ## check-inplace needs a real screen, the Accessibility grant and tmux. Run
 ## those by hand and put the numbers in the pull request.
-CHECKS := numbers replacements pipeline pipeline-config wake split dotted dates \
+CHECKS := numbers replacements pipeline pipeline-config wake split dotted dates keyed \
           transform-folders eval audio-recovery possessive suggest input join \
           profiles span-rule clipboard default-config vocabulary-config learn \
           signing-identity no-voice

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -210,6 +210,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// The current press was tap-then-hold, so its words are an instruction.
     private var keyedAtPress = false
 
+    /// Watches for the last dictation being selected again — see
+    /// `SelectionWatch`. Running from the moment there is something to select
+    /// until the next dictation replaces it.
+    private let reselect = SelectionWatch()
+
     /// The last dictation a tap can summon an offer over: its words, and where
     /// they went.
     ///
@@ -435,8 +440,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     ///
     /// Read fresh each time rather than stored, so a config reloaded between
     /// two dictations changes what the next offer says.
-    private var offerCommands: [OfferedCommand] {
-        [OfferedCommand(title: "Vocabulary", key: "V")]
+    /// `teaching` puts `Vocabulary` in front, and it is left out for words
+    /// nothing here dictated.
+    ///
+    /// The panel behind that chip maps what was HEARD to what it should be, and
+    /// over a selection in somebody else's email there is no hearing — nothing
+    /// listened to it. A rule taught from a typo somebody else typed would fire
+    /// on *your* future dictations, correcting a mistake the decoder never made.
+    ///
+    /// Before the hotkey could summon an offer over an arbitrary selection this
+    /// could not arise: the panel only ever opened over a dictation. Leaving the
+    /// chip off is the whole of the fix, and it is what the `add a word` panel
+    /// mode was going to be for.
+    private func offerCommands(teaching: Bool) -> [OfferedCommand] {
+        (teaching ? [OfferedCommand(title: "Vocabulary", key: "V")] : [])
             + config.transforms.filter(\.offer).map {
                 OfferedCommand(title: $0.name, key: $0.offerKey)
             }
@@ -1152,6 +1169,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if startsDictation {
             anchorAtPress = nil
             pressRun += 1
+            // The words it is watching for are about to be replaced. Stopped
+            // here rather than when the new ones land, so the gap in between
+            // cannot offer over a sentence that is already history.
+            reselect.stop()
             readTheAnchor()
         }
 
@@ -2906,6 +2927,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // one out of it once this has faded. Below the newer-run guard above,
         // and carrying the words as well as the field — see `lastDictated`.
         lastDictated = (press.run, text, press.element, press.owner, landing)
+        watchForReselection()
 
         // The decoder's words matched back onto the sentence that came out of
         // the pipeline — see `Confidence.read`. Taken rather than copied: this
@@ -2968,7 +2990,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         offerHeld = false
         offerPressRun = run
         offeredCorrection = (run, target)
-        let commands = offerCommands
+        // Frozen with the offer rather than asked again when a chip is pressed.
+        // `lastDictated` is one slot and push-to-talk does not wait, so the same
+        // question a few seconds later can be about a different sentence.
+        let teaching = target.dictation != nil
+        let commands = offerCommands(teaching: teaching)
         offerHeadline = headline
         offerReading = reading
         let hold = config.feedback.lowConfidence.holdReturn
@@ -2981,10 +3007,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // under the pointer, and the click would run whatever took the slot.
         pill.model.onPick = { [weak self] index in
             guard let self, self.offerIsUp, commands.indices.contains(index) else { return }
-            // Index 0 is Vocabulary, which is not a transform and cannot be
-            // one: a config free to name a transform "Vocabulary" must not be
-            // able to take that slot over.
-            self.runOfferedCommand(index == 0 ? nil : commands[index].title)
+            // Index 0 is Vocabulary *when it is there* — it is not a transform
+            // and cannot be one, so a config free to name a transform
+            // "Vocabulary" must not be able to take that slot over. Matched by
+            // position rather than by title for exactly that reason, which means
+            // an offer without it has to say so or the first transform would be
+            // run as the panel.
+            self.runOfferedCommand(teaching && index == 0 ? nil : commands[index].title)
         }
         // The highlight is the pointer's mark and does not outlive it. Leaving
         // the pill gives it up, so a chip is never lit for a command that is
@@ -3035,7 +3064,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             raiseOffer(
                 over: Correction(
                     original: selection.text, element: selection.element,
-                    owner: selection.owner, landing: .field, selection: selection
+                    owner: selection.owner, landing: .field,
+                    // Selecting part of what you just dictated and tapping is
+                    // still your dictation, so it still gets the panel — see
+                    // `dictationBehind`. Text nobody here wrote answers nil.
+                    dictation: dictationBehind(selection.text, in: selection.element),
+                    selection: selection
                 ),
                 run: pressRun, headline: "the selection", reading: Confidence.Reading()
             )
@@ -3062,6 +3096,88 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             ),
             run: pressRun, headline: nil, reading: Confidence.Reading()
         )
+    }
+
+    /// Offer again when the words are selected again.
+    ///
+    /// The other half of `summonOffer`. A tap is how you ask for the offer;
+    /// this is how it arrives without being asked, and it is bounded to the one
+    /// case where appearing uninvited is right — you selected text ParrotFlow
+    /// wrote, which is a deliberate act aimed at words it already knows about.
+    ///
+    /// Re-armed after every rewrite, so a sentence corrected and then selected
+    /// again still answers with the words that are on screen rather than the
+    /// ones that were.
+    ///
+    /// The field is what the watch judges by, so no field means no watch. A
+    /// dictation that ended on the clipboard left nothing on screen to select,
+    /// and one whose element was never captured cannot be told from any other
+    /// window.
+    private func watchForReselection() {
+        guard config.feedback.correctOffer else { reselect.stop(); return }
+        guard let last = lastDictated,
+              !last.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              case .field = last.landing, let element = last.element else {
+            reselect.stop()
+            return
+        }
+        reselect.onSelection = { [weak self] selection in
+            self?.offerOverReselected(selection)
+        }
+        reselect.start(over: last.text, in: element)
+    }
+
+    /// The offer, over words that were dictated and have been selected again.
+    ///
+    /// The selection is the target, not the whole dictation: select three words
+    /// out of a sentence and those three words are what you meant. Everything
+    /// downstream is `summonOffer`'s, because there is no difference between an
+    /// offer you asked for and one that noticed — only in how it arrived.
+    private func offerOverReselected(_ selection: SelectionReader.Selection) {
+        // Never over a recording, never over an offer already up, and never
+        // while a decode this could be about is still in flight.
+        //
+        // Refusing while one is up does not cost you a second selection, and
+        // the reason is an ordering worth keeping: an outside click dismisses
+        // the offer on mouse *down* — see `watchForOfferOutsideClick` — and this
+        // looks on mouse *up*. So selecting different words takes the old offer
+        // down before the new one is asked for. Move either monitor to the other
+        // edge and reselecting while an offer is up stops answering.
+        guard !recorder.isRecording, runsInFlight <= 0, !offerIsUp else { return }
+        guard config.feedback.correctOffer else { return }
+        aim(at: selection)
+        raiseOffer(
+            over: Correction(
+                original: selection.text, element: selection.element,
+                owner: selection.owner, landing: .field,
+                dictation: dictationBehind(selection.text, in: selection.element),
+                selection: selection
+            ),
+            run: pressRun, headline: "the selection", reading: Confidence.Reading()
+        )
+    }
+
+    /// The dictation these words came from, or nil when nothing here wrote them.
+    ///
+    /// Asked at the moment an offer is raised and frozen onto it, never read
+    /// later: `lastDictated` is one slot and push-to-talk does not wait, so the
+    /// answer a second from now can belong to a different sentence.
+    ///
+    /// `contains` rather than equality — select three words out of something you
+    /// dictated and it is still your dictation, and the part you selected is the
+    /// part you meant. What keeps that from being true of everything is the
+    /// field, not the length, which is the same judgement `SelectionWatch`
+    /// makes. "know" is four characters and sits inside half of everything
+    /// anybody says; "know" in the box those words were written into is the word
+    /// you just dictated, and it is exactly the kind of word somebody selects
+    /// because they want it fixed.
+    private func dictationBehind(_ text: String, in element: AXUIElement?) -> Int? {
+        let target = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard target.count >= SelectionWatch.floor,
+              let last = lastDictated,
+              let element, let field = last.element, CFEqual(element, field),
+              last.text.contains(target) else { return nil }
+        return last.run
     }
 
     /// What the pill says the hold is for, or nil for the one that needs no
@@ -3093,7 +3209,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func aim(at selection: SelectionReader.Selection) {
         guard let element = selection.element,
               case .found(let anchor) = CaretAnchor.read(at: element) else {
-            Log.write("summon: no geometry for the selection; the pill stays where it was")
+            Log.write("pill: no geometry for the selection; it stays where it was")
             return
         }
         pill.aim(at: anchor)
@@ -3858,6 +3974,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // words pointing at the newer dictation's field.
         guard let dictation, dictation == lastDictated?.run else { return }
         lastDictated?.text = corrected
+        // And the watch follows them. Selecting a sentence you have just had
+        // rewritten has to offer again — the words on screen are the new ones,
+        // and the old ones are not in the field to be selected any more.
+        watchForReselection()
     }
 
     private func beginCorrection(over target: Target = .whateverIsSelected) {

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -168,6 +168,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         /// would be delivered with the terminal's answer, and the reverse puts
         /// markup in front of an app that shows the tags.
         let paste: AppProfile.Paste
+        /// Tap-then-hold: what is said is an instruction, not text.
+        ///
+        /// Decided at the press because that is where the gesture is known, and
+        /// carried here for the same reason everything else is — a second press
+        /// landing mid-transcription must not be able to change what this one
+        /// was for.
+        var isCommand = false
+        /// What was selected when this recording began.
+        ///
+        /// Frozen for the reason every other field here is. `selectionAtPress`
+        /// is one slot that the next press overwrites, and a spoken command
+        /// reads its target *after* the decoder has run — so starting a second
+        /// dictation while a command is still decoding pointed that command at
+        /// the newer press's selection. "Make it bold" then applied to whatever
+        /// happened to be highlighted by the time it finished, which on a
+        /// gesture whose pill reads "editing the selection" is the one thing it
+        /// must not do.
+        var selection: SelectionReader.Selection?
+        /// The dictation this command would fall back to, frozen with it.
+        ///
+        /// "Make it terse" with nothing selected means the sentence that was
+        /// there when you said it. `lastTranscript` is one slot like the
+        /// selection is, and a dictation finishing while the router thinks
+        /// replaces it — so the command rewrote a sentence that arrived after
+        /// the instruction for it. Freezing the selection alone left this half
+        /// of the same crossing open.
+        var transcript: String?
     }
 
     /// The words the offer on screen is about, and the field they went into.
@@ -179,6 +206,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// one dictation's words against another's field. This is the same
     /// ownership `offerPressRun` already asserts, carrying what it is about.
     private var offeredCorrection: (run: Int, target: Correction)?
+
+    /// The current press was tap-then-hold, so its words are an instruction.
+    private var commandAtPress = false
 
     /// The last dictation a tap can summon an offer over: its words, and where
     /// they went.
@@ -774,7 +804,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         DispatchQueue.main.async { [weak self] in self?.askForMissingKeys() }
 
         hotkeyError = nil
-        hotKeys.onPress = { [weak self] in self?.handleHotKeyPress() }
+        hotKeys.onPress = { [weak self] afterTap in self?.handleHotKeyPress(afterTap: afterTap) }
         hotKeys.onRelease = { [weak self] in self?.handleHotKeyRelease() }
         hotKeys.onAbort = { [weak self] in self?.cancelDictation(.notTheHotkey) }
         hotKeys.onTap = { [weak self] in self?.summonOffer() }
@@ -1067,7 +1097,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Hotkey handling
 
-    private func handleHotKeyPress() {
+    private func handleHotKeyPress(afterTap: Bool = false) {
+        // The gesture, kept for the `Press` built when the recording stops.
+        // Only for a press that starts a dictation: the second press of a
+        // toggle belongs to the one already running, and it did not ask for
+        // anything different.
+        if !recorder.isRecording { commandAtPress = afterTap }
         // Read before anything this press does, so an abort later can tell the
         // transcription this press started from one that was already running.
         transcriptionRunAtPress = transcriptionRun
@@ -1449,8 +1484,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         playFeedback("Tink")
         if config.feedback.overlay {
-            pill.aim(at: anchorAtPress)
-            pill.recording(icon: appIconAtPress)
+            // Under the selection when there is one and this is a command: the
+            // words are about those words, and the pill belongs with them.
+            if commandAtPress, let selection = selectionAtPress {
+                aim(at: selection)
+            } else {
+                pill.aim(at: anchorAtPress)
+            }
+            pill.recording(icon: appIconAtPress, label: recordingLabel)
         }
 
         let tick = Timer(timeInterval: 0.1, repeats: true) { [weak self] _ in
@@ -1758,7 +1799,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             run: pressRun, element: focus?.element, owner: focus?.owner, mic: micAtPress,
             // Plain when nobody was in front, which is the answer that cannot
             // lose a sentence.
-            paste: appAtPress.map { AppProfile.of($0).paste } ?? .plain
+            paste: appAtPress.map { AppProfile.of($0).paste } ?? .plain,
+            isCommand: commandAtPress,
+            // Still this press's: the recording has only just stopped and no
+            // newer press can have landed. The gap this closes is the decode
+            // that follows, not this moment.
+            selection: selectionAtPress,
+            // The dictation before this one, which is what a command with
+            // nothing selected is about.
+            transcript: lastTranscript
         )
         Task { [weak self] in
             // Whatever happens below — decoded, cancelled, or thrown — nothing
@@ -1980,7 +2029,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
     }
 
-    private func handleVoiceCommand(_ command: String) {
+    /// `confirm: false` applies a rewrite in place instead of previewing it.
+    ///
+    /// The gesture path passes it. Tap-then-hold has already named its target
+    /// on the pill and offered ⎋ for the whole time you were speaking, and
+    /// "hey parrot, undo" puts the substitution back afterwards — so a preview
+    /// is a question that was answered twice before it was asked. The wake
+    /// phrase does not pass it: that one is found in a sentence rather than
+    /// declared by a key, so being wrong about it is a real possibility.
+    private func handleVoiceCommand(
+        _ command: String, confirm: Bool = true,
+        over target: Target = .whateverIsSelected
+    ) {
         let catalogue = Catalogue(transforms: config.transforms)
 
         // Deterministic phrases first: no model needed, and they work when
@@ -1988,13 +2048,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // own, which means the panel rather than anything the router could pick.
         if let local = VoiceCommand.local(from: command) {
             // Nothing on the pill is ours: no model was asked, so no
-            // "Thinking…" went up.
-            apply(local, command: command, progress: nil)
+            // "Thinking…" went up. The target still travels: this path opens
+            // the correction panel, which reads the selection slot, and a
+            // command that was decoded while a newer press filled that slot
+            // would open over the newer selection.
+            apply(local, command: command, progress: nil, over: target)
             return
         }
         if let capability = Router.local(instruction: command, catalogue: catalogue) {
             Log.write("router: \"\(command)\" named \(capability.name) outright")
-            run(capability, instruction: command, progress: nil)
+            run(
+                capability, instruction: command,
+                progress: nil, confirm: confirm, over: target
+            )
             return
         }
 
@@ -2021,7 +2087,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     switch decision {
                     case .matched(let capability):
                         Log.write("router: \"\(command)\" → \(capability.name)")
-                        self.run(capability, instruction: command, progress: token)
+                        self.run(
+                            capability, instruction: command,
+                            progress: token, confirm: confirm, over: target
+                        )
                     case .anything:
                         // An edit with no prompt behind it. The instruction is
                         // the whole specification, so it goes through unsplit,
@@ -2029,7 +2098,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         Log.write("router: \"\(command)\" → \(FreeForm.name)")
                         self.runTransform(
                             FreeForm.prompt(for: command).asTransform(model: catchAll),
-                            instruction: command, progress: token
+                            instruction: command, progress: token,
+                            confirm: confirm, over: target
                         )
                     case .none:
                         // Nothing fits. Deliberately not falling through to
@@ -2055,7 +2125,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     Log.write("routing failed: \(error.localizedDescription)")
                     self.endProgress(token: token)
                     let asked = self.askForKeyThenRetry(error) {
-                        self.handleVoiceCommand(command)
+                        self.handleVoiceCommand(command, confirm: confirm, over: target)
                     }
                     if !asked { self.flash(error.localizedDescription, tone: .failure) }
                 }
@@ -2068,15 +2138,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `progress` is the "Thinking…" the router put up, where a router ran, so
     /// whichever branch ends without putting its own message up takes that one
     /// down and nothing else.
-    private func run(_ capability: Capability, instruction: String, progress token: Int?) {
+    private func run(
+        _ capability: Capability, instruction: String,
+        progress token: Int?, confirm: Bool = true,
+        over target: Target = .whateverIsSelected
+    ) {
         switch capability {
         case .action(.vocabulary):
             endProgress(token: token)
-            beginCorrection()
+            beginCorrection(over: target)
         case .action(.spelling):
-            interpretSpelling(instruction, progress: token)
+            interpretSpelling(instruction, progress: token, over: target)
         case .transform(let transform):
-            runTransform(transform, instruction: instruction, progress: token)
+            runTransform(
+                transform, instruction: instruction,
+                progress: token, confirm: confirm, over: target
+            )
         }
     }
 
@@ -2141,7 +2218,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// The spelling extractor, which is a second model call rather than part of
     /// routing — it reads the last transcript and returns a rule, not a name.
-    private func interpretSpelling(_ command: String, progress inherited: Int?) {
+    private func interpretSpelling(
+        _ command: String, progress inherited: Int?,
+        over target: Target = .whateverIsSelected
+    ) {
         guard config.llmEnabled else {
             endProgress(token: inherited)
             flash("Didn't understand \"\(command)\" — enable llm in config for free-form commands", tone: .caution)
@@ -2150,7 +2230,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let token = beginProgress("Thinking…")
         let llmConfig = llmConfig()
-        let context = lastTranscript
+        // The dictation the spelling is about, frozen with the command that
+        // asked. This one reads the transcript for its whole job — "Tasmin
+        // spells T A S M E E N" finds the word in what you said before — so a
+        // newer dictation replacing it while the router thought would have sent
+        // the model looking in the wrong sentence.
+        let context: String?
+        switch target {
+        case .frozen(_, let fallback): context = fallback
+        case .whateverIsSelected: context = lastTranscript
+        }
         // From the transcript, never the command: the command is short and its
         // trigger word plus a run of loose capitals reads as English whatever
         // was actually said.
@@ -2167,7 +2256,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     command: command, lastTranscript: context,
                     language: language, config: llmConfig
                 )
-                await MainActor.run { self?.apply(result, command: command, progress: token) }
+                await MainActor.run {
+                    self?.apply(result, command: command, progress: token, over: target)
+                }
             } catch {
                 await MainActor.run {
                     guard let self else { return }
@@ -2175,8 +2266,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     self.endProgress(token: token)
                     let asked = self.askForKeyThenRetry(error) {
                         // The message above is already down, so the retry
-                        // inherits nothing.
-                        self.interpretSpelling(command, progress: nil)
+                        // inherits nothing. The target is not nothing: a retry
+                        // happens after a key dialog, which is all the time a
+                        // newer dictation needs to land, and reading the slot
+                        // then would correct that one instead.
+                        self.interpretSpelling(command, progress: nil, over: target)
                     }
                     if !asked { self.flash(error.localizedDescription, tone: .failure) }
                 }
@@ -2186,13 +2280,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Transforms
 
+    /// Where a transform's target comes from.
+    ///
+    /// Two cases rather than an optional selection, because the answer
+    /// "nothing was selected" and the answer "nobody said" are different and an
+    /// optional cannot hold both. Flattened into one, a command that began with
+    /// nothing selected fell through to the shared slot and picked up whatever
+    /// a newer press had put there — the same crossing `Press.selection` exists
+    /// to stop, surviving in the nil case.
+    private enum Target {
+        /// Read the selection now. The menu and the offer run while the slot is
+        /// still the press's own.
+        case whateverIsSelected
+        /// What a spoken command froze when its recording began: the
+        /// selection, which may be nothing, and the dictation to fall back to,
+        /// which may also be nothing. A command reads neither slot and clears
+        /// neither: by the time a decoder has answered, a newer press can own
+        /// what is in them.
+        case frozen(selection: SelectionReader.Selection?, fallback: String?)
+    }
+
     /// Runs a prompt over the selection, or over the last dictation.
     ///
     /// The selection is taken from the snapshot made when the hotkey went down,
     /// not read now — by the time this runs, our own panel may hold focus, and
     /// reading then returns nothing or something of ours.
     private func runTransform(
-        _ transform: Config.Transform, instruction: String, progress inherited: Int?
+        _ transform: Config.Transform, instruction: String,
+        progress inherited: Int?, confirm: Bool = true,
+        over target: Target = .whateverIsSelected
     ) {
         // Never the clipboard. `read()` falls back to it for the correction
         // panel, where you see the words before anything happens and can
@@ -2202,16 +2318,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // That is exactly what happened: "convert numbers to digits" ran over
         // a comment line copied minutes earlier, while the sentence the
         // speaker meant sat in the last transcript, unused.
-        let selection = selectionAtPress ?? (
-            Permissions.accessibility == .granted
-                ? SelectionReader.read(fallbackTo: false)
-                : nil
-        )
-        selectionAtPress = nil
+        //
+        // A spoken command brings its own, frozen when its recording began —
+        // see `Press.selection` and `Target`. It neither reads the slot nor
+        // clears it: by the time a decoder has answered, a newer press can own
+        // what is in there.
+        let selection: SelectionReader.Selection?
+        let dictated: String?
+        switch target {
+        case .frozen(let held, let fallback):
+            selection = held
+            dictated = fallback
+        case .whateverIsSelected:
+            selection = selectionAtPress ?? (
+                Permissions.accessibility == .granted
+                    ? SelectionReader.read(fallbackTo: false)
+                    : nil
+            )
+            selectionAtPress = nil
+            dictated = lastTranscript
+        }
 
         // Falling back to the last dictation is what makes "hey parrot, fix the
         // grammar" work immediately after speaking, with nothing selected.
-        let target = selection?.text ?? lastTranscript ?? ""
+        let target = selection?.text ?? dictated ?? ""
         guard !target.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             endProgress(token: inherited)
             Log.write("transform: nothing selected and nothing dictated yet")
@@ -2223,7 +2353,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // wrong thing is otherwise indistinguishable in the log from one that
         // worked on the right thing badly.
         Log.write("transform: \(transform.name) over \(selection == nil ? "the last dictation" : "the selection") — \"\(target.prefix(80))\"")
-        runTransform(transform, instruction: instruction, selection: selection, on: target)
+        runTransform(
+            transform, instruction: instruction, selection: selection, on: target,
+            confirm: confirm
+        )
     }
 
     /// The run itself, over text already decided.
@@ -2237,7 +2370,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         _ transform: Config.Transform,
         instruction: String,
         selection: SelectionReader.Selection?,
-        on target: String
+        on target: String,
+        confirm: Bool = true
     ) {
         let token = beginProgress(transform.progressLabel)
 
@@ -2249,7 +2383,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 await MainActor.run {
                     self?.finishTransform(
                         transform: transform, selection: selection,
-                        before: target, after: result, progress: token
+                        before: target, after: result,
+                        progress: token, confirm: confirm
                     )
                 }
             } catch {
@@ -2260,7 +2395,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     let asked = self.askForKeyThenRetry(error) {
                         self.runTransform(
                             transform, instruction: instruction,
-                            selection: selection, on: target
+                            selection: selection, on: target, confirm: confirm
                         )
                     }
                     if !asked { self.flash(error.localizedDescription, tone: .failure) }
@@ -2274,7 +2409,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         selection: SelectionReader.Selection?,
         before: String,
         after: String,
-        progress token: Int?
+        progress token: Int?,
+        confirm: Bool = true
     ) {
         endProgress(token: token)
 
@@ -2298,7 +2434,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        guard transform.confirm else {
+        // `confirm: false` overrides the transform's own setting, the way the
+        // offer's chips already do. A preview is for a command whose target you
+        // could have got wrong; tap-then-hold has already shown you the target
+        // on the pill and given you ⎋ to take it back, and the undo phrase
+        // survives the rewrite. Asking again after all that is a second answer
+        // to a question already answered.
+        guard transform.confirm, confirm else {
             applyTransform(cleaned, to: selection, replacing: before, transform: transform)
             return
         }
@@ -2616,13 +2758,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         lastTranscript = text
     }
 
-    private func apply(_ command: VoiceCommand, command spoken: String, progress token: Int?) {
+    private func apply(
+        _ command: VoiceCommand, command spoken: String, progress token: Int?,
+        over target: Target = .whateverIsSelected
+    ) {
         // Whatever happens next replaces it: a panel, or a flash of its own.
         endProgress(token: token)
 
         switch command {
         case .openCorrectionPanel:
-            beginCorrection()
+            beginCorrection(over: target)
         case .undo:
             performUndo()
         case .addRules(let rules):
@@ -2871,6 +3016,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             ),
             run: pressRun, headline: nil, reading: Confidence.Reading()
         )
+    }
+
+    /// What the pill says the hold is for, or nil for the one that needs no
+    /// saying.
+    ///
+    /// A command hold looks exactly like a dictation from outside — same key,
+    /// same mic, same meter — and the difference is that the words are routed
+    /// instead of written down. That has to be readable *before* you speak, not
+    /// worked out afterwards from a sentence that never landed. Escape is live
+    /// the whole time, so a wrong answer here costs one keystroke.
+    private var recordingLabel: String? {
+        guard commandAtPress else { return nil }
+        return selectionAtPress == nil ? "say an edit" : "editing the selection"
     }
 
     /// Put the pill under the selection instead of where the last dictation
@@ -3656,14 +3814,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         lastDictated?.text = corrected
     }
 
-    private func beginCorrection() {
+    private func beginCorrection(over target: Target = .whateverIsSelected) {
         // Reading the selection needs Accessibility; the panel does not. Open
         // it either way — typing both sides still beats editing YAML by hand,
         // and a panel that silently refuses to appear reads as a broken app.
-        let selection = selectionAtPress ?? (
-            Permissions.accessibility == .granted ? SelectionReader.read() : nil
-        )
-        selectionAtPress = nil
+        //
+        // A spoken command brings its own, frozen when its recording began. It
+        // does not read the slot: "hey parrot" is decoded like any other
+        // dictation, and a newer press can have filled that slot by the time it
+        // is understood — the panel would then open over the newer selection.
+        let selection: SelectionReader.Selection?
+        switch target {
+        case .frozen(let held, _):
+            selection = held
+        case .whateverIsSelected:
+            selection = selectionAtPress ?? (
+                Permissions.accessibility == .granted ? SelectionReader.read() : nil
+            )
+            selectionAtPress = nil
+        }
 
         Log.write("correction: selection = \(selection.map { "\"\($0.text)\"" } ?? "none")")
         pendingSelection = selection
@@ -3947,12 +4116,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // and no stage has a reason to ask for one at either end.
         let delivered = text.trimmingCharacters(in: .newlines)
 
+        // The gesture already said this is an instruction, so nothing is
+        // looked for in the words. That is the whole point of it: the phrase
+        // exists to mark a command inside an ordinary dictation, and there is
+        // nothing to mark when the key said so first.
+        if press.isCommand {
+            dictationEnded(press.run)
+            guard !trimmed.isEmpty else {
+                Log.write("command: nothing was said")
+                flash("Didn't catch that", tone: .caution)
+                updateUI()
+                return
+            }
+            Log.write("command spoken: \"\(trimmed)\"")
+            handleVoiceCommand(trimmed, confirm: false, over: .frozen(selection: press.selection, fallback: press.transcript))
+            return
+        }
+
         // Heard as a command, or nothing at all: no words are going to land,
         // so there is nothing to compare a pane against.
         if let command = commandAfterWakePhrase(trimmed) {
             Log.write("command heard: \"\(command)\"")
             dictationEnded(press.run)
-            handleVoiceCommand(command)
+            handleVoiceCommand(command, over: .frozen(selection: press.selection, fallback: press.transcript))
             return
         }
 

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -388,7 +388,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var offerOnScreen: [OfferedCommand]?
     /// The headline and the reading the offer went up with, so the pill can be
     /// drawn again without rebuilding what it is about. See `holdTheReturn`.
-    private var offerHeadline: String?
+    private var offerHeadline: Headline?
     private var offerReading = Confidence.Reading()
     /// Until when this offer's Return is held. Set when the offer goes up, so
     /// an offer whose keys arrive late — a second dictation was still running —
@@ -826,14 +826,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         hotKeys.onAbort = { [weak self] in self?.cancelDictation(.notTheHotkey) }
         hotKeys.onTap = { [weak self] in self?.summonOffer() }
         do {
-            try hotKeys.register(
+            let binding = try hotKeys.register(
                 key: config.hotkey.key,
                 modifiers: config.hotkey.modifiers,
                 pressDelay: config.hotkey.pressDelaySeconds
             )
+            // The offer's "or hold …" row names this key, so it is read from
+            // what actually registered rather than from the config: a key the
+            // config asked for and macOS refused is not the key to tell
+            // somebody to hold. Set on every reload, because the hotkey is one
+            // of the things a reload can change.
+            pill.model.hotkey = binding.displayName
         } catch {
             hotkeyError = error.localizedDescription
             Log.write("hotkey registration FAILED: \(error.localizedDescription)")
+            // `register` unregisters before it tries, so a reload that fails
+            // leaves nothing bound. Cleared rather than left saying the old
+            // key: the row would be naming a key with no handler behind it,
+            // which is worse than the row being absent. Empty takes it off the
+            // pill — see `OfferContent.hold`.
+            pill.model.hotkey = ""
         }
 
         startKeepWarm()
@@ -1119,7 +1131,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Only for a press that starts a dictation: the second press of a
         // toggle belongs to the one already running, and it did not ask for
         // anything different.
-        if !recorder.isRecording { keyedAtPress = afterTap }
+        //
+        // A plain hold counts as keyed while an offer over a *selection* is up,
+        // and only then. There the pill is pointing at words and asking what to
+        // do about them, so a hold cannot mean "start a new dictation" — and
+        // the tap that summoned it already happened, so asking for another
+        // would be asking twice for the same thing. It is also what the third
+        // row of that pill promises, and a promise nothing honoured would be
+        // worse than no row.
+        //
+        // An offer over the last dictation is not that. It carries no such row,
+        // nothing on screen offers the gesture, and holding after a sentence
+        // lands is how the next one gets said. Matched against the headline
+        // rather than against `selectionAtPress` so the rule is the one the
+        // pill is drawing: the row appears exactly when this is true, and the
+        // two cannot drift apart.
+        if !recorder.isRecording {
+            keyedAtPress = afterTap || (offerIsUp && offerHeadline?.isSelection == true)
+        }
         // Read before anything this press does, so an abort later can tell the
         // transcription this press started from one that was already running.
         transcriptionRunAtPress = transcriptionRun
@@ -2887,7 +2916,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// off `self`, so an offer can never be moved by another dictation's press.
     /// `headline` is only passed for an ending nobody chose.
     private func showCorrectOffer(
-        for press: Press, landing: Correction.Landing, headline: String? = nil
+        for press: Press, landing: Correction.Landing, headline: Headline? = nil
     ) {
         // Beside the offer, not on it: its own window, so advice about the
         // microphone never costs you the chance to fix the sentence. Here
@@ -2983,7 +3012,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// nothing else does: the microphone notice, the decoder's reading, and the
     /// search for where the words landed.
     private func raiseOffer(
-        over target: Correction, run: Int, headline: String?, reading: Confidence.Reading
+        over target: Correction, run: Int, headline: Headline?, reading: Confidence.Reading
     ) {
         offerUntil = Date().addingTimeInterval(Self.offerSeconds)
         // A new offer is never born held, whatever the last one ended as.
@@ -3071,7 +3100,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     dictation: dictationBehind(selection.text, in: selection.element),
                     selection: selection
                 ),
-                run: pressRun, headline: "the selection", reading: Confidence.Reading()
+                run: pressRun, headline: .selection(selection.text),
+                reading: Confidence.Reading()
             )
             return
         }
@@ -3153,7 +3183,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 dictation: dictationBehind(selection.text, in: selection.element),
                 selection: selection
             ),
-            run: pressRun, headline: "the selection", reading: Confidence.Reading()
+            run: pressRun, headline: .selection(selection.text),
+            reading: Confidence.Reading()
         )
     }
 
@@ -3439,6 +3470,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         offerHeld = false
         offeredCorrection = nil
         offerOnScreen = nil
+        // With the rest of what the offer was about. It decides whether a hold
+        // is an edit — see `handleHotKeyPress` — and a headline outliving its
+        // offer is one more slot that says something true about a surface that
+        // is no longer there.
+        offerHeadline = nil
         offerKeysExpiry?.cancel()
         offerKeysExpiry = nil
         offerKeys.stop()
@@ -4748,7 +4784,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     : "focus moved since the press; copied instead of pasting")
                 setLabel("Focus moved — the transcription is on your clipboard", clearAfter: 4)
                 showCorrectOffer(
-                    for: press, landing: .clipboardNow(), headline: "Focus moved · ⌘V"
+                    for: press, landing: .clipboardNow(), headline: .landing("Focus moved · ⌘V")
                 )
                 updateUI()
                 return
@@ -4782,7 +4818,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             setLabel("Nowhere to type — the transcription is on your clipboard", clearAfter: 4)
             // And on the pill: the menu bar row is inside a menu you must open.
             showCorrectOffer(
-                for: press, landing: .clipboardNow(), headline: "Nowhere to type · ⌘V"
+                for: press, landing: .clipboardNow(), headline: .landing("Nowhere to type · ⌘V")
             )
             updateUI()
             return

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -168,13 +168,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         /// would be delivered with the terminal's answer, and the reverse puts
         /// markup in front of an app that shows the tags.
         let paste: AppProfile.Paste
-        /// Tap-then-hold: what is said is an instruction, not text.
+        /// Tap-then-hold: a key said this would be an instruction, not text.
         ///
         /// Decided at the press because that is where the gesture is known, and
         /// carried here for the same reason everything else is — a second press
         /// landing mid-transcription must not be able to change what this one
-        /// was for.
-        var isCommand = false
+        /// was for. See `handleVoiceCommand(_:keyed:)` for what it buys.
+        var keyed = false
         /// What was selected when this recording began.
         ///
         /// Frozen for the reason every other field here is. `selectionAtPress`
@@ -208,7 +208,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var offeredCorrection: (run: Int, target: Correction)?
 
     /// The current press was tap-then-hold, so its words are an instruction.
-    private var commandAtPress = false
+    private var keyedAtPress = false
 
     /// The last dictation a tap can summon an offer over: its words, and where
     /// they went.
@@ -1102,7 +1102,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Only for a press that starts a dictation: the second press of a
         // toggle belongs to the one already running, and it did not ask for
         // anything different.
-        if !recorder.isRecording { commandAtPress = afterTap }
+        if !recorder.isRecording { keyedAtPress = afterTap }
         // Read before anything this press does, so an abort later can tell the
         // transcription this press started from one that was already running.
         transcriptionRunAtPress = transcriptionRun
@@ -1486,7 +1486,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if config.feedback.overlay {
             // Under the selection when there is one and this is a command: the
             // words are about those words, and the pill belongs with them.
-            if commandAtPress, let selection = selectionAtPress {
+            if keyedAtPress, let selection = selectionAtPress {
                 aim(at: selection)
             } else {
                 pill.aim(at: anchorAtPress)
@@ -1800,7 +1800,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // Plain when nobody was in front, which is the answer that cannot
             // lose a sentence.
             paste: appAtPress.map { AppProfile.of($0).paste } ?? .plain,
-            isCommand: commandAtPress,
+            keyed: keyedAtPress,
             // Still this press's: the recording has only just stopped and no
             // newer press can have landed. The gap this closes is the decode
             // that follows, not this moment.
@@ -2029,16 +2029,32 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
     }
 
-    /// `confirm: false` applies a rewrite in place instead of previewing it.
+    /// `keyed` — a keystroke said this was an instruction, before a word of it
+    /// was spoken.
     ///
-    /// The gesture path passes it. Tap-then-hold has already named its target
-    /// on the pill and offered ⎋ for the whole time you were speaking, and
-    /// "hey parrot, undo" puts the substitution back afterwards — so a preview
-    /// is a question that was answered twice before it was asked. The wake
-    /// phrase does not pass it: that one is found in a sentence rather than
-    /// declared by a key, so being wrong about it is a real possibility.
+    /// The alternative is *heard*: the phrase was found inside a sentence by a
+    /// fuzzy matcher, which fires at 0.55 a word against a 0.7 floor because
+    /// "hey parrot" arrives clipped. It can be wrong, and `tests/wake-cases.txt`
+    /// holds the sentences about parrots it must not fire on. Everything the
+    /// two paths do differently follows from that one difference.
+    ///
+    /// Keyed skips two things, and both are insurance against that doubt:
+    ///
+    /// - **The router.** It answers two questions, and the first is "was this
+    ///   an edit at all". A key has already answered it. What is left is
+    ///   "which tool", which the name match answers for free or the catch-all
+    ///   answers by taking the whole instruction as its specification.
+    /// - **The preview.** Tap-then-hold has already named its target on the
+    ///   pill and offered ⎋ for the whole time you were speaking, and "hey
+    ///   parrot, undo" puts the substitution back afterwards — so a preview is
+    ///   a question that was answered twice before it was asked. It reaches
+    ///   `finishTransform` as `confirm: !keyed`, because that leaf's job is
+    ///   previewing and it should stay honest about it.
+    ///
+    /// The saving is a model call in series. Heard costs a router round trip
+    /// and then the transform's own; keyed costs one, or none.
     private func handleVoiceCommand(
-        _ command: String, confirm: Bool = true,
+        _ command: String, keyed: Bool = false,
         over target: Target = .whateverIsSelected
     ) {
         let catalogue = Catalogue(transforms: config.transforms)
@@ -2055,11 +2071,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             apply(local, command: command, progress: nil, over: target)
             return
         }
-        if let capability = Router.local(instruction: command, catalogue: catalogue) {
+        if let capability = Router.local(
+            instruction: command, catalogue: catalogue, anywhere: keyed
+        ) {
             Log.write("router: \"\(command)\" named \(capability.name) outright")
             run(
                 capability, instruction: command,
-                progress: nil, confirm: confirm, over: target
+                progress: nil, confirm: !keyed, over: target
+            )
+            return
+        }
+
+        // Keyed and named nothing: the catch-all, with no router in between.
+        //
+        // This is the change that makes the gesture worth using. Asking a model
+        // which tool you meant, and then asking a model to do the work, is two
+        // waits where the first one usually reports what the second was going
+        // to do anyway. The name match above is what keeps the other bodies
+        // reachable — a script and a table are not prompts, and the catch-all
+        // is, so it can stand in for a prompt and for nothing else.
+        if keyed {
+            guard let catchAll = config.commands.catchAll, config.freeForm else {
+                Log.write("keyed: \"\(command)\" named nothing and the catch-all is off")
+                flash("No transform called \"\(command)\"", tone: .caution)
+                return
+            }
+            Log.write("keyed: \"\(command)\" → \(FreeForm.name), no router")
+            runTransform(
+                FreeForm.prompt(for: command).asTransform(model: catchAll),
+                instruction: command, progress: nil, confirm: false, over: target
             )
             return
         }
@@ -2089,7 +2129,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         Log.write("router: \"\(command)\" → \(capability.name)")
                         self.run(
                             capability, instruction: command,
-                            progress: token, confirm: confirm, over: target
+                            progress: token, over: target
                         )
                     case .anything:
                         // An edit with no prompt behind it. The instruction is
@@ -2098,8 +2138,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         Log.write("router: \"\(command)\" → \(FreeForm.name)")
                         self.runTransform(
                             FreeForm.prompt(for: command).asTransform(model: catchAll),
-                            instruction: command, progress: token,
-                            confirm: confirm, over: target
+                            instruction: command, progress: token, over: target
                         )
                     case .none:
                         // Nothing fits. Deliberately not falling through to
@@ -2125,7 +2164,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     Log.write("routing failed: \(error.localizedDescription)")
                     self.endProgress(token: token)
                     let asked = self.askForKeyThenRetry(error) {
-                        self.handleVoiceCommand(command, confirm: confirm, over: target)
+                        self.handleVoiceCommand(command, keyed: keyed, over: target)
                     }
                     if !asked { self.flash(error.localizedDescription, tone: .failure) }
                 }
@@ -2620,14 +2659,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         NSRange(range, in: text).location
     }
 
-    /// The toast after a substitution, and the phrase that takes it back.
+    /// The chime after a substitution, and nothing on screen.
     ///
-    /// Said every time rather than only when something looks wrong, because the
-    /// moment you can tell it went wrong is the moment you are looking at the
-    /// text and not at the menu bar. It has to already be on screen.
+    /// It used to say "<name> applied" with the undo phrase after it. Two
+    /// things retired that. The text is the confirmation — a rewrite lands
+    /// where you are already looking, and the pill sits under it — so the
+    /// notice was telling you what you had just watched happen. And the
+    /// catch-all is called `anything`, a name written for the log and for
+    /// `--check-config`, which made the message read "anything applied".
+    ///
+    /// The failures still speak. Nothing changed, the app refused the edit,
+    /// the words went to the clipboard instead: those are the cases you cannot
+    /// see, and every one of them still puts a line on the pill.
     private func applied(_ what: String) {
+        Log.write("applied: \(what)\(undoHint)")
         playFeedback("Morse")
-        flash("\(what) applied\(undoHint)", tone: .done)
     }
 
     /// `· "Hey parrot, undo"` — empty when there is no phrase to say it with.
@@ -3027,7 +3073,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// worked out afterwards from a sentence that never landed. Escape is live
     /// the whole time, so a wrong answer here costs one keystroke.
     private var recordingLabel: String? {
-        guard commandAtPress else { return nil }
+        guard keyedAtPress else { return nil }
         return selectionAtPress == nil ? "say an edit" : "editing the selection"
     }
 
@@ -4120,7 +4166,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // looked for in the words. That is the whole point of it: the phrase
         // exists to mark a command inside an ordinary dictation, and there is
         // nothing to mark when the key said so first.
-        if press.isCommand {
+        if press.keyed {
             dictationEnded(press.run)
             guard !trimmed.isEmpty else {
                 Log.write("command: nothing was said")
@@ -4128,8 +4174,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 updateUI()
                 return
             }
-            Log.write("command spoken: \"\(trimmed)\"")
-            handleVoiceCommand(trimmed, confirm: false, over: .frozen(selection: press.selection, fallback: press.transcript))
+            Log.write("command keyed: \"\(trimmed)\"")
+            handleVoiceCommand(
+                trimmed, keyed: true,
+                over: .frozen(selection: press.selection, fallback: press.transcript)
+            )
             return
         }
 

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3088,7 +3088,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // the tap reaches further than the last dictation.
         if let selection = SelectionReader.snapshot(),
            !selection.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            Log.write("summon: the offer, over the selection — \"\(selection.text.prefix(80))\"")
+            // The length, not the words. Every other line that logs a selection
+            // is reached by saying a command; this one is reached by tapping a
+            // key once, over text nothing here dictated. A count still answers
+            // what the log is for here — whether the tap found the selection
+            // you meant, or an empty one.
+            Log.write("summon: the offer, over a selection of \(selection.text.count) characters")
             aim(at: selection)
             raiseOffer(
                 over: Correction(

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -180,6 +180,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// ownership `offerPressRun` already asserts, carrying what it is about.
     private var offeredCorrection: (run: Int, target: Correction)?
 
+    /// The last dictation a tap can summon an offer over: its words, and where
+    /// they went.
+    ///
+    /// `offeredCorrection` is cleared by every ending, because it asserts that
+    /// an offer is up and about these words. This asserts nothing of the sort —
+    /// one slot, replaced by the next dictation and never cleared.
+    ///
+    /// The words are held here rather than read from `lastTranscript` at the
+    /// tap, because the two are written at different moments and a superseded
+    /// run can separate them. `lastTranscript` is set for every transcription
+    /// that finishes; this is set below the guard that refuses an offer to a
+    /// run a newer one has already overtaken. Dictate twice with the first
+    /// still decoding, and the older finish overwrites the transcript while the
+    /// landing stays with the newer run — so a tap would have offered one
+    /// dictation's words at another's field, and taking it would have rewritten
+    /// there. One record, written once, cannot come apart that way.
+    private var lastDictated: (
+        run: Int, text: String, element: AXUIElement?,
+        owner: NSRunningApplication?, landing: Correction.Landing
+    )?
+
     /// The focused element's text as it was at the press, for an app that gave
     /// no caret. What changed in it afterwards is where the words went.
     ///
@@ -756,6 +777,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         hotKeys.onPress = { [weak self] in self?.handleHotKeyPress() }
         hotKeys.onRelease = { [weak self] in self?.handleHotKeyRelease() }
         hotKeys.onAbort = { [weak self] in self?.cancelDictation(.notTheHotkey) }
+        hotKeys.onTap = { [weak self] in self?.summonOffer() }
         do {
             try hotKeys.register(
                 key: config.hotkey.key,
@@ -2689,15 +2711,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        offerUntil = Date().addingTimeInterval(Self.offerSeconds)
-        // A new offer is never born held, whatever the last one ended as.
-        offerHeld = false
-        offerPressRun = press.run
-        // This dictation's own words and its own field, frozen with the offer.
-        offeredCorrection = (press.run, Correction(
-            original: text, element: press.element, owner: press.owner, landing: landing
-        ))
-        let commands = offerCommands
+        // Kept past the offer this is about to raise, so a tap can build another
+        // one out of it once this has faded. Below the newer-run guard above,
+        // and carrying the words as well as the field — see `lastDictated`.
+        lastDictated = (press.run, text, press.element, press.owner, landing)
+
         // The decoder's words matched back onto the sentence that came out of
         // the pipeline — see `Confidence.read`. Taken rather than copied: this
         // press's dictation is over and nothing else can want them.
@@ -2718,6 +2736,48 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             )
         )
         if let warning = reading.warning { Log.write("offer: \(warning)") }
+
+        raiseOffer(
+            over: Correction(
+                original: text, element: press.element, owner: press.owner,
+                landing: landing, dictation: press.run
+            ),
+            run: press.run, headline: headline, reading: reading
+        )
+
+        // Taken at the press, and only when that press found no caret. Matched
+        // by run, so it is this dictation's own pane and nobody else's. A
+        // remembered anchor is still a guess, and this is what replaces it with
+        // the answer.
+        //
+        // Dropped on every ending, not only the one that uses it. A pane
+        // belongs to one run and no later dictation can want it, so it is
+        // retired here as `dictationEnded` would retire it — leaving it for the
+        // sweep would be keeping a copy of somebody's screen for no reason.
+        let pane = screenAtPress.removeValue(forKey: press.run)?.text
+        // Nothing landed in a field on the clipboard endings, so the diff has
+        // nothing to find. Whatever it did find would be something else moving
+        // on screen.
+        if case .field = landing, let pane, let element = press.element {
+            findWhereTheWordsLanded(comparedWith: pane, in: element, for: press.run)
+        }
+    }
+
+    /// Put the offer on screen over one target, however it got there.
+    ///
+    /// Split out of `showCorrectOffer` so `summonOffer` can reach it. What
+    /// stayed behind there is everything a *dictation's* ending owes and
+    /// nothing else does: the microphone notice, the decoder's reading, and the
+    /// search for where the words landed.
+    private func raiseOffer(
+        over target: Correction, run: Int, headline: String?, reading: Confidence.Reading
+    ) {
+        offerUntil = Date().addingTimeInterval(Self.offerSeconds)
+        // A new offer is never born held, whatever the last one ended as.
+        offerHeld = false
+        offerPressRun = run
+        offeredCorrection = (run, target)
+        let commands = offerCommands
         offerHeadline = headline
         offerReading = reading
         let hold = config.feedback.lowConfidence.holdReturn
@@ -2748,23 +2808,91 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         offerOnScreen = commands
         watchTheOfferKeys()
         watchForOfferOutsideClick()
+    }
 
-        // Taken at the press, and only when that press found no caret. Matched
-        // by run, so it is this dictation's own pane and nobody else's. A
-        // remembered anchor is still a guess, and this is what replaces it with
-        // the answer.
-        //
-        // Dropped on every ending, not only the one that uses it. A pane
-        // belongs to one run and no later dictation can want it, so it is
-        // retired here as `dictationEnded` would retire it — leaving it for the
-        // sweep would be keeping a copy of somebody's screen for no reason.
-        let pane = screenAtPress.removeValue(forKey: press.run)?.text
-        // Nothing landed in a field on the clipboard endings, so the diff has
-        // nothing to find. Whatever it did find would be something else moving
-        // on screen.
-        if case .field = landing, let pane, let element = press.element {
-            findWhereTheWordsLanded(comparedWith: pane, in: element, for: press.run)
+    /// The offer asked for rather than offered: the hotkey tapped, not held.
+    ///
+    /// Over the last dictation, in the field it landed in. This is what stops
+    /// `offerSeconds` being a deadline — an offer you can call back does not
+    /// have to be kept on screen against the chance that you want it, so
+    /// nothing here lengthens it.
+    ///
+    /// No reading. The colours and the low-confidence warning are what the
+    /// decoder said about a sentence as it arrived, and a tap minutes later is
+    /// not that moment. Showing them again would also re-arm `holdReturn`,
+    /// which exists for the Return already on its way down.
+    private func summonOffer() {
+        // Nothing while a dictation is in the air. On `toggle` the key is what
+        // stops a recording, and a stop that came out short is a stop — the
+        // press was simply never delivered. Summoning there would answer a key
+        // meant for the microphone, and do it over the *previous* sentence.
+        guard !recorder.isRecording, runsInFlight <= 0 else { return }
+        // A tap while the offer is up is a tap at nothing. Raising a second one
+        // over the first would take the letters again and restart a clock the
+        // pointer may be deliberately holding.
+        guard !offerIsUp else { return }
+        guard config.feedback.correctOffer else { return }
+
+        // The selection wins, and it never goes stale: it is what you are
+        // pointing at now. It is also the only target this can have in an app
+        // ParrotFlow has never written a word into, which is the whole of why
+        // the tap reaches further than the last dictation.
+        if let selection = SelectionReader.snapshot(),
+           !selection.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            Log.write("summon: the offer, over the selection — \"\(selection.text.prefix(80))\"")
+            aim(at: selection)
+            raiseOffer(
+                over: Correction(
+                    original: selection.text, element: selection.element,
+                    owner: selection.owner, landing: .field, selection: selection
+                ),
+                run: pressRun, headline: "the selection", reading: Confidence.Reading()
+            )
+            return
         }
+
+        guard let last = lastDictated,
+              !last.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            Log.write("summon: nothing selected and nothing dictated yet")
+            return
+        }
+        Log.write("summon: the offer, over the last dictation")
+        // `pressRun` rather than a number of its own: this offer is about that
+        // dictation, and saying so is what lets a newer one take the pill off
+        // it through the guard in `showCorrectOffer`.
+        //
+        // Not re-aimed. The pill is already pointed where the words landed,
+        // which is what "back where it was" means — and a fresh read would
+        // answer where the caret is *now*, which is a different question.
+        raiseOffer(
+            over: Correction(
+                original: last.text, element: last.element, owner: last.owner,
+                landing: last.landing, dictation: last.run
+            ),
+            run: pressRun, headline: nil, reading: Confidence.Reading()
+        )
+    }
+
+    /// Put the pill under the selection instead of where the last dictation
+    /// left it.
+    ///
+    /// `CaretAnchor.read` already answers this and needed no new call: what it
+    /// asks the element for is the selected *range*, which is the caret only
+    /// when nothing is selected. A selection over several lines comes back as
+    /// one box around the whole of it, so the pill lands under its last line,
+    /// which is where it belongs.
+    ///
+    /// Left where it is when the read misses. `aim(at: nil)` means the bottom
+    /// of the screen, and a pill still near the words it is about beats one
+    /// parked away from them — Outlook answers `0+0` for a pane holding
+    /// hundreds of thousands of characters, and `trust` is what catches it.
+    private func aim(at selection: SelectionReader.Selection) {
+        guard let element = selection.element,
+              case .found(let anchor) = CaretAnchor.read(at: element) else {
+            Log.write("summon: no geometry for the selection; the pill stays where it was")
+            return
+        }
+        pill.aim(at: anchor)
     }
 
     /// Take the offer's letters and Escape for as long as the offer is up.
@@ -3263,6 +3391,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let owner: NSRunningApplication?
         /// Where the words went, so the correction can follow them.
         let landing: Landing
+        /// The dictation these words came from, or nil when they came from a
+        /// selection instead.
+        ///
+        /// Only `noteRewritten` reads it, and only to decide whether a rewrite
+        /// belongs to the record a tap would summon. Matching text is not proof
+        /// of that: say the same short sentence twice, take the first one's
+        /// offer after the second has landed, and the text matches while the
+        /// dictation is somebody else's.
+        var dictation: Int?
+        /// The selection this offer was summoned over, when it was summoned
+        /// over one rather than raised after a dictation.
+        ///
+        /// It is here for the range. `replace` otherwise finds the words by
+        /// their text and takes the last copy, which is the right answer for a
+        /// dictation — the newest thing written is the thing the offer is
+        /// about. A selection is not: the copy that matters is the one you
+        /// highlighted, and only the range says which that is. Carrying the
+        /// whole `Selection` rather than the range alone is what lets this hand
+        /// straight to `replaceSelected`, which already recovers a range that
+        /// has moved.
+        var selection: SelectionReader.Selection?
 
         /// The two places a dictation can end up.
         ///
@@ -3355,7 +3504,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 return false
             }
             Log.write("offer: the dictation went to the clipboard; \(what) went there too")
-            noteRewritten(original, as: corrected)
+            noteRewritten(original, as: corrected, from: target.dictation)
             flash("\(what) copied — ⌘V to paste", tone: .done)
             return false
         }
@@ -3370,7 +3519,34 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Thread.sleep(forTimeInterval: 0.15)
         }
 
-        if config.transcription.insertMode == .paste, let aimed = target.element {
+        // Summoned over a selection: the path that already knows how to write
+        // one back, range and all. The text search below would take the last
+        // copy of the words in the field, and for a selection the last copy is
+        // not the one you highlighted.
+        //
+        // A miss falls through to the clipboard rather than returning, the same
+        // as every other way of not reaching the field: the rewrite is done and
+        // it has to go somewhere.
+        if let selection = target.selection {
+            switch replaceSelected(with: corrected, in: selection, describedAs: what) {
+            case .replaced:
+                noteRewritten(original, as: corrected, from: target.dictation)
+                applied(what)
+                return true
+            case .failed, .notAttempted:
+                break
+            }
+        }
+
+        // Only when this offer was not about a selection. `replaceSelected`
+        // returns `.notAttempted` precisely when the field holds several copies
+        // of the words and nothing says which was meant — and the search below
+        // takes the last copy, which is the guess it just declined to make. A
+        // highlighted earlier copy would be left alone while a later one was
+        // rewritten. So a selection that could not be written falls to the
+        // clipboard, which is what the comment above always claimed.
+        if target.selection == nil,
+           config.transcription.insertMode == .paste, let aimed = target.element {
             let now = SelectionReader.focusedElement()
             if let now, CFEqual(now, aimed), !SelectionReader.isOurs(now) {
                 // `fuzzy: false`: the words on screen are the ones we typed
@@ -3396,7 +3572,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     dictated: original, in: now, describedAs: what
                 ) {
                 case .replaced:
-                    noteRewritten(original, as: corrected)
+                    noteRewritten(original, as: corrected, from: target.dictation)
                     applied(what)
                     return true
                 case .failed, .notAttempted:
@@ -3462,10 +3638,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     ///
     /// Only if this is still the sentence the app thinks it wrote last. A newer
     /// dictation has its own, and it is one slot.
-    private func noteRewritten(_ original: String, as corrected: String) {
+    private func noteRewritten(_ original: String, as corrected: String, from dictation: Int?) {
         guard lastTranscript?.trimmingCharacters(in: .whitespacesAndNewlines) == original
         else { return }
         lastTranscript = corrected
+        // And the words a tap would summon over, which are the same words in
+        // the same field. Left behind, a summon after a rewrite would offer the
+        // sentence that is no longer on screen.
+        //
+        // By run, not by text. The panel can be open for as long as it takes to
+        // think about a spelling and push-to-talk does not wait, so an older
+        // correction can finish after a newer dictation — and if the two said
+        // the same thing, the text matches while the record belongs to the
+        // newer one. Relabelling it there would leave the older correction's
+        // words pointing at the newer dictation's field.
+        guard let dictation, dictation == lastDictated?.run else { return }
+        lastDictated?.text = corrected
     }
 
     private func beginCorrection() {

--- a/Sources/ParrotFlow/AppProfile.swift
+++ b/Sources/ParrotFlow/AppProfile.swift
@@ -1,4 +1,4 @@
-import Foundation
+import AppKit
 
 /// What an app affords, decided from its identity rather than by asking it.
 ///
@@ -65,6 +65,16 @@ struct AppProfile: Equatable {
     /// neither can be promoted out of plain text by adding a line to a set
     /// below. That is deliberate: a terminal renders no markup and shows the
     /// tags instead, and a blind app is one nothing about is known by asking.
+    /// From a running application, which is what every accessibility path has
+    /// in hand. Nil is the ordinary profile: an app nobody could name takes
+    /// plain text, which is the answer that cannot corrupt anything.
+    static func of(_ app: NSRunningApplication?) -> AppProfile {
+        guard let app else { return .ordinary }
+        return of(Pipeline.App(
+            name: app.localizedName ?? "", bundleID: app.bundleIdentifier ?? ""
+        ))
+    }
+
     static func of(_ app: Pipeline.App) -> AppProfile {
         let bundle = app.bundleID.lowercased()
         let name = app.name.lowercased()

--- a/Sources/ParrotFlow/Capability.swift
+++ b/Sources/ParrotFlow/Capability.swift
@@ -56,6 +56,15 @@ enum Capability: Equatable {
         }
     }
 
+    /// Every way of naming this out loud: its own name, and whatever `say:`
+    /// adds. Only `Router.local` reads them — see `Config.Transform.say`.
+    var spokenNames: [String] {
+        switch self {
+        case .action(let action): return [action.rawValue]
+        case .transform(let transform): return [transform.name] + transform.say
+        }
+    }
+
     /// Which of the three bodies it is, for anything printing the catalogue.
     /// The router never sees this: what a tool is made of is not a reason to
     /// pick it, and putting it in the listing would be one more thing for the

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -671,12 +671,14 @@ struct Config: Decodable, Equatable {
         var offer = false
         /// `key: f` — the letter shown on its chip.
         var offerKey = ""
+        /// `say: [slack handles, handles]` — what to call it out loud.
+        var say: [String] = []
         /// `model: gpt`, or `model: { use: gpt, reasoning: low }`.
         var model: ModelRef?
 
         enum CodingKeys: String, CodingKey {
             case name, description, display, confirm, prompt, content, replace, command
-            case tests, returns, offer, model
+            case tests, returns, offer, model, say
             case offerKey = "key"
             case timeout = "timeout_seconds"
         }
@@ -753,6 +755,25 @@ struct Config: Decodable, Equatable {
             // keycap holds one character; a key is printed in capitals whatever
             // the config wrote it as.
             offerKey = String(try trimmed(.offerKey).prefix(1)).uppercased()
+            // One string or a list, because most transforms want one alias and
+            // writing `say: bullets` should not be an error.
+            //
+            // Absent and unreadable are told apart. Both used to answer with an
+            // empty list, so `say: 42` left the transform in the catalogue with
+            // no alias — and the only symptom was that the words you had put
+            // there stopped reaching it, which is a routing bug to chase rather
+            // than a config line to fix. `--check-config` names it now.
+            if c.contains(.say) {
+                if let one = try? c.decode(String.self, forKey: .say) {
+                    say = [one]
+                } else if let listed = try? c.decode([String].self, forKey: .say) {
+                    say = listed
+                } else {
+                    unreadable = "has a `say:` that is neither a word nor a list of words"
+                }
+            }
+            say = say.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
 
             // A body written either way. The mapping is tried first and only
             // succeeds on `{ path: <string> }`, so nothing that decoded before
@@ -923,7 +944,7 @@ struct Config: Decodable, Equatable {
                 display: entry.display,
                 folder: entry.folder, timeout: entry.timeout,
                 confirm: entry.confirm, returnsJSON: entry.returnsJSON,
-                offer: entry.offer, offerKey: entry.offerKey,
+                offer: entry.offer, offerKey: entry.offerKey, say: entry.say,
                 body: body, source: entry.source,
                 tests: entry.tests, model: entry.model
             ))
@@ -1007,6 +1028,15 @@ struct Config: Decodable, Equatable {
         /// The letter shown on that chip. Empty when the config named none; the
         /// chip is still there and still clickable.
         var offerKey: String = ""
+        /// What to call this out loud, besides its name.
+        ///
+        /// A name is written for a config file — `slack_handles`, `code_identifiers` — and nobody says an underscore. An alias is what you would actually
+        /// ask for, and it is the difference between a script the keyed path
+        /// can reach without a model and one it cannot reach at all.
+        ///
+        /// Only the keyed path reads these. `"hey parrot"` goes to the router,
+        /// where a `description` is the thing written to be matched against.
+        var say: [String] = []
         var body: Body
         /// Where the body was read from, when it was read from a file at all —
         /// `prompt: { path: slack.md }`. Nil for an inline body, and nil for a

--- a/Sources/ParrotFlow/FreeForm.swift
+++ b/Sources/ParrotFlow/FreeForm.swift
@@ -15,13 +15,25 @@ import Foundation
 /// the wrong narrow tool. The router needs a separate answer, not another line
 /// in the list. See `Router.prompt(for:freeForm:)`.
 ///
-/// Scored by tests/generic-cases.yaml — 38 cases, 27 that ask for an edit and
-/// 11 that must come back untouched. On gemma4:e4b, 32/38 at 1.15s, against
-/// 11/38 for a control that returns the text unchanged. Five variants landed
-/// within one case of each other, so this wording is the model's ceiling on the
-/// task rather than the best of a wide field; the full scoreboard, including
-/// the three failures no variant fixed, is at the bottom of
-/// scripts/validate-generic.py.
+/// Scored by tests/generic-cases.yaml — 44 cases, 31 that ask for an edit and
+/// 13 that must come back untouched. On gemma4:e4b-mlx, 40/44, against 11/38
+/// for a control that returns the text unchanged. A point either way is noise:
+/// the same prompt scored 37 and then 36 across two passes. The full scoreboard is at the
+/// bottom of scripts/validate-generic.py.
+///
+/// The last two examples are a *correction* — an instruction with the
+/// imperative taken out. "make it Tuesday" and "I meant Tuesday" ask for the
+/// same edit, and the second is what people say to a machine that has just
+/// written their own sentence down. Without them this scored 3/6 on those, and
+/// it failed in one particular way: handed "no I meant three of them" it edited
+/// the *instruction* and returned that, having read the corrective phrasing as
+/// prose and therefore as the subject. The pair is one of each, because the
+/// phrase is not a marker — it introduces an edit only when it names the
+/// replacement, and bare it is a complaint with nothing to act on.
+///
+/// "no I meant three of them" still fails, and is left standing rather than
+/// argued with: fixing one case with a third example is tuning on the set. It
+/// wants fresh cases before anyone tries again.
 ///
 /// Two findings from that set shaped what shipped. The prompt beats the narrow
 /// prompts on their own ground — 14/16 against 12/16 on the cases `dates` and
@@ -71,6 +83,16 @@ enum FreeForm {
         the release is 2026-02-01
 
         instruction: how long is that going to take
+        text:
+        the migration runs on friday
+        the migration runs on friday
+
+        instruction: I meant Tuesday
+        text:
+        the meeting is on Monday
+        the meeting is on Tuesday
+
+        instruction: this is not what I had in mind
         text:
         the migration runs on friday
         the migration runs on friday

--- a/Sources/ParrotFlow/HotKeyManager.swift
+++ b/Sources/ParrotFlow/HotKeyManager.swift
@@ -49,7 +49,10 @@ final class HotKeyManager {
         }
     }
 
-    var onPress: (() -> Void)?
+    /// The key is being held. `afterTap` says a tap led straight into this
+    /// hold — see `ModifierKeyMonitor.onPress`. Always false on the Carbon
+    /// path, which has no tap to lead with.
+    var onPress: ((_ afterTap: Bool) -> Void)?
     var onRelease: (() -> Void)?
     /// A press already delivered turned out to be part of a shortcut — see
     /// `ModifierKeyMonitor`. Never fires on the Carbon path: a combo is
@@ -70,7 +73,7 @@ final class HotKeyManager {
     private let signature: OSType = 0x50_46_4C_57  // 'PFLW'
 
     init() {
-        modifierMonitor.onPress = { [weak self] in self?.onPress?() }
+        modifierMonitor.onPress = { [weak self] afterTap in self?.onPress?(afterTap) }
         modifierMonitor.onRelease = { [weak self] in self?.onRelease?() }
         modifierMonitor.onAbort = { [weak self] in self?.onAbort?() }
         modifierMonitor.onTap = { [weak self] in self?.onTap?() }
@@ -153,7 +156,7 @@ final class HotKeyManager {
                 let kind = GetEventKind(event)
                 DispatchQueue.main.async {
                     if kind == UInt32(kEventHotKeyPressed) {
-                        manager.onPress?()
+                        manager.onPress?(false)
                     } else if kind == UInt32(kEventHotKeyReleased) {
                         manager.onRelease?()
                     }

--- a/Sources/ParrotFlow/HotKeyManager.swift
+++ b/Sources/ParrotFlow/HotKeyManager.swift
@@ -55,6 +55,12 @@ final class HotKeyManager {
     /// `ModifierKeyMonitor`. Never fires on the Carbon path: a combo is
     /// unambiguous by construction.
     var onAbort: (() -> Void)?
+    /// The key was tapped rather than held — see `ModifierKeyMonitor.onTap`.
+    ///
+    /// Bare modifiers only. Carbon delivers a press on the down edge and
+    /// swallows the keystroke, so there is no sub-threshold edge to claim: a
+    /// tap of `⌃⌥Space` is a dictation, and a short one.
+    var onTap: (() -> Void)?
 
     private(set) var binding: Binding?
 
@@ -67,6 +73,7 @@ final class HotKeyManager {
         modifierMonitor.onPress = { [weak self] in self?.onPress?() }
         modifierMonitor.onRelease = { [weak self] in self?.onRelease?() }
         modifierMonitor.onAbort = { [weak self] in self?.onAbort?() }
+        modifierMonitor.onTap = { [weak self] in self?.onTap?() }
     }
 
     // MARK: Lifecycle

--- a/Sources/ParrotFlow/Markup.swift
+++ b/Sources/ParrotFlow/Markup.swift
@@ -214,14 +214,32 @@ struct Markup {
     /// The URL is kept rather than dropped. It is the fallback every paste
     /// carries, and a fallback that silently loses the address is worse than a
     /// visible one.
-    var plain: String {
+    var plain: String { flattened(keepingLinkURLs: true) }
+
+    /// The text a rich editor puts on screen for this document.
+    ///
+    /// The same as `plain` but for a labelled link, which displays as its words
+    /// alone: the address is in the anchor, not in the line. `plain` appends it
+    /// because that flavour is the fallback and a fallback that loses the
+    /// address is worse than a visible one — the opposite call, made for the
+    /// opposite reason.
+    ///
+    /// Only a read-back wants this. `Surface` verifies every write by reading
+    /// the field back, and it has to look for what will be *there*: told to
+    /// paste `[Alex](https://example.com)` into an app that takes HTML, it
+    /// would otherwise go looking for "Alex (https://example.com)" and find
+    /// "Alex". A read-back that fails runs the stray-paste repair, so that is a
+    /// correct edit one step from being undone.
+    var displayed: String { flattened(keepingLinkURLs: false) }
+
+    private func flattened(keepingLinkURLs: Bool) -> String {
         var lines: [String] = []
         var previousRoot: Int?
         var started = false
 
         for block in blocks {
             let text = block.pieces.map { piece -> String in
-                guard let link = piece.link else { return piece.text }
+                guard let link = piece.link, keepingLinkURLs else { return piece.text }
                 let url = link.absoluteString
                 return piece.text == url ? piece.text : "\(piece.text) (\(url))"
             }.joined()

--- a/Sources/ParrotFlow/MicNotice.swift
+++ b/Sources/ParrotFlow/MicNotice.swift
@@ -37,7 +37,23 @@ final class MicNotice {
     /// It only ever sees the microphone a dictation was on. Switching away and
     /// back with no dictation in between is not a change this can see, and
     /// nothing is said.
-    private var lastDevice: String?
+    ///
+    /// Kept across launches. Held in memory it was forgotten every time the app
+    /// started, so the first dictation after a relaunch said it again about a
+    /// microphone nothing had changed about — which during development is every
+    /// install, and for everyone else is every login. "Said once" has to mean
+    /// once, not once per launch, or it is a notice you learn to dismiss.
+    ///
+    /// `UserDefaults`, like the update reminder: this is a thing the app has
+    /// already told you, not a setting you chose, so it does not belong in
+    /// `config.yaml` where you would have to read past it.
+    private var lastDevice: String? {
+        get { UserDefaults.standard.string(forKey: Self.lastDeviceKey) }
+        set { UserDefaults.standard.set(newValue, forKey: Self.lastDeviceKey) }
+    }
+
+    private static let lastDeviceKey = "MicNotice.lastDevice"
+
 
     /// After a dictation, if it was recorded on Bluetooth and that microphone
     /// is not the one the last dictation used.

--- a/Sources/ParrotFlow/ModifierKey.swift
+++ b/Sources/ParrotFlow/ModifierKey.swift
@@ -159,6 +159,18 @@ final class ModifierKeyMonitor {
     /// started a dictation on `onPress` has to drop it, silently: the user
     /// pressed ⌘S and is owed a save, not a notice about dictation.
     var onAbort: (() -> Void)?
+    /// The key went down and came back up inside `pressDelay`, with nothing
+    /// else touched.
+    ///
+    /// This edge already existed and already did nothing: a hold shorter than
+    /// the delay never delivers a press, so `onRelease` does not fire for it
+    /// either. Naming it costs the dictation path nothing, because a tap is
+    /// decided by the release rather than by waiting to see whether one is
+    /// coming.
+    ///
+    /// Never fires at `pressDelay` of 0 — there the press goes out on the down
+    /// edge, so every hold has delivered one by the time it ends.
+    var onTap: (() -> Void)?
 
     private var timer: Timer?
     private var monitors: [Any] = []
@@ -269,8 +281,12 @@ final class ModifierKeyMonitor {
 
     private func finishHold() {
         let wasPressed = pressDelivered
+        // `isSpent` is the whole of what keeps a shortcut out. ⌥P types π on a
+        // French layout and is over in well under the delay, but the P marks
+        // the hold, so it can never be read as a tap.
+        let wasTap = !wasPressed && !isSpent
         endHold()
-        if wasPressed { onRelease?() }
+        if wasPressed { onRelease?() } else if wasTap { onTap?() }
     }
 
     /// The one path out of a hold that was meant for something else. Delivered

--- a/Sources/ParrotFlow/ModifierKey.swift
+++ b/Sources/ParrotFlow/ModifierKey.swift
@@ -153,7 +153,11 @@ enum ModifierKey: String, CaseIterable {
 /// watch falls back to its modifier half there. Left as is: a modifier held
 /// alone is not what happens while somebody is typing a password.
 final class ModifierKeyMonitor {
-    var onPress: (() -> Void)?
+    /// The key is being held. `afterTap` is a hold that a tap led straight
+    /// into — tap, release, press again — which is a different request from a
+    /// plain hold and is delivered here rather than through a callback of its
+    /// own, so no caller can wire one and forget the other.
+    var onPress: ((_ afterTap: Bool) -> Void)?
     var onRelease: (() -> Void)?
     /// A press that was already delivered turned out to be a shortcut. Whoever
     /// started a dictation on `onPress` has to drop it, silently: the user
@@ -164,9 +168,13 @@ final class ModifierKeyMonitor {
     ///
     /// This edge already existed and already did nothing: a hold shorter than
     /// the delay never delivers a press, so `onRelease` does not fire for it
-    /// either. Naming it costs the dictation path nothing, because a tap is
-    /// decided by the release rather than by waiting to see whether one is
-    /// coming.
+    /// either. Naming it costs the *dictation* path nothing — that one is
+    /// untouched, because a hold is still delivered on its own timing.
+    ///
+    /// It costs the tap `tapGrace`. A tap is held back that long to see whether
+    /// a hold follows it, because tap-then-hold has to be told from a tap and
+    /// the only difference is what happens next. Nothing waits on a pill, so
+    /// this is the cheap side of the trade.
     ///
     /// Never fires at `pressDelay` of 0 — there the press goes out on the down
     /// edge, so every hold has delivered one by the time it ends.
@@ -175,6 +183,27 @@ final class ModifierKeyMonitor {
     private var timer: Timer?
     private var monitors: [Any] = []
     private var armTimer: Timer?
+    /// A tap waiting to find out whether a hold is coming after it.
+    private var tapTimer: Timer?
+    /// When the tap was physically released.
+    ///
+    /// The grace window is measured between this and the next physical press,
+    /// and both are corrected for the poll — see `physicalEdge()`. Neither the
+    /// timer's liveness nor the moment the poll noticed will do. A second press
+    /// made at 0.399 s is seen up to 25 ms later, so measured off the poll it
+    /// falls outside a 0.4 s window and starts an ordinary dictation. The
+    /// poll's lag must not decide which gesture somebody made.
+    private var tappedAt: Date?
+    /// This hold began inside `tapGrace` of a tap, so it is tap-then-hold.
+    private var afterTap = false
+
+    /// How long a tap waits for a hold to follow it.
+    ///
+    /// Long enough to release the key and press it again deliberately, short
+    /// enough that a tap meant on its own does not feel ignored. It buys the
+    /// two gestures a shared prefix: the tap says "me", and what happens inside
+    /// this window says what.
+    static let tapGrace: TimeInterval = 0.4
 
     private var key: ModifierKey?
     private var pressDelay: TimeInterval = 0
@@ -221,6 +250,9 @@ final class ModifierKeyMonitor {
     func stop() {
         timer?.invalidate()
         timer = nil
+        tapTimer?.invalidate()
+        tapTimer = nil
+        tappedAt = nil
         endHold()
         key = nil
         isDown = false
@@ -251,6 +283,16 @@ final class ModifierKeyMonitor {
     private func beginHold() {
         isSpent = false
         pressDelivered = false
+        // A tap inside the grace window is this gesture's first half, not a
+        // gesture of its own. Both ends are physical times, so the poll's lag
+        // cannot reclassify a press made inside the window — see `tappedAt`. A
+        // pending timer is cancelled rather than delivered either way:
+        // summoning the pill and then opening the microphone over it is two
+        // answers to one request.
+        afterTap = pressIsTheTapsSecondHalf()
+        tappedAt = nil
+        tapTimer?.invalidate()
+        tapTimer = nil
         watchForOtherInput()
 
         guard pressDelay > 0 else {
@@ -276,7 +318,7 @@ final class ModifierKeyMonitor {
     private func deliverPress() {
         guard isDown, !isSpent, !pressDelivered else { return }
         pressDelivered = true
-        onPress?()
+        onPress?(afterTap)
     }
 
     private func finishHold() {
@@ -284,9 +326,36 @@ final class ModifierKeyMonitor {
         // `isSpent` is the whole of what keeps a shortcut out. ⌥P types π on a
         // French layout and is over in well under the delay, but the P marks
         // the hold, so it can never be read as a tap.
-        let wasTap = !wasPressed && !isSpent
+        //
+        // A tap that followed a tap is not a second tap. Two of them in a row
+        // is somebody who meant to tap-and-hold and let go too early, and
+        // summoning twice for it would be answering a gesture nobody made.
+        let wasTap = !wasPressed && !isSpent && !afterTap
         endHold()
-        if wasPressed { onRelease?() } else if wasTap { onTap?() }
+        guard !wasPressed else { onRelease?(); return }
+        guard wasTap else { return }
+        tappedAt = Self.physicalEdge()
+        let timer = Timer(timeInterval: Self.tapGrace, repeats: false) { [weak self] _ in
+            guard let self else { return }
+            self.tapTimer = nil
+            // A press the poll has not caught up with can already own this
+            // gesture. `beginHold` will classify it from the physical edges as
+            // tap-and-hold, and summoning the offer here as well would answer
+            // one gesture twice — the pill arriving and then the microphone
+            // opening over it.
+            //
+            // Both halves of the test matter. A key that is down but whose
+            // press landed outside the window is an ordinary dictation, and the
+            // tap it followed still deserves its offer. Asked of the flags
+            // rather than of `isDown`, which is the poll's view and is exactly
+            // what has not caught up yet.
+            guard self.key?.isPressed != true || !self.pressIsTheTapsSecondHalf() else {
+                return
+            }
+            self.onTap?()
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        tapTimer = timer
     }
 
     /// The one path out of a hold that was meant for something else. Delivered
@@ -306,12 +375,52 @@ final class ModifierKeyMonitor {
 
     private func endHold() {
         armTimer?.invalidate(); armTimer = nil
+        afterTap = false
         removeMonitors()
         pressDelivered = false
         isSpent = false
     }
 
     // MARK: Watching for everything that is not the key
+
+    /// Whether the press being looked at now is the second half of the tap
+    /// just made.
+    ///
+    /// One rule, asked in two places, because two places decide the same thing
+    /// and disagreeing is what goes wrong. `beginHold` asks it to classify the
+    /// press; the grace timer asks it to find out whether a press is already
+    /// holding the gesture, and so whether summoning the offer would answer
+    /// that gesture a second time.
+    ///
+    /// Written as its own answer rather than inlined twice: the first attempt
+    /// had the timer ask the cheaper question "is the key down at all", which
+    /// suppressed the offer for a press that landed *outside* the window and
+    /// was going to start an ordinary dictation. The tap then vanished for no
+    /// reason anybody could see.
+    private func pressIsTheTapsSecondHalf() -> Bool {
+        guard let tapped = tappedAt else { return false }
+        return Self.physicalEdge().timeIntervalSince(tapped) < Self.tapGrace
+    }
+
+    /// When the modifier edge the poll has just noticed actually happened.
+    ///
+    /// The poll runs every 25 ms, so `Date()` here is the moment it looked and
+    /// not the moment the key moved. `secondsSinceLastEventType` gives the age
+    /// of the last `flagsChanged`, which is that edge, and subtracting it
+    /// recovers the physical time. Same API and same reasoning as
+    /// `sawInputBeforeTheMonitors` below, which exists because this poll is
+    /// late in exactly this way.
+    ///
+    /// It costs no permission: the age of an event is not the event.
+    private static func physicalEdge() -> Date {
+        let age = CGEventSource.secondsSinceLastEventType(
+            .combinedSessionState, eventType: .flagsChanged
+        )
+        // A negative or absurd answer means no such event is on record; the
+        // poll's own clock is then the best available.
+        guard age.isFinite, age >= 0, age < 1 else { return Date() }
+        return Date().addingTimeInterval(-age)
+    }
 
     /// Whether a key or a click landed between the modifier going down and the
     /// poll noticing it.

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -112,6 +112,10 @@ enum PanelsCommand {
             model.state = state
             model.appIcon = icon
             model.level = level
+            // No hotkey is registered behind the sheet, so the selection offer
+            // is drawn against the shipped default — which is the one a reader
+            // should be checking that row against, and is not this machine's.
+            model.hotkey = "Right ⌘"
             return model
         }
 
@@ -119,8 +123,19 @@ enum PanelsCommand {
         let caution = pill(.notice("Grammar copied — this app won't let me edit it", .caution))
         let thinking = pill(.working("Thinking…"))
         let offer = pill(.offer(offerChips, nil, Confidence.Reading()))
+        // The offer over a selection: three rows, and the words themselves
+        // rather than a word for them. On the sheet because the difference from
+        // the plain one is the whole design — a pill that says which words is a
+        // different surface from one that says there are some, and a row that
+        // is only sometimes there gets looked at nowhere else.
+        let offerSelection = pill(.offer(
+            offerChips, .selection("things that turned out not to matter"),
+            Confidence.Reading()
+        ))
         // Beside the plain one: the two endings must not look the same.
-        let offerCopied = pill(.offer(offerChips, "Nowhere to type · ⌘V", Confidence.Reading()))
+        let offerCopied = pill(.offer(
+            offerChips, .landing("Nowhere to type · ⌘V"), Confidence.Reading()
+        ))
         // The warning on its own, which is what most people will ever see of
         // this: `feedback.confidence` is off by default and the thresholds are
         // not, so a shaky dictation raises one line and nothing else.
@@ -254,6 +269,8 @@ enum PanelsCommand {
             // comparison that matters: it has to not look like one.
             (AnyView(PillView().environmentObject(offer)),
              pillSize(offer), .dark, true),
+            (AnyView(PillView().environmentObject(offerSelection)),
+             pillSize(offerSelection), .dark, true),
             (AnyView(PillView().environmentObject(offerCopied)),
              pillSize(offerCopied), .dark, true),
             // The same offer with `feedback.confidence` on: two rows instead of
@@ -380,7 +397,9 @@ enum PanelsCommand {
     /// The window's size, not the capsule's — the glow needs the bleed around
     /// it or the sheet cuts the halo off square.
     private static func pillSize(_ model: PillModel) -> NSSize {
-        PillMetrics.panelSize(for: model.state, hasIcon: model.appIcon != nil)
+        PillMetrics.panelSize(
+            for: model.state, hasIcon: model.appIcon != nil, hotkey: model.hotkey
+        )
     }
 
     /// Something recognisable to sit in the pill's slot. Mail because that is

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -146,7 +146,7 @@ enum PanelsCommand {
             )
         ))
 
-        let overlay = pill(.recording, icon: sampleIcon(), level: 0.75)
+        let overlay = pill(.recording(nil), icon: sampleIcon(), level: 0.75)
 
         // The pill has two states now and the difference is the whole point of
         // the slot: with somewhere to type it holds that app's icon, with
@@ -154,7 +154,14 @@ enum PanelsCommand {
         // are told the words are going to the clipboard instead. Both are on
         // the sheet because "it looks wrong with no icon" is the kind of thing
         // that is obvious side by side and invisible a week apart.
-        let overlayBlind = pill(.recording, level: 0.75)
+        let overlayBlind = pill(.recording(nil), level: 0.75)
+
+        // And the third, which is not dictation at all: tap-then-hold, where
+        // what you say is routed instead of written down. The label is the only
+        // thing that says so, which is exactly why it belongs on this sheet.
+        let overlayCommand = pill(
+            .recording("editing the selection"), icon: sampleIcon(), level: 0.75
+        )
 
         // A row the spell check proposed, half filled in, and a row typed by
         // hand — the two shapes the panel exists for, side by side.
@@ -207,6 +214,8 @@ enum PanelsCommand {
              pillSize(overlay), .dark, true),
             (AnyView(PillView().environmentObject(overlayBlind)),
              pillSize(overlayBlind), .dark, true),
+            (AnyView(PillView().environmentObject(overlayCommand)),
+             pillSize(overlayCommand), .dark, true),
             // The one real window the app has, and the first thing anyone sees.
             // On the sheet for the same reason as the rest: it is looked at,
             // not asserted on, and two screens that drift apart are obvious

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -435,7 +435,7 @@ private struct Instrument: View {
     /// Mid-sentence, so the meter has something to show.
     private static let hearing: PillModel = {
         let model = PillModel()
-        model.state = .recording
+        model.state = .recording(nil)
         model.level = 0.62
         return model
     }()

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -497,6 +497,7 @@ final class PillHUD {
             panel.setContentSize(size)
             panel.setFrameOrigin(anchor(size))
             fadeIn(panel)
+            logFrame("raised")
         }
 
         guard let duration else { return }
@@ -633,6 +634,7 @@ final class PillHUD {
         guard let panel else { return }
         let frame = NSRect(origin: anchor(size), size: size)
         guard frame != panel.frame else { return }
+        defer { logFrame("moved") }
 
         NSAnimationContext.runAnimationGroup { context in
             context.duration = Self.motion
@@ -654,6 +656,25 @@ final class PillHUD {
         guard panel == nil else { return }
         model.onScreen = false
         build()
+    }
+
+    /// Where the window actually ended up.
+    ///
+    /// Every other line in this file is about what was *asked for* — the
+    /// anchor, the state, the keys — and a pill nobody can see has usually been
+    /// asked for perfectly and put somewhere off the screen it belongs on. That
+    /// is what this exists to tell apart, and it is how a pill that was raised,
+    /// keyed and invisible was tracked down once already.
+    private func logFrame(_ what: String) {
+        guard let panel else { return }
+        let capsule = panel.frame.insetBy(dx: PillMetrics.bleed, dy: PillMetrics.bleed)
+        let screen = NSScreen.screens.firstIndex { $0.frame.intersects(panel.frame) }
+        Log.write(String(
+            format: "pill: %@ at %.0f,%.0f %.0fx%.0f on screen %@%@",
+            what, capsule.minX, capsule.minY, capsule.width, capsule.height,
+            screen.map(String.init) ?? "none",
+            model.onScreen ? "" : " — but the surface is unmounted"
+        ))
     }
 
     private func build() {

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -57,15 +57,43 @@ enum PillState: Equatable {
     /// one the pointer is on lives in the model, not here, so moving the
     /// highlight is not a state change and does not crossfade the whole pill.
     ///
-    /// The headline is where the words went. Nil when they went into the field
-    /// you were looking at, set for the endings nobody asked for.
+    /// The headline says either where the words went or which words they are —
+    /// see `Headline`. Nil for an offer that needs neither.
     ///
     /// The reading is what the decoder made of the dictation — the sentence
     /// word by word, its score for the whole utterance, and a warning when it
     /// is worth a second look. An empty one is the whole difference: it is what
     /// decides the pill's height, so nothing about this state changes shape for
     /// a dictation that went fine.
-    case offer([OfferedCommand], String?, Confidence.Reading)
+    case offer([OfferedCommand], Headline?, Confidence.Reading)
+}
+
+/// What an offer says above its chips.
+///
+/// Two things, and they are opposite enough to be worth telling apart in the
+/// type. A landing is about the *ending* — the words went somewhere you did not
+/// ask for, and you have to know that before the chips mean anything. A
+/// selection is about the *subject*, and it is drawn as the words themselves in
+/// the highlight they wear in the field, because the one question an offer over
+/// a selection has to answer is which words, and no description of them is as
+/// exact as showing them.
+///
+/// They are also measured differently — a landing widens the chip row it sits
+/// in front of, a selection is a row of its own — which is the other half of
+/// why one `String?` could not carry both.
+enum Headline: Equatable {
+    /// "Nowhere to type · ⌘V", and the rest of the endings nobody asked for.
+    case landing(String)
+    /// The words this offer is about, shown as the field shows them.
+    case selection(String)
+
+    /// Whether this is the three-row shape: the words, the chips, and the line
+    /// about the key. Read by the metrics and by the view, so the two cannot
+    /// disagree about which shape they are describing.
+    var isSelection: Bool {
+        if case .selection = self { return true }
+        return false
+    }
 }
 
 /// A command on the offer, and the letter that runs it.
@@ -102,6 +130,18 @@ final class PillModel: ObservableObject {
     /// words are going, and a window with no caret in it is not somewhere they
     /// can go. See `Destination`.
     @Published var appIcon: NSImage?
+
+    /// The hotkey as it is written on screen — "Right ⌘", "⌃⌥Space".
+    ///
+    /// The selection offer tells you to hold it, and the key is configurable,
+    /// so the glyph cannot be a literal. It was `⌥` here while the shipped
+    /// default is `right_command`, which told everyone but this machine to hold
+    /// the wrong key.
+    ///
+    /// Here rather than in the state, for the reason the icon is: it changes
+    /// when the config is read, not when the pill changes what it is saying,
+    /// and a state change crossfades the whole surface.
+    @Published var hotkey: String = ""
 
     /// Which command the pointer is on, if any.
     ///
@@ -172,7 +212,9 @@ final class PillHUD {
     /// window — which in the middle of a morph is a width on its way somewhere
     /// rather than a width anything chose.
     private var wantedSize: NSSize {
-        PillMetrics.panelSize(for: model.state, hasIcon: model.appIcon != nil)
+        PillMetrics.panelSize(
+            for: model.state, hasIcon: model.appIcon != nil, hotkey: model.hotkey
+        )
     }
 
     /// One number for the whole surface: the rise, the morph and the fade.
@@ -220,7 +262,7 @@ final class PillHUD {
     /// usable to the last frame. The keys and the chips work the whole way
     /// down; the fading only says how long is left.
     func offer(
-        _ commands: [OfferedCommand], headline: String? = nil,
+        _ commands: [OfferedCommand], headline: Headline? = nil,
         reading: Confidence.Reading = Confidence.Reading(), for duration: TimeInterval
     ) {
         model.selected = nil
@@ -882,10 +924,12 @@ enum PillMetrics {
     /// less there is to see.
     static let bleed: CGFloat = 52
 
-    static func panelSize(for state: PillState, hasIcon: Bool) -> NSSize {
-        let width = width(for: state, hasIcon: hasIcon)
+    static func panelSize(
+        for state: PillState, hasIcon: Bool, hotkey: String = ""
+    ) -> NSSize {
+        let width = width(for: state, hasIcon: hasIcon, hotkey: hotkey)
         return NSSize(width: width + bleed * 2,
-                      height: height(for: state, width: width) + bleed * 2)
+                      height: height(for: state, width: width, hotkey: hotkey) + bleed * 2)
     }
 
     /// The face the dictated sentence is set in — the same one the chips use.
@@ -905,6 +949,51 @@ enum PillMetrics {
         NSLayoutManager().defaultLineHeight(for: sentenceFont)
     )
     static let sentenceGap: CGFloat = 4
+
+    /// Between the rows of an offer over a selection.
+    ///
+    /// Wider than `sentenceGap`, which sets the reading's lines — those are one
+    /// block of text and belong together. These three are three different
+    /// things: the words, what can be done to them, and the way out the chips
+    /// do not cover. At 4pt they read as a paragraph rather than as a list of
+    /// choices.
+    static let selectionGap: CGFloat = 8
+
+    /// What the two extra rows of a selection offer say.
+    ///
+    /// Here rather than in the view because the pill is measured before it is
+    /// drawn, and a string measured in one place and set in another is how a
+    /// chip ends up hanging over the end of a capsule. The view reads these.
+    static let editLead = "Edit"
+    static let holdLead = "or hold"
+    static let holdTail = "and say what to change"
+    /// The keycap between the two halves of the hold line, and the gaps either
+    /// side of it.
+    ///
+    /// Measured from the name it will hold, because the hotkey is configurable
+    /// and "Right ⌘" is not the width of "⌥". A fixed box is what let the glyph
+    /// be a literal in the first place.
+    static func holdKeycapWidth(_ hotkey: String) -> CGFloat {
+        max(20, title(hotkey) + 4) + 12
+    }
+    /// Its box, which is taller than a line of the text beside it.
+    static let holdKeycapHeight: CGFloat = 17
+    /// The highlight's own padding, either side of the words.
+    static let selectionFit: CGFloat = 12
+    /// The vertical padding inside the highlight, top and bottom.
+    static let selectionPadding: CGFloat = 1
+
+    /// How tall each of the two extra rows is.
+    ///
+    /// Not `sentenceLine`. The words row is that plus its highlight's padding,
+    /// and the hold row is as tall as the keycap in it — both 17 against a
+    /// 15pt line. Budgeting a bare line made the pill 4pt shorter than its own
+    /// contents, which the capsule's slack around a 26pt chip row hid: it
+    /// looked right and was wrong, and a longer selection or a different system
+    /// font would have shown it.
+    static let selectionRow: CGFloat = max(
+        sentenceLine + selectionPadding * 2, holdKeycapHeight
+    )
 
     /// Extra air above the sentence, on top of what centring the two rows
     /// already leaves. The chips sit in capsules of their own and carry their
@@ -944,11 +1033,23 @@ enum PillMetrics {
     ///
     /// An offer with nothing to say about the decode is the height the pill has
     /// always been, so a dictation that went fine changes nothing.
-    static func height(for state: PillState, width: CGFloat) -> CGFloat {
-        guard case .offer(_, _, let reading) = state else { return height }
+    static func height(for state: PillState, width: CGFloat, hotkey: String = "") -> CGFloat {
+        guard case .offer(_, let headline, let reading) = state else { return height }
+        // A selection offer is three rows: the words, the chips, and the line
+        // about the key. Two of them are extra, and they are added whatever the
+        // reading says — the two can appear together, on a dictation you
+        // selected part of after being warned about it.
+        // The words row always, and the hold row only when there is a key to
+        // name — `OfferContent.hold` draws it on the same condition.
+        var extra: CGFloat = 0
+        if headline?.isSelection == true {
+            extra = selectionRow + selectionGap
+            if !hotkey.isEmpty { extra += selectionRow + selectionGap }
+        }
         let rows = readingRows(reading, width: width)
-        guard !rows.isEmpty else { return height }
-        return height + sentenceTop + rows.reduce(0, +) + sentenceGap * CGFloat(rows.count)
+        guard !rows.isEmpty else { return height + extra }
+        return height + extra + sentenceTop
+            + rows.reduce(0, +) + sentenceGap * CGFloat(rows.count)
     }
 
     /// The height of each row the reading draws, top to bottom. The count is
@@ -1003,13 +1104,15 @@ enum PillMetrics {
     static let icon: CGFloat = 22
     static let meter: CGFloat = 66
 
-    static func width(for state: PillState, hasIcon: Bool) -> CGFloat {
+    static func width(
+        for state: PillState, hasIcon: Bool, hotkey: String = ""
+    ) -> CGFloat {
         switch state {
         case .recording(let label): return recording(hasIcon: hasIcon, label: label)
         case .working(let message): return text(message)
         case .notice(let message, _): return text(message)
         case .offer(let commands, let headline, let reading):
-            return offer(commands, headline: headline, reading: reading)
+            return offer(commands, headline: headline, reading: reading, hotkey: hotkey)
         }
     }
 
@@ -1046,23 +1149,45 @@ enum PillMetrics {
     /// title is `.fixedSize()`, so a capsule a few points too narrow lets a
     /// chip hang over the end rather than shortening it.
     ///
-    /// A headline widens it and is meant to: then the sentence is on the
-    /// clipboard and looking like a notice is the point.
+    /// A landing headline widens it and is meant to: then the sentence is on
+    /// the clipboard and looking like a notice is the point.
     /// A sentence widens it too, up to `sentenceWidth`, and then wraps. So
     /// does a warning, which never wraps.
+    ///
+    /// A selection headline does neither. It is a row of its own, so it
+    /// competes with the chip row for the pill's width rather than adding to
+    /// it — and it is capped like the sentence, because a selection can be a
+    /// paragraph and a pill as wide as one is a pill nobody can place.
     static func offer(
-        _ commands: [OfferedCommand], headline: String? = nil,
-        reading: Confidence.Reading = Confidence.Reading()
+        _ commands: [OfferedCommand], headline: Headline? = nil,
+        reading: Confidence.Reading = Confidence.Reading(), hotkey: String = ""
     ) -> CGFloat {
         // A chip is its keycap, its words and 9pt of padding either side; then
         // 4pt between one chip and the next.
         let chips = commands.reduce(CGFloat(0)) { total, command in
             total + 18 + (command.key.isEmpty ? 0 : keycap) + title(command.title)
         }
-        let lead = headline.map { title($0) + gap } ?? 0
+        let lead: CGFloat
+        if case .landing(let words) = headline { lead = title(words) + gap } else { lead = 0 }
         let row = padding * 2 + lead + chips
             + CGFloat(max(commands.count - 1, 0)) * 4 + rowFit
         var widest = row
+        if case .selection(let words) = headline {
+            widest = max(widest, min(
+                sentenceWidth,
+                padding * 2 + title(editLead) + gap + title(words) + selectionFit
+            ))
+            // Only when there is a key to name. `OfferContent.hold` draws the
+            // row on the same condition, so the two agree about whether it is
+            // there to be measured.
+            if !hotkey.isEmpty {
+                widest = max(widest, min(
+                    sentenceWidth,
+                    padding * 2 + title(holdLead)
+                        + holdKeycapWidth(hotkey) + title(holdTail)
+                ))
+            }
+        }
         if !reading.words.isEmpty {
             widest = max(widest, min(sentenceWidth, padding * 2 + sentenceRun(reading.words)))
         }
@@ -1327,7 +1452,7 @@ private struct MessageContent: View {
 private struct OfferContent: View {
     @EnvironmentObject private var model: PillModel
     let commands: [OfferedCommand]
-    let headline: String?
+    let headline: Headline?
     /// What the decoder made of the dictation. See `Confidence.Reading`.
     var reading = Confidence.Reading()
 
@@ -1344,13 +1469,18 @@ private struct OfferContent: View {
     private static let restingText = Color(white: 0.88)
 
     var body: some View {
-        VStack(alignment: .leading, spacing: PillMetrics.sentenceGap) {
+        VStack(
+            alignment: .leading,
+            spacing: centred ? PillMetrics.selectionGap : PillMetrics.sentenceGap
+        ) {
             if let warning = reading.warning { self.warning(warning) }
             if !reading.words.isEmpty {
                 words
                 if let overall = reading.overall { score(overall) }
             }
+            selection
             chips
+            hold
         }
         // The whole block is centred in the pill's height, so this lands as air
         // above the sentence rather than being split between the two rows.
@@ -1415,16 +1545,114 @@ private struct OfferContent: View {
             .padding(.horizontal, PillMetrics.padding)
     }
 
+    /// The words the offer is about, wearing the highlight they wear in the
+    /// field.
+    ///
+    /// Shown rather than described. "the selection" answered a question nobody
+    /// was asking — the doubt is never *whether* there is a selection, it is
+    /// which words are about to change, and the only exact answer to that is
+    /// the words. It also asks the accessibility layer for nothing, which is
+    /// why it survives where pointing at the span did not: web content will not
+    /// say where a span is, only where the box holding it is.
+    ///
+    /// The app's own blue, not a neutral fill. Those words are sitting in that
+    /// colour two lines above, so the pill says "these ones" by matching. This
+    /// is the one place colour goes inside a surface here — `parrotSurface`
+    /// keeps it on the rim, because "a surface washed in a feather is a surface
+    /// you have to read text off" — and it earns the exception by being a
+    /// quotation mark rather than decoration.
+    @ViewBuilder private var selection: some View {
+        if case .selection(let words) = headline {
+            HStack(spacing: PillMetrics.gap - 4) {
+                Text(PillMetrics.editLead)
+                    .font(.system(size: 12, weight: .medium, design: .rounded))
+                    .foregroundStyle(Color(white: 0.55))
+                Text(words)
+                    .font(.system(size: 12, weight: .medium, design: .rounded))
+                    .foregroundStyle(Self.quotedText)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, PillMetrics.selectionPadding)
+                    .background(
+                        RoundedRectangle(cornerRadius: 3, style: .continuous)
+                            .fill(Parrot.action.opacity(0.42))
+                    )
+            }
+            .padding(.horizontal, PillMetrics.padding)
+            .frame(maxWidth: .infinity, alignment: .center)
+        }
+    }
+
+    /// The other way out, under the chips.
+    ///
+    /// The chips are a short list; holding the key reaches every transform and
+    /// the catch-all besides. Said on the pill because this is the one surface
+    /// where the two are alternatives to each other — everywhere else the
+    /// gesture is something you either know or do not.
+    /// Only when a hotkey is bound. `register` unregisters before it tries, so
+    /// a reload that fails leaves nothing to hold — and a fallback glyph there
+    /// would name Option, which is not bound either. A row that is absent says
+    /// nothing; a row naming a dead key sends somebody pressing it.
+    ///
+    /// `PillMetrics.offer` and `height(for:)` ask the same question before they
+    /// budget for this row, so the surface is never sized for a line it does
+    /// not draw.
+    @ViewBuilder private var hold: some View {
+        if case .selection = headline, !model.hotkey.isEmpty {
+            HStack(spacing: 6) {
+                Text(PillMetrics.holdLead)
+                keycap(model.hotkey)
+                Text(PillMetrics.holdTail)
+            }
+            .font(.system(size: 12, weight: .medium, design: .rounded))
+            .foregroundStyle(Color(white: 0.5))
+            .padding(.horizontal, PillMetrics.padding)
+            .frame(maxWidth: .infinity, alignment: .center)
+        }
+    }
+
+    /// The words on the highlight: the glass text, so they read the way the
+    /// dictated sentence does two rows up rather than as white on blue.
+    private static let quotedText = Color(red: 0.875, green: 0.941, blue: 0.906)
+
+    /// Sized to what it holds, with a floor. The hotkey is configurable and
+    /// its name is anything from "fn" to "⌃⌥Space", so a fixed width either
+    /// clips the long ones or leaves the short ones swimming. The floor and the
+    /// padding are the same numbers `PillMetrics.holdKeycapWidth` measures, or
+    /// the capsule is sized for a cap it does not draw.
+    private func keycap(_ glyph: String) -> some View {
+        Text(glyph)
+            .font(.system(size: 11, weight: .bold, design: .rounded))
+            .foregroundStyle(Color(white: 0.72))
+            .fixedSize()
+            .padding(.horizontal, 2)
+            .frame(minWidth: 20, minHeight: PillMetrics.holdKeycapHeight)
+            .background(
+                RoundedRectangle(cornerRadius: 4, style: .continuous)
+                    .fill(Color.white.opacity(0.07))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4, style: .continuous)
+                            .strokeBorder(Color.white.opacity(0.12), lineWidth: 1)
+                    )
+            )
+    }
+
+    /// Whether this is the three-row shape, which is centred throughout.
+    private var centred: Bool { headline?.isSelection == true }
+
     private var chips: some View {
         HStack(spacing: 4) {
-            if let headline {
-                Text(headline)
+            if case .landing(let words) = headline {
+                Text(words)
                     .font(.system(size: 12, weight: .medium, design: .rounded))
                     .foregroundStyle(NoticeTone.caution.color)
                     .lineLimit(1)
                     .fixedSize()
                     .padding(.trailing, PillMetrics.gap - 4)
             }
+
+            if centred { Spacer(minLength: 0) }
 
             ForEach(Array(commands.enumerated()), id: \.offset) { index, command in
                 // A tap gesture rather than a `Button`. The pill is a
@@ -1444,7 +1672,10 @@ private struct OfferContent: View {
             Spacer(minLength: 0)
         }
         .padding(.horizontal, PillMetrics.padding)
-        .frame(maxWidth: .infinity, alignment: .leading)
+        // Centred under the words it is about, left where it is the only row.
+        // Three rows want one axis; one row is a thing you aim at, and a row of
+        // chips that moves as the pill grows is a row you have to find again.
+        .frame(maxWidth: .infinity, alignment: centred ? .center : .leading)
     }
 
     /// Lit carries the same leaf as a changed word and as the confirm button:

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -42,7 +42,13 @@ enum NoticeTone: Equatable {
 /// state change animates.
 enum PillState: Equatable {
     /// The mic is hot. Width depends on whether there is an app icon to show.
-    case recording
+    ///
+    /// The label is what this recording is *for*, and it is nil for the one
+    /// that needs no explaining: dictation. Tap-then-hold sets it, because a
+    /// hold that routes what you say instead of writing it down looks exactly
+    /// like one that writes it down, and the difference has to be readable
+    /// before you speak rather than after.
+    case recording(String?)
     /// Work of no predictable length — decoding, a prompt, a download.
     case working(String)
     /// A sentence, for a few seconds.
@@ -75,7 +81,7 @@ struct OfferedCommand: Equatable {
 }
 
 final class PillModel: ObservableObject {
-    @Published var state: PillState = .recording
+    @Published var state: PillState = .recording(nil)
 
     /// Whether the panel is on screen. False unmounts the surface.
     ///
@@ -178,11 +184,11 @@ final class PillHUD {
 
     // MARK: - The states
 
-    func recording(icon: NSImage?) {
+    func recording(icon: NSImage?, label: String? = nil) {
         model.elapsed = 0
         model.level = 0
         model.appIcon = icon
-        set(.recording)
+        set(.recording(label))
     }
 
     /// Stays up until something replaces it or `hide()` is called.
@@ -653,7 +659,7 @@ final class PillHUD {
     private func build() {
         let hosting = NSHostingView(rootView: PillView().environmentObject(model))
         hosting.frame = NSRect(origin: .zero,
-                               size: PillMetrics.panelSize(for: .recording, hasIcon: false))
+                               size: PillMetrics.panelSize(for: .recording(nil), hasIcon: false))
         // The panel is what resizes; the view follows it. Done this way round
         // because a SwiftUI frame inside a fixed panel centres a narrow pill in
         // a wide transparent box and takes the shadow with it.
@@ -978,7 +984,7 @@ enum PillMetrics {
 
     static func width(for state: PillState, hasIcon: Bool) -> CGFloat {
         switch state {
-        case .recording: return recording(hasIcon: hasIcon)
+        case .recording(let label): return recording(hasIcon: hasIcon, label: label)
         case .working(let message): return text(message)
         case .notice(let message, _): return text(message)
         case .offer(let commands, let headline, let reading):
@@ -988,9 +994,11 @@ enum PillMetrics {
 
     /// 15 + 8 + 10 + 66 + 15, and the icon after the meter when there is one
     /// to show.
-    static func recording(hasIcon: Bool) -> CGFloat {
+    static func recording(hasIcon: Bool, label: String? = nil) -> CGFloat {
         let base = padding * 2 + dot + gap + meter
-        return hasIcon ? base + icon + tuck : base
+        let width = hasIcon ? base + icon + tuck : base
+        guard let label else { return width }
+        return width + gap + title(label)
     }
 
     /// Wide enough for the message, the dot in front of it and the padding —
@@ -1135,8 +1143,8 @@ struct PillView: View {
         GeometryReader { geo in
             ZStack {
                 switch model.state {
-                case .recording:
-                    RecordingContent(level: model.level, icon: model.appIcon)
+                case .recording(let label):
+                    RecordingContent(level: model.level, icon: model.appIcon, label: label)
                         .transition(.opacity)
                 case .working(let message):
                     MessageContent(message: message, tone: .thinking)
@@ -1223,6 +1231,8 @@ struct PillView: View {
 private struct RecordingContent: View {
     let level: Float
     let icon: NSImage?
+    /// What this recording is for, when it is not dictation.
+    var label: String?
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var pulse = false
@@ -1246,6 +1256,14 @@ private struct RecordingContent: View {
                     .interpolation(.high)
                     .frame(width: PillMetrics.icon, height: PillMetrics.icon)
                     .padding(.leading, PillMetrics.tuck)
+            }
+
+            if let label {
+                Text(label)
+                    .font(.system(size: 12, weight: .medium, design: .rounded))
+                    .foregroundStyle(Color(white: 0.88))
+                    .fixedSize()
+                    .padding(.leading, PillMetrics.gap)
             }
         }
         .padding(.horizontal, PillMetrics.padding)

--- a/Sources/ParrotFlow/RouteTestCommand.swift
+++ b/Sources/ParrotFlow/RouteTestCommand.swift
@@ -6,9 +6,15 @@ import Foundation
 /// The routing decision is otherwise only observable by speaking and watching
 /// what happens, which conflates "routed wrong" with "the prompt is bad". This
 /// separates them, and it is what `scripts/check-routing.sh` drives.
+///
+/// `--keyed` scores the other path — tap-and-hold, where a key said this was
+/// an instruction. There is no model router at all: a name anywhere in the
+/// sentence wins, and everything else is the catch-all. It answers a different
+/// question from the default, so it has a set of its own —
+/// `scripts/check-keyed.sh`.
 enum RouteTestCommand {
 
-    static func run(text: String, quiet: Bool = false) -> Int32 {
+    static func run(text: String, quiet: Bool = false, keyed: Bool = false) -> Int32 {
         let config: Config
         do { config = try ConfigStore.load() } catch {
             print("✗ config: \(CheckConfigCommand.describe(error))")
@@ -28,8 +34,21 @@ enum RouteTestCommand {
             print("instruction: \"\(instruction)\"")
         }
 
-        if let match = Router.local(instruction: instruction, catalogue: catalogue) {
+        if let match = Router.local(
+            instruction: instruction, catalogue: catalogue, anywhere: keyed
+        ) {
             print(quiet ? match.name : "→ \(match.name)  (named outright, no model)")
+            return 0
+        }
+
+        // Keyed: no router, so the answer is already known. Named nothing means
+        // the catch-all, and the only way to get NONE is to have turned it off.
+        if keyed {
+            guard config.freeForm else {
+                print(quiet ? "NONE" : "→ NONE  (named nothing, and the catch-all is off)")
+                return 0
+            }
+            print(quiet ? "ANY" : "→ ANY  (named nothing, straight to the catch-all — no model)")
             return 0
         }
 

--- a/Sources/ParrotFlow/Router.swift
+++ b/Sources/ParrotFlow/Router.swift
@@ -34,10 +34,20 @@ enum Router {
     /// Worth having twice over: it removes a round trip from the commands you
     /// use most, and it is the only path that works when Ollama is not running.
     ///
-    /// Only the opening words are considered. "bullets" and "bullets but keep
-    /// the headings" both name `bullets`; "I was thinking about bullets"
-    /// should not, and does not, because the match is anchored at the start.
-    static func local(instruction: String, catalogue: Catalogue) -> Capability? {
+    /// Anchored by default: "bullets" and "bullets but keep the headings" both
+    /// name `bullets`, while "I was thinking about bullets" does not, because
+    /// the match starts where the sentence does. That is right for a command
+    /// *heard* inside a sentence, which might not have been a command at all.
+    ///
+    /// `anywhere` lifts the anchor, for a command declared by a key. There the
+    /// whole utterance is the instruction — you held the key down to say it —
+    /// so a name in the middle of it is still a name, and "use our slack
+    /// handles" has to reach `slack_handles` or it reaches a model that cannot
+    /// run a script. The risk the anchor was guarding against does not exist on
+    /// that path: there is no sentence for a name to be buried in by accident.
+    static func local(
+        instruction: String, catalogue: Catalogue, anywhere: Bool = false
+    ) -> Capability? {
         let words = instruction.lowercased()
             .components(separatedBy: CharacterSet.alphanumerics.inverted)
             .filter { !$0.isEmpty }
@@ -45,16 +55,25 @@ enum Router {
 
         var best: (capability: Capability, score: Double)?
         for capability in catalogue.capabilities {
-            let target = capability.name.lowercased()
-            // A capability's name may be more than one word, so try the same
-            // number of leading words as the name has, and one either side.
-            let nameWords = target.components(separatedBy: CharacterSet.alphanumerics.inverted)
-                .filter { !$0.isEmpty }.count
-            for count in 1...max(1, min(nameWords + 1, words.count)) {
-                let candidate = words.prefix(count).joined(separator: " ")
-                let score = VoiceCommand.similarity(candidate, target)
-                if score >= nameThreshold, score > (best?.score ?? 0) {
-                    best = (capability, score)
+            for spoken in capability.spokenNames {
+                // Underscores are how a config spells a space. Nobody says one,
+                // so `slack_handles` is compared as "slack handles".
+                let target = spoken.lowercased()
+                    .components(separatedBy: CharacterSet.alphanumerics.inverted)
+                    .filter { !$0.isEmpty }
+                guard !target.isEmpty else { continue }
+                let name = target.joined(separator: " ")
+                // A capability's name may be more than one word, so try the same
+                // number of words as the name has, and one either side.
+                let starts = anywhere ? Array(words.indices) : [0]
+                for from in starts {
+                    for count in 1...max(1, min(target.count + 1, words.count - from)) {
+                        let candidate = words[from..<(from + count)].joined(separator: " ")
+                        let score = VoiceCommand.similarity(candidate, name)
+                        if score >= nameThreshold, score > (best?.score ?? 0) {
+                            best = (capability, score)
+                        }
+                    }
                 }
             }
         }

--- a/Sources/ParrotFlow/SelectionWatch.swift
+++ b/Sources/ParrotFlow/SelectionWatch.swift
@@ -1,0 +1,150 @@
+import AppKit
+import ApplicationServices
+
+/// Notices when you select words ParrotFlow just wrote, so the offer can come
+/// back without being asked for.
+///
+/// ## Why this is events and not an observer
+///
+/// The obvious build is an `AXObserver` on the field, listening for
+/// `kAXSelectedTextChangedNotification`. It is also the only thing in this app
+/// that would need one — observer lifetimes, per-app registration, teardown on
+/// a window that closed while nobody was looking.
+///
+/// None of that is necessary, because a selection cannot appear on its own. It
+/// is made by dragging the mouse, by holding shift and pressing an arrow, or by
+/// ⌘A — and every one of those is an event `NSEvent` already hands out. So the
+/// question is asked at the three moments the answer can have changed, and
+/// never in between. An idle app is watching nothing.
+///
+/// ## Why the read is cheap
+///
+/// `kAXSelectedTextAttribute` returns the selected substring and nothing else.
+/// The expensive read in this app is `AXValue` — Outlook's message pane
+/// measured 395,489 characters, and `CaretAnchor` is careful about it for that
+/// reason. This is not that read. What comes back is what you highlighted.
+///
+/// ## What it refuses
+///
+/// It fires for one thing: a selection that is part of what ParrotFlow last
+/// wrote. Anything else is somebody selecting text to copy it, delete it, drag
+/// it or type over it, which is most of what selecting is for — and a surface
+/// that appeared every time would be wrong far more often than right.
+///
+/// It also never fires twice for the same words. Dismiss the offer and the
+/// selection is usually still sitting there, so the next arrow key would put it
+/// straight back up. `offered` is what stops that: the pill returns when you
+/// select something, not while you have something selected.
+final class SelectionWatch {
+
+    /// A selection worth offering on: the words, and the field they are in.
+    var onSelection: ((SelectionReader.Selection) -> Void)?
+
+    /// What the selection has to be part of. Nil stops the watch answering —
+    /// it is set from `lastTranscript`, which is empty until something is said.
+    private var haystack: String?
+    /// The field the last dictation landed in.
+    ///
+    /// This is what makes a short selection safe. "know" is four characters and
+    /// is inside half the sentences anybody dictates, but "know" *in the box
+    /// those words were written into* is the word you just said — so the
+    /// question is asked about the field rather than about the length.
+    private var field: AXUIElement?
+    private var monitors: [Any] = []
+    /// The last selection handed out, so it is not handed out again.
+    private var offered: String?
+    /// A drag ends in one event; shift-arrow makes one per keypress. Reading on
+    /// every one is cheap but pointless, and the second read of a growing
+    /// selection is a different string, so `offered` would not stop it.
+    private var lastLook = Date.distantPast
+
+    var isRunning: Bool { !monitors.isEmpty }
+
+    /// Watch for selections inside `text`.
+    ///
+    /// Called again with the new transcript every time one is written — a
+    /// rewrite changes what the words are, and the offer has to follow them.
+    func start(over text: String, in element: AXUIElement?) {
+        haystack = text
+        field = element
+        offered = nil
+        guard monitors.isEmpty else { return }
+        guard Permissions.accessibility == .granted else {
+            Log.write("reselect: accessibility is not granted; selections cannot be seen")
+            return
+        }
+
+        // Mouse up rather than down: the drag is over and the selection is
+        // final. Key up for the same reason, and it covers shift-arrow, ⌘A and
+        // shift-click's keyboard half in one mask.
+        let mask: NSEvent.EventTypeMask = [.leftMouseUp, .keyUp]
+        let look: (NSEvent) -> Void = { [weak self] _ in self?.look() }
+        if let global = NSEvent.addGlobalMonitorForEvents(matching: mask, handler: look) {
+            monitors.append(global)
+        }
+        // The local one is not for our own windows — it is for the moment our
+        // panel has focus and the selection behind it is still the one being
+        // talked about. Passing the event straight back leaves it untouched.
+        if let local = NSEvent.addLocalMonitorForEvents(matching: mask, handler: { event in
+            look(event)
+            return event
+        }) {
+            monitors.append(local)
+        }
+    }
+
+    func stop() {
+        for monitor in monitors { NSEvent.removeMonitor(monitor) }
+        monitors = []
+        haystack = nil
+        field = nil
+        offered = nil
+    }
+
+    deinit { stop() }
+
+    /// The whole of the work, at the three moments a selection can have changed.
+    private func look() {
+        guard let haystack else { return }
+        // 40ms, which is under the fastest key repeat and over the cost of one
+        // small accessibility read. Held down, an arrow key would otherwise ask
+        // this on every repeat while the selection is still growing.
+        guard Date().timeIntervalSince(lastLook) > 0.04 else { return }
+        lastLook = Date()
+
+        // `offered` survives exactly as long as the selection it was about. Let
+        // go of those words — click away, select something else — and the same
+        // words chosen again are a new request, not the old one still standing.
+        //
+        // It was cleared only when the watch restarted, which meant selecting a
+        // term, clicking off it, and selecting it again did nothing at all. The
+        // rule it was written for is narrower than that: the pill must not come
+        // back while a selection it has already answered is still sitting there.
+        guard let selection = SelectionReader.snapshot(),
+              let field, let element = selection.element, CFEqual(field, element)
+        else {
+            offered = nil
+            return
+        }
+        // In the field the words were written into. Everything else this could
+        // check — how long the selection is, how unusual — is a proxy for this
+        // one question, and a bad one: a floor high enough to rule out "the"
+        // ruled out "know", which is a word somebody selects precisely because
+        // they want it fixed.
+        let text = selection.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard text.count >= Self.floor, haystack.contains(text) else {
+            offered = nil
+            return
+        }
+        guard text != offered else { return }
+
+        offered = text
+        Log.write("reselect: \"\(text.prefix(60))\" is part of the last dictation")
+        onSelection?(selection)
+    }
+
+    /// One letter is somebody part-way through a selection, or fixing a typo
+    /// by hand. Two is a word. Nothing above this is ruled out by length —
+    /// `field` is what does the ruling out.
+    static let floor = 2
+}

--- a/Sources/ParrotFlow/Surface.swift
+++ b/Sources/ParrotFlow/Surface.swift
@@ -56,6 +56,44 @@ struct Surface {
 
     var selectedText: String? { span.map { String(content[$0]) } }
 
+    /// The pasteboard flavours this app takes, over and above plain text.
+    ///
+    /// A rewrite is written the same way a dictation is, because it is the same
+    /// text going into the same field. Without this it went in plain, so a
+    /// transform that answered `**Alex**` put four asterisks into Slack where a
+    /// dictation of the same words arrives bold. Nothing said so: a paste that
+    /// lands is a paste that worked, and the markers look like the model's
+    /// fault rather than the paste's.
+    ///
+    /// A terminal answers `.plain` here, which is what `writeScreen` needs and
+    /// gets by not asking.
+    var paste: AppProfile.Paste { AppProfile.of(owner).paste }
+
+    /// What the field will show once `replacement` has been pasted.
+    ///
+    /// Not the same string when the app takes a rich flavour: `**Alex**` goes
+    /// onto the pasteboard as markup and arrives as bold Alex, with the markers
+    /// gone. Every write here is verified by reading the field back, so the
+    /// check has to look for what will be *there* rather than for what was
+    /// sent. Measured the moment the flavour was carried into a rewrite: a
+    /// bold that applied correctly reported "this app won't let me edit it",
+    /// because the read-back went looking for two asterisks Slack had consumed.
+    ///
+    /// Only the paste renders. `setSelectedText` writes the string literally,
+    /// so that branch still reads back the markers it put there.
+    ///
+    /// `displayed` and not `plain`. They differ on one thing — a labelled link,
+    /// which `plain` writes as `words (url)` because that flavour is the
+    /// clipboard fallback and losing the address there is worse than showing
+    /// it. On screen the address is in the anchor and the line reads "words",
+    /// so a read-back against `plain` would reject a link that pasted
+    /// correctly and the repair would undo it.
+    func asShown(_ replacement: String) -> String {
+        guard paste != .plain else { return replacement }
+        let markup = Markup.parse(replacement)
+        return markup.isPlain ? replacement : markup.displayed
+    }
+
     // MARK: - Reading
 
     /// What is in front, read once.
@@ -131,11 +169,7 @@ struct Surface {
         }
 
         let front = app ?? NSWorkspace.shared.frontmostApplication
-        let isTerminal = front.map {
-            AppProfile.of(Pipeline.App(
-                name: $0.localizedName ?? "", bundleID: $0.bundleIdentifier ?? ""
-            )).focus == .screen
-        } ?? false
+        let isTerminal = AppProfile.of(front).focus == .screen
 
         if isTerminal {
             return screen(element: element, owner: front, value: value, dictated: dictated)
@@ -486,6 +520,15 @@ struct Surface {
         // value should read afterwards, and the fragment is widened against it
         // until it names one place there.
         let fragment = self.fragment(around: range, replacement: replacement, in: updated)
+        // The same check for the branches that paste, against what a paste
+        // actually leaves in the field. Identical to `fragment` whenever the
+        // app takes plain text or the replacement carries no markup, which is
+        // most of the time — see `asShown`.
+        let shown = asShown(replacement)
+        let pasted = shown == replacement ? fragment : self.fragment(
+            around: range, replacement: shown,
+            in: content.replacingCharacters(in: range, with: shown)
+        )
 
         // 1. Set the range, then write the text into it. Disturbs nothing, and
         //    is what a native field accepts.
@@ -501,8 +544,8 @@ struct Surface {
         if select(nsRange),
            confirmedSelection(matches: String(content[range]), range: nsRange) {
             Log.write("surface: the range write was ignored; pasting over a confirmed selection")
-            TextInserter.insert(replacement, mode: .paste)
-            if settled(on: fragment) {
+            TextInserter.insert(replacement, mode: .paste, paste: paste)
+            if settled(on: pasted) {
                 // Said out loud, like the branch above. Without it a success
                 // here is an absence of failure lines, and reading the log for
                 // "did the edit land" means knowing which lines are missing.
@@ -526,7 +569,7 @@ struct Surface {
         //    it is to where the span starts, and every step of that walk can be
         //    checked against the app's own account before anything is typed.
         if let outcome = writeByWalkingTheCaret(
-            nsRange, replacement: replacement, fragment: fragment, undo: undo
+            nsRange, replacement: replacement, fragment: pasted, undo: undo
         ) {
             return outcome
         }
@@ -596,7 +639,7 @@ struct Surface {
         }
 
         Log.write("surface: walked the caret to \(target.location)+\(target.length); pasting")
-        TextInserter.insert(replacement, mode: .paste)
+        TextInserter.insert(replacement, mode: .paste, paste: paste)
         if settled(on: fragment) { return .replaced(undo) }
         return .refused(repairedAfterStrayPaste())
     }

--- a/Sources/ParrotFlow/WatchModifiersCommand.swift
+++ b/Sources/ParrotFlow/WatchModifiersCommand.swift
@@ -59,7 +59,11 @@ enum WatchModifiersCommand {
             counts[edge, default: 0] += 1
             print("  \(edge)")
         }
-        monitor.onPress = { note("press   — a dictation would start here") }
+        monitor.onPress = { afterTap in
+            note(afterTap
+                ? "tap+hold — what you say would be routed as a command"
+                : "press   — a dictation would start here")
+        }
         monitor.onRelease = { note("release — and end here") }
         monitor.onAbort = { note("abort   — that was a shortcut") }
         monitor.onTap = { note("tap     — the offer would be summoned") }

--- a/Sources/ParrotFlow/WatchModifiersCommand.swift
+++ b/Sources/ParrotFlow/WatchModifiersCommand.swift
@@ -36,4 +36,71 @@ enum WatchModifiersCommand {
         print("✓ detected: \(everSaw.map(\.displayName).sorted().joined(separator: ", "))")
         return 0
     }
+
+    /// `--watch-taps <key> [seconds]` — the same key through the real
+    /// `ModifierKeyMonitor`, printing which edge each press came out as.
+    ///
+    /// A tap cannot be scored from a fixture: it is a length of time on a
+    /// physical key, and what makes it hard is that a shortcut looks like one
+    /// until the second key arrives. So this is the surface for it — press the
+    /// key alone and it says `tap`; press ⌘S and it says nothing at all, which
+    /// is the case worth checking.
+    static func taps(key name: String, seconds: Double, pressDelay: TimeInterval) -> Int32 {
+        guard let key = ModifierKey(name: name) else {
+            print("✗ \"\(name)\" is not a bare modifier — see docs/configuration.md")
+            return 1
+        }
+        print("Tap \(key.displayName), hold it, and try a shortcut with it (\(Int(seconds))s)")
+        print("press_delay is \(pressDelay)s — shorter than that is a tap.\n")
+
+        let monitor = ModifierKeyMonitor()
+        var counts: [String: Int] = [:]
+        func note(_ edge: String) {
+            counts[edge, default: 0] += 1
+            print("  \(edge)")
+        }
+        monitor.onPress = { note("press   — a dictation would start here") }
+        monitor.onRelease = { note("release — and end here") }
+        monitor.onAbort = { note("abort   — that was a shortcut") }
+        monitor.onTap = { note("tap     — the offer would be summoned") }
+        monitor.start(key: key, pressDelay: pressDelay)
+
+        // Pumped in slices so the key can be sampled alongside the monitor. An
+        // edge that never arrives has three causes and they need different
+        // answers — nothing was pressed, the flags never reached us, or every
+        // hold was somebody's shortcut — and a summary that cannot tell them
+        // apart sends you looking at the wrong one. Same cadence the monitor
+        // polls at, so a press cannot fall between two samples.
+        var samples = 0
+        var sawDown = 0
+        let deadline = Date().addingTimeInterval(seconds)
+        while Date() < deadline {
+            samples += 1
+            if key.isPressed { sawDown += 1 }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.025))
+        }
+        monitor.stop()
+
+        print("")
+        guard samples > 1 else {
+            print("✗ the run loop never pumped — no key could have been seen")
+            return 1
+        }
+        guard sawDown > 0 else {
+            print("✗ \(key.displayName) was never down in those \(Int(seconds))s")
+            print("  Either it was not pressed, or the flag state is not reaching this")
+            print("  process — `--watch-modifiers` says which.")
+            return 1
+        }
+        guard !counts.isEmpty else {
+            print("✗ \(key.displayName) went down \(sawDown) sample(s) and produced no edge")
+            print("  Every hold was ruled out as a shortcut: something else was pressed,")
+            print("  clicked or scrolled while it was held. See `press_delay_seconds`.")
+            return 1
+        }
+        for edge in counts.keys.sorted() {
+            print("  \(counts[edge] ?? 0)× \(edge.split(separator: " ")[0])")
+        }
+        return 0
+    }
 }

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -262,11 +262,12 @@ if let index = arguments.firstIndex(of: "--command") {
 
 if let index = arguments.firstIndex(of: "--route") {
     guard arguments.indices.contains(index + 1) else {
-        print("usage: ParrotFlow --route \"hey parrot, make that a bullet list\" [--quiet]")
+        print("usage: ParrotFlow --route \"hey parrot, make that a bullet list\" [--quiet] [--keyed]")
         exit(2)
     }
     exit(RouteTestCommand.run(
-        text: arguments[index + 1], quiet: arguments.contains("--quiet")
+        text: arguments[index + 1], quiet: arguments.contains("--quiet"),
+        keyed: arguments.contains("--keyed")
     ))
 }
 

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -551,6 +551,19 @@ if let index = arguments.firstIndex(of: "--watch-modifiers") {
     exit(WatchModifiersCommand.run(seconds: seconds ?? 10))
 }
 
+if let index = arguments.firstIndex(of: "--watch-taps") {
+    // The configured key and delay by default, since what this answers is
+    // whether the gesture works on the hotkey you actually use.
+    let loaded = (try? ConfigStore.load()) ?? Config()
+    let key = arguments.indices.contains(index + 1) && !arguments[index + 1].hasPrefix("-")
+        ? arguments[index + 1]
+        : loaded.hotkey.key
+    let seconds = arguments.indices.contains(index + 2) ? Double(arguments[index + 2]) : nil
+    exit(WatchModifiersCommand.taps(
+        key: key, seconds: seconds ?? 10, pressDelay: loaded.hotkey.pressDelaySeconds
+    ))
+}
+
 let app = NSApplication.shared
 let delegate = AppDelegate()
 app.delegate = delegate

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -316,6 +316,7 @@ $ ParrotFlow --forget Praisy
 $PF --record 3           # record 3s and verify the file it produced
 $PF --transcribe a.wav   # transcribe a clip
 $PF --watch-modifiers    # print which modifier keys are physically down, live
+$PF --watch-taps         # tap, hold or shortcut — which edge each press comes out as
 $PF --audio-recovery     # what the recorder does when the microphone changes
 ```
 
@@ -326,6 +327,14 @@ A silent clip or a short file gets a non-zero exit.
 `--watch-modifiers` is the one to reach for if a bare-modifier hotkey seems
 dead — it shows whether the key is reaching the app at all, and whether left
 and right are distinguishable on your keyboard.
+
+`--watch-taps` runs the same key through the real monitor and names the edge
+each press came out as: `press`/`release` for a hold, `tap` for one shorter
+than `press_delay_seconds`, `abort` for a hold that turned out to be a
+shortcut. It reads your configured hotkey and delay unless you name another
+(`--watch-taps right_option 20`). A tap is a length of time on a physical key,
+so no fixture can score it — the case worth checking by hand is that ⌘S prints
+nothing at all.
 
 `--audio-recovery` is for the other kind of dead: the microphone changed —
 AirPods connected, a headset came out — and since then dictation records

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -254,6 +254,12 @@ $PF --learn <heard> <corrected>
 matches your words against each transform's `description`, so this is how you
 find out that a description is too vague before a user does.
 
+`--route "…" --keyed` scores the other path: tap-and-hold, where a key said
+this was an instruction and there is no router at all. A name anywhere in the
+sentence wins, `say:` aliases included; everything else is `ANY`. No model, so
+it answers instantly. `scripts/check-keyed.sh` drives it against
+`tests/keyed-cases.yaml`, which supplies its own catalogue.
+
 `--prompt` runs one named transform against text you supply, with the
 instruction that would have been spoken. `--command` runs the whole
 wake-phrase path: is this a command at all, is it a correction, which words in

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -248,6 +248,25 @@ select a paragraph in Word, tap, and press a chip's letter.
 This is why the offer's six seconds are not a deadline. It is not kept on
 screen against the chance that you want it — you ask for it again.
 
+**Over a selection the pill says which words**, in the highlight they wear in
+the field, with the chips under them and one line under those:
+
+    Edit  ▏things that turned out not to matter▕
+       V Vocabulary    F Fix grammar    S Terse
+        or hold ⌥ and say what to change
+
+Shown rather than described. The doubt is never whether there is a selection —
+it is which words are about to change, and no wording is as exact as the words.
+
+**Holding while _that_ pill is up speaks the edit**, with no tap first. There a
+hold cannot mean "start a new dictation": the pill is on screen pointing at
+words and asking what to do about them, and talking over it would be answering
+a question with a different sentence.
+
+Only that pill. The offer after a plain dictation carries no such row and
+nothing on screen offers the gesture, so holding there starts the next
+sentence, exactly as it always has.
+
 **Select what it just wrote and the pill comes back on its own**, with no key
 at all. All or part of it — select three words out of a sentence you dictated
 and those three words are the target.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -248,6 +248,27 @@ select a paragraph in Word, tap, and press a chip's letter.
 This is why the offer's six seconds are not a deadline. It is not kept on
 screen against the chance that you want it — you ask for it again.
 
+**Select what it just wrote and the pill comes back on its own**, with no key
+at all. All or part of it — select three words out of a sentence you dictated
+and those three words are the target.
+
+Only for words ParrotFlow wrote, in the field it wrote them into, and only
+while they are still the last thing it wrote. Every other selection gets
+nothing, because selecting text is mostly how you copy it, delete it or type
+over it, and a surface that appeared each time would be wrong far more often
+than right. It never appears twice for the same words either: the pill returns
+when you *select* something, not while you have something selected.
+
+It costs no polling. A selection is made by a drag, a shift-arrow or ⌘A, so the
+question is asked at those three moments and never in between.
+
+**`Vocabulary` is left off the pill for words nothing here dictated.** The
+panel behind it maps what was *heard* to what it should be, and there is no
+hearing behind a paragraph somebody else typed — a rule taught from their typo
+would fire on your own future dictations, correcting a mistake the decoder
+never made. Every other chip is a rewrite and applies to any text, so they
+stay.
+
 **Bare modifiers only.** A `⌃⌥Space`-style combo goes through Carbon, which
 delivers the press on the down edge and swallows the keystroke, so there is no
 short press left over to claim: a tap there is a dictation, and a brief one.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -208,6 +208,27 @@ transform and the catch-all besides — with no phrase to remember, because the
 key already said it was an instruction. The pill says **editing the selection**
 or **say an edit** while you hold, and ⎋ cancels.
 
+**And no router.** A key said this was an instruction, so the question the
+router exists to answer — *was that even an edit?* — is already answered.
+What is left is which tool, and that is decided without a model:
+
+1. Does the sentence contain the name of one of your transforms, or one of the
+   words its `say:` lists? Then run it. No model call at all.
+2. Otherwise the catch-all takes the whole sentence as its specification. One
+   model call.
+
+Never two waits in a row. Often none. `"hey parrot, …"` keeps the router,
+because that one is *found* in a sentence and really does have to guess.
+
+Step 1 is not an optimisation, it is what keeps the rest of your catalogue
+reachable. The catch-all is a prompt. A `command:` script and a `replace:`
+table are not, so nothing can stand in for them — "flag this" sent to the
+catch-all does not file your text, it rewords it. `say:` is how a tool named
+`slack_handles` gets reached by someone saying "use our slack handles".
+
+`scripts/check-keyed.sh` scores this against `tests/keyed-cases.yaml`, with no
+model and in about a second.
+
 **It applies in place**, whatever the transform's `confirm:` says — the same
 rule a chip on the pill already follows. The target was named on the pill
 before you spoke, ⎋ was live the whole time you were speaking, and
@@ -833,6 +854,12 @@ running a full-screen program shows only what fits on the screen. Claude Code,
 vim and less all work this way, and the pill follows your words there. A pane
 sitting at an ordinary shell prompt keeps everything you have run in it, and the
 pill goes to the bottom of the screen.
+
+A rewrite that lands says nothing. The text is the confirmation — it changes
+where you are already looking, with the pill sitting under it — so a notice
+would be describing what you just watched happen. A chime plays and the log
+records it. Every way of *not* landing still speaks: nothing to change, the app
+refused the edit, the words went to the clipboard instead.
 
 `correct_offer` is what the pill does after a dictation. It stays where it
 is and names what can be done to the words, one chip per command:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -184,6 +184,35 @@ On `toggle`, right ⌥ would start recording every time you used it to type an
 accented character. Hold-to-talk is the mode that makes sense for these; it's
 also why apps in this category gravitate to `fn` or a right-hand modifier.
 
+### Tap it to bring the offer back
+
+Hold the hotkey and you dictate. **Tap it** — shorter than
+`press_delay_seconds` — and the pill comes back with its commands on it.
+
+| What is selected | What the offer is about |
+|---|---|
+| A selection, anywhere | Those words, and the pill appears under them |
+| Nothing | The last dictation, and the pill stays where it was |
+
+The selection wins because it is what you are pointing at now, and it is the
+only target the tap can have in an app ParrotFlow has never written into:
+select a paragraph in Word, tap, and press a chip's letter.
+
+This is why the offer's six seconds are not a deadline. It is not kept on
+screen against the chance that you want it — you ask for it again.
+
+**Bare modifiers only.** A `⌃⌥Space`-style combo goes through Carbon, which
+delivers the press on the down edge and swallows the keystroke, so there is no
+short press left over to claim: a tap there is a dictation, and a brief one.
+At `press_delay_seconds: 0` there is no tap either, for the same reason.
+
+Nothing is summoned while a dictation is recording or still decoding. On
+`toggle` the key is what stops a recording, and a stop that came out short is
+still a stop.
+
+`--watch-taps` says which edge each press comes out as — see
+[cli.md](cli.md). The case worth checking by hand is that ⌘S prints nothing.
+
 ## `transcription.insert_mode`
 
 `paste` types the transcript into the app you are in and needs the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -186,13 +186,39 @@ also why apps in this category gravitate to `fn` or a right-hand modifier.
 
 ### Tap it to bring the offer back
 
-Hold the hotkey and you dictate. **Tap it** — shorter than
-`press_delay_seconds` — and the pill comes back with its commands on it.
+One key, three lengths. The tap means "me"; what you do next says what.
 
-| What is selected | What the offer is about |
+| Gesture | What happens |
+|---|---|
+| **Hold** | Dictate. Unchanged. |
+| **Tap** | The pill comes back, with its commands on it |
+| **Tap, then hold** | Speak an instruction — any command, not just the chips |
+
+A tap is a press shorter than `press_delay_seconds`. Tap and hold again within
+0.4s and the hold is the second half of one gesture rather than a dictation.
+
+| What is selected | What the gesture is about |
 |---|---|
 | A selection, anywhere | Those words, and the pill appears under them |
 | Nothing | The last dictation, and the pill stays where it was |
+
+**Tap-then-hold speaks the whole catalogue.** The chips are a short list; what
+you say is routed the way `"hey parrot, …"` is routed, so it reaches every
+transform and the catch-all besides — with no phrase to remember, because the
+key already said it was an instruction. The pill says **editing the selection**
+or **say an edit** while you hold, and ⎋ cancels.
+
+**It applies in place**, whatever the transform's `confirm:` says — the same
+rule a chip on the pill already follows. The target was named on the pill
+before you spoke, ⎋ was live the whole time you were speaking, and
+`"hey parrot, undo"` puts the substitution back. A preview after all three is
+a question that was answered before it was asked. `"hey parrot, …"` still
+previews: that command is *found* in a sentence rather than declared by a key,
+so being wrong about it is a real possibility.
+
+A bare tap waits 0.4s before the pill appears, because that is how long it
+takes to find out whether a hold is coming. Nothing waits on a pill; the
+dictation path is untouched.
 
 The selection wins because it is what you are pointing at now, and it is the
 only target the tap can have in an app ParrotFlow has never written into:

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -297,6 +297,29 @@ entry costs the others room, so a transform joins it only by asking. Put a
 chip on what you reach for without thinking. Leave it off anything you would
 only ever ask for out loud — that is what the wake phrase is for.
 
+### `say` — what to call it out loud
+
+```yaml
+  - name: slack_handles
+    description: turn names into slack handles
+    say: [slack handles, handles]
+    command: slack_handles.py
+```
+
+A name is written for a config file. Nobody says an underscore, and nobody
+calls a script `code_identifiers` when asking for it. `say:` is the words you
+would actually use, and one string is as good as a list.
+
+Only the tap-and-hold path reads them, and there it decides whether a tool is
+reachable at all. That path has no router: a name anywhere in what you said
+wins, and everything else goes to the catch-all. The catch-all is a prompt, so
+it can stand in for another prompt and for nothing else — a script or a
+`replace:` table that is never named is a tool you cannot reach. See
+[configuration.md](configuration.md#tap-it-to-bring-the-offer-back).
+
+`"hey parrot, …"` ignores `say:`. That path asks a model, and `description:`
+is the field written to be matched against.
+
 `key:` is one letter, drawn as a keycap and shown in capitals whatever you
 write. More than one character is cut to the first. A transform with `offer:
 true` and no `key:` still gets a chip, without a keycap on it — clickable, and

--- a/scripts/check-keyed.sh
+++ b/scripts/check-keyed.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Scores the keyed path against tests/keyed-cases.yaml.
+#
+#   scripts/check-keyed.sh
+#
+# Tap-and-hold: a key said this was an instruction, so there is no router in
+# the path. A name anywhere in the sentence wins; everything else is the
+# catch-all. That is the whole decision, and it costs no model call — this runs
+# in under a second, unlike check-routing.sh, which is a round trip per case.
+#
+# The catalogue is written here rather than read from your config. A set that
+# inherits whichever transforms happen to be on the machine only means
+# something on that machine, and what is being scored is a matcher against a
+# list — the list is half the question. Same argument as
+# tests/routing-cases.yaml makes for itself.
+#
+# What a failure costs is not symmetrical, so read the two groups at the end.
+# A name that misses does not degrade to a slightly worse rewrite: the
+# catch-all is a prompt, and most of these tools are not. "flag this" sent to
+# ANY does not file your text, it rewords it.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/release/ParrotFlow"
+CASES="$ROOT/tests/keyed-cases.yaml"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+
+WORK="$(mktemp -d -t parrotflow-keyed)"
+trap 'rm -rf "$WORK"' EXIT
+
+cat > "$WORK/config.yaml" <<'YAML'
+transcription:
+  languages: [en]
+models:
+  local:
+    api: ollama
+    model: gemma4:e4b
+    default: true
+transforms:
+  - name: bullets
+    description: turn the text into a bullet list
+    prompt: "Rewrite as bullets."
+  - name: terse
+    description: make the text shorter
+    prompt: "Shorten."
+  - name: slack_handles
+    description: turn names into slack handles
+    say: [slack handles, handles]
+    command: 'true'
+  - name: flag
+    description: save this dictation to look at later
+    say: [flag this, save this for later]
+    command: 'true'
+  - name: punctuation
+    description: fix spoken punctuation
+    command: 'true'
+  - name: repetitions
+    description: drop repeated words
+    command: 'true'
+  - name: dotted
+    description: spoken dotted paths as code
+    replace:
+      "$1.": ['/(\w+) dot (?=\w)/']
+YAML
+
+pass=0; total=0; missed=""; forced=""
+
+route() { PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --route "$1" --keyed --quiet 2>/dev/null | tail -1; }
+
+while IFS='|' read -r instruction want; do
+  [ -z "$instruction" ] && continue
+  total=$((total + 1))
+  got="$(route "$instruction")"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1))
+    printf '  ✓ %-46s %s\n' "$instruction" "$got"
+  else
+    printf '  ✗ %-46s got %s, want %s\n' "$instruction" "$got" "$want"
+    # A name that fell through to the catch-all is the expensive failure: the
+    # tool it named is a script or a table, and a prompt cannot stand in for
+    # one. The other direction only costs a rewrite that was not asked for.
+    if [ "$got" = "ANY" ]; then
+      missed="$missed
+      $instruction → wanted $want"
+    else
+      forced="$forced
+      $instruction → $got, wanted $want"
+    fi
+  fi
+done < <(
+  awk '
+    /^  - instruction: / { sub(/^  - instruction: /, ""); ins = $0; next }
+    /^    expect: /      { sub(/^    expect: /, ""); if (ins != "") print ins "|" $0; ins = "" }
+  ' "$CASES"
+)
+
+printf '\n  %d/%d\n' "$pass" "$total"
+[ -n "$missed" ] && printf '\n  named a tool and did not reach it (a script did not run):%s\n' "$missed"
+[ -n "$forced" ] && printf '\n  reached the wrong tool:%s\n' "$forced"
+[ "$pass" = "$total" ] || exit 1

--- a/scripts/validate-generic.py
+++ b/scripts/validate-generic.py
@@ -148,6 +148,31 @@ Otherwise return only the text.
 # v5 — v3 with one edit: the worked example is a properly punctuated sentence.
 # v3 and v4 both dropped the full stop off grammar fixes that v1 and v2 got
 # right, and the only thing they added was an example written without one.
+# v6 = v3 plus two examples for a correction — an instruction with the
+# imperative taken out. v3 scored 3/6 on them and failed in one particular way:
+# handed "no I meant three of them", it edited *the instruction* and returned
+# that, having read the corrective phrasing as prose and so as the subject. The
+# pair teaches both halves at once, which is what the existing three examples
+# already do for questions.
+# Trailing newline stripped, because the Swift literal has none and the
+# comparison above is exact. A byte of whitespace at the end of a system
+# message is unlikely to move a score, and "unlikely" is not a thing this file
+# is allowed to say — it exists to describe the prompt the app sends.
+VARIANTS["v6"] = VARIANTS["v3"].rstrip("\n").replace(
+    "Return only the text.",
+    """instruction: I meant Tuesday
+text:
+the meeting is on Monday
+the meeting is on Tuesday
+
+instruction: this is not what I had in mind
+text:
+the migration runs on friday
+the migration runs on friday
+
+Return only the text.""",
+)
+
 VARIANTS["v5"] = VARIANTS["v3"].replace(
     "we saw about forty of them\nwe saw about 40 of them",
     "We saw about forty of them.\nWe saw about 40 of them.",
@@ -215,6 +240,29 @@ def ask(model, system, user, budget, endpoint="http://localhost:11434"):
     return payload["response"]
 
 
+def shipped_content():
+    """The catch-all's prompt as `FreeForm.swift` holds it, or None.
+
+    Read rather than copied. Two copies of a prompt drift, and this file exists
+    to say what the app does — a scoreboard measuring a string the app does not
+    send is worse than no scoreboard, because it reads exactly like one that
+    does.
+    """
+    source = pathlib.Path(__file__).resolve().parent.parent / "Sources/ParrotFlow/FreeForm.swift"
+    try:
+        text = source.read_text(encoding="utf-8")
+        body = text.split('content: """', 1)[1].split('"""', 1)[0]
+    except (OSError, IndexError):
+        return None
+    # A Swift multiline literal drops the newline after the opening quotes and
+    # the one before the closing quotes, and strips the closing delimiter's
+    # indentation from every line.
+    lines = body.split("\n")[1:-1]
+    indent = len(lines[-1]) - len(lines[-1].lstrip()) if lines else 0
+    return "\n".join(line[indent:] if line[:indent].isspace() or not line.strip()
+                      else line.lstrip() for line in lines)
+
+
 def shipped_prompt_for(category):
     """The narrow prompt the app ships today for this category, if any."""
     return {"digits": "digits", "dates": "dates", "grammar": "grammar"}.get(category)
@@ -252,6 +300,26 @@ def main():
         cases = [c for c in cases if shipped_prompt_for(c["category"])]
 
     content = VARIANTS[args.variant]
+    # Say whether this is the prompt the app runs, before scoring anything.
+    #
+    # The default here is v1 and has never been what ships, so a number from
+    # this runner has always needed that checked by hand — and "by hand" found
+    # the variant but not a one-byte trailing newline, which is a different
+    # system message however little it changes the answer. The comparison is
+    # exact for that reason.
+    shipped = shipped_content()
+    if shipped is None:
+        print("  ⚠ could not read FreeForm.swift; cannot say if this is the shipped prompt")
+    elif content == shipped:
+        print(f"  {args.variant} is the prompt the app ships")
+    elif content.strip() == shipped.strip():
+        print(f"  ⚠ {args.variant} differs from the shipped prompt only in whitespace"
+              f" ({len(content.encode())} bytes against {len(shipped.encode())})"
+              " — the model is being sent a different system message")
+    else:
+        print(f"  ⚠ {args.variant} is not the prompt the app ships"
+              " — this number does not describe the app")
+
     results = []
     elapsed = 0.0
 
@@ -447,3 +515,41 @@ if __name__ == "__main__":
 #
 # granite4:3b scores 6/19 on the same gate and collapses everything into
 # `bullets`. Three-way routing is a gemma-class job.
+
+# --- 2026-08-26: corrections -------------------------------------------------
+#
+# Six cases added for a *correction* — an instruction with the imperative taken
+# out. "make it Tuesday" and "I meant Tuesday" ask for the same edit, and the
+# second is what people say to a machine that has just written their own
+# sentence down. Four ask for the edit; two are the phrase with no edit behind
+# it, which is the reason the category needed negatives: "I meant" is not a
+# marker. It introduces an edit only when it names the replacement, and bare it
+# is a complaint.
+#
+#   gemma4:e4b-mlx v3 (shipped before)   36/44   corrections 2/6
+#   gemma4:e4b-mlx v6                    40/44   corrections 5/6
+#
+# Both re-run after the byte fix below, because the first pass scored a v6 one
+# trailing newline longer than the Swift literal — a different system message,
+# however little it moved the answer.
+#
+# The runs are not repeatable to the case. v3's bytes did not change between
+# the two passes and it scored 37 then 36, so a single point here is noise and
+# only the direction is a finding. Corrections went 2-or-3 of 6 to 5 of 6 in
+# both passes, which is the part worth believing.
+#
+# v6 is v3 plus two examples, one of each kind. Every other category is
+# identical between them, so the two points are the corrections and nothing
+# else. v6 shipped.
+#
+# The failure v3 had is worth keeping in mind, because it is not the one you
+# would guess: handed "no I meant three of them" it edited *the instruction*
+# and returned that. Corrective phrasing reads as prose, and prose in the
+# instruction slot reads as the subject.
+#
+# That case still fails on v6, and is left standing. Fixing one case with a
+# third example is tuning on the set — it wants fresh cases first.
+#
+# The runner's default is v1, which has never been what ships. v3 was the
+# shipped prompt before this and v6 is now; check which one matches
+# FreeForm.swift before reading any number here as a statement about the app.

--- a/tests/generic-cases.yaml
+++ b/tests/generic-cases.yaml
@@ -321,3 +321,55 @@ cases:
     category: idle
     instruction: we talked about the dates in the meeting
     input: the retro is on 2026-04-09
+
+  # --- saying what you meant, instead of what to do ------------------------
+  #
+  # A correction is an instruction with the imperative taken out. "make it
+  # Tuesday" and "I meant Tuesday" ask for the same edit, and the second is
+  # what people actually say to a machine that has just written something down
+  # for them — this is dictation, and the sentence before it was theirs.
+  #
+  # The negatives here are the whole reason the category exists. "I meant" is
+  # not a marker: it introduces an edit only when it names the replacement.
+  # Bare, it is a complaint, and there is nothing to act on in a complaint. A
+  # prompt that reads the phrase as a signal rather than reading what follows
+  # it will rewrite on a sentence that never asked for anything.
+  - name: I meant, naming the replacement
+    kind: change
+    category: correction
+    instruction: I meant Tuesday
+    input: the meeting is on Monday
+    expect: the meeting is on Tuesday
+
+  - name: I wanted to say, naming the replacement
+    kind: change
+    category: correction
+    instruction: I wanted to say Redcrawl
+    input: we shipped Redrock last week
+    expect: we shipped Redcrawl last week
+
+  - name: a correction with the apology in front
+    kind: change
+    category: correction
+    instruction: sorry I meant next Friday
+    input: let's do it this Friday
+    expect: let's do it next Friday
+
+  - name: no, I meant
+    kind: change
+    category: correction
+    instruction: no I meant three of them
+    input: we ordered two of them
+    expect: we ordered three of them
+
+  - name: a complaint with no edit in it
+    kind: keep
+    category: correction
+    instruction: this is not what I had in mind
+    input: the migration runs on friday
+
+  - name: I meant it, which is not a correction at all
+    kind: keep
+    category: correction
+    instruction: I meant what I said in the review
+    input: the config file is at ~/.config/parrotflow

--- a/tests/keyed-cases.yaml
+++ b/tests/keyed-cases.yaml
@@ -1,0 +1,96 @@
+# The keyed path: tap-and-hold, where a key said this was an instruction.
+#
+# Run with scripts/check-keyed.sh, which supplies its own catalogue — see
+# below. Unlike tests/routing-cases.yaml this needs no model and takes no time:
+# the whole point of the path is that there is no router in it.
+#
+# Two answers only. A name anywhere in the sentence wins; everything else is
+# the catch-all. There is no NONE, because a key was held down to say this —
+# "that was not a command" is a verdict the gesture has already ruled out.
+#
+# What is being scored is one thing: does a name reach the tool that owns it.
+# It matters because most tools are not prompts. A script and a substitution
+# table cannot be stood in for by the catch-all, which is a prompt, so a name
+# that misses does not degrade — it runs the wrong kind of thing entirely.
+# "flag this" going to ANY does not file your text, it rewords it.
+#
+# The catalogue is fixed in the script rather than read from your config, for
+# the reason routing-cases.yaml gives: a set that inherits whichever transforms
+# happen to be on the machine only means something on that machine.
+#
+#   bullets      prompt   — the one the catch-all could stand in for
+#   terse        prompt
+#   slack_handles command  say: [slack handles, handles]
+#   flag         command  say: [flag this, save this for later]
+#   punctuation  command
+#   repetitions  command
+#   dotted       replace
+
+cases:
+  # --- the bare name, which worked before this and still has to ------------
+  - instruction: bullets
+    expect: bullets
+  - instruction: terse
+    expect: terse
+  - instruction: punctuation
+    expect: punctuation
+
+  # --- a name at the front, with the rest of the request behind it ---------
+  - instruction: bullets but keep the headings
+    expect: bullets
+  - instruction: punctuation on that last paragraph
+    expect: punctuation
+
+  # --- a name in the middle, which is what `anywhere` adds ----------------
+  # The anchored match was written for "hey parrot", where the words around a
+  # name might not be a command at all. Held down on a key they always are.
+  - instruction: use our slack handles
+    expect: slack_handles
+  - instruction: clean up the repetitions
+    expect: repetitions
+  - instruction: fix the punctuation
+    expect: punctuation
+  - instruction: can you make that bullets
+    expect: bullets
+
+  # --- an underscore is how a config spells a space -----------------------
+  - instruction: slack handles please
+    expect: slack_handles
+
+  # --- `say:`, for a tool whose name is not what you would call it --------
+  - instruction: handles
+    expect: slack_handles
+  - instruction: save this for later
+    expect: flag
+  - instruction: flag this
+    expect: flag
+
+  # --- misheard, because every one of these arrived through a decoder -----
+  - instruction: fix the punctuation marks
+    expect: punctuation
+  - instruction: terce
+    expect: terse
+
+  # --- the catch-all, which is the other half of the design ---------------
+  # These name nothing and must not be forced onto the nearest tool. One model
+  # call, and the instruction is the whole specification.
+  - instruction: make this three bullet points
+    expect: bullets
+  - instruction: shorten it
+    expect: ANY
+  - instruction: use the 24 hour clock
+    expect: ANY
+  - instruction: sort that list alphabetically
+    expect: ANY
+  - instruction: make sure the amounts are formatted as money
+    expect: ANY
+  - instruction: rewrite this so my manager will read it
+    expect: ANY
+
+  # --- a name that is also an ordinary word -------------------------------
+  # `dotted` is a table for spoken paths. "join the dotted line" is prose about
+  # a dotted line, and there is no tool called join in this catalogue — so the
+  # risk is `dotted` eating it. It may: a keyed instruction is a command, and
+  # the speaker did say the word. Recorded rather than argued with.
+  - instruction: dotted
+    expect: dotted

--- a/tests/keyed-cases.yaml
+++ b/tests/keyed-cases.yaml
@@ -94,3 +94,26 @@ cases:
   # the speaker did say the word. Recorded rather than argued with.
   - instruction: dotted
     expect: dotted
+
+  # --- a correction, which is an instruction with the imperative taken out ---
+  #
+  # "I meant Tuesday" names no transform and must reach the catch-all, where
+  # the prompt decides what to do with it — `tests/generic-cases.yaml` scores
+  # that half. What is scored here is only that the name match does not eat it
+  # first, which is a real risk and not a theoretical one: this fixture has a
+  # tool called `flag`, and a correction naming a person or a day is one word
+  # away from a tool name in any catalogue somebody actually configures.
+  #
+  # The complaint goes to the same place, and that is correct rather than a
+  # gap: routing cannot tell "I meant Tuesday" from "this is not what I had in
+  # mind" without reading the text, which is the catch-all's job. The prompt
+  # returns the complaint unchanged, and the case for that is in the generic
+  # set where it can be measured.
+  - instruction: I meant Tuesday
+    expect: ANY
+  - instruction: no I meant three of them
+    expect: ANY
+  - instruction: this is not what I had in mind
+    expect: ANY
+  - instruction: sorry I meant next Friday
+    expect: ANY

--- a/tests/routing-cases.yaml
+++ b/tests/routing-cases.yaml
@@ -57,7 +57,37 @@
 # which says the description is not what decides it. The preview is what stands
 # between this and a lost selection.
 
+# --- corrections, added 2026-08-27 -----------------------------------------
+#
+# A correction is an instruction with the imperative taken out: "I meant
+# Tuesday" asks for the edit "make it Tuesday". The catch-all was taught to
+# handle them (tests/generic-cases.yaml, corrections 2/6 -> 5/6), and the keyed
+# path reaches it — but nothing here covered the *heard* path, where the router
+# decides. Greptile asked for it and was right to.
+#
+# One of the four fails, and it does not fail cheaply:
+#
+#     I meant Tuesday                            -> repetitions
+#
+# The router picks a script. "hey parrot, I meant Tuesday" runs the repetitions
+# transform over the sentence instead of reaching the catch-all, and a script
+# rewrite is not a no-op you can see coming the way a grammar pass over numbers
+# is. It is left standing here rather than argued with because the fix is a
+# description, and a description is changed against this set with a number
+# before and after — not in the pull request that found it.
+#
+# The keyed path is unaffected: it has no router, and its four correction cases
+# pass (tests/keyed-cases.yaml, 26/26).
+
 cases:
+  - instruction: I meant Tuesday
+    expect: ANY
+  - instruction: no I meant three of them
+    expect: ANY
+  - instruction: this is not what I had in mind
+    expect: NONE
+  - instruction: I meant what I said in the review
+    expect: NONE
   # --- named outright: should never reach the model -----------------------
   - instruction: bullets
     expect: bullets


### PR DESCRIPTION
Tap the hotkey and the correction offer comes back over the last dictation, or over whatever you have selected. Tap it and then hold, and what you say next is an instruction rather than text: "make it terse", "use our slack handles". The offer also returns on its own when you select words ParrotFlow just wrote.

This reaches text ParrotFlow never wrote. Until now the offer only ever appeared after a dictation, over that dictation. Selecting a paragraph in somebody else's email and tapping the key now edits it.

Everything is behind `feedback.correct_offer`, which is already on by default. The new gesture needs a bare-modifier hotkey — `right_command` is the shipped default. On a combo hotkey like `⌃⌥Space` there is no tap to claim, and the branch says so rather than pretending.

Six commits, already reviewed as #211–#216 into this branch. Start with `AppDelegate.summonOffer` and `ModifierKeyMonitor.finishHold`.

<details>
<summary>The gestures, and what each one costs</summary>

| gesture | what happens |
|---|---|
| hold | dictation, as before |
| tap | the offer, over the selection if there is one, else over the last dictation |
| tap then hold | the mic opens and what you say is routed as an instruction |
| hold, while an offer over a selection is up | same as tap-then-hold — the pill's third row promises it |
| select words ParrotFlow wrote | the offer returns unasked |

A tap is held back by `ModifierKeyMonitor.tapGrace` (0.4 s) to see whether a hold follows. Nothing waits on a pill, so that is the cheap side of the trade. The dictation path is untouched — a hold is still delivered on its own timing.

Two taps in a row is somebody who meant to tap-and-hold and let go too early. The second does not summon a second offer.

</details>

<details>
<summary>The poll is 25 ms late, and that decides which gesture you made</summary>

`ModifierKeyMonitor` polls the modifier flags every 25 ms, so `Date()` at the moment it notices is not the moment the key moved. A second press made at 0.399 s is seen up to 25 ms later, which puts it outside a 0.4 s window measured off the poll — and it would start an ordinary dictation instead of a command.

`physicalEdge()` subtracts `CGEventSource.secondsSinceLastEventType(.combinedSessionState, eventType: .flagsChanged)` to recover the real time of the edge. Both ends of the grace window are measured that way. It costs no permission: the age of an event is not the event.

`pressIsTheTapsSecondHalf()` is one rule asked in two places — `beginHold` classifies the press, the grace timer decides whether a press already owns the gesture. The first attempt had the timer ask the cheaper question "is the key down at all", which suppressed the offer for a press that landed *outside* the window. The tap then vanished for no reason anybody could see.

`--watch-taps` prints which edge each press comes out as, on your real hotkey. A tap cannot be scored from a fixture: it is a length of time on a physical key, and a shortcut looks like one until the second key arrives.

</details>

<details>
<summary>Keyed commands skip the router, which halves the wait</summary>

A key has already answered "was this an edit at all". What is left is "which tool", and the name match answers that for free or the catch-all takes the whole instruction as its specification. Heard commands — "hey parrot, …" — still route, because a fuzzy matcher firing at 0.55 against a 0.7 floor can be wrong.

So keyed costs one model call, or none. Heard costs a router round trip and then the transform's own.

`Router.local` gains `anywhere:`. Anchored at the start of the sentence is right for a phrase heard inside one; for a keyed command the whole utterance *is* the instruction, so "use our slack handles" has to reach `slack_handles` or it reaches a model that cannot run a script.

`transforms[].say` is the new config key — what to call a transform out loud. A name is written for a config file (`slack_handles`, `code_identifiers`) and nobody says an underscore. One string or a list; `say: 42` is now named by `--check-config` rather than silently leaving the transform unreachable.

Scored by `scripts/check-keyed.sh` against `tests/keyed-cases.yaml`, in the `make test` set. No model, so it runs in under a second.

</details>

<details>
<summary>Why the pill shows the words rather than saying "the selection"</summary>

The doubt is never *whether* there is a selection. It is which words are about to change, and the only exact answer is the words. They wear the app's own blue, matching the highlight two lines above, so the pill says "these ones".

It also asks the accessibility layer for nothing, which is why it survives where pointing at the span did not. In web content there is no way to ask where a *span* is — only where the box holding it is.

The `Vocabulary` chip is left off an offer over words nothing here dictated. That panel maps what was HEARD to what it should be, and over a selection in somebody else's email there was no hearing. A rule taught from a typo somebody else typed would fire on your future dictations, correcting a mistake the decoder never made. Before the hotkey could summon an offer over an arbitrary selection this could not arise.

</details>

<details>
<summary>Rewrites now paste in the app's flavour, and read back what will be on screen</summary>

A rewrite is the same text going into the same field as a dictation, so it takes the same pasteboard flavours. Without this a transform answering `**Alex**` put four asterisks into Slack, where a dictation of the same words arrives bold. Nothing said so: a paste that lands is a paste that worked, and the markers look like the model's fault.

`Surface` verifies every write by reading the field back, so the check has to look for what will be *there*. Measured the moment the flavour was carried in: a bold that applied correctly reported "this app won't let me edit it", because the read-back went looking for two asterisks Slack had consumed. `Markup.displayed` is `plain` minus the link URL, because on screen the address is in the anchor.

</details>

<details>
<summary>Nine slots that could come apart under overlapping dictations</summary>

Push-to-talk does not wait. A command reads its target *after* the decoder has run, and `selectionAtPress` and `lastTranscript` are one slot each — so starting a second dictation while a command was still decoding pointed that command at the newer press's selection. "Make it bold" then applied to whatever happened to be highlighted, on a gesture whose pill reads "editing the selection".

`Press` freezes the selection and the fallback transcript at the moment the recording stops. `Target.frozen` carries them down; `.whateverIsSelected` is the menu and offer path, which run while the slot is still the press's own. Two cases rather than an optional, because "nothing was selected" and "nobody said" are different answers and the nil case is exactly where the crossing survived.

`lastDictated` is written below the guard that refuses an offer to a superseded run, so the words and the field cannot belong to different dictations. `Correction.dictation` matches a rewrite to the record by run, not by text: say the same short sentence twice and the text matches while the dictation is somebody else's.

</details>

<details>
<summary>What the rebase changed, and the one thing to check by hand</summary>

Rebased onto `f0eebee` (#217, "the pill opens where the words are"). The old merge of `origin/main` into this branch is gone; history is six linear commits.

One conflict, in `CaretAnchor.swift`. #214 had added a comment recording a negative result: the `AXSelectedTextMarkerRange` → `AXBoundsForTextMarkerRange` pair "was tried here and answered nothing on Slack's composer". #217 then shipped exactly that pair, working, with measurements. The comment was wrong, so it is dropped and main's implementation stands. No code from either side was lost.

**Check by hand:** `AppDelegate.aim(at:)` puts the pill under a selection by calling `CaretAnchor.read`, which now has `markerCaret` in its path. For a selection, step 1 (`selectedRange` + `bounds`) still answers first and nothing changes. Where step 1 declines — a Chromium contenteditable — the pill may now land on the caret rather than under the whole selection, and a selection taller than 100pt is rejected by the height gate and falls through as before. Not a regression, since that path did not exist, but the `aim(at:)` comment describing a box around the whole selection is now only true for step 1.

`check-inplace` needs a real screen, the Accessibility grant and tmux, so this is not covered by `make test`.

</details>

<details>
<summary>What was run, and what was not</summary>

`make test` passes on the rebased tip — every check, including the new `keyed`.

Not run, and unchanged by the rebase:

| check | needs | last scored |
|---|---|---|
| `check-generic` | Ollama, gemma4:e4b-mlx | 40/44 (`FreeForm.swift`) |
| `check-routing` | Ollama, gemma4:e4b | on `tests/routing-cases.yaml` |
| `check-spelling` | Ollama, gemma4:e4b | — |
| `check-inplace` | a screen, Accessibility, tmux | — |

The catch-all prompt gained two correction examples — "I meant Tuesday" and one that names no replacement. Without them it scored 3/6 on that shape, and it failed by editing the *instruction* and returning that. "no I meant three of them" still fails and is left standing: fixing one case with a third example is tuning on the set.

</details>
