### PR TITLE
fix: a contraction is not a name to overwrite

### DIFF
--- a/Sources/ParrotFlow/Vocabulary.swift
+++ b/Sources/ParrotFlow/Vocabulary.swift
@@ -513,6 +513,38 @@ actor Vocabulary {
         return (String(lower.dropLast(suffix.count)), suffix)
     }
 
+    /// Whether the heard word carries an apostrophe the term does not.
+    ///
+    /// `bare` is letters only, so `wouldn't` is looked up as `wouldnt` — a form
+    /// neither list has ever seen, where `wouldn't` itself is an ordinary
+    /// English word. The apostrophe walks a contraction straight past both
+    /// lists, exactly as it did a possessive. Measured on the shipped binary:
+    /// 9 of 14 common contractions read `auto-apply`, and the 5 that do not
+    /// survive by accident, because their stripped form is a word of its own —
+    /// `cant`, `wont`, `dont`, `its`, `lets`.
+    ///
+    /// Asked here and not in `SlotGate`, because the slot is never consulted
+    /// on a word the free tier has already decided: `I wouldn't do that` reads
+    /// slot `Verb`, which the gate blocks, and the word was written anyway.
+    ///
+    /// A rule, not a threshold, and the same rule `dropsPossessive` is. Writing
+    /// a name over `wouldn't` changes what the sentence says, in every
+    /// sentence. It routes rather than refuses: the judge reads the sentence.
+    static func dropsApostrophe(heard: String, term: String) -> Bool {
+        inner(in: heard) && !inner(in: term)
+    }
+
+    /// An apostrophe with a letter on each side. A quoted word carries one at
+    /// an end, and that says nothing about the word itself.
+    private static func inner(in word: String) -> Bool {
+        let marks: Set<Character> = ["'", "\u{2019}"]
+        let letters = Array(word)
+        return letters.indices.contains { i in
+            marks.contains(letters[i]) && i > 0 && i < letters.count - 1
+                && letters[i - 1].isLetter && letters[i + 1].isLetter
+        }
+    }
+
     /// The punctuation a replaced word carried, so the sentence keeps its end.
     ///
     /// The rescorer replaces the word and not what followed it, so "on Olama?"
@@ -580,6 +612,7 @@ actor Vocabulary {
         let bare = String(letters)
         guard !bare.isEmpty else { return false }
         guard !dropsPossessive(heard: heard, term: term) else { return false }
+        guard !dropsApostrophe(heard: heard, term: term) else { return false }
         return unseenWord(bare)
     }
 

--- a/tests/word-gate-cases.yaml
+++ b/tests/word-gate-cases.yaml
@@ -208,3 +208,41 @@ cases:
     possessive: kept
     gate: auto-apply
     why: a word neither list knows, with no possessive anywhere, still goes through
+
+  # --- a contraction, which is the same apostrophe wearing another hat -------
+  # `wouldn't` is looked up as `wouldnt`, and neither list has seen that
+  # either. Measured on the shipped binary before the fix: 9 of 14 common
+  # contractions read `auto-apply`. The 5 that did not survived by accident —
+  # `cant`, `wont`, `dont`, `its` and `lets` are words in their own right.
+  #
+  # The slot gate cannot catch these. "I wouldn't do that" reads slot `Verb`,
+  # which it blocks, but the free tier had already decided and the slot is
+  # never asked.
+
+  - word: "wouldn't"
+    term: Redcrawl
+    possessive: kept
+    gate: judge
+    why: >
+      "I wouldn't do that today" — the letters-only form walks past both lists
+      the way a possessive does. Writing a name here deletes the negation.
+
+  - word: "they're"
+    term: Praisy
+    possessive: kept
+    gate: judge
+    why: not a possessive, and the apostrophe is doing the same damage
+
+  - word: "I've"
+    term: Arexvy
+    possessive: kept
+    gate: judge
+    why: two letters and an apostrophe, unknown to both lists as `Ive`
+
+  - word: "don't"
+    term: Redrock
+    possessive: kept
+    gate: judge
+    why: >
+      one of the five that already reached the judge, because `dont` is a
+      word — kept so the fix is not the only thing holding this case


### PR DESCRIPTION
## The bug

`Vocabulary.autoApplies` reads letters only, so `wouldn't` is looked up as `wouldnt` — a form neither word list has ever seen, where `wouldn't` itself is ordinary English. The apostrophe walked a contraction straight past both lists, exactly as it walked a possessive past them before #223.

Measured on the shipped binary, before the fix:

```
  wouldn't  didn't  isn't  shouldn't  hasn't  aren't  they're  I've  you'd   auto-apply
  can't  won't  don't  it's  let's                                          judge
```

9 of 14. The 5 that reached the judge survived by accident: `cant`, `wont`, `dont`, `its` and `lets` are words in their own right.

## Why the slot gate does not catch it

```
  --word-gate "wouldn't" Redcrawl --in "I wouldn't do that today."
    gate    auto-apply
    slot    Verb          <- in SlotGate.blocks
    route   apply         <- written anyway
```

The free tier had already decided, and `slotRoute` is never asked once it has. That ordering is deliberate and measured — the decline tier before the apply rules drops the stack from 47/50 to 44/50 — so the fix does not touch it.

## The fix

The guard goes where the possessive guard is and has its shape. An apostrophe between two letters that the term does not carry sends the proposal to the judge, which reads the sentence.

A rule, not a threshold. Writing a name over `wouldn't` deletes the negation, in every sentence, so there is nothing here to tune and nothing to drift.

## Nothing else moved

Routing on the 50 English cases of `tests/judge-cases.yaml`, before and after:

```
  applied 15   declined 14   judge 21
  wrong applies 0   wrong declines 0
```

`OLAMA -> Ollama` and `red crawl -> Redcrawl` still auto-apply. `Mirza's` still reaches the judge by the possessive rule.

Four cases added to `tests/word-gate-cases.yaml`, including `don't` — one of the five that already passed, so the fix is not the only thing holding that row.

## How it was found

While measuring whether a vocabulary can work from spelling alone, with no mined `heard:` renderings. That answer is no, and this fell out of the run.