### PR TITLE
fix: a word with a possessive is no longer overwritten without asking

### DIFF
--- a/Sources/ParrotFlow/Vocabulary.swift
+++ b/Sources/ParrotFlow/Vocabulary.swift
@@ -484,17 +484,33 @@ actor Vocabulary {
     /// One shape can still fool it: a term shorter than a contraction's stem,
     /// where dropping a character helps the length ratio instead of hurting it.
     /// That needs a two-letter term, and there is none.
+    ///
+    /// The auto-apply path reaches this far less often since `dropsPossessive`
+    /// sends that pair to the judge. It is still what writes the reading the
+    /// judge is offered, which is where the possessive now has to survive.
     static func inflected(_ term: String, like heard: String) -> String {
-        let trimmed = heard.trimmingCharacters(in: CharacterSet.alphanumerics.inverted
+        guard let (stem, suffix) = possessive(in: heard), !stem.isEmpty,
+              gluedSimilarity(stem, term) >= gluedSimilarity(stem + suffix, term)
+        else { return term }
+        return term + suffix
+    }
+
+    /// The trailing `'s` a word carries, and the stem under it — lowercased,
+    /// with surrounding punctuation dropped and the apostrophe kept.
+    ///
+    /// Both apostrophes. The recogniser writes the typographic one and a
+    /// keyboard writes the straight one, and a decoded token can be either.
+    ///
+    /// This says nothing about whether the `'s` is a possessive. `it's` and
+    /// `let's` come back from here too; what separates them is the comparison
+    /// in `inflected` and, for the gate, the term.
+    static func possessive(in word: String) -> (stem: String, suffix: String)? {
+        let trimmed = word.trimmingCharacters(in: CharacterSet.alphanumerics.inverted
             .subtracting(CharacterSet(charactersIn: "'\u{2019}s")))
         let lower = trimmed.lowercased()
         guard let suffix = ["'s", "\u{2019}s"].first(where: { lower.hasSuffix($0) })
-        else { return term }
-        let stem = String(lower.dropLast(suffix.count))
-        guard !stem.isEmpty,
-              gluedSimilarity(stem, term) >= gluedSimilarity(lower, term)
-        else { return term }
-        return term + suffix
+        else { return nil }
+        return (String(lower.dropLast(suffix.count)), suffix)
     }
 
     /// The punctuation a replaced word carried, so the sentence keeps its end.
@@ -514,7 +530,11 @@ actor Vocabulary {
 
     /// Whether a proposal is safe to write without asking anything.
     ///
-    /// The first rule is the spell-check gate, measured at 38/38 on declines
+    /// One rule is about the sentence and comes first, because no word list
+    /// can see it: a possessive the heard text carries and the term does not
+    /// — see `dropsPossessive`.
+    ///
+    /// The rest is the spell-check gate, measured at 38/38 on declines
     /// and 0.00s: never overwrite a real word. Used here as a router rather
     /// than a filter — a real word is not refused, it is passed to the judge,
     /// which is the only thing that can read the sentence.
@@ -559,7 +579,35 @@ actor Vocabulary {
         guard termScore > heardScore else { return false }
         let bare = String(letters)
         guard !bare.isEmpty else { return false }
+        guard !dropsPossessive(heard: heard, term: term) else { return false }
         return unseenWord(bare)
+    }
+
+    /// Whether writing the term here would take away a possessive the speaker
+    /// said.
+    ///
+    /// Asked before the word test, because the word test cannot see it. `bare`
+    /// is letters only, so `Mirza's` is looked up as `Mirzas` — a form neither
+    /// list has ever seen, where `Mirza` itself is known to one of them. The
+    /// apostrophe walks the proposal straight past both lists: measured on the
+    /// shipped binary, `--word-gate Frederick` says `judge` and
+    /// `--word-gate "Frederick's"` said `auto-apply`.
+    ///
+    /// A rule and not a threshold. "Mirza's thoughts" is not "Mirza thoughts";
+    /// dropping a possessive changes what the sentence says, in every sentence,
+    /// so there is nothing here to tune and nothing to drift. What it does is
+    /// route: the proposal is not refused, it goes to the judge, which is the
+    /// only thing that reads the sentence.
+    ///
+    /// One direction only. `Matthew at` -> `Matthieu's` is the same class the
+    /// other way round — the term carries the possessive and the decoded span
+    /// does not — and that correction is right. Nothing here fires on it.
+    ///
+    /// A contraction reaches the judge too, since `it's` also ends in `'s`.
+    /// That is the safe direction and it is nearly free: a contraction is a
+    /// real word, so `unseenWord` was already sending it there.
+    static func dropsPossessive(heard: String, term: String) -> Bool {
+        possessive(in: heard) != nil && possessive(in: term) == nil
     }
 
     /// The word half of the gate: both lists have to say they have never seen

--- a/Sources/ParrotFlow/WordGateCommand.swift
+++ b/Sources/ParrotFlow/WordGateCommand.swift
@@ -14,14 +14,26 @@ import Foundation
 /// `scripts/check-word-gate.sh` scores, so the set runs against the shipped
 /// lists rather than a copy of them.
 ///
-/// No audio, no model, no scores. The gate's other conditions — the term must
-/// beat what was heard, a split compound is matched glued — are about one
-/// proposal; these two are about one word.
+/// Name the term and the whole gate answers instead, about that pair:
+///
+///     ParrotFlow --word-gate "Mirza's" Mirza
+///     possessive dropped
+///     gate       judge
+///
+/// One condition of the gate is not about a word at all. A possessive the
+/// heard text carries and the term does not is a question about the sentence,
+/// so it needs both halves of the proposal — see `Vocabulary.dropsPossessive`.
+///
+/// No audio and no model either way. The pair form fixes the scores so the
+/// term wins, because the acoustic half is not what it is asking; a proposal
+/// whose term loses on sound never reaches these conditions.
 enum WordGateCommand {
-    static func run(word: String) -> Int32 {
+    static func run(word: String, term: String? = nil) -> Int32 {
+        if let term, !term.isEmpty { return pair(heard: word, term: term) }
+
         let letters = String(word.filter { $0.isLetter })
         guard !letters.isEmpty else {
-            print("usage: ParrotFlow --word-gate <word>")
+            print("usage: ParrotFlow --word-gate <word> [term]")
             return 2
         }
         // The decision comes from the shipped test. The two verdicts above it
@@ -36,6 +48,21 @@ enum WordGateCommand {
         case .none:        print("wordpiece  unavailable")
         }
         print("gate       \(Vocabulary.unseenWord(letters) ? "auto-apply" : "judge")")
+        return 0
+    }
+
+    /// The gate on one proposal, from the shipped `Vocabulary.autoApplies`.
+    ///
+    /// The two lists are not printed here. They are not consulted at all on a
+    /// span the gate matches glued — `"Matthew at"` — so printing them would
+    /// report a lookup that decided nothing.
+    private static func pair(heard: String, term: String) -> Int32 {
+        let drops = Vocabulary.dropsPossessive(heard: heard, term: term)
+        print("possessive \(drops ? "dropped" : "kept")")
+        let applies = Vocabulary.autoApplies(
+            heard: heard, term: term, heardScore: -1, termScore: 0
+        )
+        print("gate       \(applies ? "auto-apply" : "judge")")
         return 0
     }
 }

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -215,10 +215,14 @@ if let index = arguments.firstIndex(of: "--inflected") {
 
 if let index = arguments.firstIndex(of: "--word-gate") {
     guard arguments.indices.contains(index + 1) else {
-        print("usage: ParrotFlow --word-gate <word>")
+        print("usage: ParrotFlow --word-gate <word> [term]")
         exit(2)
     }
-    exit(WordGateCommand.run(word: arguments[index + 1]))
+    // The term is optional, and the next argument is only the term when it is
+    // not another flag.
+    let term = arguments.indices.contains(index + 2)
+        && !arguments[index + 2].hasPrefix("--") ? arguments[index + 2] : nil
+    exit(WordGateCommand.run(word: arguments[index + 1], term: term))
 }
 
 if let index = arguments.firstIndex(of: "--suggest") {

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -385,7 +385,7 @@ to a built-in stage or to the router have nowhere else to be and stay in
 | Where | Sets |
 |---|---|
 | `examples/transforms/<name>/` | `code_identifiers` (78), `dotted` (84), `punctuation` (57), `grammar` (17), `email` (26), `repetitions` (60), `self_correction` (89) |
-| `tests/` | `spelling` (62), `french` (45), `numbers` (97), `routing` (45), `wake` (25), `split` (14), `generic`, `dates`, `inplace`, `pipeline`, `replacement`, `word-gate` (19) |
+| `tests/` | `spelling` (62), `french` (45), `numbers` (97), `routing` (45), `wake` (25), `split` (14), `generic`, `dates`, `inplace`, `pipeline`, `replacement`, `word-gate` (25) |
 
 Each has a runner in `scripts/`; the transform sets can also be scored with
 `--eval`. `examples/transforms/` is copied whole into

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -101,7 +101,7 @@ $PF --numbers "two hundred forty three" [--lang fr]
 $PF --normalize "<text>"
 $PF --dates "<instruction>" "<text>" [--locale FR] [--lang en,fr]
 $PF --inflected <term> <heard>
-$PF --word-gate <word>
+$PF --word-gate <word> [term]
 $PF --verdicts <count> "<reply>"
 $PF --teaching "<sentence>" <word>
 $PF --suggest "<sentence>" [--lang fr]
@@ -120,7 +120,13 @@ to say they have never seen the word: `NSSpellChecker`, which has no first
 names in it, and the whole-word half of a tokenizer vocabulary
 (`data/wordpiece.txt`), which has no rare compounds in it. Both verdicts are
 printed, because a word reaches `judge` from either side. No model runs — it is
-a set lookup. `scripts/check-word-gate.sh` scores it against
+a set lookup.
+
+Name the term as well and the whole gate answers about that pair —
+`--word-gate "Mirza's" Mirza` prints `possessive dropped` and `judge`. One
+condition is not about a word at all: a `'s` the heard text carries and the
+term does not would be taken out of the sentence, so it goes to the judge.
+`scripts/check-word-gate.sh` scores both forms against
 `tests/word-gate-cases.yaml`.
 
 `--verdicts` asks what the name judge reads out of a model's reply —

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -319,9 +319,19 @@ Some words are missed by both and still auto-apply: `webhook`, `worktree`,
 `kubernetes`, and the first names `Priya` and `Siobhan`. Two lists remove most
 of that class, not all of it.
 
+One condition is not a list. Both lists are asked about letters, so `Mirza's`
+is looked up as `Mirzas` — a form neither has seen, where `Mirza` itself is
+known to one of them. So a `'s` the heard text carries and the term does not
+is refused before the lists are asked, and the proposal goes to the judge.
+Dropping a possessive changes what the sentence says — "Mirza's thoughts" is
+not "Mirza thoughts" — and only something that reads the sentence can decide
+it. The other direction is untouched: `Matthew at` -> `Matthieu's` is a term
+carrying a possessive the decoded span does not, and that correction is right.
+
 If the list cannot be read the gate stops auto-applying entirely and every
 proposal goes to the judge. `--word-gate <word>` prints both verdicts and the
-decision; `scripts/check-word-gate.sh` scores them.
+decision, and `--word-gate <word> <term>` prints the possessive verdict and the
+decision for that pair; `scripts/check-word-gate.sh` scores them.
 
 Every exchange is written to `trace.jsonl` under the stage's variables, so a
 verdict can be replayed rather than guessed at.

--- a/scripts/check-word-gate.sh
+++ b/scripts/check-word-gate.sh
@@ -61,6 +61,32 @@ same() { [ -z "$1" ] || [ "$1" = "$2" ]; }
 
 pass=0; total=0; overwrote=0
 
+# Read once into a file, and stop if the read failed. Piped straight into the
+# loop, a set that could not be parsed halfway through would end the loop early
+# and the run would report a clean score over the cases it had reached.
+CASES="$CONFIG/cases"
+if ! python3 -c '
+import sys, yaml
+# A key that is absent and a key written `word:` with nothing after it both
+# come out empty, so the shape check below sees them the same way. Without
+# this, YAML reads the second as None and str() makes it the word "None".
+#
+# Anything that is not text is a broken case and not a value to coerce.
+# `word: [Frederick]` would arrive as "[\x27Frederick\x27]" and be asked about.
+KEYS = ("word", "term", "spell", "wordpiece", "possessive", "gate")
+for number, case in enumerate(yaml.safe_load(open(sys.argv[1]))["cases"], 1):
+    fields = []
+    for key in KEYS:
+        value = case.get(key)
+        if value is not None and not isinstance(value, str):
+            sys.exit("case %d: %s is %r, which is not text" % (number, key, value))
+        fields.append("" if value is None else value)
+    print("\x1f".join(fields))
+' "$ROOT/tests/word-gate-cases.yaml" > "$CASES"; then
+  echo "  ✗ tests/word-gate-cases.yaml could not be read"
+  exit 1
+fi
+
 # Unit separator, not a tab. A tab is whitespace, so bash collapses two of
 # them into one and a case with no `term` arrives with its fields shifted.
 while IFS=$'\x1f' read -r word term spell wordpiece possessive gate; do
@@ -128,16 +154,7 @@ while IFS=$'\x1f' read -r word term spell wordpiece possessive gate; do
   fi
   printf '  ✗ %-12s got   %s\n' "$word" "$got_line"
   printf '    %-12s want  %s\n' "" "$want_line"
-done < <(python3 -c '
-import sys, yaml
-# A key that is absent and a key written `word:` with nothing after it both
-# come out empty, so the shape check above sees them the same way. Without
-# this, YAML reads the second as None and str() makes it the word "None".
-for case in yaml.safe_load(open(sys.argv[1]))["cases"]:
-    fields = [case.get(key) for key in
-              ("word", "term", "spell", "wordpiece", "possessive", "gate")]
-    print("\x1f".join("" if value is None else str(value) for value in fields))
-' "$ROOT/tests/word-gate-cases.yaml")
+done < "$CASES"
 
 echo
 # A set that read no cases is not a passing run.

--- a/scripts/check-word-gate.sh
+++ b/scripts/check-word-gate.sh
@@ -54,7 +54,9 @@ verdicts() {
 field() { printf '%s\n' "$1" | awk -v k="$2" '$1 == k { print $2 }'; }
 
 # A verdict the case does not name is not asked for. A word case names no
-# `possessive`, a pair case names neither list.
+# `possessive`, a pair case names neither list. Which verdicts a case has to
+# name is checked separately, at the top of the loop — read as "not asked",
+# an empty expectation would also let a case that names nothing pass.
 same() { [ -z "$1" ] || [ "$1" = "$2" ]; }
 
 pass=0; total=0; overwrote=0
@@ -64,6 +66,23 @@ pass=0; total=0; overwrote=0
 while IFS=$'\x1f' read -r word term spell wordpiece possessive gate; do
   [ -z "$word" ] && continue
   total=$((total + 1))
+
+  # The shape of the case, before its answer. A case that leaves out a verdict
+  # its shape needs is a broken case and not a passing one — `same` would read
+  # the gap as "not asked" and the binary printing nothing there would agree.
+  missing=""
+  [ -z "$gate" ] && missing="$missing gate"
+  if [ -n "$term" ]; then
+    [ -z "$possessive" ] && missing="$missing possessive"
+  else
+    [ -z "$spell" ] && missing="$missing spell"
+    [ -z "$wordpiece" ] && missing="$missing wordpiece"
+  fi
+  if [ -n "$missing" ]; then
+    printf '  ✗ %-12s the case names no%s\n' "$word" "$missing"
+    continue
+  fi
+
   # Asked twice when the first answer is wrong, and only then. NSSpellChecker
   # is a service that times out, a timeout is indistinguishable from "known
   # word", and `isRealWord` caches per process — so a second process is a
@@ -76,11 +95,15 @@ while IFS=$'\x1f' read -r word term spell wordpiece possessive gate; do
     got_piece="$(field "$out" wordpiece)"
     got_poss="$(field "$out" possessive)"
     got_gate="$(field "$out" gate)"
+    ok=0
     same "$spell" "$got_spell" && same "$wordpiece" "$got_piece" \
-      && same "$possessive" "$got_poss" && same "$gate" "$got_gate" && break
+      && same "$possessive" "$got_poss" && same "$gate" "$got_gate" && ok=1
+    [ "$ok" = 1 ] && break
   done
 
-  # What this case was about, for the report: the two lists, or the pair.
+  # What this case was about, for the report: the two lists, or the pair. The
+  # verdict above is what decides — a case may name a field this does not
+  # print, and it is still checked.
   if [ -n "$term" ]; then
     got_line="$(printf 'term %-12s possessive %-9s %s' "$term" "$got_poss" "$got_gate")"
     want_line="$(printf 'term %-12s possessive %-9s %s' "$term" "$possessive" "$gate")"
@@ -89,7 +112,7 @@ while IFS=$'\x1f' read -r word term spell wordpiece possessive gate; do
     want_line="$(printf 'spell %-11s wordpiece %-11s %s' "$spell" "$wordpiece" "$gate")"
   fi
 
-  if [ "$got_line" = "$want_line" ]; then
+  if [ "$ok" = 1 ]; then
     pass=$((pass + 1))
     printf '  ✓ %-12s %s\n' "$word" "$got_line"
     continue

--- a/scripts/check-word-gate.sh
+++ b/scripts/check-word-gate.sh
@@ -130,9 +130,13 @@ while IFS=$'\x1f' read -r word term spell wordpiece possessive gate; do
   printf '    %-12s want  %s\n' "" "$want_line"
 done < <(python3 -c '
 import sys, yaml
+# A key that is absent and a key written `word:` with nothing after it both
+# come out empty, so the shape check above sees them the same way. Without
+# this, YAML reads the second as None and str() makes it the word "None".
 for case in yaml.safe_load(open(sys.argv[1]))["cases"]:
-    print("\x1f".join(str(case.get(key, "")) for key in
-                    ("word", "term", "spell", "wordpiece", "possessive", "gate")))
+    fields = [case.get(key) for key in
+              ("word", "term", "spell", "wordpiece", "possessive", "gate")]
+    print("\x1f".join("" if value is None else str(value) for value in fields))
 ' "$ROOT/tests/word-gate-cases.yaml")
 
 echo

--- a/scripts/check-word-gate.sh
+++ b/scripts/check-word-gate.sh
@@ -1,17 +1,22 @@
 #!/usr/bin/env bash
-# Scores the auto-apply gate's two word lists against tests/word-gate-cases.yaml.
+# Scores the auto-apply gate against tests/word-gate-cases.yaml.
 #
 #   scripts/check-word-gate.sh
 #
-# The question is which words a vocabulary term may overwrite with nothing
-# reading the sentence. `Vocabulary.autoApplies` asks two lists and needs both
-# to say "unknown": NSSpellChecker, which has no first names in it, and the
-# whole-word half of a tokenizer vocabulary, which has no rare compounds in it.
-# Either one alone overwrites a whole class of ordinary word.
+# The question is what a vocabulary term may overwrite with nothing reading the
+# sentence. `Vocabulary.autoApplies` asks two word lists and needs both to say
+# "unknown": NSSpellChecker, which has no first names in it, and the whole-word
+# half of a tokenizer vocabulary, which has no rare compounds in it. Either one
+# alone overwrites a whole class of ordinary word.
 #
 # Both verdicts are checked, not only the decision. A word reaches `judge` from
 # either side, so a set that read the decision alone would pass with one half
 # broken — `Chloé` in particular, where the accent is the thing under test.
+#
+# A case with a `term` asks the whole gate about that pair instead, and checks
+# the `possessive` verdict beside the decision. Same reason: `Matthew at`
+# reaches `judge` from the glued-compound branch whatever the possessive rule
+# says, so the decision alone would not show the rule firing on the wrong side.
 #
 # The last block is the fail-open case, and it is the reason the lookup answers
 # three things rather than two. With the list missing, `Versal` must stop
@@ -35,16 +40,28 @@ CONFIG="$(mktemp -d -t parrotflow-word-gate)"
 trap 'rm -rf "$CONFIG"' EXIT
 export PARROTFLOW_CONFIG_DIR="$CONFIG"
 
-# `<key> <value>` lines, everything the binary logs dropped.
+# `<key> <value>` lines, everything the binary logs dropped. The term is
+# passed only when the case names one — an empty second argument would be one
+# argument too many for a set that is asking about a word.
 verdicts() {
-  "$BIN" --word-gate "$1" 2>/dev/null | awk '$1 ~ /^(spell|wordpiece|gate)$/ { print $1, $2 }'
+  if [ -n "${2:-}" ]; then
+    "$BIN" --word-gate "$1" "$2" 2>/dev/null
+  else
+    "$BIN" --word-gate "$1" 2>/dev/null
+  fi | awk '$1 ~ /^(spell|wordpiece|possessive|gate)$/ { print $1, $2 }'
 }
 
 field() { printf '%s\n' "$1" | awk -v k="$2" '$1 == k { print $2 }'; }
 
+# A verdict the case does not name is not asked for. A word case names no
+# `possessive`, a pair case names neither list.
+same() { [ -z "$1" ] || [ "$1" = "$2" ]; }
+
 pass=0; total=0; overwrote=0
 
-while IFS=$'\t' read -r word spell wordpiece gate; do
+# Unit separator, not a tab. A tab is whitespace, so bash collapses two of
+# them into one and a case with no `term` arrives with its fields shifted.
+while IFS=$'\x1f' read -r word term spell wordpiece possessive gate; do
   [ -z "$word" ] && continue
   total=$((total + 1))
   # Asked twice when the first answer is wrong, and only then. NSSpellChecker
@@ -53,23 +70,28 @@ while IFS=$'\t' read -r word spell wordpiece gate; do
   # second sample. Seen once while writing this: `Versal` came back `known`
   # under load, then `unknown` ten times in a row. A real regression fails
   # both times; nothing here is retried until it passes.
-  out="$(verdicts "$word")"
-  got_spell="$(field "$out" spell)"
-  got_piece="$(field "$out" wordpiece)"
-  got_gate="$(field "$out" gate)"
-  if [ "$got_spell" != "$spell" ] || [ "$got_piece" != "$wordpiece" ] \
-     || [ "$got_gate" != "$gate" ]; then
-    out="$(verdicts "$word")"
+  for _ in 1 2; do
+    out="$(verdicts "$word" "$term")"
     got_spell="$(field "$out" spell)"
     got_piece="$(field "$out" wordpiece)"
+    got_poss="$(field "$out" possessive)"
     got_gate="$(field "$out" gate)"
+    same "$spell" "$got_spell" && same "$wordpiece" "$got_piece" \
+      && same "$possessive" "$got_poss" && same "$gate" "$got_gate" && break
+  done
+
+  # What this case was about, for the report: the two lists, or the pair.
+  if [ -n "$term" ]; then
+    got_line="$(printf 'term %-12s possessive %-9s %s' "$term" "$got_poss" "$got_gate")"
+    want_line="$(printf 'term %-12s possessive %-9s %s' "$term" "$possessive" "$gate")"
+  else
+    got_line="$(printf 'spell %-11s wordpiece %-11s %s' "$got_spell" "$got_piece" "$got_gate")"
+    want_line="$(printf 'spell %-11s wordpiece %-11s %s' "$spell" "$wordpiece" "$gate")"
   fi
 
-  if [ "$got_spell" = "$spell" ] && [ "$got_piece" = "$wordpiece" ] && [ "$got_gate" = "$gate" ]
-  then
+  if [ "$got_line" = "$want_line" ]; then
     pass=$((pass + 1))
-    printf '  ✓ %-12s spell %-11s wordpiece %-11s %s\n' \
-      "$word" "$got_spell" "$got_piece" "$got_gate"
+    printf '  ✓ %-12s %s\n' "$word" "$got_line"
     continue
   fi
 
@@ -78,14 +100,13 @@ while IFS=$'\t' read -r word spell wordpiece gate; do
   if [ "$gate" = "judge" ] && [ "$got_gate" = "auto-apply" ]; then
     overwrote=$((overwrote + 1))
   fi
-  printf '  ✗ %-12s got   spell %-11s wordpiece %-11s %s\n' \
-    "$word" "$got_spell" "$got_piece" "$got_gate"
-  printf '    %-12s want  spell %-11s wordpiece %-11s %s\n' \
-    "" "$spell" "$wordpiece" "$gate"
+  printf '  ✗ %-12s got   %s\n' "$word" "$got_line"
+  printf '    %-12s want  %s\n' "" "$want_line"
 done < <(python3 -c '
 import sys, yaml
 for case in yaml.safe_load(open(sys.argv[1]))["cases"]:
-    print("\t".join([case["word"], case["spell"], case["wordpiece"], case["gate"]]))
+    print("\x1f".join(str(case.get(key, "")) for key in
+                    ("word", "term", "spell", "wordpiece", "possessive", "gate")))
 ' "$ROOT/tests/word-gate-cases.yaml")
 
 echo

--- a/scripts/check-word-gate.sh
+++ b/scripts/check-word-gate.sh
@@ -64,13 +64,16 @@ pass=0; total=0; overwrote=0
 # Unit separator, not a tab. A tab is whitespace, so bash collapses two of
 # them into one and a case with no `term` arrives with its fields shifted.
 while IFS=$'\x1f' read -r word term spell wordpiece possessive gate; do
-  [ -z "$word" ] && continue
   total=$((total + 1))
 
-  # The shape of the case, before its answer. A case that leaves out a verdict
+  # The shape of the case, before its answer. A case that leaves out something
   # its shape needs is a broken case and not a passing one — `same` would read
   # the gap as "not asked" and the binary printing nothing there would agree.
+  # A case with no word used to be skipped, which kept it out of the count as
+  # well as out of the run: a malformed one could be added and the set still
+  # said 25/25.
   missing=""
+  [ -z "$word" ] && missing="$missing word"
   [ -z "$gate" ] && missing="$missing gate"
   if [ -n "$term" ]; then
     [ -z "$possessive" ] && missing="$missing possessive"
@@ -79,7 +82,7 @@ while IFS=$'\x1f' read -r word term spell wordpiece possessive gate; do
     [ -z "$wordpiece" ] && missing="$missing wordpiece"
   fi
   if [ -n "$missing" ]; then
-    printf '  ✗ %-12s the case names no%s\n' "$word" "$missing"
+    printf '  ✗ %-12s the case names no%s\n' "${word:-(no word)}" "$missing"
     continue
   fi
 

--- a/tests/word-gate-cases.yaml
+++ b/tests/word-gate-cases.yaml
@@ -1,4 +1,4 @@
-# Which words may be overwritten by a vocabulary term without anything asking.
+# What may be overwritten by a vocabulary term without anything asking.
 #
 # Two lists decide, and both have to say "unknown" — `Vocabulary.autoApplies`.
 # `spell` is `Replacements.isRealWord`: NSSpellChecker, `en` then `fr`.
@@ -7,6 +7,14 @@
 #
 #   gate: judge       something reads the sentence before the word is replaced
 #   gate: auto-apply  the word is replaced, and nothing reads the sentence
+#
+# A case with a `term` asks the whole gate about that pair, and reads
+# `possessive` instead of the two lists:
+#
+#   possessive: dropped   the heard text carries a `'s` the term does not, so
+#                         writing the term in would take a possessive out of
+#                         the sentence — `Vocabulary.dropsPossessive`
+#   possessive: kept      it would not
 #
 # The two blocks below are the two blind spots, and they are why one list is
 # not enough. A dictionary has no first names in it. A tokenizer has no rare
@@ -139,3 +147,64 @@ cases:
     wordpiece: unknown
     gate: auto-apply
     why: a first name both lists miss
+
+  # --- a possessive the term does not carry ---------------------------------
+  # The two lists are asked about letters, so `Mirza's` is looked up as
+  # `Mirzas` — a form neither list has ever seen. The apostrophe walks the
+  # proposal past both of them, including past the first names the block at
+  # the top of this file is about. Dropping a possessive changes what the
+  # sentence says, so these go to the judge, which reads it.
+
+  - word: "Mirza's"
+    term: Mirza
+    possessive: dropped
+    gate: judge
+    why: >
+      "I'm just waiting for Mirza's thoughts about whether it's worth fixing
+      the extension" — the case is in tests/judge-cases.yaml as a decline.
+      "Mirza thoughts" is not what was said.
+
+  - word: "Mirza’s"
+    term: Mirza
+    possessive: dropped
+    gate: judge
+    why: the typographic apostrophe, which is the one the recogniser writes
+
+  - word: "Frederick's"
+    term: Redrock
+    possessive: dropped
+    gate: judge
+    why: >
+      the first block of this file, defeated by one apostrophe. `Frederick`
+      goes to the judge because the tokenizer knows it; `Fredericks` is known
+      to neither list, so before this rule the possessive form auto-applied
+      and `--inflected Redrock "Frederick's"` wrote `Redrock's`.
+
+  # --- the same class the other way round ------------------------------------
+  # The term carries the possessive and the heard text does not. That
+  # correction is right and nothing here fires on it: `possessive` reads
+  # `kept`, and a rule that ran in both directions would read `dropped`.
+
+  - word: "Matthew at"
+    term: "Matthieu's"
+    possessive: kept
+    gate: judge
+    why: >
+      observed live, 2026-08-08. The judge kept "Matthew at" where the speaker
+      said "Matthieu's". `judge` here is the glued-compound branch, which
+      decides before the possessive is looked at — so `possessive` is the
+      field under test and the decision is not.
+
+  - word: Versal
+    term: "Vercel's"
+    possessive: kept
+    gate: auto-apply
+    why: >
+      the same direction where the decision does move. A rule that fired on
+      the term's possessive would send this to the judge.
+
+  - word: Versal
+    term: Vercel
+    possessive: kept
+    gate: auto-apply
+    why: a word neither list knows, with no possessive anywhere, still goes through


### PR DESCRIPTION
Was stacked on #222. That merged, so this is rebased onto `main` and retargeted there.

`Vocabulary.autoApplies` decides when a vocabulary term is written into a transcript with nothing reading the sentence. The word half of that test asks two lists about letters only, so `Mirza's` is looked up as `Mirzas` — a form neither list has ever seen. One apostrophe walks the proposal past both of them, including past the first names #222 just protected: `--word-gate Frederick` says `judge`, and before this change `--word-gate "Frederick's"` said `auto-apply`.

This refuses to auto-apply when the heard text carries a `'s` the term does not, and sends the proposal to the judge instead. The judge is the only thing that reads the sentence. Both apostrophes, straight and typographic — the recogniser writes the typographic one.

The other direction is untouched. `Matthew at` -> `Matthieu's` is the same class the other way round: the term carries the possessive, the decoded span does not, and that correction is right.

Reviewers: start at `Vocabulary.dropsPossessive`, then the six new cases at the bottom of `tests/word-gate-cases.yaml`.

<details>
<summary>Why a rule and not a threshold</summary>

Dropping a possessive changes what the sentence says. *Mirza's thoughts* is not *Mirza thoughts*. That is true in every sentence, whatever a corpus says about how often it happens, so there is nothing here to tune and nothing that can drift.

It is a router, not a filter. The proposal is not refused — it goes to the judge, which is what the rest of `autoApplies` does with a word it does not want to overwrite unasked.

The owner flagged this class independently. `~/Recordings/ParrotFlow Dev/flagged.txt` carries a dictation whose comment reads: *"when the judge it's not invoked, uh the possessive is lost"*.

A contraction reaches the judge now too, since `it's` also ends in `'s`. That is the safe direction and it is nearly free: a contraction is a real word, so the spell list was already sending it there.

</details>

<details>
<summary>What it looks like on the shipped binary</summary>

Before, on `feat/wordpiece-auto-apply`:

```
$ ParrotFlow --word-gate Frederick      $ ParrotFlow --word-gate "Frederick's"
spell      unknown                      spell      unknown
wordpiece  known                        wordpiece  unknown
gate       judge                        gate       auto-apply
```

`Frederick` is known to the tokenizer, so it goes to the judge. `Fredericks` is known to neither list, so it did not. `ParrotFlow --inflected Redrock "Frederick's"` prints `Redrock's` — that is what would have been written into "Um not Peter, uh Frederick's."

After, naming the term:

```
$ ParrotFlow --word-gate "Frederick's" Redrock
possessive dropped
gate       judge

$ ParrotFlow --word-gate "Matthew at" "Matthieu's"
possessive kept
gate       judge
```

</details>

<details>
<summary>Measurements — the menu holds and the sets pass; this moves no score</summary>

`scripts/menu-recall.py --runs 3`, on the same 141 labelled clips, same machine:

| | recall | picked | clips that flipped between runs |
|---|---|---|---|
| before (`feat/wordpiece-auto-apply`) | 97/141 | 97/141 | 0/141 |
| after | 97/141 | 97/141 | 0/141 |

No regression, and no improvement either. Do not read this PR off that number. The argument is that a possessive is not noise and must not be dropped silently, not that a score moved.

`make test` passes, including `word-gate`, now 25/25 (19 before), and `possessive` at 35/35 — `Vocabulary.inflected` was refactored to share the apostrophe parse and its set says the behaviour is identical.

Everything measured here comes from one speaker's archive, hand-labelled: 59 cases in `tests/judge-cases.yaml` and 141 labelled clips in `tests/menu-cases.yaml`. `Mirza's` -> `Mirza` is one of the 59, labelled `decline`. It is one case in about fifty.

</details>

<details>
<summary>Tests, and what each one pins</summary>

Six cases at the bottom of `tests/word-gate-cases.yaml`. A case that names a `term` asks the whole gate about that pair through `--word-gate <word> <term>`, and reads a `possessive` verdict beside the decision.

| word | term | possessive | gate | pins |
|---|---|---|---|---|
| `Mirza's` | `Mirza` | dropped | judge | the case from `tests/judge-cases.yaml` |
| `Mirza’s` | `Mirza` | dropped | judge | the typographic apostrophe |
| `Frederick's` | `Redrock` | dropped | judge | #222's fix, defeated by one apostrophe |
| `Matthew at` | `Matthieu's` | kept | judge | the reverse direction, observed live |
| `Versal` | `Vercel's` | kept | auto-apply | the reverse direction, where the decision moves |
| `Versal` | `Vercel` | kept | auto-apply | a plain unknown word still goes through |

`Matthew at` reaches `judge` from the glued-compound branch whatever the possessive rule says, so the decision alone would not show a rule firing on the wrong side. `possessive kept` is the field under test there; `Versal` / `Vercel's` is the pair where a bidirectional rule would also change the decision.

The harness gained two things it needed. It now splits on the unit separator rather than a tab, because bash collapses two tabs into one and a case with no `term` arrived with its fields shifted — same reason `scripts/check-verdicts.sh` does it. And it checks the shape of a case before its answer: reading an absent expectation as "not asked" is what lets one set hold both shapes, and it would also have let a case that named nothing pass. A word case has to name `spell`, `wordpiece` and `gate`, a pair case `possessive` and `gate`, and every case a `word`.

</details>

<details>
<summary>What this does not fix</summary>

Only the trailing `'s`. A plural possessive (`the teams' plan`), a French elision (`l'équipe`) and any other inflection are outside it.

The gate still auto-applies over a possessive when the term carries one too — `Mathieu's` -> `Matthieu's`. Nothing is dropped there, so nothing needs to read the sentence.

`Vocabulary.inflected` still carries the `'s` on the paths that remain, and it is still a similarity comparison rather than a rule. This PR does not touch it beyond sharing the parse.

The judge, its prompt, and the word lists are untouched.

</details>
