### PR TITLE
fix: `review: false` stops the model and nothing else

### DIFF
--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -1006,14 +1006,6 @@ struct Pipeline: Equatable, Codable {
             return StageResult(text: text, vars: wrote.merging(vars) { _, new in new })
         }
 
-        // `review: false`. The exact matches ship as the rules wrote them, and
-        // the near-miss pass is skipped with the review rather than left to
-        // run: nothing it proposes is ever written without a model reading the
-        // sentence first.
-        guard step.reviewEnabled ?? true else {
-            return result(text, ["asked": .int(0), "slots": .int(0)])
-        }
-
         let caps = step.caps ?? VocabularyJudge.Caps.standard
         // Both sources. The acoustic pass proposes with positions; a
         // `replacements` rule publishes none, so its substitutions are found by
@@ -1190,6 +1182,32 @@ struct Pipeline: Equatable, Codable {
                 "judged": .string(chosen),
             ])
         }
+        // `review: false` — no model, and nothing else.
+        //
+        // It used to return above all of this, so it also turned off the
+        // near-miss pass, the sound pass and the free rules in front of the
+        // judge. The reason given was that nothing those propose is ever
+        // written without a model reading the sentence first, and that was
+        // true until the gate existed. It is not true now: the two word lists
+        // write a name with no model at all, measured at no errors over this
+        // speaker's archive, and refusing to run them because the model is off
+        // throws away the half of the stage that needs no model.
+        //
+        // So what is settled is written and what is not keeps what is already
+        // there — the same three-way answer every other no-model path in this
+        // stage gives.
+        guard step.reviewEnabled ?? true else {
+            let chosen = VocabularyJudge.settling(decided, in: text, changes: changes)
+            if chosen != text {
+                Log.write("pipeline: vocabulary rewrote the transcript (no review)")
+                Log.write("    before: \(text)")
+                Log.write("    after:  \(chosen)")
+            }
+            return result(chosen, [
+                "asked": .int(0), "slots": .int(slots.count), "judged": .string(chosen),
+            ])
+        }
+
         // Checked here rather than at the top so that a pipeline with no model
         // still publishes what the stage found. `vocabulary.slots` is the one
         // thing about this stage a fixture can assert — the verdict comes from

--- a/tests/pipeline-cases.yaml
+++ b/tests/pipeline-cases.yaml
@@ -788,17 +788,24 @@ cases:
     expect: Supabase is up
     expect_vars:
       vocabulary.count: 1
-      vocabulary.slots: 0
+      vocabulary.slots: 1
 
   # And the other half: with nobody to read the sentence, a near miss is left
   # where it stands rather than written on the strength of the edit alone.
+  #
+  # `slots: 1` and not 0. The stage used to return before it had counted
+  # anything, so `review: false` reported an empty sentence whatever was in it.
+  # It now gathers the proposals, settles the ones the free rules are sure of,
+  # and stops there — so the count says one place was found, and `expect:
+  # unchanged` says nothing was written in it. Those are two different facts
+  # and only one of them used to be visible.
   - name: review off leaves the near misses alone
     pipeline: review-off
     input: our app is deployed on Versel
     expect: unchanged
     expect_vars:
-      vocabulary.count: 0
-      vocabulary.slots: 0
+      vocabulary.count: 1
+      vocabulary.slots: 1
 
   # --- named word lists ------------------------------------------------------
   #


### PR DESCRIPTION
`review: false` returned before the stage had gathered anything, so it also
turned off the near-miss pass, the sound pass, and the free rules in front of
the judge. The reason written above it was that nothing those propose is ever
written without a model reading the sentence first.

That was true until the gate existed. It is not true now: the two word lists
write a name with no model at all, measured at no errors over one speaker's
archive, and refusing to run them because the model is off throws away the half
of the stage that never needed one.

So the guard moves below the gathering and below the gate. What the free rules
settle is written, what they do not keeps what is already there — the same
three-way answer every other no-model path in this stage gives.

```
- stage: vocabulary
  review: false
```

```
"I opened Ghost E this morning"  ->  "I opened Ghostty this morning"
vocabulary gate: 1 of 1 settled without asking
vocabulary.asked = 0
```

## The two cases that moved

`tests/pipeline-cases.yaml` had `slots: 0` on both `review-off` cases and they
are now `slots: 1`. The text each asserts on is unchanged.

That is the point rather than a concession. The stage used to return before it
had counted anything, so `review: false` reported an empty sentence whatever
was in it. "One place was found" and "nothing was written in it" are two
different facts and only one of them used to be visible.

## Testing

`make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMVgtb4jmhQtvWtSJr1bce
