### PR TITLE
fix: a capital at the start of a sentence is not a name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ release-certificate:
 CHECKS := numbers replacements pipeline pipeline-config wake split dotted dates keyed \
           transform-folders eval audio-recovery possessive word-gate suggest input join \
           profiles span-rule clipboard default-config vocabulary-config learn \
-          signing-identity no-voice sound tokenizer sentence-case term-uses edit-diff
+          signing-identity no-voice sound tokenizer sentence-case term-uses edit-diff sentence-open
 
 test:
 	@swift build -c release

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3772,7 +3772,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // correcting `Fais` to `Et` at the start of a sentence mid-line read
         // as a name because of it, and a French grammar fix was offered as a
         // vocabulary rule.
-        let opens = EditWatch.opensSentence(in: change.sentence, at: change.at)
+        let opens = EditWatch.opensSentence(in: change.sentence, at: change.nowAt)
         if change.now.first?.isUppercase == true, !opens { return true }
         Log.write("correction: \"\(change.was)\" -> \"\(change.now)\" is ordinary English;"
             + " not offered")

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3765,8 +3765,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         if Vocabulary.unseenWord(letters(change.now)) { return true }
         // A capital that is not the one every sentence starts with.
-        let line = change.sentence.trimmingCharacters(in: .whitespaces)
-        let opens = line.hasPrefix(change.now) || line.dropFirst().hasPrefix(change.now)
+        // A capital that is not the one every sentence starts with.
+        //
+        // The first word of the *line* was not the right test. A line holds
+        // several sentences, and every one of them opens with a capital:
+        // correcting `Fais` to `Et` at the start of a sentence mid-line read
+        // as a name because of it, and a French grammar fix was offered as a
+        // vocabulary rule.
+        let opens = EditWatch.opensSentence(in: change.sentence, at: change.at)
         if change.now.first?.isUppercase == true, !opens { return true }
         Log.write("correction: \"\(change.was)\" -> \"\(change.now)\" is ordinary English;"
             + " not offered")

--- a/Sources/ParrotFlow/EditDiffCommand.swift
+++ b/Sources/ParrotFlow/EditDiffCommand.swift
@@ -16,7 +16,14 @@ enum EditDiffCommand {
             print("no single change")
             return 0
         }
-        for change in changes { print("\(change.was) -> \(change.now)") }
+        for change in changes {
+            print("\(change.was) -> \(change.now)")
+            // Whether a capital here means anything. `teaches` offers a
+            // correction onto a capitalised word unless the word opens a
+            // sentence, where every word is capitalised and the capital says
+            // nothing about the word.
+            print("  opens: \(EditWatch.opensSentence(in: change.sentence, at: change.at))")
+        }
         print("  in: \(changes[0].sentence)")
         return 0
     }

--- a/Sources/ParrotFlow/EditDiffCommand.swift
+++ b/Sources/ParrotFlow/EditDiffCommand.swift
@@ -22,7 +22,7 @@ enum EditDiffCommand {
             // correction onto a capitalised word unless the word opens a
             // sentence, where every word is capitalised and the capital says
             // nothing about the word.
-            print("  opens: \(EditWatch.opensSentence(in: change.sentence, at: change.at))")
+            print("  opens: \(EditWatch.opensSentence(in: change.sentence, at: change.nowAt))")
         }
         print("  in: \(changes[0].sentence)")
         return 0

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -393,6 +393,17 @@ final class EditWatch {
         return text.split(whereSeparator: { $0.isWhitespace }).map(String.init)
     }
 
+    /// Whether the word at `at` opens a sentence on this line.
+    ///
+    /// The first word of the line does, and so does any word after one that
+    /// ends in a stop. Both are places a capital means nothing.
+    static func opensSentence(in line: String, at index: Int) -> Bool {
+        guard index > 0 else { return true }
+        let said = words(of: line)
+        guard index - 1 < said.count else { return true }
+        return ".!?".contains(said[index - 1].last ?? " ")
+    }
+
     /// What terminals and shells put in front of the line being typed.
     ///
     /// A terminal artefact and nothing more general: it is here because the

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -37,8 +37,14 @@ final class EditWatch {
         let sentence: String
         /// Which word of the line as it was written. Two occurrences of one
         /// word are two corrections, and telling them apart needs the place
-        /// rather than the word.
+        /// rather than the word. Keyed on the written line because that is the
+        /// fixed baseline: the line on screen changes under every keystroke.
         let at: Int
+        /// The same change's place in `sentence`, which is the line as it
+        /// stands now. The two drift the moment an earlier change merges two
+        /// words into one or splits one into two, so anything reading
+        /// `sentence` by index has to use this one.
+        let nowAt: Int
     }
 
     /// Every correction of one settling, handed over at once.
@@ -341,7 +347,7 @@ final class EditWatch {
                 was: old[fromI ..< i].joined(separator: " "),
                 now: new[fromJ ..< j].joined(separator: " ")
             )
-            found.append(Change(was: pair.was, now: pair.now, sentence: now, at: fromI))
+            found.append(Change(was: pair.was, now: pair.now, sentence: now, at: fromI, nowAt: fromJ))
         }
         return found
     }
@@ -401,7 +407,15 @@ final class EditWatch {
         guard index > 0 else { return true }
         let said = words(of: line)
         guard index - 1 < said.count else { return true }
-        return ".!?".contains(said[index - 1].last ?? " ")
+        // The stop is not always the last character. `He said "hello."` ends
+        // on a quote, `(that was it.)` on a bracket. So the whole run of
+        // punctuation the word ends on is what gets asked, not one character.
+        //
+        // The run is empty for `Node.js`, which is what keeps a stop inside a
+        // word from reading as the end of one.
+        let before = said[index - 1]
+        let tail = before.reversed().prefix { !$0.isLetter && !$0.isNumber }
+        return tail.contains { ".!?".contains($0) }
     }
 
     /// What terminals and shells put in front of the line being typed.

--- a/scripts/check-edit-diff.sh
+++ b/scripts/check-edit-diff.sh
@@ -21,7 +21,7 @@ failed=0
 seen=0
 while IFS=$'\t' read -r written now want; do
   seen=$((seen + 1))
-  got="$("$BIN" --edit-diff "$written" "$now" 2>/dev/null | grep -vE "^  in: " \
+  got="$("$BIN" --edit-diff "$written" "$now" 2>/dev/null | grep -vE "^  (in|opens): " \
     | paste -sd '|' - | sed 's/|/ | /g')"
   [ "$want" = "none" ] && want="no single change"
   if [ "$got" = "$want" ]; then

--- a/scripts/check-sentence-open.sh
+++ b/scripts/check-sentence-open.sh
@@ -17,10 +17,13 @@ BIN="$ROOT/.build/release/ParrotFlow"
 [ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
 
 pass=0; fail=0
+# A line can hold more than one correction, so the case names the word it is
+# asking about rather than taking the first answer.
 check() {
-  local what="$1" written="$2" now="$3" want="$4"
+  local what="$1" written="$2" now="$3" word="$4" want="$5"
   local got
-  got="$("$BIN" --edit-diff "$written" "$now" 2>/dev/null | awk '/^  opens: /{print $2; exit}')"
+  got="$("$BIN" --edit-diff "$written" "$now" 2>/dev/null \
+    | awk -v w=" -> $word" '$0 ~ w {found=1; next} found && /^  opens: /{print $2; exit}')"
   if [ "$got" = "$want" ]; then
     pass=$((pass + 1)); printf '  ✓ %s\n' "$what"
   else
@@ -29,22 +32,34 @@ check() {
 }
 
 check "the first word of the line opens one" \
-  "Fais on verra demain." "Et on verra demain." true
+  "Fais on verra demain." "Et on verra demain." Et true
 
 check "a word after a stop opens one" \
-  "C'est fait. Fais on verra." "C'est fait. Et on verra." true
+  "C'est fait. Fais on verra." "C'est fait. Et on verra." Et true
 
 check "a word after a question mark opens one" \
-  "Tu viens? Fais on verra." "Tu viens? Et on verra." true
+  "Tu viens? Fais on verra." "Tu viens? Et on verra." Et true
 
 check "a word in the middle does not" \
-  "I use the versal dashboard daily." "I use the Vercel dashboard daily." false
+  "I use the versal dashboard daily." "I use the Vercel dashboard daily." Vercel false
 
 check "a word after a stop inside a word does not" \
-  "We run Node.js and gwen here." "We run Node.js and Qwen here." false
+  "We run Node.js and gwen here." "We run Node.js and Qwen here." Qwen false
 
 check "the second word does not" \
-  "The versal deploy went out." "The Vercel deploy went out." false
+  "The versal deploy went out." "The Vercel deploy went out." Vercel false
+
+check "a stop inside a closing quote still opens one" \
+  'He said "it is done." Fais on verra.' 'He said "it is done." Et on verra.' Et true
+
+check "a stop inside a closing bracket still opens one" \
+  "(that was it.) Fais on verra." "(that was it.) Et on verra." Et true
+
+check "an earlier merge does not shift the answer" \
+  "I use Ghost D daily. versal is fine." "I use Ghostty daily. Vercel is fine." Vercel true
+
+check "an earlier merge does not invent an opening" \
+  "I use Ghost D and the versal dashboard." "I use Ghostty and the Vercel dashboard." Vercel false
 
 echo
 if [ "$fail" -gt 0 ]; then

--- a/scripts/check-sentence-open.sh
+++ b/scripts/check-sentence-open.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Does a capital mean anything where it stands?
+#
+#   scripts/check-sentence-open.sh
+#
+# `AppDelegate.teaches` offers a correction onto a capitalised word, on the
+# grounds that a capital mid-sentence is how a name looks. That is only true
+# away from a sentence opening, where every word is capitalised and the capital
+# says nothing.
+#
+# The test used to ask whether the word opened the *line*. A line holds several
+# sentences: correcting `Fais` to `Et` at the start of one, mid-line, read as a
+# name and offered a French grammar fix as a vocabulary rule.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/release/ParrotFlow"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+
+pass=0; fail=0
+check() {
+  local what="$1" written="$2" now="$3" want="$4"
+  local got
+  got="$("$BIN" --edit-diff "$written" "$now" 2>/dev/null | awk '/^  opens: /{print $2; exit}')"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1)); printf '  ✓ %s\n' "$what"
+  else
+    fail=$((fail + 1)); printf '  ✗ %s: got "%s", expected "%s"\n' "$what" "$got" "$want"
+  fi
+}
+
+check "the first word of the line opens one" \
+  "Fais on verra demain." "Et on verra demain." true
+
+check "a word after a stop opens one" \
+  "C'est fait. Fais on verra." "C'est fait. Et on verra." true
+
+check "a word after a question mark opens one" \
+  "Tu viens? Fais on verra." "Tu viens? Et on verra." true
+
+check "a word in the middle does not" \
+  "I use the versal dashboard daily." "I use the Vercel dashboard daily." false
+
+check "a word after a stop inside a word does not" \
+  "We run Node.js and gwen here." "We run Node.js and Qwen here." false
+
+check "the second word does not" \
+  "The versal deploy went out." "The Vercel deploy went out." false
+
+echo
+if [ "$fail" -gt 0 ]; then
+  printf '  %d/%d\n' "$pass" "$((pass + fail))"
+  exit 1
+fi
+echo "Every check passed."


### PR DESCRIPTION
The vocabulary panel offered `Fais` → `Et` as a rule. That is a French grammar fix, not a name, and it should never have been shown. The filter excludes a capitalised word when it is the first word of the **line**, but a line holds several sentences and every one of them opens with a capital — so a correction at the start of a sentence mid-line read as a name because of its capital.

Reviewers: the whole change is `EditWatch.opensSentence(in:at:)` and the one line in `AppDelegate.teaches` that calls it. `Change.at` already carries the word's index, so nothing new is tracked.

<details>
<summary>The word lists were not at fault — the capital was</summary>

`teaches` offers a correction when it is not punctuation or case alone, **and** either the corrected-to word is unknown to both word lists, or it is capitalised away from a sentence opening.

Measured against the shipped binary:

```
--word-gate Et      spell known   wordpiece known   judge
--word-gate Fais    spell known   wordpiece unknown  judge
--word-gate Mais    spell known   wordpiece unknown  judge
```

`Et` is known to both, so the dictionary half correctly said this is not a name. `Replacements.isRealWord` already checks `["en", "fr"]`, so French is covered there.

It was offered by the capitalisation half alone.

</details>

<details>
<summary>Why the old test was written that way, and why it was wrong</summary>

The `or` on the capital exists for a reason worth keeping: the day a term enters a dictionary, the word-list half stops recognising it, and the capital is what still offers it. `Sentry` is the live example — an English word, and the one miss of nine in the measurement that set this rule.

So the capital has to stay. What was wrong is where it was allowed to mean something. The old test asked `line.hasPrefix(change.now)`, which is true only for the first word of the whole line. Every later sentence on that line was treated as mid-sentence, and its opening capital read as a name.

</details>

<details>
<summary>Six cases, and why this needed a new script at all</summary>

`teaches` cannot be driven from the command line — it needs a vocabulary and a live dictation. So `--edit-diff` now prints `opens:` per change, and `scripts/check-sentence-open.sh` scores that:

```
  ✓ the first word of the line opens one
  ✓ a word after a stop opens one
  ✓ a word after a question mark opens one
  ✓ a word in the middle does not
  ✓ a word after a stop inside a word does not
  ✓ the second word does not
```

The fifth is the one that would break a naive fix: `Node.js` holds a stop, and the word after it does not open a sentence.

`check-edit-diff.sh` filters the new line the same way it already filters `in:`, and is unchanged otherwise — 20 cases, still passing. `make test` runs the new script; `sentence-open` is in `CHECKS`.

</details>

<details>
<summary>What this does not fix</summary>

A capitalised word that genuinely is a name, corrected at the start of a sentence, is now **not** offered. `Vercel` at the head of a sentence, where `Vercel` is not yet in any dictionary, still reaches the panel through the word-list half — but a name that *is* in a dictionary and *is* sentence-initial is missed.

That is the same trade the rule already made in the other direction, and it errs toward silence rather than toward a panel about grammar.

</details>
