### PR TITLE
perf: the sentence tokenizer is parsed once, not once per probe

### DIFF
--- a/Sources/ParrotFlow/BPETokenizer.swift
+++ b/Sources/ParrotFlow/BPETokenizer.swift
@@ -16,7 +16,7 @@ import Foundation
 /// `firstID(of: "That")`, 2773. The period is the bare `.`, 15, not `Ġ.`, 964.
 /// `assertBoundaryIDs` checks that against a real tokenization at load, because
 /// getting it wrong returns numbers rather than an error.
-struct BPETokenizer {
+struct BPETokenizer: Sendable {
 
     enum Failure: LocalizedError {
         case unreadable(String)
@@ -181,6 +181,9 @@ struct BPETokenizer {
                 bytes.append(contentsOf: Array(String(scalar).utf8))
             }
         }
+        // Lossy on purpose. A failable initializer returns nil for the pieces
+        // that are half a character, and those still have to print.
+        // swiftlint:disable:next optional_data_string_conversion
         return String(decoding: bytes, as: UTF8.self)
     }
 

--- a/Sources/ParrotFlow/SentenceModel.swift
+++ b/Sources/ParrotFlow/SentenceModel.swift
@@ -147,6 +147,20 @@ actor SentenceModel {
         try MLModel(contentsOf: compiledURL)
     }
 
+    private var tokenizers: [URL: BPETokenizer] = [:]
+
+    /// Parsed once per file. Reading the 2 MB `tokenizer.json` and building its
+    /// two 50k tables costs about 90 ms, against 8 ms for the forward pass the
+    /// caller wanted, so a caller loading a probe per sentence would spend the
+    /// whole budget here. Keyed by URL because `PARROTFLOW_TOKENIZER` points
+    /// the check script at another copy.
+    func tokenizer(at url: URL) throws -> BPETokenizer {
+        if let cached = tokenizers[url] { return cached }
+        let loaded = try BPETokenizer.load(contentsOf: url)
+        tokenizers[url] = loaded
+        return loaded
+    }
+
     /// Fetches into a staging directory, compiles, then moves the result into
     /// place. Staging sits inside `directory` so the move is a rename on the
     /// same volume — across volumes `moveItem` copies, and a copy is not

--- a/Sources/ParrotFlow/SentenceProbe.swift
+++ b/Sources/ParrotFlow/SentenceProbe.swift
@@ -56,9 +56,9 @@ struct SentenceProbe {
 
     static func load(progress: (@Sendable (String) -> Void)? = nil) async throws -> SentenceProbe {
         let model = try await SentenceModel.shared.prepare(progress: progress)
-        // `load` runs `assertBoundaryIDs`, so a tokenizer that would score the
-        // wrong ids throws here rather than answering.
-        let tokenizer = try BPETokenizer.load(contentsOf: tokenizerURL)
+        // The tokenizer runs `assertBoundaryIDs` as it parses, so one that
+        // would score the wrong ids throws here rather than answering.
+        let tokenizer = try await SentenceModel.shared.tokenizer(at: tokenizerURL)
         guard let period = tokenizer.firstID(of: ".") else {
             throw Failure.shape("\".\" does not encode")
         }
@@ -81,20 +81,18 @@ struct SentenceProbe {
     }
 
     func read(left: String, right: String) throws -> Reading {
-        let head = Array(left.split(whereSeparator: \.isWhitespace).map(String.init))
-        let tail = Array(right.split(whereSeparator: \.isWhitespace).map(String.init))
+        // The period under test is dropped before the words are counted, so a
+        // caller that kept it and one that did not get the same window.
+        let kept = String(left.reversed().drop { $0 == "." }.reversed())
+        let before = kept.split(whereSeparator: \.isWhitespace).suffix(Self.radius).map(String.init)
+        let tail = right.split(whereSeparator: \.isWhitespace).map(String.init)
         guard var next = tail.first else { throw Failure.empty }
-        // The trailing period is the one under test, and a caller may or may
-        // not have kept it.
-        var before = head.suffix(Self.radius).map { $0 }
-        if let last = before.last {
-            let stripped = String(last.reversed().drop { $0 == "." }.reversed())
-            if stripped.isEmpty { before.removeLast() } else { before[before.count - 1] = stripped }
-        }
         next = next.prefix(1).lowercased() + next.dropFirst()
         let after = ([next] + tail.dropFirst()).prefix(Self.radius).joined(separator: " ")
 
-        guard let nextID = tokenizer.firstID(of: " " + next) else { throw Failure.empty }
+        guard let nextID = tokenizer.firstID(of: " " + next) else {
+            throw Failure.shape("\((" " + next).debugDescription) does not encode")
+        }
         let slot = try at(left: before.joined(separator: " "), right: " " + after)
         let periodLogProbability = slot.logProbability(of: period)
         let nextLogProbability = slot.logProbability(of: nextID)
@@ -168,6 +166,11 @@ struct SentenceProbe {
                     Array($0[row..<(row + width)])
                 }
             case .float16:
+                // `Float16` conforms to `MLShapedArrayScalar` only from macOS 15,
+                // and this type ships to macOS 14.
+                guard #available(macOS 15, *) else {
+                    throw Failure.shape("float16 logits need macOS 15")
+                }
                 self.logits = array.withUnsafeBufferPointer(ofType: Float16.self) {
                     $0[row..<(row + width)].map { Float($0) }
                 }

--- a/scripts/check-tokenizer.sh
+++ b/scripts/check-tokenizer.sh
@@ -56,10 +56,9 @@ pass=0; total=0
 while IFS= read -r quoted && IFS= read -r want; do
   total=$((total + 1))
   text="$(python3 -c 'import json,sys; sys.stdout.write(json.loads(sys.argv[1]))' "$quoted")"
-  got="$("$BIN" --sentence-probe --encode "$text" 2>/dev/null | awk '/^ids / { print $2 }')"
-  # `ids` with nothing after it is the empty string's answer, and awk prints
-  # nothing for it. That is a pass, not a missing line.
-  [ -z "$got" ] && got="$(printf '')"
+  # `ids` with nothing after it is the empty string's answer, and `$2` is then
+  # empty. That is a pass, not a missing line.
+  got="$("$BIN" --sentence-probe --encode "$text" 2>/dev/null | awk '/^ids/ { print $2 }')"
   if [ "$got" = "$want" ]; then
     pass=$((pass + 1))
     printf '  ✓ %s\n' "$quoted"


### PR DESCRIPTION
The three fixes that were pushed to #227 after it merged. Same commits, rebased
onto `main`.

The one that matters is the parse. `SentenceProbe.load` read and parsed
`tokenizer.json` on every call. Reading the 2 MB file and building its two 50k
tables costs about 90 ms, against 8 ms for the forward pass the caller wanted,
so the PR that calls the probe per boundary would have spent its whole budget
there. The cache now sits on the `SentenceModel` actor, beside the compiled
model.

Check the cache key first: it is the URL, not a single slot, so
`PARROTFLOW_TOKENIZER` still reaches its own copy and
`scripts/check-tokenizer.sh` still runs against a downloaded file.

`make test` green. `scripts/check-tokenizer.sh` 19/19.
`scripts/check-sentence-probe.sh` 40/40 within 0.05, worst gap 0.0050 —
unchanged by any of this, which is the point.

<details>
<summary>The other two — a macOS 15 conformance and an off-by-one in the window</summary>

**`Float16` needs a macOS 15 guard.** `SentenceProbe` is
`@available(macOS 14, *)`, but `Float16` conforms to `MLShapedArrayScalar` only
from macOS 15, so `withUnsafeBufferPointer(ofType: Float16.self)` built with a
warning that is an error in the Swift 6 language mode. The branch now throws
`float16 logits need macOS 15` rather than falling through to a wrong number.
This model returns float32, so nothing reaches it today.

**The window counted the period as a word.** `SentenceProbe.read` took the last
12 words and then stripped the trailing `.` from the last one. The reference
strips first and then counts. The two agree unless the caller wrote a space
before the period, where the old order kept 11 words instead of 12. No fixture
case had that shape, so it was found by reading rather than by failing.

</details>

<details>
<summary>Measurement — 63 ms for a process that does nothing, 150 ms for one that parses</summary>

Ten runs each, wall clock per run:

```
ParrotFlow --version                      63 ms
ParrotFlow --sentence-probe --encode "hi"  150 ms
```

So the read, the JSON parse, the 50280-entry vocabulary and the 50009-entry
merge table are about 90 ms of that. The same measurement on the closed #226
branch came to 132 ms. Either number is the whole budget against an 8 ms
forward pass.

`--sentence-probe --encode` still calls `BPETokenizer.load` directly and is not
cached. It is a process that parses once and exits, and it must not touch the
actor that owns the 300 MB model — that is what lets the check script run
without it.

`BPETokenizer` is now `Sendable` so it can leave the actor.

</details>
