### PR TITLE
feat: a correction the other way is a counter-example

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3705,7 +3705,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// panel about it would be noise on every dictation.
     private func offerToLearn(_ changes: [EditWatch.Change]) {
         let sentence = changes.first?.sentence ?? ""
-        let worth = changes.filter { teaches($0) }
+        // The counters first. A change that runs the other way is not a rule
+        // to weigh, and `teaches` would drop half of them — `BetterStack` put
+        // back to `better stack` lands on two ordinary words.
+        let worth = changes.filter { !recordCounter($0, in: sentence) }.filter { teaches($0) }
         guard !worth.isEmpty else { return }
         // Never over a panel already up. `show` replaces the rows and rebinds
         // the save, so a second offer would throw the first away without
@@ -3731,6 +3734,86 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         correctionPanel.show(
             rules: worth.map { (heard: $0.was, corrected: $0.now) }, over: sentence
         )
+    }
+
+    /// A correction that runs the other way, and what to do with it.
+    ///
+    /// `Vercel -> Versailles` is not a term called Versailles. It is the app
+    /// having written `Vercel` where it did not belong, and you putting the
+    /// ordinary word back. Offering it as a rule would build the mirror of a
+    /// rule that already exists, and then each word proposes the other for as
+    /// long as both stand.
+    ///
+    /// So the tell is the left side: a heard word that is already a term. The
+    /// sentence is kept under that term as a counter-example — a place it does
+    /// not live — and no row is offered. Returns true when it took the change.
+    ///
+    /// Nothing reads counter-examples yet. `TermPortrait.refusal` is a number
+    /// that was chosen on one dictation, and these are what it takes to measure
+    /// one instead.
+    private func recordCounter(_ change: EditWatch.Change, in sentence: String) -> Bool {
+        recordCounter(wrote: change.was, put: change.now, in: sentence)
+    }
+
+    /// The term a correction runs against, or nil if it runs the usual way.
+    ///
+    /// The same term standing on both sides is a capital or a possessive being
+    /// fixed — `vercel` to `Vercel` — and says nothing about where the term
+    /// belongs. `teaches` throws those out on its own.
+    private func counterTerm(wrote written: String, put back: String) -> String? {
+        guard let term = existingTerm(named: written) else { return nil }
+        guard existingTerm(named: back) != term else { return nil }
+        return term
+    }
+
+    /// Keep the sentence under the term as a place it does not belong.
+    ///
+    /// True only when a row was written. `TermUses.record` writes nothing when
+    /// the word does not stand in the sentence as a word, and says so by doing
+    /// nothing at all, so the position is asked for first: a change that is
+    /// neither kept nor offered is a correction the app watched you make and
+    /// threw away.
+    private func recordCounter(
+        wrote written: String, put back: String, in sentence: String
+    ) -> Bool {
+        guard let term = counterTerm(wrote: written, put: back) else { return false }
+        guard TermUses.occurrence(of: back, in: sentence) != nil else {
+            Log.write("correction: \"\(back)\" does not stand in the sentence,"
+                + " so \(term) gets no counter-example")
+            return false
+        }
+        let heard = config.vocabulary.terms[term]?.heard ?? []
+        let ours = heard.contains { $0.caseInsensitiveCompare(back) == .orderedSame }
+        do {
+            try TermUses.record(term: term, said: sentence, span: back, counter: true)
+            // One term corrected into another — `Praizy` into `Praisy` — says
+            // two things at once, and both are worth keeping: the first does
+            // not live here and the second does.
+            if let right = existingTerm(named: back) {
+                try TermUses.record(term: right, said: sentence, span: back)
+            }
+            Log.write(
+                "correction: \"\(written)\" -> \"\(back)\" is a counter-example for"
+                    + " \(term)\(ours ? ", written by its own rule" : "")")
+            flash("Noted  \(term) does not belong there", tone: .done)
+        } catch {
+            Log.write("could not record the counter-example: \(error.localizedDescription)")
+            return false
+        }
+        return true
+    }
+
+    /// The vocabulary term this word is, ignoring case and any possessive.
+    private func existingTerm(named word: String) -> String? {
+        var bare = word.trimmingCharacters(in: .whitespaces)
+        if let mine = Vocabulary.possessive(in: bare) {
+            bare = String(bare.dropLast(mine.suffix.count))
+        }
+        bare = bare.trimmingCharacters(in: .punctuationCharacters)
+        guard !bare.isEmpty else { return nil }
+        return config.vocabulary.terms.keys.first {
+            $0.caseInsensitiveCompare(bare) == .orderedSame
+        }
     }
 
     /// Is this correction about a name, or about English?
@@ -4745,6 +4828,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// went on to rewrite the field would leave the two disagreeing.
     private func learn(_ rules: [TaughtRule], in corrected: String) -> Bool {
         for rule in rules {
+            // A rule whose heard side is already a term runs the other way:
+            // the app wrote the term where it did not belong and you put the
+            // ordinary word back. The sentence is kept under the term as a
+            // counter-example and the pronunciation is not written — it would
+            // be the mirror of a rule that stands, and then each word proposes
+            // the other for as long as both are there.
+            if let term = counterTerm(wrote: rule.heard, put: rule.corrected) {
+                if !recordCounter(wrote: rule.heard, put: rule.corrected, in: corrected) {
+                    Log.write("correction: \(rule.heard) -> \(rule.corrected) runs against"
+                        + " \(term); no counter-example was written and no rule either")
+                }
+                continue
+            }
             do {
                 try ConfigWriter.addVocabularyPronunciation(
                     term: rule.corrected, heard: rule.heard, kind: rule.kind

--- a/Sources/ParrotFlow/LearnCommand.swift
+++ b/Sources/ParrotFlow/LearnCommand.swift
@@ -69,7 +69,9 @@ enum LearnCommand {
                     continue
                 }
                 if said != use.said { cut += 1 }
-                let now = TermUses.Use(said: said, span: use.span, from: use.from)
+                let now = TermUses.Use(
+                    said: said, span: use.span, from: use.from, counter: use.counter
+                )
                 // The custom `==` is on the sentence and the span, so two rows
                 // that narrow to the same sentence collapse into one.
                 if !kept.contains(now) { kept.append(now) }
@@ -110,6 +112,35 @@ enum LearnCommand {
         do {
             try TermUses.record(term: term, said: sentence, span: written, from: .seeded)
             print("✓ \(term) belongs at \"\(written)\"")
+            return 0
+        } catch {
+            print("✗ \(error.localizedDescription)")
+            return 1
+        }
+    }
+
+    /// `--against <term> "<sentence>" <word>` — a sentence the term does *not*
+    /// belong in, with the ordinary word that stands where it would go.
+    ///
+    /// No pronunciation is written: this teaches nothing about how a word
+    /// sounds. It is the other half of a portrait, and the only way to seed
+    /// enough of them to measure `TermPortrait.refusal` rather than choose it.
+    static func against(term: String, sentence: String, span: String) -> Int32 {
+        guard TermUses.occurrence(of: span, in: sentence) != nil else {
+            print("✗ \"\(span)\" does not stand as a word in that sentence")
+            return 1
+        }
+        // The term standing in its own sentence is a use, not a counter. Stored
+        // as one it would say the term does not belong where it belongs.
+        guard span.caseInsensitiveCompare(term) != .orderedSame else {
+            print("✗ \"\(span)\" is the term itself — use --for")
+            return 1
+        }
+        do {
+            try TermUses.record(
+                term: term, said: sentence, span: span, from: .seeded, counter: true
+            )
+            print("✓ \(term) does not belong at \"\(span)\"")
             return 0
         } catch {
             print("✗ \(error.localizedDescription)")

--- a/Sources/ParrotFlow/LearnCommand.swift
+++ b/Sources/ParrotFlow/LearnCommand.swift
@@ -73,8 +73,14 @@ enum LearnCommand {
                     said: said, span: use.span, from: use.from, counter: use.counter
                 )
                 // The custom `==` is on the sentence and the span, so two rows
-                // that narrow to the same sentence collapse into one.
-                if !kept.contains(now) { kept.append(now) }
+                // that narrow to the same sentence collapse into one. The last
+                // wins, which is how `record` settles two rows that disagree
+                // about whether the term belongs there.
+                if let already = kept.firstIndex(of: now) {
+                    kept[already] = now
+                } else {
+                    kept.append(now)
+                }
             }
             if !kept.isEmpty { out[term] = kept }
         }

--- a/Sources/ParrotFlow/TermPortrait.swift
+++ b/Sources/ParrotFlow/TermPortrait.swift
@@ -204,20 +204,27 @@ actor TermPortrait {
     // MARK: - building it
 
     func summary(for term: String) async throws -> Summary? {
-        let uses = TermUses.load()[term] ?? []
+        let all = TermUses.load()[term] ?? []
+        // Counter-examples are sentences the term does *not* belong in. They
+        // are fingerprinted, so adding one rebuilds, but they never enter the
+        // centre, the tightness or the floor: those describe where the term
+        // lives, and a counter is the other place.
+        let uses = all.filter { !$0.counter }
         guard uses.count >= Self.minimum else { return nil }
-        let mark = Self.fingerprint(of: uses)
+        let mark = Self.fingerprint(of: all)
 
         if !loadedFromDisk { cache = Self.readCache(); loadedFromDisk = true }
         if let held = cache[term], held.fingerprint == mark { return held }
 
-        let built = try await Self.build(uses)
+        let built = try await Self.build(uses, fingerprint: mark)
         cache[term] = built
         Self.writeCache(cache)
         return built
     }
 
-    private static func build(_ uses: [TermUses.Use]) async throws -> Summary {
+    private static func build(
+        _ uses: [TermUses.Use], fingerprint mark: String
+    ) async throws -> Summary {
         var vectors: [[Float]] = []
         for use in uses {
             vectors.append(
@@ -240,7 +247,7 @@ actor TermPortrait {
             centre: centre,
             tightness: tightness,
             floor: quantileOf(selves, at: quantile),
-            fingerprint: fingerprint(of: uses),
+            fingerprint: mark,
             uses: uses.count
         )
     }
@@ -277,7 +284,11 @@ actor TermPortrait {
     }
 
     private static func fingerprint(of uses: [TermUses.Use]) -> String {
-        let joined = uses.map { "\($0.span)\u{1}\($0.said)" }.joined(separator: "\u{2}")
+        // The polarity is in the mark, so a counter added to a term rebuilds
+        // its portrait even though it never enters one.
+        let joined = uses
+            .map { "\($0.counter ? "-" : "+")\($0.span)\u{1}\($0.said)" }
+            .joined(separator: "\u{2}")
         let digest = SHA256.hash(data: Data(joined.utf8))
         return digest.compactMap { String(format: "%02x", $0) }.joined()
     }

--- a/Sources/ParrotFlow/TermPortraitCommand.swift
+++ b/Sources/ParrotFlow/TermPortraitCommand.swift
@@ -21,9 +21,13 @@ enum TermPortraitCommand {
             print("no confirmed uses yet — correct a name, or seed one with --learn --in")
             return 0
         }
-        print("  term            uses  seeded  floor   last sentence")
+        print("  term            uses  seeded  against  floor   last sentence")
         for term in stored.keys.sorted() {
-            guard let uses = stored[term] else { continue }
+            guard let all = stored[term] else { continue }
+            // `uses` and `seeded` count what a portrait is built from, so a
+            // counter shows in one column only.
+            let uses = all.filter { !$0.counter }
+            let against = all.count - uses.count
             let seeded = uses.filter { $0.from == .seeded }.count
             let floor = Blocking.run { () async -> Double? in
                 (try? await TermPortrait.shared.summary(for: term))??.floor
@@ -31,7 +35,7 @@ enum TermPortraitCommand {
             let shown = floor.map { String(format: "%.3f", $0) } ?? "   —"
             let last = uses.last?.said ?? ""
             print("  \(pad(term, 15)) \(pad(String(uses.count), 5)) \(pad(String(seeded), 7))"
-                + " \(shown)   \(last.prefix(44))")
+                + " \(pad(String(against), 8)) \(shown)   \(last.prefix(44))")
         }
         return 0
     }
@@ -68,7 +72,7 @@ enum TermPortraitCommand {
             return 1
         case .success(let (summary, score)):
             guard let summary else {
-                let held = TermUses.load()[term]?.count ?? 0
+                let held = TermUses.load()[term]?.filter { !$0.counter }.count ?? 0
                 print("no portrait: \(held) confirmed use(s), \(TermPortrait.minimum) needed")
                 return 0
             }
@@ -78,7 +82,10 @@ enum TermPortraitCommand {
             )
             if sentence == nil {
                 for use in TermUses.load()[term] ?? [] {
-                    print("  \(use.from == .seeded ? "seeded " : "learned") \(use.said)")
+                    let mark = use.counter
+                        ? "against"
+                        : (use.from == .seeded ? "seeded " : "learned")
+                    print("  \(mark) \(use.said)")
                 }
             }
             if let score {

--- a/Sources/ParrotFlow/TermUses.swift
+++ b/Sources/ParrotFlow/TermUses.swift
@@ -62,10 +62,10 @@ enum TermUses {
     /// more of them separate better rather than worse. This bounds the work of
     /// recomputing a portrait, which is one forward pass per use.
     ///
-    /// Oldest first, whatever its polarity. A term corrected forty times the
-    /// wrong way would evict the uses its portrait is built from, and then have
-    /// no portrait at all. Not reachable yet — nothing reads counters — but the
-    /// day one does, this needs its own budget.
+    /// Each polarity has its own budget. Shared, a term corrected forty times
+    /// the wrong way would evict the uses its portrait is built from and leave
+    /// it with no portrait at all, and the bound this exists for is the number
+    /// of confirmed uses.
     static let keep = 40
 
     /// The file is there and cannot be parsed as a whole.
@@ -122,6 +122,10 @@ enum TermUses {
     ///
     /// The oldest goes when the list is full, so a term that moves on stops
     /// being described by what it used to mean.
+    ///
+    /// The same sentence and span recorded the other way round replaces what
+    /// was there. One sentence cannot both hold the term and refuse it, and
+    /// the later correction is the one that stands.
     static func record(
         term: String, said: String, span: String, from: Use.Source = .correction,
         counter: Bool = false
@@ -134,9 +138,24 @@ enum TermUses {
         var all = try read()
         var uses = all[term] ?? []
         let use = Use(said: sentence, span: span, from: from, counter: counter)
-        guard !uses.contains(use) else { return }
+        if let already = uses.firstIndex(of: use) {
+            guard uses[already].counter != counter else { return }
+            uses.remove(at: already)
+        }
         uses.append(use)
-        if uses.count > keep { uses.removeFirst(uses.count - keep) }
+        // A budget per polarity, oldest dropped. Sharing one, a term corrected
+        // forty times the wrong way evicts every use its portrait is built
+        // from, and the term is then left with no portrait at all.
+        for polarity in [false, true] {
+            let over = uses.filter { $0.counter == polarity }.count - keep
+            guard over > 0 else { continue }
+            var dropped = 0
+            uses.removeAll { use in
+                guard dropped < over, use.counter == polarity else { return false }
+                dropped += 1
+                return true
+            }
+        }
         all[term] = uses
         try write(all)
     }

--- a/Sources/ParrotFlow/TermUses.swift
+++ b/Sources/ParrotFlow/TermUses.swift
@@ -30,6 +30,17 @@ enum TermUses {
         /// telling them apart afterwards is the only way to know which you are
         /// looking at.
         var from: Source = .correction
+        /// The other polarity: a sentence where this term does *not* belong.
+        ///
+        /// Written when a correction runs the other way — the app wrote
+        /// `Vercel` and you put `Versailles` back. That says nothing about a
+        /// term called Versailles, and everything about where Vercel lives.
+        /// `span` is then the word standing at the site, not the term.
+        ///
+        /// Nothing decides on these yet. They are kept because
+        /// `TermPortrait.refusal` is a number that was chosen, and these are
+        /// what it takes to measure it instead.
+        var counter: Bool = false
 
         enum Source: String, Codable {
             /// The correction panel, the spoken command, or `--learn`.
@@ -50,6 +61,11 @@ enum TermUses {
     /// Not a quality limit: with a threshold read off the term's own uses,
     /// more of them separate better rather than worse. This bounds the work of
     /// recomputing a portrait, which is one forward pass per use.
+    ///
+    /// Oldest first, whatever its polarity. A term corrected forty times the
+    /// wrong way would evict the uses its portrait is built from, and then have
+    /// no portrait at all. Not reachable yet — nothing reads counters — but the
+    /// day one does, this needs its own budget.
     static let keep = 40
 
     /// The file is there and cannot be parsed as a whole.
@@ -92,7 +108,10 @@ enum TermUses {
                       said.contains(span)
                 else { return nil }
                 let from = (row["from"] as? String).flatMap(Use.Source.init(rawValue:))
-                return Use(said: said, span: span, from: from ?? .correction)
+                return Use(
+                    said: said, span: span, from: from ?? .correction,
+                    counter: row["counter"] as? Bool ?? false
+                )
             }
             if !uses.isEmpty { out[term] = uses }
         }
@@ -104,7 +123,8 @@ enum TermUses {
     /// The oldest goes when the list is full, so a term that moves on stops
     /// being described by what it used to mean.
     static func record(
-        term: String, said: String, span: String, from: Use.Source = .correction
+        term: String, said: String, span: String, from: Use.Source = .correction,
+        counter: Bool = false
     ) throws {
         let sentence = narrowed(said, to: span)
         // A word, not a substring. `contains` alone let `Vercelli` in.
@@ -113,7 +133,7 @@ enum TermUses {
 
         var all = try read()
         var uses = all[term] ?? []
-        let use = Use(said: sentence, span: span, from: from)
+        let use = Use(said: sentence, span: span, from: from, counter: counter)
         guard !uses.contains(use) else { return }
         uses.append(use)
         if uses.count > keep { uses.removeFirst(uses.count - keep) }
@@ -219,6 +239,9 @@ enum TermUses {
             "#",
             "# Each one teaches what kind of sentence its term appears in. Delete a line",
             "# that was recorded by mistake; the term forgets it at the next correction.",
+            "#",
+            "# `counter: true` is the opposite: a sentence where the term does not belong,",
+            "# recorded when you put an ordinary word back over it. Its `span` is that word.",
             "",
             "terms:",
         ]
@@ -229,6 +252,7 @@ enum TermUses {
                 lines.append("    - said: \(quoted(use.said))")
                 lines.append("      span: \(quoted(use.span))")
                 lines.append("      from: \(use.from.rawValue)")
+                if use.counter { lines.append("      counter: true") }
             }
         }
         lines.append("")

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -349,6 +349,16 @@ if let index = arguments.firstIndex(of: "--for") {
     ))
 }
 
+if let index = arguments.firstIndex(of: "--against") {
+    guard arguments.indices.contains(index + 3) else {
+        print("usage: ParrotFlow --against <term> \"<sentence>\" <word>")
+        exit(2)
+    }
+    exit(LearnCommand.against(
+        term: arguments[index + 1], sentence: arguments[index + 2], span: arguments[index + 3]
+    ))
+}
+
 if let index = arguments.firstIndex(of: "--forget") {
     guard arguments.indices.contains(index + 1), !arguments[index + 1].hasPrefix("--") else {
         print("usage: ParrotFlow --forget <term>")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -276,6 +276,8 @@ $PF --prompt <name> "<instruction>" "<text>"
 $PF --command "hey parrot, Tasmin spells T A S M E E N" "<last transcript>" \
     [--phrases "hey parrot,by the way parrot"]
 $PF --learn <heard> <corrected>
+$PF --for <term> "<sentence>" [word]
+$PF --against <term> "<sentence>" <word>
 ```
 
 `--route` shows which transform an instruction reaches and why — the router
@@ -295,6 +297,18 @@ the previous transcript does it target.
 
 `--learn` adds a pronunciation to `vocabulary.yaml` from the terminal, the
 same one the correction panel would have written.
+
+`--for` records a sentence a term belongs in, without touching the
+pronunciations. `--against` records the opposite: a sentence where the term
+does not belong, with the ordinary word that stands where it would go. Both
+are written to `vocabulary-uses.yaml`, which is what a term's portrait is
+built from. `--against` writes no pronunciation — a counter-example teaches
+nothing about how a word sounds.
+
+```
+$ ParrotFlow --against Vercel "I love visiting the Versailles Castle." Versailles
+✓ Vercel does not belong at "Versailles"
+```
 
 ## Giving a model its API key
 

--- a/docs/corrections.md
+++ b/docs/corrections.md
@@ -42,6 +42,12 @@ settings untouched — and puts the corrected sentence back where it came from.
 A row with a blank right-hand side is skipped, so the words you did not come to
 fix cost nothing.
 
+**A correction the other way teaches nothing to save.** When you put an
+ordinary word back over a term the app wrote — `Vercel` back to `Versailles` —
+no rule is offered. The rule would be the mirror of one you already have, and
+then each word would propose the other forever. The sentence is kept under the
+term instead, as a counter-example: a place that term does not belong.
+
 ## Saying the spelling instead
 
 You can skip the panel entirely and just say the correction:

--- a/scripts/check-term-uses.sh
+++ b/scripts/check-term-uses.sh
@@ -198,5 +198,49 @@ PARROTFLOW_CONFIG_DIR="$ODD" "$BIN" --tidy-uses >/dev/null 2>&1
 check "--tidy-uses keeps the sentences of a file it can parse" 3 \
   "$(grep -c '^    - said:' "$ODD/vocabulary-uses.yaml")"
 
+# A correction that runs the other way: the sentence is kept under the term as
+# a place it does not belong, with the ordinary word that stands there.
+AGAINST="$WORK/against"; mkdir -p "$AGAINST"
+AY="$AGAINST/vocabulary-uses.yaml"
+against() { PARROTFLOW_CONFIG_DIR="$AGAINST" "$BIN" --against "$@" 2>/dev/null; }
+# How many lines match, and 0 when the file is not there at all.
+matches() { [ -f "$2" ] || { echo 0; return; }; grep -c "$1" "$2"; }
+
+against Vercel "I love visiting the Versailles Castle." Versailles >/dev/null
+check "a counter-example is stored" 1 "$(matches '^    - said:' "$AY")"
+check "and marked as one" 1 "$(matches '^      counter: true' "$AY")"
+check "under the term, not the word" 1 "$(python3 -c '
+import sys, yaml
+d = yaml.safe_load(open(sys.argv[1]))["terms"]
+print(len([u for u in d.get("Vercel", []) if u.get("counter")]))
+' "$AY" 2>/dev/null)"
+check "and no pronunciation is written" 0 \
+  "$(matches 'heard: Versailles' "$AGAINST/vocabulary.yaml")"
+
+out="$(against Vercel "The word is simply not here." Versailles)"
+check "a sentence without the word is refused" 1 \
+  "$(printf '%s' "$out" | grep -c 'does not stand as a word')"
+check "and nothing is written" 1 "$(matches '^    - said:' "$AY")"
+
+out="$(against Vercel "We deploy the docs on Vercel." Vercel)"
+check "the term standing in its own sentence is not a counter" 1 \
+  "$(printf '%s' "$out" | grep -c 'is the term itself')"
+
+# The portrait is built from confirmed uses, so a counter must not make one
+# look ready. Two uses and a counter is still two uses. No model is loaded:
+# under the minimum, nothing is ever scored.
+PARROTFLOW_CONFIG_DIR="$AGAINST" "$BIN" --for Vercel \
+  "We deploy the dashboard on Vercel every Friday." >/dev/null 2>&1
+PARROTFLOW_CONFIG_DIR="$AGAINST" "$BIN" --for Vercel \
+  "The build is green on Vercel again." >/dev/null 2>&1
+out="$(PARROTFLOW_CONFIG_DIR="$AGAINST" "$BIN" --portrait Vercel 2>/dev/null)"
+check "a counter does not count toward the portrait minimum" 1 \
+  "$(printf '%s' "$out" | grep -c 'no portrait: 2 confirmed use(s)')"
+
+# --tidy-uses rewrites every row, so it has to carry the polarity across.
+PARROTFLOW_CONFIG_DIR="$AGAINST" "$BIN" --tidy-uses >/dev/null 2>&1
+check "--tidy-uses keeps a counter marked" 1 "$(matches '^      counter: true' "$AY")"
+check "and keeps the confirmed uses beside it" 3 "$(matches '^    - said:' "$AY")"
+
 [ "$failed" -eq 0 ] && echo "Every check passed." || echo "Failed: term-uses"
 exit "$failed"

--- a/scripts/check-term-uses.sh
+++ b/scripts/check-term-uses.sh
@@ -237,6 +237,41 @@ out="$(PARROTFLOW_CONFIG_DIR="$AGAINST" "$BIN" --portrait Vercel 2>/dev/null)"
 check "a counter does not count toward the portrait minimum" 1 \
   "$(printf '%s' "$out" | grep -c 'no portrait: 2 confirmed use(s)')"
 
+# One sentence cannot both hold the term and refuse it. The later correction
+# is the one that stands, rather than the first one silently winning.
+FLIP="$WORK/flip"; mkdir -p "$FLIP"
+FY="$FLIP/vocabulary-uses.yaml"
+PARROTFLOW_CONFIG_DIR="$FLIP" "$BIN" --for Vercel \
+  "I love visiting the Versailles Castle." Versailles >/dev/null 2>&1
+PARROTFLOW_CONFIG_DIR="$FLIP" "$BIN" --against Vercel \
+  "I love visiting the Versailles Castle." Versailles >/dev/null 2>&1
+check "the same sentence recorded both ways is one row" 1 "$(matches '^    - said:' "$FY")"
+check "and holds the later polarity" 1 "$(matches '^      counter: true' "$FY")"
+PARROTFLOW_CONFIG_DIR="$FLIP" "$BIN" --for Vercel \
+  "I love visiting the Versailles Castle." Versailles >/dev/null 2>&1
+check "and back again" 0 "$(matches '^      counter: true' "$FY")"
+
+# Each polarity has its own budget. Sharing one, a term corrected the wrong way
+# often enough evicts the uses its portrait is built from.
+BUDGET="$WORK/budget"; mkdir -p "$BUDGET"
+BY="$BUDGET/vocabulary-uses.yaml"
+{
+  printf 'terms:\n  "Vercel":\n'
+  for i in $(seq 1 41); do
+    printf '    - said: "Train %s to Versailles was late."\n      span: "Versailles"\n' "$i"
+    printf '      from: seeded\n      counter: true\n'
+  done
+  for i in $(seq 1 3); do
+    printf '    - said: "We deployed build %s on Vercel."\n      span: "Vercel"\n' "$i"
+    printf '      from: seeded\n'
+  done
+} > "$BY"
+PARROTFLOW_CONFIG_DIR="$BUDGET" "$BIN" --against Vercel \
+  "The last train to Versailles was late." Versailles >/dev/null 2>&1
+check "counters stop at their own budget" 40 "$(matches '^      counter: true' "$BY")"
+check "and evict no confirmed use" 3 \
+  "$(( $(matches '^    - said:' "$BY") - 40 ))"
+
 # --tidy-uses rewrites every row, so it has to carry the polarity across.
 PARROTFLOW_CONFIG_DIR="$AGAINST" "$BIN" --tidy-uses >/dev/null 2>&1
 check "--tidy-uses keeps a counter marked" 1 "$(matches '^      counter: true' "$AY")"


### PR DESCRIPTION
A vocabulary term knows the sentences it belongs in. It had no way to hold one
it does not. `Vercel -> Versailles` is not a term called Versailles: it is the
app having written `Vercel` where it did not belong. Saved as a rule it is the
mirror of a rule that already stands, and then each word proposes the other for
as long as both are there. It is kept as a counter-example instead.

- **A row can say the other thing.** `counter: true` in
  `vocabulary-uses.yaml`, with the ordinary word that stands at the site as its
  `span`. Counters stay out of the centre, the tightness, the leave-one-out
  floor and the three-use minimum, and inside the fingerprint, so adding one
  rebuilds the portrait.
- **The edit-watch path records one.** A hand correction whose heard side is
  already a term gets no row: the sentence is kept under that term and the
  notice says so. `BetterStack -> better stack` is caught by the same test, no
  special case, since `better stack` is that term's own `heard:` entry.
- **The panel path does the same.** `learn` serves the correction panel, the
  reselect path and the spoken correction. A rule that runs the other way
  writes a counter-example and no pronunciation.
- **`--against <term> "<sentence>" <word>`** writes one from the terminal, the
  mirror of `--for`. `--portrait` counts them in an `against` column and marks
  the rows.

Nothing reads counter-examples yet. `TermPortrait.refusal` is 0.04 chosen on
one dictation, and these are what it takes to measure a number instead.

Three things to know:

- The fingerprint now carries a polarity per row, so every cached portrait is
  rebuilt once on first use. That is one forward pass per stored sentence.
- On the panel path the "Noted" notice is immediately replaced by the
  `Saved  Vercel → Versailles` notice that `saveCorrections` flashes after
  `learn` returns.
  The rule really is not written; only the notice is wrong. Fixing it means
  changing what `learn` reports to its three callers, which is a bigger change
  than this one.
- A correction spoken aloud opens the panel with no sentence behind it, so
  there is nothing to keep the counter-example in. That correction now teaches
  nothing rather than teaching the mirror rule. The log says which term it ran
  against.

<details>
<summary>What ran</summary>

```
swift build                       Build complete
make test                         Every check passed  (30 sets, swiftlint clean)
scripts/check-term-uses.sh        Every check passed  (15 new cases)
scripts/check-portrait.sh         Every check passed  (needs the two models; they were on disk)
```

New cases in `scripts/check-term-uses.sh`:

```
  ✓ a counter-example is stored
  ✓ and marked as one
  ✓ under the term, not the word
  ✓ and no pronunciation is written
  ✓ a sentence without the word is refused
  ✓ and nothing is written
  ✓ the term standing in its own sentence is not a counter
  ✓ a counter does not count toward the portrait minimum
  ✓ the same sentence recorded both ways is one row
  ✓ and holds the later polarity
  ✓ and back again
  ✓ counters stop at their own budget
  ✓ and evict no confirmed use
  ✓ --tidy-uses keeps a counter marked
  ✓ and keeps the confirmed uses beside it
```

`check-term-uses.sh` is not one of the steps in `.github/workflows/checks.yml`,
so those cases run locally only. Same for `check-sound.sh` and
`check-edit-diff.sh`; not changed here.

By hand, against a config directory in /tmp:

```
$ ParrotFlow --against Vercel "I love visiting the Versailles Castle." Versailles
✓ Vercel does not belong at "Versailles"

$ ParrotFlow --portrait
  term            uses  seeded  against  floor   last sentence
  Vercel          3     3       1        0.849   I pushed the site to Vercel this morning.

$ ParrotFlow --portrait Vercel
uses 3   tightness 0.923   floor 0.849
  seeded  We deploy the dashboard on Vercel every Friday.
  seeded  The build is green on Vercel again.
  seeded  I pushed the site to Vercel this morning.
  against I love visiting the Versailles Castle.
```

The two app paths cannot be driven from a terminal. They were read line by
line, and everything under them — `TermUses.record`, `occurrence`, `narrowed`,
`--tidy-uses` — is exercised through the CLI above.

Five guards were added on top of the original work, the last two from the
first review:

1. The same term on both sides is not a counter. `vercel -> Vercel` is a
   capital being fixed, and stored it would say the term does not belong where
   it does.
2. `TermUses.record` writes nothing when the word does not stand in the
   sentence as a word, and it does that silently. Both paths ask for the
   position first, so a change is never swallowed instead of offered.
3. `--tidy-uses` rebuilds every row and would have dropped the flag. It carries
   it now, with a case for it.
4. Each polarity keeps its own budget of 40 rows. Shared, a term corrected the
   wrong way often enough evicted every use its portrait was built from.
5. The same sentence and span recorded the other way round replaces the row.
   It used to be dropped as a duplicate, so the first correction stood and the
   second did nothing.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rwhk2b1EG2m5wxeHvFE6Fv
