### PR TITLE
feat: the sentence model arrives on the first English dictation

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1836,7 +1836,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // download is about 470 MB and the pill would sit on one word for all
         // of it. Say what is actually happening, with the figure.
         var starting = "Transcribing…"
-        if case .downloading(let what) = transcriberStatus {
+        // Only a download this dictation is waiting on. A background fetch is
+        // running while the words are being decoded, and the pill would tell
+        // the user to wait for something that is not in their way.
+        if case .downloading(let what, blocking: true) = transcriberStatus {
             pillDownloadRun = run
             starting = "Downloading \(what)"
         }
@@ -5184,13 +5187,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func handleTranscriberStatus(_ status: Transcriber.Status) {
         transcriberStatus = status
         switch status {
-        case .downloading(let what):
+        case .downloading(let what, let blocking):
             setLabel("Downloading \(what)")
             // `what` already carries the percentage, so replacing the text in
             // place is what makes the number climb. Only for the dictation that
             // put the download up: it is waiting on exactly this, and
             // "Transcribing…" over a 470 MB fetch reads as a hang.
-            if ownsDownloadPill {
+            if blocking, ownsDownloadPill {
                 updateProgress("Downloading \(what)", token: dictationProgressToken)
             }
             // After the pill, which writes the label too: this has to hold the
@@ -5202,7 +5205,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let percent = what.split(separator: " ").last.flatMap { token -> Int? in
                 token.hasSuffix("%") ? Int(token.dropLast()) : nil
             }
-            permissions.model.speechModel = .preparing(percent: percent)
+            // Only for a download that holds dictation up. This row says
+            // whether you can speak yet, and a background fetch does not
+            // change that answer.
+            if blocking { permissions.model.speechModel = .preparing(percent: percent) }
         case .loading:
             setLabel("Loading speech model…")
             if ownsDownloadPill {

--- a/Sources/ParrotFlow/AppVariant.swift
+++ b/Sources/ParrotFlow/AppVariant.swift
@@ -37,6 +37,20 @@ enum AppVariant {
         isDev ? "ParrotFlow-Dev.log" : "ParrotFlow.log"
     }
 
+    /// `~/Library/Application Support/ParrotFlow` or `.../ParrotFlow Dev`.
+    ///
+    /// For what the app downloads rather than for what a person edits — the
+    /// config directory holds files somebody opens in an editor, and a 300 MB
+    /// model cache does not belong next to them. Split per variant like
+    /// everything else here.
+    static var supportDirectory: URL {
+        let base = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent("Library/Application Support", isDirectory: true)
+        return base.appendingPathComponent(displayName, isDirectory: true)
+    }
+
     static var defaultOutputDir: String {
         isDev ? "~/Recordings/ParrotFlow Dev" : "~/Recordings/ParrotFlow"
     }

--- a/Sources/ParrotFlow/HubDownload.swift
+++ b/Sources/ParrotFlow/HubDownload.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+/// Fetches files from a public HuggingFace repository.
+///
+/// Ours rather than FluidAudio's `ModelHub`, which is the only downloader
+/// already linked here: its `Repo` is a closed enum, so it cannot be pointed at
+/// a repository outside its own list.
+///
+/// The failure this is built against is a truncated file. A `weight.bin` that
+/// stops at 200 of its 299 MB still opens, and a model loaded from it returns
+/// numbers rather than an error. So every file is fetched to a temporary path,
+/// its length is checked against the repository listing, and only then does it
+/// move into the caller's directory.
+enum HubDownload {
+
+    enum Failure: LocalizedError {
+        case http(path: String, status: Int)
+        case unlisted(path: String)
+        case truncated(path: String, expected: Int64, got: Int64)
+
+        var errorDescription: String? {
+            switch self {
+            case .http(let path, let status):
+                return "\(path): HTTP \(status)"
+            case .unlisted(let path):
+                return "\(path): not in the repository listing"
+            case .truncated(let path, let expected, let got):
+                return "\(path): \(got) bytes of \(expected)"
+            }
+        }
+    }
+
+    static func url(repo: String, path: String) -> URL? {
+        let escaped = path
+            .addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? path
+        return URL(string: "https://huggingface.co/\(repo)/resolve/main/\(escaped)")
+    }
+
+    /// Downloads `paths` into `directory`, keeping the repository's own layout.
+    ///
+    /// `progress` gets the fraction of the whole set, so the caller reports one
+    /// number rather than one per file. Sequential, not parallel: one 299 MB
+    /// file is 99% of this set, and racing three small ones against it only
+    /// makes the number jump.
+    static func fetch(
+        repo: String,
+        paths: [String],
+        into directory: URL,
+        progress: @escaping @Sendable (Double) -> Void
+    ) async throws {
+        let listed = try await sizes(repo: repo)
+        var sizes: [String: Int64] = [:]
+        for path in paths {
+            guard let size = listed[path] else { throw Failure.unlisted(path: path) }
+            sizes[path] = size
+        }
+        let total = sizes.values.reduce(0, +)
+
+        var done: Int64 = 0
+        for path in paths {
+            let expected = sizes[path] ?? 0
+            let before = done
+            try await download(
+                repo: repo, path: path, expecting: expected,
+                to: directory.appendingPathComponent(path)
+            ) { written in
+                progress(Double(before + min(written, expected)) / Double(max(total, 1)))
+            }
+            done += expected
+            progress(Double(done) / Double(max(total, 1)))
+        }
+    }
+
+    /// Every file in the repository with its length, from one call.
+    ///
+    /// Not `Content-Length` on the download. HuggingFace serves `tokenizer.json`
+    /// gzipped, and a gzipped response carries no length at all — the header
+    /// that does arrive describes the compressed bytes, not the file. This
+    /// listing gives the real size, which is what the length check needs.
+    private static func sizes(repo: String) async throws -> [String: Int64] {
+        let path = "api/models/\(repo)/tree/main?recursive=true"
+        guard let url = URL(string: "https://huggingface.co/\(path)") else { return [:] }
+        let (data, response) = try await URLSession.shared.data(from: url)
+        if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+            throw Failure.http(path: path, status: http.statusCode)
+        }
+        let entries = try JSONSerialization.jsonObject(with: data) as? [[String: Any]] ?? []
+        var sizes: [String: Int64] = [:]
+        for entry in entries {
+            guard entry["type"] as? String == "file",
+                  let path = entry["path"] as? String,
+                  let size = (entry["size"] as? NSNumber)?.int64Value
+            else { continue }
+            sizes[path] = size
+        }
+        return sizes
+    }
+
+    private static func download(
+        repo: String,
+        path: String,
+        expecting: Int64,
+        to destination: URL,
+        progress: @escaping @Sendable (Int64) -> Void
+    ) async throws {
+        guard let url = url(repo: repo, path: path) else {
+            throw Failure.unlisted(path: path)
+        }
+        let watcher = Watcher(onWrite: progress)
+        // Session delegate, not the `delegate:` of `download(from:delegate:)`.
+        // That one only gets life-cycle and authentication callbacks, so
+        // `didWriteData` never arrives and the fetch reports 0% then 100%.
+        let session = URLSession(configuration: .default, delegate: watcher, delegateQueue: nil)
+        defer { session.finishTasksAndInvalidate() }
+
+        let temporary = try await withCheckedThrowingContinuation { continuation in
+            watcher.begin(continuation)
+            session.downloadTask(with: url).resume()
+        }
+        defer { try? FileManager.default.removeItem(at: temporary) }
+
+        if let status = watcher.status, status != 200 {
+            throw Failure.http(path: path, status: status)
+        }
+
+        let got = (try FileManager.default.attributesOfItem(atPath: temporary.path)[.size]
+            as? NSNumber)?.int64Value ?? 0
+        guard got == expecting else {
+            throw Failure.truncated(path: path, expected: expecting, got: got)
+        }
+
+        try FileManager.default.createDirectory(
+            at: destination.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try? FileManager.default.removeItem(at: destination)
+        try FileManager.default.moveItem(at: temporary, to: destination)
+    }
+
+    /// Reports bytes as they land and hands back the finished file.
+    private final class Watcher: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
+        private let onWrite: @Sendable (Int64) -> Void
+        private let lock = NSLock()
+        private var continuation: CheckedContinuation<URL, Error>?
+        private(set) var status: Int?
+
+        init(onWrite: @escaping @Sendable (Int64) -> Void) {
+            self.onWrite = onWrite
+        }
+
+        func begin(_ continuation: CheckedContinuation<URL, Error>) {
+            lock.lock()
+            defer { lock.unlock() }
+            self.continuation = continuation
+        }
+
+        private func finish(_ result: Result<URL, Error>) {
+            lock.lock()
+            let waiting = continuation
+            continuation = nil
+            lock.unlock()
+            waiting?.resume(with: result)
+        }
+
+        func urlSession(
+            _ session: URLSession, downloadTask: URLSessionDownloadTask,
+            didWriteData bytesWritten: Int64, totalBytesWritten: Int64,
+            totalBytesExpectedToWrite: Int64
+        ) {
+            onWrite(totalBytesWritten)
+        }
+
+        func urlSession(
+            _ session: URLSession, downloadTask: URLSessionDownloadTask,
+            didFinishDownloadingTo location: URL
+        ) {
+            status = (downloadTask.response as? HTTPURLResponse)?.statusCode
+            // The file is deleted the moment this returns, so it has to move
+            // here rather than after the await.
+            let kept = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("parrotflow-\(UUID().uuidString)")
+            do {
+                try FileManager.default.moveItem(at: location, to: kept)
+                finish(.success(kept))
+            } catch {
+                finish(.failure(error))
+            }
+        }
+
+        func urlSession(
+            _ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?
+        ) {
+            // Runs after `didFinishDownloadingTo` on success, where the
+            // continuation is already gone and this does nothing.
+            finish(.failure(error ?? URLError(.unknown)))
+        }
+    }
+}

--- a/Sources/ParrotFlow/HubDownload.swift
+++ b/Sources/ParrotFlow/HubDownload.swift
@@ -49,16 +49,16 @@ enum HubDownload {
         progress: @escaping @Sendable (Double) -> Void
     ) async throws {
         let listed = try await sizes(repo: repo)
-        var sizes: [String: Int64] = [:]
+        var wanted: [String: Int64] = [:]
         for path in paths {
             guard let size = listed[path] else { throw Failure.unlisted(path: path) }
-            sizes[path] = size
+            wanted[path] = size
         }
-        let total = sizes.values.reduce(0, +)
+        let total = wanted.values.reduce(0, +)
 
         var done: Int64 = 0
         for path in paths {
-            let expected = sizes[path] ?? 0
+            let expected = wanted[path] ?? 0
             let before = done
             try await download(
                 repo: repo, path: path, expecting: expected,

--- a/Sources/ParrotFlow/SentenceModel.swift
+++ b/Sources/ParrotFlow/SentenceModel.swift
@@ -52,6 +52,21 @@ actor SentenceModel {
         directory.appendingPathComponent("tokenizer.json")
     }
 
+    /// Beside the cache directory, not inside it, so a fetch that deletes the
+    /// cache does not delete the lock somebody is holding.
+    private static var lockURL: URL {
+        directory.deletingLastPathComponent()
+            .appendingPathComponent("modernbert-base-64.lock")
+    }
+
+    enum Failure: LocalizedError {
+        case busy
+
+        var errorDescription: String? {
+            "another ParrotFlow process is fetching the sentence model"
+        }
+    }
+
     /// What `MLModel.compileModel` writes, checked before the model is loaded.
     ///
     /// Not belt and braces. A compiled model missing `model.mil` segfaults
@@ -103,11 +118,29 @@ actor SentenceModel {
                     "sentence model: the cached copy will not load"
                         + " (\(error.localizedDescription)); fetching it again"
                 )
-                try? FileManager.default.removeItem(at: directory)
             }
         }
-        try await fetch(progress: progress)
+        try await underLock { try await fetch(progress: progress) }
         return try load()
+    }
+
+    /// One process at a time inside `fetch`.
+    ///
+    /// The app and `--sentence-model` share this cache, and the second one in
+    /// would delete the first one's staging directory mid-download. It does
+    /// not wait for the lock: this is background work, and the next English
+    /// dictation asks again.
+    private static func underLock(_ body: () async throws -> Void) async throws {
+        try FileManager.default.createDirectory(
+            at: lockURL.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        let handle = open(lockURL.path, O_CREAT | O_RDWR, 0o644)
+        guard handle >= 0 else { throw Failure.busy }
+        // Closing the descriptor releases the lock, and the kernel closes it
+        // for a process that dies holding one.
+        defer { close(handle) }
+        guard flock(handle, LOCK_EX | LOCK_NB) == 0 else { throw Failure.busy }
+        try await body()
     }
 
     private static func load() throws -> MLModel {
@@ -123,7 +156,9 @@ actor SentenceModel {
         let files = FileManager.default
         try files.createDirectory(at: directory, withIntermediateDirectories: true)
         // A process that quits mid-download leaves its staging directory and
-        // whatever it had fetched, which is up to 299 MB nothing will ever read.
+        // whatever it had fetched, which is up to 299 MB nothing will ever
+        // read. Safe to delete every one of them because `underLock` means no
+        // other process is fetching.
         let left = try? files.contentsOfDirectory(atPath: directory.path)
         for name in left ?? [] where name.hasPrefix(".staging-") {
             try? files.removeItem(at: directory.appendingPathComponent(name))

--- a/Sources/ParrotFlow/SentenceModel.swift
+++ b/Sources/ParrotFlow/SentenceModel.swift
@@ -1,0 +1,173 @@
+import CoreML
+import Foundation
+
+/// ModernBERT, fetched on the first English dictation and kept.
+///
+/// Nothing reads it yet. It is here so the download happens once, early, and
+/// out of the way of the sentence that triggered it — the model is 300 MB and
+/// the first Core ML compile of it costs about 7 seconds, and neither is a
+/// thing to discover on the dictation that needs it.
+///
+/// What it is for: a masked word probe over a ±12-word window, which repairs a
+/// sentence a pause cut in two. Measured at about 8 ms per call at sequence
+/// length 64, which is the only length this conversion is faithful at.
+///
+/// `znaat/modernbert-coreml` and not `finnvoorhees/ModernBERT-CoreML`. That one
+/// is traced at a single token, where ModernBERT's sliding-window mask is
+/// optimised away, and past that length its answers are noise — "The capital of
+/// Ireland is [MASK]" comes back "£, isation, organisation".
+@available(macOS 14, *)
+actor SentenceModel {
+
+    static let shared = SentenceModel()
+
+    private static let repository = "znaat/modernbert-coreml"
+    private static let packageName = "ModernBERT-base-64.mlpackage"
+
+    private static var files: [String] {
+        [
+            "\(packageName)/Manifest.json",
+            "\(packageName)/Data/com.apple.CoreML/model.mlmodel",
+            "\(packageName)/Data/com.apple.CoreML/weights/weight.bin",
+            // Nothing reads it yet either. It belongs with the weights it was
+            // trained against, and fetching it now means the stage that needs
+            // it needs no download of its own.
+            "tokenizer.json",
+        ]
+    }
+
+    static var directory: URL {
+        AppVariant.supportDirectory
+            .appendingPathComponent("models/modernbert-base-64", isDirectory: true)
+    }
+
+    /// The compiled form, which is what gets kept. The `.mlpackage` it was
+    /// built from is deleted after the compile: it is another 299 MB, and a
+    /// cache that will not load is re-fetched rather than rebuilt.
+    static var compiledURL: URL {
+        directory.appendingPathComponent("ModernBERT-base-64.mlmodelc", isDirectory: true)
+    }
+
+    static var tokenizerURL: URL {
+        directory.appendingPathComponent("tokenizer.json")
+    }
+
+    /// What `MLModel.compileModel` writes, checked before the model is loaded.
+    ///
+    /// Not belt and braces. A compiled model missing `model.mil` segfaults
+    /// inside CoreML's `makeProgramWithMemoryLayout` rather than throwing, so
+    /// the `catch` below cannot recover from a damaged cache — only this can.
+    private static let compiledParts = ["model.mil", "coremldata.bin", "weights/weight.bin"]
+
+    static var isCached: Bool {
+        let files = FileManager.default
+        return files.fileExists(atPath: tokenizerURL.path)
+            && compiledParts.allSatisfy {
+                files.fileExists(atPath: compiledURL.appendingPathComponent($0).path)
+            }
+    }
+
+    private var model: MLModel?
+
+    /// The fetch in flight, if any. Same reason as `Transcriber.loadingModels`:
+    /// actor isolation stops a torn read of `model`, not two callers both
+    /// finding it nil on either side of the same `await`.
+    private var loading: Task<MLModel, Error>?
+
+    /// Downloads, compiles and loads, or returns what is already loaded.
+    ///
+    /// `progress` gets a label shaped like "sentence model 43%", already
+    /// de-duplicated — the handler behind it fires far more often than the
+    /// number changes.
+    @discardableResult
+    func prepare(progress: (@Sendable (String) -> Void)? = nil) async throws -> MLModel {
+        if let model { return model }
+        if let loading { return try await loading.value }
+
+        let task = Task<MLModel, Error> {
+            try await Self.build(progress: progress)
+        }
+        loading = task
+        defer { loading = nil }
+        let loaded = try await task.value
+        model = loaded
+        return loaded
+    }
+
+    private static func build(
+        progress: (@Sendable (String) -> Void)?
+    ) async throws -> MLModel {
+        if isCached {
+            do { return try load() } catch {
+                Log.write(
+                    "sentence model: the cached copy will not load"
+                        + " (\(error.localizedDescription)); fetching it again"
+                )
+                try? FileManager.default.removeItem(at: directory)
+            }
+        }
+        try await fetch(progress: progress)
+        return try load()
+    }
+
+    private static func load() throws -> MLModel {
+        try MLModel(contentsOf: compiledURL)
+    }
+
+    /// Fetches into a staging directory, compiles, then moves the result into
+    /// place. Staging sits inside `directory` so the move is a rename on the
+    /// same volume — across volumes `moveItem` copies, and a copy is not
+    /// atomic. Half a cache that loads and answers nonsense is the failure
+    /// this whole shape exists to prevent.
+    private static func fetch(progress: (@Sendable (String) -> Void)?) async throws {
+        let files = FileManager.default
+        try files.createDirectory(at: directory, withIntermediateDirectories: true)
+        // A process that quits mid-download leaves its staging directory and
+        // whatever it had fetched, which is up to 299 MB nothing will ever read.
+        let left = try? files.contentsOfDirectory(atPath: directory.path)
+        for name in left ?? [] where name.hasPrefix(".staging-") {
+            try? files.removeItem(at: directory.appendingPathComponent(name))
+        }
+        let staging = directory
+            .appendingPathComponent(".staging-\(UUID().uuidString)", isDirectory: true)
+        try files.createDirectory(at: staging, withIntermediateDirectories: true)
+        defer { try? files.removeItem(at: staging) }
+
+        let reported = Reported()
+        try await HubDownload.fetch(
+            repo: repository, paths: Self.files, into: staging
+        ) { fraction in
+            guard let progress else { return }
+            let percent = Int((fraction * 100).rounded())
+            guard reported.advanced(to: percent) else { return }
+            progress("sentence model \(percent)%")
+        }
+
+        let compiled = try await MLModel.compileModel(
+            at: staging.appendingPathComponent(packageName)
+        )
+        defer { try? files.removeItem(at: compiled) }
+
+        // The tokenizer first and the compiled model last, so `isCached` only
+        // ever answers true for a pair that is both there.
+        try? files.removeItem(at: tokenizerURL)
+        try files.moveItem(at: staging.appendingPathComponent("tokenizer.json"), to: tokenizerURL)
+        try? files.removeItem(at: compiledURL)
+        try files.moveItem(at: compiled, to: compiledURL)
+    }
+
+    /// The percentage last reported. A class rather than a captured `var`
+    /// because the progress closure is `@Sendable` and escapes.
+    private final class Reported: @unchecked Sendable {
+        private var last = -1
+        private let lock = NSLock()
+
+        func advanced(to percent: Int) -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            guard percent != last else { return false }
+            last = percent
+            return true
+        }
+    }
+}

--- a/Sources/ParrotFlow/SentenceModelCommand.swift
+++ b/Sources/ParrotFlow/SentenceModelCommand.swift
@@ -1,0 +1,65 @@
+import CoreML
+import Foundation
+
+/// `--sentence-model` — fetches, compiles and loads ModernBERT, then says what
+/// it got and how long it took.
+///
+///     ParrotFlow --sentence-model
+///       sentence model 43%…
+///     ✓ sentence model ready in 41.2s
+///       cache   ~/Library/Application Support/ParrotFlow/models/modernbert-base-64
+///       inputs  input_ids [1, 64]
+///       outputs logits [1, 64, 50368]
+///
+/// The same call the first English dictation makes, without a microphone. Run
+/// it twice: the second run skips the download and the 7s compile, which is
+/// the only proof the cache is being used.
+@available(macOS 14, *)
+enum SentenceModelCommand {
+
+    static func run() -> Int32 {
+        var exitCode: Int32 = 0
+        let done = DispatchSemaphore(value: 0)
+
+        Task {
+            let started = Date()
+            let cached = SentenceModel.isCached
+            do {
+                let model = try await SentenceModel.shared.prepare { label in
+                    print("\r  \(label)…", terminator: "")
+                    fflush(stdout)
+                }
+                let seconds = Date().timeIntervalSince(started)
+                print(String(
+                    format: "\r\u{1B}[K✓ sentence model ready in %.1fs (%@)",
+                    seconds, cached ? "cached" : "downloaded and compiled"
+                ))
+                print("  cache   \(tilde(SentenceModel.directory.path))")
+                describe("inputs ", model.modelDescription.inputDescriptionsByName)
+                describe("outputs", model.modelDescription.outputDescriptionsByName)
+            } catch {
+                print("\r\u{1B}[K✗ \(error.localizedDescription)")
+                exitCode = 1
+            }
+            done.signal()
+        }
+
+        done.wait()
+        return exitCode
+    }
+
+    private static func describe(
+        _ title: String, _ features: [String: MLFeatureDescription]
+    ) {
+        for name in features.keys.sorted() {
+            let shape = features[name]?.multiArrayConstraint?.shape.map(\.stringValue)
+                .joined(separator: ", ")
+            print("  \(title) \(name)\(shape.map { " [\($0)]" } ?? "")")
+        }
+    }
+
+    private static func tilde(_ path: String) -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return path.hasPrefix(home) ? "~" + path.dropFirst(home.count) : path
+    }
+}

--- a/Sources/ParrotFlow/TranscribeCommand.swift
+++ b/Sources/ParrotFlow/TranscribeCommand.swift
@@ -36,7 +36,7 @@ enum TranscribeCommand {
 
         Task {
             let transcriber = Transcriber { status in
-                if case .downloading(let what) = status {
+                if case .downloading(let what, _) = status {
                     // \r keeps the download on one line instead of scrolling.
                     print("\r  downloading \(what)…", terminator: "")
                     fflush(stdout)

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -17,7 +17,11 @@ actor Transcriber {
 
     enum Status: Equatable {
         case idle
-        case downloading(String)
+        /// `blocking` is false for a fetch no dictation is waiting on. The
+        /// sentence model is fetched in the background, so the pill must not
+        /// say a dictation is stuck behind it and the setup window must not
+        /// say the speech model is still coming.
+        case downloading(String, blocking: Bool)
         case loading
         case ready
         case failed(String)
@@ -67,7 +71,7 @@ actor Transcriber {
 
     private func loadModels() async throws -> AsrModels {
         if let loadingModels { return try await loadingModels.value }
-        setStatus(.downloading("speech model"))
+        setStatus(.downloading("speech model", blocking: true))
         let task = Task<AsrModels, Error> {
             try await AsrModels.downloadAndLoad(
                 progressHandler: { [weak self] progress in
@@ -83,7 +87,7 @@ actor Transcriber {
 
     private func loadVad() async throws -> VadManager? {
         if let loadingVad { return try await loadingVad.value }
-        setStatus(.downloading("voice detector"))
+        setStatus(.downloading("voice detector", blocking: true))
         let task = Task<VadManager?, Error> {
             let vad = try? await VadManager(config: .default)
             if vad == nil { Log.write("speech gate: VAD unavailable; transcribing everything") }
@@ -102,7 +106,47 @@ actor Transcriber {
         let percent = Int((progress.fractionCompleted * 100).rounded())
         guard percent != lastReportedPercent else { return }
         lastReportedPercent = percent
-        setStatus(.downloading("\(label) \(percent)%"))
+        setStatus(.downloading("\(label) \(percent)%", blocking: true))
+    }
+
+    /// The sentence model fetch, once per process. Cleared when it fails, so
+    /// the next English dictation tries again.
+    private var sentenceModelFetch: Task<Void, Never>?
+
+    /// Starts the sentence model download and does not wait for it.
+    ///
+    /// Nothing reads the model yet, so awaiting it would park the first
+    /// English dictation behind 300 MB for no gain. It reports progress but
+    /// never `.failed`: a model no stage consumes must not put "Model error"
+    /// in the menu bar.
+    private func warmSentenceModel() {
+        guard sentenceModelFetch == nil else { return }
+        sentenceModelFetch = Task { [weak self] in
+            guard let self else { return }
+            var failed = false
+            do {
+                try await SentenceModel.shared.prepare { label in
+                    Task { await self.reportSentenceModel(label) }
+                }
+            } catch {
+                Log.write("sentence model: \(error.localizedDescription); nothing reads it yet")
+                failed = true
+            }
+            await self.finishSentenceModel(failed: failed)
+        }
+    }
+
+    private func reportSentenceModel(_ label: String) {
+        // Reported, not recorded. `status` says whether the transcriber can
+        // transcribe, and during this fetch it can.
+        onStatusChange(.downloading(label, blocking: false))
+    }
+
+    private func finishSentenceModel(failed: Bool) {
+        if failed { sentenceModelFetch = nil }
+        // Whatever was true before this started is true again. Usually
+        // `.ready`, which is what clears the label the fetch put up.
+        onStatusChange(status)
     }
 
 
@@ -355,7 +399,7 @@ actor Transcriber {
         if Vocabulary.wanted(config) {
             do {
                 try await Vocabulary.shared.prepare(config: config) { [weak self] label in
-                    Task { await self?.setStatus(.downloading(label)) }
+                    Task { await self?.setStatus(.downloading(label, blocking: true)) }
                 }
                 // The gate has already read the clip, so re-reading it would
                 // be a second decode of the same file for the same array.
@@ -384,6 +428,14 @@ actor Transcriber {
                 Log.write("vocabulary: \(error.localizedDescription); left as decoded")
             }
             setStatus(.ready)
+        }
+
+        // After the vocabulary pass, not before: that pass fetches its own
+        // 98 MB on a first run and this dictation is waiting on it. Two
+        // downloads at once halve the bandwidth of the one somebody is
+        // watching.
+        if Pipeline.language(of: text, config: config) == "en" {
+            warmSentenceModel()
         }
 
         // After the vocabulary pass rather than before it, though the words

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -113,6 +113,12 @@ actor Transcriber {
     /// the next English dictation tries again.
     private var sentenceModelFetch: Task<Void, Never>?
 
+    /// True while that fetch is running. Its progress callback reaches this
+    /// actor through an unstructured task, so a percentage can arrive after
+    /// the fetch has already put the real status back — and the menu bar then
+    /// keeps a finished download's number until something else writes to it.
+    private var sentenceModelRunning = false
+
     /// Starts the sentence model download and does not wait for it.
     ///
     /// Nothing reads the model yet, so awaiting it would park the first
@@ -121,6 +127,7 @@ actor Transcriber {
     /// in the menu bar.
     private func warmSentenceModel() {
         guard sentenceModelFetch == nil else { return }
+        sentenceModelRunning = true
         sentenceModelFetch = Task { [weak self] in
             guard let self else { return }
             var failed = false
@@ -137,12 +144,14 @@ actor Transcriber {
     }
 
     private func reportSentenceModel(_ label: String) {
+        guard sentenceModelRunning else { return }
         // Reported, not recorded. `status` says whether the transcriber can
         // transcribe, and during this fetch it can.
         onStatusChange(.downloading(label, blocking: false))
     }
 
     private func finishSentenceModel(failed: Bool) {
+        sentenceModelRunning = false
         if failed { sentenceModelFetch = nil }
         // Whatever was true before this started is true again. Usually
         // `.ready`, which is what clears the label the fetch put up.

--- a/Sources/ParrotFlow/WarmModelsCommand.swift
+++ b/Sources/ParrotFlow/WarmModelsCommand.swift
@@ -29,7 +29,7 @@ enum WarmModelsCommand {
 
         Task {
             let transcriber = Transcriber { status in
-                if case .downloading(let what) = status {
+                if case .downloading(let what, _) = status {
                     print("\r  downloading \(what)…", terminator: "")
                     fflush(stdout)
                 }

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -120,6 +120,14 @@ if arguments.contains("--warm-models") {
     exit(WarmModelsCommand.run())
 }
 
+if arguments.contains("--sentence-model") {
+    guard #available(macOS 14, *) else {
+        print("✗ the sentence model needs macOS 14 or later")
+        exit(1)
+    }
+    exit(SentenceModelCommand.run())
+}
+
 
 
 


### PR DESCRIPTION
The first English dictation now starts a background download of ModernBERT from
`znaat/modernbert-coreml`, about 300 MB. It is compiled once and the compiled
form is kept under `~/Library/Application Support/ParrotFlow/models/`. The pill
and the menu bar show the progress the way they already show the speech model.

Nothing reads the model yet. A later PR adds the tokenizer and the sentence
boundary probe. The fetch is not awaited, so the dictation that starts it is
never held up.

Check two things first. One, `Status.downloading` gains a `blocking` flag —
without it a dictation started mid-fetch shows the download on its pill.
Two, `HubDownload` is a new downloader; FluidAudio's `ModelHub` could not be
used.

Verify with `ParrotFlow --sentence-model`. Run it twice: the second run says
`cached` and skips both the download and the compile.

<details>
<summary>The pill claim was the one real race, and it needed a flag to fix</summary>

The task was to check that `.ready` and the label token still clear when the
download outlives the dictation that started it. They do. `pillDownloadRun` is
only set at `AppDelegate.swift:1839` when a dictation starts while a download is
already running, and the sentence fetch starts after transcription, so it never
claimed the pill of the run that began it. `transcriberLabelToken` clears on
`.ready` as before.

The break is one dictation later. Hold the hotkey again while the sentence model
is still coming down and `transcribe()` reads `transcriberStatus`, finds
`.downloading`, and puts `Downloading sentence model 62%` on that dictation's
pill instead of `Transcribing…`. That dictation is not waiting on anything. The
same status also set `permissions.model.speechModel = .preparing`, which tells
the setup window the speech model has not arrived and you cannot speak yet.

So `Status.downloading` now carries `blocking: Bool`. Three consumers read it:

| Site | With `blocking: false` |
|---|---|
| `AppDelegate.swift:1839` | no pill claim |
| `AppDelegate.swift:5195` | no `updateProgress` |
| `AppDelegate.swift:5208` | no `speechModel = .preparing` |

The menu bar label is written either way, which is the progress line this PR is
for.

The fetch also reports through `onStatusChange` without writing
`Transcriber.status`. `status` answers "can this transcribe", and during a
background fetch it can. When the fetch ends it re-sends whatever `status`
actually holds, so a blocking download running at the same time keeps its label
and its pill.

A progress report can also arrive late. The callback reaches the actor through
an unstructured task, so a percentage could land after the fetch had already put
the real status back, leaving a finished download's number in the menu bar.
`Transcriber.sentenceModelRunning` drops a report that arrives after the fetch
ended; both halves run on the actor, so they are ordered.

One case is left. While the sentence fetch runs it overwrites the menu bar label
of a concurrent vocabulary download. Both downloads have to be in flight at once
for it to happen, which is at most once per install, and only the menu bar text
is affected — the pill and the setup window are correct.

</details>

<details>
<summary>A truncated 299 MB weight file loads and answers nonsense, so it is checked</summary>

Every file goes to a temporary path, gets its length checked, and only then
moves into a staging directory inside the cache directory. Staging is inside the
cache directory on purpose: `moveItem` across volumes copies rather than
renames, and a copy is not atomic. The compiled model moves in last, so
`isCached` is never true for a half-built cache.

The length comes from `https://huggingface.co/api/models/<repo>/tree/main`, not
from `Content-Length` on the download. HuggingFace serves `tokenizer.json`
gzipped, and a gzipped response carries no length at all:

    $ curl -sIL -H 'Accept-Encoding: gzip' .../resolve/main/tokenizer.json
    HTTP/2 200
    content-encoding: gzip
    (no content-length)

The tree call gives the real byte count for all four files in one request.

A cache that is damaged after the fact cannot be recovered by catching the load
error. Deleting `model.mil` from the compiled model segfaults inside CoreML:

    EXC_BAD_ACCESS (SIGSEGV) at 0x0
    CoreML makeProgramWithMemoryLayout(...)
    CoreML -[MLE5ProgramLibrary prepareAndReturnError:]
    CoreML +[MLLoader loadModelFromAssetAtURL:configuration:error:]

So `isCached` checks that `model.mil`, `coremldata.bin` and
`weights/weight.bin` are all present before anything is loaded. With that check
the same damage re-downloads instead of crashing. Measured both ways.

A process that quits mid-download leaves a `.staging-<uuid>` directory holding
up to 299 MB. The next fetch deletes any it finds. Killed with `kill -9` ten
seconds in, the cache directory holds this and nothing else:

    drwxr-xr-x  .staging-6E61F6DD-0E0C-43F9-A325-60F13CD0BB75
    296K  total

No `ModernBERT-base-64.mlmodelc`, so `isCached` is false and nothing can load
it. The next run cleaned the staging directory up and finished in 43.4s.

Two processes share this cache: the app and `--sentence-model`. Before the fix
below, the second one's staging cleanup deleted the first one's live download,
and the first died with `A valid manifest does not exist at path:
.../.staging-C32FE695/ModernBERT-base-64.mlpackage/Manifest.json`. `fetch` now
runs under an exclusive `flock` on `models/modernbert-base-64.lock`, beside the
cache directory rather than inside it, so clearing the cache cannot delete a
lock somebody holds. It does not wait for the lock — the second process gives
up and the next English dictation asks again.

</details>

<details>
<summary>Four things were decided rather than found, and here is why</summary>

**Our own downloader.** FluidAudio's `ModelHub.download` takes a `Repo`, which
is a closed enum in `ModelNames.swift`. It cannot name a repository outside its
own list. No new package dependency was added.

**A session delegate, not `download(from:delegate:)`.** The `delegate:` argument
of the async download only receives life-cycle and authentication callbacks.
`didWriteData` never arrives, and the fetch reports 0% then 100%. Measured: with
a real session delegate the label climbs through every percent.

**The `.mlpackage` is deleted after the compile.** Keeping it would cost another
299 MB and buy nothing — a cache that will not load is re-fetched, not rebuilt.

**Application Support, not `~/.config/parrotflow`.** The config directory holds
files a person opens in an editor. `AppVariant.supportDirectory` keeps the
dev/release split every other path here has, so a dev build cannot damage the
installed app's cache.

</details>

<details>
<summary>What this run looks like, and what the checks say</summary>

Cold, with the cache removed:

    $ ParrotFlow --sentence-model
      sentence model 0%…
      sentence model 1%…
      ... every percent ...
      sentence model 100%…
    ✓ sentence model ready in 43.9s (downloaded and compiled)
      cache   ~/Library/Application Support/ParrotFlow/models/modernbert-base-64
      inputs  input_ids [1, 64]
      outputs logits [1, 64, 50368]

Warm:

    ✓ sentence model ready in 0.1s (cached)

The cache is 288 MB. `make test` passes: `swift build -c release`, swiftlint,
and all 25 check scripts. swiftlint reports no new warnings — the two in
`Transcriber.swift` and `main.swift` are on `main` already.

</details>

<details>
<summary>What this does not do</summary>

- Nothing reads the model or the tokenizer. `tokenizer.json` is fetched anyway
  so the next PR needs no downloader change.
- French dictation never triggers the fetch. The gate is
  `Pipeline.language(of:config:) == "en"` on the transcript, which is the same
  call the correction prompt uses.
- `warmUpTranscriber()` is untouched. This is first use, not launch.
- There is no way to delete the cache from inside the app.

</details>
