### PR TITLE
feat: --word-gate shows the numbers the rules decided on

### DIFF
--- a/Sources/ParrotFlow/SlotGate.swift
+++ b/Sources/ParrotFlow/SlotGate.swift
@@ -100,8 +100,43 @@ struct SlotGate {
     ///
     /// Ties go to the more likely filler, because the fillers arrive sorted.
     func wants(_ words: [String], at span: Range<Int>) throws -> String {
+        try tagged(words, at: span).0
+    }
+
+    /// What the slot itself makes of two readings of it.
+    ///
+    /// The masked slot is a distribution over the whole vocabulary, and the
+    /// rule reads two things off it today: the modal tag of its top ten, and
+    /// where the word present sits in a ranking of the whole sentence. It
+    /// never asks the one question the slot can answer directly — is the word
+    /// that is there more likely here than the word somebody wants to put in
+    /// its place.
+    ///
+    /// Returned for `--word-gate` to print. Nothing decides on it yet.
+    func weighs(
+        _ words: [String], at span: Range<Int>, against term: String
+    ) throws -> (heard: Double, term: Double)? {
         let (left, right) = Self.masked(words, at: span)
         let slot = try probe.at(left: left, right: right)
+        let lead = left.isEmpty ? "" : " "
+        guard let here = probe.tokenizer.firstID(of: lead + Self.bare(words[span.lowerBound])),
+              let there = probe.tokenizer.firstID(of: lead + Self.bare(term))
+        else { return nil }
+        return (slot.logProbability(of: here), slot.logProbability(of: there))
+    }
+
+    /// The same reading, with the words it was taken from.
+    ///
+    /// The rule keeps one tag out of ten guesses and throws the guesses away.
+    /// They are what makes the tag readable — "Determiner" means nothing until
+    /// you see `second, my, your, any, some` under it — so the diagnostic asks
+    /// for both. Nothing decides on the words.
+    func tagged(
+        _ words: [String], at span: Range<Int>
+    ) throws -> (String, [(word: String, tag: String)]) {
+        let (left, right) = Self.masked(words, at: span)
+        let slot = try probe.at(left: left, right: right)
+        var seen: [(word: String, tag: String)] = []
 
         var counts: [String: Int] = [:]
         var order: [String] = []
@@ -113,15 +148,36 @@ struct SlotGate {
             guard let tag = Self.tag(in: sentence, at: at, length: word.count) else { continue }
             if counts[tag] == nil { order.append(tag) }
             counts[tag, default: 0] += 1
+            let named = Self.named(in: sentence, at: at, length: word.count) ?? tag
+            seen.append((word, named == tag ? tag : "\(tag)/\(named)"))
         }
         var best = ""
         for tag in order where counts[tag, default: 0] > counts[best, default: 0] { best = tag }
-        return best
+        return (best, seen)
     }
 
     /// `.lexicalClass` and not `.nameTypeOrLexicalClass`. The question is what
     /// kind of slot this is, and a filler that happens to be a name would come
     /// back `PersonalName` rather than `Noun` and split the vote.
+    /// The same tagging, asked for a name type first.
+    ///
+    /// `lexicalClass` collapses every proper noun into `Noun`, so the rule
+    /// cannot tell "a name goes here" from "a thing goes here".
+    /// `nameTypeOrLexicalClass` answers `PersonalName`, `PlaceName` or
+    /// `OrganizationName` where it can. Printed by `--word-gate`; nothing
+    /// decides on it.
+    static func named(in sentence: String, at offset: Int, length: Int) -> String? {
+        guard let from = sentence.index(
+                sentence.startIndex, offsetBy: offset, limitedBy: sentence.endIndex),
+              let to = sentence.index(from, offsetBy: length, limitedBy: sentence.endIndex)
+        else { return nil }
+        let tagger = NLTagger(tagSchemes: [.nameTypeOrLexicalClass])
+        tagger.string = sentence
+        tagger.setLanguage(.english, range: sentence.startIndex..<sentence.endIndex)
+        _ = to
+        return tagger.tag(at: from, unit: .word, scheme: .nameTypeOrLexicalClass).0?.rawValue
+    }
+
     private static func tag(in sentence: String, at offset: Int, length: Int) -> String? {
         guard let from = sentence.index(
                 sentence.startIndex, offsetBy: offset, limitedBy: sentence.endIndex),
@@ -156,7 +212,23 @@ struct SlotGate {
     /// the 50 cases where the span was the word the speaker said. Adding the
     /// word ranking takes those three out and costs nothing else.
     func weakest(_ words: [String], at span: Range<Int>) throws -> (rank: Int, windows: Int) {
-        guard words.count >= 2 else { return (Int.max, 0) }
+        try ranked(words, at: span).0
+    }
+
+    /// The same walk, with the numbers it decided on.
+    ///
+    /// The rank is a place in a queue and says nothing about the distance to
+    /// the word behind it. Two sentences can both put a name first and mean
+    /// very different things by it — a nonsense spelling sits nats below
+    /// everything else, a rare proper noun sits a fraction below its
+    /// neighbour. Only the scores tell those apart, and the rule cannot: it
+    /// reads the place and not the gap.
+    ///
+    /// Returned for `--word-gate` to print. Nothing decides on it.
+    func ranked(
+        _ words: [String], at span: Range<Int>
+    ) throws -> ((rank: Int, windows: Int), [(word: String, score: Double)]) {
+        guard words.count >= 2 else { return ((Int.max, 0), []) }
         var scores: [Double] = []
         for index in words.indices {
             let (left, right) = Self.masked(words, at: index..<(index + 1))
@@ -173,7 +245,10 @@ struct SlotGate {
         let byWindow = windows.indices.sorted { windows[$0] < windows[$1] }
         // A window holds the span when either of its two words is in it.
         let pair = byWindow.firstIndex { span.contains($0) || span.contains($0 + 1) } ?? Int.max
-        return (max(word, pair), windows.count)
+        return (
+            (max(word, pair), windows.count),
+            byWord.map { (words[$0], scores[$0]) }
+        )
     }
 
     // MARK: - The sentence, as words

--- a/Sources/ParrotFlow/WordGateCommand.swift
+++ b/Sources/ParrotFlow/WordGateCommand.swift
@@ -127,7 +127,34 @@ enum WordGateCommand {
             return
         }
         print("slot       \(reading.tag.isEmpty ? "untagged" : reading.tag)")
+        // The ten words the tag was taken from. "Determiner" means nothing
+        // until you see `second, my, your, any, some` under it.
+        let (allWords, span) = SlotGate.sentence(around: range, in: sentence)
+        if let guesses = try? gate.tagged(allWords, at: span), !guesses.1.isEmpty {
+            print("  fills    " + guesses.1.map { "\($0.word) (\($0.tag))" }
+                .joined(separator: ", "))
+        }
+        if let weighed = try? gate.weighs(allWords, at: span, against: term ?? "") ?? nil {
+            print(String(format: "  slot says  here %.2f   there %.2f   %@",
+                         weighed.heard, weighed.term,
+                         weighed.heard > weighed.term
+                            ? "it prefers what is there" : "it prefers the term"))
+        }
         print("rank       \(reading.rank.map { "\($0) of \(reading.windows)" } ?? "not asked")")
+        // Every word with the number the rank sorted on, least expected first.
+        // The rank is a place in that queue and says nothing about the gap to
+        // the word behind it, which is the whole of what it gets wrong on a
+        // rare proper noun.
+        if reading.rank != nil {
+            if let ranked = try? gate.ranked(allWords, at: span) {
+                for (index, entry) in ranked.1.enumerated() {
+                    let mine = span.contains(allWords.firstIndex(of: entry.word) ?? -1)
+                    print(String(format: "  %@ %2d  %-18s %7.2f",
+                                 mine ? "→" : " ", index, (entry.word as NSString).utf8String!,
+                                 entry.score))
+                }
+            }
+        }
         let route = applies
             ? SlotGate.Route.apply
             : (Vocabulary.dropsPossessive(heard: heard, term: term) ? .judge : reading.route)


### PR DESCRIPTION
The command said which way each rule went and never what it read. That is
enough while the rules agree with you and useless the moment one does not.

Three readings are printed now, and nothing decides on any of them.

## Every word with the score the rank sorted on

```
rank       0 of 15
  →  0  Versailles          -13.74
     1  Versal              -12.71
     2  Mirza                -9.06
     3  deploying            -8.33
    ...
    15  the                  -0.16
```

One nat between the word the rule calls wrong and the word that actually is.
The four weakest are all proper nouns. The rank reads a place and not a gap,
and this is that stated as a number rather than as a worry.

## The ten words the slot's tag came from

```
slot       Noun
  fills    Windsor (Noun/PlaceName), White (Noun/OrganizationName), Vatican
           (Noun/OrganizationName), Prague (Noun/PlaceName), Edinburgh
           (Noun/PlaceName), Kremlin (Noun/OrganizationName), …
```

"Determiner" means nothing until `second, my, your, any` sits under it. And
`Noun` hides the difference between a list of castles and a list of deployment
platforms, which is exactly the difference the rule needs and does not have —
`I deploy my app on ___` predicts Android, localhost, GitHub, Linux, Docker,
Kubernetes, and NLTagger calls almost none of them names.

## What the slot makes of the two readings

```
  slot says  here -14.95   there -9.89   it prefers the term
```

Printed with a caveat attached. A vocabulary term is by construction a word
nobody knows, so the tokenizer splits it and this number is its first
fragment's. `Red Cross` and `Redcrawl` score identically because both start
with `Red`. It is shown because seeing that is how the trap gets found, not
because it can be read as evidence.

## Notes

`SlotGate.weakest` and `.wants` keep their shapes and delegate to `ranked` and
`tagged`, which return the same answers with the working shown. `make test`
green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMVgtb4jmhQtvWtSJr1bce