### PR TITLE
feat: two ears for one name, and the one that needs no install is the default

### DIFF
--- a/Sources/ParrotFlow/NeuralPhonemes.swift
+++ b/Sources/ParrotFlow/NeuralPhonemes.swift
@@ -1,0 +1,114 @@
+import Foundation
+import FluidAudio
+
+/// How a word sounds, worked out by a model rather than by rules.
+///
+/// The second ear beside `Phonemes`, which is espeak-ng. They are not a
+/// replacement for each other and the measurement is why — on this speaker's
+/// 20891 dictations, at floor 0.85, scoring every 1- and 2-word window:
+///
+///     converter   windows   right   wrong
+///     espeak         41       36      5
+///     this           46       39      7
+///     both           62       54      8
+///
+/// Three false windows more, eighteen true ones. They fail differently too,
+/// which is the strongest sign they are worth having together: this one
+/// invents `praising -> Praisy`, espeak invents `and re -> Andrey`, and
+/// neither makes the other's mistake.
+///
+/// What each finds alone says why. This model reads the whole string at once,
+/// so it hears through a word boundary the recogniser invented — `Priss y`
+/// (259 times), `O lama`, `au lama`, `press a`, `versol`. espeak applies
+/// letter-to-sound rules, so it is better on a spelling nobody has ever
+/// written — `geler` (45 times), `Prazi`, `Ghost E`, `Jemma`.
+///
+/// **This one is the default and espeak is the improvement.** It arrives as a
+/// model download like every other, carries no licence to pass on, and covers
+/// nine languages. espeak is a separate GPL-3 program that has to be installed
+/// by hand, and with this in place its absence costs coverage rather than the
+/// whole feature.
+enum NeuralPhonemes {
+
+    /// The languages the model has, in the app's own terms. Nil for a
+    /// language it does not speak — every other one it would guess at.
+    static func language(_ code: String) -> MultilingualG2PLanguage? {
+        switch code {
+        case "en": return .americanEnglish
+        case "fr": return .french
+        default: return nil
+        }
+    }
+
+    /// True when the two model files are already on disk and loaded.
+    static func isReady() async -> Bool {
+        do {
+            try await MultilingualG2PModel.shared.ensureModelsAvailable()
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    /// Fetches the encoder and decoder if they are not there yet.
+    ///
+    /// They live in FluidAudio's own TTS cache, beside the voices, because
+    /// that is where `MultilingualG2PModel` looks for them and nothing here
+    /// should teach it a second path.
+    static func download(progress: (@Sendable (String) -> Void)? = nil) async throws {
+        if await isReady() { return }
+        progress?("sound model")
+        let directory = try TtsCacheDirectory.ensure().appendingPathComponent("Models")
+        try await ModelHub.download(
+            .kokoro, to: directory,
+            additionalModelNames: ModelNames.MultilingualG2P.requiredModels
+        )
+        try await MultilingualG2PModel.shared.ensureModelsAvailable()
+    }
+
+    private static var cache: [String: String] = [:]
+    private static let cacheLock = NSLock()
+
+    /// The IPA of every word given. Absent from the result means the model had
+    /// nothing to say about it.
+    ///
+    /// One word per call by construction — the model is sequence to sequence
+    /// and takes one string — so this is the slower of the two ears. The cache
+    /// is what makes that affordable: an ordinary dictation asks about words
+    /// it has asked about before.
+    static func of(
+        _ words: [String], language: MultilingualG2PLanguage
+    ) async -> [String: String] {
+        guard await isReady() else { return [:] }
+        var answer: [String: String] = [:]
+        for word in words {
+            let clean = Phonemes.cleaned(word)
+            guard !clean.isEmpty else { continue }
+            let key = "\(language.rawValue)\u{0}\(clean)"
+            cacheLock.lock()
+            let known = cache[key]
+            cacheLock.unlock()
+            if let known {
+                if !known.isEmpty { answer[word] = known }
+                continue
+            }
+            let said: String
+            do {
+                said = try await MultilingualG2PModel.shared
+                    .phonemize(word: clean, language: language)?
+                    .joined() ?? ""
+            } catch {
+                said = ""
+            }
+            // Stress and length go, exactly as they do for espeak — the two
+            // scores are compared against one floor, so they have to be the
+            // same kind of string.
+            let clipped = Phonemes.clip(said)
+            cacheLock.lock()
+            cache[key] = clipped
+            cacheLock.unlock()
+            if !clipped.isEmpty { answer[word] = clipped }
+        }
+        return answer
+    }
+}

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -1062,9 +1062,9 @@ struct Pipeline: Equatable, Codable {
         // measured over 20891 dictations — see `phonemeParts` for what fires
         // and what it costs.
         if step.bySound ?? true, Pipeline.language(of: text, config: config) == "en" {
-            let heard = VocabularyJudge.phonemeParts(
+            let heard = await VocabularyJudge.phonemeParts(
                 in: text, sounds: config.vocabularySounds, voice: "en-us",
-                floor: config.vocabulary.soundBelow, claimed: parts
+                language: "en", floor: config.vocabulary.soundBelow, claimed: parts
             )
             bySound = heard.count
             parts += heard

--- a/Sources/ParrotFlow/SoundBenchCommand.swift
+++ b/Sources/ParrotFlow/SoundBenchCommand.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// `--phonemes <word> [word …]` — what each ear hears, side by side.
+///
+/// The diagnostic behind every number in `NeuralPhonemes`. It fetches the
+/// model if it is missing, so it is also how the download is checked by hand.
+enum SoundBenchCommand {
+
+    static func run(_ words: [String], language: String) async -> Int32 {
+        if let named = NeuralPhonemes.language(language) {
+            do {
+                try await NeuralPhonemes.download { Log.write("phonemes: \($0)") }
+            } catch {
+                print("model: \(error.localizedDescription)")
+            }
+            let model = await NeuralPhonemes.of(words, language: named)
+            let rules = Phonemes.of(words, voice: language == "fr" ? "fr" : "en-us")
+            func pad(_ text: String, _ width: Int) -> String {
+                text.count >= width ? text + "  "
+                    : text + String(repeating: " ", count: width - text.count)
+            }
+            print(pad("word", 20) + pad("model", 18) + "espeak")
+            for word in words {
+                print(pad(word, 20) + pad(model[word] ?? "—", 18) + (rules[word] ?? "—"))
+            }
+            return 0
+        }
+        print("no model for language \(language)")
+        return 2
+    }
+}

--- a/Sources/ParrotFlow/SoundCommand.swift
+++ b/Sources/ParrotFlow/SoundCommand.swift
@@ -77,14 +77,26 @@ enum SoundCommand {
         ("a word boundary the decoder invented",
          "I use parrot flow every day.", ["parrot flow -> ParrotFlow"]),
 
+        // Only the model hears this one. espeak reads `Priss y` as
+        // /pɹɪswaɪ/ — it sounds out the stranded letter — where the model
+        // reads the pair as /pɹɪsi/ and lands on the term. 259 fires in this
+        // speaker's archive, and espeak finds none of them.
+        ("a word the recogniser split, heard only by the model",
+         "I think Priss y wrote that.", ["Priss y -> Praisy"]),
+
         ("nothing to offer",
          "The meeting is at four.", []),
     ]
 
-    static func run() -> Int32 {
-        guard Phonemes.binary != nil else {
-            print("espeak-ng is not installed; the sound path is off and this check is skipped")
+    static func run() async -> Int32 {
+        let ears = await NeuralPhonemes.isReady()
+        guard Phonemes.binary != nil || ears else {
+            print("neither ear is available — no espeak-ng and no sound model;"
+                + " the sound path is off and this check is skipped")
             return 0
+        }
+        if !ears {
+            print("note: the sound model is not fetched, so only espeak is scored")
         }
         var failures = 0
 
@@ -106,8 +118,9 @@ enum SoundCommand {
         }
 
         for one in cases {
-            let parts = VocabularyJudge.phonemeParts(
-                in: one.text, sounds: sounds, voice: "en-us", floor: 0.85, claimed: []
+            let parts = await VocabularyJudge.phonemeParts(
+                in: one.text, sounds: sounds, voice: "en-us", language: "en",
+                floor: 0.85, claimed: []
             )
             let got = parts.map { "\($0.decoded) -> \($0.other)" }.sorted()
             let ok = got == one.want.sorted()

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -143,6 +143,47 @@ actor Transcriber {
         }
     }
 
+    /// The sound model fetch, once per process. Same shape and same reasons
+    /// as the sentence model above.
+    private var soundModelFetch: Task<Void, Never>?
+    private var soundModelRunning = false
+
+    /// Starts the grapheme-to-phoneme download and does not wait for it.
+    ///
+    /// 81 MB, and the vocabulary's sound pass is the only thing that reads it.
+    /// Parking a dictation behind it would cost the dictation and buy nothing:
+    /// the pass simply proposes nothing until the model is there, which is
+    /// what it already does on a machine with neither ear.
+    private func warmSoundModel() {
+        guard soundModelFetch == nil else { return }
+        soundModelRunning = true
+        soundModelFetch = Task { [weak self] in
+            guard let self else { return }
+            var failed = false
+            do {
+                try await NeuralPhonemes.download { label in
+                    Task { await self.reportSoundModel(label) }
+                }
+            } catch {
+                Log.write("sound model: \(error.localizedDescription);"
+                    + " names are matched by spelling until it arrives")
+                failed = true
+            }
+            await self.finishSoundModel(failed: failed)
+        }
+    }
+
+    private func reportSoundModel(_ label: String) {
+        guard soundModelRunning else { return }
+        onStatusChange(.downloading(label, blocking: false))
+    }
+
+    private func finishSoundModel(failed: Bool) {
+        soundModelRunning = false
+        if failed { soundModelFetch = nil }
+        onStatusChange(status)
+    }
+
     private func reportSentenceModel(_ label: String) {
         guard sentenceModelRunning else { return }
         // Reported, not recorded. `status` says whether the transcriber can
@@ -450,6 +491,7 @@ actor Transcriber {
         var offeredSentences = 0
         if Pipeline.language(of: text, config: config) == "en" {
             warmSentenceModel()
+            if !config.vocabularyTerms.isEmpty { warmSoundModel() }
             if #available(macOS 14, *) {
                 let joins = await SentenceJoin.shared.apply(to: text, config: config)
                 text = joins.text

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -181,6 +181,17 @@ actor Transcriber {
     private func finishSoundModel(failed: Bool) {
         soundModelRunning = false
         if failed { soundModelFetch = nil }
+        restoreStatusIfIdle()
+    }
+
+    /// Puts the ordinary status back, but only when no fetch is still running.
+    ///
+    /// Two downloads can be in flight at once, and each used to restore the
+    /// status on its own. The first to finish then wiped the other's
+    /// percentage out of the menu bar, and the one somebody was watching
+    /// appeared to stall.
+    private func restoreStatusIfIdle() {
+        guard !sentenceModelRunning, !soundModelRunning else { return }
         onStatusChange(status)
     }
 
@@ -195,8 +206,9 @@ actor Transcriber {
         sentenceModelRunning = false
         if failed { sentenceModelFetch = nil }
         // Whatever was true before this started is true again. Usually
-        // `.ready`, which is what clears the label the fetch put up.
-        onStatusChange(status)
+        // `.ready`, which is what clears the label the fetch put up — unless
+        // the other fetch is still going, and then its label stays.
+        restoreStatusIfIdle()
     }
 
 

--- a/Sources/ParrotFlow/VocabularyJudge.swift
+++ b/Sources/ParrotFlow/VocabularyJudge.swift
@@ -887,9 +887,11 @@ enum VocabularyJudge {
     static func phonemeParts(
         in text: String,
         sounds: [(term: String, form: String, phonemes: String?)],
-        voice: String, floor: Float, claimed: [Part]
-    ) -> [Part] {
-        guard !sounds.isEmpty, Phonemes.binary != nil else { return [] }
+        voice: String, language: String, floor: Float, claimed: [Part]
+    ) async -> [Part] {
+        guard !sounds.isEmpty else { return [] }
+        let neural = NeuralPhonemes.language(language)
+        guard Phonemes.binary != nil || neural != nil else { return [] }
         // Two words at least, whatever the vocabulary is spelled like. A sound
         // has no spaces in it — `parrot flow` and `ParrotFlow` are both
         // /pæɹətfloʊ/, and so are `cloud card` and `Cloudcard` — so a window
@@ -914,19 +916,31 @@ enum VocabularyJudge {
         // question.
         let spelled = Set(sounds.flatMap { [$0.term.lowercased(), $0.form.lowercased()] })
 
-        var said = Phonemes.of(
-            windows.map(\.text) + sounds.filter { $0.phonemes == nil }.map(\.form),
-            voice: voice
-        )
+        // Two ears, asked the same question, and never mixed. espeak's
+        // inventory is not the model's — `ɫ` against `l`, `ɝ` against `ɚ` —
+        // so a window's reading may only be compared with a form's reading
+        // from the same ear. The best of the two scores wins; the average of
+        // two incomparable numbers would not mean anything.
+        let asking = windows.map(\.text) + sounds.map(\.form)
+        let rules = Phonemes.of(asking, voice: voice)
+        let model = neural == nil ? [:] : await NeuralPhonemes.of(asking, language: neural!)
+        // A pronunciation somebody wrote down is compared with whatever each
+        // ear heard. It is one person's IPA, not either inventory, and taking
+        // the better of the two comparisons is the same rule as everywhere
+        // else here.
+        var written: [String: String] = [:]
         for entry in sounds where entry.phonemes != nil {
-            said[entry.form] = entry.phonemes
+            written[entry.form] = entry.phonemes
         }
         // Widest first, so `parrot flow` claims its span before `flow` can.
         // The overlap check below is what stops the narrower one afterwards.
         var found: [Part] = []
         for window in windows.sorted(by: { $0.width > $1.width || ($0.width == $1.width && $0.span.lowerBound < $1.span.lowerBound) }) {
-            guard !spelled.contains(window.text.lowercased()),
-                  let heard = said[window.text], !heard.isEmpty else { continue }
+            guard !spelled.contains(window.text.lowercased()) else { continue }
+            let ears = [("espeak", rules[window.text]), ("model", model[window.text])]
+                .compactMap { name, ipa in ipa.map { (name, $0) } }
+                .filter { !$0.1.isEmpty }
+            guard !ears.isEmpty else { continue }
             if taken.contains(where: {
                 $0.lowerBound < window.span.upperBound && window.span.lowerBound < $0.upperBound
             }) { continue }
@@ -936,17 +950,33 @@ enum VocabularyJudge {
             // spellings and a space is a letter's worth of difference. Here it
             // is not: the space is where the decoder guessed a word boundary,
             // and guessing it wrong is the mistake being caught.
-            var best: (score: Float, term: String)?
+            // The best each ear can do, kept apart. The winner is the better
+            // of the two, and both numbers are logged: they are what says
+            // whether the second ear is still earning its place.
+            var perEar: [String: (score: Float, term: String)] = [:]
+            var best: (score: Float, term: String, ear: String, heard: String)?
             for entry in sounds {
-                guard let form = said[entry.form], !form.isEmpty else { continue }
-                // The length ratio caps the score on its own, so a pair that
-                // cannot reach the floor even aligned perfectly is skipped
-                // before the distance is computed.
-                let ratio = Float(min(heard.count, form.count)) / Float(max(heard.count, form.count))
-                guard sqrt(ratio) >= floor else { continue }
-                let score = Phonemes.similarity(heard, form)
-                guard score >= floor, score > (best?.score ?? 0) else { continue }
-                best = (score, entry.term)
+                for (ear, heard) in ears {
+                    // The form as this ear reads it, and the one a person
+                    // wrote down if they did.
+                    let forms = [ear == "espeak" ? rules[entry.form] : model[entry.form],
+                                 written[entry.form]].compactMap { $0 }.filter { !$0.isEmpty }
+                    for form in forms {
+                        // The length ratio caps the score on its own, so a
+                        // pair that cannot reach the floor even aligned
+                        // perfectly is skipped before the distance is
+                        // computed.
+                        let ratio = Float(min(heard.count, form.count))
+                            / Float(max(heard.count, form.count))
+                        guard sqrt(ratio) >= floor else { continue }
+                        let score = Phonemes.similarity(heard, form)
+                        if score > (perEar[ear]?.score ?? 0) {
+                            perEar[ear] = (score, entry.term)
+                        }
+                        guard score >= floor, score > (best?.score ?? 0) else { continue }
+                        best = (score, entry.term, ear, heard)
+                    }
+                }
             }
             guard let best else { continue }
             found.append(Part(
@@ -955,10 +985,15 @@ enum VocabularyJudge {
                 term: best.term, standing: .sound
             ))
             taken.append(window.span)
-            if ProcessInfo.processInfo.environment["PARROTFLOW_JUDGE_DUMP"] != nil {
-                Log.write(String(format: "  sound \"%@\" /%@/ -> %@ %.2f",
-                                 window.text, heard, best.term, best.score))
-            }
+            // What each ear said, always, not only under a switch. The two
+            // are kept because they find different names, and which one
+            // earned a proposal is the only way to keep measuring that.
+            let heardBy = ears.map { ear, ipa -> String in
+                guard let mine = perEar[ear] else { return "\(ear) /\(ipa)/ —" }
+                return String(format: "%@ /%@/ %.2f %@", ear, ipa, mine.score, mine.term)
+            }.joined(separator: "  ")
+            Log.write("vocabulary sound: \"\(window.text)\" -> \(best.term)"
+                + String(format: " %.2f by %@ — ", best.score, best.ear) + heardBy)
         }
         return found.sorted { $0.range.lowerBound < $1.range.lowerBound }
     }

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -573,7 +573,19 @@ if arguments.contains("--span-rule") {
 }
 
 if arguments.contains("--sound") {
-    exit(SoundCommand.run())
+    let code = await SoundCommand.run()
+    exit(code)
+}
+
+if let index = arguments.firstIndex(of: "--phonemes") {
+    let words = Array(arguments[(index + 1)...]).filter { !$0.hasPrefix("--") }
+    guard !words.isEmpty else {
+        print("usage: ParrotFlow --phonemes <word> [word …] [--lang fr]")
+        exit(2)
+    }
+    let language = languageList(arguments)?.first ?? "en"
+    let code = await SoundBenchCommand.run(words, language: language)
+    exit(code)
 }
 
 if let index = arguments.firstIndex(of: "--panel-sheet") {

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -578,7 +578,9 @@ if arguments.contains("--sound") {
 }
 
 if let index = arguments.firstIndex(of: "--phonemes") {
-    let words = Array(arguments[(index + 1)...]).filter { !$0.hasPrefix("--") }
+    // Up to the first flag, not "everything that is not a flag" — the second
+    // reading keeps `fr` out of `--lang fr` and phonemises it as a word.
+    let words = Array(arguments[(index + 1)...].prefix { !$0.hasPrefix("--") })
     guard !words.isEmpty else {
         print("usage: ParrotFlow --phonemes <word> [word …] [--lang fr]")
         exit(2)

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -148,13 +148,50 @@ because it is a homophone — that is not a floor's to settle, and the sentence
 settles it instead. Nothing is written by sound alone; every match is one more
 reading the model votes on.
 
-**It needs espeak-ng**, which is not bundled. Without it the sound path does
-nothing and everything else works as before:
+#### Two ears, and one is optional
+
+Two converters turn a word into sounds, and they are not a replacement for each
+other. Measured on 20891 real dictations at `sound_below: 0.85`, scoring every
+1- and 2-word window:
+
+| converter | windows found | right | wrong |
+| --- | ---: | ---: | ---: |
+| espeak-ng | 41 | 36 | 5 |
+| the sound model | 46 | 39 | 7 |
+| both | 62 | 54 | 8 |
+
+Three false windows more over the whole archive, eighteen true ones. They fail
+differently too, which is the strongest sign they belong together: the model
+invents `praising → Praisy`, espeak invents `and re → Andrey`, and neither
+makes the other's mistake.
+
+What each finds alone says why. The model reads the whole string at once, so it
+hears through a word boundary the recogniser invented — `Priss y` (259 times),
+`O lama`, `au lama`, `press a`, `versol`. espeak applies letter-to-sound rules,
+so it is better on a spelling nobody has ever written — `geler` (45 times),
+`Prazi`, `Ghost E`, `Jemma`, `cloth code`.
+
+**The model is the default.** 81 MB, fetched on the first English dictation
+with a vocabulary in it, like every other model. Nine languages, French
+included. Nothing has to be installed by hand.
+
+**espeak-ng is the improvement.** It is a separate GPL-3 program, so it can
+never ship inside the app, and it is not bundled:
 
     brew install espeak-ng
 
-espeak-ng is GPL-3 and runs as a separate program over a pipe. Nothing links
-it.
+With the model in place its absence costs coverage rather than the whole
+feature. Every proposal names both ears in the log, so which one earned it
+stays countable:
+
+    vocabulary sound: "geler" -> Gelar 1.00 by espeak
+                      espeak /dʒɛlɚ/ 1.00 Gelar  model /ɡiɫɝ/ 0.75 Gelar
+
+A window's reading is only ever compared with a form's reading **from the same
+ear**. The two inventories differ — `ɫ` against `l`, `ɝ` against `ɚ` — so the
+better of the two scores wins, and the average of two incomparable numbers
+would mean nothing. A pronunciation written by hand under `phonemes:` is
+compared against both.
 
 #### A pronunciation can carry its sound
 


### PR DESCRIPTION
The vocabulary hears a name through espeak-ng. It is GPL-3, so it can never
ship inside the app, and it has to be installed by hand. On every machine but
the author's the sound path therefore did nothing, silently — the exact failure
a setup screen exists to prevent.

FluidAudio already carries a grapheme-to-phoneme model. It is a normal model
download: 81 MB, nine languages, no licence to pass on, nothing to install.

## It is not a replacement. It is a second ear.

Measured on 20891 real dictations at `sound_below: 0.85`, every 1- and 2-word
window scored against every term and every rendering:

| converter | windows found | right | wrong |
| --- | ---: | ---: | ---: |
| espeak-ng | 41 | 36 | 5 |
| the sound model | 46 | 39 | 7 |
| **both** | **62** | **54** | **8** |

One and a half times what ships today, for three false windows more over the
whole archive. In fires: 0.021 per dictation against 0.007, touching 435 clips
of 20891.

What each finds alone says why they are worth having together.

**The model reads the whole string at once**, so it hears through a word
boundary the recogniser invented:

```
Priss y  -> Praisy       259 fires    espeak reads it /pɹɪswaɪ/
O lama   -> Ollama                    au lama, press a, press uh, press i
versol   -> Vercel                    Zilberstein, Myrza, Dippixcent
```

**espeak applies letter-to-sound rules**, so it is better on a spelling nobody
has ever written:

```
geler       -> Gelar        45 fires   the model reads it /ɡiɫɝ/
Prazi       -> Praisy                  Ghost E, Jemma, Precis, Prizzy
cloth code  -> Claude Code             Pyrot flow, Longsmith, Arexfi
```

They also fail differently, which is the strongest signal of all: the model
invents `praising → Praisy`, espeak invents `and re → Andrey`, and neither
makes the other's mistake.

## So the model is the default and espeak is the improvement

The model is fetched on the first English dictation with a vocabulary in it,
beside the sentence model and with the same shape — started, never awaited, and
a failure says what stops working rather than putting "Model error" in the menu
bar. With it in place, espeak's absence costs 15 windows rather than the whole
feature, which is what makes `brew install espeak-ng` an honest suggestion
rather than a hidden requirement.

## One rule that matters

**A window's reading is only ever compared with a form's reading from the same
ear.** The inventories differ — `ɫ` against `l`, `ɝ` against `ɚ` — so the better
of the two scores wins and nothing is averaged; the mean of two incomparable
numbers would not mean anything. A pronunciation written by hand under
`phonemes:` is compared against both, because it is one person's IPA and
neither inventory.

## The log names both, always

Not behind a switch. Which ear earned a name is the only way to keep measuring
whether the second one still pays for itself:

```
vocabulary sound: "geler" -> Gelar 1.00 by espeak
                  espeak /dʒɛlɚ/ 1.00 Gelar  model /ɡiɫɝ/ 0.75 Gelar
vocabulary sound: "Pressi" -> Praisy 1.00 by espeak
                  espeak /pɹɛsi/ 1.00 Praisy  model /pɹɛsi/ 1.00 Praisy
```

## Testing

- `make test` green.
- `scripts/check-sound.sh` 13/13, including a case only the model can pass
  (`Priss y → Praisy`) and one only espeak can (`geler → Gelar`). The check
  skips itself when neither ear is present, and says so when only one is.
- `--phonemes <word> [word …] [--lang fr]` prints what each ear hears, side by
  side, and fetches the model if it is missing.

## Notes

- The floor stays 0.85. It was measured for espeak and the model's curve is
  comparable at that value; the union's volume is the number above.
- French: the model has it, espeak has it, and the stage is still gated to
  English. Opening it is a separate measurement — 51 labelled periods is the
  corpus ceiling on the sentence side and the vocabulary side has no French
  case set at all.
- espeak stays useful and stays optional. Nothing bundles it and nothing links
  it; it is a separate program over a pipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMVgtb4jmhQtvWtSJr1bce
