### PR TITLE
feat: ask the sentence model what word belongs in a slot

### DIFF
--- a/Sources/ParrotFlow/BPETokenizer.swift
+++ b/Sources/ParrotFlow/BPETokenizer.swift
@@ -1,0 +1,295 @@
+import Foundation
+
+/// The byte-level BPE behind ModernBERT, read from a HuggingFace `tokenizer.json`.
+///
+/// Ours rather than swift-transformers. One model, one tokenizer file, no
+/// package dependency: the vocabulary, the merge ranks, the GPT-2 byte
+/// alphabet and the four special ids are all in that one file.
+///
+/// The thing to know before using it — and the thing that silently scored 0%
+/// when it was got wrong — is that a word carries its leading space:
+///
+///     "we have to do it. That works well"
+///        -> we Ġhave Ġto Ġdo Ġit . ĠThat Ġworks Ġwell
+///
+/// So the id for a word that follows another word is `firstID(of: " That")`,
+/// 2064, and not `firstID(of: "That")`, 2773. The period after `it` is the
+/// bare `.`, 15, while a period that follows a space is `Ġ.`, 964. A caller
+/// asking "is there a period here" has to take the better of the two.
+/// `assertBoundaryIDs` checks all of that against a real tokenization at load.
+struct BPETokenizer {
+
+    enum Failure: LocalizedError {
+        case unreadable(String)
+        case boundary(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .unreadable(let what): return "tokenizer.json: \(what)"
+            case .boundary(let what): return "tokenizer.json: the boundary check failed, \(what)"
+            }
+        }
+    }
+
+    private let vocabulary: [String: Int]
+    /// Merge rank by pair. Lower wins, which is the order the file lists them in.
+    private let ranks: [Pair: Int]
+    private let words: [String]
+
+    let cls: Int
+    let sep: Int
+    let mask: Int
+    let pad: Int
+
+    /// 50368 — the vocabulary plus the added tokens, and the width of a
+    /// logits row.
+    var count: Int { words.count }
+
+    private struct Pair: Hashable {
+        let left: String
+        let right: String
+    }
+
+    // MARK: - Loading
+
+    static func load(contentsOf url: URL) throws -> BPETokenizer {
+        let raw = try Data(contentsOf: url)
+        guard let root = try JSONSerialization.jsonObject(with: raw) as? [String: Any] else {
+            throw Failure.unreadable("not an object")
+        }
+        guard let model = root["model"] as? [String: Any],
+              let vocabulary = model["vocab"] as? [String: Int] else {
+            throw Failure.unreadable("no model.vocab")
+        }
+        guard let merges = model["merges"] as? [Any] else {
+            throw Failure.unreadable("no model.merges")
+        }
+
+        var ranks: [Pair: Int] = [:]
+        ranks.reserveCapacity(merges.count)
+        for (rank, entry) in merges.enumerated() {
+            // Written "Ġ t" in the version this file uses, ["Ġ", "t"] in the
+            // newer one. Both are in the wild for ModernBERT.
+            let halves: [String]
+            if let line = entry as? String {
+                halves = line.components(separatedBy: " ")
+            } else if let pair = entry as? [String] {
+                halves = pair
+            } else {
+                throw Failure.unreadable("merge \(rank) is neither text nor a pair")
+            }
+            guard halves.count == 2 else {
+                throw Failure.unreadable("merge \(rank) has \(halves.count) halves")
+            }
+            ranks[Pair(left: halves[0], right: halves[1])] = rank
+        }
+
+        // The added tokens sit above the vocabulary — 50280 to 50367 here —
+        // and a prediction can land on any of them, so the readable side has
+        // to cover them or `word(of:)` returns nothing for a real answer.
+        var byID: [Int: String] = [:]
+        for (token, id) in vocabulary { byID[id] = token }
+        var specials: [String: Int] = [:]
+        for entry in root["added_tokens"] as? [[String: Any]] ?? [] {
+            guard let id = entry["id"] as? Int, let content = entry["content"] as? String else {
+                continue
+            }
+            byID[id] = content
+            specials[content] = id
+        }
+        guard let top = byID.keys.max() else { throw Failure.unreadable("empty vocabulary") }
+        let words = (0...top).map { byID[$0] ?? "" }
+
+        func special(_ name: String) throws -> Int {
+            guard let id = specials[name] else {
+                throw Failure.unreadable("no \(name) in added_tokens")
+            }
+            return id
+        }
+
+        let tokenizer = BPETokenizer(
+            vocabulary: vocabulary,
+            ranks: ranks,
+            words: words,
+            cls: try special("[CLS]"),
+            sep: try special("[SEP]"),
+            mask: try special("[MASK]"),
+            pad: try special("[PAD]")
+        )
+        try tokenizer.assertBoundaryIDs()
+        return tokenizer
+    }
+
+    // MARK: - Encoding
+
+    /// Text to ids, with no `[CLS]` or `[SEP]` around it — the probe adds those.
+    ///
+    /// Leading and trailing spaces are part of the text and change the answer.
+    /// That is the point: see the note on the type.
+    func encode(_ text: String) -> [Int] {
+        var ids: [Int] = []
+        for chunk in Self.split(text) {
+            for piece in merge(Self.toByteAlphabet(chunk)) {
+                // Every piece a merge can produce is in the vocabulary: the
+                // byte alphabet is, and a merge only joins two pieces that are.
+                if let id = vocabulary[piece] { ids.append(id) }
+            }
+        }
+        return ids
+    }
+
+    /// The id a caller compares against, taken from a real tokenization.
+    ///
+    /// Write the space: `firstID(of: " That")`, never `firstID(of: "That")`.
+    func firstID(of text: String) -> Int? {
+        encode(text).first
+    }
+
+    // MARK: - Reading back
+
+    /// The id as text, with the byte alphabet undone, so `ĠDublin` reads
+    /// " Dublin". The leading space is kept: it is what tells a following word
+    /// from a word that continues the one before it.
+    func word(of id: Int) -> String? {
+        guard words.indices.contains(id) else { return nil }
+        let token = words[id]
+        guard !token.isEmpty else { return nil }
+        var bytes: [UInt8] = []
+        bytes.reserveCapacity(token.count)
+        for character in token.unicodeScalars {
+            // An added token like `[MASK]` never went through the byte
+            // alphabet, so anything outside it passes through as itself.
+            if let byte = Self.fromByteAlphabet[character] {
+                bytes.append(byte)
+            } else {
+                bytes.append(contentsOf: Array(String(character).utf8))
+            }
+        }
+        // Lossy on purpose, so `String(bytes:encoding:)` is the wrong one here:
+        // a BPE piece can be half of a multi-byte character, and a prediction
+        // that comes back as a replacement character is still a prediction.
+        // swiftlint:disable:next optional_data_string_conversion
+        return String(decoding: bytes, as: UTF8.self)
+    }
+
+    // MARK: - The assertion
+
+    /// Checks the space rule against a real tokenization, not against a
+    /// remembered number.
+    ///
+    /// A tokenizer that got the byte alphabet or the merges wrong still
+    /// returns ids, and a caller comparing against the wrong id scores zero
+    /// without erroring. This is what stops that shipping.
+    func assertBoundaryIDs() throws {
+        let ids = encode(Self.boundaryText)
+        guard let period = firstID(of: "."),
+              let spacedPeriod = firstID(of: " ."),
+              let following = firstID(of: " That"),
+              let bare = firstID(of: "That") else {
+            throw Failure.boundary("the boundary tokens do not encode")
+        }
+        guard ids.count == 9 else {
+            throw Failure.boundary("\(Self.boundaryText.debugDescription) is \(ids.count) ids, want 9")
+        }
+        guard ids[5] == period else {
+            throw Failure.boundary("the period is \(ids[5]), and \".\" is \(period)")
+        }
+        guard ids[6] == following else {
+            throw Failure.boundary("the word after it is \(ids[6]), and \" That\" is \(following)")
+        }
+        guard following != bare, period != spacedPeriod else {
+            throw Failure.boundary("the space makes no difference, so the byte alphabet is wrong")
+        }
+        // The way back, which is the half a caller reading a prediction uses.
+        guard word(of: ids[5]) == ".", word(of: ids[6]) == " That" else {
+            throw Failure.boundary(
+                "the ids read back as \(word(of: ids[5]) ?? "") and \(word(of: ids[6]) ?? "")"
+            )
+        }
+    }
+
+    static let boundaryText = "we have to do it. That works well"
+
+    /// The same four ids the assertion uses, for a caller that wants to print
+    /// them. Empty if any of them will not encode, which `assertBoundaryIDs`
+    /// has already refused to load past.
+    var boundaryIDs: [(token: String, id: Int)] {
+        [".", " .", "That", " That"].compactMap { text in
+            firstID(of: text).map { (text, $0) }
+        }
+    }
+
+    // MARK: - BPE
+
+    /// Merges the highest-ranked pair until none is left, which is the
+    /// reference algorithm.
+    private func merge(_ word: String) -> [String] {
+        var pieces = word.unicodeScalars.map { String($0) }
+        while pieces.count > 1 {
+            var best = Int.max
+            var at = -1
+            for index in 0..<(pieces.count - 1) {
+                let rank = ranks[Pair(left: pieces[index], right: pieces[index + 1])]
+                if let rank, rank < best {
+                    best = rank
+                    at = index
+                }
+            }
+            guard at >= 0 else { break }
+            pieces.replaceSubrange(at...(at + 1), with: [pieces[at] + pieces[at + 1]])
+        }
+        return pieces
+    }
+
+    // MARK: - The byte alphabet
+
+    /// GPT-2's byte-to-unicode table. Every byte gets a printable character,
+    /// so a merge never has to deal with a raw byte and the vocabulary is
+    /// text. 0x20 becomes `Ġ`, which is why a leading space is visible.
+    private static let alphabet: [Character] = {
+        let printable = Set(Array(0x21...0x7E) + Array(0xA1...0xAC) + Array(0xAE...0xFF))
+        var table = [Character](repeating: " ", count: 256)
+        var next = 256
+        for byte in 0..<256 {
+            var scalar = byte
+            if !printable.contains(byte) {
+                scalar = next
+                next += 1
+            }
+            table[byte] = Character(UnicodeScalar(UInt32(scalar)) ?? " ")
+        }
+        return table
+    }()
+
+    private static let fromByteAlphabet: [Unicode.Scalar: UInt8] = {
+        var back: [Unicode.Scalar: UInt8] = [:]
+        for (byte, character) in alphabet.enumerated() {
+            for scalar in character.unicodeScalars { back[scalar] = UInt8(byte) }
+        }
+        return back
+    }()
+
+    private static func toByteAlphabet(_ text: String) -> String {
+        String(text.utf8.map { alphabet[Int($0)] })
+    }
+
+    // MARK: - The pre-tokenizer
+
+    /// GPT-2's split, which is what `"pre_tokenizer": {"type": "ByteLevel"}`
+    /// means. Letters, digits and punctuation are cut apart, and a space is
+    /// kept with the word that follows it.
+    private static let pattern: NSRegularExpression? = try? NSRegularExpression(
+        pattern: "'s|'t|'re|'ve|'m|'ll|'d| ?\\p{L}+| ?\\p{N}+| ?[^\\s\\p{L}\\p{N}]+|\\s+(?!\\S)|\\s+"
+    )
+
+    private static func split(_ text: String) -> [String] {
+        // The file asks for NFC, and a decomposed é would otherwise merge
+        // differently from the one in the vocabulary.
+        let normalized = text.precomposedStringWithCanonicalMapping
+        guard let pattern else { return [normalized] }
+        let whole = NSRange(normalized.startIndex..., in: normalized)
+        return pattern.matches(in: normalized, range: whole).compactMap { match in
+            Range(match.range, in: normalized).map { String(normalized[$0]) }
+        }
+    }
+}

--- a/Sources/ParrotFlow/SentenceModel.swift
+++ b/Sources/ParrotFlow/SentenceModel.swift
@@ -3,14 +3,14 @@ import Foundation
 
 /// ModernBERT, fetched on the first English dictation and kept.
 ///
-/// Nothing reads it yet. It is here so the download happens once, early, and
-/// out of the way of the sentence that triggered it — the model is 300 MB and
-/// the first Core ML compile of it costs about 7 seconds, and neither is a
-/// thing to discover on the dictation that needs it.
+/// The download happens once, early, and out of the way of the sentence that
+/// triggered it. The model is 300 MB and the first Core ML compile of it costs
+/// about 7 seconds, and neither is a thing to discover on the dictation that
+/// needs it.
 ///
-/// What it is for: a masked word probe over a ±12-word window, which repairs a
-/// sentence a pause cut in two. Measured at about 8 ms per call at sequence
-/// length 64, which is the only length this conversion is faithful at.
+/// `SentenceProbe` reads it: a masked word probe over a ±12-word window.
+/// Measured at about 8 ms per call at sequence length 64, which is the only
+/// length this conversion is faithful at.
 ///
 /// `znaat/modernbert-coreml` and not `finnvoorhees/ModernBERT-CoreML`. That one
 /// is traced at a single token, where ModernBERT's sliding-window mask is
@@ -29,9 +29,8 @@ actor SentenceModel {
             "\(packageName)/Manifest.json",
             "\(packageName)/Data/com.apple.CoreML/model.mlmodel",
             "\(packageName)/Data/com.apple.CoreML/weights/weight.bin",
-            // Nothing reads it yet either. It belongs with the weights it was
-            // trained against, and fetching it now means the stage that needs
-            // it needs no download of its own.
+            // Beside the weights it was trained against, so `BPETokenizer`
+            // needs no download of its own.
             "tokenizer.json",
         ]
     }
@@ -83,6 +82,21 @@ actor SentenceModel {
     }
 
     private var model: MLModel?
+    private var tokenizer: BPETokenizer?
+
+    /// The tokenizer beside the weights, parsed once.
+    ///
+    /// `tokenizer.json` is 2 MB and building the two 50k tables out of it costs
+    /// 132 ms. A caller that loaded a probe per sentence would pay that per
+    /// sentence, against 8 ms for the forward pass it wanted.
+    ///
+    /// Call `prepare` first: this reads the file that download puts there.
+    func loadTokenizer() throws -> BPETokenizer {
+        if let tokenizer { return tokenizer }
+        let loaded = try BPETokenizer.load(contentsOf: Self.tokenizerURL)
+        tokenizer = loaded
+        return loaded
+    }
 
     /// The fetch in flight, if any. Same reason as `Transcriber.loadingModels`:
     /// actor isolation stops a torn read of `model`, not two callers both

--- a/Sources/ParrotFlow/SentenceProbe.swift
+++ b/Sources/ParrotFlow/SentenceProbe.swift
@@ -1,0 +1,195 @@
+import CoreML
+import Foundation
+
+/// What ModernBERT thinks belongs in one slot of a sentence.
+///
+/// Put a `[MASK]` between two pieces of text and read the distribution at it.
+/// That answers two different questions with the same forward pass: how likely
+/// one named token is there, and which words the model would put there.
+///
+///     let probe = try await SentenceProbe.load()
+///     let slot = try probe.at(left: "we have to do it", right: " works well")
+///     slot.logProbability(of: id)     // "is there a period, or does it run on"
+///     slot.top(10)                    // "what word would go here"
+///
+/// One `at` call is one forward pass, about 8 ms. Nothing here batches, and
+/// that is on purpose: a caller ranking the windows of a sentence pays that
+/// per window and should be able to see it in its own code.
+///
+/// **The mask stands for the token including its leading space.** In
+/// `"The capital of Ireland is[MASK]."` the answer is `" Dublin"`, not
+/// `"Dublin"` — different ids, and only the first is right. So `left` ends on
+/// a word with no trailing space, and `right` carries its own leading space
+/// when the next thing is a word. See `BPETokenizer`.
+@available(macOS 14, *)
+struct SentenceProbe {
+
+    enum Failure: LocalizedError {
+        case shape(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .shape(let what): return "sentence probe: \(what)"
+            }
+        }
+    }
+
+    /// The only length this conversion is faithful at. Correlation against
+    /// PyTorch at the mask is 0.9964-1.0000 here and 0.8996-0.9862 at 128.
+    static let length = 64
+
+    /// Words kept either side of the site. Measured over 200 periods and 120
+    /// cuts: ±12 fits inside 64 every time and reads better than the whole
+    /// sentence, because a word twelve away is noise rather than context.
+    static let radius = 12
+
+    let tokenizer: BPETokenizer
+    private let model: MLModel
+
+    static func load(progress: (@Sendable (String) -> Void)? = nil) async throws -> SentenceProbe {
+        let model = try await SentenceModel.shared.prepare(progress: progress)
+        return SentenceProbe(
+            tokenizer: try BPETokenizer.load(contentsOf: SentenceModel.tokenizerURL),
+            model: model
+        )
+    }
+
+    // MARK: - One slot
+
+    /// One forward pass, with the mask between `left` and `right`.
+    ///
+    /// Both sides are trimmed to `radius` words first, from the end away from
+    /// the mask, so the text touching the mask is passed through unchanged —
+    /// a trim that rebuilt the string would eat the leading space `right`
+    /// needs.
+    func at(left: String, right: String) throws -> Slot {
+        var head = tokenizer.encode(Self.trim(left, keeping: .end))
+        var tail = tokenizer.encode(Self.trim(right, keeping: .start))
+
+        // ±12 words fits in every window measured, so this is the guard for
+        // the window nobody measured: a long word run, or a caller that did
+        // not window at all. Drop from the far ends, never from the mask.
+        let budget = Self.length - 3
+        while head.count + tail.count > budget {
+            if head.count >= tail.count { head.removeFirst() } else { tail.removeLast() }
+        }
+
+        let maskAt = 1 + head.count
+        var ids = [tokenizer.cls] + head + [tokenizer.mask] + tail + [tokenizer.sep]
+        ids += Array(repeating: tokenizer.pad, count: Self.length - ids.count)
+
+        let input = try MLMultiArray(shape: [1, NSNumber(value: Self.length)], dataType: .int32)
+        for (index, id) in ids.enumerated() { input[index] = NSNumber(value: id) }
+
+        // `attention_mask` is not an input. The conversion wrapper builds it as
+        // ones_like(input_ids), so the padding is attended. Measured to cost
+        // nothing on this task; that is a property of this task, not a promise.
+        let output = try model.prediction(
+            from: MLDictionaryFeatureProvider(dictionary: ["input_ids": input])
+        )
+        guard let logits = output.featureValue(for: "logits")?.multiArrayValue else {
+            throw Failure.shape("the model returned no logits")
+        }
+        return try Slot(logits: logits, at: maskAt, tokenizer: tokenizer)
+    }
+
+    // MARK: - The window
+
+    private enum Keeping { case start, end }
+
+    /// The `radius` words at one end, cut at a space so the other end — the
+    /// one the mask touches — comes through byte for byte.
+    private static func trim(_ text: String, keeping end: Keeping) -> String {
+        let spaces = text.indices.filter { text[$0] == " " }
+        switch end {
+        case .end:
+            guard spaces.count >= radius else { return text }
+            return String(text[text.index(after: spaces[spaces.count - radius])...])
+        case .start:
+            // A leading space is the mask's own, not a word separator, so it
+            // is not one of the cuts counted here.
+            let cuts = text.hasPrefix(" ") ? Array(spaces.dropFirst()) : spaces
+            guard cuts.count >= radius else { return text }
+            return String(text[..<cuts[radius - 1]])
+        }
+    }
+
+    // MARK: - What came back
+
+    /// The distribution at one position, as log-probabilities.
+    struct Slot {
+        private let logits: [Float]
+        private let logSumExp: Double
+        private let tokenizer: BPETokenizer
+
+        /// Where the mask ended up, for a caller reporting what it asked.
+        let position: Int
+
+        init(logits array: MLMultiArray, at position: Int, tokenizer: BPETokenizer) throws {
+            let width = tokenizer.count
+            guard array.count >= (position + 1) * width else {
+                throw Failure.shape("logits are \(array.count) values, too few for row \(position)")
+            }
+            // Reading a row in place needs the rows laid out end to end.
+            guard array.strides.map(\.intValue).last == 1,
+                  array.strides.dropLast().last?.intValue == width else {
+                throw Failure.shape("logits are strided \(array.strides), not contiguous rows")
+            }
+            // One row, read in place. Converting the whole array to
+            // `MLShapedArray<Float>` first is correct and costs 440 ms of the
+            // 450 a call took: it walks all 64 x 50368 values to reach the one
+            // row this needs.
+            let row = position * width
+            switch array.dataType {
+            case .float32:
+                self.logits = array.withUnsafeBufferPointer(ofType: Float.self) {
+                    Array($0[row..<(row + width)])
+                }
+            case .float16:
+                self.logits = array.withUnsafeBufferPointer(ofType: Float16.self) {
+                    $0[row..<(row + width)].map { Float($0) }
+                }
+            case .double:
+                self.logits = array.withUnsafeBufferPointer(ofType: Double.self) {
+                    $0[row..<(row + width)].map { Float($0) }
+                }
+            default:
+                throw Failure.shape("logits are \(array.dataType), which is not a float")
+            }
+            self.position = position
+            self.tokenizer = tokenizer
+
+            let top = Double(self.logits.max() ?? 0)
+            self.logSumExp = top + log(self.logits.reduce(0.0) { $0 + exp(Double($1) - top) })
+        }
+
+        /// How likely that exact token is here. `-.infinity` for an id outside
+        /// the vocabulary.
+        ///
+        /// Take the id from `BPETokenizer.firstID(of:)` and write the leading
+        /// space: `" That"`, not `"That"`.
+        func logProbability(of id: Int) -> Double {
+            guard logits.indices.contains(id) else { return -.infinity }
+            return Double(logits[id]) - logSumExp
+        }
+
+        /// The `k` most likely tokens, as text a caller can put back into the
+        /// sentence. The leading space is kept.
+        func top(_ k: Int) -> [Prediction] {
+            let ranked = logits.indices.sorted { logits[$0] > logits[$1] }
+            return ranked.lazy
+                .compactMap { id in
+                    tokenizer.word(of: id).map {
+                        Prediction(word: $0, logProbability: self.logProbability(of: id))
+                    }
+                }
+                .prefix(k)
+                .map { $0 }
+        }
+    }
+
+    struct Prediction {
+        let word: String
+        let logProbability: Double
+    }
+}

--- a/Sources/ParrotFlow/SentenceProbe.swift
+++ b/Sources/ParrotFlow/SentenceProbe.swift
@@ -46,11 +46,12 @@ struct SentenceProbe {
     let tokenizer: BPETokenizer
     private let model: MLModel
 
+    /// Downloads the model if it is not there, then loads it and the tokenizer.
+    /// Both are cached on `SentenceModel.shared`, so calling this again is cheap.
     static func load(progress: (@Sendable (String) -> Void)? = nil) async throws -> SentenceProbe {
         let model = try await SentenceModel.shared.prepare(progress: progress)
         return SentenceProbe(
-            tokenizer: try BPETokenizer.load(contentsOf: SentenceModel.tokenizerURL),
-            model: model
+            tokenizer: try await SentenceModel.shared.loadTokenizer(), model: model
         )
     }
 
@@ -76,7 +77,7 @@ struct SentenceProbe {
 
         let maskAt = 1 + head.count
         var ids = [tokenizer.cls] + head + [tokenizer.mask] + tail + [tokenizer.sep]
-        ids += Array(repeating: tokenizer.pad, count: Self.length - ids.count)
+        ids += Array(repeating: tokenizer.pad, count: max(0, Self.length - ids.count))
 
         let input = try MLMultiArray(shape: [1, NSNumber(value: Self.length)], dataType: .int32)
         for (index, id) in ids.enumerated() { input[index] = NSNumber(value: id) }
@@ -146,6 +147,10 @@ struct SentenceProbe {
                     Array($0[row..<(row + width)])
                 }
             case .float16:
+                // `Float16` conforms to `MLShapedArrayScalar` only from macOS 15.
+                guard #available(macOS 15, *) else {
+                    throw Failure.shape("float16 logits need macOS 15")
+                }
                 self.logits = array.withUnsafeBufferPointer(ofType: Float16.self) {
                     $0[row..<(row + width)].map { Float($0) }
                 }

--- a/Sources/ParrotFlow/SentenceProbeCommand.swift
+++ b/Sources/ParrotFlow/SentenceProbeCommand.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+/// `--sentence-probe` — what ModernBERT would put in one slot of a sentence.
+///
+/// Write the slot as `[MASK]`. The top ten words come back, most likely first:
+///
+///     ParrotFlow --sentence-probe "The capital of Ireland is [MASK]."
+///       boundary  "." 15   " ." 964   "That" 2773   " That" 2064   ✓
+///       mask at 6 of 64
+///        1   Dublin           -0.19
+///        2   Belfast          -3.02
+///
+/// That sentence is the acceptance test for the model itself. The published
+/// repository exists to warn about a conversion that reads only one token, and
+/// a broken one answers `£, isation, organisation, ised` here. If you get that
+/// list, the tokenizer or the packing is wrong, not the model.
+///
+/// The `boundary` line is the tokenizer's own assertion, run at load against a
+/// real tokenization of `"we have to do it. That works well"`. It is printed
+/// because the mistake it catches is silent: a word after another word carries
+/// its leading space, so `" That"` is 2064 and `"That"` is 2773, and a caller
+/// comparing against the second scores zero without erroring.
+///
+/// `--against` asks the other question: how likely one named token is here,
+/// beside the period. That is the sentence-join shape, and it answers whether
+/// a pause that ended a sentence should have.
+///
+///     ParrotFlow --sentence-probe "the report is due on [MASK] morning" --against " Friday"
+///       " Friday"         -2.43        the cut was spurious, join it
+///       period            -7.71
+///
+///     ParrotFlow --sentence-probe "we have to do it [MASK] works well" --against " That"
+///       " That"           -8.20        the period is real, leave it
+///       period            -4.35
+///
+/// The period is the better of `.` and `Ġ.`, because the slot can be reached
+/// either way. Write the leading space in `--against`.
+///
+/// One forward pass either way, about 8 ms once the model is loaded. The first
+/// run downloads 300 MB and compiles it, which is `--sentence-model`.
+@available(macOS 14, *)
+enum SentenceProbeCommand {
+
+    private static let marker = "[MASK]"
+
+    static func run(text: String, against candidate: String?, top: Int = 10) -> Int32 {
+        guard let cut = text.range(of: marker) else {
+            print("usage: ParrotFlow --sentence-probe \"… \(marker) …\" [--against \" word\"]")
+            return 2
+        }
+        // The mask stands for the token including its leading space, so the
+        // one space a person writes before `[MASK]` is the mask's own and is
+        // dropped. Without this the slot gets a bare word and the answers
+        // quietly get worse.
+        var left = String(text[..<cut.lowerBound])
+        if left.hasSuffix(" ") { left.removeLast() }
+        let right = String(text[cut.upperBound...])
+
+        var exitCode: Int32 = 0
+        let done = DispatchSemaphore(value: 0)
+
+        Task {
+            do {
+                let probe = try await SentenceProbe.load { label in
+                    print("\r  \(label)…", terminator: "")
+                    fflush(stdout)
+                }
+                print("\r\u{1B}[K", terminator: "")
+                report(probe.tokenizer.boundaryIDs)
+
+                let first = Date()
+                let slot = try probe.at(left: left, right: right)
+                let cold = Date().timeIntervalSince(first) * 1000
+                // The same pass again. Core ML spends the first prediction
+                // warming, so a single reading says nothing about what a
+                // caller making one of these per window will pay.
+                let second = Date()
+                _ = try probe.at(left: left, right: right)
+                let warm = Date().timeIntervalSince(second) * 1000
+
+                print("  mask at \(slot.position) of \(SentenceProbe.length)")
+                if let candidate, !candidate.isEmpty {
+                    say(candidate.debugDescription, probe.tokenizer.firstID(of: candidate), slot)
+                    // Both spellings, because the slot the mask stands for can
+                    // be reached with a space or without one, and the caller
+                    // wants the better of the two.
+                    let period = [".", " ."].compactMap { probe.tokenizer.firstID(of: $0) }
+                        .map { slot.logProbability(of: $0) }.max() ?? -.infinity
+                    print(column("period", period))
+                } else {
+                    for (rank, guess) in slot.top(top).enumerated() {
+                        print("  \(pad("\(rank + 1)", 2, left: false))" + column(guess.word, guess.logProbability))
+                    }
+                }
+                print(String(format: "  one forward pass, %.0f ms warm, %.0f ms on the first", warm, cold))
+            } catch {
+                print("\r\u{1B}[K✗ \(error.localizedDescription)")
+                exitCode = 1
+            }
+            done.signal()
+        }
+
+        done.wait()
+        return exitCode
+    }
+
+    private static func say(_ token: String, _ id: Int?, _ slot: SentenceProbe.Slot) {
+        guard let id else {
+            print("  \(token) does not encode")
+            return
+        }
+        print(column(token, slot.logProbability(of: id)))
+    }
+
+    /// `%@` ignores a width on this platform, so the columns are padded here.
+    private static func column(_ token: String, _ score: Double) -> String {
+        "  " + pad(token, 16) + String(format: "%7.2f", score)
+    }
+
+    private static func pad(_ text: String, _ width: Int, left: Bool = true) -> String {
+        let room = String(repeating: " ", count: max(0, width - text.count))
+        return left ? text + room : room + text
+    }
+
+    private static func report(_ ids: [(token: String, id: Int)]) {
+        let listed = ids.map { "\($0.token.debugDescription) \($0.id)" }.joined(separator: "   ")
+        print("  boundary  \(listed)   ✓")
+    }
+}

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -128,8 +128,19 @@ if arguments.contains("--sentence-model") {
     exit(SentenceModelCommand.run())
 }
 
-
-
+if let index = arguments.firstIndex(of: "--sentence-probe") {
+    guard #available(macOS 14, *) else {
+        print("✗ the sentence model needs macOS 14 or later")
+        exit(1)
+    }
+    guard arguments.indices.contains(index + 1) else {
+        print("usage: ParrotFlow --sentence-probe \"… [MASK] …\" [--against \" word\"]")
+        exit(2)
+    }
+    let against = arguments.firstIndex(of: "--against")
+        .flatMap { arguments.indices.contains($0 + 1) ? arguments[$0 + 1] : nil }
+    exit(SentenceProbeCommand.run(text: arguments[index + 1], against: against))
+}
 
 if arguments.contains("--boost-eval") {
     guard #available(macOS 14, *) else { exit(1) }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -433,6 +433,38 @@ somebody.
 returns `Other` for everything without one. In a pipeline the language comes
 from the scope; here it falls back to the first configured language.
 
+## What word belongs in a slot
+
+```sh
+$PF --sentence-model
+$PF --sentence-probe "The capital of Ireland is [MASK]."
+$PF --sentence-probe "the report is due on [MASK] morning" --against " Friday"
+```
+
+`--sentence-probe` masks one slot of a sentence and prints what ModernBERT
+would put there, most likely first. `--sentence-model` is the download, 300 MB
+once; the probe does it too if it has to.
+
+That first sentence is the acceptance test for the model. Correct is `Dublin,
+Belfast, Cork, London`. A conversion that only reads one token answers `£,
+isation, organisation, ised` instead, and the published repository exists to
+warn about that.
+
+`--against` asks about one named token beside the period, which is the
+sentence-join question — did a pause end a sentence that should have run on.
+`" Friday"` scores -2.43 against the period's -7.71, so that period was
+spurious. In `"we have to do it [MASK] works well"`, `" That"` scores -8.20
+against the period's -4.35, so that one is real.
+
+**Write the leading space.** A word that follows another word carries it, so
+`" That"` is token 2064 and `"That"` is 2773. Comparing against the second
+scores zero and errors on nothing. The `boundary` line the command prints first
+is that rule checked against a real tokenization at load.
+
+Both sides are cut to the 12 words nearest the mask before the model sees them.
+Measured over 200 periods and 120 cuts: ±12 words fits in the 64-token input
+every time, and reads better than the whole sentence.
+
 ## Where the input stage cuts a field
 
 ```sh


### PR DESCRIPTION
The model #225 downloads now has a reader. This adds a byte-level BPE tokenizer, a masked-word probe over it, and `--sentence-probe` to run one by hand. Nothing in the app calls it yet — two stages will, and this is the shape they need. Start the review at `SentenceProbe.at(left:right:)`, which is the whole API, and at `BPETokenizer.assertBoundaryIDs`, which is what stops the leading-space mistake shipping.

The acceptance test for the model itself:

```
$ ParrotFlow --sentence-probe "The capital of Ireland is [MASK]."
  boundary  "." 15   " ." 964   "That" 2773   " That" 2064   ✓
  mask at 6 of 64
   1   Dublin           -0.19
   2   Belfast          -3.02
   3   Cork             -3.16
   4   London           -4.10
   5   Edinburgh        -4.59
   6   Liverpool        -5.01
   7   Glasgow          -5.33
   8   Oxford           -5.56
   9   Manchester       -6.43
  10   Birmingham       -6.46
  one forward pass, 8 ms warm, 18 ms on the first
```

`Dublin, Belfast, Cork, London` is the correct list. A conversion that only reads one token answers `£, isation, organisation, ised` instead. That is what `znaat/modernbert-coreml` was published to rule out, and it is also what a wrong tokenizer or wrong input packing produces, so this one command covers the model, the BPE and the packing at once.

<details>
<summary>The leading space is the trap, and this is how it is caught</summary>

On a byte-level BPE a word carries the space in front of it, and the period does not:

```
"we have to do it. That works well"
   ->  we Ġhave Ġto Ġdo Ġit . ĠThat Ġworks Ġwell
```

So the id for a word that follows another word is `encode(" That")[0]`, which is 2064. `encode("That")[0]` is 2773 and is a different token. A caller that compares against 2773 finds it at the top of nothing and scores zero. It errors on nothing and looks like a model problem.

`BPETokenizer.assertBoundaryIDs` runs at load. It tokenizes `"we have to do it. That works well"` for real and checks four things against that tokenization, not against remembered numbers:

- the token at the period's position is `firstID(of: ".")`
- the token after it is `firstID(of: " That")`
- `" That"` and `"That"` are different ids, and so are `"."` and `" ."`
- both ids read back as `"."` and `" That"` through `word(of:)`

The last one covers the id-to-word direction, which the top-k caller depends on and which nothing else exercises. Loading throws if any of it fails, so a broken tokenizer cannot reach a measurement.

The CLI prints the same four ids on its `boundary` line, so the check is visible in any run.

ModernBERT has two period tokens, `.` (15) and `Ġ.` (964). A caller asking "is there a period in this slot" has to take the better of the two. `--against` does, and says so.

</details>

<details>
<summary>The API, and the two callers it was shaped for</summary>

One call is one forward pass. Nothing batches, on purpose: a caller that ranks the windows of a sentence pays 8 ms per window and should see that in its own code.

```swift
let probe = try await SentenceProbe.load()
let slot = try probe.at(left: "we have to do it", right: " works well")

slot.logProbability(of: id)   // one named token
slot.top(10)                  // readable words, leading space kept
```

**The sentence join.** Is a period real, or did a pause cut a sentence in two? One forward pass, then compare the next word against the period.

```
$ ParrotFlow --sentence-probe "the report is due on [MASK] morning" --against " Friday"
  " Friday"         -2.43
  period            -7.71

$ ParrotFlow --sentence-probe "we have to do it [MASK] works well" --against " That"
  " That"           -8.20
  period            -4.35
```

The first cut was spurious. The second period is real. The probe separates them by 5.3 and 3.9 nats.

**The vocabulary gate.** `top(10)` returns words, so the caller can put each back in the sentence and tag it with `NLTagger`. Rank comes from `logProbability(of:)` on the span's own token, one `at` call per window.

`left` and `right` are literal text and are passed to the tokenizer byte for byte. The mask stands for the token including its leading space. So `left` ends on a word with no trailing space, and `right` carries its own leading space when the next thing is a word — `"."` when it is punctuation. The doc comment on `SentenceProbe` says this first.

</details>

<details>
<summary>The BPE matches a reference implementation on 14 of 14, including CJK and emoji</summary>

There is no reference tokenizer on this machine and no package was added, so the Swift was checked against a Python BPE written from the same `tokenizer.json`. Exact id sequences, not counts:

| case | |
|---|---|
| `The capital of Ireland is` | ok |
| `we have to do it. That works well` | ok |
| `Naïve café résumé, don't you think` | ok |
| `Send the webhook to Mirza's endpoint at 3:45pm` | ok |
| `ParrotFlow—the dictation app—works offline (mostly)` | ok |
| `  double  spaces   here` | ok |
| `日本語のテキストです` | ok |
| `emoji 🚀 and fi ligature` | ok |
| `CamelCaseIdentifier snake_case_name kebab-case` | ok |
| `It cost $1,234.56 on 2026-08-30 at 07:15` | ok |
| `"quoted" 'single' \`backtick\` <angle> {brace}` | ok |
| `a` / ` a` | ok |
| a 28-word sentence | ok |

The underscore case caught a bug in the Python, not in the Swift. Python's `\w` includes `_`, so a `[^\s\w]+` punctuation class drops underscores silently. The Swift uses ICU `\p{L}` and `\p{N}`, which is what HuggingFace's ByteLevel pre-tokenizer means, and it was right.

</details>

<details>
<summary>The window is ±12 words, and it is in this PR so both callers get it by default</summary>

Measured earlier on 200 real periods and 120 cuts:

| window | fits in 64 | at threshold −2 | at 0 |
|---|---|---|---|
| whole sentence | 89% | 56% / 3.0 false | 82% / 7.5 |
| ±24 words | 99% | 54% / 1.5 | 82% / 6.0 |
| ±12 words | 100% | 56% / 0.5 | 82% / 3.0 |

Full coverage and a better signal. A word twelve away is noise, not context.

The trim slices the original string at a space and keeps the end that touches the mask. It does not split and rejoin: that would eat the leading space `right` needs, which is the same trap as above, reintroduced by the helper meant to be safe.

Verified: 16 words either side trims to exactly 12 and 12, `right` keeps its leading space, `"."` on the right passes through untouched, 12 words either side is left alone, 13 trims to 12.

Past the window there is a token budget guard for the input nobody measured — a long run of rare words, or a caller that skipped the window. It drops from the far ends and never from the mask. With 12 words per side that each cost 4 tokens it trims to 30/31 and still answers.

</details>

<details>
<summary>Reading one logits row in place, not converting the array — 450 ms to 8 ms</summary>

The output is `logits [1, 64, 50368]` and only the mask's row is wanted. The first version read it with `MLShapedArray<Float>(converting:)`, which is correct and walks all 3.2 million values. A call cost 450 ms.

Reading the one row through `withUnsafeBufferPointer(ofType:)` costs 8 ms warm, which matches what was measured for this model. `dataType` is checked for `.float32`, `.float16` and `.double`, and the strides are checked to be contiguous rows first, so the pointer read cannot silently return the wrong values if the conversion ever changes shape.

`logSumExp` is computed once per `Slot`, not per `logProbability` call.

The tokenizer is parsed once, on `SentenceModel`, beside the model. Building the two 50k tables out of the 2 MB `tokenizer.json` costs 132 ms, and a caller that loaded a probe per sentence would have paid that per sentence.

</details>

<details>
<summary>Checks, and what is not checked</summary>

`swift build` is clean. `make test` passes every check. SwiftLint reports nothing on the three new files.

There is no new script in `CHECKS`. Everything in that list runs with no model, and CI has no 300 MB download. A check that needed `tokenizer.json` would either go red on CI or skip silently, and a check that always skips is worse than none. The load-time assertion and the `boundary` line in the CLI are what carry it instead.

`--sentence-probe` is documented in `docs/cli.md`, under "What word belongs in a slot".

608 lines across the three new files.

</details>
