### PR TITLE
feat: notice when one word of a dictation is changed by hand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ release-certificate:
 CHECKS := numbers replacements pipeline pipeline-config wake split dotted dates keyed \
           transform-folders eval audio-recovery possessive word-gate suggest input join \
           profiles span-rule clipboard default-config vocabulary-config learn \
-          signing-identity no-voice sound tokenizer sentence-case term-uses
+          signing-identity no-voice sound tokenizer sentence-case term-uses edit-diff
 
 test:
 	@swift build -c release

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3450,16 +3450,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// anybody touched it.
     private func watchForEdits(in element: AXUIElement) {
         guard let last = lastDictated else { edits.stop(); return }
-        guard let snapshot = CaretAnchor.snapshot(of: element) else {
-            Log.write("edit watch: not watching — the field would not give up its text")
-            edits.stop()
-            return
-        }
         edits.onChange = { change in
             Log.write("correction: \"\(change.was)\" -> \"\(change.now)\"")
             Log.write("    in: \(change.sentence)")
         }
-        edits.start(field: snapshot, dictated: last.text, in: element)
+        edits.start(dictated: last.text, in: element)
     }
 
     /// The offer, over words that were dictated and have been selected again.

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3414,11 +3414,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// and one whose element was never captured cannot be told from any other
     /// window.
     private func watchForReselection() {
-        guard config.feedback.correctOffer else { reselect.stop(); return }
+        guard config.feedback.correctOffer else { reselect.stop(); edits.stop(); return }
         guard let last = lastDictated,
               !last.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
               case .field = last.landing, let element = last.element else {
+            // Said out loud, because the two watches below are the only way the
+            // app ever learns what a name should have been, and a dictation
+            // that lands anywhere else silently teaches nothing.
+            let why: String
+            if lastDictated == nil {
+                why = "nothing was dictated"
+            } else if lastDictated?.element == nil {
+                why = "the field it went into was never captured"
+            } else {
+                why = "it landed as \(String(describing: lastDictated?.landing))"
+            }
+            Log.write("edit watch: not watching — \(why)")
             reselect.stop()
+            edits.stop()
             return
         }
         reselect.onSelection = { [weak self] selection in
@@ -3437,9 +3450,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// anybody touched it.
     private func watchForEdits(in element: AXUIElement) {
         guard let snapshot = CaretAnchor.snapshot(of: element) else {
+            Log.write("edit watch: not watching — the field would not give up its text")
             edits.stop()
             return
         }
+        Log.write("edit watch: watching \(snapshot.count) chars")
         edits.onChange = { change in
             Log.write("correction: \"\(change.was)\" -> \"\(change.now)\"")
             Log.write("    in: \(change.sentence)")

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -215,6 +215,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// until the next dictation replaces it.
     private let reselect = SelectionWatch()
 
+    /// Watches for one word of the last dictation being changed by hand — see
+    /// `EditWatch`. A correction is the only thing that says what the right
+    /// answer was in a particular sentence, and it is thrown away today.
+    private let edits = EditWatch()
+
     /// The last dictation a tap can summon an offer over: its words, and where
     /// they went.
     ///
@@ -1225,6 +1230,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // here rather than when the new ones land, so the gap in between
             // cannot offer over a sentence that is already history.
             reselect.stop()
+            edits.stop()
             readTheAnchor()
         }
 
@@ -3419,6 +3425,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.offerOverReselected(selection)
         }
         reselect.start(over: last.text, in: element)
+        watchForEdits(in: element)
+    }
+
+    /// Watch the field the dictation landed in for one word being changed.
+    ///
+    /// The snapshot is the whole field and not the dictation, because both
+    /// sides of the comparison have to be the same thing — see
+    /// `EditWatch.change`. Reading it costs one accessibility call, here rather
+    /// than at the first keystroke so that what is captured is the field before
+    /// anybody touched it.
+    private func watchForEdits(in element: AXUIElement) {
+        guard let snapshot = CaretAnchor.snapshot(of: element) else {
+            edits.stop()
+            return
+        }
+        edits.onChange = { change in
+            Log.write("correction: \"\(change.was)\" -> \"\(change.now)\"")
+            Log.write("    in: \(change.sentence)")
+        }
+        edits.start(field: snapshot, in: element)
     }
 
     /// The offer, over words that were dictated and have been selected again.

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3455,7 +3455,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             edits.stop()
             return
         }
-        Log.write("edit watch: watching \(snapshot.count) chars")
         edits.onChange = { change in
             Log.write("correction: \"\(change.was)\" -> \"\(change.now)\"")
             Log.write("    in: \(change.sentence)")

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3449,6 +3449,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// than at the first keystroke so that what is captured is the field before
     /// anybody touched it.
     private func watchForEdits(in element: AXUIElement) {
+        guard let last = lastDictated else { edits.stop(); return }
         guard let snapshot = CaretAnchor.snapshot(of: element) else {
             Log.write("edit watch: not watching — the field would not give up its text")
             edits.stop()
@@ -3459,7 +3460,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Log.write("correction: \"\(change.was)\" -> \"\(change.now)\"")
             Log.write("    in: \(change.sentence)")
         }
-        edits.start(field: snapshot, in: element)
+        edits.start(field: snapshot, dictated: last.text, in: element)
     }
 
     /// The offer, over words that were dictated and have been selected again.

--- a/Sources/ParrotFlow/EditDiffCommand.swift
+++ b/Sources/ParrotFlow/EditDiffCommand.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// `--edit-diff "<before>" "<now>"` — the one span that changed, or nothing.
+///
+///     ParrotFlow --edit-diff "the Vercel Castle is closed" "the Versailles Castle is closed"
+///     Vercel -> Versailles
+///
+/// `EditWatch.change` decides whether a field that no longer says what was
+/// dictated holds a correction or a rewrite, and a rewrite read as a correction
+/// teaches a term the wrong sentence. It is a pure function with no
+/// accessibility and no timing behind it, so it has a set.
+enum EditDiffCommand {
+    static func run(before: String, now: String) -> Int32 {
+        guard let change = EditWatch.change(from: before, to: now) else {
+            print("no single change")
+            return 0
+        }
+        print("\(change.was.isEmpty ? "(nothing)" : change.was)"
+            + " -> \(change.now.isEmpty ? "(nothing)" : change.now)")
+        return 0
+    }
+}

--- a/Sources/ParrotFlow/EditDiffCommand.swift
+++ b/Sources/ParrotFlow/EditDiffCommand.swift
@@ -11,12 +11,13 @@ import Foundation
 /// accessibility and no timing behind it, so it has a set.
 enum EditDiffCommand {
     static func run(before: String, now: String) -> Int32 {
-        guard let change = EditWatch.change(from: before, to: now) else {
+        let changes = EditWatch.changes(from: before, to: now)
+        guard !changes.isEmpty else {
             print("no single change")
             return 0
         }
-        print("\(change.was) -> \(change.now)")
-        print("  in: \(change.sentence)")
+        for change in changes { print("\(change.was) -> \(change.now)") }
+        print("  in: \(changes[0].sentence)")
         return 0
     }
 }

--- a/Sources/ParrotFlow/EditDiffCommand.swift
+++ b/Sources/ParrotFlow/EditDiffCommand.swift
@@ -15,8 +15,8 @@ enum EditDiffCommand {
             print("no single change")
             return 0
         }
-        print("\(change.was.isEmpty ? "(nothing)" : change.was)"
-            + " -> \(change.now.isEmpty ? "(nothing)" : change.now)")
+        print("\(change.was) -> \(change.now)")
+        print("  in: \(change.sentence)")
         return 0
     }
 }

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -55,9 +55,9 @@ final class EditWatch {
     private var field: AXUIElement?
     private var monitors: [Any] = []
     private var reported: Set<String> = []
-    /// What each replaced word has become so far, so a correction typed in
-    /// stages is told once and not once per pause.
-    private var seen: [String: String] = [:]
+    /// What each replaced word has become so far. Only the last state of each
+    /// is a correction, so they are held here until the watch ends.
+    private var seen: [String: Change] = [:]
     private var lastLook = Date.distantPast
     /// The read waiting for you to stop typing. Cancelled and replaced by every
     /// key, so it only ever runs once the field has been still.
@@ -128,11 +128,14 @@ final class EditWatch {
             Log.write("edit watch: watching \"\(line.prefix(60))\"")
             return
         }
-        guard attempt < 6 else {
+        guard attempt < 15 else {
             Log.write("edit watch: the words never reached the field; not watching")
             stop()
             return
         }
+        // Three seconds in all. A long sentence is typed into a terminal one
+        // character at a time, and `Superbase` was still arriving when six
+        // attempts over a second gave up on it.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
             self?.findLine(attempt: attempt + 1)
         }
@@ -148,6 +151,7 @@ final class EditWatch {
             settling = nil
             read()
         }
+        tell()
         for monitor in monitors { NSEvent.removeMonitor(monitor) }
         monitors = []
         before = nil
@@ -171,6 +175,7 @@ final class EditWatch {
             guard event.type == .keyDown else { return }
             settling = nil
             read()
+            tell()
             return
         }
         // Everything else is read once you stop, and only on the way up, so a
@@ -179,6 +184,17 @@ final class EditWatch {
         let work = DispatchWorkItem { [weak self] in self?.read() }
         settling = work
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.quiet, execute: work)
+    }
+
+    /// Hand over what was found, once, in the order it was found.
+    private func tell() {
+        guard !seen.isEmpty else { return }
+        let changes = seen.values.sorted { $0.was < $1.was }
+        seen = [:]
+        for change in changes {
+            Log.write("edit watch: \"\(change.was)\" became \"\(change.now)\"")
+            onChange?(change)
+        }
     }
 
     private func read() {
@@ -212,16 +228,11 @@ final class EditWatch {
             }
             return
         }
-        for change in found {
-            // Typed in stages: correcting `length chain` to `Langchain` settled
-            // three times on the way and was reported three times. Keyed on what
-            // was replaced, so a later stage of the same correction takes the
-            // place of the earlier one instead of joining it.
-            if let earlier = seen[change.was], earlier == change.now { continue }
-            seen[change.was] = change.now
-            Log.write("edit watch: \"\(change.was)\" became \"\(change.now)\"")
-            onChange?(change)
-        }
+        // Kept, not told. A correction typed in stages passes through states
+        // nobody meant — deleting `Prezi` back to `P` before typing `Praisy`
+        // reported `Prezi -> P` as a correction — and only the last state is
+        // one. Told when the watch ends, which is when you move on.
+        for change in found { seen[change.was] = change }
     }
 
     // MARK: - the comparison
@@ -348,8 +359,9 @@ final class EditWatch {
         var pool: [String: Int] = [:]
         for word in words(of: a) { pool[word, default: 0] += 1 }
         var count = 0
-        for word in words(of: b) where (pool[word] ?? 0) > 0 {
-            pool[word]! -= 1
+        for word in words(of: b) {
+            guard let left = pool[word], left > 0 else { continue }
+            pool[word] = left - 1
             count += 1
         }
         return count

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -142,14 +142,15 @@ final class EditWatch {
             Log.write("edit watch: watching \"\(line.prefix(60))\"")
             return
         }
-        guard attempt < 15 else {
+        guard attempt < 40 else {
             Log.write("edit watch: the words never reached the field; not watching")
             stop()
             return
         }
-        // Three seconds in all. A long sentence is typed into a terminal one
-        // character at a time, and `Superbase` was still arriving when six
-        // attempts over a second gave up on it.
+        // Eight seconds in all. A long sentence is typed into a terminal one
+        // character at a time, and an 84-character one was still arriving when
+        // three seconds gave up on it. Nothing is read until the line is found,
+        // so waiting costs only the wait.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
             self?.findLine(attempt: attempt + 1)
         }
@@ -315,9 +316,20 @@ final class EditWatch {
 
     /// The words of a line, punctuation kept: `Vercel.` and `Vercel` are not the
     /// same correction, and the one with the stop is what was on the screen.
+    ///
+    /// The prompt is not a word. A terminal draws one at the head of the line
+    /// you are typing into, and it corrected `❯ Prizzy` to `❯ Praizy` — true,
+    /// and not a correction of anything.
     private static func words(of line: String) -> [String] {
-        line.split(separator: " ").map(String.init)
+        var text = Substring(line).drop(while: { $0.isWhitespace })
+        if let first = text.first, Self.prompts.contains(first) {
+            text = text.dropFirst().drop(while: { $0.isWhitespace })
+        }
+        return text.split(separator: " ").map(String.init)
     }
+
+    /// What terminals and shells put in front of the line being typed.
+    private static let prompts: Set<Character> = ["❯", ">", "$", "%", "#", "›", "→"]
 
     /// The line the words went on.
     ///

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -122,6 +122,20 @@ final class EditWatch {
     /// once found nothing and gave up; the words arrived a moment later.
     private func findLine(attempt: Int) {
         guard let field, let dictated, before == nil else { return }
+        if let snapshot = CaretAnchor.snapshot(of: field) {
+            // The whole field, once, while this is being built. Every failure
+            // this watch has had came from a wrong idea of what a field holds,
+            // and guessing at it cost more than printing it will.
+            if attempt == 0 {
+                let lines = snapshot.components(separatedBy: .newlines)
+                Log.write("edit watch: field has \(snapshot.count) chars,"
+                    + " \(lines.count) line(s)")
+                for (number, line) in lines.enumerated() where !line.isEmpty {
+                    Log.write(String(format: "    %3d | %@", number + 1,
+                                     String(line.prefix(110))))
+                }
+            }
+        }
         if let snapshot = CaretAnchor.snapshot(of: field),
            let line = Self.line(holding: dictated, in: snapshot) {
             before = line

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -83,7 +83,7 @@ final class EditWatch {
         // Key up, so the character is in the field by the time it is read. A
         // paste arrives as ⌘V, which is a key event too.
         let mask: NSEvent.EventTypeMask = [.keyUp]
-        let look: (NSEvent) -> Void = { [weak self] _ in self?.look() }
+        let look: (NSEvent) -> Void = { [weak self] event in self?.look(event) }
         if let global = NSEvent.addGlobalMonitorForEvents(matching: mask, handler: look) {
             monitors.append(global)
         }
@@ -97,8 +97,15 @@ final class EditWatch {
     }
 
     func stop() {
-        settling?.cancel()
-        settling = nil
+        // The read that was waiting for you to stop typing, run before the
+        // watch goes. Correcting a word and reaching straight for the hotkey is
+        // the ordinary way to use this app, and cancelling here threw away
+        // every correction made that way — which was all of them.
+        if settling != nil {
+            settling?.cancel()
+            settling = nil
+            read()
+        }
         for monitor in monitors { NSEvent.removeMonitor(monitor) }
         monitors = []
         before = nil
@@ -108,11 +115,20 @@ final class EditWatch {
 
     deinit { stop() }
 
-    /// A key went by. Read once the typing stops, not now.
-    private func look() {
+    /// A key went by. Read once the typing stops, not now — unless the key was
+    /// the one that ends the line, which says the typing is over.
+    private func look(_ event: NSEvent?) {
         if keysSeen == 0 { Log.write("edit watch: first key seen") }
         keysSeen += 1
         settling?.cancel()
+        // Return and Enter. In a terminal the line is gone a moment later, so
+        // waiting out the quiet period would read a field that no longer holds
+        // what was corrected.
+        if let event, event.keyCode == 36 || event.keyCode == 76 {
+            settling = nil
+            read()
+            return
+        }
         let work = DispatchWorkItem { [weak self] in self?.read() }
         settling = work
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.quiet, execute: work)

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -224,7 +224,10 @@ final class EditWatch {
         }
         // The line again, found by what it still shares with the one that was
         // written. Anything else on the screen is somebody else's.
-        guard let now = Self.nearest(to: before, in: whole) else {
+        // The same way it was found: a prompt line is the prompt line whatever
+        // it now says, and looking for it by resemblance would lose it exactly
+        // when it has changed most.
+        guard let now = Self.promptLine(in: whole) ?? Self.nearest(to: before, in: whole) else {
             if reported.insert("lost").inserted {
                 Log.write("edit watch: the line the words went on is no longer on screen")
             }
@@ -333,15 +336,34 @@ final class EditWatch {
 
     /// The line the words went on.
     ///
-    /// By resemblance and not by containment. Asking which line *holds* the
-    /// dictation fails the moment somebody starts correcting it — the words are
-    /// no longer there — and that is exactly when this is looking: a sentence
-    /// typed into a terminal takes a second to arrive, and the correction often
-    /// starts before the search gives up. Two of three corrections were lost
-    /// that way, with the watch reporting that the words never reached the
-    /// field while they sat on the screen half-fixed.
+    /// The prompt first. A terminal draws one at the head of the line you are
+    /// typing into, so that line can be picked out **before the words arrive**
+    /// — and the wait for them to arrive is what lost the longest sentence of
+    /// every test: eighty-four characters typed one at a time outran every
+    /// budget it was given.
+    ///
+    /// Resemblance is the fallback, for a real text field where the whole value
+    /// is the text and there is no prompt to look for.
     static func line(holding text: String, in field: String) -> String? {
-        nearest(to: text.trimmingCharacters(in: .whitespacesAndNewlines), in: field)
+        if let prompt = promptLine(in: field) { return prompt }
+        return nearest(to: text.trimmingCharacters(in: .whitespacesAndNewlines), in: field)
+    }
+
+    /// The last line that starts with a prompt.
+    ///
+    /// From the bottom, because a terminal shows its history and a prompt
+    /// character can sit anywhere in what has already been printed. The one
+    /// being typed into is the last.
+    static func promptLine(in field: String) -> String? {
+        for line in field.components(separatedBy: .newlines).reversed() {
+            let trimmed = line.drop(while: { $0.isWhitespace })
+            guard let first = trimmed.first, prompts.contains(first) else { continue }
+            // A prompt with nothing after it is a shell waiting, not a line
+            // somebody is editing.
+            guard trimmed.dropFirst().contains(where: { !$0.isWhitespace }) else { continue }
+            return line
+        }
+        return nil
     }
 
     /// The line of `field` that is most nearly `wanted`.

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -1,0 +1,152 @@
+import AppKit
+import ApplicationServices
+
+/// Notices when you change one word of what ParrotFlow just wrote.
+///
+/// That change is the most useful thing this app can learn and the only one it
+/// never sees. A vocabulary term is written or missed, and the person fixes it
+/// in the field — and the fix, which says exactly what the right answer was in
+/// this sentence, is thrown away.
+///
+/// ## Why events and not a timer
+///
+/// Same reason as `SelectionWatch`: text cannot change on its own. Every edit
+/// is a keystroke or a paste, so the question is asked at the moments the
+/// answer can have changed and never in between. An idle app watches nothing.
+///
+/// ## What it refuses
+///
+/// One span, and the rest of the sentence unchanged. Two edits, a rewrite, or
+/// clearing the line are not corrections of a word — they are somebody writing
+/// something else, and reading them as a lesson would teach nonsense. The rule
+/// is deliberately strict here, because the alternative is a portrait poisoned
+/// by its own noise.
+///
+/// It also fires once. The same span keeps being read as long as the field is
+/// open, and a correction told twice is not two corrections.
+final class EditWatch {
+
+    /// One word of the dictation became another.
+    struct Change: Equatable {
+        /// What ParrotFlow wrote there.
+        let was: String
+        /// What is there now.
+        let now: String
+        /// The whole line as it stands, which is the sentence the change
+        /// belongs to.
+        let sentence: String
+    }
+
+    var onChange: ((Change) -> Void)?
+
+    /// The whole field as it stood when the dictation landed. Both sides of the
+    /// comparison are field snapshots, so neither has to be located in the
+    /// other.
+    private var before: String?
+    private var field: AXUIElement?
+    private var monitors: [Any] = []
+    private var reported: Set<String> = []
+    private var lastLook = Date.distantPast
+
+    var isRunning: Bool { !monitors.isEmpty }
+
+    /// Watch the field the dictation just landed in.
+    ///
+    /// `snapshot` is the whole field as it stands now, not the dictation alone.
+    /// Called again for every dictation: an older snapshot is not something
+    /// anybody is still editing.
+    func start(field snapshot: String, in element: AXUIElement?) {
+        before = snapshot
+        field = element
+        reported = []
+        guard monitors.isEmpty else { return }
+        guard Permissions.accessibility == .granted else {
+            Log.write("edit watch: accessibility is not granted; corrections cannot be seen")
+            return
+        }
+
+        // Key up, so the character is in the field by the time it is read. A
+        // paste arrives as ⌘V, which is a key event too.
+        let mask: NSEvent.EventTypeMask = [.keyUp]
+        let look: (NSEvent) -> Void = { [weak self] _ in self?.look() }
+        if let global = NSEvent.addGlobalMonitorForEvents(matching: mask, handler: look) {
+            monitors.append(global)
+        }
+        if let local = NSEvent.addLocalMonitorForEvents(matching: mask, handler: { event in
+            look(event)
+            return event
+        }) {
+            monitors.append(local)
+        }
+    }
+
+    func stop() {
+        for monitor in monitors { NSEvent.removeMonitor(monitor) }
+        monitors = []
+        before = nil
+        field = nil
+        reported = []
+    }
+
+    deinit { stop() }
+
+    private func look() {
+        guard let before, let field else { return }
+        // Under the fastest key repeat, over one small accessibility read.
+        guard Date().timeIntervalSince(lastLook) > 0.15 else { return }
+        lastLook = Date()
+
+        guard let now = CaretAnchor.snapshot(of: field) else { return }
+        guard let change = Self.change(from: before, to: now) else { return }
+        guard reported.insert(change.was + "\u{1}" + change.now).inserted else { return }
+        Log.write("edit watch: \"\(change.was)\" became \"\(change.now)\"")
+        onChange?(change)
+    }
+
+    // MARK: - the comparison
+
+    /// The one span that differs, or nil if it is not one span.
+    ///
+    /// Both sides are the whole field: what it held when the dictation landed,
+    /// and what it holds now. Comparing the dictation against the field instead
+    /// meant hunting for where the words sat, and every anchor for that hunt is
+    /// a word the edit may have been. Two snapshots of the same field need no
+    /// anchor at all — what they share at the front and at the back is
+    /// untouched, and what is left in the middle is the edit.
+    static func change(from before: String, to now: String) -> Change? {
+        guard before != now, !before.isEmpty, !now.isEmpty else { return nil }
+
+        let old = Array(before)
+        let new = Array(now)
+        var front = 0
+        while front < old.count, front < new.count, old[front] == new[front] { front += 1 }
+        var back = 0
+        while back < old.count - front, back < new.count - front,
+              old[old.count - 1 - back] == new[new.count - 1 - back] { back += 1 }
+
+        // Snap to whole words. "the Vercel Castle" against "the Versailles
+        // Castle" shares "the Ver" at the front and "el Castle" at the back, so
+        // the raw span is "cel" becoming "sailles" — true, and useless. A
+        // correction is a word for a word.
+        while front > 0, !old[front - 1].isWhitespace { front -= 1 }
+        while back > 0, back < old.count - front, back < new.count - front,
+              !old[old.count - back].isWhitespace { back -= 1 }
+
+        let was = String(old[front ..< (old.count - back)])
+        let became = String(new[front ..< (new.count - back)])
+
+        // Both sides, or it is not a correction. An empty left side is text
+        // typed after the dictation; an empty right side is a word deleted, and
+        // a deletion says where a term does not belong without saying what
+        // belongs there instead — nothing a portrait can be built from.
+        guard !was.isEmpty, !became.isEmpty else { return nil }
+
+        // One word each side, give or take. A longer span is a rewrite, and a
+        // rewrite is not a correction of a name.
+        guard was.count <= 24, became.count <= 24 else { return nil }
+        guard was.split(separator: " ").count <= 2 else { return nil }
+        guard became.split(separator: " ").count <= 2 else { return nil }
+
+        return Change(was: was, now: became, sentence: now)
+    }
+}

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -47,6 +47,17 @@ final class EditWatch {
     private var monitors: [Any] = []
     private var reported: Set<String> = []
     private var lastLook = Date.distantPast
+    /// The read waiting for you to stop typing. Cancelled and replaced by every
+    /// key, so it only ever runs once the field has been still.
+    private var settling: DispatchWorkItem?
+
+    /// How long the field has to be still before it is read.
+    ///
+    /// Reading on every key catches the edit half-typed: correcting `Versailles`
+    /// to `Vercel` reported `Verce` first, which is not a word anybody meant.
+    /// Long enough to type a name through, short enough to land before the next
+    /// sentence is dictated.
+    private static let quiet: TimeInterval = 1.2
 
     var isRunning: Bool { !monitors.isEmpty }
 
@@ -81,6 +92,8 @@ final class EditWatch {
     }
 
     func stop() {
+        settling?.cancel()
+        settling = nil
         for monitor in monitors { NSEvent.removeMonitor(monitor) }
         monitors = []
         before = nil
@@ -90,9 +103,16 @@ final class EditWatch {
 
     deinit { stop() }
 
+    /// A key went by. Read once the typing stops, not now.
     private func look() {
+        settling?.cancel()
+        let work = DispatchWorkItem { [weak self] in self?.read() }
+        settling = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.quiet, execute: work)
+    }
+
+    private func read() {
         guard let before, let field else { return }
-        // Under the fastest key repeat, over one small accessibility read.
         guard Date().timeIntervalSince(lastLook) > 0.15 else { return }
         lastLook = Date()
 
@@ -172,6 +192,20 @@ final class EditWatch {
         guard was.split(separator: " ").count <= 2 else { return nil }
         guard became.split(separator: " ").count <= 2 else { return nil }
 
-        return Change(was: was, now: became, sentence: now)
+        return Change(was: was, now: became, sentence: lineAround(front, in: new))
+    }
+
+    /// The line the change sits on.
+    ///
+    /// The field is not always one sentence. In a terminal it is the whole
+    /// buffer — 2443 characters on the first real correction, most of it
+    /// somebody else's output — and a portrait built out of that would describe
+    /// the screen rather than the term.
+    private static func lineAround(_ index: Int, in text: [Character]) -> String {
+        var start = min(index, text.count)
+        while start > 0, !text[start - 1].isNewline { start -= 1 }
+        var end = min(index, text.count)
+        while end < text.count, !text[end].isNewline { end += 1 }
+        return String(text[start ..< end]).trimmingCharacters(in: .whitespaces)
     }
 }

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -55,6 +55,9 @@ final class EditWatch {
     private var field: AXUIElement?
     private var monitors: [Any] = []
     private var reported: Set<String> = []
+    /// What each replaced word has become so far, so a correction typed in
+    /// stages is told once and not once per pause.
+    private var seen: [String: String] = [:]
     private var lastLook = Date.distantPast
     /// The read waiting for you to stop typing. Cancelled and replaced by every
     /// key, so it only ever runs once the field has been still.
@@ -83,6 +86,7 @@ final class EditWatch {
         dictated = words
         field = element
         reported = []
+        seen = [:]
         keysSeen = 0
         guard monitors.isEmpty else { return }
         guard Permissions.accessibility == .granted else {
@@ -92,7 +96,11 @@ final class EditWatch {
 
         // Key up, so the character is in the field by the time it is read. A
         // paste arrives as ⌘V, which is a key event too.
-        let mask: NSEvent.EventTypeMask = [.keyUp]
+        // Key down for the line-ending keys and key up for the rest. Return is
+        // read at once and has to be read before the app it went to acts on it:
+        // in a terminal the line leaves the field on the press, and reading
+        // after found a screen that no longer held what was corrected.
+        let mask: NSEvent.EventTypeMask = [.keyUp, .keyDown]
         let look: (NSEvent) -> Void = { [weak self] event in self?.look(event) }
         if let global = NSEvent.addGlobalMonitorForEvents(matching: mask, handler: look) {
             monitors.append(global)
@@ -160,10 +168,14 @@ final class EditWatch {
         // waiting out the quiet period would read a field that no longer holds
         // what was corrected.
         if let event, event.keyCode == 36 || event.keyCode == 76 {
+            guard event.type == .keyDown else { return }
             settling = nil
             read()
             return
         }
+        // Everything else is read once you stop, and only on the way up, so a
+        // held key is not one read per repeat.
+        guard event == nil || event?.type == .keyUp else { return }
         let work = DispatchWorkItem { [weak self] in self?.read() }
         settling = work
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.quiet, execute: work)
@@ -188,88 +200,98 @@ final class EditWatch {
             return
         }
         if now == before {
-            // Once per watch, so a field nobody touched does not fill the log.
             if reported.insert("still").inserted {
                 Log.write("edit watch: read \(now.count) chars, unchanged")
             }
             return
         }
-        guard let change = Self.change(from: before, to: now) else {
-            // Said out loud while this is new. A field that changed and was not
-            // read as a correction is either a rewrite — right to refuse — or a
-            // correction the rule is too strict for, and the two are told apart
-            // by looking at them.
-            if let raw = Self.span(from: before, to: now), raw.was.count + raw.now.count < 120,
-               reported.insert("skip\u{1}" + raw.was + "\u{1}" + raw.now).inserted {
-                Log.write("edit watch: refused \"\(raw.was)\" -> \"\(raw.now)\"")
+        let found = Self.changes(from: before, to: now)
+        guard !found.isEmpty else {
+            if reported.insert("skip\u{1}" + now).inserted {
+                Log.write("edit watch: nothing in \"\(now.prefix(60))\" reads as a correction")
             }
             return
         }
-        guard reported.insert(change.was + "\u{1}" + change.now).inserted else { return }
-        Log.write("edit watch: \"\(change.was)\" became \"\(change.now)\"")
-        onChange?(change)
+        for change in found {
+            // Typed in stages: correcting `length chain` to `Langchain` settled
+            // three times on the way and was reported three times. Keyed on what
+            // was replaced, so a later stage of the same correction takes the
+            // place of the earlier one instead of joining it.
+            if let earlier = seen[change.was], earlier == change.now { continue }
+            seen[change.was] = change.now
+            Log.write("edit watch: \"\(change.was)\" became \"\(change.now)\"")
+            onChange?(change)
+        }
     }
 
     // MARK: - the comparison
 
-    /// The changed span with no rule applied, for saying what was refused.
-    static func span(from before: String, to now: String) -> (was: String, now: String)? {
-        guard before != now, !before.isEmpty, !now.isEmpty else { return nil }
-        let old = Array(before), new = Array(now)
-        var front = 0
-        while front < old.count, front < new.count, old[front] == new[front] { front += 1 }
-        var back = 0
-        while back < old.count - front, back < new.count - front,
-              old[old.count - 1 - back] == new[new.count - 1 - back] { back += 1 }
-        while front > 0, !old[front - 1].isWhitespace { front -= 1 }
-        while back > 0, back < old.count - front, back < new.count - front,
-              !old[old.count - back].isWhitespace { back -= 1 }
-        return (String(old[front ..< (old.count - back)]), String(new[front ..< (new.count - back)]))
+    /// Every word that was replaced by another, in order.
+    ///
+    /// Word by word, not by the two ends. Comparing what two lines share at
+    /// their front and back works for one change and collapses for two: the
+    /// prefix stops at the first and the suffix at the last, so the whole
+    /// middle counts as different. On "So we have Prezi in our team. She's an
+    /// expert about the versal platform" with both names corrected, that measure
+    /// found 33% in common and decided the line had left the screen.
+    ///
+    /// A run where one word became one word is a correction. A run of two words
+    /// against three is a rewrite of a phrase, and there is no telling which
+    /// part of it was meant, so it is left alone.
+    static func changes(from before: String, to now: String) -> [Change] {
+        guard before != now else { return [] }
+        let old = words(of: before), new = words(of: now)
+        guard !old.isEmpty, !new.isEmpty else { return [] }
+
+        // Longest common subsequence, then walk it: the gaps between what the
+        // two lines share are the edits.
+        var table = [[Int]](repeating: [Int](repeating: 0, count: new.count + 1),
+                            count: old.count + 1)
+        for i in stride(from: old.count - 1, through: 0, by: -1) {
+            for j in stride(from: new.count - 1, through: 0, by: -1) {
+                table[i][j] = old[i] == new[j]
+                    ? table[i + 1][j + 1] + 1
+                    : max(table[i + 1][j], table[i][j + 1])
+            }
+        }
+
+        var found: [Change] = []
+        var i = 0, j = 0
+        // `||`, not `&&`. A change at the very last word leaves one side spent
+        // while the other still has the word that replaced it, and stopping
+        // there lost every correction of a sentence's final word.
+        while i < old.count || j < new.count {
+            if i < old.count, j < new.count, old[i] == new[j] { i += 1; j += 1; continue }
+            let fromI = i, fromJ = j
+            while i < old.count || j < new.count {
+                if i < old.count, j < new.count, old[i] == new[j] { break }
+                if i < old.count, j >= new.count || table[i + 1][j] >= table[i][j + 1] {
+                    i += 1
+                } else {
+                    j += 1
+                }
+            }
+            let left = i - fromI, right = j - fromJ
+            // One word for one, and one word for two either way: the recogniser
+            // splits a name as often as it mangles it, and `Ghost D` becoming
+            // `Ghostty` is the same correction as `Prezi` becoming `Praisy`.
+            // Two words for two is a phrase, and there is no telling which part
+            // of it was meant.
+            guard left >= 1, right >= 1, left <= 2, right <= 2, left + right <= 3
+            else { continue }
+            found.append(Change(
+                was: old[fromI ..< i].joined(separator: " "),
+                now: new[fromJ ..< j].joined(separator: " "),
+                sentence: now
+            ))
+        }
+        return found
     }
 
-    /// The one span that differs, or nil if it is not one span.
-    ///
-    /// Both sides are the whole field: what it held when the dictation landed,
-    /// and what it holds now. Comparing the dictation against the field instead
-    /// meant hunting for where the words sat, and every anchor for that hunt is
-    /// a word the edit may have been. Two snapshots of the same field need no
-    /// anchor at all — what they share at the front and at the back is
-    /// untouched, and what is left in the middle is the edit.
-    static func change(from before: String, to now: String) -> Change? {
-        guard before != now, !before.isEmpty, !now.isEmpty else { return nil }
-
-        let old = Array(before)
-        let new = Array(now)
-        var front = 0
-        while front < old.count, front < new.count, old[front] == new[front] { front += 1 }
-        var back = 0
-        while back < old.count - front, back < new.count - front,
-              old[old.count - 1 - back] == new[new.count - 1 - back] { back += 1 }
-
-        // Snap to whole words. "the Vercel Castle" against "the Versailles
-        // Castle" shares "the Ver" at the front and "el Castle" at the back, so
-        // the raw span is "cel" becoming "sailles" — true, and useless. A
-        // correction is a word for a word.
-        while front > 0, !old[front - 1].isWhitespace { front -= 1 }
-        while back > 0, back < old.count - front, back < new.count - front,
-              !old[old.count - back].isWhitespace { back -= 1 }
-
-        let was = String(old[front ..< (old.count - back)])
-        let became = String(new[front ..< (new.count - back)])
-
-        // Both sides, or it is not a correction. An empty left side is text
-        // typed after the dictation; an empty right side is a word deleted, and
-        // a deletion says where a term does not belong without saying what
-        // belongs there instead — nothing a portrait can be built from.
-        guard !was.isEmpty, !became.isEmpty else { return nil }
-
-        // One word each side, give or take. A longer span is a rewrite, and a
-        // rewrite is not a correction of a name.
-        guard was.count <= 24, became.count <= 24 else { return nil }
-        guard was.split(separator: " ").count <= 2 else { return nil }
-        guard became.split(separator: " ").count <= 2 else { return nil }
-
-        return Change(was: was, now: became, sentence: now)
+    /// The words of a line, punctuation kept: `Vercel.` and `Vercel` are not the
+    /// same correction, and the one with the stop is what was on the screen.
+    private static func words(of line: String) -> [String] {
+        line.split(separator: " ").map(String.init)
     }
 
     /// The line `text` sits on, or the whole thing if it is not there.
@@ -314,17 +336,22 @@ final class EditWatch {
         // Two thirds, not half. A screen carrying this app's output has lines
         // that quote the sentence and share a great deal of it without being
         // it, and one changed word leaves far more than two thirds intact.
-        return bestShared * 3 > wanted.count * 2 ? best : nil
+        return bestShared * 3 > words(of: wanted).count * 2 ? best : nil
     }
 
-    /// How many characters two strings share at their two ends.
+    /// How many words two lines have in common, counting repeats once each.
+    ///
+    /// Not what they share at the ends. Two corrections in one line leave the
+    /// ends agreeing on almost nothing while every other word is untouched, and
+    /// the ends measure said the line had gone.
     private static func shared(_ a: String, _ b: String) -> Int {
-        let x = Array(a), y = Array(b)
-        var front = 0
-        while front < x.count, front < y.count, x[front] == y[front] { front += 1 }
-        var back = 0
-        while back < x.count - front, back < y.count - front,
-              x[x.count - 1 - back] == y[y.count - 1 - back] { back += 1 }
-        return front + back
+        var pool: [String: Int] = [:]
+        for word in words(of: a) { pool[word, default: 0] += 1 }
+        var count = 0
+        for word in words(of: b) where (pool[word] ?? 0) > 0 {
+            pool[word]! -= 1
+            count += 1
+        }
+        return count
     }
 }

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -76,7 +76,13 @@ final class EditWatch {
     /// Called again for every dictation: an older snapshot is not something
     /// anybody is still editing.
     func start(field snapshot: String, dictated: String, in element: AXUIElement?) {
-        before = Self.line(holding: dictated, in: snapshot)
+        guard let line = Self.line(holding: dictated, in: snapshot) else {
+            Log.write("edit watch: the words are not in the field yet; not watching")
+            stop()
+            return
+        }
+        Log.write("edit watch: watching \"\(line.prefix(60))\"")
+        before = line
         field = element
         reported = []
         keysSeen = 0
@@ -243,15 +249,18 @@ final class EditWatch {
     }
 
     /// The line `text` sits on, or the whole thing if it is not there.
-    static func line(holding text: String, in field: String) -> String {
+    static func line(holding text: String, in field: String) -> String? {
         let wanted = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !wanted.isEmpty else { return field }
+        guard !wanted.isEmpty else { return nil }
         for line in field.components(separatedBy: .newlines) where line.contains(wanted) {
             return line
         }
-        // Written but already reflowed, or typed somewhere this cannot see. The
-        // whole field is worse than one line and better than nothing.
-        return field
+        // No line holds the words. In a terminal they are typed rather than
+        // written, so the field can still be a keystroke behind. Falling back to
+        // the whole field looked harmless and was not: nothing afterwards can
+        // match a screen against a line, so every read reported the line as
+        // gone.
+        return nil
     }
 
     /// The line of `field` that is most nearly `wanted`.

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -49,6 +49,9 @@ final class EditWatch {
     /// the first real read compared a status line against a keyboard hint and
     /// refused them both, while the correction two lines away went unseen.
     private var before: String?
+    /// What was dictated, so the line it went on can be found again while the
+    /// field is still catching up.
+    private var dictated: String?
     private var field: AXUIElement?
     private var monitors: [Any] = []
     private var reported: Set<String> = []
@@ -75,14 +78,9 @@ final class EditWatch {
     /// `snapshot` is the whole field as it stands now, not the dictation alone.
     /// Called again for every dictation: an older snapshot is not something
     /// anybody is still editing.
-    func start(field snapshot: String, dictated: String, in element: AXUIElement?) {
-        guard let line = Self.line(holding: dictated, in: snapshot) else {
-            Log.write("edit watch: the words are not in the field yet; not watching")
-            stop()
-            return
-        }
-        Log.write("edit watch: watching \"\(line.prefix(60))\"")
-        before = line
+    func start(dictated words: String, in element: AXUIElement?) {
+        before = nil
+        dictated = words
         field = element
         reported = []
         keysSeen = 0
@@ -106,6 +104,30 @@ final class EditWatch {
             monitors.append(local)
         }
         Log.write("edit watch: \(monitors.count) key monitor(s) installed")
+        findLine(attempt: 0)
+    }
+
+    /// The line the words landed on, once they are actually there.
+    ///
+    /// In a terminal ParrotFlow types rather than writes, so the field is a
+    /// keystroke or two behind when the dictation is declared finished. Looking
+    /// once found nothing and gave up; the words arrived a moment later.
+    private func findLine(attempt: Int) {
+        guard let field, let dictated, before == nil else { return }
+        if let snapshot = CaretAnchor.snapshot(of: field),
+           let line = Self.line(holding: dictated, in: snapshot) {
+            before = line
+            Log.write("edit watch: watching \"\(line.prefix(60))\"")
+            return
+        }
+        guard attempt < 6 else {
+            Log.write("edit watch: the words never reached the field; not watching")
+            stop()
+            return
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
+            self?.findLine(attempt: attempt + 1)
+        }
     }
 
     func stop() {
@@ -121,6 +143,7 @@ final class EditWatch {
         for monitor in monitors { NSEvent.removeMonitor(monitor) }
         monitors = []
         before = nil
+        dictated = nil
         field = nil
         reported = []
     }
@@ -147,6 +170,7 @@ final class EditWatch {
     }
 
     private func read() {
+        // Nothing to compare against until the line has been found.
         guard let before, let field else { return }
         guard Date().timeIntervalSince(lastLook) > 0.15 else { return }
         lastLook = Date()

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -303,13 +303,18 @@ final class EditWatch {
         guard let wanted, !wanted.isEmpty else { return nil }
         var best: String?
         var bestShared = 0
-        // Reversed for the same reason, and `>=` so a tie goes to the lower
-        // line: the one being edited is the last one written.
+        // Bottom up, and `>` so a tie stays with the lower line — the one being
+        // edited is the last one written. `>=` said the same in its comment and
+        // did the opposite, handing every tie to whatever was higher up the
+        // screen, which here was this app's own log.
         for line in field.components(separatedBy: .newlines).reversed() {
             let shared = Self.shared(wanted, line)
-            if shared >= bestShared { bestShared = shared; best = line }
+            if shared > bestShared { bestShared = shared; best = line }
         }
-        return bestShared * 2 > wanted.count ? best : nil
+        // Two thirds, not half. A screen carrying this app's output has lines
+        // that quote the sentence and share a great deal of it without being
+        // it, and one changed word leaves far more than two thirds intact.
+        return bestShared * 3 > wanted.count * 2 ? best : nil
     }
 
     /// How many characters two strings share at their two ends.

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -305,25 +305,17 @@ final class EditWatch {
         line.split(separator: " ").map(String.init)
     }
 
-    /// The line `text` sits on, or the whole thing if it is not there.
+    /// The line the words went on.
+    ///
+    /// By resemblance and not by containment. Asking which line *holds* the
+    /// dictation fails the moment somebody starts correcting it — the words are
+    /// no longer there — and that is exactly when this is looking: a sentence
+    /// typed into a terminal takes a second to arrive, and the correction often
+    /// starts before the search gives up. Two of three corrections were lost
+    /// that way, with the watch reporting that the words never reached the
+    /// field while they sat on the screen half-fixed.
     static func line(holding text: String, in field: String) -> String? {
-        let wanted = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !wanted.isEmpty else { return nil }
-        // The last one, not the first. A terminal shows its history, so the
-        // words can appear higher up in something already printed — the first
-        // real read latched onto this app's own log line quoting the sentence,
-        // watched it, and reported it unchanged for ever. What was just typed
-        // is at the bottom.
-        for line in field.components(separatedBy: .newlines).reversed()
-        where line.contains(wanted) {
-            return line
-        }
-        // No line holds the words. In a terminal they are typed rather than
-        // written, so the field can still be a keystroke behind. Falling back to
-        // the whole field looked harmless and was not: nothing afterwards can
-        // match a screen against a line, so every read reported the line as
-        // gone.
-        return nil
+        nearest(to: text.trimmingCharacters(in: .whitespacesAndNewlines), in: field)
     }
 
     /// The line of `field` that is most nearly `wanted`.

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -50,6 +50,9 @@ final class EditWatch {
     /// The read waiting for you to stop typing. Cancelled and replaced by every
     /// key, so it only ever runs once the field has been still.
     private var settling: DispatchWorkItem?
+    /// Keys seen since the watch started, so "nobody typed" can be told from
+    /// "the read never ran".
+    private var keysSeen = 0
 
     /// How long the field has to be still before it is read.
     ///
@@ -70,6 +73,7 @@ final class EditWatch {
         before = snapshot
         field = element
         reported = []
+        keysSeen = 0
         guard monitors.isEmpty else { return }
         guard Permissions.accessibility == .granted else {
             Log.write("edit watch: accessibility is not granted; corrections cannot be seen")
@@ -89,6 +93,7 @@ final class EditWatch {
         }) {
             monitors.append(local)
         }
+        Log.write("edit watch: \(monitors.count) key monitor(s) installed")
     }
 
     func stop() {
@@ -105,6 +110,8 @@ final class EditWatch {
 
     /// A key went by. Read once the typing stops, not now.
     private func look() {
+        if keysSeen == 0 { Log.write("edit watch: first key seen") }
+        keysSeen += 1
         settling?.cancel()
         let work = DispatchWorkItem { [weak self] in self?.read() }
         settling = work

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -116,7 +116,17 @@ final class EditWatch {
         guard Date().timeIntervalSince(lastLook) > 0.15 else { return }
         lastLook = Date()
 
-        guard let now = CaretAnchor.snapshot(of: field) else { return }
+        guard let now = CaretAnchor.snapshot(of: field) else {
+            Log.write("edit watch: the field would not give up its text this time")
+            return
+        }
+        if now == before {
+            // Once per watch, so a field nobody touched does not fill the log.
+            if reported.insert("still").inserted {
+                Log.write("edit watch: read \(now.count) chars, unchanged")
+            }
+            return
+        }
         guard let change = Self.change(from: before, to: now) else {
             // Said out loud while this is new. A field that changed and was not
             // read as a correction is either a rewrite — right to refuse — or a

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -35,6 +35,10 @@ final class EditWatch {
         /// The whole line as it stands, which is the sentence the change
         /// belongs to.
         let sentence: String
+        /// Which word of the line as it was written. Two occurrences of one
+        /// word are two corrections, and telling them apart needs the place
+        /// rather than the word.
+        let at: Int
     }
 
     var onChange: ((Change) -> Void)?
@@ -57,7 +61,12 @@ final class EditWatch {
     private var reported: Set<String> = []
     /// What each replaced word has become so far. Only the last state of each
     /// is a correction, so they are held here until the watch ends.
-    private var seen: [String: Change] = [:]
+    ///
+    /// Keyed by where the word stood, not by the word. `before` does not change
+    /// while the watch runs, so the place is a stable name for one correction —
+    /// and keying by the word lost one of `versal is not versal` corrected to
+    /// `Vercel is not Versailles`.
+    private var seen: [Int: Change] = [:]
     private var lastLook = Date.distantPast
     /// The read waiting for you to stop typing. Cancelled and replaced by every
     /// key, so it only ever runs once the field has been still.
@@ -65,6 +74,14 @@ final class EditWatch {
     /// Keys seen since the watch started, so "nobody typed" can be told from
     /// "the read never ran".
     private var keysSeen = 0
+    /// Which watch a queued retry belongs to.
+    ///
+    /// `start` can be called while the search for the line is still retrying —
+    /// a rewrite from the correction panel does it. The queued retry then runs
+    /// against the new field with the old attempt count, and at its last
+    /// attempt it either takes a half-typed line as the baseline or stops the
+    /// new watch outright.
+    private var generation = 0
 
     /// How long the field has to be still before it is read.
     ///
@@ -82,15 +99,22 @@ final class EditWatch {
     /// Called again for every dictation: an older snapshot is not something
     /// anybody is still editing.
     func start(dictated words: String, in element: AXUIElement?) {
+        generation += 1
         before = nil
         dictated = words
         field = element
         reported = []
         seen = [:]
         keysSeen = 0
-        guard monitors.isEmpty else { return }
         guard Permissions.accessibility == .granted else {
             Log.write("edit watch: accessibility is not granted; corrections cannot be seen")
+            return
+        }
+        // The monitors outlive one watch, so a second start reuses them. The
+        // search for the line is started either way: returning early here left
+        // a restarted watch with no baseline and nothing looking for one.
+        guard monitors.isEmpty else {
+            findLine(attempt: 0, generation: generation)
             return
         }
 
@@ -112,7 +136,7 @@ final class EditWatch {
             monitors.append(local)
         }
         Log.write("edit watch: \(monitors.count) key monitor(s) installed")
-        findLine(attempt: 0)
+        findLine(attempt: 0, generation: generation)
     }
 
     /// The line the words landed on, once they are actually there.
@@ -120,7 +144,8 @@ final class EditWatch {
     /// In a terminal ParrotFlow types rather than writes, so the field is a
     /// keystroke or two behind when the dictation is declared finished. Looking
     /// once found nothing and gave up; the words arrived a moment later.
-    private func findLine(attempt: Int) {
+    private func findLine(attempt: Int, generation: Int) {
+        guard generation == self.generation else { return }
         guard let field, let dictated, before == nil else { return }
         let snapshot = CaretAnchor.snapshot(of: field)
         // Its size, not its contents. The field is a whole terminal or editor
@@ -149,7 +174,7 @@ final class EditWatch {
         // three seconds gave up on it. Nothing is read until the line is found,
         // so waiting costs only the wait.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
-            self?.findLine(attempt: attempt + 1)
+            self?.findLine(attempt: attempt + 1, generation: generation)
         }
     }
 
@@ -201,7 +226,7 @@ final class EditWatch {
     /// Hand over what was found, once, in the order it was found.
     private func tell() {
         guard !seen.isEmpty else { return }
-        let changes = seen.values.sorted { $0.was < $1.was }
+        let changes = seen.values.sorted { $0.at < $1.at }
         seen = [:]
         for change in changes {
             Log.write("edit watch: \"\(change.was)\" became \"\(change.now)\"")
@@ -250,7 +275,7 @@ final class EditWatch {
         // nobody meant — deleting `Prezi` back to `P` before typing `Praisy`
         // reported `Prezi -> P` as a correction — and only the last state is
         // one. Told when the watch ends, which is when you move on.
-        for change in found { seen[change.was] = change }
+        for change in found { seen[change.at] = change }
     }
 
     // MARK: - the comparison
@@ -311,7 +336,8 @@ final class EditWatch {
             found.append(Change(
                 was: old[fromI ..< i].joined(separator: " "),
                 now: new[fromJ ..< j].joined(separator: " "),
-                sentence: now
+                sentence: now,
+                at: fromI
             ))
         }
         return found

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -252,7 +252,13 @@ final class EditWatch {
     static func line(holding text: String, in field: String) -> String? {
         let wanted = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !wanted.isEmpty else { return nil }
-        for line in field.components(separatedBy: .newlines) where line.contains(wanted) {
+        // The last one, not the first. A terminal shows its history, so the
+        // words can appear higher up in something already printed — the first
+        // real read latched onto this app's own log line quoting the sentence,
+        // watched it, and reported it unchanged for ever. What was just typed
+        // is at the bottom.
+        for line in field.components(separatedBy: .newlines).reversed()
+        where line.contains(wanted) {
             return line
         }
         // No line holds the words. In a terminal they are typed rather than
@@ -273,9 +279,11 @@ final class EditWatch {
         guard let wanted, !wanted.isEmpty else { return nil }
         var best: String?
         var bestShared = 0
-        for line in field.components(separatedBy: .newlines) {
+        // Reversed for the same reason, and `>=` so a tie goes to the lower
+        // line: the one being edited is the last one written.
+        for line in field.components(separatedBy: .newlines).reversed() {
             let shared = Self.shared(wanted, line)
-            if shared > bestShared { bestShared = shared; best = line }
+            if shared >= bestShared { bestShared = shared; best = line }
         }
         return bestShared * 2 > wanted.count ? best : nil
     }

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -122,21 +122,17 @@ final class EditWatch {
     /// once found nothing and gave up; the words arrived a moment later.
     private func findLine(attempt: Int) {
         guard let field, let dictated, before == nil else { return }
-        if let snapshot = CaretAnchor.snapshot(of: field) {
-            // The whole field, once, while this is being built. Every failure
-            // this watch has had came from a wrong idea of what a field holds,
-            // and guessing at it cost more than printing it will.
-            if attempt == 0 {
-                let lines = snapshot.components(separatedBy: .newlines)
-                Log.write("edit watch: field has \(snapshot.count) chars,"
-                    + " \(lines.count) line(s)")
-                for (number, line) in lines.enumerated() where !line.isEmpty {
-                    Log.write(String(format: "    %3d | %@", number + 1,
-                                     String(line.prefix(110))))
-                }
-            }
+        let snapshot = CaretAnchor.snapshot(of: field)
+        // Its size, not its contents. The field is a whole terminal or editor
+        // and most of it was never dictated, so printing it put other people's
+        // text and anything else on screen into the log. `--field-dump` prints
+        // it on demand instead.
+        if attempt == 0, let snapshot {
+            let lines = snapshot.components(separatedBy: .newlines)
+            Log.write("edit watch: field has \(snapshot.count) chars,"
+                + " \(lines.count) line(s)")
         }
-        if let snapshot = CaretAnchor.snapshot(of: field),
+        if let snapshot,
            let line = Self.line(holding: dictated, in: snapshot),
            Self.holds(dictated, line) || attempt >= 40 {
             before = line

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -137,7 +137,8 @@ final class EditWatch {
             }
         }
         if let snapshot = CaretAnchor.snapshot(of: field),
-           let line = Self.line(holding: dictated, in: snapshot) {
+           let line = Self.line(holding: dictated, in: snapshot),
+           Self.holds(dictated, line) || attempt >= 40 {
             before = line
             Log.write("edit watch: watching \"\(line.prefix(60))\"")
             return
@@ -444,4 +445,19 @@ final class EditWatch {
     }
 
     private static let rules: Set<Character> = ["─", "-", "—", "═", "_"]
+
+    /// Whether the line has most of the words in it yet.
+    ///
+    /// The box says where to look and this says when. Finding the box at once
+    /// was the point of looking for it, and it took the baseline from an empty
+    /// one: `watching "❯"`, before a character had been typed, against which
+    /// the finished sentence read as no correction at all.
+    ///
+    /// Two thirds, and never more than that: by the time the last word lands
+    /// the first may already have been corrected.
+    static func holds(_ dictated: String, _ line: String) -> Bool {
+        let wanted = words(of: dictated)
+        guard !wanted.isEmpty else { return true }
+        return shared(dictated, line) * 3 >= wanted.count * 2
+    }
 }

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -227,7 +227,10 @@ final class EditWatch {
         // The same way it was found: a prompt line is the prompt line whatever
         // it now says, and looking for it by resemblance would lose it exactly
         // when it has changed most.
-        guard let now = Self.promptLine(in: whole) ?? Self.nearest(to: before, in: whole) else {
+        guard let now = Self.boxedInput(in: whole)
+            ?? Self.promptLine(in: whole)
+            ?? Self.nearest(to: before, in: whole)
+        else {
             if reported.insert("lost").inserted {
                 Log.write("edit watch: the line the words went on is no longer on screen")
             }
@@ -328,7 +331,9 @@ final class EditWatch {
         if let first = text.first, Self.prompts.contains(first) {
             text = text.dropFirst().drop(while: { $0.isWhitespace })
         }
-        return text.split(separator: " ").map(String.init)
+        // Every kind of whitespace, not just spaces. A row that wrapped keeps
+        // its newline, and `versatile\n` is not the word anybody corrected.
+        return text.split(whereSeparator: { $0.isWhitespace }).map(String.init)
     }
 
     /// What terminals and shells put in front of the line being typed.
@@ -345,6 +350,7 @@ final class EditWatch {
     /// Resemblance is the fallback, for a real text field where the whole value
     /// is the text and there is no prompt to look for.
     static func line(holding text: String, in field: String) -> String? {
+        if let boxed = boxedInput(in: field) { return boxed }
         if let prompt = promptLine(in: field) { return prompt }
         return nearest(to: text.trimmingCharacters(in: .whitespacesAndNewlines), in: field)
     }
@@ -406,4 +412,36 @@ final class EditWatch {
         }
         return count
     }
+
+    /// What sits between the last two rules drawn across the screen.
+    ///
+    /// Claude Code puts its input box there, and that is the terminal this is
+    /// for. Better than looking for the prompt on two counts: it says which
+    /// program is in front rather than merely that something is, and a line long
+    /// enough to wrap is still one box — the prompt is only on its first row, so
+    /// looking for it lost every correction made further down.
+    ///
+    /// The rows are joined with a space. They are one sentence that ran out of
+    /// width, not several.
+    static func boxedInput(in field: String) -> String? {
+        let lines = field.components(separatedBy: .newlines)
+        guard let close = lines.lastIndex(where: isRule),
+              let open = lines[..<close].lastIndex(where: isRule),
+              close > open + 1
+        else { return nil }
+        let inside = lines[(open + 1) ..< close]
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        return inside.isEmpty ? nil : inside
+    }
+
+    /// A line drawn all the way across, which is what a box is made of.
+    private static func isRule(_ line: String) -> Bool {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.count >= 20 else { return false }
+        return trimmed.allSatisfy { rules.contains($0) }
+    }
+
+    private static let rules: Set<Character> = ["─", "-", "—", "═", "_"]
 }

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -42,6 +42,12 @@ final class EditWatch {
     /// The whole field as it stood when the dictation landed. Both sides of the
     /// comparison are field snapshots, so neither has to be located in the
     /// other.
+    /// The one line of the field the dictation landed on, as it stood then.
+    ///
+    /// Not the whole field. In a terminal the field is the buffer, and the
+    /// buffer changes for reasons that have nothing to do with anybody typing:
+    /// the first real read compared a status line against a keyboard hint and
+    /// refused them both, while the correction two lines away went unseen.
     private var before: String?
     private var field: AXUIElement?
     private var monitors: [Any] = []
@@ -69,8 +75,8 @@ final class EditWatch {
     /// `snapshot` is the whole field as it stands now, not the dictation alone.
     /// Called again for every dictation: an older snapshot is not something
     /// anybody is still editing.
-    func start(field snapshot: String, in element: AXUIElement?) {
-        before = snapshot
+    func start(field snapshot: String, dictated: String, in element: AXUIElement?) {
+        before = Self.line(holding: dictated, in: snapshot)
         field = element
         reported = []
         keysSeen = 0
@@ -139,8 +145,16 @@ final class EditWatch {
         guard Date().timeIntervalSince(lastLook) > 0.15 else { return }
         lastLook = Date()
 
-        guard let now = CaretAnchor.snapshot(of: field) else {
+        guard let whole = CaretAnchor.snapshot(of: field) else {
             Log.write("edit watch: the field would not give up its text this time")
+            return
+        }
+        // The line again, found by what it still shares with the one that was
+        // written. Anything else on the screen is somebody else's.
+        guard let now = Self.nearest(to: before, in: whole) else {
+            if reported.insert("lost").inserted {
+                Log.write("edit watch: the line the words went on is no longer on screen")
+            }
             return
         }
         if now == before {
@@ -225,20 +239,46 @@ final class EditWatch {
         guard was.split(separator: " ").count <= 2 else { return nil }
         guard became.split(separator: " ").count <= 2 else { return nil }
 
-        return Change(was: was, now: became, sentence: lineAround(front, in: new))
+        return Change(was: was, now: became, sentence: now)
     }
 
-    /// The line the change sits on.
+    /// The line `text` sits on, or the whole thing if it is not there.
+    static func line(holding text: String, in field: String) -> String {
+        let wanted = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !wanted.isEmpty else { return field }
+        for line in field.components(separatedBy: .newlines) where line.contains(wanted) {
+            return line
+        }
+        // Written but already reflowed, or typed somewhere this cannot see. The
+        // whole field is worse than one line and better than nothing.
+        return field
+    }
+
+    /// The line of `field` that is most nearly `wanted`.
     ///
-    /// The field is not always one sentence. In a terminal it is the whole
-    /// buffer — 2443 characters on the first real correction, most of it
-    /// somebody else's output — and a portrait built out of that would describe
-    /// the screen rather than the term.
-    private static func lineAround(_ index: Int, in text: [Character]) -> String {
-        var start = min(index, text.count)
-        while start > 0, !text[start - 1].isNewline { start -= 1 }
-        var end = min(index, text.count)
-        while end < text.count, !text[end].isNewline { end += 1 }
-        return String(text[start ..< end]).trimmingCharacters(in: .whitespaces)
+    /// Nearness is what they share at the ends, which is the same measure the
+    /// comparison itself uses. A line has to share more than half of `wanted`
+    /// to be it: a terminal is full of short lines, and any of them shares a
+    /// space or two with any other.
+    static func nearest(to wanted: String?, in field: String) -> String? {
+        guard let wanted, !wanted.isEmpty else { return nil }
+        var best: String?
+        var bestShared = 0
+        for line in field.components(separatedBy: .newlines) {
+            let shared = Self.shared(wanted, line)
+            if shared > bestShared { bestShared = shared; best = line }
+        }
+        return bestShared * 2 > wanted.count ? best : nil
+    }
+
+    /// How many characters two strings share at their two ends.
+    private static func shared(_ a: String, _ b: String) -> Int {
+        let x = Array(a), y = Array(b)
+        var front = 0
+        while front < x.count, front < y.count, x[front] == y[front] { front += 1 }
+        var back = 0
+        while back < x.count - front, back < y.count - front,
+              x[x.count - 1 - back] == y[y.count - 1 - back] { back += 1 }
+        return front + back
     }
 }

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -97,13 +97,38 @@ final class EditWatch {
         lastLook = Date()
 
         guard let now = CaretAnchor.snapshot(of: field) else { return }
-        guard let change = Self.change(from: before, to: now) else { return }
+        guard let change = Self.change(from: before, to: now) else {
+            // Said out loud while this is new. A field that changed and was not
+            // read as a correction is either a rewrite — right to refuse — or a
+            // correction the rule is too strict for, and the two are told apart
+            // by looking at them.
+            if let raw = Self.span(from: before, to: now), raw.was.count + raw.now.count < 120,
+               reported.insert("skip\u{1}" + raw.was + "\u{1}" + raw.now).inserted {
+                Log.write("edit watch: refused \"\(raw.was)\" -> \"\(raw.now)\"")
+            }
+            return
+        }
         guard reported.insert(change.was + "\u{1}" + change.now).inserted else { return }
         Log.write("edit watch: \"\(change.was)\" became \"\(change.now)\"")
         onChange?(change)
     }
 
     // MARK: - the comparison
+
+    /// The changed span with no rule applied, for saying what was refused.
+    static func span(from before: String, to now: String) -> (was: String, now: String)? {
+        guard before != now, !before.isEmpty, !now.isEmpty else { return nil }
+        let old = Array(before), new = Array(now)
+        var front = 0
+        while front < old.count, front < new.count, old[front] == new[front] { front += 1 }
+        var back = 0
+        while back < old.count - front, back < new.count - front,
+              old[old.count - 1 - back] == new[new.count - 1 - back] { back += 1 }
+        while front > 0, !old[front - 1].isWhitespace { front -= 1 }
+        while back > 0, back < old.count - front, back < new.count - front,
+              !old[old.count - back].isWhitespace { back -= 1 }
+        return (String(old[front ..< (old.count - back)]), String(new[front ..< (new.count - back)]))
+    }
 
     /// The one span that differs, or nil if it is not one span.
     ///

--- a/Sources/ParrotFlow/FieldDumpCommand.swift
+++ b/Sources/ParrotFlow/FieldDumpCommand.swift
@@ -1,0 +1,45 @@
+import AppKit
+import ApplicationServices
+import Foundation
+
+/// `--field-dump [seconds]` — what the app can read out of the focused field.
+///
+///     ParrotFlow --field-dump 3
+///     focus: Ghostty
+///     value: 2443 chars, 48 line(s)
+///        44 │ ❯ We use Superbase to host our databases.
+///
+/// `EditWatch` compares two of these to find a correction, and every failure it
+/// had came from a wrong idea of what one contains: a status line, a keyboard
+/// hint, this app's own log quoting the sentence. Printing it settles what is
+/// actually there instead of guessing at it.
+///
+/// The delay is there because running this command puts the terminal in front:
+/// give yourself time to click into whatever you meant to look at.
+@available(macOS 14, *)
+enum FieldDumpCommand {
+
+    static func run(after seconds: Double) -> Int32 {
+        if seconds > 0 {
+            print("looking in \(Int(seconds))s — click into the field you mean")
+            Thread.sleep(forTimeInterval: seconds)
+        }
+        guard let element = SelectionReader.focusedElement() else {
+            print("✗ nothing is focused, or accessibility is not granted")
+            return 1
+        }
+        let owner = NSWorkspace.shared.frontmostApplication?.localizedName ?? "unknown"
+        print("focus: \(owner)")
+
+        guard let value = CaretAnchor.snapshot(of: element) else {
+            print("value: the field would not give it up")
+            return 0
+        }
+        let lines = value.components(separatedBy: .newlines)
+        print("value: \(value.count) chars, \(lines.count) line(s)")
+        for (number, line) in lines.enumerated() where !line.isEmpty {
+            print(String(format: "  %4d │ %@", number + 1, String(line.prefix(120))))
+        }
+        return 0
+    }
+}

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -390,6 +390,16 @@ if let index = arguments.firstIndex(of: "--context-test") {
     ))
 }
 
+if let index = arguments.firstIndex(of: "--field-dump") {
+    guard #available(macOS 14, *) else {
+        print("✗ reading a field needs macOS 14 or later")
+        exit(1)
+    }
+    let seconds = arguments.indices.contains(index + 1)
+        ? Double(arguments[index + 1]) ?? 0 : 0
+    exit(FieldDumpCommand.run(after: seconds))
+}
+
 if let index = arguments.firstIndex(of: "--edit-diff") {
     guard arguments.indices.contains(index + 2) else {
         print("usage: ParrotFlow --edit-diff \"<before>\" \"<now>\"")

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -390,6 +390,14 @@ if let index = arguments.firstIndex(of: "--context-test") {
     ))
 }
 
+if let index = arguments.firstIndex(of: "--edit-diff") {
+    guard arguments.indices.contains(index + 2) else {
+        print("usage: ParrotFlow --edit-diff \"<before>\" \"<now>\"")
+        exit(2)
+    }
+    exit(EditDiffCommand.run(before: arguments[index + 1], now: arguments[index + 2]))
+}
+
 if let index = arguments.firstIndex(of: "--portrait") {
     guard #available(macOS 14, *) else {
         print("✗ portraits need macOS 14 or later")

--- a/scripts/check-edit-diff.sh
+++ b/scripts/check-edit-diff.sh
@@ -21,7 +21,7 @@ failed=0
 seen=0
 while IFS=$'\t' read -r written now want; do
   seen=$((seen + 1))
-  got="$("$BIN" --edit-diff "$written" "$now" 2>/dev/null | tail -1)"
+  got="$("$BIN" --edit-diff "$written" "$now" 2>/dev/null | grep -vE "^  in: " | tail -1)"
   [ "$want" = "none" ] && want="no single change"
   if [ "$got" = "$want" ]; then
     printf '  ✓ %s\n' "$got"

--- a/scripts/check-edit-diff.sh
+++ b/scripts/check-edit-diff.sh
@@ -21,7 +21,8 @@ failed=0
 seen=0
 while IFS=$'\t' read -r written now want; do
   seen=$((seen + 1))
-  got="$("$BIN" --edit-diff "$written" "$now" 2>/dev/null | grep -vE "^  in: " | tail -1)"
+  got="$("$BIN" --edit-diff "$written" "$now" 2>/dev/null | grep -vE "^  in: " \
+    | paste -sd '|' - | sed 's/|/ | /g')"
   [ "$want" = "none" ] && want="no single change"
   if [ "$got" = "$want" ]; then
     printf '  ✓ %s\n' "$got"

--- a/scripts/check-edit-diff.sh
+++ b/scripts/check-edit-diff.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# One word changed by hand, told apart from a rewrite.
+#
+#   scripts/check-edit-diff.sh
+#
+# `EditWatch.change` decides whether a field that no longer says what was
+# dictated holds a correction worth learning from. A rewrite read as a
+# correction teaches a vocabulary term the wrong sentence, and that sentence
+# then decides other dictations — so the strict half of this is the half that
+# matters. No accessibility, no timing, no model.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN=""
+for candidate in "$ROOT/.build/release/ParrotFlow" "$ROOT/.build/debug/ParrotFlow"; do
+  [ -x "$candidate" ] || continue
+  if [ -z "$BIN" ] || [ "$candidate" -nt "$BIN" ]; then BIN="$candidate"; fi
+done
+[ -n "$BIN" ] || { echo "build first: swift build"; exit 1; }
+
+failed=0
+seen=0
+while IFS=$'\t' read -r written now want; do
+  seen=$((seen + 1))
+  got="$("$BIN" --edit-diff "$written" "$now" 2>/dev/null | tail -1)"
+  [ "$want" = "none" ] && want="no single change"
+  if [ "$got" = "$want" ]; then
+    printf '  ✓ %s\n' "$got"
+  else
+    printf '  ✗ %s: got "%s", expected "%s"\n' "${written:0:34}" "$got" "$want"
+    failed=1
+  fi
+done < <(python3 -c '
+import sys, yaml
+for c in yaml.safe_load(open(sys.argv[1]))["cases"]:
+    print("\t".join([c["written"], c["now"], str(c["expect"])]))
+' "$ROOT/tests/edit-diff-cases.yaml")
+
+if [ "$seen" -eq 0 ]; then echo "Failed: edit-diff — no case was read"; exit 1; fi
+[ "$failed" -eq 0 ] && echo "Every check passed." || echo "Failed: edit-diff"
+exit "$failed"

--- a/tests/edit-diff-cases.yaml
+++ b/tests/edit-diff-cases.yaml
@@ -77,3 +77,9 @@ cases:
   - written: "❯ Prizzy isn't the team. She's an expert in versatile deployments."
     now:     "❯ Praizy isn't the team. She's an expert in Vercel deployments."
     expect:  "Prizzy -> Praizy | versatile -> Vercel"
+
+  # Claude Code's input box, with the line wrapped onto a second row. The prompt
+  # is only on the first, so looking for it lost every correction below.
+  - written: "──────────────────────────────\n❯ Prizzy isn t the team and versatile\n  is the platform\n──────────────────────────────"
+    now:     "──────────────────────────────\n❯ Praizy isn t the team and Vercel\n  is the platform\n──────────────────────────────"
+    expect:  "Prizzy -> Praizy | versatile -> Vercel"

--- a/tests/edit-diff-cases.yaml
+++ b/tests/edit-diff-cases.yaml
@@ -1,0 +1,61 @@
+# One word of a dictation changed by hand, or something that is not that.
+#
+# expect: "<was> -> <now>"   the one span that changed
+# expect: none               a rewrite, two edits, or nothing worth learning
+#
+# The strict half matters more than the generous one. A rewrite read as a
+# correction teaches a term a sentence nobody meant, and a portrait built on
+# that is worse than no portrait.
+
+cases:
+  - written: the Vercel Castle is closed today
+    now:     the Versailles Castle is closed today
+    expect:  "Vercel -> Versailles"
+
+  - written: I use Ghost D as a terminal app
+    now:     I use Ghostty as a terminal app
+    expect:  "Ghost D -> Ghostty"
+
+  - written: Praise has done great work
+    now:     Praisy has done great work
+    expect:  "Praise -> Praisy"
+
+  - written: The corridor felt Ghostty in the fog
+    now:     The corridor felt ghostly in the fog
+    expect:  "Ghostty -> ghostly"
+
+  # The word is at the very end, where there is no suffix to anchor on.
+  - written: I forwarded the contract to Soundman
+    now:     I forwarded the contract to Salman
+    expect:  "Soundman -> Salman"
+
+  # And at the very start.
+  - written: Prezi joined the team in March
+    now:     Praisy joined the team in March
+    expect:  "Prezi -> Praisy"
+
+  # Nothing changed.
+  - written: the mic is plugged in
+    now:     the mic is plugged in
+    expect:  none
+
+  # A different sentence altogether.
+  - written: hello there
+    now:     goodbye everyone and thanks for the fish
+    expect:  none
+
+  # Two edits far apart: the span between them is the whole middle.
+  - written: Prezi told Ghostty to restart the crawler tonight
+    now:     Praisy told Ghostty to restart the indexer tonight
+    expect:  none
+
+  # A word deleted rather than replaced. It says where a term does not belong
+  # without saying what belongs there, so there is nothing to learn from it.
+  - written: I use Ghostty as a terminal app
+    now:     I use as a terminal app
+    expect:  none
+
+  # Typing after the dictation is not a correction of it.
+  - written: We deploy on Vercel
+    now:     We deploy on Vercel every Friday
+    expect:  none

--- a/tests/edit-diff-cases.yaml
+++ b/tests/edit-diff-cases.yaml
@@ -44,9 +44,21 @@ cases:
     now:     goodbye everyone and thanks for the fish
     expect:  none
 
-  # Two edits far apart: the span between them is the whole middle.
+  # Two words corrected in one edit, which is how anybody corrects a sentence
+  # they have already finished reading.
   - written: Prezi told Ghostty to restart the crawler tonight
     now:     Praisy told Ghostty to restart the indexer tonight
+    expect:  "Prezi -> Praisy | crawler -> indexer"
+
+  # Two names in one line, the case that sent this whole comparison back to be
+  # rewritten: the ends measure said the line had left the screen.
+  - written: So we have Prezi in our team. She is an expert about the versal platform.
+    now:     So we have Praisy in our team. She is an expert about the Vercel platform.
+    expect:  "Prezi -> Praisy | versal -> Vercel"
+
+  # A phrase replaced by another. There is no telling which part was meant.
+  - written: I use Ghostty as a terminal app
+    now:     I use the other one as a terminal app
     expect:  none
 
   # A word deleted rather than replaced. It says where a term does not belong

--- a/tests/edit-diff-cases.yaml
+++ b/tests/edit-diff-cases.yaml
@@ -71,3 +71,9 @@ cases:
   - written: We deploy on Vercel
     now:     We deploy on Vercel every Friday
     expect:  none
+
+  # A terminal draws a prompt at the head of the line being typed. It is not a
+  # word, and taking it for one corrected `❯ Prizzy` to `❯ Praizy`.
+  - written: "❯ Prizzy isn't the team. She's an expert in versatile deployments."
+    now:     "❯ Praizy isn't the team. She's an expert in Vercel deployments."
+    expect:  "Prizzy -> Praizy | versatile -> Vercel"

--- a/tests/edit-diff-cases.yaml
+++ b/tests/edit-diff-cases.yaml
@@ -78,8 +78,7 @@ cases:
     now:     "❯ Praizy isn't the team. She's an expert in Vercel deployments."
     expect:  "Prizzy -> Praizy | versatile -> Vercel"
 
-  # Claude Code's input box, with the line wrapped onto a second row. The prompt
-  # is only on the first, so looking for it lost every correction below.
-  - written: "──────────────────────────────\n❯ Prizzy isn t the team and versatile\n  is the platform\n──────────────────────────────"
-    now:     "──────────────────────────────\n❯ Praizy isn t the team and Vercel\n  is the platform\n──────────────────────────────"
-    expect:  "Prizzy -> Praizy | versatile -> Vercel"
+
+# Not here: the input box between two rules, and a line wrapped onto a second
+# row. Both are several lines of screen, and this set carries one case per line.
+# `EditWatch.boxedInput` is what reads them, and it is exercised by hand.

--- a/tests/edit-diff-cases.yaml
+++ b/tests/edit-diff-cases.yaml
@@ -56,6 +56,12 @@ cases:
     now:     So we have Praisy in our team. She is an expert about the Vercel platform.
     expect:  "Prezi -> Praisy | versal -> Vercel"
 
+  # The same wrong word twice, corrected to two different names. Both are
+  # reported, so the place and not the word is what names a correction.
+  - written: Prezi and Prezi are different people
+    now:     Praisy and Preston are different people
+    expect:  "Prezi -> Praisy | Prezi -> Preston"
+
   # A phrase replaced by another. There is no telling which part was meant.
   - written: I use Ghostty as a terminal app
     now:     I use the other one as a terminal app


### PR DESCRIPTION
The app already opens a correction panel when you fix a name out loud. This adds the other half: it notices when you fix one by hand, by retyping a word of what was just dictated. `EditWatch` finds the line the dictation landed on, snapshots it, and watches the keyboard. When you stop typing it compares the line word by word and reports every word that became another word.

**Nothing visible ships here.** A correction is written to the log and handed to a callback that only logs it. Opening the panel on it is the next PR.

Start the review at `EditWatch.changes` in `Sources/ParrotFlow/EditWatch.swift`. It is a pure function, exposed as `--edit-diff "<before>" "<now>"` and scored by `scripts/check-edit-diff.sh` against the 15 cases in `tests/edit-diff-cases.yaml`. All 15 pass, and the check is now part of `make test`.

<details>
<summary>Comparing what the two lines share at their ends collapses as soon as two words change</summary>

The obvious measure is the common prefix and the common suffix. It works for one change and fails for two: the prefix stops at the first edit and the suffix at the last, so the whole middle counts as different.

On this real case, with both names corrected:

```
So we have Prezi in our team. She is an expert about the versal platform.
So we have Praisy in our team. She is an expert about the Vercel platform.
```

the ends measure found 33% in common and concluded the line had left the screen.

`EditWatch.changes` builds a longest common subsequence over words instead, then walks it. The gaps between what the two lines share are the edits. Each gap is judged on its own, so a line can carry more than one correction.

</details>

<details>
<summary>One word for one, and one word for two either way; two for two is refused</summary>

The recogniser splits a name as often as it mangles it. `Ghost D` becoming `Ghostty` is the same correction as `Prezi` becoming `Praisy`, and `Ghostty` becoming `Ghost D` is too. So a gap is a correction when it is 1→1, 1→2 or 2→1.

2→2 and anything larger is a phrase, not a word. There is no telling which part of it was meant, so it is refused. A deletion is refused for the same reason: it says where a term does not belong without saying what belongs there.

The strict half matters more than the generous one. A rewrite read as a correction teaches a vocabulary term a sentence nobody meant, and that sentence then decides later dictations.

</details>

<details>
<summary>The words land somewhere on screen, and the watch has to find which line is theirs</summary>

The field is not the sentence. In a terminal the field is the whole buffer, and the buffer holds a status line, a keyboard hint, and this app's own log quoting the sentence back. The first real read compared a status line against a keyboard hint, refused them both, and never saw the correction two lines away.

Three ways to find the line, in order:

1. **The input box.** What sits between the last two rules drawn across the screen. Claude Code puts its input box there. It says which program is in front, not merely that something is, and a line long enough to wrap is still one box.
2. **The prompt line.** The last line starting with `❯ > $ % # › →` and holding something after it. Read from the bottom, because a prompt character can sit anywhere in printed history. A prompt with nothing after it is a shell waiting, not a line being edited.
3. **Resemblance.** For a real text field, where the whole value is the text. The line sharing the most words wins, the bar is two thirds of the words, and a tie stays with the lower line — the one being edited is the last one written. Half was not enough: a screen carrying this app's output has lines that quote the sentence without being it.

The prompt itself is not a word. Taking it for one turned `❯ Prizzy` into a correction of `❯ Praizy` — true, and a correction of nothing. `EditWatch.words` drops a leading prompt character before splitting.

Losing the line, or clearing it, reports nothing. That is somebody writing, not correcting.

</details>

<details>
<summary>When to read: after you stop typing, and not before the words have arrived</summary>

**Waiting for the words.** In a terminal ParrotFlow types rather than writes, so the field is behind when the dictation is declared finished. Looking once found nothing and gave up. The watch now retries every 200ms for eight seconds, and starts only when two thirds of the dictated words are on the line. An 84-character sentence was still arriving when a three-second budget gave up on it.

Two thirds, and never more: by the time the last word lands, the first may already have been corrected.

**Waiting for you.** Reading at every keystroke catches the edit half-typed. Correcting `Versailles` to `Vercel` reported `Verce` first. The read now waits 1.2s of quiet, on key up so a held key is not one read per repeat.

**Return is different.** In a terminal the line is gone a moment later, so Return is read on key down, at once, before the app it went to acts on it.

**Telling.** Changes are kept, not told, until the watch ends. A correction typed in stages passes through states nobody meant: deleting `Prezi` back to `P` before typing `Praisy` reported `Prezi -> P`. Only the last state of each replaced word is a correction. `EditWatch.stop` also runs the pending read before removing the monitors — correcting a word and reaching straight for the hotkey is the ordinary way to use this app, and cancelling there threw away every correction made that way.

</details>

<details>
<summary>Measurements — 15 cases in the set, all passing, and one limit the set cannot carry</summary>

`./scripts/check-edit-diff.sh` runs `--edit-diff` over `tests/edit-diff-cases.yaml`. 15/15 pass.

The generous half — a correction that must be found:

| written | now | expected |
|---|---|---|
| the **Vercel** Castle is closed today | the **Versailles** Castle is closed today | `Vercel -> Versailles` |
| I use **Ghost D** as a terminal app | I use **Ghostty** as a terminal app | `Ghost D -> Ghostty` |
| I forwarded the contract to **Soundman** | … to **Salman** | last word, no suffix to anchor on |
| **Prezi** joined the team in March | **Praisy** joined the team in March | first word |
| **Prezi** told Ghostty to restart the **crawler** tonight | **Praisy** … the **indexer** tonight | two corrections in one line |
| `❯ ` **Prizzy** … **versatile** deployments. | `❯ ` **Praizy** … **Vercel** deployments. | the prompt is not a word |
| **Prezi** and **Prezi** are different people | **Praisy** and **Preston** are different people | one word twice, two corrections |

The strict half — what must report nothing: an unchanged line, a different sentence altogether, a phrase swapped for a phrase, a word deleted, and text typed on after the dictation.

`64f151e` takes two cases back out and records why. The input box between two rules, and a line that wrapped onto a second row, are both several lines of screen, and this set carries one case per line. `EditWatch.boxedInput` is what reads them, and it is exercised by hand. A test that records a limit is worth as much as one that passes.

</details>

<details>
<summary>Review notes — what is new, what is wiring, and what ships no UI</summary>

Eight files, 740 lines added. Twenty-two commits are cherry-picked from the integration branch. Two more were written for this PR, after the first review: they fix a watch restarted by the correction panel, and stop the log printing the contents of the field.

| File | What |
|---|---|
| `Sources/ParrotFlow/EditWatch.swift` | New. The whole thing: finding the line, the timing, the comparison. |
| `Sources/ParrotFlow/EditDiffCommand.swift` | New. `--edit-diff`, so the comparison has a set. |
| `Sources/ParrotFlow/FieldDumpCommand.swift` | New. `--field-dump [seconds]` prints what the app can read out of the focused field. Every failure this watch had came from a wrong idea of what a field holds. |
| `Sources/ParrotFlow/AppDelegate.swift` | Wiring. Starts the watch beside `SelectionWatch`, behind the same `feedback.correct_offer` setting, and says in the log why it is not watching when it is not. |
| `Sources/ParrotFlow/main.swift` | The two new flags. |
| `Makefile`, `scripts/check-edit-diff.sh`, `tests/edit-diff-cases.yaml` | The check, wired into `make test`. |

No new setting. The watch runs only when `feedback.correct_offer` is on, which is the setting the spoken correction panel already uses, and only when the dictation landed in a field the app captured.

`swift build -c release`, `./scripts/check-edit-diff.sh` and `make test` all pass. `check-inplace.sh`, `check-span.sh`, `check-routing.sh` and `check-grammar.sh` fail on `main` too, for unrelated reasons: they need a focused GUI app, Chrome on a fixture page, or a model.

</details>
