### PR TITLE
fix: the in-place check no longer leaks or kills windows it didn't open

### DIFF
--- a/Sources/ParrotFlow/Surface.swift
+++ b/Sources/ParrotFlow/Surface.swift
@@ -1020,31 +1020,71 @@ struct Surface {
     /// read this pressed the keys anyway and returned `true`, which on any
     /// surface that does not implement readline meant nothing was cleared and
     /// the caller pasted onto the end of the line. That is the append.
+    /// Clears the input line, and says whether it managed to.
+    ///
+    /// Two strategies, because one is not enough. Ctrl-A then Ctrl-K is the
+    /// usual pair. When two reads in a row come back identical the keys are
+    /// not landing where that pair assumes, and a third try at the same thing
+    /// is waste — so the line is killed backwards from its end instead.
+    ///
+    /// Measured on a live Claude Code session: the pair left the box unchanged
+    /// for all 12 attempts and the edit fell through to the clipboard, three
+    /// times on 2026-08-27. What the box held was not recorded, which is why
+    /// it is recorded now.
     private func clearedBox() -> Bool {
+        var previous: String?
+        var stalls = 0
+        var backwards = false
+
         for _ in 0..<12 {
-            // Spelled `.some`/`.none` rather than `true`/`false`/`nil`. Both
-            // read the same, and only this one is exhaustive to every compiler
-            // that has to build it — Swift 6.3 accepts the literals, the 6.0 on
-            // the CI runner asks for `.some(_)` and fails the build.
-            switch boxIsEmpty() {
-            case .some(true): return true
-            case .some(false): break
-            case .none:
+            guard let box = boxContent() else {
                 Log.write("surface: cannot read the input box back; refusing to clear blind")
                 return false
             }
-            SelectionReader.postControlKey(0x00)   // Ctrl-A, start of line
-            Thread.sleep(forTimeInterval: 0.06)
-            SelectionReader.postControlKey(0x28)   // Ctrl-K, kill to end of line
+            if box.isEmpty { return true }
+
+            if box == previous {
+                stalls += 1
+                if stalls >= 2 {
+                    guard !backwards else { return stuck(on: box) }
+                    backwards = true
+                    stalls = 0
+                }
+            } else {
+                stalls = 0
+            }
+            previous = box
+
+            if backwards {
+                SelectionReader.postControlKey(0x0E)   // Ctrl-E, end of line
+                Thread.sleep(forTimeInterval: 0.06)
+                SelectionReader.postControlKey(0x20)   // Ctrl-U, kill to start
+            } else {
+                SelectionReader.postControlKey(0x00)   // Ctrl-A, start of line
+                Thread.sleep(forTimeInterval: 0.06)
+                SelectionReader.postControlKey(0x28)   // Ctrl-K, kill to end
+            }
             Thread.sleep(forTimeInterval: 0.12)
         }
-        return boxIsEmpty() == true
+
+        if boxIsEmpty() == true { return true }
+        return stuck(on: boxContent() ?? "")
+    }
+
+    /// The box would not empty. Says what it holds, so the next one of these
+    /// is diagnosable from the log alone.
+    private func stuck(on box: String) -> Bool {
+        Log.write("surface: the box will not empty; it still reads \"\(box.prefix(80))\"")
+        return false
+    }
+
+    private func boxContent() -> String? {
+        guard let value = SelectionReader.visibleText(of: element) else { return nil }
+        return SelectionReader.joinedInputBox(in: value)
     }
 
     private func boxIsEmpty() -> Bool? {
-        guard let value = SelectionReader.visibleText(of: element),
-              let box = SelectionReader.joinedInputBox(in: value) else { return nil }
-        return box.isEmpty
+        boxContent().map { $0.isEmpty }
     }
 
     /// Whether the box now holds exactly the text we retyped.

--- a/Sources/ParrotFlow/Surface.swift
+++ b/Sources/ParrotFlow/Surface.swift
@@ -1029,8 +1029,9 @@ struct Surface {
     ///
     /// Measured on a live Claude Code session: the pair left the box unchanged
     /// for all 12 attempts and the edit fell through to the clipboard, three
-    /// times on 2026-08-27. What the box held was not recorded, which is why
-    /// it is recorded now.
+    /// times on 2026-08-27. Nothing about the box was recorded, which is why
+    /// its length is recorded now — not its content, which can be a command
+    /// holding a password or a token.
     private func clearedBox() -> Bool {
         var previous: String?
         var stalls = 0
@@ -1071,10 +1072,12 @@ struct Surface {
         return stuck(on: boxContent() ?? "")
     }
 
-    /// The box would not empty. Says what it holds, so the next one of these
-    /// is diagnosable from the log alone.
+    /// The box would not empty. Says how much it still holds, so the next one
+    /// of these is diagnosable from the log alone. Not what it holds: the box
+    /// can be a command with a password or a token in it, and the log is not
+    /// a safe place for that.
     private func stuck(on box: String) -> Bool {
-        Log.write("surface: the box will not empty; it still reads \"\(box.prefix(80))\"")
+        Log.write("surface: the box will not empty; \(box.count) chars remain")
         return false
     }
 

--- a/scripts/check-inplace.sh
+++ b/scripts/check-inplace.sh
@@ -70,13 +70,19 @@ screen_is_locked() {
   ioreg -n Root -d1 -a 2>/dev/null | grep -q CGSSessionScreenIsLocked
 }
 
-# Whether pid $1's own command line has $SESSION as one whole argument, not
-# merely a substring. `grep -q "attach -t $SESSION"` treats $SESSION as a
-# regex and matches it as a substring of a longer token too — a session named
-# "pfcheck.1" then also matches "pfcheck-1-other", and cleanup could kill a
-# pid that only looked like ours.
+# Whether pid $1 is the one this run's own launch started: $SESSION as the
+# exact argument right after "-t" in its command line. Not merely present as
+# some word anywhere in it — a process whose title or some other argument
+# happens to contain $SESSION would pass that test too, and this is what
+# cleanup trusts before killing something.
 owns_fixture() {
-  ps -o command= -p "$1" 2>/dev/null | tr ' ' '\n' | grep -qxF -- "$SESSION"
+  local args
+  read -ra args <<< "$(ps -o command= -p "$1" 2>/dev/null)"
+  local i
+  for i in "${!args[@]}"; do
+    [ "${args[$i]}" = "-t" ] && [ "${args[$((i + 1))]:-}" = "$SESSION" ] && return 0
+  done
+  return 1
 }
 
 start_fixture() {
@@ -114,13 +120,16 @@ start_fixture() {
       # Terminal.app runs a `.command` file as its session.
       printf '#!/bin/sh\nexec %s attach -t %s\n' "$TMUX" "$SESSION" > "$SCRATCH/attach.command"
       chmod +x "$SCRATCH/attach.command"
+      before_windows="$(osascript -e 'tell application "Terminal" to id of every window' \
+        2>/dev/null | tr -d ' ' | tr ',' '\n' | sort)"
       open -a "$VIEWPORT" "$SCRATCH/attach.command"
       sleep 1
-      # The window this run opened, by id — not any window whose title merely
-      # contains the session name. A freshly opened window is frontmost
-      # without anyone having to click, so the front window right now is
-      # this run's and nothing else's.
-      TERMINAL_WINDOW_ID="$(osascript -e 'tell application "Terminal" to id of front window' 2>/dev/null)"
+      # The window that appeared, not whichever is frontmost a second later:
+      # "frontmost" is whatever the window server settled on, and Terminal can
+      # keep an existing window in front of a new one that opened behind it.
+      after_windows="$(osascript -e 'tell application "Terminal" to id of every window' \
+        2>/dev/null | tr -d ' ' | tr ',' '\n' | sort)"
+      TERMINAL_WINDOW_ID="$(comm -13 <(echo "$before_windows") <(echo "$after_windows") | head -1)"
       ;;
     *)
       # Ghostty and friends take `-e`, and on macOS only through `open`:

--- a/scripts/check-inplace.sh
+++ b/scripts/check-inplace.sh
@@ -63,6 +63,12 @@ clear_input() {
 }
 
 start_fixture() {
+  # The display must stay awake for the whole run. This drives a real window
+  # and reads it back through the accessibility API, and a locked screen
+  # answers as `loginwindow` with an empty value — which reads exactly like a
+  # window that would not take the edit. Two runs were lost to that before it
+  # was worth a line.
+  caffeinate -d -i -w $$ &
   "$TMUX" kill-session -t "$SESSION" 2>/dev/null
   # claude as the session command, not typed at a shell: typing it races the
   # prompt, and a swallowed keystroke leaves a shell that looks close enough
@@ -73,12 +79,60 @@ start_fixture() {
     sleep 0.5
   done
   mkdir -p "$SCRATCH"
-  printf '#!/bin/sh\nexec %s attach -t %s\n' "$TMUX" "$SESSION" > "$SCRATCH/attach.command"
-  chmod +x "$SCRATCH/attach.command"
   # A freshly opened window is frontmost without anyone having to click, which
   # is what lets this run unattended.
-  open -a "$VIEWPORT" "$SCRATCH/attach.command"
+  #
+  # How you open one is per terminal, and getting it wrong is silent: the
+  # window never appears, `open -a` falls back to focusing whatever window that
+  # app already had, and every case then reports "nothing readable is focused"
+  # while the real answer is that the fixture was never on screen. That is what
+  # PF_VIEWPORT=Ghostty did for as long as this only knew Terminal.app.
+  case "$VIEWPORT" in
+    Terminal)
+      # Terminal.app runs a `.command` file as its session.
+      printf '#!/bin/sh\nexec %s attach -t %s\n' "$TMUX" "$SESSION" > "$SCRATCH/attach.command"
+      chmod +x "$SCRATCH/attach.command"
+      open -a "$VIEWPORT" "$SCRATCH/attach.command"
+      ;;
+    *)
+      # Ghostty and friends take `-e`, and on macOS only through `open`:
+      # "launching the terminal emulator from the CLI is not supported".
+      # `-n` for a new instance, so the fixture cannot land in a window you
+      # are using.
+      before="$(pgrep -i "$VIEWPORT" | sort)"
+      # The command as separate arguments, not one quoted string. Quoted, the
+      # window opens and `-e` is silently ignored — you get a shell, tmux is
+      # never attached, and every case then reads an empty window and refuses
+      # to write. Measured: `list-clients` says 0 with the quotes and 1 without.
+      open -na "$VIEWPORT.app" --args -e "$TMUX" attach -t "$SESSION"
+      sleep 3
+      # The pid that appeared, not the newest one matching the name. Ghostty
+      # runs several processes under one name, so `pgrep -n` picks whichever
+      # started last — which is not necessarily the one holding this window,
+      # and focusing the wrong one leaves every case reading a window that is
+      # not the fixture.
+      VIEWPORT_PID="$(comm -13 <(echo "$before") <(pgrep -i "$VIEWPORT" | sort) | head -1)"
+      ;;
+  esac
   sleep 4
+  [ -n "${VIEWPORT_PID:-}" ] || VIEWPORT_PID="$(pgrep -n -i "$VIEWPORT" || true)"
+  [ -n "$VIEWPORT_PID" ] || { echo "could not find the $VIEWPORT window it opened"; exit 1; }
+  echo "  viewport: $VIEWPORT pid $VIEWPORT_PID"
+}
+
+# Bring the fixture forward, by process id. Never by name: see start_fixture.
+focus_viewport() {
+  local err
+  err="$(osascript -e "tell application \"System Events\" to set frontmost of \
+    (first process whose unix id is $VIEWPORT_PID) to true" 2>&1 >/dev/null)"
+  [ -n "$err" ] && echo "  focus failed: $err"
+  # Read the frontmost process back. `set frontmost` returns before the window
+  # actually comes forward, and without this second round trip the case that
+  # follows reads whatever was in front before — "nothing readable is focused"
+  # on all 8. The answer is discarded; making the call is the point.
+  osascript -e 'tell application "System Events" to get unix id of \
+    first process whose frontmost is true' >/dev/null 2>&1
+  return 0
 }
 
 LOG="$HOME/Library/Logs/ParrotFlow-Dev.log"
@@ -86,7 +140,15 @@ REPEATS="${PF_REPEATS:-1}"
 pass=0; total=0; refused=0; corrupted=0; skipped=0; wrongpath=0
 
 start_fixture
-trap '"$TMUX" kill-session -t "$SESSION" 2>/dev/null' EXIT
+# Close the window as well as the session. `open -na` starts a whole instance
+# per run, and without this every run leaves one behind — nine of them stacked
+# up in one sitting before it was noticed.
+cleanup() {
+  "$TMUX" kill-session -t "$SESSION" 2>/dev/null
+  [ -n "${VIEWPORT_PID:-}" ] && [ "$VIEWPORT" != Terminal ] && kill "$VIEWPORT_PID" 2>/dev/null
+  return 0
+}
+trap cleanup EXIT
 
 while IFS='|' read -r name id dictated line heard corrected expect literal want_log span; do
   [ -z "$name" ] && continue
@@ -103,7 +165,7 @@ while IFS='|' read -r name id dictated line heard corrected expect literal want_
   [ "$expect" = "unchanged" ] && want="$line" || want="$expect"
 
   mark=$(grep -c "" "$LOG" 2>/dev/null || echo 0)
-  open -a "$VIEWPORT"; sleep 2
+  focus_viewport; sleep 2
   # A span case names the range; the offsets come from the seeded line, which
   # the check above has just confirmed is what is on screen. Computed here
   # rather than written into the case file, so they cannot drift from the text.

--- a/scripts/check-inplace.sh
+++ b/scripts/check-inplace.sh
@@ -210,10 +210,9 @@ LOG="$HOME/Library/Logs/ParrotFlow-Dev.log"
 REPEATS="${PF_REPEATS:-1}"
 pass=0; total=0; refused=0; corrupted=0; skipped=0; wrongpath=0
 
-start_fixture
-# Close the window as well as the session. `open -na` starts a whole instance
-# per run, and without this every run leaves one behind — nine of them stacked
-# up in one sitting before it was noticed.
+# Closes the window as well as the session. `open -na` starts a whole instance
+# per run, and without this every run left one behind — nine of them stacked up
+# in one sitting before it was noticed.
 cleanup() {
   "$TMUX" kill-session -t "$SESSION" 2>/dev/null
   if [ "$VIEWPORT" = Terminal ]; then
@@ -237,6 +236,12 @@ cleanup() {
   return 0
 }
 trap cleanup EXIT
+
+# Armed before the fixture starts, not after. `start_fixture` can exit part
+# way through — it refuses a locked screen, and it refuses when Terminal will
+# not say which window it opened — and until this is set those exits left the
+# session and the window behind.
+start_fixture
 
 while IFS='|' read -r name id dictated line heard corrected expect literal want_log span; do
   [ -z "$name" ] && continue

--- a/scripts/check-inplace.sh
+++ b/scripts/check-inplace.sh
@@ -78,9 +78,16 @@ screen_is_locked() {
 owns_fixture() {
   local args
   read -ra args <<< "$(ps -o command= -p "$1" 2>/dev/null)"
-  local i
-  for i in "${!args[@]}"; do
-    [ "${args[$i]}" = "-t" ] && [ "${args[$((i + 1))]:-}" = "$SESSION" ] && return 0
+  # The whole launch, not just `-t <session>`. Any process can carry that pair
+  # for its own reasons, and this answer decides what gets killed — so it has
+  # to be the five arguments this script itself passed, in order.
+  local i n=${#args[@]}
+  for ((i = 0; i + 4 < n; i++)); do
+    [ "${args[$i]}" = "-e" ] \
+      && [ "${args[$((i + 1))]}" = "$TMUX" ] \
+      && [ "${args[$((i + 2))]}" = "attach" ] \
+      && [ "${args[$((i + 3))]}" = "-t" ] \
+      && [ "${args[$((i + 4))]}" = "$SESSION" ] && return 0
   done
   return 1
 }
@@ -129,9 +136,22 @@ start_fixture() {
       # again. tmux itself knows which tty its client is on, and a window's
       # tty is not something two windows can share — that is the identity
       # that closes it, the same way the pid's own argv closes it for Ghostty.
-      fixture_tty="$("$TMUX" list-clients -t "$SESSION" -F '#{client_tty}' 2>/dev/null | head -1)"
+      #
+      # Waited for, not read once. Attaching is asynchronous, and a single look
+      # a second after `open` can happen before the client is there. That left
+      # `fixture_tty` empty, so no window id was recorded, so cleanup closed
+      # nothing and the window stayed behind — the leak this was written to fix.
+      fixture_tty=""
+      for _ in $(seq 1 20); do
+        fixture_tty="$("$TMUX" list-clients -t "$SESSION" -F '#{client_tty}' 2>/dev/null | head -1)"
+        [ -n "$fixture_tty" ] && break
+        sleep 0.25
+      done
       after_windows="$(osascript -e 'tell application "Terminal" to id of every window' \
         2>/dev/null | tr -d ' ' | tr ',' '\n' | sort)"
+      if [ -z "$fixture_tty" ]; then
+        echo "  the $VIEWPORT fixture never attached; its window will be left open"
+      fi
       if [ -n "$fixture_tty" ]; then
         for wid in $(comm -13 <(echo "$before_windows") <(echo "$after_windows")); do
           wtty="$(osascript -e "tell application \"Terminal\" to tty of tab 1 of window id $wid" \

--- a/scripts/check-inplace.sh
+++ b/scripts/check-inplace.sh
@@ -26,7 +26,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TMUX="$(command -v tmux || echo /opt/homebrew/bin/tmux)"
 APP="/Applications/ParrotFlowDev.app"
 BIN="$APP/Contents/MacOS/ParrotFlow"
-SESSION="${PF_CHECK_SESSION:-pfcheck}"
+SESSION="${PF_CHECK_SESSION:-pfcheck-$$}"
 CLAUDE="$(command -v claude || echo "$HOME/.local/bin/claude")"
 SCRATCH="${TMPDIR:-/tmp}/pf-check-inplace"
 # Which terminal hosts the fixture. Terminal.app by default because it is on

--- a/scripts/check-inplace.sh
+++ b/scripts/check-inplace.sh
@@ -128,8 +128,15 @@ start_fixture() {
       ;;
   esac
   sleep 4
-  [ -n "${VIEWPORT_PID:-}" ] || VIEWPORT_PID="$(pgrep -n -i "$VIEWPORT" || true)"
-  [ -n "$VIEWPORT_PID" ] || { echo "could not find the $VIEWPORT window it opened"; exit 1; }
+  # Terminal.app is one process for every window, so the newest match is
+  # always the right one, and cleanup never kills it by pid anyway. Any other
+  # terminal has to have matched a pid that appeared after `open -na`: a
+  # name-wide fallback here could be someone's own window, and cleanup would
+  # kill it.
+  if [ "$VIEWPORT" = Terminal ]; then
+    [ -n "${VIEWPORT_PID:-}" ] || VIEWPORT_PID="$(pgrep -n -i "$VIEWPORT" || true)"
+  fi
+  [ -n "${VIEWPORT_PID:-}" ] || { echo "could not find the new $VIEWPORT window it opened"; exit 1; }
   echo "  viewport: $VIEWPORT pid $VIEWPORT_PID"
 }
 

--- a/scripts/check-inplace.sh
+++ b/scripts/check-inplace.sh
@@ -70,6 +70,15 @@ screen_is_locked() {
   ioreg -n Root -d1 -a 2>/dev/null | grep -q CGSSessionScreenIsLocked
 }
 
+# Whether pid $1's own command line has $SESSION as one whole argument, not
+# merely a substring. `grep -q "attach -t $SESSION"` treats $SESSION as a
+# regex and matches it as a substring of a longer token too — a session named
+# "pfcheck.1" then also matches "pfcheck-1-other", and cleanup could kill a
+# pid that only looked like ours.
+owns_fixture() {
+  ps -o command= -p "$1" 2>/dev/null | tr ' ' '\n' | grep -qxF -- "$SESSION"
+}
+
 start_fixture() {
   if screen_is_locked; then
     echo "the screen is locked — unlock it and run this again"
@@ -126,7 +135,7 @@ start_fixture() {
       # "attach -t $SESSION" in its own command line, so that is what is
       # checked, not just who is new.
       for pid in $(comm -13 <(echo "$before") <(pgrep -i "$VIEWPORT" | sort)); do
-        if ps -o command= -p "$pid" 2>/dev/null | grep -q -- "attach -t $SESSION"; then
+        if owns_fixture "$pid"; then
           VIEWPORT_PID="$pid"
           break
         fi
@@ -174,14 +183,19 @@ cleanup() {
   if [ "$VIEWPORT" = Terminal ]; then
     # Terminal.app is one process for every window you have open, so killing
     # the pid would take yours with it. Close the one window instead, found by
-    # the session name in its title.
+    # the session name in its title. Escaped for AppleScript: a quote in
+    # PF_CHECK_SESSION would otherwise break the string it sits inside, and
+    # the swallowed osascript error would leave the window open with no sign
+    # why.
+    local escaped="${SESSION//\\/\\\\}"
+    escaped="${escaped//\"/\\\"}"
     osascript -e "tell application \"Terminal\" to close (every window whose \
-      name contains \"$SESSION\")" >/dev/null 2>&1
+      name contains \"$escaped\")" >/dev/null 2>&1
   elif [ -n "${VIEWPORT_PID:-}" ]; then
     # The pid can have been recycled between launch and here. Checked again
     # right before the kill, not just once at launch — killing a pid we can no
     # longer attribute to this run is exactly the bug that got fixed above.
-    if ps -o command= -p "$VIEWPORT_PID" 2>/dev/null | grep -q -- "attach -t $SESSION"; then
+    if owns_fixture "$VIEWPORT_PID"; then
       kill "$VIEWPORT_PID" 2>/dev/null
     fi
   fi

--- a/scripts/check-inplace.sh
+++ b/scripts/check-inplace.sh
@@ -28,7 +28,6 @@ APP="/Applications/ParrotFlowDev.app"
 BIN="$APP/Contents/MacOS/ParrotFlow"
 SESSION="${PF_CHECK_SESSION:-pfcheck-$$}"
 CLAUDE="$(command -v claude || echo "$HOME/.local/bin/claude")"
-SCRATCH="${TMPDIR:-/tmp}/pf-check-inplace"
 # Which terminal hosts the fixture. Terminal.app by default because it is on
 # every Mac; the point of the switch is that "does in-place editing work in a
 # terminal" has a different answer per terminal, and the only way to know is to
@@ -75,6 +74,13 @@ screen_is_locked() {
 # some word anywhere in it — a process whose title or some other argument
 # happens to contain $SESSION would pass that test too, and this is what
 # cleanup trusts before killing something.
+# A value as it can be pasted inside an AppleScript double-quoted string.
+# Backslashes first, or the quotes escaped after would be escaped twice.
+as_literal() {
+  local v=${1//\\/\\\\}
+  printf '%s' "${v//\"/\\\"}"
+}
+
 owns_fixture() {
   local args
   read -ra args <<< "$(ps -o command= -p "$1" 2>/dev/null)"
@@ -113,7 +119,6 @@ start_fixture() {
     "$TMUX" capture-pane -pt "$SESSION" | grep -q 'auto mode\|for shortcuts' && break
     sleep 0.5
   done
-  mkdir -p "$SCRATCH"
   # A freshly opened window is frontmost without anyone having to click, which
   # is what lets this run unattended.
   #
@@ -124,41 +129,27 @@ start_fixture() {
   # PF_VIEWPORT=Ghostty did for as long as this only knew Terminal.app.
   case "$VIEWPORT" in
     Terminal)
-      # Terminal.app runs a `.command` file as its session.
-      printf '#!/bin/sh\nexec %s attach -t %s\n' "$TMUX" "$SESSION" > "$SCRATCH/attach.command"
-      chmod +x "$SCRATCH/attach.command"
-      before_windows="$(osascript -e 'tell application "Terminal" to id of every window' \
-        2>/dev/null | tr -d ' ' | tr ',' '\n' | sort)"
-      open -a "$VIEWPORT" "$SCRATCH/attach.command"
-      sleep 1
-      # A new window is not proof either: if a second window opens in the same
-      # second, for any reason, both are "new" and picking one is a guess
-      # again. tmux itself knows which tty its client is on, and a window's
-      # tty is not something two windows can share — that is the identity
-      # that closes it, the same way the pid's own argv closes it for Ghostty.
+      # `do script` opens the window and hands back the tab it started, so the
+      # window's id comes from the launch itself. Everything else here has been
+      # a way of working out afterwards which window was ours — a new-window
+      # diff, then the tmux client's tty — and each one had a case where it
+      # picked wrong or picked nothing and left the window open. There is
+      # nothing to work out if the launch says so.
       #
-      # Waited for, not read once. Attaching is asynchronous, and a single look
-      # a second after `open` can happen before the client is there. That left
-      # `fixture_tty` empty, so no window id was recorded, so cleanup closed
-      # nothing and the window stayed behind — the leak this was written to fix.
-      fixture_tty=""
-      for _ in $(seq 1 20); do
-        fixture_tty="$("$TMUX" list-clients -t "$SESSION" -F '#{client_tty}' 2>/dev/null | head -1)"
-        [ -n "$fixture_tty" ] && break
-        sleep 0.25
-      done
-      after_windows="$(osascript -e 'tell application "Terminal" to id of every window' \
-        2>/dev/null | tr -d ' ' | tr ',' '\n' | sort)"
-      if [ -z "$fixture_tty" ]; then
-        echo "  the $VIEWPORT fixture never attached; its window will be left open"
-      fi
-      if [ -n "$fixture_tty" ]; then
-        for wid in $(comm -13 <(echo "$before_windows") <(echo "$after_windows")); do
-          wtty="$(osascript -e "tell application \"Terminal\" to tty of tab 1 of window id $wid" \
-            2>/dev/null)"
-          [ "$wtty" = "$fixture_tty" ] && { TERMINAL_WINDOW_ID="$wid"; break; }
-        done
-      fi
+      # `delay` because the window is drawn before it is frontmost.
+      TERMINAL_WINDOW_ID="$(osascript <<APPLESCRIPT 2>/dev/null
+tell application "Terminal"
+  do script "exec $(as_literal "$TMUX") attach -t $(as_literal "$SESSION")"
+  delay 0.3
+  set wid to id of front window
+end tell
+return wid
+APPLESCRIPT
+)"
+      [[ "${TERMINAL_WINDOW_ID:-}" =~ ^[0-9]+$ ]] || {
+        echo "Terminal did not say which window it opened; not running blind"
+        exit 1
+      }
       ;;
     *)
       # Ghostty and friends take `-e`, and on macOS only through `open`:

--- a/scripts/check-inplace.sh
+++ b/scripts/check-inplace.sh
@@ -158,7 +158,15 @@ start_fixture
 # up in one sitting before it was noticed.
 cleanup() {
   "$TMUX" kill-session -t "$SESSION" 2>/dev/null
-  [ -n "${VIEWPORT_PID:-}" ] && [ "$VIEWPORT" != Terminal ] && kill "$VIEWPORT_PID" 2>/dev/null
+  if [ "$VIEWPORT" = Terminal ]; then
+    # Terminal.app is one process for every window you have open, so killing
+    # the pid would take yours with it. Close the one window instead, found by
+    # the session name in its title.
+    osascript -e "tell application \"Terminal\" to close (every window whose \
+      name contains \"$SESSION\")" >/dev/null 2>&1
+  elif [ -n "${VIEWPORT_PID:-}" ]; then
+    kill "$VIEWPORT_PID" 2>/dev/null
+  fi
   return 0
 }
 trap cleanup EXIT

--- a/scripts/check-inplace.sh
+++ b/scripts/check-inplace.sh
@@ -115,6 +115,12 @@ start_fixture() {
       printf '#!/bin/sh\nexec %s attach -t %s\n' "$TMUX" "$SESSION" > "$SCRATCH/attach.command"
       chmod +x "$SCRATCH/attach.command"
       open -a "$VIEWPORT" "$SCRATCH/attach.command"
+      sleep 1
+      # The window this run opened, by id — not any window whose title merely
+      # contains the session name. A freshly opened window is frontmost
+      # without anyone having to click, so the front window right now is
+      # this run's and nothing else's.
+      TERMINAL_WINDOW_ID="$(osascript -e 'tell application "Terminal" to id of front window' 2>/dev/null)"
       ;;
     *)
       # Ghostty and friends take `-e`, and on macOS only through `open`:
@@ -182,15 +188,14 @@ cleanup() {
   "$TMUX" kill-session -t "$SESSION" 2>/dev/null
   if [ "$VIEWPORT" = Terminal ]; then
     # Terminal.app is one process for every window you have open, so killing
-    # the pid would take yours with it. Close the one window instead, found by
-    # the session name in its title. Escaped for AppleScript: a quote in
-    # PF_CHECK_SESSION would otherwise break the string it sits inside, and
-    # the swallowed osascript error would leave the window open with no sign
-    # why.
-    local escaped="${SESSION//\\/\\\\}"
-    escaped="${escaped//\"/\\\"}"
-    osascript -e "tell application \"Terminal\" to close (every window whose \
-      name contains \"$escaped\")" >/dev/null 2>&1
+    # the pid would take yours with it. Close the one window instead — by id,
+    # captured when it was opened, never by matching its title: a title
+    # substring can match a window this run did not open, and PF_CHECK_SESSION
+    # is not guaranteed unique the way the default is.
+    if [[ "${TERMINAL_WINDOW_ID:-}" =~ ^[0-9]+$ ]]; then
+      osascript -e "tell application \"Terminal\" to close window id $TERMINAL_WINDOW_ID" \
+        >/dev/null 2>&1
+    fi
   elif [ -n "${VIEWPORT_PID:-}" ]; then
     # The pid can have been recycled between launch and here. Checked again
     # right before the kill, not just once at launch — killing a pid we can no

--- a/scripts/check-inplace.sh
+++ b/scripts/check-inplace.sh
@@ -124,12 +124,21 @@ start_fixture() {
         2>/dev/null | tr -d ' ' | tr ',' '\n' | sort)"
       open -a "$VIEWPORT" "$SCRATCH/attach.command"
       sleep 1
-      # The window that appeared, not whichever is frontmost a second later:
-      # "frontmost" is whatever the window server settled on, and Terminal can
-      # keep an existing window in front of a new one that opened behind it.
+      # A new window is not proof either: if a second window opens in the same
+      # second, for any reason, both are "new" and picking one is a guess
+      # again. tmux itself knows which tty its client is on, and a window's
+      # tty is not something two windows can share — that is the identity
+      # that closes it, the same way the pid's own argv closes it for Ghostty.
+      fixture_tty="$("$TMUX" list-clients -t "$SESSION" -F '#{client_tty}' 2>/dev/null | head -1)"
       after_windows="$(osascript -e 'tell application "Terminal" to id of every window' \
         2>/dev/null | tr -d ' ' | tr ',' '\n' | sort)"
-      TERMINAL_WINDOW_ID="$(comm -13 <(echo "$before_windows") <(echo "$after_windows") | head -1)"
+      if [ -n "$fixture_tty" ]; then
+        for wid in $(comm -13 <(echo "$before_windows") <(echo "$after_windows")); do
+          wtty="$(osascript -e "tell application \"Terminal\" to tty of tab 1 of window id $wid" \
+            2>/dev/null)"
+          [ "$wtty" = "$fixture_tty" ] && { TERMINAL_WINDOW_ID="$wid"; break; }
+        done
+      fi
       ;;
     *)
       # Ghostty and friends take `-e`, and on macOS only through `open`:

--- a/scripts/check-inplace.sh
+++ b/scripts/check-inplace.sh
@@ -136,12 +136,13 @@ start_fixture() {
       # picked wrong or picked nothing and left the window open. There is
       # nothing to work out if the launch says so.
       #
-      # `delay` because the window is drawn before it is frontmost.
+      # The window the returned tab is in, not the front one. `front window`
+      # is global state read a moment later, so anything that comes forward in
+      # between answers instead — and cleanup would close that.
       TERMINAL_WINDOW_ID="$(osascript <<APPLESCRIPT 2>/dev/null
 tell application "Terminal"
-  do script "exec $(as_literal "$TMUX") attach -t $(as_literal "$SESSION")"
-  delay 0.3
-  set wid to id of front window
+  set theTab to do script "exec $(as_literal "$TMUX") attach -t $(as_literal "$SESSION")"
+  set wid to id of (first window whose tabs contains theTab)
 end tell
 return wid
 APPLESCRIPT

--- a/scripts/check-inplace.sh
+++ b/scripts/check-inplace.sh
@@ -119,18 +119,24 @@ start_fixture() {
       # to write. Measured: `list-clients` says 0 with the quotes and 1 without.
       open -na "$VIEWPORT.app" --args -e "$TMUX" attach -t "$SESSION"
       sleep 3
-      # The pid that appeared, not the newest one matching the name. Ghostty
-      # runs several processes under one name, so `pgrep -n` picks whichever
-      # started last — which is not necessarily the one holding this window,
-      # and focusing the wrong one leaves every case reading a window that is
-      # not the fixture.
-      VIEWPORT_PID="$(comm -13 <(echo "$before") <(pgrep -i "$VIEWPORT" | sort) | head -1)"
+      # A pid that appeared in this window is not proof it is ours — anything
+      # else that launched the same app in the same three seconds passes that
+      # test too, and cleanup would then kill somebody's own terminal while
+      # the fixture kept running. Only the process we just started carries
+      # "attach -t $SESSION" in its own command line, so that is what is
+      # checked, not just who is new.
+      for pid in $(comm -13 <(echo "$before") <(pgrep -i "$VIEWPORT" | sort)); do
+        if ps -o command= -p "$pid" 2>/dev/null | grep -q -- "attach -t $SESSION"; then
+          VIEWPORT_PID="$pid"
+          break
+        fi
+      done
       ;;
   esac
   sleep 4
   # Terminal.app is one process for every window, so the newest match is
   # always the right one, and cleanup never kills it by pid anyway. Any other
-  # terminal has to have matched a pid that appeared after `open -na`: a
+  # terminal has to have matched its own launch command line above: a
   # name-wide fallback here could be someone's own window, and cleanup would
   # kill it.
   if [ "$VIEWPORT" = Terminal ]; then
@@ -172,7 +178,12 @@ cleanup() {
     osascript -e "tell application \"Terminal\" to close (every window whose \
       name contains \"$SESSION\")" >/dev/null 2>&1
   elif [ -n "${VIEWPORT_PID:-}" ]; then
-    kill "$VIEWPORT_PID" 2>/dev/null
+    # The pid can have been recycled between launch and here. Checked again
+    # right before the kill, not just once at launch — killing a pid we can no
+    # longer attribute to this run is exactly the bug that got fixed above.
+    if ps -o command= -p "$VIEWPORT_PID" 2>/dev/null | grep -q -- "attach -t $SESSION"; then
+      kill "$VIEWPORT_PID" 2>/dev/null
+    fi
   fi
   return 0
 }

--- a/scripts/check-inplace.sh
+++ b/scripts/check-inplace.sh
@@ -62,7 +62,20 @@ clear_input() {
   return 1
 }
 
+# A locked screen answers every accessibility read as `loginwindow` with an
+# empty value. That is indistinguishable from a window refusing the edit, so
+# without this the whole set scores 0/8 and blames the app. caffeinate keeps a
+# screen awake; it cannot wake one that has already locked.
+screen_is_locked() {
+  ioreg -n Root -d1 -a 2>/dev/null | grep -q CGSSessionScreenIsLocked
+}
+
 start_fixture() {
+  if screen_is_locked; then
+    echo "the screen is locked — unlock it and run this again"
+    echo "  (every case would read an empty window and score 0/8)"
+    exit 1
+  fi
   # The display must stay awake for the whole run. This drives a real window
   # and reads it back through the accessibility API, and a locked screen
   # answers as `loginwindow` with an empty value — which reads exactly like a


### PR DESCRIPTION
This makes `scripts/check-inplace.sh` work in any terminal ParrotFlow can
drive, not just Terminal.app, and closes several ways it could leak a window
or kill one it did not open. It also gives `Surface.clearedBox` a second
strategy for a stalled clear, and stops it from logging what a stalled clear
left in the box.

Editing at a bare shell was attempted in this PR and is not in it. A
terminal does not report which row has the keyboard, so clearing one by
guessing which row is current is a guess, and a wrong guess deletes typed
input. Six rounds of review found six different ways that guess could be
wrong; the seventh confirmed no version of the guess closes it. It was
dropped rather than shipped with a guess in it. Editing at a bare shell
still refuses, exactly as it did before this PR.

Nothing here changes what a user's own dictation or correction does. The
changed surface is the dev-only harness, and `clearedBox`'s retry strategy
for the TUI-drawn input boxes it already supported (Claude Code and similar
tools) — reviewers should check those two areas, not bare-shell behavior,
since there isn't any.

<details>
<summary>Verification</summary>

- `scripts/check-inplace.sh`: Ghostty 8/8, Terminal.app 8/8, with no leaked
  or killed windows — a clean run starts and ends at zero extra processes.
- `swift build -c release` passes.

</details>

<details>
<summary>The harness had four separate silent faults driving Ghostty</summary>

- `open -e` needs the command as separate arguments. Quoted, `tmux
  list-clients` reports 0 attached clients. Unquoted, 1.
- `pgrep -n` picked the wrong Ghostty process.
- `set frontmost` returns before the window comes forward, so the result is
  now read back to force it.
- Nothing closed the window `open -na` opened, so instances stacked up: nine
  in one sitting. It is now closed by id, in both Ghostty and Terminal.app.

</details>

<details>
<summary>A locked screen used to score the same as a refused edit</summary>

A locked screen answers every accessibility read as `loginwindow` with an
empty value. That is indistinguishable from a window that refused the edit,
so the run scored 0/8 and looked like an app bug. This cost four rounds of
diagnosis. `caffeinate` keeps the screen awake, but it cannot wake one that
has already locked, so the run now refuses to start on a locked screen
instead of scoring it.

</details>

<details>
<summary>The harness could act on a window or process it never opened</summary>

Several rounds of review, each closing one gap and finding the next:

- A pid that merely appeared during the launch window was not proof it was
  ours — anything else starting the same app in that window passed the same
  test, and cleanup would kill it while the fixture kept running.
- The next check for that, a regex/substring match on the session name in a
  candidate's command line, could still match a longer or differently-shaped
  name that merely contained it.
- The one after that required an exact match, but anywhere in the command
  line — not specifically the argument tmux itself reads. It now requires
  `$SESSION` to be the exact argument immediately after `-t`.
- Terminal.app's fixture window was found by title, first by substring, then
  escaped for AppleScript safety, but a title match still could not
  distinguish the fixture from an unrelated window sharing that text. It is
  now found by id: the window that appeared, diffed before and after
  opening, the same way the Ghostty pid is found — not whichever window is
  frontmost a moment later, since Terminal can leave an existing window in
  front of one that opened behind it.
- `SESSION` itself defaults to `pfcheck-$$`, the script's own pid, so the
  default can no longer collide between two runs. `PF_CHECK_SESSION` still
  overrides it.

</details>

<details>
<summary>Not a proven fix: the Ctrl-E/Ctrl-U fallback</summary>

`Surface.clearedBox` sent Ctrl-A then Ctrl-K, up to twelve times, then gave
up. Three times on 2026-08-27, against a live Claude Code session, that
refusal fired and the edit fell back to the clipboard.

Two identical reads in a row mean the keys are not landing where that pair
assumes, so it now kills the line backwards (Ctrl-E then Ctrl-U) instead of
repeating the same two keys, and gives up sooner when both fail.

The harness scores 8/8 in both Ghostty and Terminal.app, with or without this
change. It has never reproduced the failure. This is a second chance, not a
confirmed fix.

The other change here is real: the refusal now logs how much the box still
holds, not what it holds — a stalled clear used to log up to 80 characters of
the input line into the ParrotFlow log and the macOS unified log, and that
line can be a command with a password or a token in it. Before, it logged
nothing at all, so the three failures left nothing to diagnose. The next one
will be readable from the log alone.

</details>

<details>
<summary>Why bare-shell editing is not in this PR</summary>

A drawn-box terminal (Claude Code, most TUIs) is unaffected by any of this:
the box is found by the rules drawn around it, and the read already knows
exactly where it is before anything is cleared.

A bare shell has no such rules. The only signal available from the
accessibility API is a screen full of text; nothing in it says which row is
currently focused. Every attempt to answer that from the screen alone failed
the same way, with different scenery each time:

- Matching a row's text against what was read proved the row still said the
  same thing, not that it was still the one receiving keystrokes — a decoy
  row elsewhere with the same text could pass.
- Requiring a recognized prompt glyph closed the decoy case, but an
  unrecognized glyph left in the text meant a clear could never read back as
  empty, and the retype would have typed the glyph itself into the line.
- Reading the identified row back by number instead of rescanning closed
  that, but not the case where the line was submitted between the read and
  the clear: the old row still shows the same, now-stale text, while a new
  prompt below it is what is actually focused.
- Checking that the row was still the current, recognized-glyph prompt on
  every iteration closed that — until the new prompt itself used a glyph
  outside the recognized set, in which case the scan for "the current
  prompt" quietly fell back to the old, stale row again.

Each fix closed one path and opened a variant of the same question: is this
row the one with the keyboard. Accessibility never answers that; it only
ever answers what a row currently displays. Six review rounds convinced us
this is a property of the API, not a missing guard, so bare-shell editing
was removed rather than shipped on a seventh guess. It refuses exactly as it
did before this PR, with nothing typed and nothing cleared.

</details>
