### PR TITLE
feat: a name is only written where the sentence says it belongs

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -509,6 +509,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // The other half of the first press. The engine warms above; this is
         // the pill's own window, which costs as much again.
         pill.warm()
+        warmModels()
         recorder.onLevel = { [weak self] level in
             self?.pill.model.level = level
         }
@@ -2023,6 +2024,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `transcriber.prepare` is safe to call again from `transcribe(...)`
     /// once this is in flight: overlapping callers converge on the same
     /// download rather than racing two.
+    /// Every model the app will use, fetched at launch rather than on the
+    /// dictation that first wants one.
+    ///
+    /// Each of these used to arrive on first use, and each of them therefore
+    /// had a window where the thing it powers was switched on and silently
+    /// doing nothing. `SentenceGate` will not make a dictation wait on a load,
+    /// so it skipped; `SentenceJoin` did the same. "Versailles is a fantastic
+    /// castle" shipped as "Vercel is a fantastic castle" inside one of those
+    /// windows, and nothing on screen said why.
+    ///
+    /// The dictation path still calls both. A fetch that fails clears itself,
+    /// and the next English dictation is the next chance.
+    private func warmModels() {
+        guard config.transcription.enabled else { return }
+        let transcriber = transcriber
+        Task.detached(priority: .background) { await transcriber.warmSentenceModel() }
+        // 335 MB, and only the sentence gate reads them. Someone who turns the
+        // gate off should not pay for it.
+        if #available(macOS 14, *), config.vocabulary.gateSentence {
+            Task.detached(priority: .background) { await WordVectors.shared.warm() }
+        }
+    }
+
     private func warmUpTranscriber() {
         guard config.transcription.enabled else { return }
 

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2025,7 +2025,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// once this is in flight: overlapping callers converge on the same
     /// download rather than racing two.
     /// Every model the app will use, fetched at launch rather than on the
-    /// dictation that first wants one.
+    /// dictation that first wants one. About 1.16 GB on a default install:
+    /// Parakeet 461 MB, ModernBERT 288 MB, the word vectors 335 MB, the sound
+    /// model 81 MB.
     ///
     /// Each of these used to arrive on first use, and each of them therefore
     /// had a window where the thing it powers was switched on and silently
@@ -2040,6 +2042,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard config.transcription.enabled else { return }
         let transcriber = transcriber
         Task.detached(priority: .background) { await transcriber.warmSentenceModel() }
+        // 81 MB, and the sound pass is on by default, so it is one of the three
+        // rather than something a first dictation waits for.
+        Task.detached(priority: .background) {
+            guard await !NeuralPhonemes.isReady() else { return }
+            do { try await NeuralPhonemes.download() } catch {
+                Log.write("sound model: \(error.localizedDescription); the next"
+                    + " dictation that needs it tries again")
+            }
+        }
         // 335 MB, and only the sentence gate reads them. Someone who turns the
         // gate off should not pay for it.
         if #available(macOS 14, *), config.vocabulary.gateSentence {

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2017,13 +2017,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// Starts the Parakeet (and VAD) download at launch, so it's already
-    /// running — ideally already done — by the time the first dictation
-    /// needs it, instead of the first dictation triggering and waiting on it.
-    ///
-    /// `transcriber.prepare` is safe to call again from `transcribe(...)`
-    /// once this is in flight: overlapping callers converge on the same
-    /// download rather than racing two.
     /// Every model the app will use, fetched at launch rather than on the
     /// dictation that first wants one. About 1.16 GB on a default install:
     /// Parakeet 461 MB, ModernBERT 288 MB, the word vectors 335 MB, the sound
@@ -2058,6 +2051,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    /// Starts the Parakeet (and VAD) download at launch, so it's already
+    /// running — ideally already done — by the time the first dictation
+    /// needs it, instead of the first dictation triggering and waiting on it.
+    ///
+    /// `transcriber.prepare` is safe to call again from `transcribe(...)`
+    /// once this is in flight: overlapping callers converge on the same
+    /// download rather than racing two.
     private func warmUpTranscriber() {
         guard config.transcription.enabled else { return }
 

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -218,6 +218,18 @@ struct Config: Decodable, Equatable {
         /// `and me` reaching `Andrey`.
         var soundBelow: Float = 0.85
 
+        /// Whether the two tests that read the sentence run at all.
+        ///
+        /// One asks whether the term belongs in this position, measured
+        /// against the ten words a masked model expects there, and can only
+        /// refuse. The other asks whether the sentence looks like the ones the
+        /// term was confirmed in, and can only authorise. When they disagree
+        /// neither wins and the reading is offered.
+        ///
+        /// Off by default. It needs a 400 MB model, and it has been measured on
+        /// four dictations of one speaker and nothing else.
+        var gateSentence: Bool = false
+
         /// One way this speaker's mouth turns a term into something else, and
         /// what is known about that.
         ///
@@ -502,6 +514,7 @@ struct Config: Decodable, Equatable {
             case decideAbove = "decide_above"
             case soundBelow = "sound_below"
             case gateRank = "gate_rank"
+            case gateSentence = "gate_sentence"
         }
 
         init() {}
@@ -557,6 +570,9 @@ struct Config: Decodable, Equatable {
                         + " it is a similarity, where 1.0 is the term said exactly."
                         + " Running at \(soundBelow)")
                 }
+            }
+            if let on = try c.decodeIfPresent(Bool.self, forKey: .gateSentence) {
+                gateSentence = on
             }
             // `gate_rank` switched a rule that wrote a name when its span read
             // worst in the sentence. The rule is gone — see `SlotGate` — so the

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -226,9 +226,12 @@ struct Config: Decodable, Equatable {
         /// term was confirmed in, and can only authorise. When they disagree
         /// neither wins and the reading is offered.
         ///
-        /// Off by default. It needs a 400 MB model, and it has been measured on
-        /// four dictations of one speaker and nothing else.
-        var gateSentence: Bool = false
+        /// On. It needs a 400 MB model, which is fetched at launch along with
+        /// the others rather than on the dictation that first wants it — see
+        /// `AppDelegate.warmModels`. A gate that is switched on and silently
+        /// doing nothing while its model loads is worse than one that is off:
+        /// it shipped `Versailles` as `Vercel` inside that window.
+        var gateSentence: Bool = true
 
         /// One way this speaker's mouth turns a term into something else, and
         /// what is known about that.

--- a/Sources/ParrotFlow/LearnCommand.swift
+++ b/Sources/ParrotFlow/LearnCommand.swift
@@ -42,6 +42,39 @@ enum LearnCommand {
         return 0
     }
 
+    /// `--tidy-uses` — cuts every stored use down to its own sentence.
+    ///
+    /// The migration for `TermUses.narrowed`. Rows written before it exist hold
+    /// the whole prompt line, and two of Ghostty's three uses were teaching it
+    /// that "The night was very ghostly" is where it lives.
+    static func tidy() -> Int32 {
+        let all = TermUses.load()
+        var out: [String: [TermUses.Use]] = [:]
+        var cut = 0
+        for (term, uses) in all {
+            var kept: [TermUses.Use] = []
+            for use in uses {
+                let said = TermUses.narrowed(use.said, to: use.span)
+                if said != use.said { cut += 1 }
+                let now = TermUses.Use(said: said, span: use.span, from: use.from)
+                // The custom `==` is on the sentence and the span, so two rows
+                // that narrow to the same sentence collapse into one.
+                if !kept.contains(now) { kept.append(now) }
+            }
+            if !kept.isEmpty { out[term] = kept }
+        }
+        do {
+            try TermUses.write(out)
+            let was = all.values.map(\.count).reduce(0, +)
+            let now = out.values.map(\.count).reduce(0, +)
+            print("✓ \(cut) use(s) cut to their own sentence, \(was - now) duplicate(s) dropped")
+            return 0
+        } catch {
+            print("✗ \(error.localizedDescription)")
+            return 1
+        }
+    }
+
     /// `--for <term> "<sentence>" [word]` — a sentence the term *does* belong
     /// in, recorded without touching the pronunciations.
     ///

--- a/Sources/ParrotFlow/LearnCommand.swift
+++ b/Sources/ParrotFlow/LearnCommand.swift
@@ -26,7 +26,12 @@ enum LearnCommand {
         // the correction was lost when it was not.
         if let sentence, !sentence.isEmpty {
             do {
-                try TermUses.record(term: corrected, said: sentence, span: corrected)
+                // From the terminal, so it was typed and not lived. A portrait
+                // built out of sentences somebody invented behaves differently
+                // from one built out of real dictation.
+                try TermUses.record(
+                    term: corrected, said: sentence, span: corrected, from: .seeded
+                )
             } catch {
                 print("! the sentence was not recorded in"
                     + " \(TermUses.url.lastPathComponent): \(error.localizedDescription)")

--- a/Sources/ParrotFlow/LearnCommand.swift
+++ b/Sources/ParrotFlow/LearnCommand.swift
@@ -48,7 +48,13 @@ enum LearnCommand {
     /// the whole prompt line, and two of Ghostty's three uses were teaching it
     /// that "The night was very ghostly" is where it lives.
     static func tidy() -> Int32 {
-        let all = TermUses.load()
+        // `read`, not `load`. A file that does not parse reads as no uses, and
+        // this writes what it read back over it.
+        let all: [String: [TermUses.Use]]
+        do { all = try TermUses.read() } catch {
+            print("✗ \(error.localizedDescription)")
+            return 1
+        }
         var out: [String: [TermUses.Use]] = [:]
         var cut = 0
         for (term, uses) in all {

--- a/Sources/ParrotFlow/LearnCommand.swift
+++ b/Sources/ParrotFlow/LearnCommand.swift
@@ -57,10 +57,17 @@ enum LearnCommand {
         }
         var out: [String: [TermUses.Use]] = [:]
         var cut = 0
+        var notAWord = 0
         for (term, uses) in all {
             var kept: [TermUses.Use] = []
             for use in uses {
                 let said = TermUses.narrowed(use.said, to: use.span)
+                // The term only inside a longer word. `Vercelli` was stored as
+                // a use of `Vercel` before `record` asked for a word.
+                guard TermUses.occurrence(of: use.span, in: said) != nil else {
+                    notAWord += 1
+                    continue
+                }
                 if said != use.said { cut += 1 }
                 let now = TermUses.Use(said: said, span: use.span, from: use.from)
                 // The custom `==` is on the sentence and the span, so two rows
@@ -73,7 +80,9 @@ enum LearnCommand {
             try TermUses.write(out)
             let was = all.values.map(\.count).reduce(0, +)
             let now = out.values.map(\.count).reduce(0, +)
-            print("✓ \(cut) use(s) cut to their own sentence, \(was - now) duplicate(s) dropped")
+            print("✓ \(cut) use(s) cut to their own sentence,"
+                + " \(was - now - notAWord) duplicate(s) dropped,"
+                + " \(notAWord) where the term is not a word")
             return 0
         } catch {
             print("✗ \(error.localizedDescription)")
@@ -94,8 +103,8 @@ enum LearnCommand {
     /// it — `Praisy's` — and defaults to the term itself.
     static func supporting(term: String, sentence: String, span: String? = nil) -> Int32 {
         let written = span ?? term
-        guard sentence.contains(written) else {
-            print("✗ \"\(written)\" is not in that sentence")
+        guard TermUses.occurrence(of: written, in: sentence) != nil else {
+            print("✗ \"\(written)\" does not stand as a word in that sentence")
             return 1
         }
         do {

--- a/Sources/ParrotFlow/LearnCommand.swift
+++ b/Sources/ParrotFlow/LearnCommand.swift
@@ -41,4 +41,31 @@ enum LearnCommand {
         print("✓ \(heard) → \(corrected)")
         return 0
     }
+
+    /// `--for <term> "<sentence>" [word]` — a sentence the term *does* belong
+    /// in, recorded without touching the pronunciations.
+    ///
+    /// `--learn` also seeds a use, but only alongside a `heard:` rendering, so
+    /// there was no way to record a genuine use on its own. Passing the term as
+    /// its own rendering is not a workaround: `VocabularyJudge.ruleParts` finds
+    /// a rule substitution by searching for the term, so a self-mapping makes
+    /// every correctly spelled occurrence look like something a rule wrote.
+    ///
+    /// `word` is what stands where the term goes, for a sentence that inflects
+    /// it — `Praisy's` — and defaults to the term itself.
+    static func supporting(term: String, sentence: String, span: String? = nil) -> Int32 {
+        let written = span ?? term
+        guard sentence.contains(written) else {
+            print("✗ \"\(written)\" is not in that sentence")
+            return 1
+        }
+        do {
+            try TermUses.record(term: term, said: sentence, span: written, from: .seeded)
+            print("✓ \(term) belongs at \"\(written)\"")
+            return 0
+        } catch {
+            print("✗ \(error.localizedDescription)")
+            return 1
+        }
+    }
 }

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -1090,6 +1090,12 @@ struct Pipeline: Equatable, Codable {
         var decided: [Bool?] = changes.indices.map { index in
             index < taught.count && taught[index] ? false : settled[index]
         }
+        // The two tests that read the sentence, on whatever is still open. A
+        // place they do not settle is left exactly as it was, which is why this
+        // can be turned on without any case getting worse.
+        if config.vocabulary.gateSentence, #available(macOS 14, *) {
+            decided = await SentenceGate.settle(changes, in: text, given: decided)
+        }
         let gated = decided.enumerated().filter { $0.element != nil && !taught[$0.offset] }.count
         if gated > 0 {
             Log.write("vocabulary gate: \(gated) of \(changes.count) settled without asking")

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -1096,6 +1096,7 @@ struct Pipeline: Equatable, Codable {
         if config.vocabulary.gateSentence, #available(macOS 14, *) {
             decided = await SentenceGate.settle(changes, in: text, given: decided)
         }
+
         let gated = decided.enumerated().filter { $0.element != nil && !taught[$0.offset] }.count
         if gated > 0 {
             Log.write("vocabulary gate: \(gated) of \(changes.count) settled without asking")

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -1062,6 +1062,7 @@ struct Pipeline: Equatable, Codable {
         // spells names into it on runs where nothing was even offered.
         var census = "vocabulary judge: \(slots.count) slot(s) from \(parts.count) proposal(s)"
         if bySound > 0 { census += " (\(bySound) by sound)" }
+        if config.vocabulary.gateSentence { census += ", sentence gate on" }
         if !slots.isEmpty, ProcessInfo.processInfo.environment["PARROTFLOW_JUDGE_DUMP"] != nil {
             census += " — " + slots.map {
                 "\"\(text[$0.range])\" (\($0.terms.joined(separator: "/")))"

--- a/Sources/ParrotFlow/SentenceGate.swift
+++ b/Sources/ParrotFlow/SentenceGate.swift
@@ -53,7 +53,12 @@ enum SentenceGate {
         for (index, change) in changes.enumerated() {
             guard index < out.count, out[index] != false else { continue }
             guard let term = change.terms.first else { continue }
-            guard text.contains(change.was) else { continue }
+            guard change.range.upperBound <= text.endIndex else { continue }
+            // What actually stands there, which is not always what was heard.
+            // A rule writes its term into the text before this runs, so looking
+            // for the heard word found nothing and every rule substitution fell
+            // through in silence — the whole reason this stage never spoke.
+            let standing = String(text[change.range])
 
             // A place an earlier rule already decided to write. The two word
             // lists write a name whenever the heard word is in neither of them,
@@ -65,7 +70,7 @@ enum SentenceGate {
             // refusal on its own.
             if out[index] == true {
                 let portrait = await TermPortrait.shared.reads(
-                    change.was, in: text, as: term
+                    standing, in: text, as: term
                 )
                 looked += 1
                 if portrait == .refuses {
@@ -94,7 +99,7 @@ enum SentenceGate {
                 continue
             }
             let portrait = await TermPortrait.shared.reads(
-                change.was, in: text, as: term
+                standing, in: text, as: term
             )
 
             switch (refuses, portrait) {

--- a/Sources/ParrotFlow/SentenceGate.swift
+++ b/Sources/ParrotFlow/SentenceGate.swift
@@ -78,7 +78,7 @@ enum SentenceGate {
             let refuses: Bool
             do {
                 let gap = try await SlotReference.gap(
-                    term: change.now, heard: change.was, in: text
+                    term: change.now, heard: change.was, at: change.range, in: text
                 )
                 refuses = gap < -SlotReference.floor
             } catch {

--- a/Sources/ParrotFlow/SentenceGate.swift
+++ b/Sources/ParrotFlow/SentenceGate.swift
@@ -6,8 +6,9 @@ import Foundation
 /// whether the term belongs where the word was heard, and a term is unknown to
 /// the tokenizer by construction, so its vector sits further from any centre
 /// than a real word's and the comparison cannot be made to write.
-/// `TermPortrait` only authorises: it asks whether this sentence looks like the
-/// ones the term was confirmed in, and says nothing about the alternative.
+/// `TermPortrait` answers about the term alone: whether this sentence looks like
+/// the ones it was confirmed in. It authorises when it does, refuses when the
+/// sentence is well outside, and says nothing between.
 ///
 /// So there are four outcomes and only one of them is a disagreement:
 ///
@@ -49,9 +50,30 @@ enum SentenceGate {
 
         var out = settled
         for (index, change) in changes.enumerated() {
-            guard index < out.count, out[index] == nil else { continue }
+            guard index < out.count, out[index] != false else { continue }
             guard let term = change.terms.first else { continue }
             guard text.contains(change.was) else { continue }
+
+            // A place an earlier rule already decided to write. The two word
+            // lists write a name whenever the heard word is in neither of them,
+            // which is right almost always and wrong when the word is simply
+            // rare: `on the moon on its superbase` became `its Supabase`. The
+            // portrait is the only test that separates that from `we host our
+            // databases on superbase` — 0.665 against 0.944 — so it may hand
+            // such a place back, and only back: it never turns a write into a
+            // refusal on its own.
+            if out[index] == true {
+                let portrait = await TermPortrait.shared.reads(
+                    change.was, in: text, as: term
+                )
+                if portrait == .refuses {
+                    out[index] = nil
+                    Log.write(
+                        "sentence gate: \"\(change.was)\" -> \(term) handed back"
+                            + " — \(term) does not live in this sentence")
+                }
+                continue
+            }
 
             let refuses: Bool
             do {
@@ -65,20 +87,21 @@ enum SentenceGate {
                 Log.write("sentence gate: \(change.was) — \(error.localizedDescription)")
                 continue
             }
-            let authorises = await TermPortrait.shared.authorises(
+            let portrait = await TermPortrait.shared.reads(
                 change.was, in: text, as: term
             )
 
-            switch (refuses, authorises) {
-            case (true, true):
+            switch (refuses, portrait) {
+            case (true, .authorises):
                 Log.write("sentence gate: \"\(change.was)\" -> \(term) — the two disagree")
-            case (true, false):
+            case (true, _), (false, .refuses):
                 out[index] = false
-                Log.write("sentence gate: \"\(change.was)\" kept — it belongs here")
-            case (false, true):
+                let why = refuses ? "it belongs here" : "\(term) does not live in this sentence"
+                Log.write("sentence gate: \"\(change.was)\" kept — \(why)")
+            case (false, .authorises):
                 out[index] = true
                 Log.write("sentence gate: \"\(change.was)\" -> \(term) — this is where it lives")
-            case (false, false):
+            case (false, .nothing):
                 break
             }
         }

--- a/Sources/ParrotFlow/SentenceGate.swift
+++ b/Sources/ParrotFlow/SentenceGate.swift
@@ -34,6 +34,19 @@ enum SentenceGate {
     static func settle(
         _ changes: [VocabularyJudge.Change], in text: String, given settled: [Bool?]
     ) async -> [Bool?] {
+        // Never on the dictation's time. The word vectors are 400 MB and the
+        // first MLX call warms Metal; waiting for that with the pill on screen
+        // reads as the app having hung, which is what it did.
+        guard await WordVectors.shared.isLoaded else {
+            await WordVectors.shared.warm()
+            Log.write("sentence gate: the word vectors are not loaded yet; skipped")
+            return settled
+        }
+        guard SentenceModel.isCached else {
+            Log.write("sentence gate: the sentence model is not cached yet; skipped")
+            return settled
+        }
+
         var out = settled
         for (index, change) in changes.enumerated() {
             guard index < out.count, out[index] == nil else { continue }

--- a/Sources/ParrotFlow/SentenceGate.swift
+++ b/Sources/ParrotFlow/SentenceGate.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// The two tests that read the sentence, put together.
+///
+/// They never speak on the same side. `SlotReference` only refuses: it asks
+/// whether the term belongs where the word was heard, and a term is unknown to
+/// the tokenizer by construction, so its vector sits further from any centre
+/// than a real word's and the comparison cannot be made to write.
+/// `TermPortrait` only authorises: it asks whether this sentence looks like the
+/// ones the term was confirmed in, and says nothing about the alternative.
+///
+/// So there are four outcomes and only one of them is a disagreement:
+///
+///     refuses, authorises   ->  neither wins, the reading is offered
+///     refuses               ->  keep what was heard
+///     authorises            ->  write the term
+///     neither               ->  the stage decides as it did before
+///
+/// The last line is what makes this safe to turn on: a place neither test
+/// settles behaves exactly as it does today.
+///
+/// Measured on 24 sentences dictated for the purpose, none of them in any
+/// portrait: no correct rewrite refused, one ordinary word overwritten, 10 of
+/// 13 names written, 10 places handed back. The shipped stack on the same
+/// sentences wrote 9 names and overwrote 2 ordinary words.
+@available(macOS 14, *)
+enum SentenceGate {
+
+    /// Fills in the places the earlier rules left open.
+    ///
+    /// `settled` carries one entry per change: `true` writes the term, `false`
+    /// keeps what was heard, `nil` is still open. Only the open ones are asked
+    /// about, so a place the word lists already settled costs nothing.
+    static func settle(
+        _ changes: [VocabularyJudge.Change], in text: String, given settled: [Bool?]
+    ) async -> [Bool?] {
+        var out = settled
+        for (index, change) in changes.enumerated() {
+            guard index < out.count, out[index] == nil else { continue }
+            guard let term = change.terms.first else { continue }
+            guard text.contains(change.was) else { continue }
+
+            let refuses: Bool
+            do {
+                let gap = try await SlotReference.gap(
+                    term: change.now, heard: change.was, in: text
+                )
+                refuses = gap < -SlotReference.floor
+            } catch {
+                // A place the slot cannot read is a place this stage has no
+                // opinion about, not one to guess at.
+                Log.write("sentence gate: \(change.was) — \(error.localizedDescription)")
+                continue
+            }
+            let authorises = await TermPortrait.shared.authorises(
+                change.was, in: text, as: term
+            )
+
+            switch (refuses, authorises) {
+            case (true, true):
+                Log.write("sentence gate: \"\(change.was)\" -> \(term) — the two disagree")
+            case (true, false):
+                out[index] = false
+                Log.write("sentence gate: \"\(change.was)\" kept — it belongs here")
+            case (false, true):
+                out[index] = true
+                Log.write("sentence gate: \"\(change.was)\" -> \(term) — this is where it lives")
+            case (false, false):
+                break
+            }
+        }
+        return out
+    }
+}

--- a/Sources/ParrotFlow/SentenceGate.swift
+++ b/Sources/ParrotFlow/SentenceGate.swift
@@ -49,6 +49,7 @@ enum SentenceGate {
         }
 
         var out = settled
+        var looked = 0
         for (index, change) in changes.enumerated() {
             guard index < out.count, out[index] != false else { continue }
             guard let term = change.terms.first else { continue }
@@ -66,11 +67,16 @@ enum SentenceGate {
                 let portrait = await TermPortrait.shared.reads(
                     change.was, in: text, as: term
                 )
+                looked += 1
                 if portrait == .refuses {
                     out[index] = nil
                     Log.write(
                         "sentence gate: \"\(change.was)\" -> \(term) handed back"
                             + " — \(term) does not live in this sentence")
+                } else {
+                    Log.write(
+                        "sentence gate: \"\(change.was)\" -> \(term) already written,"
+                            + " and \(term)'s own sentences do not object")
                 }
                 continue
             }
@@ -104,6 +110,10 @@ enum SentenceGate {
             case (false, .nothing):
                 break
             }
+            looked += 1
+        }
+        if looked == 0 {
+            Log.write("sentence gate: nothing left to read in \(changes.count) place(s)")
         }
         return out
     }

--- a/Sources/ParrotFlow/SentenceGate.swift
+++ b/Sources/ParrotFlow/SentenceGate.swift
@@ -63,19 +63,29 @@ enum SentenceGate {
             // databases on superbase` — 0.665 against 0.944 — so it may hand
             // such a place back, and only back: it never turns a write into a
             // refusal on its own.
-            // What actually stands there, which is not always what was heard.
-            // A rule writes its term into the text before this runs, so looking
-            // for the heard word found nothing and every rule substitution fell
-            // through in silence — the whole reason this stage never spoke.
-            let standing = String(text[change.range])
-
-            // The words around the span, not the whole transcript — see
+            // The words around the span, and the span as it was *heard* — see
             // `TermPortrait.radius`.
-            let near = TermPortrait.window(around: change.range, in: text)
+            //
+            // A rule writes its term into the text before this runs, and the
+            // vectors are contextual: the term standing in the span colours
+            // every word around it, so the sentence reads like one of the
+            // term's own and the gate grades the rule's own homework. Measured
+            // on the seeded Vercel portrait, floor 0.898:
+            //
+            //     "Vercel and its king."      0.941  authorises
+            //     "Versailles and its king."  0.712  refuses
+            //
+            // and the same flip on three more. A sound proposal has written
+            // nothing, so for those this is the text it already was.
+            let start = text.distance(from: text.startIndex, to: change.range.lowerBound)
+            let heard = text.replacingCharacters(in: change.range, with: change.was)
+            let from = heard.index(heard.startIndex, offsetBy: start)
+            let upto = heard.index(from, offsetBy: change.was.count)
+            let near = TermPortrait.window(around: from ..< upto, in: heard)
 
             if out[index] == true {
                 let portrait = await TermPortrait.shared.reads(
-                    standing, in: near, as: term
+                    change.was, in: near, as: term
                 )
                 looked += 1
                 if portrait == .refuses {
@@ -104,7 +114,7 @@ enum SentenceGate {
                 continue
             }
             let portrait = await TermPortrait.shared.reads(
-                standing, in: near, as: term
+                change.was, in: near, as: term
             )
 
             switch (refuses, portrait) {

--- a/Sources/ParrotFlow/SentenceGate.swift
+++ b/Sources/ParrotFlow/SentenceGate.swift
@@ -54,11 +54,6 @@ enum SentenceGate {
             guard index < out.count, out[index] != false else { continue }
             guard let term = change.terms.first else { continue }
             guard change.range.upperBound <= text.endIndex else { continue }
-            // What actually stands there, which is not always what was heard.
-            // A rule writes its term into the text before this runs, so looking
-            // for the heard word found nothing and every rule substitution fell
-            // through in silence — the whole reason this stage never spoke.
-            let standing = String(text[change.range])
 
             // A place an earlier rule already decided to write. The two word
             // lists write a name whenever the heard word is in neither of them,
@@ -68,9 +63,19 @@ enum SentenceGate {
             // databases on superbase` — 0.665 against 0.944 — so it may hand
             // such a place back, and only back: it never turns a write into a
             // refusal on its own.
+            // What actually stands there, which is not always what was heard.
+            // A rule writes its term into the text before this runs, so looking
+            // for the heard word found nothing and every rule substitution fell
+            // through in silence — the whole reason this stage never spoke.
+            let standing = String(text[change.range])
+
+            // The words around the span, not the whole transcript — see
+            // `TermPortrait.radius`.
+            let near = TermPortrait.window(around: change.range, in: text)
+
             if out[index] == true {
                 let portrait = await TermPortrait.shared.reads(
-                    standing, in: text, as: term
+                    standing, in: near, as: term
                 )
                 looked += 1
                 if portrait == .refuses {
@@ -99,7 +104,7 @@ enum SentenceGate {
                 continue
             }
             let portrait = await TermPortrait.shared.reads(
-                standing, in: text, as: term
+                standing, in: near, as: term
             )
 
             switch (refuses, portrait) {

--- a/Sources/ParrotFlow/SlotReference.swift
+++ b/Sources/ParrotFlow/SlotReference.swift
@@ -78,6 +78,19 @@ enum SlotReference {
     /// says how far apart the two readings are, not how sure the answer is.
     static func gap(term: String, heard: String, in sentence: String) async throws -> Double {
         guard let found = sentence.range(of: heard) else { throw Failure.noSlot(heard) }
+        return try await gap(term: term, heard: heard, at: found, in: sentence)
+    }
+
+    /// The same, about one position rather than the first one that matches.
+    ///
+    /// A sentence can hold the word twice — "deploying apps on Versailles while
+    /// visiting the Versailles castle" — and the whole point of reading the
+    /// sentence is that the two get different answers. Searching for the word
+    /// scored both at the first one, so the second was decided by a slot it was
+    /// not in.
+    static func gap(
+        term: String, heard: String, at found: Range<String.Index>, in sentence: String
+    ) async throws -> Double {
         let left = String(sentence[sentence.startIndex ..< found.lowerBound])
             .trimmingCharacters(in: .whitespaces)
         let right = String(sentence[found.upperBound...])

--- a/Sources/ParrotFlow/TermPortrait.swift
+++ b/Sources/ParrotFlow/TermPortrait.swift
@@ -39,6 +39,20 @@ actor TermPortrait {
     /// Where the floor is read off the leave-one-out scores.
     static let quantile = 0.10
 
+    /// How far below the floor a sentence has to fall before the term is held
+    /// back rather than merely not written.
+    ///
+    /// The portrait was built to authorise only. It is the one test that tells
+    /// `We host our databases on superbase` from `The rocket landed on the moon
+    /// on its superbase` — 0.944 against 0.665 — and the one that tells
+    /// `I deploy my app on Versal` from `I love visiting the Versailles Castle`
+    /// — 1.001 against 0.690. Neither pair moves the slot test at all.
+    ///
+    /// 0.04 on the fourth dictation: 6 of 11 overwrites refused, 1 of 13
+    /// correct writes lost. Chosen on that set, which was the last one held
+    /// out, so it is a number to re-measure and not one to trust.
+    static let refusal = 0.04
+
     struct Summary: Codable, Equatable {
         let centre: [Float]
         let tightness: Double
@@ -74,16 +88,27 @@ actor TermPortrait {
         return WordVectors.cosine(vector, summary.centre) / summary.tightness
     }
 
-    /// True to authorise the rewrite, false to say nothing. Never refuses.
-    func authorises(_ span: String, in sentence: String, as term: String) async -> Bool {
+    /// What the term's own sentences say about this one.
+    enum Verdict {
+        /// This is where the term lives.
+        case authorises
+        /// This is somewhere else entirely.
+        case refuses
+        /// Not far enough either way, or the term has no portrait.
+        case nothing
+    }
+
+    func reads(_ span: String, in sentence: String, as term: String) async -> Verdict {
         do {
             guard let summary = try await summary(for: term),
                   let score = try await score(of: span, in: sentence, for: term)
-            else { return false }
-            return score > summary.floor
+            else { return .nothing }
+            if score > summary.floor { return .authorises }
+            if score < summary.floor - Self.refusal { return .refuses }
+            return .nothing
         } catch {
             Log.write("portrait: \(term) could not be scored (\(error.localizedDescription))")
-            return false
+            return .nothing
         }
     }
 

--- a/Sources/ParrotFlow/TermPortrait.swift
+++ b/Sources/ParrotFlow/TermPortrait.swift
@@ -103,9 +103,19 @@ actor TermPortrait {
             guard let summary = try await summary(for: term),
                   let score = try await score(of: span, in: sentence, for: term)
             else { return .nothing }
-            if score > summary.floor { return .authorises }
-            if score < summary.floor - Self.refusal { return .refuses }
-            return .nothing
+            let verdict: Verdict
+            if score > summary.floor {
+                verdict = .authorises
+            } else if score < summary.floor - Self.refusal {
+                verdict = .refuses
+            } else {
+                verdict = .nothing
+            }
+            Log.write(String(
+                format: "portrait: %@ at \"%@\" scores %.3f against a floor of %.3f — %@",
+                term, span, score, summary.floor, "\(verdict)"
+            ))
+            return verdict
         } catch {
             Log.write("portrait: \(term) could not be scored (\(error.localizedDescription))")
             return .nothing

--- a/Sources/ParrotFlow/TermPortrait.swift
+++ b/Sources/ParrotFlow/TermPortrait.swift
@@ -39,6 +39,85 @@ actor TermPortrait {
     /// Where the floor is read off the leave-one-out scores.
     static let quantile = 0.10
 
+    /// How many words either side of the span the portrait reads.
+    ///
+    /// It used to read whatever string it was handed, and `SentenceGate` hands
+    /// it the whole transcript. So a dictation that mentioned the term earlier
+    /// scored every later span as if the term belonged there — "I deployed the
+    /// app on Vercel. I love visiting the Versailles Castle." scored the castle
+    /// at 1.034 where the castle sentence alone scores 0.754. Not even a
+    /// sentence boundary stopped it.
+    ///
+    /// Measured on the seeded Vercel portrait, the two spans of "I deploy my
+    /// apps on Versal but I love visiting the Versailles Castle", which the
+    /// whole string gets both wrong:
+    ///
+    ///     radius   Versailles (want refuse)   Versal (want write)
+    ///     whole      1.019  writes            1.012  writes
+    ///     5          0.833  refuses           1.010  writes
+    ///     3          0.809  refuses           0.924  writes
+    ///     2          0.824  refuses           0.890  nothing
+    ///
+    /// 2 is too tight — it drops a correct write on a clean sentence as well.
+    /// `SentenceProbe.radius` is 12 for the other test, which reads a mask and
+    /// not a topic; this one is narrower because a topic changes inside a
+    /// sentence and a mask does not.
+    static let radius = 5
+
+    /// The `radius` words either side of the span, never leaving its sentence.
+    ///
+    /// Both bounds are needed and neither alone is enough. The sentence stops a
+    /// name said in one sentence from deciding the next — mention Vercel once
+    /// and every later `Versailles` was overwritten. The radius cuts inside a
+    /// sentence, where the sentence bound does nothing: "deployed on Versal but
+    /// visiting the Versailles Castle" is one sentence holding two topics.
+    ///
+    /// Measured on the 20-case held-out set, each case also read with one
+    /// earlier sentence about the same term in front of it:
+    ///
+    ///     window                     alone          with a lead-in
+    ///     the whole text             18 / 1 wrong   10 / 10 wrong
+    ///     radius only                18 / 1 wrong   14 /  5 wrong
+    ///     radius and the sentence    18 / 1 wrong   18 /  1 wrong
+    ///
+    /// The last row is the same either way, which is the property wanted: what
+    /// was said earlier no longer reaches the span at all. The one that stays
+    /// wrong is wrong without a lead-in too, and is a thin portrait rather than
+    /// a window.
+    static func window(
+        around range: Range<String.Index>, in text: String, radius: Int = TermPortrait.radius
+    ) -> String {
+        var bounds = text.startIndex ..< text.endIndex
+        text.enumerateSubstrings(
+            in: text.startIndex ..< text.endIndex,
+            options: [.bySentences, .substringNotRequired]
+        ) { _, at, _, stop in
+            if at.contains(range.lowerBound) || at.lowerBound == range.lowerBound {
+                bounds = at
+                stop = true
+            }
+        }
+        // A span reaching past its own sentence is not one this can cut down.
+        if range.upperBound > bounds.upperBound { bounds = text.startIndex ..< text.endIndex }
+
+        var words: [Range<String.Index>] = []
+        var holds: [Int] = []
+        var cursor = bounds.lowerBound
+        while cursor < bounds.upperBound {
+            guard let from = text[cursor ..< bounds.upperBound]
+                .firstIndex(where: { !$0.isWhitespace }) else { break }
+            let to = text[from ..< bounds.upperBound].firstIndex(where: \.isWhitespace)
+                ?? bounds.upperBound
+            if from < range.upperBound && to > range.lowerBound { holds.append(words.count) }
+            words.append(from ..< to)
+            cursor = to
+        }
+        guard let first = holds.first, let last = holds.last else { return text }
+        let lo = words[max(0, first - radius)].lowerBound
+        let hi = words[min(words.count - 1, last + radius)].upperBound
+        return String(text[lo ..< hi])
+    }
+
     /// How far below the floor a sentence has to fall before the term is held
     /// back rather than merely not written.
     ///

--- a/Sources/ParrotFlow/TermPortraitCommand.swift
+++ b/Sources/ParrotFlow/TermPortraitCommand.swift
@@ -48,8 +48,10 @@ enum TermPortraitCommand {
                     return .success((summary, nil))
                 }
                 // Windowed the way the gate windows, so this scores the
-                // shipped path and not a wider version of it.
-                let near = (sentence.range(of: span)).map {
+                // shipped path and not a wider version of it. The gate is
+                // handed a range; here the span has to be found, and it is
+                // found as a word for the same reason `TermUses` does.
+                let near = TermUses.occurrence(of: span, in: sentence).map {
                     TermPortrait.window(around: $0, in: sentence)
                 } ?? sentence
                 let score = try await TermPortrait.shared.score(

--- a/Sources/ParrotFlow/TermPortraitCommand.swift
+++ b/Sources/ParrotFlow/TermPortraitCommand.swift
@@ -47,8 +47,13 @@ enum TermPortraitCommand {
                 guard summary != nil, let sentence, let span else {
                     return .success((summary, nil))
                 }
+                // Windowed the way the gate windows, so this scores the
+                // shipped path and not a wider version of it.
+                let near = (sentence.range(of: span)).map {
+                    TermPortrait.window(around: $0, in: sentence)
+                } ?? sentence
                 let score = try await TermPortrait.shared.score(
-                    of: span, in: sentence, for: term
+                    of: span, in: near, for: term
                 )
                 return .success((summary, score))
             } catch {

--- a/Sources/ParrotFlow/TermPortraitCommand.swift
+++ b/Sources/ParrotFlow/TermPortraitCommand.swift
@@ -14,6 +14,32 @@ import Foundation
 @available(macOS 14, *)
 enum TermPortraitCommand {
 
+    /// Every term that has uses, with what each has decided about itself.
+    static func all() -> Int32 {
+        let stored = TermUses.load()
+        guard !stored.isEmpty else {
+            print("no confirmed uses yet — correct a name, or seed one with --learn --in")
+            return 0
+        }
+        print("  term            uses  seeded  floor   last sentence")
+        for term in stored.keys.sorted() {
+            guard let uses = stored[term] else { continue }
+            let seeded = uses.filter { $0.from == .seeded }.count
+            let floor = Blocking.run { () async -> Double? in
+                (try? await TermPortrait.shared.summary(for: term))??.floor
+            }
+            let shown = floor.map { String(format: "%.3f", $0) } ?? "   —"
+            let last = uses.last?.said ?? ""
+            print("  \(pad(term, 15)) \(pad(String(uses.count), 5)) \(pad(String(seeded), 7))"
+                + " \(shown)   \(last.prefix(44))")
+        }
+        return 0
+    }
+
+    private static func pad(_ text: String, _ width: Int) -> String {
+        text.count >= width ? text : text + String(repeating: " ", count: width - text.count)
+    }
+
     static func run(term: String, sentence: String?, span: String?) -> Int32 {
         let outcome = Blocking.run { () async -> Result<(TermPortrait.Summary?, Double?), Error> in
             do {
@@ -43,8 +69,20 @@ enum TermPortraitCommand {
                 "uses \(summary.uses)   tightness \(String(format: "%.3f", summary.tightness))"
                     + "   floor \(String(format: "%.3f", summary.floor))"
             )
+            if sentence == nil {
+                for use in TermUses.load()[term] ?? [] {
+                    print("  \(use.from == .seeded ? "seeded " : "learned") \(use.said)")
+                }
+            }
             if let score {
-                let verdict = score > summary.floor ? "authorises" : "no opinion"
+                let verdict: String
+                if score > summary.floor {
+                    verdict = "authorises"
+                } else if score < summary.floor - TermPortrait.refusal {
+                    verdict = "refuses"
+                } else {
+                    verdict = "no opinion"
+                }
                 print("score \(String(format: "%.3f", score))   \(verdict)")
             }
             return 0

--- a/Sources/ParrotFlow/TermUses.swift
+++ b/Sources/ParrotFlow/TermUses.swift
@@ -147,7 +147,7 @@ enum TermUses {
     /// using" has to come apart — while `Node.js` and `3.5` must not.
     static func narrowed(_ said: String, to span: String) -> String {
         let text = said.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let at = text.range(of: span) else { return text }
+        guard let at = occurrence(of: span, in: text) else { return text }
 
         func ends(_ i: String.Index) -> Bool {
             guard ".!?".contains(text[i]) else { return false }
@@ -176,6 +176,30 @@ enum TermUses {
             cut = String(cut.dropFirst()).trimmingCharacters(in: .whitespaces)
         }
         return cut.contains(span) ? cut : text
+    }
+
+    /// Where `span` stands as a word, rather than wherever its letters first
+    /// appear.
+    ///
+    /// `range(of:)` matches inside a longer word, so `Vercel` found itself in
+    /// `Vercelli` and the sentence about an Italian town was stored as a use of
+    /// the hosting platform. A term that occurs twice as a word still takes the
+    /// first: both are genuine uses, and nothing that records one carries the
+    /// position of the occurrence that was corrected.
+    static func occurrence(of span: String, in text: String) -> Range<String.Index>? {
+        func word(_ c: Character) -> Bool { c.isLetter || c.isNumber }
+        var from = text.startIndex
+        while let found = text.range(of: span, range: from ..< text.endIndex) {
+            let before = found.lowerBound == text.startIndex
+                || !word(text[text.index(before: found.lowerBound)])
+            let after = found.upperBound == text.endIndex || !word(text[found.upperBound])
+            if before && after { return found }
+            guard found.lowerBound < text.endIndex else { break }
+            from = text.index(after: found.lowerBound)
+        }
+        // No boundary anywhere: the caller's guard still decides, on the text
+        // it was given.
+        return text.range(of: span)
     }
 
     /// What terminals and shells draw in front of the line being typed.

--- a/Sources/ParrotFlow/TermUses.swift
+++ b/Sources/ParrotFlow/TermUses.swift
@@ -25,6 +25,20 @@ enum TermUses {
         /// The term inside `said`. Kept because a sentence can hold the word
         /// twice, and the portrait needs to know which one to leave out.
         let span: String
+        /// Who put it here. A portrait built from sentences somebody typed by
+        /// hand behaves differently from one built out of real dictation, and
+        /// telling them apart afterwards is the only way to know which you are
+        /// looking at.
+        var from: Source = .correction
+
+        enum Source: String, Codable {
+            /// The correction panel, the spoken command, or `--learn`.
+            case correction
+            /// Written by hand with `--learn --in`, to fill a portrait early.
+            case seeded
+        }
+
+        static func == (a: Use, b: Use) -> Bool { a.said == b.said && a.span == b.span }
     }
 
     static var url: URL {
@@ -77,7 +91,8 @@ enum TermUses {
                       let span = row["span"] as? String,
                       said.contains(span)
                 else { return nil }
-                return Use(said: said, span: span)
+                let from = (row["from"] as? String).flatMap(Use.Source.init(rawValue:))
+                return Use(said: said, span: span, from: from ?? .correction)
             }
             if !uses.isEmpty { out[term] = uses }
         }
@@ -88,13 +103,15 @@ enum TermUses {
     ///
     /// The oldest goes when the list is full, so a term that moves on stops
     /// being described by what it used to mean.
-    static func record(term: String, said: String, span: String) throws {
+    static func record(
+        term: String, said: String, span: String, from: Use.Source = .correction
+    ) throws {
         let sentence = said.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !sentence.isEmpty, !span.isEmpty, sentence.contains(span) else { return }
 
         var all = try read()
         var uses = all[term] ?? []
-        let use = Use(said: sentence, span: span)
+        let use = Use(said: sentence, span: span, from: from)
         guard !uses.contains(use) else { return }
         uses.append(use)
         if uses.count > keep { uses.removeFirst(uses.count - keep) }
@@ -135,6 +152,7 @@ enum TermUses {
             for use in uses {
                 lines.append("    - said: \(quoted(use.said))")
                 lines.append("      span: \(quoted(use.span))")
+                lines.append("      from: \(use.from.rawValue)")
             }
         }
         lines.append("")

--- a/Sources/ParrotFlow/TermUses.swift
+++ b/Sources/ParrotFlow/TermUses.swift
@@ -107,7 +107,9 @@ enum TermUses {
         term: String, said: String, span: String, from: Use.Source = .correction
     ) throws {
         let sentence = narrowed(said, to: span)
-        guard !sentence.isEmpty, !span.isEmpty, sentence.contains(span) else { return }
+        // A word, not a substring. `contains` alone let `Vercelli` in.
+        guard !sentence.isEmpty, !span.isEmpty,
+              occurrence(of: span, in: sentence) != nil else { return }
 
         var all = try read()
         var uses = all[term] ?? []
@@ -183,9 +185,12 @@ enum TermUses {
     ///
     /// `range(of:)` matches inside a longer word, so `Vercel` found itself in
     /// `Vercelli` and the sentence about an Italian town was stored as a use of
-    /// the hosting platform. A term that occurs twice as a word still takes the
-    /// first: both are genuine uses, and nothing that records one carries the
-    /// position of the occurrence that was corrected.
+    /// the hosting platform. Nil means the term does not stand in this text at
+    /// all, whatever `contains` says, and nothing should be recorded.
+    ///
+    /// A term that occurs twice as a word still takes the first: both are
+    /// genuine uses, and nothing that records one carries the position of the
+    /// occurrence that was corrected.
     static func occurrence(of span: String, in text: String) -> Range<String.Index>? {
         func word(_ c: Character) -> Bool { c.isLetter || c.isNumber }
         var from = text.startIndex
@@ -197,9 +202,9 @@ enum TermUses {
             guard found.lowerBound < text.endIndex else { break }
             from = text.index(after: found.lowerBound)
         }
-        // No boundary anywhere: the caller's guard still decides, on the text
-        // it was given.
-        return text.range(of: span)
+        // Nowhere. `Vercel` in `I visited Vercelli last year.` is not a use of
+        // the term, and a caller that only asked `contains` stored it as one.
+        return nil
     }
 
     /// What terminals and shells draw in front of the line being typed.

--- a/Sources/ParrotFlow/TermUses.swift
+++ b/Sources/ParrotFlow/TermUses.swift
@@ -106,7 +106,7 @@ enum TermUses {
     static func record(
         term: String, said: String, span: String, from: Use.Source = .correction
     ) throws {
-        let sentence = said.trimmingCharacters(in: .whitespacesAndNewlines)
+        let sentence = narrowed(said, to: span)
         guard !sentence.isEmpty, !span.isEmpty, sentence.contains(span) else { return }
 
         var all = try read()
@@ -133,6 +133,53 @@ enum TermUses {
         try write(all)
         return gone
     }
+
+    /// The one sentence `span` stands in, without the shell prompt in front.
+    ///
+    /// What is captured is the whole field, and in a terminal that is the whole
+    /// prompt line — every dictation glued together since the last Return.
+    /// Recorded whole, it taught `Ghostty` that "The night was very ghostly" is
+    /// where it lives, in two of its three uses. `RedCrawl`, `Sentry` and
+    /// `Tasmeen` each arrived with a single use that was somebody else's text.
+    ///
+    /// A full stop only ends a sentence when what follows is a space, an
+    /// upper-case letter, or nothing. Dictation arrives glued — "terminal.I'm
+    /// using" has to come apart — while `Node.js` and `3.5` must not.
+    static func narrowed(_ said: String, to span: String) -> String {
+        let text = said.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let at = text.range(of: span) else { return text }
+
+        func ends(_ i: String.Index) -> Bool {
+            guard ".!?".contains(text[i]) else { return false }
+            let after = text.index(after: i)
+            guard after < text.endIndex else { return true }
+            let next = text[after]
+            return next.isWhitespace || next.isUppercase
+        }
+
+        var from = text.startIndex
+        var i = text.startIndex
+        while i < at.lowerBound {
+            if ends(i) { from = text.index(after: i) }
+            i = text.index(after: i)
+        }
+        var to = text.endIndex
+        i = at.upperBound
+        while i < text.endIndex {
+            if ends(i) { to = text.index(after: i); break }
+            i = text.index(after: i)
+        }
+
+        var cut = String(text[from ..< to]).trimmingCharacters(in: .whitespaces)
+        // The prompt the terminal draws, which is not something anybody said.
+        while let first = cut.first, prompts.contains(first) {
+            cut = String(cut.dropFirst()).trimmingCharacters(in: .whitespaces)
+        }
+        return cut.contains(span) ? cut : text
+    }
+
+    /// What terminals and shells draw in front of the line being typed.
+    static let prompts: Set<Character> = ["❯", ">", "$", "%", "#", "›", "→"]
 
     /// Rendered by hand rather than by `Yams.dump`, for the same reason
     /// `ConfigWriter` splices `vocabulary.yaml`: this file is meant to be read,

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -471,6 +471,12 @@ actor Transcriber {
         var offeredSentences = 0
         if Pipeline.language(of: text, config: config) == "en" {
             warmSentenceModel()
+            // Only when something will read them. They are 400 MB, and the gate
+            // that needs them stands aside until they are in memory rather than
+            // making a dictation wait.
+            if config.vocabulary.gateSentence, #available(macOS 14, *) {
+                Task { await WordVectors.shared.warm() }
+            }
             // The set the sound pass actually reads, not the shorter one the
             // audio search needed. `vocabularyTerms` drops anything under five
             // letters or with a space in it, so a vocabulary of `Claude Code`

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -125,7 +125,7 @@ actor Transcriber {
     /// English dictation behind 300 MB for no gain. It reports progress but
     /// never `.failed`: a model no stage consumes must not put "Model error"
     /// in the menu bar.
-    private func warmSentenceModel() {
+    func warmSentenceModel() {
         guard sentenceModelFetch == nil else { return }
         sentenceModelRunning = true
         sentenceModelFetch = Task { [weak self] in
@@ -470,10 +470,10 @@ actor Transcriber {
         var joinedSentences = 0
         var offeredSentences = 0
         if Pipeline.language(of: text, config: config) == "en" {
+            // Both are fetched at launch now. These are the retry: a fetch
+            // that failed clears itself, and the next English dictation is the
+            // next chance to try again.
             warmSentenceModel()
-            // Only when something will read them. They are 400 MB, and the gate
-            // that needs them stands aside until they are in memory rather than
-            // making a dictation wait.
             if config.vocabulary.gateSentence, #available(macOS 14, *) {
                 Task { await WordVectors.shared.warm() }
             }

--- a/Sources/ParrotFlow/WordVectors.swift
+++ b/Sources/ParrotFlow/WordVectors.swift
@@ -83,6 +83,23 @@ actor WordVectors {
     /// `loaded`, not two callers both finding it nil across the same `await`.
     private var loading: Task<ModelContext, Error>?
 
+    /// True once the weights are in memory.
+    ///
+    /// The gate asks before it runs. A dictation must never wait on a 400 MB
+    /// download and an MLX warm-up: the first one cost about twenty seconds
+    /// with the pill on screen, which reads as the app having hung.
+    var isLoaded: Bool { loaded != nil }
+
+    /// Starts the load if nothing is doing it, and returns at once.
+    func warm() {
+        guard loaded == nil, loading == nil else { return }
+        Task { [weak self] in
+            do { try await self?.prepare() } catch {
+                Log.write("word vectors: \(error.localizedDescription); nothing reads them yet")
+            }
+        }
+    }
+
     /// Downloads and loads, or does nothing if it is already loaded.
     ///
     /// `progress` gets a label shaped like "word vectors 43%", already

--- a/Sources/ParrotFlow/WordVectors.swift
+++ b/Sources/ParrotFlow/WordVectors.swift
@@ -95,7 +95,8 @@ actor WordVectors {
         guard loaded == nil, loading == nil else { return }
         Task { [weak self] in
             do { try await self?.prepare() } catch {
-                Log.write("word vectors: \(error.localizedDescription); nothing reads them yet")
+                Log.write("word vectors: \(error.localizedDescription);"
+                    + " the sentence gate stands aside until they load")
             }
         }
     }

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -340,6 +340,10 @@ if let index = arguments.firstIndex(of: "--learn") {
                           kind: kind, sentence: sentence))
 }
 
+if arguments.contains("--tidy-uses") {
+    exit(LearnCommand.tidy())
+}
+
 if let index = arguments.firstIndex(of: "--for") {
     guard arguments.indices.contains(index + 2) else {
         print("usage: ParrotFlow --for <term> \"<sentence>\" [word]")

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -387,8 +387,7 @@ if let index = arguments.firstIndex(of: "--portrait") {
         exit(1)
     }
     guard arguments.indices.contains(index + 1) else {
-        print("usage: ParrotFlow --portrait <term> [\"<sentence>\" <span>]")
-        exit(2)
+        exit(TermPortraitCommand.all())
     }
     let sentence = arguments.indices.contains(index + 2) ? arguments[index + 2] : nil
     let span = arguments.indices.contains(index + 3) ? arguments[index + 3] : nil

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -340,6 +340,18 @@ if let index = arguments.firstIndex(of: "--learn") {
                           kind: kind, sentence: sentence))
 }
 
+if let index = arguments.firstIndex(of: "--for") {
+    guard arguments.indices.contains(index + 2) else {
+        print("usage: ParrotFlow --for <term> \"<sentence>\" [word]")
+        exit(2)
+    }
+    let span = arguments.indices.contains(index + 3)
+        && !arguments[index + 3].hasPrefix("--") ? arguments[index + 3] : nil
+    exit(LearnCommand.supporting(
+        term: arguments[index + 1], sentence: arguments[index + 2], span: span
+    ))
+}
+
 if let index = arguments.firstIndex(of: "--forget") {
     guard arguments.indices.contains(index + 1), !arguments[index + 1].hasPrefix("--") else {
         print("usage: ParrotFlow --forget <term>")

--- a/scripts/check-portrait.sh
+++ b/scripts/check-portrait.sh
@@ -37,7 +37,8 @@ out="$(run --portrait Praisy | tail -1)"
 check "two uses are still too few" "no portrait" "$out"
 
 run --learn Prizy Praisy --in "Praisy wrote the onboarding guide." >/dev/null
-out="$(run --portrait Praisy | tail -1)"
+# head, not tail: the command lists the sentences under the numbers.
+out="$(run --portrait Praisy | head -1)"
 check "three uses build one" "^uses 3   tightness 0\..*   floor 0\." "$out"
 
 # The hardest pair measured. The portrait alone is wrong on both.
@@ -46,8 +47,13 @@ check "the portrait authorises an ordinary word here" "authorises" "$keep"
 slot="$(run --slot-gap "The review was full of praise." praise Praisy | tail -1)"
 check "and the slot refuses it, so the two disagree" "refuse" "$slot"
 
+# It used to have no opinion here. `refusal = 0.04` turned that into a refusal:
+# 0.716 against a floor of 0.821. This is the one correct write of thirteen that
+# the refusal band was measured to cost, and it is this one. The slot says
+# nothing, so the gate keeps `Prezi` and the name is not written.
 write="$(run --portrait Praisy "Prezi joined the team in March." Prezi | tail -1)"
-check "the portrait has no opinion on a real one" "no opinion" "$write"
+check "the portrait refuses a real one, which is what the band costs" \
+  "refuses" "$write"
 slot="$(run --slot-gap "Prezi joined the team in March." Prezi Praisy | tail -1)"
 check "and neither does the slot, so it falls through" "no opinion" "$slot"
 

--- a/scripts/check-term-uses.sh
+++ b/scripts/check-term-uses.sh
@@ -144,6 +144,29 @@ PARROTFLOW_CONFIG_DIR="$ODD" "$BIN" --learn Prizy Praisy \
 check "a control character does not make the file unreadable" 3 \
   "$(grep -c '^    - said:' "$ODD/vocabulary-uses.yaml")"
 
+# Which occurrence the sentence is cut around. `range(of:)` matches inside a
+# longer word, so `Vercel` found itself in `Vercelli` and an Italian town was
+# stored as a use of the hosting platform.
+said_of() { PARROTFLOW_CONFIG_DIR="$1" python3 -c '
+import sys, yaml
+d = yaml.safe_load(open(sys.argv[1]))["terms"]
+print(next(iter(d.values()))[0]["said"])
+' "$1/vocabulary-uses.yaml" 2>/dev/null; }
+
+INSIDE="$WORK/inside"; mkdir -p "$INSIDE"
+PARROTFLOW_CONFIG_DIR="$INSIDE" "$BIN" --for Vercel \
+  "I visited Vercelli last year. We deploy on Vercel." >/dev/null 2>&1
+check "the term is found as a word, not inside a longer one" \
+  "We deploy on Vercel." "$(said_of "$INSIDE")"
+
+TWICE="$WORK/twice"; mkdir -p "$TWICE"
+PARROTFLOW_CONFIG_DIR="$TWICE" "$BIN" --for Vercel \
+  "Vercel is where we deploy. Vercel also hosts the docs." >/dev/null 2>&1
+# Twice as a word takes the first. Both are genuine uses, and nothing that
+# records one carries the position of the occurrence that was corrected.
+check "a term twice as a word takes the first" \
+  "Vercel is where we deploy." "$(said_of "$TWICE")"
+
 # `--tidy-uses` rewrites the whole file, so it has to read it the strict way.
 # Reading a broken file as "no uses" and writing that back is how every stored
 # sentence goes at once.

--- a/scripts/check-term-uses.sh
+++ b/scripts/check-term-uses.sh
@@ -125,7 +125,7 @@ check "and says the term was only partly forgotten" 1 \
 # portrait is built from, so both are escaped.
 ODD="$WORK/odd"
 mkdir -p "$ODD"
-two="$(printf 'We shipped it.\nPraisy wrote the guide.')"
+two="$(printf 'Praisy wrote\nthe guide.')"
 PARROTFLOW_CONFIG_DIR="$ODD" "$BIN" --learn Precy Praisy --in "$two" >/dev/null 2>&1
 back="$(python3 -c '
 import sys, yaml

--- a/scripts/check-term-uses.sh
+++ b/scripts/check-term-uses.sh
@@ -159,6 +159,24 @@ PARROTFLOW_CONFIG_DIR="$INSIDE" "$BIN" --for Vercel \
 check "the term is found as a word, not inside a longer one" \
   "We deploy on Vercel." "$(said_of "$INSIDE")"
 
+PREFIX="$WORK/prefix"; mkdir -p "$PREFIX"
+out="$(PARROTFLOW_CONFIG_DIR="$PREFIX" "$BIN" --for Vercel \
+  "I visited Vercelli last year." 2>&1)"
+check "the term only inside a longer word is not a use" 1 \
+  "$(printf '%s' "$out" | grep -c 'does not stand as a word')"
+check "and nothing is written" 0 \
+  "$(grep -c '^    - said:' "$PREFIX/vocabulary-uses.yaml" 2>/dev/null || echo 0)"
+
+# A correction still saves its pronunciation. Losing the mapping because the
+# sentence was unusable would say the correction failed, and it did not.
+PRE2="$WORK/prefix-learn"; mkdir -p "$PRE2"
+PARROTFLOW_CONFIG_DIR="$PRE2" "$BIN" --learn Verceli Vercel \
+  --in "I visited Vercelli last year." >/dev/null 2>&1
+check "a correction over a prefix-only sentence still writes the rule" 1 \
+  "$(grep -c 'heard: Verceli' "$PRE2/vocabulary.yaml" 2>/dev/null | head -1)"
+check "and records no use from it" 0 \
+  "$(grep -c '^    - said:' "$PRE2/vocabulary-uses.yaml" 2>/dev/null || echo 0)"
+
 TWICE="$WORK/twice"; mkdir -p "$TWICE"
 PARROTFLOW_CONFIG_DIR="$TWICE" "$BIN" --for Vercel \
   "Vercel is where we deploy. Vercel also hosts the docs." >/dev/null 2>&1

--- a/scripts/check-term-uses.sh
+++ b/scripts/check-term-uses.sh
@@ -144,5 +144,18 @@ PARROTFLOW_CONFIG_DIR="$ODD" "$BIN" --learn Prizy Praisy \
 check "a control character does not make the file unreadable" 3 \
   "$(grep -c '^    - said:' "$ODD/vocabulary-uses.yaml")"
 
+# `--tidy-uses` rewrites the whole file, so it has to read it the strict way.
+# Reading a broken file as "no uses" and writing that back is how every stored
+# sentence goes at once.
+sum_before="$(shasum "$BROKE/vocabulary-uses.yaml" | cut -d' ' -f1)"
+PARROTFLOW_CONFIG_DIR="$BROKE" "$BIN" --tidy-uses >/dev/null 2>&1
+check "--tidy-uses fails on a file it cannot parse" 1 "$?"
+check "and leaves it exactly as it was" "$sum_before" \
+  "$(shasum "$BROKE/vocabulary-uses.yaml" | cut -d' ' -f1)"
+
+PARROTFLOW_CONFIG_DIR="$ODD" "$BIN" --tidy-uses >/dev/null 2>&1
+check "--tidy-uses keeps the sentences of a file it can parse" 3 \
+  "$(grep -c '^    - said:' "$ODD/vocabulary-uses.yaml")"
+
 [ "$failed" -eq 0 ] && echo "Every check passed." || echo "Failed: term-uses"
 exit "$failed"


### PR DESCRIPTION
A vocabulary rewrite now consults the sentence it stands in. Two tests read that sentence: `SlotReference` asks whether the term belongs where the word was heard and can only refuse, and `TermPortrait` asks whether this sentence looks like the ones the term was confirmed in, which can authorise or refuse. Where neither speaks, the stage decides exactly as it did before — that is what makes it safe to turn on. `gate_sentence` now defaults to **on**, and every model is fetched at launch instead of on the dictation that first wants it: about **1.16 GB on a default install**. Anyone who already has a `vocabulary-uses.yaml` should run `ParrotFlow --tidy-uses` once. Start the review at the four fixes below — each one is a defect found by using the gate, and together they are the measurement that the default rests on.

<details>
<summary>Four defects found by using it, and the four fixes are the interesting half of this PR</summary>

**1. The window was the whole dictation.** `SentenceGate` handed `TermPortrait` the whole transcript, and the portrait averages every token of whatever string it gets. So one earlier mention of a term made every later confusable word score as if the term belonged there.

```
"I love visiting the Versailles Castle."      0.754  refuses
+ one unrelated Vercel sentence in front      1.034  writes it
```

`TermPortrait.window` now takes five words either side of the span and never crosses a full stop. Both bounds are needed. The sentence bound stops a name said in one sentence from deciding the next. The radius cuts inside a sentence, where the sentence bound does nothing: "deployed on Versal but visiting the Versailles Castle" is one sentence holding two topics.

Measured on a twenty-case held-out set, none of it seeded, each case also read with an earlier sentence about the same term in front of it:

| window | alone | with a lead-in |
|---|---|---|
| the whole text | 18 / 1 wrong | 10 / 10 wrong |
| radius only | 18 / 1 wrong | 14 / 5 wrong |
| radius and the sentence | 18 / 1 wrong | 18 / 1 wrong |

The last row is the same either way, which is the property wanted. Radius 2 is too tight — it drops a correct write on a clean sentence.

**2. The gate was grading the rule's own write.** A rule writes its term into the text before the gate runs, and the vectors are contextual. `vector(.around, …)` drops the span's own tokens, but every remaining token was encoded sitting next to it, so with the term in the slot the words around it read like the term's own sentences.

Measured on the seeded Vercel portrait, floor 0.898:

| sentence | as the rule left it | as it was heard |
|---|---|---|
| `___ such a magnificent castle.` | 0.886 no opinion | 0.740 refuses |
| `___ is a castle.` | 0.873 no opinion | 0.697 refuses |
| `___ and its king.` | 0.941 **authorises** | 0.712 refuses |
| `___ in its garden are beautiful.` | 0.888 no opinion | 0.731 refuses |

Four of four flip from wrong to right. This was found by a disagreement between the live log and an offline replay of the same sentences, where the replay used the heard word and the app did not. It is the cause of every short-sentence failure logged that night; the refusal band and the missing counter-portrait were symptoms being chased.

**3. A use was the whole prompt line, not one sentence.** What gets captured is the whole field, and in a terminal that is every dictation glued together since the last Return. Recorded whole, it poisoned portraits as the app was used:

```
Ghostty   3 uses, 2 of them containing "The night was very ghostly"
RedCrawl  1 use,  which was the Ghostty dictation
Sentry    1 use,  which was the Tasmeen dictation
Tasmeen   1 use,  which was the Vercel dictation
```

Two of Ghostty's three examples were teaching it that ghostly-night sentences are where it lives — the exact sentence the portrait exists to reject. `TermUses.narrowed` cuts to the sentence holding the span and drops the shell prompt in front of it. It sits inside `record`, so the panel, `--learn --in` and `--for` are covered by one rule. A full stop ends a sentence only when what follows is a space, an upper-case letter, or nothing, so "terminal.I'm using" comes apart while `Node.js` and `3.5` do not.

`--tidy-uses` migrates rows written before this: **37 cut to their own sentence, 13 duplicates dropped**. Floors moved for the better (BetterStack 0.828 → 0.856, Praisy 0.904 → 0.914). Ghostty drops to one use and so loses its portrait: it never had three distinct sentences, it had three copies of one.

**4. There was no way to record a genuine use on its own.** `--learn` seeds a use, but only alongside a `heard:` rendering. Passing the term as its own rendering is not a workaround: `VocabularyJudge.ruleParts` finds a rule substitution by searching for the term, so a self-mapping makes every correctly spelled occurrence look like something a rule wrote. `--for <term> "<sentence>" [word]` records the sentence and touches no pronunciation. The optional word is what stands where the term goes, for a sentence that inflects it (`Praisy's`).

</details>

<details>
<summary>The two tests never speak on the same side, and one of the four outcomes is a disagreement</summary>

`SlotReference` (from #243) can only refuse. A vocabulary term is unknown to the tokenizer by construction, so its vector is built from fragments and sits further from any centre than a real word's. The comparison cannot be made to write.

`TermPortrait` (from #244) answers about the term alone: whether this sentence looks like the ones it was confirmed in. It authorises above its floor, refuses well below it, and says nothing between.

`SentenceGate.settle` puts them together:

```
refuses, authorises  ->  neither wins, the reading is offered
refuses              ->  keep what was heard
authorises           ->  write the term
neither              ->  the stage decides as it did before
```

The last line is the safety property. A place neither test settles behaves exactly as it does today, so turning the gate on cannot change a decision that neither test has an opinion about.

Two rules constrain it further:

- A place an earlier rule already wrote can only be **handed back**, never overturned. The word lists write a name whenever the heard word is in neither of them, which is right almost always and wrong when the word is merely rare. A rule measured at no errors over this speaker's archive is not something one portrait built from four sentences should reverse on its own.
- The gate never makes a dictation wait. If the word vectors are not in memory or the sentence model is not cached, it skips and logs why. That is exactly why the models now load at launch — see below.

Measured on 24 sentences dictated for the purpose, none of them in any portrait: no correct rewrite refused, one ordinary word overwritten, 10 of 13 names written, 10 places handed back. The shipped stack on the same sentences wrote 9 names and overwrote 2 ordinary words.

</details>

<details>
<summary>`SlotReference.floor` is 0.20 here and stays 0.20 — 0.25 is the measured zero-error point, and a later PR</summary>

This is the one number in the PR that is knowingly not at its best value, so it is said plainly rather than left in the diff.

A later measurement on 150 real decisions says 0.25 is the zero-error point:

| floor | refusals | wrong |
|---|---|---|
| 0.20 | 55 | 1 |
| 0.25 | 45 | 0 |

A separate check found the app and the PyTorch harness differ by up to **0.058** on the same input, which is more margin than 0.20 leaves.

Both facts argue for raising it. Neither is this PR's business. Changing the floor changes what the slot test refuses on every dictation, and it should land as its own change with its own before-and-after, not as a line inside a nineteen-commit slice. The floor is unchanged here.

</details>

<details>
<summary>1.16 GB fetched at launch, and the word vectors are the only part behind a setting</summary>

This is a product decision, not a technical detail.

Each model used to arrive on the dictation that first wanted it, and each therefore had a window where the thing it powers was switched on and silently doing nothing. That is not hypothetical. "So we're still using Vercel. Versailles is a fantastic castle." shipped as "Vercel is a fantastic castle" inside one of those windows. The gate's own verdict on that sentence is 0.726 against a floor of 0.898 — a clear refusal it never got to make. Nothing on screen said why, and the only record was a log line in a file that truncates itself.

`AppDelegate.warmModels` now fetches everything at launch. A default install downloads about **1.16 GB**:

| model | size | gated on |
|---|---|---|
| Parakeet | 461 MB | `transcription.enabled` |
| ModernBERT (sentence model) | 288 MB | `transcription.enabled` |
| word vectors (Qwen3-Embedding-0.6B) | 335 MB | `transcription.enabled` **and** `gate_sentence` |
| sound model | 81 MB | `transcription.enabled` |

The word vectors are the only one behind a second setting. They are 335 MB and only the sentence gate reads them, so someone who turns the gate off does not pay for them. The other three power passes that are on by default, so putting them behind a flag would only recreate the window this change closes.

The dictation path still calls the warm-ups. A fetch that fails clears itself, and the next English dictation is the next chance.

`gate_sentence` was off because it needed a model that was not fetched until something wanted it, and because it had been measured on four dictations of one speaker. Both reasons are gone: the model arrives at launch, and it has since been measured on a 238-case bench, the 20-case held-out set above, and a session of live dictation that produced three of the four fixes in this PR.

</details>

<details>
<summary>Nineteen commits, not eight — three gate commits sit between the four late fixes, two commits are adapted, and six defects were found reviewing the result</summary>

The slice was specified as eight commits off `main`. Three of them do not apply without three more, two needed a small edit, and reviewing the result turned up six defects. All of it is written down here rather than left to be found in the diff.

**Three commits had to come with them.** `64119df` and `76a948d` are built on three commits that are not correction-panel work — they are sentence-gate work, they touch no `AppDelegate`, and they change no default:

| commit | why it is needed |
|---|---|
| `fix: each occurrence is judged where it stands` | adds `SlotReference.gap(at:)`. A sentence can hold the heard word twice, and searching for it scored both at the first one. `64119df` calls the new overload. |
| `chore: the sentence gate says what it looked at` | adds the `looked` counter that both late fixes patch around. |
| `fix: the gate reads the word that stands there, not the one that was heard` | adds the `change.range` guard the late fixes build on, the portrait's score-and-floor log line, and the **`check-portrait.sh` update**. |

That last one is a hard constraint, not a preference. `ede3b74` adds the refusal band, which turns the Prezi case from "no opinion" into "refuses". Without this commit `check-portrait.sh` fails on `main`. It is also the commit whose behaviour `76a948d` reverses — reading the standing word rather than the heard one — so the pair reads as the mistake and its correction, which is what happened.

**Two commits are adapted, and their messages say so.**

- `fix: a use is one sentence, not the whole prompt line` referenced `EditWatch.prompts` and a `counter` flag. `EditWatch` is a 503-line file that ships with the correction panel, and `counter` ships with `--against`. The prompt characters are defined in `TermUses` instead, byte-identical to the list in `EditWatch`. When the panel lands, one of the two definitions should go.
- `fix: the sound model arrives at launch too…` also repaired two counter-example expectations in `check-term-uses.sh`. Those checks ship with `--against`, so only its other repair is here: the newline case now stores one sentence holding a newline instead of two sentences, because the one-sentence rule makes reading two back whole impossible. It still tests that the writer escapes the newline rather than folding it to a space. **The second bullet of that commit message describes work that is not in this PR.**

**Six more defects found reviewing the result, all fixed here.**

- **`--tidy-uses` emptied a file it could not read.** `TermUses.load` reads an unparseable file as no uses, and `tidy` rewrites the whole file from what it read. One unbalanced quote wiped every stored sentence, printed `0 use(s) cut` and exited 0. `TermUses.read` is the strict form that exists for exactly this; `record` and `forget` already use it, `tidy` was the one writer that did not. Reproduced against `.build/release/ParrotFlow` before fixing, and two checks in `check-term-uses.sh` now hold it: the broken file is byte-identical after a failed tidy, and a file that does parse keeps its sentences.
- **`warmUpTranscriber` lost its doc comment.** `warmModels` was inserted between the comment describing the Parakeet download and the function it describes, so the comment read as `warmModels`'s. Moved back.
- **A use was cut around the term found inside a longer word.** `narrowed` located the span with `range(of:)`. `--for Vercel "I visited Vercelli last year. We deploy on Vercel."` stored the sentence about the Italian town — the exact poisoning this stage exists to stop. `TermUses.occurrence` now takes the first occurrence with a non-word character on each side. Raised by Greptile from a different angle; the reproduction and the reasoning are in the [review thread](https://github.com/znat/parrotflow/pull/245#discussion_r3908974468).
- **`--portrait` found its span with a plain search** while `TermUses` looks for it as a word, so the diagnostic and the stored uses disagreed on a span standing inside a longer word. Aligned.
- **A term standing only inside a longer word was stored as a use of it.** `record` guarded on `contains`, so `--for Vercel "I visited Vercelli last year."` reported success and stored the sentence. `TermUses.occurrence` now returns nil when the span stands nowhere as a word. A correction still saves its pronunciation — losing the mapping because the sentence was unusable would say the correction failed — and `--tidy-uses` drops rows already stored this way. Raised by Greptile, reproduced, fixed in `6848fc3`.
- **The word-vector failure line said "nothing reads them yet".** True when the gate was off. The gate reads them now, so the one line somebody debugging a skipped gate would find sent them elsewhere.

**Verified:** outside the deliberately excluded counter-example code and the two fixes above, this branch is byte-identical to the integration branch.

```
$ git diff feat/a-correction-teaches-the-term HEAD \
    -- Sources/ParrotFlow/SentenceGate.swift \
       Sources/ParrotFlow/SlotReference.swift \
       Sources/ParrotFlow/Config.swift \
       Sources/ParrotFlow/WordVectors.swift \
       scripts/check-portrait.sh
$                                    # empty
```

</details>

<details>
<summary>What this does not do, and what is checked</summary>

**Not done here.**

- `SlotReference.floor` stays 0.20. See above.
- `gate_sentence` is not documented in `docs/configuration.md` or `config.example.yaml`. Neither are its sibling `vocabulary:` keys, so this PR does not open that gap, but a setting that is now on by default and fetches 335 MB should be written down.
- **A term standing twice as a word in one dictation records the first, and Greptile calls that P1 twice.** Both sentences were confirmed by the user, and no signal exists to prefer one: `TaughtRule` carries `heard`, `corrected` and `kind`, `AppDelegate.learn` receives only the corrected text, and `--for` and `--learn --in` take a sentence typed by hand. Carrying a range means widening the panel types, which ship in the correction-panel slice, and this then becomes a one-line change. Recording every occurrence over-weights one dictation; refusing when ambiguous drops a use the user did confirm. Held as deliberate, asserted by a check, and argued out in [thread 1](https://github.com/znat/parrotflow/pull/245#discussion_r3908974468) and [thread 2](https://github.com/znat/parrotflow/pull/245#discussion_r3909014746). Greptile has stopped raising it and the review is green, but it is the one thing here that was argued rather than fixed, **so it is a decision to ratify rather than a thing to discover.**
- `--against` and counter-examples are not here. They ship with the correction-panel slice.
- `check-term-uses.sh` is in `make test` but not in `.github/workflows/checks.yml`, so the two new data-loss cases do not run in CI. It needs no model, so it could. That gap predates this PR — #244 shipped the same way — and adding it is a one-line change better made on its own.
- `--tidy-uses` is a command the user runs, not a migration that runs itself, and it is not in `docs/cli.md`. Neither are `--portrait` and `--slot-gap` from #243 and #244, so the whole group wants one entry rather than three.

**Checks run against `.build/release/ParrotFlow` on this branch.**

```
swift build -c release          Build complete
make test                       Every check passed (exit 0)
scripts/check-portrait.sh       Every check passed
swiftlint lint                  clean
scripts/check-term-uses.sh      Every check passed (32 cases, 9 new)
scripts/check-slot-gate.sh      50 scored, wrong applies 0, wrong declines 0
scripts/check-slot-gap.sh       Every check passed
scripts/check-learn.sh          45/45
```

CI on the merge commit: `checks` pass, `dco` pass, `title` pass, `Greptile Review` pass.

`check-inplace.sh`, `check-span.sh`, `check-routing.sh` and `check-grammar.sh` fail on `main` for reasons unrelated to this change and are untouched.

</details>
