### PR TITLE
feat: the sentence decides whether a name can go where a word stands

### DIFF
--- a/Sources/ParrotFlow/SlotGate.swift
+++ b/Sources/ParrotFlow/SlotGate.swift
@@ -1,0 +1,231 @@
+import Foundation
+import NaturalLanguage
+
+/// Can a name stand where this word stands? Asked of the sentence, not of the
+/// word.
+///
+/// The judge is a model call of about 900 ms and every proposal the lexical
+/// gate does not settle goes to it. This settles some of them with the masked
+/// language model `SentenceProbe` already loads: one forward pass to see what
+/// the slot wants, and one per word only when that pass says a name could go
+/// there. A pass is about 8 ms at sequence length 64.
+///
+/// Three rules, and they run in this order:
+///
+///     slot POS accepts a name    apply    with the rank rule below
+///     rank 0                     apply    ANDed with the rule above
+///     slot POS refuses a name    decline
+///     else                       judge
+///
+/// **Slot POS.** Mask the heard word, take the ten most likely fillers, put
+/// each back in the sentence and tag it. The modal tag is what the slot wants.
+/// Tagging the word that is already there says nothing — it describes a word
+/// that may be wrong. Masking asks the sentence instead. It is the only signal
+/// that catches `Mirza's -> Mirza`: "waiting for ___ thoughts" predicts
+/// `second, my, your, any, some, more, the, first`, and a bare name does not
+/// go in a determiner slot.
+///
+/// **Rank 0.** The heard word is the weakest place in its sentence: no word
+/// surprises the model more, and no two-word window more than the one it sits
+/// on. One forward pass per word — see `weakest`.
+///
+/// **ANDed, cheapest first.** An AND already fails once the POS refuses, and
+/// the POS is one pass against the rank's one per word, so the rank is not
+/// computed then.
+///
+/// **Rule 6 runs after the apply rules, never before.** Put in front of the
+/// lexical gate it declines four cases that gate is right to write.
+///
+/// **`Determiner` is not blocked.** A determiner slot is a modifier position
+/// and names do sit there — `cloud code`, `bedrock principles`. Blocking it
+/// costs a wrong decline.
+///
+/// Measured over the 50 English cases of `tests/judge-cases.yaml` by
+/// `scripts/check-slot-gate.sh`: 15 auto-applied, 14 declined, 21 left for the
+/// judge, and no error of either kind.
+@available(macOS 14, *)
+struct SlotGate {
+
+    enum Route: String {
+        case apply, decline, judge
+    }
+
+    /// Tags a name can stand in. Rule 4.
+    static let hosts: Set<String> = ["Noun", "Adjective", "Pronoun"]
+
+    /// Tags a name cannot stand in. Rule 6.
+    static let blocks: Set<String> = ["Verb", "Adverb", "Preposition"]
+
+    /// How many fillers vote on what the slot wants.
+    static let fillers = 10
+
+    let probe: SentenceProbe
+
+    struct Reading {
+        /// The modal tag of the fillers, or "" when nothing tagged.
+        let tag: String
+        /// How far the span is from being the weakest place in the sentence —
+        /// see `weakest`. Absent when the POS refused and the rank was skipped.
+        let rank: Int?
+        let windows: Int
+        let route: Route
+    }
+
+    /// Where one proposal should go. `range` is a range in `text`.
+    func read(in text: String, at range: Range<String.Index>) throws -> Reading {
+        let (words, span) = Self.sentence(around: range, in: text)
+        guard !span.isEmpty, span.upperBound <= words.count else {
+            return Reading(tag: "", rank: nil, windows: 0, route: .judge)
+        }
+
+        let tag = try wants(words, at: span)
+        guard Self.hosts.contains(tag) else {
+            return Reading(
+                tag: tag, rank: nil, windows: 0,
+                route: Self.blocks.contains(tag) ? .decline : .judge
+            )
+        }
+        let (rank, windows) = try weakest(words, at: span)
+        return Reading(
+            tag: tag, rank: rank, windows: windows,
+            route: rank == 0 ? .apply : .judge
+        )
+    }
+
+    // MARK: - Rule 4 and rule 6, the slot's part of speech
+
+    /// The modal tag of the most likely fillers of the masked span.
+    ///
+    /// Ties go to the more likely filler, because the fillers arrive sorted.
+    func wants(_ words: [String], at span: Range<Int>) throws -> String {
+        let (left, right) = Self.masked(words, at: span)
+        let slot = try probe.at(left: left, right: right)
+
+        var counts: [String: Int] = [:]
+        var order: [String] = []
+        for filler in slot.top(Self.fillers) {
+            let word = filler.word.trimmingCharacters(in: .whitespaces)
+            guard !word.isEmpty, word.contains(where: \.isLetter) else { continue }
+            let sentence = left + (left.isEmpty ? "" : " ") + word + right
+            let at = left.isEmpty ? 0 : left.count + 1
+            guard let tag = Self.tag(in: sentence, at: at, length: word.count) else { continue }
+            if counts[tag] == nil { order.append(tag) }
+            counts[tag, default: 0] += 1
+        }
+        var best = ""
+        for tag in order where counts[tag, default: 0] > counts[best, default: 0] { best = tag }
+        return best
+    }
+
+    /// `.lexicalClass` and not `.nameTypeOrLexicalClass`. The question is what
+    /// kind of slot this is, and a filler that happens to be a name would come
+    /// back `PersonalName` rather than `Noun` and split the vote.
+    private static func tag(in sentence: String, at offset: Int, length: Int) -> String? {
+        guard let from = sentence.index(
+                sentence.startIndex, offsetBy: offset, limitedBy: sentence.endIndex),
+              let to = sentence.index(from, offsetBy: length, limitedBy: sentence.endIndex)
+        else { return nil }
+        let tagger = NLTagger(tagSchemes: [.lexicalClass])
+        tagger.string = sentence
+        tagger.setLanguage(.english, range: sentence.startIndex..<sentence.endIndex)
+        return tagger.tag(at: from, unit: .word, scheme: .lexicalClass).0?.rawValue
+    }
+
+    // MARK: - Rule 5, the weakest window
+
+    /// How far the span is from being the weakest place in its sentence.
+    ///
+    /// One forward pass per word: mask it, read the log-probability of the word
+    /// that is there. Two rankings come off that one array — the words, and the
+    /// adjacent pairs summed — and the rank returned is the worse of the two.
+    /// Rank 0 therefore means both: no word surprises the model more than the
+    /// span, and no pair more than the pair the span sits on.
+    ///
+    /// The window alone is not enough. On a sentence of ordinary words the
+    /// weakest pair is decided by noise, and it landed on the span in three of
+    /// the 50 cases where the span was the word the speaker said. Adding the
+    /// word ranking takes those three out and costs nothing else.
+    func weakest(_ words: [String], at span: Range<Int>) throws -> (rank: Int, windows: Int) {
+        guard words.count >= 2 else { return (Int.max, 0) }
+        var scores: [Double] = []
+        for index in words.indices {
+            let (left, right) = Self.masked(words, at: index..<(index + 1))
+            let slot = try probe.at(left: left, right: right)
+            let bare = Self.bare(words[index])
+            let id = probe.tokenizer.firstID(of: (index == 0 ? "" : " ") + bare)
+            scores.append(id.map { slot.logProbability(of: $0) } ?? -.infinity)
+        }
+
+        let byWord = scores.indices.sorted { scores[$0] < scores[$1] }
+        let word = byWord.firstIndex { span.contains($0) } ?? Int.max
+
+        let windows = (0..<(words.count - 1)).map { scores[$0] + scores[$0 + 1] }
+        let byWindow = windows.indices.sorted { windows[$0] < windows[$1] }
+        // A window holds the span when either of its two words is in it.
+        let pair = byWindow.firstIndex { span.contains($0) || span.contains($0 + 1) } ?? Int.max
+        return (max(word, pair), windows.count)
+    }
+
+    // MARK: - The sentence, as words
+
+    /// The sentence `range` sits in, split into words, and which of them the
+    /// range covers.
+    ///
+    /// The sentence and not the whole transcript: "its sentence" is what the
+    /// rank is measured against, and a second sentence only adds windows the
+    /// span can never win.
+    static func sentence(
+        around range: Range<String.Index>, in text: String
+    ) -> (words: [String], span: Range<Int>) {
+        var found = text.startIndex..<text.endIndex
+        text.enumerateSubstrings(
+            in: text.startIndex..<text.endIndex, options: [.bySentences, .substringNotRequired]
+        ) { _, at, _, stop in
+            if at.contains(range.lowerBound) || at.lowerBound == range.lowerBound {
+                found = at
+                stop = true
+            }
+        }
+        // A span that straddles two sentences is measured against the whole
+        // text rather than against half of itself.
+        if range.upperBound > found.upperBound { found = text.startIndex..<text.endIndex }
+
+        var words: [String] = []
+        var span = 0..<0
+        var cursor = found.lowerBound
+        while cursor < found.upperBound {
+            guard let start = text[cursor..<found.upperBound]
+                .firstIndex(where: { !$0.isWhitespace }) else { break }
+            let end = text[start..<found.upperBound].firstIndex(where: \.isWhitespace)
+                ?? found.upperBound
+            if start < range.upperBound && end > range.lowerBound {
+                let from = span.isEmpty ? words.count : span.lowerBound
+                span = from..<(words.count + 1)
+            }
+            words.append(String(text[start..<end]))
+            cursor = end
+        }
+        return (words, span)
+    }
+
+    /// The words either side of the span, as `SentenceProbe.at` wants them:
+    /// the left with no trailing space, the right carrying its own leading one.
+    ///
+    /// The span's trailing punctuation stays on the right. "cancel." masked
+    /// whole takes the full stop with it, and the slot then reads as the middle
+    /// of a sentence rather than the end of one.
+    static func masked(_ words: [String], at span: Range<Int>) -> (left: String, right: String) {
+        let head = words[..<span.lowerBound].suffix(SentenceProbe.radius)
+        let tail = words[span.upperBound...].prefix(SentenceProbe.radius)
+        let marks = String(words[span.upperBound - 1].suffix(
+            words[span.upperBound - 1].count - bare(words[span.upperBound - 1]).count
+        ))
+        let rest = tail.isEmpty ? "" : " " + tail.joined(separator: " ")
+        return (head.joined(separator: " "), marks + rest)
+    }
+
+    /// The word without the punctuation it ends on.
+    static func bare(_ word: String) -> String {
+        String(word.reversed().drop { !$0.isLetter && !$0.isNumber }.reversed())
+    }
+}

--- a/Sources/ParrotFlow/SlotGate.swift
+++ b/Sources/ParrotFlow/SlotGate.swift
@@ -10,12 +10,11 @@ import NaturalLanguage
 /// the slot wants, and one per word only when that pass says a name could go
 /// there. A pass is about 8 ms at sequence length 64.
 ///
-/// Three rules, and they run in this order:
+/// The rules, in the order they run:
 ///
-///     slot POS accepts a name    apply    with the rank rule below
-///     rank 0                     apply    ANDed with the rule above
-///     slot POS refuses a name    decline
-///     else                       judge
+///     the slot accepts a name, and the word is rank 0    apply
+///     the slot refuses a name                            decline
+///     anything else                                      judge
 ///
 /// **Slot POS.** Mask the heard word, take the ten most likely fillers, put
 /// each back in the sentence and tag it. The modal tag is what the slot wants.
@@ -27,14 +26,17 @@ import NaturalLanguage
 ///
 /// **Rank 0.** The heard word is the weakest place in its sentence: no word
 /// surprises the model more, and no two-word window more than the one it sits
-/// on. One forward pass per word — see `weakest`.
+/// on. One forward pass per word, each word read by its first BPE piece — see
+/// `weakest`.
 ///
 /// **ANDed, cheapest first.** An AND already fails once the POS refuses, and
 /// the POS is one pass against the rank's one per word, so the rank is not
 /// computed then.
 ///
-/// **Rule 6 runs after the apply rules, never before.** Put in front of the
-/// lexical gate it declines four cases that gate is right to write.
+/// **The decline runs last, after the lexical gate.** `Vocabulary.slotRoute`
+/// is only asked about a proposal that gate left open. The gate decides on
+/// evidence the slot cannot see — the sound, and a spelling neither word list
+/// knows — and a slot must not overrule it.
 ///
 /// **`Determiner` is not blocked.** A determiner slot is a modifier position
 /// and names do sit there — `cloud code`, `bedrock principles`. Blocking it
@@ -140,6 +142,14 @@ struct SlotGate {
     /// adjacent pairs summed — and the rank returned is the worse of the two.
     /// Rank 0 therefore means both: no word surprises the model more than the
     /// span, and no pair more than the pair the span sits on.
+    ///
+    /// A word is scored by its **first BPE piece**, not by all of them. One
+    /// masked position holds one token, so the rest of a multi-piece word would
+    /// need a pass each with the pieces before it revealed — a different and
+    /// far more expensive question. `SentenceProbe.read` reads the word after a
+    /// boundary the same way. It costs little here: the rare piece of a
+    /// misheard name is the first one, and this is a ranking, so every word in
+    /// the sentence is measured on the same footing.
     ///
     /// The window alone is not enough. On a sentence of ordinary words the
     /// weakest pair is decided by noise, and it landed on the span in three of

--- a/Sources/ParrotFlow/Vocabulary.swift
+++ b/Sources/ParrotFlow/Vocabulary.swift
@@ -627,6 +627,57 @@ actor Vocabulary {
         return WordPieces.knows(bare) == false
     }
 
+    /// The masked language model, once per process, and only if it is already
+    /// on disk. `SentenceModel` fetches it in the background after the first
+    /// English dictation; nothing here waits for that.
+    private var loadedSlotGate: SlotGate?
+    private var slotGateFailed = false
+
+    private func slotGate() async -> SlotGate? {
+        if let loadedSlotGate { return loadedSlotGate }
+        guard !slotGateFailed, SentenceModel.isCached else { return nil }
+        do {
+            loadedSlotGate = SlotGate(probe: try await SentenceProbe.load())
+        } catch {
+            slotGateFailed = true
+            Log.write("vocabulary: no slot gate (\(error.localizedDescription)); the judge decides")
+        }
+        return loadedSlotGate
+    }
+
+    /// Where the model tier sends a proposal the lexical gate did not settle.
+    ///
+    /// `judge` on everything it cannot answer — no cached model, a probe that
+    /// threw, a possessive the term would drop. Never apply and never decline
+    /// without the model, which is the shape `WordPieces.knows` already has and
+    /// is there for this reason.
+    ///
+    /// The possessive is asked here and not inside `SlotGate`. It is a rule
+    /// about the pair, it already routes to the judge in `autoApplies`, and the
+    /// slot would otherwise be free to overrule it.
+    private func slotRoute(
+        heard: String, term: String, in text: String, at range: Range<String.Index>
+    ) async -> SlotGate.Route {
+        guard !Self.dropsPossessive(heard: heard, term: term),
+              let gate = await slotGate() else { return .judge }
+        do {
+            let reading = try gate.read(in: text, at: range)
+            Log.write(
+                "vocabulary: \"\(heard)\" -> \"\(term)\" slot wants"
+                    + " \(reading.tag.isEmpty ? "nothing nameable" : reading.tag)"
+                    + (reading.rank.map { ", rank \($0) of \(reading.windows)" } ?? "")
+                    + " — \(reading.route.rawValue)"
+            )
+            return reading.route
+        } catch {
+            Log.write(
+                "vocabulary: the slot gate could not read \"\(heard)\""
+                    + " (\(error.localizedDescription)); the judge decides"
+            )
+            return .judge
+        }
+    }
+
     /// The transcript, with the names the audio is sure about written in and
     /// the rest published for a judge to decide.
     ///
@@ -707,8 +758,11 @@ actor Vocabulary {
             // one from `text` against a copy being mutated is undefined — it
             // silently dropped every replacement before this was written that
             // way.
-            var decided: [(raw: Float, bonus: Float, applied: Bool, dropped: Bool)] = []
+            var decided: [
+                (raw: Float, bonus: Float, applied: Bool, dropped: Bool, declined: Bool)
+            ] = []
             let margin = Self.proposalMargin(config)
+            let english = Pipeline.language(of: text, config: config) == "en"
             var rebuilt = ""
             var cursor = text.startIndex
             // Where a position in `text` lands in `rebuilt`, as a running
@@ -721,10 +775,18 @@ actor Vocabulary {
                     baseCbw: cbw, tokenCount: tokenCounts[term] ?? 0
                 )
                 let raw = (change.replacementScore ?? 0) - bonus
-                let applies = Self.autoApplies(
+                let lexical = Self.autoApplies(
                     heard: change.originalWord, term: term,
                     heardScore: change.originalScore, termScore: raw
                 )
+                // Dropped when the audio argues hard against it — neither
+                // applied nor offered.
+                let dropped = !lexical && change.originalScore - raw > margin
+                // The model tier, on what the free tier did not settle.
+                let route = lexical || dropped || !english
+                    ? SlotGate.Route.judge
+                    : await slotRoute(heard: change.originalWord, term: term, in: text, at: range)
+                let applies = lexical || route == .apply
                 rebuilt += text[cursor..<range.lowerBound]
                 let was = String(text[range])
                 let now = applies
@@ -738,11 +800,8 @@ actor Vocabulary {
                     ))
                 }
                 cursor = range.upperBound
-                // Dropped when the audio argues hard against it — neither
-                // applied nor offered. Kept in the list so the index still
-                // lines up with `found`.
-                let dropped = !applies && change.originalScore - raw > margin
-                decided.append((raw, bonus, applies, dropped))
+                // Kept in the list so the index still lines up with `found`.
+                decided.append((raw, bonus, applies, dropped, route == .decline))
             }
             rebuilt += text[cursor...]
             let written = rebuilt
@@ -778,6 +837,14 @@ actor Vocabulary {
                         change.originalScore - verdict.raw))
                     continue
                 }
+                if verdict.declined {
+                    Log.write(
+                        "vocabulary: \"\(change.originalWord)\" -> "
+                            + "\"\(change.replacementWord ?? "")\" declined,"
+                            + " no name fits that slot"
+                    )
+                    continue
+                }
                 let term = change.replacementWord ?? ""
                 Log.write(String(
                     format: "vocabulary: \"%@\" -> \"%@\" %@ (raw %.2f vs %.2f, bonus %.2f) (%@)",
@@ -810,7 +877,9 @@ actor Vocabulary {
             // acoustically, and inventing a number for the judge to weigh
             // would be worse than telling it there is none (F6).
             let untouched = Set(
-                zip(found, decided).compactMap { ($0.1.applied || $0.1.dropped) ? nil : $0.0.range }
+                zip(found, decided).compactMap {
+                    ($0.1.applied || $0.1.dropped || $0.1.declined) ? nil : $0.0.range
+                }
             ).union(heardSpans.map { $0.range })
             for span in wider where untouched.contains(where: { $0.overlaps(span.range) }) {
                 guard let placed = moved(span.range, holding: span.heard) else { continue }

--- a/Sources/ParrotFlow/Vocabulary.swift
+++ b/Sources/ParrotFlow/Vocabulary.swift
@@ -876,10 +876,13 @@ actor Vocabulary {
             // for a longer reading to sit on. No scores: nothing scored these
             // acoustically, and inventing a number for the judge to weigh
             // would be worse than telling it there is none (F6).
+            //
+            // A declined span still counts as untouched. The slot gate refused
+            // a name over those words; a wider span is a different reading over
+            // different words, and refusing it too would lose a name on a
+            // question nothing asked.
             let untouched = Set(
-                zip(found, decided).compactMap {
-                    ($0.1.applied || $0.1.dropped || $0.1.declined) ? nil : $0.0.range
-                }
+                zip(found, decided).compactMap { ($0.1.applied || $0.1.dropped) ? nil : $0.0.range }
             ).union(heardSpans.map { $0.range })
             for span in wider where untouched.contains(where: { $0.overlaps(span.range) }) {
                 guard let placed = moved(span.range, holding: span.heard) else { continue }

--- a/Sources/ParrotFlow/WordGateCommand.swift
+++ b/Sources/ParrotFlow/WordGateCommand.swift
@@ -24,12 +24,36 @@ import Foundation
 /// heard text carries and the term does not is a question about the sentence,
 /// so it needs both halves of the proposal — see `Vocabulary.dropsPossessive`.
 ///
-/// No audio and no model either way. The pair form fixes the scores so the
-/// term wins, because the acoustic half is not what it is asking; a proposal
-/// whose term loses on sound never reaches these conditions.
+/// Name the sentence too and the model tiers answer as well:
+///
+///     ParrotFlow --word-gate merge Vercel --in "Go back to main and merge."
+///     possessive kept
+///     gate       judge
+///     slot       Verb
+///     rank       not asked
+///     route      decline
+///
+/// `slot` is what the masked slot wants, `rank` is where the span's two-word
+/// window sits among the sentence's, and `route` is where the proposal goes —
+/// see `SlotGate`. Nothing is downloaded: with no cached model the slot reads
+/// `unavailable` and the route is `judge`.
+///
+/// No audio. The pair form fixes the scores so the term wins, because the
+/// acoustic half is not what it is asking; a proposal whose term loses on
+/// sound never reaches these conditions.
 enum WordGateCommand {
-    static func run(word: String, term: String? = nil) -> Int32 {
-        if let term, !term.isEmpty { return pair(heard: word, term: term) }
+    static func run(word: String, term: String? = nil, sentence: String? = nil) -> Int32 {
+        if let term, !term.isEmpty {
+            let applies = pair(heard: word, term: term)
+            guard let sentence, !sentence.isEmpty else { return 0 }
+            guard #available(macOS 14, *) else {
+                print("slot       unavailable")
+                print("route      judge")
+                return 0
+            }
+            printSlot(heard: word, term: term, in: sentence, applies: applies)
+            return 0
+        }
 
         let letters = String(word.filter { $0.isLetter })
         guard !letters.isEmpty else {
@@ -56,13 +80,67 @@ enum WordGateCommand {
     /// The two lists are not printed here. They are not consulted at all on a
     /// span the gate matches glued — `"Matthew at"` — so printing them would
     /// report a lookup that decided nothing.
-    private static func pair(heard: String, term: String) -> Int32 {
+    private static func pair(heard: String, term: String) -> Bool {
         let drops = Vocabulary.dropsPossessive(heard: heard, term: term)
         print("possessive \(drops ? "dropped" : "kept")")
         let applies = Vocabulary.autoApplies(
             heard: heard, term: term, heardScore: -1, termScore: 0
         )
         print("gate       \(applies ? "auto-apply" : "judge")")
-        return 0
+        return applies
+    }
+
+    /// The model tiers, on the proposal the lexical gate did not settle.
+    ///
+    /// Nothing is downloaded. With no cached model the slot is `unavailable`
+    /// and the route is `judge`, which is what the app does — see
+    /// `Vocabulary.slotRoute`.
+    @available(macOS 14, *)
+    private static func printSlot(
+        heard: String, term: String, in sentence: String, applies: Bool
+    ) {
+        let config = (try? ConfigStore.load()) ?? Config()
+        let language = Pipeline.language(of: sentence, config: config)
+        print("language   \(language)")
+        guard language == "en" else {
+            print("slot       not english")
+            print("route      judge")
+            return
+        }
+        guard let range = Vocabulary.spans(of: heard, in: sentence).first else {
+            print("slot       not found in the sentence")
+            print("route      judge")
+            return
+        }
+        guard let gate = load() else {
+            print("slot       unavailable")
+            print("route      judge")
+            return
+        }
+        guard let reading = try? gate.read(in: sentence, at: range) else {
+            print("slot       unreadable")
+            print("route      judge")
+            return
+        }
+        print("slot       \(reading.tag.isEmpty ? "untagged" : reading.tag)")
+        print("rank       \(reading.rank.map { "\($0) of \(reading.windows)" } ?? "not asked")")
+        let route = applies
+            ? SlotGate.Route.apply
+            : (Vocabulary.dropsPossessive(heard: heard, term: term) ? .judge : reading.route)
+        print("route      \(route.rawValue)")
+    }
+
+    /// The probe, or nil when the model has never been fetched.
+    @available(macOS 14, *)
+    static func load() -> SlotGate? {
+        guard SentenceModel.isCached else { return nil }
+        var gate: SlotGate?
+        let done = DispatchSemaphore(value: 0)
+        Task {
+            gate = (try? await SentenceProbe.load()).map(SlotGate.init(probe:))
+            done.signal()
+        }
+        done.wait()
+        return gate
     }
 }

--- a/Sources/ParrotFlow/WordGateCommand.swift
+++ b/Sources/ParrotFlow/WordGateCommand.swift
@@ -55,9 +55,13 @@ enum WordGateCommand {
             return 0
         }
 
+        // The slot tiers are about a proposal, so `--in` without a term is a
+        // question this cannot answer. Refused rather than ignored: a set that
+        // dropped the term would otherwise report the word lists and look like
+        // it had scored the route.
         let letters = String(word.filter { $0.isLetter })
-        guard !letters.isEmpty else {
-            print("usage: ParrotFlow --word-gate <word> [term]")
+        guard !letters.isEmpty, sentence == nil else {
+            print("usage: ParrotFlow --word-gate <word> [term] [--in \"<sentence>\"]")
             return 2
         }
         // The decision comes from the shipped test. The two verdicts above it

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -246,7 +246,10 @@ if let index = arguments.firstIndex(of: "--word-gate") {
     // not another flag.
     let term = arguments.indices.contains(index + 2)
         && !arguments[index + 2].hasPrefix("--") ? arguments[index + 2] : nil
-    exit(WordGateCommand.run(word: arguments[index + 1], term: term))
+    let sentence = arguments.firstIndex(of: "--in").flatMap {
+        arguments.indices.contains($0 + 1) ? arguments[$0 + 1] : nil
+    }
+    exit(WordGateCommand.run(word: arguments[index + 1], term: term, sentence: sentence))
 }
 
 if let index = arguments.firstIndex(of: "--suggest") {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -101,7 +101,7 @@ $PF --numbers "two hundred forty three" [--lang fr]
 $PF --normalize "<text>"
 $PF --dates "<instruction>" "<text>" [--locale FR] [--lang en,fr]
 $PF --inflected <term> <heard>
-$PF --word-gate <word> [term]
+$PF --word-gate <word> [term] [--in "<sentence>"]
 $PF --verdicts <count> "<reply>"
 $PF --teaching "<sentence>" <word>
 $PF --suggest "<sentence>" [--lang fr]
@@ -128,6 +128,18 @@ condition is not about a word at all: a `'s` the heard text carries and the
 term does not would be taken out of the sentence, so it goes to the judge.
 `scripts/check-word-gate.sh` scores both forms against
 `tests/word-gate-cases.yaml`.
+
+Name the sentence too and the model tiers answer as well —
+`--word-gate merge Vercel --in "Go back to main and merge."` prints
+`slot Verb` and `route decline`. `slot` is what the masked slot wants, from
+ten fillers put back and tagged; `rank` is how far the word is from being the
+weakest place in its sentence; `route` is where the proposal goes. A name goes
+in a `Noun`, `Adjective` or `Pronoun` slot and never in a `Verb`, `Adverb` or
+`Preposition` one — see `SlotGate`. Nothing is downloaded: with no cached
+sentence model the slot reads `unavailable` and the route is `judge`.
+`scripts/check-slot-gate.sh` scores the whole route against
+`tests/judge-cases.yaml`. It needs the 300 MB model, so it is not in
+`make test`.
 
 `--verdicts` asks what the name judge reads out of a model's reply —
 `--verdicts 2 "1. KEEP` newline `2. REVERT"` prints `KEEP REVERT`. It is
@@ -671,6 +683,7 @@ scripts/check-span-rule.sh         # which range a rewrite is written as, before
 scripts/check-bug-report.sh        # what a bug report carries, and that it carries no home path
 scripts/check-tokenizer.sh         # the hand-written BPE against HuggingFace's own
 scripts/check-sentence-probe.sh    # the boundary score against coremltools (needs the model)
+scripts/check-slot-gate.sh         # where a name proposal is routed (needs the model)
 
 PF_VIEWPORT=Ghostty scripts/check-inplace.sh   # the same set, in another terminal
 $PF --peek 3 --via-copy                        # what Select All + Copy hands back

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -129,7 +129,7 @@ term does not would be taken out of the sentence, so it goes to the judge.
 `scripts/check-word-gate.sh` scores both forms against
 `tests/word-gate-cases.yaml`.
 
-Name the sentence too and the model tiers answer as well —
+Name the sentence too — with the term, which the model tiers are about —
 `--word-gate merge Vercel --in "Go back to main and merge."` prints
 `slot Verb` and `route decline`. `slot` is what the masked slot wants, from
 ten fillers put back and tagged; `rank` is how far the word is from being the

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -333,6 +333,27 @@ proposal goes to the judge. `--word-gate <word>` prints both verdicts and the
 decision, and `--word-gate <word> <term>` prints the possessive verdict and the
 decision for that pair; `scripts/check-word-gate.sh` scores them.
 
+**What the lists cannot settle, the sentence model can.** The word lists are
+about one word. A second tier reads the slot the word sits in, using the
+masked language model `SentenceModel` already fetches. Mask the word, take the
+ten most likely fillers, put each one back and tag it: the modal tag is what
+the slot wants. A name goes in a `Noun`, `Adjective` or `Pronoun` slot and
+never in a `Verb`, `Adverb` or `Preposition` one, so `merge` -> `Vercel` and
+`ready` -> `Arexvy` are refused with nothing asked. A term is written unasked
+only when the slot accepts a name **and** the word is the weakest place in its
+sentence — no word surprises the model more, and no two-word window more than
+the one it sits on. Everything else still goes to the judge, `Determiner`
+slots included: those are modifier positions and names do sit in them
+(`cloud code`, `bedrock principles`).
+
+Measured over the 50 English cases of `tests/judge-cases.yaml`: 15 written
+unasked, 14 refused unasked, 21 left for the judge, and no error either way.
+`scripts/check-slot-gate.sh` is the run. See `SlotGate`.
+
+The model is never waited for. Until it is on disk — and on a language it was
+not trained for — every proposal goes to the judge, which is the behaviour
+before this tier.
+
 Every exchange is written to `trace.jsonl` under the stage's variables, so a
 verdict can be replayed rather than guessed at.
 

--- a/scripts/check-slot-gate.sh
+++ b/scripts/check-slot-gate.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Scores the whole route in front of the judge, against tests/judge-cases.yaml.
+#
+#   scripts/check-slot-gate.sh
+#
+# Four numbers, and the last two are the ones that decide: how many proposals
+# were written without asking, how many were refused without asking, how many
+# still cost a judge call, and how many of the first two were wrong.
+#
+# The judge is a model call of about 900 ms. Every proposal the free lexical
+# gate does not settle goes to it today. `SlotGate` settles some of them with a
+# masked language model — see that file for the rules and their order.
+#
+# Not in `make test` and not in CI: it needs the 300 MB sentence model, which
+# CI has no business downloading. Run it by hand after touching `SlotGate`,
+# `Vocabulary.autoApplies` or the tag sets. Nothing is downloaded here either —
+# with no cached model every case routes to `judge` and the run says so.
+#
+# Nine of the 59 cases are not scored, and both exclusions are made by shipped
+# code rather than by a list here:
+#
+#   five are French. `Pipeline.language` says so, and the model is English.
+#   four are spelling lessons. `VocabularyJudge.teaching` reverts them with no
+#   model, so they are not a routing decision — scripts/check-spells-rule.sh
+#   is where that rule is scored.
+#
+# That leaves the 50 English cases the routing was measured on.
+#
+# Runs against a scratch PARROTFLOW_CONFIG_DIR, so it says nothing about the
+# config on the machine. The language detector needs `languages: [en, fr]`,
+# which is what config.example.yaml gives a fresh directory.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/release/ParrotFlow"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+
+WORK="$(mktemp -d -t parrotflow-slot-gate)"
+trap 'rm -rf "$WORK"' EXIT
+export PARROTFLOW_CONFIG_DIR="$WORK"
+
+# Unit separator, not a tab: a case holding a tab would arrive with its fields
+# shifted. Read into a file first, so a set that could not be parsed fails here
+# rather than ending the loop early with a clean score over half of it.
+if ! python3 -c '
+import sys, yaml
+for number, case in enumerate(yaml.safe_load(open(sys.argv[1]))["cases"], 1):
+    print("\x1f".join([str(number)] + [case[k] for k in ("said", "heard", "term", "expect")]))
+' "$ROOT/tests/judge-cases.yaml" > "$WORK/cases"; then
+  echo "  ✗ tests/judge-cases.yaml could not be read"
+  exit 1
+fi
+
+applied=0; declined=0; asked=0; skipped=0
+wrong_apply=0; wrong_decline=0; total=0
+
+field() { printf '%s\n' "$1" | awk -v k="$2" '$1 == k { print $2 }'; }
+
+while IFS=$'\x1f' read -r number said heard term expect; do
+  [ -z "$number" ] && continue
+
+  if [ "$("$BIN" --teaching "$said" "$heard" 2>/dev/null | tail -1)" = REVERT ]; then
+    skipped=$((skipped + 1))
+    printf '  ·  %-14s %-10s spelling lesson\n' "$heard" "$term"
+    continue
+  fi
+
+  out="$("$BIN" --word-gate "$heard" "$term" --in "$said" 2>/dev/null)"
+  if [ "$(field "$out" language)" != en ]; then
+    skipped=$((skipped + 1))
+    printf '  ·  %-14s %-10s not english\n' "$heard" "$term"
+    continue
+  fi
+
+  total=$((total + 1))
+  route="$(field "$out" route)"
+  slot="$(field "$out" slot)"
+  case "$route" in
+    apply)   applied=$((applied + 1)) ;;
+    decline) declined=$((declined + 1)) ;;
+    judge)   asked=$((asked + 1)) ;;
+    *)       echo "  ✗ case $number: the binary printed no route"; exit 1 ;;
+  esac
+
+  # A route that decided is checked against the label. `judge` is not an
+  # answer, so it can be neither right nor wrong here.
+  mark=" "
+  if [ "$route" = apply ] && [ "$expect" = decline ]; then
+    wrong_apply=$((wrong_apply + 1)); mark="✗"
+  elif [ "$route" = decline ] && [ "$expect" = approve ]; then
+    wrong_decline=$((wrong_decline + 1)); mark="✗"
+  fi
+  printf '  %s  %-14s %-10s %-12s %-8s want %s\n' \
+    "$mark" "$heard" "$term" "$slot" "$route" "$expect"
+done < "$WORK/cases"
+
+echo
+if [ "$total" -eq 0 ]; then
+  echo "  ✗ no cases read from tests/judge-cases.yaml"
+  exit 1
+fi
+
+printf '  %d scored, %d not (tests/judge-cases.yaml)\n' "$total" "$skipped"
+printf '  applied %d   declined %d   judge %d\n' "$applied" "$declined" "$asked"
+printf '  wrong applies %d   wrong declines %d\n' "$wrong_apply" "$wrong_decline"
+
+# A wrong apply writes a word nobody said with no menu behind it. A wrong
+# decline loses a name the speaker did say. Neither may be traded for fewer
+# judge calls, so either one fails the run.
+[ "$wrong_apply" -eq 0 ] && [ "$wrong_decline" -eq 0 ]


### PR DESCRIPTION
The vocabulary judge is a local model call of about 900 ms, and today every proposal the free word-list gate does not settle goes to it. This adds a second tier between the two. It reads the slot the word sits in, using the masked language model `SentenceModel` already fetches, and answers one of three things: write it, refuse it, or ask the judge.

On the 50 English cases of `tests/judge-cases.yaml` it takes the judge from 37 calls to 21, with no error of either kind. The other 13 already auto-applied on the word lists and never reached the judge. Run `scripts/check-slot-gate.sh` to see it — it needs the 300 MB model, so it is not in `make test` or CI.

`Vocabulary.autoApplies` is untouched: still synchronous, still pure, still no model. With no cached model, a non-English transcript, or a probe that throws, every proposal goes to the judge — never applied, never declined. That is the same three-answer shape `WordPieces.knows` already has.

Start the review at `Sources/ParrotFlow/SlotGate.swift`. The call site is `Vocabulary.slotRoute`, called from `apply` on the proposals the lexical gate left open.

<details>
<summary>The three rules, in the order they run</summary>

Three rules already ship. These are the three that need the model.

| | rule | answer | where |
|---|---|---|---|
| 1 | multi-word, glued == term | apply | ships |
| 2 | possessive the term lacks | judge | ships (#223) |
| 3 | both lexicons say unknown | apply, else judge | ships (#222) |
| 4 | slot POS accepts a name | apply | this PR |
| 5 | rank 0 | apply | this PR |
| 6 | slot POS refuses a name | decline | this PR |
| 7 | else | judge | |

**Rule 4, the slot POS.** Mask the heard word. Take the ten most likely fillers. Put each one back in the sentence and tag it with `NLTagger`. The modal tag is what the slot wants. A name goes in a `Noun`, `Adjective` or `Pronoun` slot.

Tagging the word that is already there says nothing, because it describes a word that may be wrong. Masking asks the sentence instead. It is the only signal that catches `Mirza's -> Mirza`: the slot in "waiting for ___ thoughts" predicts `second, my, your, any, some, more, the, first`, and a bare name does not go in a determiner slot.

**Rule 5, rank 0.** The heard word is the weakest place in its sentence. One forward pass per word: mask it, read the log-probability of the word that is there. Two rankings come off that one array — the words, and the adjacent pairs summed — and both have to put the word first. A word is read by its first BPE piece: a masked position holds one token, so scoring the rest of a multi-piece word would cost a pass per piece. `SentenceProbe.read` reads the word after a boundary the same way.

**Rules 4 and 5 are ANDed, cheapest first.** An AND already fails once the POS refuses, and the POS is one pass against the rank's one per word, so the rank is not computed then.

**Rule 6 is the same signal run backwards.** If the slot cannot host a name the proposal is impossible, so it is refused with nothing asked. `Verb`, `Adverb` and `Preposition` are blocked. The refusals read as obvious once seen: `please -> Supabase`, `merge -> Vercel`, `ready -> Arexvy`, `probably -> Praisy`.

**Rule 6 runs after the apply rules, never before.** `slotRoute` is only asked about a proposal the lexical gate left open. That gate decides on evidence the slot cannot see — the sound, and a spelling neither word list knows — and a slot must not overrule it. On this case set the order happens not to change the outcome: none of the 15 written unasked lands in a blocked slot. The order is still the safe one.

**`Determiner` is not blocked.** A determiner slot is a modifier position and names do sit there — `cloud code`, `bedrock principles`.

</details>

<details>
<summary>Measured: 15 applied, 14 declined, 21 to the judge, no error of either kind</summary>

`scripts/check-slot-gate.sh`, on `tests/judge-cases.yaml`:

```
  50 scored, 9 not (tests/judge-cases.yaml)
  applied 15   declined 14   judge 21
  wrong applies 0   wrong declines 0
```

Nine of the 59 cases are not scored, and both exclusions are made by shipped code rather than by a list in the script:

- five are French. `Pipeline.language` says so, and the model is English.
- four are spelling lessons. `VocabularyJudge.teaching` reverts them with no model, so they are not a routing decision. `scripts/check-spells-rule.sh` is where that rule is scored.

Of the 15 written unasked, 13 are the lexical gate's own and were already being written before this PR. The two the new tier adds are `Prissy -> Praisy` and `Matthew at -> Matthieu's`, both correct, both cases the word lists cannot reach.

All 14 refusals are correct. The tier never refuses a name the speaker said.

The judge's own score is not re-measured here. This PR does not change the judge, only which questions reach it.

</details>

<details>
<summary>The blocked tag set was chosen after seeing these 50 cases, and it now carries 16 decisions</summary>

This is the honest weak point. `Verb`, `Adverb` and `Preposition` are linguistically motivated — a name cannot be a verb — rather than a threshold fitted to a number. But the set was picked while looking at this case set, and on this set it went from carrying three decisions to carrying 16. Fourteen of those are refusals nothing can appeal.

The measured sweep, judge calls against errors:

| reject when the slot wants | judge calls | wrong applies | wrong declines |
|---|---|---|---|
| nothing | 35 | 0 | 0 |
| verb | 26 | 0 | 0 |
| verb, adverb | 23 | 0 | 0 |
| verb, adverb, preposition | 21 | 0 | 0 |
| + determiner | 16 | 0 | 1 |

The set stops before `determiner` because that is where the one wrong refusal appears. Nothing further was tuned: n=50 cannot separate one case from another, and the tag set should be validated against fresh dictations before it is widened.

</details>

<details>
<summary>What was tried and rejected</summary>

**Rule 5 on the two-word window alone.** The brief for this work described the rank as the weakest two-word window. Measured that way it wrote three words the speaker had actually said — `ready -> Arexvy` twice and `level. -> Vercel`. On a sentence of ordinary words the weakest pair is decided by noise. Requiring the word itself to rank first as well takes all three out and costs nothing else, so the shipped rule asks for both.

**`OR` instead of `AND` for rules 4 and 5.** It writes more, and on this set it writes nothing wrong. It is still not shipped: one negative case is not evidence that two gates cannot both be wrong at once.

**`.nameTypeOrLexicalClass` for the tagger.** Measured, and it moves one case. `.lexicalClass` is used instead: the question is what kind of slot this is, and a filler that happens to be a name would come back `PersonalName` rather than `Noun` and split the vote.

**GLiNER.** Not tried here. It was measured earlier and it loses the zero-error property.

</details>

<details>
<summary>Review notes: where the risk is</summary>

- `Vocabulary.swift`. `autoApplies` is unchanged. The loop in `apply` now computes `dropped` before the model tier instead of after, so the model tier is skipped on a proposal the audio has already argued down. `applies` is `lexical || route == .apply`, and a refusal is a new `declined` flag: no substitution, no proposal, nothing offered to the judge, and a line in the log saying why. It stops that proposal only. A wider span sitting on the same words is a different reading whose own slot was never asked about, so it is still offered — the first version suppressed it and the review caught that.
- `slotGate()` loads the model once per process and only when it is already on disk. Nothing downloads inside a dictation. The first proposal in a process pays about 250 ms for the load; after that `SentenceModel.shared` returns the loaded model.
- `--word-gate <heard> <term> --in "<sentence>"` prints the new tiers beside the old ones. With no cached model it prints `slot unavailable` and `route judge`, which was checked by moving the cache aside.
- `SlotGate.masked` keeps the span's trailing punctuation on the right of the mask. Masking `cancel.` whole takes the full stop with it, and the slot then reads as the middle of a sentence rather than the end of one.

</details>
