### PR TITLE
perf: speech downloads first, the other three follow

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2054,7 +2054,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     format: "transcriber: warmed up in %.1fs", Date().timeIntervalSince(started)
                 ))
             } catch {
-                Log.write("transcriber: warm-up failed — \(error.localizedDescription)")
+                // Nothing else is worth fetching. Without speech the app
+                // cannot transcribe at all, so 700 MB more buys nothing, and
+                // whatever stopped this will most likely stop those too. Each
+                // has its own retry on the dictation that first needs it.
+                Log.write("transcriber: warm-up failed — \(error.localizedDescription);"
+                    + " the other models are left for first use")
+                return
             }
 
             // The rest together, once speech is in. None of them blocks a

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -549,7 +549,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         warmUpLLM()
-        warmUpTranscriber()
 
         // Anything still missing opens the walk, and nothing is asked for yet.
         // The prompt used to fire here, the moment the window appeared — a
@@ -2034,36 +2033,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func warmModels() {
         guard config.transcription.enabled else { return }
         let transcriber = transcriber
-        Task.detached(priority: .background) { await transcriber.warmSentenceModel() }
-        // 81 MB, and the sound pass is on by default, so it is one of the three
-        // rather than something a first dictation waits for.
-        Task.detached(priority: .background) {
-            guard await !NeuralPhonemes.isReady() else { return }
-            do { try await NeuralPhonemes.download() } catch {
-                Log.write("sound model: \(error.localizedDescription); the next"
-                    + " dictation that needs it tries again")
-            }
-        }
-        // 335 MB, and only the sentence gate reads them. Someone who turns the
-        // gate off should not pay for it.
-        if #available(macOS 14, *), config.vocabulary.gateSentence {
-            Task.detached(priority: .background) { await WordVectors.shared.warm() }
-        }
-    }
-
-    /// Starts the Parakeet (and VAD) download at launch, so it's already
-    /// running — ideally already done — by the time the first dictation
-    /// needs it, instead of the first dictation triggering and waiting on it.
-    ///
-    /// `transcriber.prepare` is safe to call again from `transcribe(...)`
-    /// once this is in flight: overlapping callers converge on the same
-    /// download rather than racing two.
-    private func warmUpTranscriber() {
-        guard config.transcription.enabled else { return }
-
-        let transcriber = transcriber
         let config = config
         Task.detached(priority: .background) {
+            // Speech first, on its own. Nothing can be transcribed until it
+            // lands, and it is the only one somebody is waiting for. Started
+            // together, four fetches share the connection and the one that
+            // gates the app finishes last.
+            //
+            // `transcriber.prepare` is safe to call again from `transcribe(...)`
+            // once this is in flight: overlapping callers converge on the same
+            // download rather than racing two.
             let started = Date()
             do {
                 try await transcriber.prepare(config: config)
@@ -2072,6 +2051,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 ))
             } catch {
                 Log.write("transcriber: warm-up failed — \(error.localizedDescription)")
+            }
+
+            // The rest together, once speech is in. None of them blocks a
+            // dictation: the stages that read them stand aside until they are
+            // in memory.
+            await transcriber.warmSentenceModel()
+            // 81 MB, and the sound pass is on by default.
+            Task.detached(priority: .background) {
+                guard await !NeuralPhonemes.isReady() else { return }
+                do { try await NeuralPhonemes.download() } catch {
+                    Log.write("sound model: \(error.localizedDescription); the next"
+                        + " dictation that needs it tries again")
+                }
+            }
+            // 335 MB, and only the sentence gate reads them. Someone who turns
+            // the gate off should not pay for it.
+            if #available(macOS 14, *), config.vocabulary.gateSentence {
+                Task.detached(priority: .background) { await WordVectors.shared.warm() }
             }
         }
     }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -509,7 +509,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // The other half of the first press. The engine warms above; this is
         // the pill's own window, which costs as much again.
         pill.warm()
-        warmModels()
         recorder.onLevel = { [weak self] level in
             self?.pill.model.level = level
         }
@@ -547,6 +546,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
             return
         }
+        // After the preview flags return. Those launches draw a panel and
+        // quit; nothing there transcribes, and fetching 1.16 GB for them
+        // is what `warmUpTranscriber` avoided by sitting below this point.
+        warmModels()
+
 
         warmUpLLM()
 


### PR DESCRIPTION
`warmModels` starts three downloads and `warmUpTranscriber` starts Parakeet forty lines later in the same function, both detached. So all four run at once — and the three nobody is waiting on start first. Nothing can be transcribed until Parakeet lands, so the only fetch a user is actually blocked on shares its bandwidth with three that block nothing. This makes speech go alone and starts the other three when it is done.

The total download is unchanged. Time to first usable dictation is not.

Reviewers: the whole change is `AppDelegate.warmModels`. `warmUpTranscriber` is deleted because it is now the first half of that function; leaving it would start the same fetch a second time.

<details>
<summary>Why the other three can wait and speech cannot</summary>

A default install fetches about 1.16 GB at launch:

```
  Parakeet      461 MB   speech
  ModernBERT    288 MB   the sentence probe
  word vectors  335 MB   the vocabulary gate — skipped when gate_sentence is off
  sound model    81 MB   the phoneme pass
```

Only the first blocks anything. The stages that read the other three stand aside until they are in memory — `SentenceGate` will not make a dictation wait on a load, and `SentenceJoin` does the same. So a dictation arriving before they land is degraded, not stopped.

A dictation arriving before Parakeet lands cannot happen at all.

</details>

<details>
<summary>The doc comment that had to survive the move</summary>

`warmUpTranscriber` carried a line worth keeping: `transcriber.prepare` is safe to call again from `transcribe(...)` once a fetch is in flight, because overlapping callers converge on the same download rather than racing two. That is what makes the retry path safe — a failed fetch clears itself and the next dictation tries again.

It moved into `warmModels` with the code.

</details>

<details>
<summary>How this was missed</summary>

The commit was written before #245 and did not make that PR's cut. The merged code has been starting all four together since.

It was caught by another session reading the merged `AppDelegate` after being told the ordering was already in place — it was not, and the claim did not survive contact with the file.

</details>

<details>
<summary>What is not measured here</summary>

Time to first usable dictation on a cold launch, before and after. The metric exists in principle — #240 adds `capture.first_sample` to `trace.jsonl`, seconds from the key going down to the first sample written — but tracing needs `audio.output_dir` set and this has not been run end to end on a cold install.

The argument for the change does not depend on the number: three fetches that nothing waits on were competing with the one that everything waits on, and there is no reading of that which favours the old order.

</details>
