### PR TITLE
feat: a term learns where it belongs from its own corrections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ release-certificate:
 CHECKS := numbers replacements pipeline pipeline-config wake split dotted dates keyed \
           transform-folders eval audio-recovery possessive word-gate suggest input join \
           profiles span-rule clipboard default-config vocabulary-config learn \
-          signing-identity no-voice sound tokenizer sentence-case
+          signing-identity no-voice sound tokenizer sentence-case term-uses
 
 test:
 	@swift build -c release

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -4356,12 +4356,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// False means one could not be written and the user has already been shown
     /// why. Nothing after it should run: a correction that half-saved and then
     /// went on to rewrite the field would leave the two disagreeing.
-    private func learn(_ rules: [TaughtRule]) -> Bool {
+    private func learn(_ rules: [TaughtRule], in corrected: String) -> Bool {
         for rule in rules {
             do {
                 try ConfigWriter.addVocabularyPronunciation(
                     term: rule.corrected, heard: rule.heard, kind: rule.kind
                 )
+                // The sentence too, not only the mapping. It is what a term's
+                // portrait is built from, and this is the only moment the app
+                // knows a sentence is right.
+                do {
+                    try TermUses.record(
+                        term: rule.corrected, said: corrected, span: rule.corrected
+                    )
+                } catch {
+                    // A portrait that missed one sentence is worth less than a
+                    // correction that refused to save over it.
+                    Log.write("could not record the use: \(error.localizedDescription)")
+                }
                 Log.write("learned pronunciation: \(rule.heard) -> \(rule.corrected)")
                 Trace.correction(heard: rule.heard, corrected: rule.corrected, via: "command")
             } catch {
@@ -4391,7 +4403,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         into target: Correction,
         clipboardWhenChosen: Int
     ) {
-        guard learn(rules) else { return }
+        guard learn(rules, in: correctedText) else { return }
         // On the clipboard, or not written at all, and `replace` has said which.
         // A rule notice on top of that would bury the one thing you need to act
         // on.
@@ -4412,7 +4424,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         _ rules: [TaughtRule],
         correctedText: String
     ) {
-        guard learn(rules) else {
+        guard learn(rules, in: correctedText) else {
             pendingSelection = nil
             return
         }

--- a/Sources/ParrotFlow/ForgetCommand.swift
+++ b/Sources/ParrotFlow/ForgetCommand.swift
@@ -52,19 +52,23 @@ enum ForgetCommand {
             // behind, the sentences would go on describing a term whose
             // renderings have all been thrown away.
             var uses = 0
+            var stayed: Error?
             do {
                 uses = try TermUses.forget(name)
             } catch {
-                // vocabulary.yaml is already edited by here, so refusing now
-                // would report a correction that did happen as a failure.
-                print("! the confirmed sentences were left alone:"
-                    + " \(error.localizedDescription)")
+                stayed = error
             }
-            if renderings == 0, gone.observations == 0, gone.samples == 0, uses == 0 {
+            if renderings == 0, gone.observations == 0, gone.samples == 0, uses == 0,
+               stayed == nil {
                 print("· nothing recorded for \(name)")
                 return 0
             }
-            print("✓ forgot \(name)")
+            // The rest is already deleted, so the tally still prints. What it
+            // must not say is that the term was forgotten when its sentences
+            // can still rebuild the portrait.
+            print(stayed == nil
+                ? "✓ forgot \(name)"
+                : "✗ \(name) was only partly forgotten")
             print("  \(renderings) pronunciation(s) from"
                 + " \(ConfigStore.vocabularyURL.lastPathComponent)")
             print("  \(gone.observations) observation(s) from voice/observations.jsonl")
@@ -74,6 +78,15 @@ enum ForgetCommand {
             let from = gone.folders.isEmpty
                 ? "voice/samples/" : gone.folders.map { "voice/samples/\($0)/" }.joined(separator: ", ")
             print("  \(gone.samples) sample(s) from \(from)")
+            if let stayed {
+                print("  the confirmed sentences in"
+                    + " \(TermUses.url.lastPathComponent) stayed:"
+                    + " \(stayed.localizedDescription)")
+                Log.write("forget: \(name) — \(renderings) pronunciation(s),"
+                    + " \(gone.observations) observation(s), \(gone.samples) sample(s);"
+                    + " the uses stayed (\(stayed.localizedDescription))")
+                return 1
+            }
             print("  \(uses) confirmed sentence(s) from \(TermUses.url.lastPathComponent)")
             Log.write("forget: \(name) — \(renderings) pronunciation(s),"
                 + " \(gone.observations) observation(s), \(gone.samples) sample(s),"

--- a/Sources/ParrotFlow/ForgetCommand.swift
+++ b/Sources/ParrotFlow/ForgetCommand.swift
@@ -2,9 +2,10 @@ import Foundation
 
 /// `--forget <term>` — everything learnt about how one name sounds, gone.
 ///
-/// Three places hold it, and until now none of them had a way out:
+/// Four places hold it, and until now none of them had a way out:
 /// `vocabulary.yaml` holds the renderings, `voice/observations.jsonl` holds
-/// every time one was seen, and `voice/samples/<Term>/` holds the audio. Data
+/// every time one was seen, `voice/samples/<Term>/` holds the audio, and
+/// `vocabulary-uses.yaml` holds the sentences it was confirmed in. Data
 /// that only accumulates is data nobody can correct — a rendering learnt from
 /// one bad clip goes on shaping the search forever, and the only remedy was to
 /// edit a file the header tells you not to edit.
@@ -47,7 +48,19 @@ enum ForgetCommand {
                 return 1
             }
             let gone = try VoiceStore.forget(name)
-            if renderings == 0, gone.observations == 0, gone.samples == 0 {
+            // A fourth place, and the same rule: what was learnt goes. Left
+            // behind, the sentences would go on describing a term whose
+            // renderings have all been thrown away.
+            var uses = 0
+            do {
+                uses = try TermUses.forget(name)
+            } catch {
+                // vocabulary.yaml is already edited by here, so refusing now
+                // would report a correction that did happen as a failure.
+                print("! the confirmed sentences were left alone:"
+                    + " \(error.localizedDescription)")
+            }
+            if renderings == 0, gone.observations == 0, gone.samples == 0, uses == 0 {
                 print("· nothing recorded for \(name)")
                 return 0
             }
@@ -61,8 +74,10 @@ enum ForgetCommand {
             let from = gone.folders.isEmpty
                 ? "voice/samples/" : gone.folders.map { "voice/samples/\($0)/" }.joined(separator: ", ")
             print("  \(gone.samples) sample(s) from \(from)")
+            print("  \(uses) confirmed sentence(s) from \(TermUses.url.lastPathComponent)")
             Log.write("forget: \(name) — \(renderings) pronunciation(s),"
-                + " \(gone.observations) observation(s), \(gone.samples) sample(s)")
+                + " \(gone.observations) observation(s), \(gone.samples) sample(s),"
+                + " \(uses) confirmed sentence(s)")
             return 0
         } catch {
             print("✗ \(error.localizedDescription)")

--- a/Sources/ParrotFlow/LearnCommand.swift
+++ b/Sources/ParrotFlow/LearnCommand.swift
@@ -1,16 +1,25 @@
 import Foundation
 
-/// `--learn <heard> <corrected> [kind]` — adds a vocabulary pronunciation from
-/// the terminal.
+/// `--learn <heard> <corrected> [kind] [--in "<sentence>"]` — adds a vocabulary
+/// pronunciation from the terminal.
 ///
 /// The same code path the correction panel uses, minus the UI. Useful on its
 /// own, and it makes the config-rewriting logic testable without a GUI.
+///
+/// `--in` records the sentence as well, which is what a term's portrait is
+/// built from. The panel always has one; this command only has one if it is
+/// given, so without it the mapping is saved and nothing else.
 enum LearnCommand {
-    static func run(heard: String, corrected: String, kind: WordKind? = nil) -> Int32 {
+    static func run(
+        heard: String, corrected: String, kind: WordKind? = nil, sentence: String? = nil
+    ) -> Int32 {
         do {
             try ConfigWriter.addVocabularyPronunciation(
                 term: corrected, heard: heard, kind: kind
             )
+            if let sentence, !sentence.isEmpty {
+                try TermUses.record(term: corrected, said: sentence, span: corrected)
+            }
             Trace.correction(heard: heard, corrected: corrected, via: "learn")
             print("✓ \(heard) → \(corrected)")
             return 0

--- a/Sources/ParrotFlow/LearnCommand.swift
+++ b/Sources/ParrotFlow/LearnCommand.swift
@@ -17,15 +17,23 @@ enum LearnCommand {
             try ConfigWriter.addVocabularyPronunciation(
                 term: corrected, heard: heard, kind: kind
             )
-            if let sentence, !sentence.isEmpty {
-                try TermUses.record(term: corrected, said: sentence, span: corrected)
-            }
-            Trace.correction(heard: heard, corrected: corrected, via: "learn")
-            print("✓ \(heard) → \(corrected)")
-            return 0
         } catch {
             print("✗ \(error.localizedDescription)")
             return 1
         }
+        // The mapping is already saved by here, so a sentence that could not be
+        // written is a warning and not a failure. Reporting it as one would say
+        // the correction was lost when it was not.
+        if let sentence, !sentence.isEmpty {
+            do {
+                try TermUses.record(term: corrected, said: sentence, span: corrected)
+            } catch {
+                print("! the sentence was not recorded in"
+                    + " \(TermUses.url.lastPathComponent): \(error.localizedDescription)")
+            }
+        }
+        Trace.correction(heard: heard, corrected: corrected, via: "learn")
+        print("✓ \(heard) → \(corrected)")
+        return 0
     }
 }

--- a/Sources/ParrotFlow/TermPortrait.swift
+++ b/Sources/ParrotFlow/TermPortrait.swift
@@ -1,0 +1,192 @@
+import CryptoKit
+import Foundation
+
+/// What a term's confirmed sentences say about where it belongs.
+///
+/// Three numbers per term, computed from the sentences `TermUses` keeps:
+///
+///   - `centre`, the mean of the context vectors — every token of a sentence
+///     except the term's own, so it describes the sentence and not the word;
+///   - `tightness`, how close those sentences sit to that centre;
+///   - `floor`, what a genuine use of this term scores against it.
+///
+/// A new sentence is scored against the centre and divided by the tightness.
+/// Above the floor, the rewrite is authorised.
+///
+/// **Why divide by the tightness.** A portrait built from many varied sentences
+/// has a centre further from everything, so the same cosine means less. Dividing
+/// puts every term on one scale: 1.00 is "as typical of this term as its own
+/// sentences are".
+///
+/// **Why the floor is a low quantile and not an average.** As a term collects
+/// uses, a held-out one sits almost on top of the rest, so the average climbs
+/// toward 1.00 while a genuinely new sentence stays near 0.96 and gets refused.
+/// Measured on one term grown to 32 uses: the average makes 2 wrong decisions of
+/// 5, the tenth percentile none.
+///
+/// This half only ever authorises. `SlotReference` is the half that refuses, and
+/// when the two disagree neither wins — the reading is offered instead.
+@available(macOS 14, *)
+actor TermPortrait {
+
+    static let shared = TermPortrait()
+
+    /// Fewer than this and the numbers mean nothing: at two uses the floor came
+    /// out below every ordinary word, at three it holds. Under it, a term has
+    /// no portrait and the stage decides as it does today.
+    static let minimum = 3
+
+    /// Where the floor is read off the leave-one-out scores.
+    static let quantile = 0.10
+
+    struct Summary: Codable, Equatable {
+        let centre: [Float]
+        let tightness: Double
+        let floor: Double
+        /// The sentences this was built from, so a portrait is recomputed when
+        /// they change and not otherwise.
+        let fingerprint: String
+        let uses: Int
+    }
+
+    private var cache: [String: Summary] = [:]
+    private var loadedFromDisk = false
+
+    /// Keyed by the model, because the numbers are only comparable within one
+    /// set of weights. A model change invalidates every summary and no
+    /// sentence.
+    private static var cacheURL: URL {
+        AppVariant.supportDirectory
+            .appendingPathComponent("portraits-qwen3-embedding-0.6b-4bit.json")
+    }
+
+    // MARK: - the answer
+
+    /// How typical this sentence is of the term, or nil if the term has no
+    /// portrait yet.
+    ///
+    /// `span` is the word standing where the term would go — what was heard,
+    /// not the term. It is left out of the vector, so what is measured is the
+    /// sentence around it.
+    func score(of span: String, in sentence: String, for term: String) async throws -> Double? {
+        guard let summary = try await summary(for: term) else { return nil }
+        let vector = try await WordVectors.shared.vector(.around, of: span, in: sentence)
+        return WordVectors.cosine(vector, summary.centre) / summary.tightness
+    }
+
+    /// True to authorise the rewrite, false to say nothing. Never refuses.
+    func authorises(_ span: String, in sentence: String, as term: String) async -> Bool {
+        do {
+            guard let summary = try await summary(for: term),
+                  let score = try await score(of: span, in: sentence, for: term)
+            else { return false }
+            return score > summary.floor
+        } catch {
+            Log.write("portrait: \(term) could not be scored (\(error.localizedDescription))")
+            return false
+        }
+    }
+
+    // MARK: - building it
+
+    func summary(for term: String) async throws -> Summary? {
+        let uses = TermUses.load()[term] ?? []
+        guard uses.count >= Self.minimum else { return nil }
+        let mark = Self.fingerprint(of: uses)
+
+        if !loadedFromDisk { cache = Self.readCache(); loadedFromDisk = true }
+        if let held = cache[term], held.fingerprint == mark { return held }
+
+        let built = try await Self.build(uses)
+        cache[term] = built
+        Self.writeCache(cache)
+        return built
+    }
+
+    private static func build(_ uses: [TermUses.Use]) async throws -> Summary {
+        var vectors: [[Float]] = []
+        for use in uses {
+            vectors.append(
+                try await WordVectors.shared.vector(.around, of: use.span, in: use.said)
+            )
+        }
+        let (centre, tightness) = middle(of: vectors)
+
+        // What a genuine use scores, each one measured against a portrait that
+        // does not contain it. Anything else compares a sentence with itself.
+        var selves: [Double] = []
+        for index in vectors.indices {
+            let rest = vectors.enumerated().filter { $0.offset != index }.map(\.element)
+            guard rest.count > 1 else { continue }
+            let (restCentre, restTightness) = middle(of: rest)
+            guard restTightness > 0 else { continue }
+            selves.append(cosine(vectors[index], restCentre) / restTightness)
+        }
+        return Summary(
+            centre: centre,
+            tightness: tightness,
+            floor: quantileOf(selves, at: quantile),
+            fingerprint: fingerprint(of: uses),
+            uses: uses.count
+        )
+    }
+
+    /// The unit mean, and how close the members sit to it.
+    private static func middle(of vectors: [[Float]]) -> ([Float], Double) {
+        guard let width = vectors.first?.count, width > 0 else { return ([], 0) }
+        var sum = [Double](repeating: 0, count: width)
+        for vector in vectors where vector.count == width {
+            for i in 0 ..< width { sum[i] += Double(vector[i]) }
+        }
+        let length = sum.reduce(0) { $0 + $1 * $1 }.squareRoot()
+        guard length > 0 else { return ([], 0) }
+        let centre = sum.map { Float($0 / length) }
+        let tightness = vectors.reduce(0.0) { $0 + cosine($1, centre) } / Double(vectors.count)
+        return (centre, tightness)
+    }
+
+    private static func cosine(_ a: [Float], _ b: [Float]) -> Double {
+        WordVectors.cosine(a, b)
+    }
+
+    /// Linear interpolation between the two neighbouring values, which is what
+    /// numpy does and what every measurement here was made with.
+    private static func quantileOf(_ values: [Double], at fraction: Double) -> Double {
+        guard !values.isEmpty else { return .infinity }
+        let sorted = values.sorted()
+        guard sorted.count > 1 else { return sorted[0] }
+        let position = fraction * Double(sorted.count - 1)
+        let lower = Int(position.rounded(.down))
+        let upper = min(lower + 1, sorted.count - 1)
+        let share = position - Double(lower)
+        return sorted[lower] * (1 - share) + sorted[upper] * share
+    }
+
+    private static func fingerprint(of uses: [TermUses.Use]) -> String {
+        let joined = uses.map { "\($0.span)\u{1}\($0.said)" }.joined(separator: "\u{2}")
+        let digest = SHA256.hash(data: Data(joined.utf8))
+        return digest.compactMap { String(format: "%02x", $0) }.joined()
+    }
+
+    // MARK: - the cache
+
+    private static func readCache() -> [String: Summary] {
+        guard let data = try? Data(contentsOf: cacheURL),
+              let decoded = try? JSONDecoder().decode([String: Summary].self, from: data)
+        else { return [:] }
+        return decoded
+    }
+
+    private static func writeCache(_ summaries: [String: Summary]) {
+        do {
+            try FileManager.default.createDirectory(
+                at: cacheURL.deletingLastPathComponent(), withIntermediateDirectories: true
+            )
+            try JSONEncoder().encode(summaries).write(to: cacheURL, options: .atomic)
+        } catch {
+            // The portrait is still in memory for this run, and the next run
+            // rebuilds it. Not worth failing a correction over.
+            Log.write("portrait: could not cache (\(error.localizedDescription))")
+        }
+    }
+}

--- a/Sources/ParrotFlow/TermPortraitCommand.swift
+++ b/Sources/ParrotFlow/TermPortraitCommand.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// `--portrait <term> ["<sentence>" <span>]` — what a term's confirmed uses say.
+///
+///     ParrotFlow --portrait Praisy
+///     uses 3   tightness 0.874   floor 0.821
+///
+///     ParrotFlow --portrait Praisy "Let us praise the team." praise
+///     uses 3   tightness 0.874   floor 0.821
+///     score 0.795   no opinion
+///
+/// The floor is read off the term's own sentences and never chosen, so printing
+/// it is the only way to see what a term has decided about itself.
+@available(macOS 14, *)
+enum TermPortraitCommand {
+
+    static func run(term: String, sentence: String?, span: String?) -> Int32 {
+        let outcome = Blocking.run { () async -> Result<(TermPortrait.Summary?, Double?), Error> in
+            do {
+                let summary = try await TermPortrait.shared.summary(for: term)
+                guard summary != nil, let sentence, let span else {
+                    return .success((summary, nil))
+                }
+                let score = try await TermPortrait.shared.score(
+                    of: span, in: sentence, for: term
+                )
+                return .success((summary, score))
+            } catch {
+                return .failure(error)
+            }
+        }
+        switch outcome {
+        case .failure(let error):
+            print("✗ \(error.localizedDescription)")
+            return 1
+        case .success(let (summary, score)):
+            guard let summary else {
+                let held = TermUses.load()[term]?.count ?? 0
+                print("no portrait: \(held) confirmed use(s), \(TermPortrait.minimum) needed")
+                return 0
+            }
+            print(
+                "uses \(summary.uses)   tightness \(String(format: "%.3f", summary.tightness))"
+                    + "   floor \(String(format: "%.3f", summary.floor))"
+            )
+            if let score {
+                let verdict = score > summary.floor ? "authorises" : "no opinion"
+                print("score \(String(format: "%.3f", score))   \(verdict)")
+            }
+            return 0
+        }
+    }
+}

--- a/Sources/ParrotFlow/TermUses.swift
+++ b/Sources/ParrotFlow/TermUses.swift
@@ -57,7 +57,12 @@ enum TermUses {
     /// at the next correction. A row that is gone or malformed is still
     /// forgiven — deleting a row is how the header says to forget a use.
     static func read() throws -> [String: [Use]] {
-        guard let text = try? String(contentsOf: url, encoding: .utf8) else { return [:] }
+        guard FileManager.default.fileExists(atPath: url.path) else { return [:] }
+        // Present and unreadable is not the same as absent. Bytes that are not
+        // UTF-8 have to refuse the write like a syntax error does.
+        guard let text = try? String(contentsOf: url, encoding: .utf8) else {
+            throw Unreadable()
+        }
         guard let root = try Yams.load(yaml: text) else { return [:] }
         guard let mapping = root as? [String: Any] else { throw Unreadable() }
         let held = mapping["terms"]

--- a/Sources/ParrotFlow/TermUses.swift
+++ b/Sources/ParrotFlow/TermUses.swift
@@ -38,11 +38,31 @@ enum TermUses {
     /// recomputing a portrait, which is one forward pass per use.
     static let keep = 40
 
+    /// The file is there and cannot be parsed as a whole.
+    struct Unreadable: LocalizedError {
+        var errorDescription: String? {
+            "vocabulary-uses.yaml could not be read, so nothing was written over it"
+        }
+    }
+
+    /// What a reader gets: a file it cannot parse is no uses.
     static func load() -> [String: [Use]] {
-        guard let text = try? String(contentsOf: url, encoding: .utf8),
-              let root = try? Yams.load(yaml: text) as? [String: Any],
-              let terms = root["terms"] as? [String: Any]
-        else { return [:] }
+        (try? read()) ?? [:]
+    }
+
+    /// The same, but a file that is there and does not parse throws.
+    ///
+    /// A writer has to know the difference. The file is hand-edited, and one
+    /// unbalanced quote read as "no uses" would drop every sentence a term had
+    /// at the next correction. A row that is gone or malformed is still
+    /// forgiven — deleting a row is how the header says to forget a use.
+    static func read() throws -> [String: [Use]] {
+        guard let text = try? String(contentsOf: url, encoding: .utf8) else { return [:] }
+        guard let root = try Yams.load(yaml: text) else { return [:] }
+        guard let mapping = root as? [String: Any] else { throw Unreadable() }
+        let held = mapping["terms"]
+        if held == nil || held is NSNull { return [:] }
+        guard let terms = held as? [String: Any] else { throw Unreadable() }
 
         var out: [String: [Use]] = [:]
         for (term, value) in terms {
@@ -67,7 +87,7 @@ enum TermUses {
         let sentence = said.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !sentence.isEmpty, !span.isEmpty, sentence.contains(span) else { return }
 
-        var all = load()
+        var all = try read()
         var uses = all[term] ?? []
         let use = Use(said: sentence, span: span)
         guard !uses.contains(use) else { return }
@@ -75,6 +95,21 @@ enum TermUses {
         if uses.count > keep { uses.removeFirst(uses.count - keep) }
         all[term] = uses
         try write(all)
+    }
+
+    /// Drops every use of one term, and says how many went.
+    ///
+    /// Case-insensitive, like `--forget` itself: somebody typing `praisy` means
+    /// the term.
+    @discardableResult
+    static func forget(_ term: String) throws -> Int {
+        var all = try read()
+        let keys = all.keys.filter { $0.caseInsensitiveCompare(term) == .orderedSame }
+        let gone = keys.reduce(0) { $0 + (all[$1]?.count ?? 0) }
+        guard gone > 0 else { return 0 }
+        for key in keys { all[key] = nil }
+        try write(all)
+        return gone
     }
 
     /// Rendered by hand rather than by `Yams.dump`, for the same reason

--- a/Sources/ParrotFlow/TermUses.swift
+++ b/Sources/ParrotFlow/TermUses.swift
@@ -141,11 +141,35 @@ enum TermUses {
         try lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
     }
 
-    /// Double quotes with the two escapes YAML needs inside them.
+    /// Double quotes, with everything a double-quoted YAML scalar cannot carry
+    /// as itself written as an escape.
+    ///
+    /// A raw newline is folded back into a space by the parser, which changes
+    /// the sentence the portrait is built from. A raw control character —
+    /// `\u{7}`, say — makes the whole file unparseable, and then nothing is
+    /// ever recorded again.
     private static func quoted(_ text: String) -> String {
-        let escaped = text
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"")
-        return "\"\(escaped)\""
+        var out = "\""
+        for scalar in text.unicodeScalars {
+            switch scalar {
+            case "\\": out += "\\\\"
+            case "\"": out += "\\\""
+            case "\n": out += "\\n"
+            case "\r": out += "\\r"
+            case "\t": out += "\\t"
+            case "\u{2028}": out += "\\L"
+            case "\u{2029}": out += "\\P"
+            default:
+                // C0, DEL, and C1 — the last because YAML reads \u{85} as a
+                // line break.
+                let code = scalar.value
+                if code < 0x20 || code == 0x7F || (code >= 0x80 && code <= 0x9F) {
+                    out += String(format: "\\x%02X", code)
+                } else {
+                    out.unicodeScalars.append(scalar)
+                }
+            }
+        }
+        return out + "\""
     }
 }

--- a/Sources/ParrotFlow/TermUses.swift
+++ b/Sources/ParrotFlow/TermUses.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Yams
+
+/// The sentences a term has been confirmed in, and where it sat in each.
+///
+/// A term's portrait is built from these: the mean of the context vectors,
+/// each sentence with the term itself removed. It says what kind of sentence
+/// the term appears in, which is the one thing the six shipped tests cannot
+/// read.
+///
+/// **Sentences, not vectors.** A vector of 1024 numbers is unreadable and does
+/// not survive a change of model, and both models here are expected to change.
+/// A sentence is recomputed. It also lets the user see, correct or delete
+/// whatever taught a term.
+///
+/// Its own file, not `vocabulary.yaml`. That one is hand-edited, and a term
+/// with eight sentences under it would bury the list it exists to hold.
+enum TermUses {
+
+    /// One confirmed use.
+    struct Use: Codable, Equatable {
+        /// The sentence as it stood when the correction was made, with the term
+        /// already written in.
+        let said: String
+        /// The term inside `said`. Kept because a sentence can hold the word
+        /// twice, and the portrait needs to know which one to leave out.
+        let span: String
+    }
+
+    static var url: URL {
+        ConfigStore.directory.appendingPathComponent("vocabulary-uses.yaml")
+    }
+
+    /// How many uses one term keeps.
+    ///
+    /// Not a quality limit: with a threshold read off the term's own uses,
+    /// more of them separate better rather than worse. This bounds the work of
+    /// recomputing a portrait, which is one forward pass per use.
+    static let keep = 40
+
+    static func load() -> [String: [Use]] {
+        guard let text = try? String(contentsOf: url, encoding: .utf8),
+              let root = try? Yams.load(yaml: text) as? [String: Any],
+              let terms = root["terms"] as? [String: Any]
+        else { return [:] }
+
+        var out: [String: [Use]] = [:]
+        for (term, value) in terms {
+            guard let rows = value as? [[String: Any]] else { continue }
+            let uses = rows.compactMap { row -> Use? in
+                guard let said = row["said"] as? String,
+                      let span = row["span"] as? String,
+                      said.contains(span)
+                else { return nil }
+                return Use(said: said, span: span)
+            }
+            if !uses.isEmpty { out[term] = uses }
+        }
+        return out
+    }
+
+    /// Adds one use, unless the same sentence is already there.
+    ///
+    /// The oldest goes when the list is full, so a term that moves on stops
+    /// being described by what it used to mean.
+    static func record(term: String, said: String, span: String) throws {
+        let sentence = said.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !sentence.isEmpty, !span.isEmpty, sentence.contains(span) else { return }
+
+        var all = load()
+        var uses = all[term] ?? []
+        let use = Use(said: sentence, span: span)
+        guard !uses.contains(use) else { return }
+        uses.append(use)
+        if uses.count > keep { uses.removeFirst(uses.count - keep) }
+        all[term] = uses
+        try write(all)
+    }
+
+    /// Rendered by hand rather than by `Yams.dump`, for the same reason
+    /// `ConfigWriter` splices `vocabulary.yaml`: this file is meant to be read,
+    /// and a dumper reorders and requotes everything it touches.
+    static func write(_ all: [String: [Use]]) throws {
+        var lines = [
+            "# Sentences where a vocabulary term was confirmed, written by the app.",
+            "#",
+            "# Each one teaches what kind of sentence its term appears in. Delete a line",
+            "# that was recorded by mistake; the term forgets it at the next correction.",
+            "",
+            "terms:",
+        ]
+        for term in all.keys.sorted() {
+            guard let uses = all[term], !uses.isEmpty else { continue }
+            lines.append("  \(quoted(term)):")
+            for use in uses {
+                lines.append("    - said: \(quoted(use.said))")
+                lines.append("      span: \(quoted(use.span))")
+            }
+        }
+        lines.append("")
+        try lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    /// Double quotes with the two escapes YAML needs inside them.
+    private static func quoted(_ text: String) -> String {
+        let escaped = text
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        return "\"\(escaped)\""
+    }
+}

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -381,6 +381,20 @@ if let index = arguments.firstIndex(of: "--context-test") {
     ))
 }
 
+if let index = arguments.firstIndex(of: "--portrait") {
+    guard #available(macOS 14, *) else {
+        print("✗ portraits need macOS 14 or later")
+        exit(1)
+    }
+    guard arguments.indices.contains(index + 1) else {
+        print("usage: ParrotFlow --portrait <term> [\"<sentence>\" <span>]")
+        exit(2)
+    }
+    let sentence = arguments.indices.contains(index + 2) ? arguments[index + 2] : nil
+    let span = arguments.indices.contains(index + 3) ? arguments[index + 3] : nil
+    exit(TermPortraitCommand.run(term: arguments[index + 1], sentence: sentence, span: span))
+}
+
 if let index = arguments.firstIndex(of: "--slot-gap") {
     guard #available(macOS 14, *) else {
         print("✗ the slot reference needs macOS 14 or later")

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -328,13 +328,16 @@ if let index = arguments.firstIndex(of: "--dates") {
 
 if let index = arguments.firstIndex(of: "--learn") {
     guard arguments.indices.contains(index + 2) else {
-        print("usage: ParrotFlow --learn <heard> <corrected> [person|place|organization|word]")
+        print("usage: ParrotFlow --learn <heard> <corrected> [kind] [--in \"<sentence>\"]")
         exit(2)
     }
     let kind = arguments.indices.contains(index + 3)
         ? WordKind(rawValue: arguments[index + 3]) : nil
+    let sentence = arguments.firstIndex(of: "--in").flatMap {
+        arguments.indices.contains($0 + 1) ? arguments[$0 + 1] : nil
+    }
     exit(LearnCommand.run(heard: arguments[index + 1], corrected: arguments[index + 2],
-                          kind: kind))
+                          kind: kind, sentence: sentence))
 }
 
 if let index = arguments.firstIndex(of: "--forget") {

--- a/scripts/check-portrait.sh
+++ b/scripts/check-portrait.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# What a term's confirmed sentences say, and whether the two tests agree.
+#
+#   scripts/check-portrait.sh
+#
+# The floor is read off the term's own uses and never chosen, so the only way
+# to see it is to build one and print it. The pair of cases below is the hardest
+# term measured: on its own, the portrait gets both of them wrong. Together with
+# the slot test they come out right — one as an offer, one handed back.
+#
+# Not in `make test`: it needs the 400 MB word-vector model and the 300 MB
+# sentence model. Run it by hand after touching TermPortrait or WordVectors.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN=""
+for candidate in "$ROOT/.build/release/ParrotFlow" "$ROOT/.build/debug/ParrotFlow"; do
+  [ -x "$candidate" ] || continue
+  if [ -z "$BIN" ] || [ "$candidate" -nt "$BIN" ]; then BIN="$candidate"; fi
+done
+[ -n "$BIN" ] || { echo "build first: swift build"; exit 1; }
+
+WORK="$(mktemp -d -t parrotflow-portrait)"
+trap 'rm -rf "$WORK"' EXIT
+run() { PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" "$@" 2>/dev/null; }
+failed=0
+check() {
+  if printf '%s' "$3" | grep -q "$2"; then printf '  ✓ %s\n' "$1"
+  else printf '  ✗ %s: %s\n' "$1" "${3:-no output}"; failed=1; fi
+}
+
+out="$(run --portrait Praisy | tail -1)"
+check "a term with no uses has no portrait" "no portrait" "$out"
+
+run --learn Precy Praisy --in "Praisy has done great work on the crawler." >/dev/null
+run --learn Praise Praisy --in "I asked Praisy to review the migration." >/dev/null
+out="$(run --portrait Praisy | tail -1)"
+check "two uses are still too few" "no portrait" "$out"
+
+run --learn Prizy Praisy --in "Praisy wrote the onboarding guide." >/dev/null
+out="$(run --portrait Praisy | tail -1)"
+check "three uses build one" "^uses 3   tightness 0\..*   floor 0\." "$out"
+
+# The hardest pair measured. The portrait alone is wrong on both.
+keep="$(run --portrait Praisy "The review was full of praise." praise | tail -1)"
+check "the portrait authorises an ordinary word here" "authorises" "$keep"
+slot="$(run --slot-gap "The review was full of praise." praise Praisy | tail -1)"
+check "and the slot refuses it, so the two disagree" "refuse" "$slot"
+
+write="$(run --portrait Praisy "Prezi joined the team in March." Prezi | tail -1)"
+check "the portrait has no opinion on a real one" "no opinion" "$write"
+slot="$(run --slot-gap "Prezi joined the team in March." Prezi Praisy | tail -1)"
+check "and neither does the slot, so it falls through" "no opinion" "$slot"
+
+[ "$failed" -eq 0 ] && echo "Every check passed." || echo "Failed: portrait"
+exit "$failed"

--- a/scripts/check-term-uses.sh
+++ b/scripts/check-term-uses.sh
@@ -94,5 +94,31 @@ check "three terms hold five sentences between them" 5 "$(count)"
 PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --forget praisy >/dev/null 2>&1
 check "--forget takes one term's three, whatever the case" 2 "$(count)"
 
+# Bytes that are not UTF-8 are the same problem as a syntax error: the file is
+# there, it cannot be read, and it is not a file to write over.
+BYTES="$WORK/bytes"
+mkdir -p "$BYTES"
+printf 'terms:\n  "Praisy":\n    - said: "Praisy joined the team."\n      span: "Praisy"\n' \
+  > "$BYTES/vocabulary-uses.yaml"
+printf '\xff\xfe\xc3\x28\n' >> "$BYTES/vocabulary-uses.yaml"
+sum_before="$(shasum "$BYTES/vocabulary-uses.yaml" | cut -d' ' -f1)"
+PARROTFLOW_CONFIG_DIR="$BYTES" "$BIN" --learn Prezi Praisy \
+  --in "Praisy wrote the guide." >/dev/null 2>&1
+check "a file that is not UTF-8 is left alone" "$sum_before" \
+  "$(shasum "$BYTES/vocabulary-uses.yaml" | cut -d' ' -f1)"
+
+# A forget that could not reach the sentences has to say so. The renderings are
+# already gone by then, so silence would leave a term half forgotten.
+HALF="$WORK/half"
+mkdir -p "$HALF"
+PARROTFLOW_CONFIG_DIR="$HALF" "$BIN" --learn Precy Praisy \
+  --in "Praisy fixed the crawler." >/dev/null 2>&1
+sed -i '' 's|    - said: "Praisy fixed the crawler."|    - said: "Praisy fixed the crawler.|' \
+  "$HALF/vocabulary-uses.yaml"
+out="$(PARROTFLOW_CONFIG_DIR="$HALF" "$BIN" --forget Praisy 2>/dev/null)"
+check "a forget that cannot reach the sentences fails" 1 "$?"
+check "and says the term was only partly forgotten" 1 \
+  "$(printf '%s' "$out" | grep -c 'only partly forgotten')"
+
 [ "$failed" -eq 0 ] && echo "Every check passed." || echo "Failed: term-uses"
 exit "$failed"

--- a/scripts/check-term-uses.sh
+++ b/scripts/check-term-uses.sh
@@ -61,5 +61,38 @@ check "the mapping still lands in vocabulary.yaml" 1 \
   "$(grep -c 'heard: Prezzy' "$WORK/vocabulary.yaml" 2>/dev/null | head -1)"
 check "and the sentence beside it" 5 "$(count)"
 
+# A file the app cannot parse is not a file to write over. One unbalanced
+# quote read as "no uses" would drop every sentence the term had.
+BROKE="$WORK/broken"
+mkdir -p "$BROKE"
+printf 'terms:\n  "Praisy":\n    - said: "Praisy joined the team.\n      span: "Praisy"\n' \
+  > "$BROKE/vocabulary-uses.yaml"
+sum_before="$(shasum "$BROKE/vocabulary-uses.yaml" | cut -d' ' -f1)"
+out="$(PARROTFLOW_CONFIG_DIR="$BROKE" "$BIN" --learn Prezi Praisy \
+  --in "Praisy wrote the guide." 2>/dev/null)"
+code=$?
+sum_after="$(shasum "$BROKE/vocabulary-uses.yaml" | cut -d' ' -f1)"
+check "a file that does not parse is left alone" "$sum_before" "$sum_after"
+check "and the correction still succeeds" 0 "$code"
+check "and says the sentence was not recorded" 1 \
+  "$(printf '%s' "$out" | grep -c 'was not recorded')"
+check "and the mapping went in anyway" 1 \
+  "$(grep -c 'heard: Prezi' "$BROKE/vocabulary.yaml" 2>/dev/null | head -1)"
+
+# The mapping is written first, so a sentence that cannot be stored is a
+# warning. Reporting it as a failure would say the correction was lost.
+BLOCKED="$WORK/blocked"
+mkdir -p "$BLOCKED/vocabulary-uses.yaml"
+out="$(PARROTFLOW_CONFIG_DIR="$BLOCKED" "$BIN" --learn Precy Praisy \
+  --in "Praisy fixed the crawler." 2>/dev/null)"
+check "an unwritable uses file does not fail the correction" 0 "$?"
+check "and the mapping is still there" 1 \
+  "$(grep -c 'heard: Precy' "$BLOCKED/vocabulary.yaml" 2>/dev/null | head -1)"
+
+# --forget takes the sentences too, or a forgotten term keeps describing itself.
+check "three terms hold five sentences between them" 5 "$(count)"
+PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --forget praisy >/dev/null 2>&1
+check "--forget takes one term's three, whatever the case" 2 "$(count)"
+
 [ "$failed" -eq 0 ] && echo "Every check passed." || echo "Failed: term-uses"
 exit "$failed"

--- a/scripts/check-term-uses.sh
+++ b/scripts/check-term-uses.sh
@@ -120,5 +120,29 @@ check "a forget that cannot reach the sentences fails" 1 "$?"
 check "and says the term was only partly forgotten" 1 \
   "$(printf '%s' "$out" | grep -c 'only partly forgotten')"
 
+# A newline written as itself is folded back into a space, and a raw control
+# character makes the whole file unparseable. Both change or lose what a
+# portrait is built from, so both are escaped.
+ODD="$WORK/odd"
+mkdir -p "$ODD"
+two="$(printf 'We shipped it.\nPraisy wrote the guide.')"
+PARROTFLOW_CONFIG_DIR="$ODD" "$BIN" --learn Precy Praisy --in "$two" >/dev/null 2>&1
+back="$(python3 -c '
+import sys, yaml
+print(yaml.safe_load(open(sys.argv[1]))["terms"]["Praisy"][0]["said"])
+' "$ODD/vocabulary-uses.yaml" 2>/dev/null)"
+check "a sentence holding a newline reads back unchanged" "$two" "$back"
+
+PARROTFLOW_CONFIG_DIR="$ODD" "$BIN" --learn Prezi Praisy --in "$two" >/dev/null 2>&1
+check "and is still recognised as the same sentence" 1 \
+  "$(grep -c '^    - said:' "$ODD/vocabulary-uses.yaml")"
+
+bell="$(printf 'Praisy fixed \athe crawler.')"
+PARROTFLOW_CONFIG_DIR="$ODD" "$BIN" --learn Praise Praisy --in "$bell" >/dev/null 2>&1
+PARROTFLOW_CONFIG_DIR="$ODD" "$BIN" --learn Prizy Praisy \
+  --in "Praisy joined in March." >/dev/null 2>&1
+check "a control character does not make the file unreadable" 3 \
+  "$(grep -c '^    - said:' "$ODD/vocabulary-uses.yaml")"
+
 [ "$failed" -eq 0 ] && echo "Every check passed." || echo "Failed: term-uses"
 exit "$failed"

--- a/scripts/check-term-uses.sh
+++ b/scripts/check-term-uses.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# The sentences a term was confirmed in, written and read back.
+#
+#   scripts/check-term-uses.sh
+#
+# A term's portrait is built from these sentences, so what is stored has to be
+# exactly what was said and nothing else. No model is loaded: this is the file,
+# the deduplication and the guards.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN=""
+for candidate in "$ROOT/.build/release/ParrotFlow" "$ROOT/.build/debug/ParrotFlow"; do
+  [ -x "$candidate" ] || continue
+  if [ -z "$BIN" ] || [ "$candidate" -nt "$BIN" ]; then BIN="$candidate"; fi
+done
+[ -n "$BIN" ] || { echo "build first: swift build"; exit 1; }
+
+WORK="$(mktemp -d -t parrotflow-term-uses)"
+trap 'rm -rf "$WORK"' EXIT
+USES="$WORK/vocabulary-uses.yaml"
+failed=0
+
+learn() { PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --learn "$@" >/dev/null 2>&1; }
+count() { grep -c '^    - said:' "$USES" 2>/dev/null | head -1; }
+
+check() {
+  local what="$1" want="$2" got="$3"
+  if [ "$got" = "$want" ]; then printf '  ✓ %s\n' "$what"
+  else printf '  ✗ %s: %s, expected %s\n' "$what" "$got" "$want"; failed=1; fi
+}
+
+learn Prezi Praisy person --in "Praisy joined the team in March."
+check "the first use is written" 1 "$(count)"
+
+learn Precy Praisy --in "Praisy has done great work on the crawler."
+check "a second use is added" 2 "$(count)"
+
+learn Prazi Praisy --in "Praisy joined the team in March."
+check "the same sentence is not stored twice" 2 "$(count)"
+
+# The term has to be in the sentence, or the portrait cannot leave it out.
+learn Vercell Vercel --in "This sentence does not hold the term."
+check "a sentence without the term is refused" 2 "$(count)"
+
+learn Versal Vercel --in "We deploy the dashboard on Vercel every Friday."
+check "a second term keeps its own list" 3 "$(count)"
+
+# A quote in the sentence has to survive the round trip.
+learn Ghosty Ghostty --in "He said \"open it in Ghostty\" and left."
+check "a sentence holding a quote is stored" 4 "$(count)"
+back="$(PARROTFLOW_CONFIG_DIR="$WORK" python3 -c '
+import sys, yaml
+d = yaml.safe_load(open(sys.argv[1]))["terms"]
+print(d["Ghostty"][0]["said"])
+' "$USES" 2>/dev/null)"
+check "and reads back unchanged" 'He said "open it in Ghostty" and left.' "$back"
+
+# The two files are written by the same call and have to agree.
+learn Prezzy Praisy --in "Praisy reviewed the migration."
+check "the mapping still lands in vocabulary.yaml" 1 \
+  "$(grep -c 'heard: Prezzy' "$WORK/vocabulary.yaml" 2>/dev/null | head -1)"
+check "and the sentence beside it" 5 "$(count)"
+
+[ "$failed" -eq 0 ] && echo "Every check passed." || echo "Failed: term-uses"
+exit "$failed"


### PR DESCRIPTION
A vocabulary term now keeps the sentences it was confirmed in, and reads a threshold off them. Recording is live: a correction made in the panel, or `--learn <heard> <corrected> --in "<sentence>"`, writes the sentence into `vocabulary-uses.yaml` beside the mapping. Reading is inert: nothing in the pipeline consults a portrait, and `--portrait <term>` is the only thing that builds one. The stage that acts on a portrait is a later PR. Start the review at `AppDelegate.learn` — recording must never break a correction — and at `TermPortrait.build`, which holds the two numbers the measurements chose.

<details>
<summary>Two files: the sentences, then the three numbers computed from them</summary>

`Sources/ParrotFlow/TermUses.swift` stores one row per confirmed use: the sentence as it stood, and the term inside it. A sentence that does not hold the term is refused, because the portrait has to be able to leave the term out. The same sentence is not stored twice. A term keeps 40 uses and the oldest goes first, so a term that moves on stops being described by what it used to mean.

Sentences, not vectors. A vector of 1024 numbers is unreadable and does not survive a change of model, and both models here are expected to change. A sentence is recomputed. The user can also read `vocabulary-uses.yaml` and delete a line that was recorded by mistake.

Its own file rather than `vocabulary.yaml`. That one is hand-edited, and a term with eight sentences under it would bury the list the file exists to hold.

`Sources/ParrotFlow/TermPortrait.swift` turns those sentences into three numbers per term:

| Number | What it is |
|---|---|
| `centre` | the mean of the context vectors — every token of a sentence except the term's own, so it describes the sentence and not the word |
| `tightness` | how close those sentences sit to that centre |
| `floor` | what a genuine use of this term scores against a portrait that leaves it out |

A new sentence is scored against the centre and divided by the tightness. A portrait built from many varied sentences has a centre further from everything, so the same cosine means less there. Dividing puts every term on one scale: 1.00 means "as typical of this term as its own sentences are". Above the floor, the rewrite is authorised.

The model is Qwen3-Embedding-0.6B through MLX, added in #243. Summaries are cached under the model name, because the numbers only compare within one set of weights. A model change invalidates every summary and no sentence.

</details>

<details>
<summary>Three uses minimum and a tenth-percentile floor — both were measured, neither was chosen</summary>

**Minimum three uses.** At two, the floor came out below every ordinary word, so the portrait authorised anything. At three it holds. Under the minimum a term has no portrait at all and `--portrait` says so.

**The floor is the 10th percentile of the leave-one-out scores, not their average.** As a term collects uses, a held-out one sits almost on top of the rest. The average therefore climbs toward 1.00 while a genuinely new sentence stays near 0.96 and gets refused. On one term grown to 32 uses the average makes 2 wrong decisions of 5. The tenth percentile makes none.

The floor is never written down by a person, so `--portrait <term>` printing it is the only way to see what a term has decided about itself:

Real output, from three `--learn --in` sentences into an empty `PARROTFLOW_CONFIG_DIR`:

```
$ ParrotFlow --portrait Vercel
no portrait: 0 confirmed use(s), 3 needed

$ ParrotFlow --portrait Praisy
uses 3   tightness 0.910   floor 0.821

$ ParrotFlow --portrait Praisy "Prezi joined the team in March." Prezi
uses 3   tightness 0.910   floor 0.821
score 0.716   no opinion
```

The doc comment above `TermPortraitCommand.run` shows older numbers from a different build. It is illustration, not a claim any check reads.

</details>

<details>
<summary>Six defects the review found, all reproduced with the binary and all fixed</summary>

Greptile raised three P1s on the cherry-picked commits, then two on the fixes, then one more. All six reproduce against `.build/release/ParrotFlow`, so all six are fixed rather than argued with. Its runner has no Swift toolchain, so every finding was re-checked with the real binary before anything was changed; none turned out to be wrong.

| What went wrong | Fixed by |
|---|---|
| `--learn` wrote the mapping, then failed to write the sentence, then printed `✗` and exited 1 — reporting a saved correction as lost | `d8d41c3` |
| A `vocabulary-uses.yaml` that did not parse read as no uses, and the next correction wrote that back, dropping every sentence every term had | `c6e567e` |
| `--forget` removed the renderings, the observations and the audio, and left the sentences, so a forgotten term still had a portrait | `9ca931e` |
| The parse guard used `try?` around the file read, so bytes that were not UTF-8 still read as no uses and were written over | `c320ffb` |
| A `--forget` that could not reach the sentences warned but still printed `✓ forgot` and exited 0 | `467dd41` |
| The YAML renderer escaped only `\` and `"`, so a newline in a sentence came back as a space, and one control character stopped the whole file parsing | `85be319` |

The second is the one that costs data. The file is hand-edited — its own header tells you to delete a line you did not mean — so one unbalanced quote was enough:

```
$ grep -c 'said:' $W/vocabulary-uses.yaml
2
# a quote deleted by hand, then one more correction
$ ParrotFlow --learn Prizy Praisy --in "Praisy wrote the guide."
✓ Prizy → Praisy
$ grep -c 'said:' $W/vocabulary-uses.yaml
1
```

After `c6e567e` the same sequence leaves the file byte-identical, warns, and still saves the mapping:

```
$ ParrotFlow --learn Prizy Praisy --in "Praisy wrote the guide."
! the sentence was not recorded in vocabulary-uses.yaml: … (Yams.YamlError error 2.)
✓ Prizy → Praisy
$ exit=0, file unchanged: yes, uses still: 2
```

A single bad row is still forgiven — deleting one row is the documented way to forget a use. Only a file that does not parse as a whole refuses the write.

`306dfd9`, `e89ff79` and `2058cf1` add fourteen cases to `scripts/check-term-uses.sh`, one per defect and one per guard. The script is now 23/23.

</details>

<details>
<summary>The first commit carried a stray dictation file; nothing referenced it, so it is dropped here</summary>

`4192f8d` added `dictee-controle-4.txt` at the repository root — 29 lines of French dictation control text. It is a test artefact and has nothing to do with this change.

Nothing references it. `grep -rn dictee` over the whole tree hits only the file itself, and `git log --all -S dictee-controle-4` finds no other commit that ever named it. It is left out of the cherry-pick. No other change was made to either commit; both keep their original `Signed-off-by`.

</details>

<details>
<summary>What runs, and what a reviewer should check</summary>

All run on this branch alone, cherry-picked onto `main` with none of the work that follows it:

- `swift build -c release` — clean, 138s cold. `swiftlint lint` reports nothing on any file this branch touches.
- `make test` — every check passed. `term-uses` is added to the list. `scripts/check-term-uses.sh` writes and reads the file with the real binary and loads no model: the file format, the deduplication and the guards. 23/23.
- `scripts/check-portrait.sh` by hand — 7/7, with the models present. It is not in `make test` because it needs the 400 MB word-vector model and the 300 MB sentence model.

Nothing had to be added to make the slice build or pass. The nine commits after the two cherry-picks are review fixes, described above.

`check-inplace.sh`, `check-span.sh`, `check-routing.sh` and `check-grammar.sh` fail here for reasons this branch does not touch: they need a focused GUI app, Chrome on a fixture page, or a model.

Worth checking first:

- `AppDelegate.learn` records the sentence inside the loop that writes the mapping. A failure to record is logged and swallowed. A correction that half-saved and then rewrote the field would leave the two disagreeing, so recording must not be able to fail a correction.
- Nothing reads a portrait. `TermPortrait.authorises` has no caller at all in this branch. `summary` and `score` have one each, `TermPortraitCommand`. `grep -rn TermPortrait Sources/` shows the whole list, and the only other hit is a doc comment in `SlotReference.swift` that #243 already wrote.
- The minimum and the quantile are the measured values above. This PR does not change either, and does not wire the portrait into the pipeline.
- `term-uses` is in the `Makefile` list but not in `.github/workflows/checks.yml`, which names its steps one by one. So `make test` runs it locally and CI does not. Left as the commit had it; adding the step is a separate change.

</details>
