### PR TITLE
fix: the rank rule goes, it was wrong more often than right

### DIFF
--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -218,19 +218,6 @@ struct Config: Decodable, Equatable {
         /// `and me` reaching `Andrey`.
         var soundBelow: Float = 0.85
 
-        /// Whether the gate in front of the judge may write a name because its
-        /// span is the worst-reading spot in its sentence.
-        ///
-        /// The other three rules of that gate ask absolute questions — is this
-        /// a word anybody has written, can a name stand in this spot. This one
-        /// is relative to the rest of the sentence, and it answers "unexpected"
-        /// where the question is "wrong". A rare proper noun is both: on
-        /// "visiting the Versailles Castle" it ranks `Versailles` first of
-        /// fifteen and would write `Vercel Castle` without asking.
-        ///
-        /// On because it was measured at no errors over 50 cases, switchable
-        /// because that sentence is not one of them.
-        var gateRank: Bool = true
 
         /// One way this speaker's mouth turns a term into something else, and
         /// what is known about that.
@@ -572,8 +559,14 @@ struct Config: Decodable, Equatable {
                         + " Running at \(soundBelow)")
                 }
             }
-            if let on = try c.decodeIfPresent(Bool.self, forKey: .gateRank) {
-                gateRank = on
+            // `gate_rank` switched a rule that wrote a name when its span read
+            // worst in the sentence. The rule is gone — see `SlotGate` — so the
+            // key is read and says so rather than being ignored in silence.
+            if try c.decodeIfPresent(Bool.self, forKey: .gateRank) != nil {
+                legacy.append("`gate_rank:` switched a rule that wrote a name"
+                    + " because its span read worst in its sentence. That rule is"
+                    + " gone: over 150 real decisions it wrote 27 names and 17"
+                    + " were wrong. The key is read and does nothing")
             }
             // Nats, and the audio arguing against a reading by a negative
             // amount is the audio agreeing with it. At or below 0 every

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -218,7 +218,6 @@ struct Config: Decodable, Equatable {
         /// `and me` reaching `Andrey`.
         var soundBelow: Float = 0.85
 
-
         /// One way this speaker's mouth turns a term into something else, and
         /// what is known about that.
         ///

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -1085,8 +1085,7 @@ struct Pipeline: Equatable, Codable {
         let settled = (step.gate ?? true)
             ? VocabularyJudge.settle(
                 changes, in: text, by: [.sound: .full, .rule: .lists],
-                gate: await Vocabulary.shared.slotGate(),
-                rank: config.vocabulary.gateRank)
+                gate: await Vocabulary.shared.slotGate())
             : [Bool?](repeating: nil, count: changes.count)
         var decided: [Bool?] = changes.indices.map { index in
             index < taught.count && taught[index] ? false : settled[index]

--- a/Sources/ParrotFlow/SlotGate.swift
+++ b/Sources/ParrotFlow/SlotGate.swift
@@ -10,11 +10,10 @@ import NaturalLanguage
 /// the slot wants, and one per word only when that pass says a name could go
 /// there. A pass is about 8 ms at sequence length 64.
 ///
-/// The rules, in the order they run:
+/// One rule:
 ///
-///     the slot accepts a name, and the word is rank 0    apply
-///     the slot refuses a name                            decline
-///     anything else                                      judge
+///     the slot refuses a name    decline
+///     anything else              judge
 ///
 /// **Slot POS.** Mask the heard word, take the ten most likely fillers, put
 /// each back in the sentence and tag it. The modal tag is what the slot wants.
@@ -24,14 +23,13 @@ import NaturalLanguage
 /// `second, my, your, any, some, more, the, first`, and a bare name does not
 /// go in a determiner slot.
 ///
-/// **Rank 0.** The heard word is the weakest place in its sentence: no word
-/// surprises the model more, and no two-word window more than the one it sits
-/// on. One forward pass per word, each word read by its first BPE piece — see
-/// `weakest`.
-///
-/// **ANDed, cheapest first.** An AND already fails once the POS refuses, and
-/// the POS is one pass against the rank's one per word, so the rank is not
-/// computed then.
+/// **There was a second rule and it is gone.** It wrote a name when the span
+/// was the weakest-reading place in its sentence. It asked whether a word was
+/// *unexpected* where the question is whether it is *wrong*, and a rare proper
+/// noun is both. Measured over the 150 real decisions of the vocabulary bench
+/// it wrote 27 names and 17 were wrong — `ghostly` to `Ghostty` four times,
+/// `bedrock` to `Redrock` twice, `verbatim` to `Mirza`, `gamma` to `Gemma`.
+/// Its recorded 47/50 was real and came from a set holding none of those.
 ///
 /// **The decline runs last, after the lexical gate.** `Vocabulary.slotRoute`
 /// is only asked about a proposal that gate left open. The gate decides on
@@ -49,13 +47,10 @@ import NaturalLanguage
 struct SlotGate {
 
     enum Route: String {
-        case apply, decline, judge
+        case decline, judge
     }
 
-    /// Tags a name can stand in. Rule 4.
-    static let hosts: Set<String> = ["Noun", "Adjective", "Pronoun"]
-
-    /// Tags a name cannot stand in. Rule 6.
+    /// Tags a name cannot stand in.
     static let blocks: Set<String> = ["Verb", "Adverb", "Preposition"]
 
     /// How many fillers vote on what the slot wants.
@@ -66,10 +61,6 @@ struct SlotGate {
     struct Reading {
         /// The modal tag of the fillers, or "" when nothing tagged.
         let tag: String
-        /// How far the span is from being the weakest place in the sentence —
-        /// see `weakest`. Absent when the POS refused and the rank was skipped.
-        let rank: Int?
-        let windows: Int
         let route: Route
     }
 
@@ -77,21 +68,10 @@ struct SlotGate {
     func read(in text: String, at range: Range<String.Index>) throws -> Reading {
         let (words, span) = Self.sentence(around: range, in: text)
         guard !span.isEmpty, span.upperBound <= words.count else {
-            return Reading(tag: "", rank: nil, windows: 0, route: .judge)
+            return Reading(tag: "", route: .judge)
         }
-
         let tag = try wants(words, at: span)
-        guard Self.hosts.contains(tag) else {
-            return Reading(
-                tag: tag, rank: nil, windows: 0,
-                route: Self.blocks.contains(tag) ? .decline : .judge
-            )
-        }
-        let (rank, windows) = try weakest(words, at: span)
-        return Reading(
-            tag: tag, rank: rank, windows: windows,
-            route: rank == 0 ? .apply : .judge
-        )
+        return Reading(tag: tag, route: Self.blocks.contains(tag) ? .decline : .judge)
     }
 
     // MARK: - Rule 4 and rule 6, the slot's part of speech
@@ -133,57 +113,14 @@ struct SlotGate {
         return tagger.tag(at: from, unit: .word, scheme: .lexicalClass).0?.rawValue
     }
 
-    // MARK: - Rule 5, the weakest window
-
-    /// How far the span is from being the weakest place in its sentence.
-    ///
-    /// One forward pass per word: mask it, read the log-probability of the word
-    /// that is there. Two rankings come off that one array — the words, and the
-    /// adjacent pairs summed — and the rank returned is the worse of the two.
-    /// Rank 0 therefore means both: no word surprises the model more than the
-    /// span, and no pair more than the pair the span sits on.
-    ///
-    /// A word is scored by its **first BPE piece**, not by all of them. One
-    /// masked position holds one token, so the rest of a multi-piece word would
-    /// need a pass each with the pieces before it revealed — a different and
-    /// far more expensive question. `SentenceProbe.read` reads the word after a
-    /// boundary the same way. It costs little here: the rare piece of a
-    /// misheard name is the first one, and this is a ranking, so every word in
-    /// the sentence is measured on the same footing.
-    ///
-    /// The window alone is not enough. On a sentence of ordinary words the
-    /// weakest pair is decided by noise, and it landed on the span in three of
-    /// the 50 cases where the span was the word the speaker said. Adding the
-    /// word ranking takes those three out and costs nothing else.
-    func weakest(_ words: [String], at span: Range<Int>) throws -> (rank: Int, windows: Int) {
-        guard words.count >= 2 else { return (Int.max, 0) }
-        var scores: [Double] = []
-        for index in words.indices {
-            let (left, right) = Self.masked(words, at: index..<(index + 1))
-            let slot = try probe.at(left: left, right: right)
-            let bare = Self.bare(words[index])
-            let id = probe.tokenizer.firstID(of: (index == 0 ? "" : " ") + bare)
-            scores.append(id.map { slot.logProbability(of: $0) } ?? -.infinity)
-        }
-
-        let byWord = scores.indices.sorted { scores[$0] < scores[$1] }
-        let word = byWord.firstIndex { span.contains($0) } ?? Int.max
-
-        let windows = (0..<(words.count - 1)).map { scores[$0] + scores[$0 + 1] }
-        let byWindow = windows.indices.sorted { windows[$0] < windows[$1] }
-        // A window holds the span when either of its two words is in it.
-        let pair = byWindow.firstIndex { span.contains($0) || span.contains($0 + 1) } ?? Int.max
-        return (max(word, pair), windows.count)
-    }
-
     // MARK: - The sentence, as words
 
     /// The sentence `range` sits in, split into words, and which of them the
     /// range covers.
     ///
-    /// The sentence and not the whole transcript: "its sentence" is what the
-    /// rank is measured against, and a second sentence only adds windows the
-    /// span can never win.
+    /// The sentence and not the whole transcript: what the slot wants is
+    /// decided by the words around the span, and a second sentence only puts
+    /// words in the window that were never near it.
     static func sentence(
         around range: Range<String.Index>, in text: String
     ) -> (words: [String], span: Range<Int>) {

--- a/Sources/ParrotFlow/SlotGate.swift
+++ b/Sources/ParrotFlow/SlotGate.swift
@@ -41,8 +41,8 @@ import NaturalLanguage
 /// costs a wrong decline.
 ///
 /// Measured over the 50 English cases of `tests/judge-cases.yaml` by
-/// `scripts/check-slot-gate.sh`: 15 auto-applied, 14 declined, 21 left for the
-/// judge, and no error of either kind.
+/// `scripts/check-slot-gate.sh`: 13 applied by the lexical gate, 14 declined
+/// here, 23 left for the judge, and no error of either kind.
 @available(macOS 14, *)
 struct SlotGate {
 

--- a/Sources/ParrotFlow/VocabularyJudge.swift
+++ b/Sources/ParrotFlow/VocabularyJudge.swift
@@ -1118,13 +1118,9 @@ enum VocabularyJudge {
     ///    the model would put there, tag them. A spot that wants a verb, an
     ///    adverb or a preposition cannot hold a name, so the reading is
     ///    impossible and there is nothing to ask. Refuse it.
-    /// 3. **Is that the spot the sentence reads worst?** The span must be both
-    ///    the least expected word and inside the least expected pair. Write the
-    ///    term. Anything else goes to the model.
     ///
-    /// Measured at 47/50 with 21 model calls instead of 50 and no error either
-    /// way — on `tests/judge-cases.yaml`, with no audio in it. See
-    /// `Vocabulary.autoApplies(heard:term:)` for why that matters.
+    /// There was a third — write the term when its span reads worst in the
+    /// sentence — and it is gone. See `SlotGate` for what it cost.
     ///
     /// **What each source may be settled by is not the same.** A rule
     /// substitution is already written into the text, so keeping one costs
@@ -1139,17 +1135,11 @@ enum VocabularyJudge {
     /// ask. `Versailles -> Vercel` fires the same rule in the same sentence and
     /// is *not* settled: the spell checker knows the word, the lists say
     /// nothing, and it goes to the judge — which is where it belongs, and where
-    /// the judge got it right. Under `.full` the rank would have ranked
-    /// `Versailles` first of fifteen and written `Vercel Castle`.
+    /// the judge got it right.
     ///
-    /// Rule 3 is the weak one and it is on by `rank`. It asks whether a word is
-    /// *unexpected*, not whether it is *wrong*, and a rare proper noun is both
-    /// unexpected and correct: on "visiting the Versailles Castle" it ranks
-    /// `Versailles` first of fifteen and would write `Vercel Castle`. Rules 1
-    /// and 2 have no such confound.
     static func settle(
         _ changes: [Change], in text: String, by policy: [Standing: Gating],
-        gate: SlotGate?, rank: Bool
+        gate: SlotGate?
     ) -> [Bool?] {
         changes.map { change -> Bool? in
             guard let allowed = policy[change.standing] else { return nil }
@@ -1169,15 +1159,6 @@ enum VocabularyJudge {
                 Log.write("vocabulary gate: \"\(change.was)\" -> \"\(change.now)\""
                     + " — the spot wants \(reading.tag), which cannot hold a name; refused")
                 return false
-            case .apply:
-                // The rank is the half that can be wrong in silence, so it is
-                // the half with a switch.
-                guard rank else { return nil }
-                Log.write("vocabulary gate: \"\(change.was)\" -> \"\(change.now)\""
-                    + " is the worst-reading spot of its sentence"
-                    + (reading.rank.map { " (rank \($0) of \(reading.windows))" } ?? "")
-                    + " — written, not asked")
-                return true
             case .judge:
                 return nil
             }

--- a/Sources/ParrotFlow/VocabularyJudge.swift
+++ b/Sources/ParrotFlow/VocabularyJudge.swift
@@ -1136,7 +1136,6 @@ enum VocabularyJudge {
     /// is *not* settled: the spell checker knows the word, the lists say
     /// nothing, and it goes to the judge — which is where it belongs, and where
     /// the judge got it right.
-    ///
     static func settle(
         _ changes: [Change], in text: String, by policy: [Standing: Gating],
         gate: SlotGate?

--- a/Sources/ParrotFlow/WordGateCommand.swift
+++ b/Sources/ParrotFlow/WordGateCommand.swift
@@ -30,12 +30,10 @@ import Foundation
 ///     possessive kept
 ///     gate       judge
 ///     slot       Verb
-///     rank       not asked
 ///     route      decline
 ///
-/// `slot` is what the masked slot wants, `rank` is where the span's two-word
-/// window sits among the sentence's, and `route` is where the proposal goes —
-/// see `SlotGate`. Nothing is downloaded: with no cached model the slot reads
+/// `slot` is what the masked slot wants and `route` is where the proposal goes
+/// — see `SlotGate`. Nothing is downloaded: with no cached model the slot reads
 /// `unavailable` and the route is `judge`.
 ///
 /// No audio. The pair form fixes the scores so the term wins, because the
@@ -127,11 +125,12 @@ enum WordGateCommand {
             return
         }
         print("slot       \(reading.tag.isEmpty ? "untagged" : reading.tag)")
-        print("rank       \(reading.rank.map { "\($0) of \(reading.windows)" } ?? "not asked")")
+        // `apply` is not a route any more — the lexical gate is the only thing
+        // that writes without asking, and it has already printed its verdict.
         let route = applies
-            ? SlotGate.Route.apply
-            : (Vocabulary.dropsPossessive(heard: heard, term: term) ? .judge : reading.route)
-        print("route      \(route.rawValue)")
+            ? "apply"
+            : (Vocabulary.dropsPossessive(heard: heard, term: term) ? "judge" : reading.route.rawValue)
+        print("route      \(route)")
     }
 
     /// The probe, or nil when the model has never been fetched.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -132,10 +132,10 @@ term does not would be taken out of the sentence, so it goes to the judge.
 Name the sentence too — with the term, which the model tiers are about —
 `--word-gate merge Vercel --in "Go back to main and merge."` prints
 `slot Verb` and `route decline`. `slot` is what the masked slot wants, from
-ten fillers put back and tagged; `rank` is how far the word is from being the
-weakest place in its sentence; `route` is where the proposal goes. A name goes
-in a `Noun`, `Adjective` or `Pronoun` slot and never in a `Verb`, `Adverb` or
-`Preposition` one — see `SlotGate`. Nothing is downloaded: with no cached
+ten fillers put back and tagged; `route` is where the proposal goes. The slot
+only ever declines: a name goes in a `Noun`, `Adjective` or `Pronoun` slot and
+never in a `Verb`, `Adverb` or `Preposition` one, and every other proposal
+reads `judge` — see `SlotGate`. Nothing is downloaded: with no cached
 sentence model the slot reads `unavailable` and the route is `judge`.
 `scripts/check-slot-gate.sh` scores the whole route against
 `tests/judge-cases.yaml`. It needs the 300 MB model, so it is not in

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -409,16 +409,15 @@ masked language model `SentenceModel` already fetches. Mask the word, take the
 ten most likely fillers, put each one back and tag it: the modal tag is what
 the slot wants. A name goes in a `Noun`, `Adjective` or `Pronoun` slot and
 never in a `Verb`, `Adverb` or `Preposition` one, so `merge` -> `Vercel` and
-`ready` -> `Arexvy` are refused with nothing asked. A term is written unasked
-only when the slot accepts a name **and** the word is the weakest place in its
-sentence — no word surprises the model more, and no two-word window more than
-the one it sits on. Everything else still goes to the judge, `Determiner`
-slots included: those are modifier positions and names do sit in them
-(`cloud code`, `bedrock principles`).
+`ready` -> `Arexvy` are refused with nothing asked. This tier only refuses. It
+never writes a term, and everything it does not refuse goes to the judge,
+`Determiner` slots included: those are modifier positions and names do sit in
+them (`cloud code`, `bedrock principles`).
 
-Measured over the 50 English cases of `tests/judge-cases.yaml`: 15 written
-unasked, 14 refused unasked, 21 left for the judge, and no error either way.
-`scripts/check-slot-gate.sh` is the run. See `SlotGate`.
+Measured over the 50 English cases of `tests/judge-cases.yaml`: 13 written
+unasked by the word lists, 14 refused unasked by the slot, 23 left for the
+judge, and no error either way. `scripts/check-slot-gate.sh` is the run. See
+`SlotGate`.
 
 The model is never waited for. Until it is on disk — and on a language it was
 not trained for — every proposal goes to the judge, which is the behaviour


### PR DESCRIPTION
`SlotGate` had two rules in front of the judge. The first asks whether a name can stand where the word stands. The second wrote the term whenever its span was the weakest-reading place in the sentence. This removes the second one.

It is wrong more often than it is right. Driving the shipped `--word-gate` over 150 real decisions, it wrote 27 names and 17 of them were wrong — `ghostly` became `Ghostty` four times, `bedrock` became `Redrock` twice, `gamma` became `Gemma`. Those writes now go to the judge, which is where every other unsettled proposal already goes.

No setting turns this on or off any more. `gate_rank:` is still read, and a config that carries it is told the key does nothing, the way `min_similarity:` and `acoustic:` are.

Reviewers: start with `SlotGate.read`, which loses its second half. `scripts/check-slot-gate.sh` is the set that scores this, and it passes before and after.

<details>
<summary>Why the rule was wrong — it measures "unexpected", not "wrong"</summary>

The rank asks whether a word is the least expected in its sentence. The question the stage needs answered is whether the word is wrong. A rare proper noun is both.

Over the 150 real decisions of the vocabulary bench:

| rule | writes | right | wrong |
|---|---|---|---|
| the two word lists | 46 | 38 | 8 |
| **the rank** | **27** | **10** | **17** |
| the slot's part of speech | 25 refusals | 25 | 0 |

Every failure has the same shape — a rare but correct ordinary word, ranked weakest in its sentence:

```
ghostly    -> Ghostty   x4   "The old house looked ghostly in the fog."
bedrock    -> Redrock   x2   "we hit bedrock about two metres down."
Red Cross  -> Redcrawl  x2   "Red Cross finished the run last night."
Versailles -> Vercel    x3   "We went to visit the Versailles Castle."
verbatim   -> Mirza          "I'm asking for a verbatim example…"
gamma      -> Gemma          "adjust the gamma before you export the video."
crawl      -> Redcrawl       "The crawl data lives in another table."
praise     -> Praisy         "They were full of praise afterwards."
```

</details>

<details>
<summary>Correcting the record — the 47/50 was real, on a set holding none of these</summary>

The comment on this rule says it was measured at 47/50 with no errors either way, and that is true. `scripts/check-slot-gate.sh` still passes on that set, before and after this change.

Those 50 cases in `tests/judge-cases.yaml` contain none of the confounds above. So the rule is not "sound, with one known bad case", which is how the comment reads. The bad case is most of what it does.

The wider measurement is 150 real decisions from `tests/judge-cases.yaml` plus a second labelled set, and the harness is not in the tree — the numbers are recorded here and in the commit body.

</details>

<details>
<summary>What the routing costs now — 15/14/21 becomes 13/14/23</summary>

`scripts/check-slot-gate.sh` on this base:

```
before   applied 15   declined 14   judge 21
after    applied 13   declined 14   judge 23     wrong applies 0, wrong declines 0
```

Two more model calls of about 900 ms each on that 50-case set, against seventeen wrong names across the wider bench. The script's pass criterion is zero wrong applies and zero wrong declines, and it holds both ways.

</details>

<details>
<summary>Review notes — what is mechanical and what is a decision</summary>

Mechanical:

- `SlotGate.weakest` and its MARK section are deleted whole.
- `Reading` loses `rank` and `windows`.
- `settle` loses its `rank:` parameter and its `.apply` branch.
- `Pipeline` drops the argument.
- `--word-gate` no longer prints a `rank` line.

Two deliberate choices:

- **`Route` keeps two cases** rather than collapsing to a boolean. `settle` reads it and `--word-gate` prints it, and a removal is the wrong place to also rework a type.
- **`hosts` goes with the rank.** `read` no longer consults it — it was only ever the other half of a rule that no longer exists. `blocks` stays and is what the decline is built on.

`gate_rank:` is read and reported, not ignored. A key that silently stops mattering is the failure this config's own rules are written against — `VocabularyJudge` refuses a config that still names a prompt file for the same reason.

</details>

<details>
<summary>What this does not fix</summary>

The two word lists still make 8 wrong writes of 46 on the same bench. That is a separate rule with a separate fix, and it is not touched here.

</details>
