### PR TITLE
feat: a name corrected by hand opens the vocabulary panel

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3457,11 +3457,46 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// anybody touched it.
     private func watchForEdits(in element: AXUIElement) {
         guard let last = lastDictated else { edits.stop(); return }
-        edits.onChange = { change in
-            Log.write("correction: \"\(change.was)\" -> \"\(change.now)\"")
-            Log.write("    in: \(change.sentence)")
+        edits.onCorrections = { [weak self] changes in
+            self?.offerToLearn(changes)
         }
         edits.start(dictated: last.text, in: element)
+    }
+
+    /// Put what was corrected by hand in front of you, as rules to keep or not.
+    ///
+    /// The panel rather than a notice, because a correction read off a screen is
+    /// a guess about what somebody meant: the words are right, what they are a
+    /// rule *for* is not always. Reviewing it is a second, and a rule saved
+    /// wrongly decides other sentences for as long as it stands.
+    ///
+    /// Only names. A correction into a word both word lists know — `remain` to
+    /// `remaining` — is English being fixed, not a term being taught, and a
+    /// panel about it would be noise on every dictation.
+    private func offerToLearn(_ changes: [EditWatch.Change]) {
+        let known = Set(config.vocabulary.terms.keys.map { $0.lowercased() })
+        let worth = changes.filter { change in
+            let word = change.now.trimmingCharacters(in: .punctuationCharacters)
+            guard !word.isEmpty else { return false }
+            return known.contains(word.lowercased()) || Vocabulary.unseenWord(word)
+        }
+        guard !worth.isEmpty else {
+            if !changes.isEmpty {
+                Log.write("correction: \(changes.count) change(s), none of them a name")
+            }
+            return
+        }
+        Log.write("correction: offering \(worth.count) rule(s) to keep")
+        let sentence = worth.first?.sentence ?? ""
+        correctionPanel.onSave = { [weak self] rules, _ in
+            // The field is already right — the person fixed it themselves. Only
+            // the rules are new, so `learn` and nothing after it.
+            _ = self?.learn(rules, in: sentence)
+        }
+        correctionPanel.onCancel = { Log.write("correction: the rules were declined") }
+        correctionPanel.show(
+            rules: worth.map { (heard: $0.was, corrected: $0.now) }, over: sentence
+        )
     }
 
     /// The offer, over words that were dictated and have been selected again.

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3477,6 +3477,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let sentence = changes.first?.sentence ?? ""
         let worth = changes.filter { teaches($0) }
         guard !worth.isEmpty else { return }
+        // Never over a panel already up. `show` replaces the rows and rebinds
+        // the save, so a second offer would throw the first away without
+        // showing it — and this is the only caller that arrives uninvited, so
+        // it is the only one that can do that to you. The reselection offer
+        // refuses for the same reason.
+        guard !correctionPanel.isUp else {
+            Log.write("correction: a panel is already up; not offering "
+                + worth.map { "\"\($0.was)\" -> \"\($0.now)\"" }.joined(separator: ", "))
+            return
+        }
         // The pairs, not just the count. What the panel was offering could not
         // be read back off the log, so the noise it was showing could not be
         // described — only that there was some.

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3474,21 +3474,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `remaining` — is English being fixed, not a term being taught, and a
     /// panel about it would be noise on every dictation.
     private func offerToLearn(_ changes: [EditWatch.Change]) {
-        let known = Set(config.vocabulary.terms.keys.map { $0.lowercased() })
-        let worth = changes.filter { change in
-            let word = change.now.trimmingCharacters(in: .punctuationCharacters)
-            guard !word.isEmpty else { return false }
-            let isTerm = known.contains(word.lowercased())
-            let unseen = Vocabulary.unseenWord(word)
-            Log.write("correction: \"\(word)\" — term \(isTerm), unseen \(unseen)")
-            return isTerm || unseen
-        }
-        guard !worth.isEmpty else {
-            if !changes.isEmpty {
-                Log.write("correction: \(changes.count) change(s), none of them a name")
-            }
-            return
-        }
+        // No filter, for now. Deciding what a term is from the two word lists
+        // is a bet on what dictionaries do not know yet, and it ages badly: the
+        // day `Vercel` enters them, every correction toward it stops being
+        // offered — and the shipped auto-apply rule stops firing too, since it
+        // asks the same question. The panel is a better filter than any guess
+        // while this is being tried out: the rows are removed there.
+        let worth = changes
+        guard !worth.isEmpty else { return }
         Log.write("correction: offering \(worth.count) rule(s) to keep")
         let sentence = worth.first?.sentence ?? ""
         correctionPanel.onSave = { [weak self] rules, _ in

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3474,16 +3474,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `remaining` — is English being fixed, not a term being taught, and a
     /// panel about it would be noise on every dictation.
     private func offerToLearn(_ changes: [EditWatch.Change]) {
-        // No filter, for now. Deciding what a term is from the two word lists
-        // is a bet on what dictionaries do not know yet, and it ages badly: the
-        // day `Vercel` enters them, every correction toward it stops being
-        // offered — and the shipped auto-apply rule stops firing too, since it
-        // asks the same question. The panel is a better filter than any guess
-        // while this is being tried out: the rows are removed there.
-        let worth = changes
+        let sentence = changes.first?.sentence ?? ""
+        let worth = changes.filter { teaches($0) }
         guard !worth.isEmpty else { return }
-        Log.write("correction: offering \(worth.count) rule(s) to keep")
-        let sentence = worth.first?.sentence ?? ""
+        // The pairs, not just the count. What the panel was offering could not
+        // be read back off the log, so the noise it was showing could not be
+        // described — only that there was some.
+        Log.write("correction: offering \(worth.count) rule(s) to keep — "
+            + worth.map { "\"\($0.was)\" -> \"\($0.now)\"" }.joined(separator: ", "))
         correctionPanel.onSave = { [weak self] rules, _ in
             // The field is already right — the person fixed it themselves. Only
             // the rules are new, so `learn` and nothing after it.
@@ -3493,6 +3491,46 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         correctionPanel.show(
             rules: worth.map { (heard: $0.was, corrected: $0.now) }, over: sentence
         )
+    }
+
+    /// Is this correction about a name, or about English?
+    ///
+    /// The panel used to show every one-word change, which is every typo and
+    /// every reword. Distance does not separate them — measured on this
+    /// speaker's own `heard:` lists against ordinary edits, `its -> it\'s`
+    /// scores 1.000 and `Prezi -> Praisy` scores 0.304, so any floor drawn
+    /// through spelling keeps the noise and drops the names.
+    ///
+    /// What separates them is the word the correction lands *on*. Measured on
+    /// the same two sets: the two word lists call 8 of 9 real corrections
+    /// unknown and all 10 of the ordinary ones known. `Sentry` is the miss, and
+    /// it is capitalised, so the second half catches it.
+    ///
+    /// An `or`, which is also the answer to why this was left out before: the
+    /// day `Vercel` enters a dictionary, the capital still offers it.
+    private func teaches(_ change: EditWatch.Change) -> Bool {
+        let letters = { (s: String) in String(s.filter { $0.isLetter || $0.isNumber }) }
+        // Punctuation or case alone is not a pronunciation. Spacing is: gluing
+        // two words into one is most of this vocabulary — `Red Rock` to
+        // `Redrock`, `Better Stack` to `BetterStack`, `Ghost T` to `Ghostty` —
+        // so the test that ignores punctuation must not ignore the space, or it
+        // throws away the commonest correction there is.
+        let spaced = { (s: String) in
+            String(s.filter { $0.isLetter || $0.isNumber || $0.isWhitespace }).lowercased()
+        }
+        guard spaced(change.was) != spaced(change.now) else {
+            Log.write("correction: \"\(change.was)\" -> \"\(change.now)\" is punctuation,"
+                + " not a name; not offered")
+            return false
+        }
+        if Vocabulary.unseenWord(letters(change.now)) { return true }
+        // A capital that is not the one every sentence starts with.
+        let line = change.sentence.trimmingCharacters(in: .whitespaces)
+        let opens = line.hasPrefix(change.now) || line.dropFirst().hasPrefix(change.now)
+        if change.now.first?.isUppercase == true, !opens { return true }
+        Log.write("correction: \"\(change.was)\" -> \"\(change.now)\" is ordinary English;"
+            + " not offered")
+        return false
     }
 
     /// The offer, over words that were dictated and have been selected again.

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3478,7 +3478,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let worth = changes.filter { change in
             let word = change.now.trimmingCharacters(in: .punctuationCharacters)
             guard !word.isEmpty else { return false }
-            return known.contains(word.lowercased()) || Vocabulary.unseenWord(word)
+            let isTerm = known.contains(word.lowercased())
+            let unseen = Vocabulary.unseenWord(word)
+            Log.write("correction: \"\(word)\" — term \(isTerm), unseen \(unseen)")
+            return isTerm || unseen
         }
         guard !worth.isEmpty else {
             if !changes.isEmpty {

--- a/Sources/ParrotFlow/CorrectionPanel.swift
+++ b/Sources/ParrotFlow/CorrectionPanel.swift
@@ -31,6 +31,10 @@ final class CorrectionPanel {
         present()
     }
 
+    /// The application that was in front when the panel opened, so the focus
+    /// can go back to it. Nil while no panel is up.
+    private var cameFrom: NSRunningApplication?
+
     private func present() {
         model.onSubmit = { [weak self] in self?.commit() }
         model.onCancel = { [weak self] in self?.dismiss(cancelled: true) }
@@ -39,6 +43,12 @@ final class CorrectionPanel {
         resize()
         reposition()
         watchForTab()
+        // Whoever was in front, recorded before we take the focus off them.
+        // Read now and not on the way out: by then it is this app.
+        let front = NSWorkspace.shared.frontmostApplication
+        if front?.processIdentifier != ProcessInfo.processInfo.processIdentifier {
+            cameFrom = front
+        }
         NSApp.activate(ignoringOtherApps: true)
         panel?.riseIntoView(makeKey: true)
 
@@ -74,6 +84,16 @@ final class CorrectionPanel {
         guard panel?.isVisible == true else { return }
         stopWatchingForTab()
         panel?.orderOut(nil)
+        // Back to what you were typing in. The panel took the focus to draw a
+        // caret in its own field, and `orderOut` alone leaves this app frontmost
+        // — so saving a rule mid-sentence left you typing into nothing.
+        //
+        // The application, not the field. Steering focus back to one element
+        // means setting `kAXFocused` and trusting the app to honour it; every
+        // other place here that returns focus activates the application and
+        // lets it restore its own.
+        if let owner = cameFrom, !owner.isActive { owner.activate() }
+        cameFrom = nil
         if cancelled { onCancel?() }
     }
 

--- a/Sources/ParrotFlow/CorrectionPanel.swift
+++ b/Sources/ParrotFlow/CorrectionPanel.swift
@@ -31,6 +31,10 @@ final class CorrectionPanel {
         present()
     }
 
+    /// Is a panel on screen right now? `show` replaces what is in the one
+    /// panel, so a caller that was not asked for has to look first.
+    var isUp: Bool { panel?.isVisible == true }
+
     /// The application that was in front when the panel opened, so the focus
     /// can go back to it. Nil while no panel is up.
     private var cameFrom: NSRunningApplication?

--- a/Sources/ParrotFlow/CorrectionTable.swift
+++ b/Sources/ParrotFlow/CorrectionTable.swift
@@ -94,7 +94,19 @@ final class CorrectionModel: ObservableObject {
     /// this way has a heard word like any other.
     func load(rules proposed: [(heard: String, corrected: String)], over sentence: String = "") {
         self.sentence = sentence
+        // What the vocabulary already says about this term beats what a tagger
+        // guesses about the word. A term you have already labelled is labelled,
+        // and offering a different answer for it invites you to disagree with
+        // yourself one row at a time.
+        let known = ((try? ConfigStore.load())?.vocabulary.terms ?? [:])
+            .reduce(into: [String: WordKind]()) { out, entry in
+                if let kind = entry.value.kind { out[entry.key.lowercased()] = kind }
+            }
         rows = proposed.map { rule in
+            let word = rule.corrected.trimmingCharacters(in: .punctuationCharacters)
+            if let already = known[word.lowercased()] {
+                return CorrectionRow(heard: rule.heard, corrected: rule.corrected, kind: already)
+            }
             let tag = Tagger.tokens(in: rule.corrected, language: nil).first?.tag
             return CorrectionRow(
                 heard: rule.heard, corrected: rule.corrected, kind: .from(tag: tag)

--- a/Sources/ParrotFlow/CorrectionTable.swift
+++ b/Sources/ParrotFlow/CorrectionTable.swift
@@ -102,7 +102,17 @@ final class CorrectionModel: ObservableObject {
             .reduce(into: [String: WordKind]()) { out, entry in
                 if let kind = entry.value.kind { out[entry.key.lowercased()] = kind }
             }
-        rows = proposed.map { rule in
+        rows = proposed.map { proposal in
+            // The possessive belongs to the sentence, not to the name. Saved as
+            // it stands, `Precey's -> Praizy's` teaches a term called `Praizy's`
+            // beside the one called `Praizy`, and a vocabulary that holds both
+            // is worse than one that holds neither.
+            var rule = proposal
+            if let mine = Vocabulary.possessive(in: rule.corrected),
+               let theirs = Vocabulary.possessive(in: rule.heard) {
+                rule.corrected = String(rule.corrected.dropLast(mine.suffix.count))
+                rule.heard = String(rule.heard.dropLast(theirs.suffix.count))
+            }
             let word = rule.corrected.trimmingCharacters(in: .punctuationCharacters)
             if let already = known[word.lowercased()] {
                 return CorrectionRow(heard: rule.heard, corrected: rule.corrected, kind: already)

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -337,14 +337,44 @@ final class EditWatch {
             // of it was meant.
             guard left >= 1, right >= 1, left <= 2, right <= 2, left + right <= 3
             else { continue }
-            found.append(Change(
+            let pair = Self.trimmed(
                 was: old[fromI ..< i].joined(separator: " "),
-                now: new[fromJ ..< j].joined(separator: " "),
-                sentence: now,
-                at: fromI
-            ))
+                now: new[fromJ ..< j].joined(separator: " ")
+            )
+            found.append(Change(was: pair.was, now: pair.now, sentence: now, at: fromI))
         }
         return found
+    }
+
+    /// The two readings with the punctuation they share taken off both.
+    ///
+    /// A word here is whatever stood between two spaces, and two dictations
+    /// that ran together have none: "terminal.Ghost" became "terminal.Ghostty"
+    /// and the whole run was offered as the rule. What was corrected is the
+    /// letters, so the shared prompt, stop or comma comes off first.
+    ///
+    /// Only punctuation is cut, never letters. `Prizzy -> Praizy` shares "Pr"
+    /// and "zy" and must survive whole; cutting shared letters would offer
+    /// "iz -> aiz", which is not a word anybody said.
+    static func trimmed(was: String, now: String) -> (was: String, now: String) {
+        let a = Array(was), b = Array(now)
+        func plain(_ c: Character) -> Bool { c.isLetter || c.isNumber }
+
+        var shared = 0
+        while shared < a.count, shared < b.count, a[shared] == b[shared] { shared += 1 }
+        var head = 0
+        for i in 0 ..< shared where !plain(a[i]) { head = i + 1 }
+
+        var tail = 0
+        while tail < a.count - head, tail < b.count - head,
+              a[a.count - 1 - tail] == b[b.count - 1 - tail],
+              !plain(a[a.count - 1 - tail]) {
+            tail += 1
+        }
+
+        guard head + tail > 0, a.count - head - tail > 0, b.count - head - tail > 0
+        else { return (was, now) }
+        return (String(a[head ..< (a.count - tail)]), String(b[head ..< (b.count - tail)]))
     }
 
     /// The words of a line, punctuation kept: `Vercel.` and `Vercel` are not the
@@ -364,6 +394,10 @@ final class EditWatch {
     }
 
     /// What terminals and shells put in front of the line being typed.
+    ///
+    /// A terminal artefact and nothing more general: it is here because the
+    /// field being watched is often a shell prompt, not because a chevron means
+    /// anything anywhere else.
     private static let prompts: Set<Character> = ["❯", ">", "$", "%", "#", "›", "→"]
 
     /// The line the words went on.

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -41,7 +41,11 @@ final class EditWatch {
         let at: Int
     }
 
-    var onChange: ((Change) -> Void)?
+    /// Every correction of one settling, handed over at once.
+    ///
+    /// At once because they are reviewed at once: several words fixed in one
+    /// pass are one act, and one panel listing them is what that act deserves.
+    var onCorrections: (([Change]) -> Void)?
 
     /// The whole field as it stood when the dictation landed. Both sides of the
     /// comparison are field snapshots, so neither has to be located in the
@@ -230,8 +234,8 @@ final class EditWatch {
         seen = [:]
         for change in changes {
             Log.write("edit watch: \"\(change.was)\" became \"\(change.now)\"")
-            onChange?(change)
         }
+        onCorrections?(changes)
     }
 
     private func read() {

--- a/tests/edit-diff-cases.yaml
+++ b/tests/edit-diff-cases.yaml
@@ -84,6 +84,33 @@ cases:
     now:     "❯ Praizy isn't the team. She's an expert in Vercel deployments."
     expect:  "Prizzy -> Praizy | versatile -> Vercel"
 
+  # Two dictations that ran together have no space between them, so the whole
+  # glued run is one "word" and the whole run was offered as the rule. Only the
+  # letters that changed belong in it.
+  - written: "I like it.Ghost T is my terminal"
+    now:     "I like it.Ghostty is my terminal"
+    expect:  "Ghost T -> Ghostty"
+
+  # The same at the other end.
+  - written: "the ghostly, terminal"
+    now:     "the Ghostty, terminal"
+    expect:  "ghostly -> Ghostty"
+
+  - written: "I use Ghost E."
+    now:     "I use Ghostty."
+    expect:  "Ghost E -> Ghostty"
+
+  # Only punctuation comes off, never letters. `Prizzy` and `Praizy` share "Pr"
+  # and "zy"; cutting those would offer "iz -> aiz", which nobody said.
+  - written: "hello Prizzy there"
+    now:     "hello Praizy there"
+    expect:  "Prizzy -> Praizy"
+
+  # A stop inside a word is not a sentence end.
+  - written: "we run Node.js and Gwen"
+    now:     "we run Node.js and Qwen"
+    expect:  "Gwen -> Qwen"
+
 
 # Not here: the input box between two rules, and a line wrapped onto a second
 # row. Both are several lines of screen, and this set carries one case per line.


### PR DESCRIPTION
Correct a dictated name by hand and the vocabulary panel now opens with the rule already filled in. The panel and the rule already existed; they only opened when you corrected a name **out loud**. This wires them to the hand corrections #247 notices, so a name you fix by typing can be taught the same way.

Not every hand edit opens it. Only a correction that lands on a name does, so a typo or a reword stays silent.

**Read #247 first.** This is based on `feat/a-correction-made-by-hand`, not on `main`. GitHub will retarget it to `main` when #247 merges.

Start the review at `AppDelegate.teaches` — it is the only judgement call in the eight commits. The rest is plumbing.

<details>
<summary>The filter: how close the two words are does not separate a name from a typo, so it looks at the word the correction lands on</summary>

Every one-word change used to open the panel. That is every typo and every reword, on every dictation.

The obvious filter is spelling distance — a name correction should look different from a typo. It does not. Measured on the speaker's own recorded corrections against ordinary edits:

| Correction | What it is | Score |
|---|---|---|
| `its -> it's` | ordinary English | 1.000 |
| `Prezi -> Praisy` | a name | 0.304 |

The noise scores higher than the signal. No threshold exists.

What separates them is the word the correction lands **on**. The two word lists — the spell checker and the WordPiece vocabulary — call 8 of 9 real targets unknown, and all 10 ordinary ones known.

So the rule is: not punctuation or case alone, **and** either unknown to both lists **or** capitalised away from the start of the line.

The `or` is why this was left out of the first version. The day a term enters a dictionary, the first half stops firing. The capital still offers it. `Sentry` is the one real target both lists already know, and it is the case the second half is there for.

**Spacing is not punctuation.** Gluing two words into one is most of this vocabulary — `Red Rock` to `RedRock`, `Better Stack` to `BetterStack`. A first version of the punctuation test ignored the space and threw away the commonest correction there is. It was caught in live use, four times in a row. The test now keeps whitespace.

</details>

<details>
<summary>The rule offered is the letters that changed, not the glued run around them</summary>

A word here is whatever stood between two spaces. Two dictations that ran together have none: `terminal.Ghost` became `terminal.Ghostty`, and the whole glued run was offered as the rule.

`EditWatch.trimmed` now takes off the punctuation the two readings share, from both.

Only punctuation, never letters. `Prizzy -> Praizy` shares `Pr` and `zy`; cutting shared letters would offer `iz -> aiz`, which nobody said.

Five cases were added to `tests/edit-diff-cases.yaml`, including `Node.js`, where a stop inside a word must not read as the end of one.

</details>

<details>
<summary>The panel gave the focus back to the wrong place, so saving a rule mid-sentence left you typing into nothing</summary>

The panel takes focus to draw a caret in its own field. On the way out it only called `orderOut`, so the app stayed frontmost.

It now activates the application it came from. The application, not the field: steering focus to one element means setting `kAXFocused` and trusting an app to honour it.

</details>

<details>
<summary>What is covered by a check, and what was not</summary>

Green by script, on this branch:

- `swift build -c release`
- `./scripts/check-edit-diff.sh` — 20 cases, 5 of them added here
- `make test` — all 30 checks, `edit-diff` included

`check-inplace.sh`, `check-span.sh`, `check-routing.sh` and `check-grammar.sh` are not in `make test` and were not run. They fail for reasons unrelated to this change.

Verified by hand, not by script:

- **The filter's dictionary half.** `--word-gate` reads the same `Vocabulary.unseenWord` that `teaches` calls. Against the built binary, the 9 real targets and the 10 ordinary words come out as the table above says: 8 unknown, `Sentry` known, all 10 ordinary ones known.
- **The filter as a whole** needs a vocabulary and a live dictation. It was tried in live use during development, which is where the spacing bug was caught.
- **The focus return** needs two applications. It was tried by hand during development; no script covers it.

</details>

<details>
<summary>Two commits were adapted to the newer base, and neither carries anything from the branch it was written on</summary>

The eight commits come from an integration branch that predates #245 and #246. Two needed a hand:

- `feat: the panel only offers a correction onto a name` was written next to a counter-example handler — a correction that runs the *other* way. That is not in this PR. The filter landed without the `recordCounter` call and without the two functions behind it.
- `fix: the panel offers the letters that changed` made `EditWatch.prompts` non-private for a reader that does not exist here, and its comment said so. On this base `TermUses` keeps its own copy. The comment lost that sentence and `prompts` stayed private. Whichever later commit unifies the two lists can widen it again.

Nothing else was changed. The eight touch five files: `AppDelegate.swift`, `EditWatch.swift`, `CorrectionTable.swift`, `CorrectionPanel.swift`, `tests/edit-diff-cases.yaml`.

A ninth commit answers a review comment. `CorrectionPanel.show` replaces the rows and rebinds the save of the one panel, and nothing dismisses the panel when it loses key. Every other caller of `show` is something you asked for. `offerToLearn` is the only one that arrives uninvited, so it is the only one that can throw away a review you have not answered. It now refuses over a visible panel and logs the pair it dropped. Same two files.

</details>

<details>
<summary>Not fixed here: correcting a name back to an ordinary word still offers the mirror rule</summary>

Correct `Vercel` to `Versailles` and this offers a rule teaching a term called Versailles. It is not one. It is the app having written `Vercel` where it did not belong, and you putting the ordinary word back.

Handling that — recording it as a counter-example instead of offering a row — is the next PR. It is known, not missed.

</details>
