### PR TITLE
feat: every rule a name crossed says what it saw

### DIFF
--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -1268,6 +1268,17 @@ struct Pipeline: Equatable, Codable {
         let reverted = zip(changes, verdicts).filter { !$0.1 }.map {
             "\($0.0.now) -> \($0.0.was)"
         }
+        // The end of every walk, so a proposal that crossed all the free rules
+        // and reached the model does not stop being traceable there. What the
+        // gate settled is named as the gate's, not the model's — the model was
+        // shown only the places still in question.
+        for (index, change) in changes.enumerated() {
+            let kept = index < verdicts.count ? verdicts[index] : true
+            let who = index < taught.count && taught[index] ? "lesson"
+                : (index < decided.count && decided[index] != nil ? "gate" : "judge")
+            Log.write("vocabulary verdict: \"\(change.was)\" -> \"\(change.now)\""
+                + " (\(change.standing)) \(who) \(kept ? "kept" : "reverted")")
+        }
         if chosen != text {
             Log.write("pipeline: vocabulary rewrote the transcript")
             Log.write("    before: \(text)")

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -1104,6 +1104,27 @@ struct Pipeline: Equatable, Codable {
         //
         // `taught` wins over the gate, because a spelling lesson is settled by
         // a rule that is 4/4 where the models are 0/4.
+        /// One line per place, wherever the stage stops.
+        ///
+        /// Every walk ends somewhere and only one of the endings used to say
+        /// so: the model's. A sentence the free rules settled outright, or one
+        /// the cap declined, or one with no model to ask, wrote its steps and
+        /// then vanished — so the counts a reader takes off these lines missed
+        /// exactly the dictations where no model ran, which is most of them.
+        ///
+        /// `nil` is a place nothing decided, which is a real outcome and not a
+        /// missing one: what is already in the text ships.
+        func report(_ said: [Bool?], _ decided: [Bool?], _ taught: [Bool]) {
+            for (index, change) in changes.enumerated() {
+                let who = index < taught.count && taught[index] ? "lesson"
+                    : (index < decided.count && decided[index] != nil ? "gate" : "judge")
+                let verdict = index < said.count ? said[index] : nil
+                Log.write("vocabulary verdict: \"\(change.was)\" -> \"\(change.now)\""
+                    + " (\(change.standing)) \(who) "
+                    + (verdict.map { $0 ? "kept" : "reverted" } ?? "left as it stands"))
+            }
+        }
+
         let settled = (step.gate ?? true)
             ? VocabularyJudge.settle(
                 changes, in: text, by: [.sound: .full, .rule: .lists],
@@ -1122,6 +1143,7 @@ struct Pipeline: Equatable, Codable {
         // the ~0.9s the model costs.
         if decided.allSatisfy({ $0 != nil }) {
             let chosen = VocabularyJudge.settling(decided, in: text, changes: changes)
+            report(decided, decided, taught)
             if chosen != text {
                 Log.write("pipeline: vocabulary rewrote the transcript")
                 Log.write("    before: \(text)")
@@ -1163,6 +1185,7 @@ struct Pipeline: Equatable, Codable {
         // lesson, which was never going to a model anyway, and a place the
         // gate settled, which keeps its answer.
         guard asking.count <= caps.slots else {
+            report(decided, decided, taught)
             return declined("\(asking.count) slots > \(caps.slots); kept as they are",
                             ["asked": .int(0), "slots": .int(slots.count)],
                             fallback: VocabularyJudge.settling(decided, in: text, changes: changes))
@@ -1202,6 +1225,7 @@ struct Pipeline: Equatable, Codable {
         // ordinary change is left exactly as it arrived, same as every other
         // decline in this stage.
         guard config.llmEnabled else {
+            report(decided, decided, taught)
             return declined("`models:` defines no model",
                             ["asked": .int(0), "slots": .int(slots.count)],
                             fallback: VocabularyJudge.settling(
@@ -1240,6 +1264,7 @@ struct Pipeline: Equatable, Codable {
                 config: judgeModel
             )
         } catch {
+            report(decided, decided, taught)
             return declined("\(error.localizedDescription); kept as they are",
                             ["asked": .int(asked.count), "slots": .int(slots.count)],
                             fallback: VocabularyJudge.settling(
@@ -1272,18 +1297,7 @@ struct Pipeline: Equatable, Codable {
         // and reached the model does not stop being traceable there. What the
         // gate settled is named as the gate's, not the model's — the model was
         // shown only the places still in question.
-        for (index, change) in changes.enumerated() {
-            let kept = index < verdicts.count ? verdicts[index] : true
-            let who = index < taught.count && taught[index] ? "lesson"
-                : (index < decided.count && decided[index] != nil ? "gate" : "judge")
-            Log.write("vocabulary verdict: \"\(change.was)\" -> \"\(change.now)\""
-                + " (\(change.standing)) \(who) \(kept ? "kept" : "reverted")")
-        }
-        if chosen != text {
-            Log.write("pipeline: vocabulary rewrote the transcript")
-            Log.write("    before: \(text)")
-            Log.write("    after:  \(chosen)")
-        }
+        report(verdicts.map { $0 }, decided, taught)
         return result(chosen, [
             "asked": .int(asked.count),
             "slots": .int(slots.count),

--- a/Sources/ParrotFlow/Vocabulary.swift
+++ b/Sources/ParrotFlow/Vocabulary.swift
@@ -625,6 +625,21 @@ actor Vocabulary {
     /// always true. So the 47/50 and the zero errors behind this whole tier
     /// were measured on exactly this function, with no audio in them at all.
     /// Leaving the line out here loses no evidence, because there is none.
+    /// The pair the word lists are actually asked about.
+    ///
+    /// A possessive both sides carry is taken off both. Exposed rather than
+    /// kept inside `autoApplies` because anything that *reports* what the
+    /// lists said has to look up the same thing the gate looked up — a
+    /// diagnostic that answers for `Precys` while the gate asked about
+    /// `precy` says the opposite of what happened, on the one line somebody
+    /// reads to find out what happened.
+    static func looksUp(heard: String, term: String) -> (heard: String, term: String) {
+        guard let left = possessive(in: heard), let right = possessive(in: term),
+              !left.stem.isEmpty, !right.stem.isEmpty
+        else { return (heard, term) }
+        return (left.stem, right.stem)
+    }
+
     static func autoApplies(heard: String, term: String) -> Bool {
         // A possessive both sides carry is taken off both before anything is
         // looked up.
@@ -639,12 +654,7 @@ actor Vocabulary {
         // Only when both carry one. A reading that takes a possessive away is
         // a different proposal, and `dropsPossessive` below still has to see
         // it.
-        var heard = heard, term = term
-        if let left = possessive(in: heard), let right = possessive(in: term),
-           !left.stem.isEmpty, !right.stem.isEmpty {
-            heard = left.stem
-            term = right.stem
-        }
+        let (heard, term) = looksUp(heard: heard, term: term)
         let letters = heard.filter { $0.isLetter || $0.isWhitespace }
         if letters.contains(" ") {
             let glued = letters.replacingOccurrences(of: " ", with: "").lowercased()

--- a/Sources/ParrotFlow/VocabularyJudge.swift
+++ b/Sources/ParrotFlow/VocabularyJudge.swift
@@ -1299,6 +1299,15 @@ enum VocabularyJudge {
             let lists = "spell \(spelled ? "knows it" : "unknown"), wordpiece "
                 + (piece.map { $0 ? "knows it" : "unknown" } ?? "unavailable") + stripped
             if Vocabulary.autoApplies(heard: change.was, term: change.now) {
+                // Two rules can say yes here and they are not the same rule. A
+                // span of several words is accepted because it glues to the
+                // term and the lists are never asked; anything else is
+                // accepted because neither list has seen it. Reporting the
+                // second for the first names a lookup nobody made.
+                if word.contains(" ") {
+                    step("glued", "\(bare.lowercased()) is \(asked.term.lowercased())", "apply")
+                    return done(true, "the same word, split in two")
+                }
                 step("lists", lists, "apply")
                 return done(true, "in neither word list")
             }

--- a/Sources/ParrotFlow/VocabularyJudge.swift
+++ b/Sources/ParrotFlow/VocabularyJudge.swift
@@ -1284,13 +1284,20 @@ enum VocabularyJudge {
             // `Precy's -> Praisy's` keeps its possessive; asking about
             // `Praisy` made `dropsPossessive` read it as one being thrown
             // away, and the name was sent to a model that reverted it.
-            let word = change.was.filter { $0.isLetter || $0.isWhitespace }
+            // The pair the gate itself looks up, not one this line works out
+            // again. `autoApplies` takes a shared possessive off both sides
+            // before it asks the lists anything, so a trace that reported the
+            // answer for `Precys` while the gate had asked about `precy` would
+            // name a branch nobody took.
+            let asked = Vocabulary.looksUp(heard: change.was, term: change.now)
+            let word = asked.heard.filter { $0.isLetter || $0.isWhitespace }
             let bare = String(word.filter { !$0.isWhitespace })
             let forms = bare == bare.uppercased() ? [bare.lowercased()] : [bare, bare.lowercased()]
             let spelled = forms.contains { Replacements.isRealWord($0) }
             let piece = WordPieces.knows(bare)
+            let stripped = asked.heard != change.was ? " (\(change.was) without its possessive)" : ""
             let lists = "spell \(spelled ? "knows it" : "unknown"), wordpiece "
-                + (piece.map { $0 ? "knows it" : "unknown" } ?? "unavailable")
+                + (piece.map { $0 ? "knows it" : "unknown" } ?? "unavailable") + stripped
             if Vocabulary.autoApplies(heard: change.was, term: change.now) {
                 step("lists", lists, "apply")
                 return done(true, "in neither word list")
@@ -1299,8 +1306,10 @@ enum VocabularyJudge {
             // look identical from outside and mean different things.
             if word.contains(" ") {
                 // A span of several words never reaches the lists at all: it
-                // is glued and compared with the term, and nothing else.
-                step("lists", "\(bare.lowercased()) is not \(change.now.lowercased())", "on")
+                // is glued and compared with the term, and nothing else. So
+                // this line names the comparison the gate made and does not
+                // report a list answer nobody asked for.
+                step("glued", "\(bare.lowercased()) is not \(asked.term.lowercased())", "on")
             } else if Vocabulary.dropsPossessive(heard: change.was, term: change.now) {
                 step("lists", "the reading drops a possessive", "on")
             } else if Vocabulary.dropsApostrophe(heard: change.was, term: change.now) {

--- a/Sources/ParrotFlow/VocabularyJudge.swift
+++ b/Sources/ParrotFlow/VocabularyJudge.swift
@@ -1251,34 +1251,94 @@ enum VocabularyJudge {
         gate: SlotGate?, rank: Bool
     ) -> [Bool?] {
         changes.map { change -> Bool? in
-            guard let allowed = policy[change.standing] else { return nil }
+            var trace: [String] = []
+            // `padding(toLength:)` truncates when the text is longer than the
+            // width, which quietly ate the end of every long sentence here.
+            func pad(_ text: String, _ width: Int) -> String {
+                text.count >= width ? text + "  "
+                    : text + String(repeating: " ", count: width - text.count)
+            }
+            func step(_ name: String, _ saw: String, _ went: String) {
+                trace.append("    " + pad(name, 8) + pad(saw, 40) + went)
+            }
+            /// Writes the whole walk down and hands the verdict back.
+            ///
+            /// One line per rule the proposal actually reached, not one line
+            /// for the rule that settled it. A proposal that crossed every
+            /// rule and came out the far side used to leave no trace of having
+            /// been anywhere, so nothing downstream could count what the free
+            /// rules failed to settle — which is the number that says whether
+            /// the model in front of them earns its 0.9 seconds.
+            func done(_ verdict: Bool?, _ why: String) -> Bool? {
+                step("result", why, verdict == nil ? "to the judge"
+                    : (verdict! ? "written, not asked" : "refused, not asked"))
+                Log.write("vocabulary step: \"\(change.was)\" -> \"\(change.now)\""
+                    + " by \(change.standing)\n" + trace.joined(separator: "\n"))
+                return verdict
+            }
+
+            guard let allowed = policy[change.standing] else {
+                return done(nil, "this source is not gated")
+            }
             // The reading that is actually going in, not the canonical term.
             // `Precy's -> Praisy's` keeps its possessive; asking about
             // `Praisy` made `dropsPossessive` read it as one being thrown
             // away, and the name was sent to a model that reverted it.
+            let word = change.was.filter { $0.isLetter || $0.isWhitespace }
+            let bare = String(word.filter { !$0.isWhitespace })
+            let forms = bare == bare.uppercased() ? [bare.lowercased()] : [bare, bare.lowercased()]
+            let spelled = forms.contains { Replacements.isRealWord($0) }
+            let piece = WordPieces.knows(bare)
+            let lists = "spell \(spelled ? "knows it" : "unknown"), wordpiece "
+                + (piece.map { $0 ? "knows it" : "unknown" } ?? "unavailable")
             if Vocabulary.autoApplies(heard: change.was, term: change.now) {
-                Log.write("vocabulary gate: \"\(change.was)\" -> \"\(change.now)\""
-                    + " is in neither word list — written, not asked")
-                return true
+                step("lists", lists, "apply")
+                return done(true, "in neither word list")
             }
-            guard allowed == .full, let gate else { return nil }
-            guard let reading = try? gate.read(in: text, at: change.range) else { return nil }
+            // Named rather than inferred: the three ways this rule declines
+            // look identical from outside and mean different things.
+            if word.contains(" ") {
+                // A span of several words never reaches the lists at all: it
+                // is glued and compared with the term, and nothing else.
+                step("lists", "\(bare.lowercased()) is not \(change.now.lowercased())", "on")
+            } else if Vocabulary.dropsPossessive(heard: change.was, term: change.now) {
+                step("lists", "the reading drops a possessive", "on")
+            } else if Vocabulary.dropsApostrophe(heard: change.was, term: change.now) {
+                step("lists", "the reading drops an apostrophe", "on")
+            } else {
+                step("lists", lists, "on")
+            }
+
+            guard allowed == .full else {
+                return done(nil, "a rule keeps what it wrote; no further rule applies")
+            }
+            guard let gate else { return done(nil, "no sentence model") }
+            guard let reading = try? gate.read(in: text, at: change.range) else {
+                return done(nil, "the sentence could not be read")
+            }
             switch reading.route {
             case .decline:
-                Log.write("vocabulary gate: \"\(change.was)\" -> \"\(change.now)\""
-                    + " — the spot wants \(reading.tag), which cannot hold a name; refused")
-                return false
+                step("slot", "wants \(reading.tag)", "refuse")
+                return done(false, "no name stands where \(reading.tag.lowercased()) goes")
             case .apply:
-                // The rank is the half that can be wrong in silence, so it is
-                // the half with a switch.
-                guard rank else { return nil }
-                Log.write("vocabulary gate: \"\(change.was)\" -> \"\(change.now)\""
-                    + " is the worst-reading spot of its sentence"
-                    + (reading.rank.map { " (rank \($0) of \(reading.windows))" } ?? "")
-                    + " — written, not asked")
-                return true
+                step("slot", "wants \(reading.tag), a name fits", "on")
+                let placed = reading.rank.map { "rank \($0) of \(reading.windows)" } ?? "unranked"
+                guard rank else {
+                    step("rank", placed, "off by `gate_rank`")
+                    return done(nil, "the rank rule is off")
+                }
+                step("rank", placed, "apply")
+                return done(true, "the worst-reading spot of its sentence")
             case .judge:
-                return nil
+                let tagged = reading.tag.isEmpty ? "nothing nameable" : reading.tag
+                if SlotGate.hosts.contains(reading.tag) {
+                    step("slot", "wants \(tagged), a name fits", "on")
+                    step("rank", reading.rank.map { "rank \($0) of \(reading.windows)" }
+                        ?? "unranked", "on")
+                } else {
+                    step("slot", "wants \(tagged)", "on")
+                }
+                return done(nil, "no free rule settles it")
             }
         }
     }


### PR DESCRIPTION
Only the rule that settled a proposal wrote anything down. A proposal that
crossed all four free rules and came out the far side left no trace of having
been anywhere.

That matters more than a diagnostic usually does, because it is the number the
gate is judged on. If the free rules routinely hand the model a name they
should have written themselves, the model earns its 0.9 seconds; if they hand
it two in a hundred, it does not. Neither answer was countable.

## What it looks like

A proposal the gate settles, and every rule it crossed to get there:

```
vocabulary step: "Ghost E" -> "Ghostty" by sound
    lists   ghoste is not ghostty                   on
    slot    wants Pronoun, a name fits              on
    rank    rank 0 of 5                             apply
    result  the worst-reading spot of its sentence  written, not asked
```

One the gate does not settle, and the model's answer closing the walk:

```
vocabulary step: "Versailles" -> "Vercel" by rule
    lists   spell knows it, wordpiece knows it      on
    result  a rule keeps what it wrote              to the judge

vocabulary verdict: "Versailles" -> "Vercel" (rule) judge reverted
```

## What each line says

The rule's own reading, not a restatement of the outcome.

- **The two word lists are named separately.** Which one knew a word is the
  thing that makes the pair work — the spell checker has no first names in it,
  the tokenizer has no rare compounds — and a single "unknown" hides that.
- **The three ways the list rule declines are named.** A glued span that is not
  the term, a possessive the reading would drop, an apostrophe. They look
  identical from outside and mean different things.
- **A settled place is attributed to the gate, not the model.** The model was
  shown only the places still in question, so crediting it with the rest would
  make the log say the opposite of what happened.

## Notes

- Names appear in the log on the same terms as everything else in this stage:
  only where a proposal was made. `PARROTFLOW_JUDGE_DUMP` stays the switch for
  spelling out a sentence nothing happened in.
- `padding(toLength:)` truncates when the text is longer than the width, which
  ate the end of every long sentence in the first draft. Worth knowing; it is
  used elsewhere.
- `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMVgtb4jmhQtvWtSJr1bce
