### PR TITLE
chore: the repo description says it is a Mac dictation app

### DIFF
--- a/settings/repo.yml
+++ b/settings/repo.yml
@@ -124,8 +124,8 @@ topics:
   - voice-to-text # 587
   - apple-silicon # 3969
   # The app does not link MLX. It is here because the model
-  # config.example.yaml ships with is an MLX build, `gemma4:e4b-mlx` on line
-  # 128. That is the whole claim; drop the topic if the default changes.
+  # config.example.yaml ships with is an MLX build: `models: gemma: model:` is
+  # `gemma4:e4b-mlx`. That is the whole claim; drop the topic if it changes.
   - mlx # 2152
 
 # SECURITY.md sends people to the advisory form. That form only exists when

--- a/settings/repo.yml
+++ b/settings/repo.yml
@@ -14,10 +14,18 @@
 # and secrets are untouched.
 
 repository:
-  # The live description, kept word for word — it is the README's one-liner
-  # trimmed, and the owner wrote it. Two places say what this app is, so change
-  # them together.
-  description: Local, fast and programmable dictation app
+  # Written for search, not only for a reader. GitHub matches the description,
+  # so the words people type have to be in it: "dictation app", "mac"/"macOS",
+  # "voice to text", "Wispr Flow alternative". Measured 2026-09-01: the query
+  # `dictation app mac` returns 112 repositories and this one is not among
+  # them, because the old description never said Mac.
+  #
+  # 350 characters is the GitHub limit. Keep every claim true — local-first,
+  # learns your vocabulary, programmable — and do not add one to win a word.
+  #
+  # The README's one-liner is shorter and no longer the same sentence. That is
+  # the owner's call, not this file's.
+  description: Local-first dictation app for macOS. A Wispr Flow alternative that keeps voice to text on your Mac, learns the names and jargon you actually say, and lets you program what happens to the text before it lands.
 
   # Deliberately empty. There is no site yet. The owner sets this in
   # Settings → General when there is one; do not invent a URL here.
@@ -105,6 +113,20 @@ topics:
   - voice-typing
   - local-first
   - ollama
+  # Added 2026-09-01, picked on how many repositories already hold the topic.
+  # A small pool is worth more: this repository is visible in it. The number
+  # after each one is that count, measured on the day.
+  #
+  # superwhisper-alternative is the cheapest of all of them at 14.
+  - superwhisper-alternative # 14
+  - dictation-app # 18
+  - voice-input # 460
+  - voice-to-text # 587
+  - apple-silicon # 3969
+  # The app does not link MLX. It is here because the model
+  # config.example.yaml ships with is an MLX build, `gemma4:e4b-mlx` on line
+  # 128. That is the whole claim; drop the topic if the default changes.
+  - mlx # 2152
 
 # SECURITY.md sends people to the advisory form. That form only exists when
 # this is on, so the link in SECURITY.md is dead without it.


### PR DESCRIPTION
People looking for a Mac dictation app do not find this one, and the reason is the description. It says "Local, fast and programmable dictation app" and never says Mac. GitHub's search for `dictation app mac` returns 112 repositories on 2026-09-01; this one is not among them, and the #4 result has 31 stars. This pull request rewrites the description around the words people type, adds six topics chosen on how few repositories already hold them, and leaves `homepage` empty because there is no site. Only `settings/repo.yml` changes — no code, no README.

**A human has to apply this.** Merging changes the file, not GitHub. See the last block.

<details>
<summary>The new description is 208 characters and every claim in it is already true</summary>

Before, 42 characters:

    Local, fast and programmable dictation app

After, 208 characters, under GitHub's 350 limit:

    Local-first dictation app for macOS. A Wispr Flow alternative that keeps
    voice to text on your Mac, learns the names and jargon you actually say,
    and lets you program what happens to the text before it lands.

It carries the tokens the searches use: `dictation app`, `macOS`, `mac`, `voice to text`, `Wispr Flow alternative`.

Each claim maps to something shipped:

| Claim | Where it comes from |
|---|---|
| macOS | `Package.swift` sets `.macOS(.v14)`; the README badge says macOS 14+, Apple silicon |
| local-first | ASR runs on device through FluidAudio; the `local-first` topic is already set |
| learns the names and jargon you actually say | the vocabulary stage, `docs/` and `examples/transforms/` |
| program what happens to the text | pipelines and transforms, `docs/pipelines.md` |

For size: FluidVoice has 11,171 stars and a 218-character description. This is in the same range.

The README's one-liner is "A fast and programmable dictation app you can shape around your work". It is now a different sentence from the description. The comment in `settings/repo.yml` used to say the two were kept word for word; that comment is rewritten. Changing the README is out of scope here and is the owner's call.

</details>

<details>
<summary>The six new topics were picked on repository count, not on how they read</summary>

A topic is worth having when the pool is small enough to be visible in. Counts measured 2026-09-01:

| Topic | Repos holding it |
|---|---|
| `superwhisper-alternative` | 14 |
| `dictation-app` | 18 |
| `voice-input` | 460 |
| `voice-to-text` | 587 |
| `mlx` | 2,152 |
| `apple-silicon` | 3,969 |

`voice-typing` (319) was already on the list, so it is not added again.

Two were deliberately not added. `speech-to-text` holds 9,871 repositories and `whisper` holds 8,018. Both are already set and stay set, but neither can be found in, so nothing here leans on them.

`mlx` is the weakest of the six and the file says so. The app does not link MLX. The topic is there because the model `config.example.yaml` ships with is an MLX build: `models.gemma.model` is `gemma4:e4b-mlx`. Drop the topic if that default changes.

Total is 17 topics. GitHub allows 20.

</details>

<details>
<summary>homepage stays empty because there is no site to point it at</summary>

7 of the 9 leading repositories in this category set `homepage`, so the field is worth having. There is nothing to put in it: `gh api repos/znat/parrotflow/pages` returns 404, `has_pages` is false, and there is no `gh-pages` branch. No site was created for this pull request.

The comment already in `settings/repo.yml` says the same thing and is left alone. When a site exists, the owner sets the field there and applies.

</details>

<details>
<summary>Merging this does not change GitHub — the maintainer runs one command</summary>

`.github/workflows/repo-settings.yml` only reads. It runs `scripts/repo-settings.sh --check` weekly, Monday 07:17 UTC, and fails the run on drift. It cannot write: changing repository settings needs the `administration` permission, and the default `GITHUB_TOKEN` cannot be granted it.

So after merge:

    scripts/repo-settings.sh            # dry run, prints the drift
    scripts/repo-settings.sh --apply    # writes it

Run it as someone with admin on the repository. Until it runs, the Monday check will report the description and the six topics as drift.

The file is already ahead of the live repository, which is what this looks like today. Live has 7 topics; `settings/repo.yml` listed 11 before this change and 17 after. `--apply` also picks up the three settings the file already flags as changing the live value: `has_wiki`, `has_projects`, `web_commit_signoff_required`. Read the dry run before applying.

Editing the description in Settings instead would work but is worse. The file's own header calls a browser edit that is not written here drift, and the Monday check would then fail on the value that was just set by hand.

</details>

<details>
<summary>What a reviewer should check</summary>

One file, `settings/repo.yml`. The diff is a description string, six list entries and their comments.

- The description is truthful. Every clause in it is a shipped capability, listed in the first block above.
- No topic was dropped. `PUT /repos/{owner}/{repo}/topics` replaces the whole list, so a removal here removes it live.
- Topics are lowercase, hyphenated and under 50 characters. GitHub rejects anything else.
- The file still parses: `python3 -c "import yaml; yaml.safe_load(open('settings/repo.yml'))"`.

Out of scope on purpose: `README.md`, any comparison page, renaming anything, and `Sources/`.

</details>
