### PR TITLE
fix: a word added beside another is not a correction of it

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -259,3 +259,10 @@ jobs:
       # scripts/check-sentence-join.sh, is run by hand.
       - name: The capital after a period the join removes
         run: scripts/check-sentence-case.sh
+
+      # Endings Parakeet writes over silence. Word arrays out of trace.jsonl,
+      # so no audio and no model — and the half that can go wrong quietly is
+      # scored too: the text is a separate string from the token timings, and
+      # a run dropped from one and not the other is invisible.
+      - name: Endings the decoder invented
+        run: scripts/check-invented-tail.sh

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,8 @@ release-certificate:
 CHECKS := numbers replacements pipeline pipeline-config wake split dotted dates keyed \
           transform-folders eval audio-recovery possessive word-gate suggest input join \
           profiles span-rule clipboard default-config vocabulary-config learn \
-          signing-identity no-voice sound tokenizer sentence-case term-uses edit-diff sentence-open
+          signing-identity no-voice sound tokenizer sentence-case term-uses edit-diff sentence-open \
+          invented-tail
 
 test:
 	@swift build -c release

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3795,11 +3795,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let ours = heard.contains { $0.caseInsensitiveCompare(back) == .orderedSame }
         do {
             try TermUses.record(term: term, said: sentence, span: back, counter: true)
+            rebuildPortrait(for: term)
             // One term corrected into another — `Praizy` into `Praisy` — says
             // two things at once, and both are worth keeping: the first does
             // not live here and the second does.
             if let right = existingTerm(named: back) {
                 try TermUses.record(term: right, said: sentence, span: back)
+                rebuildPortrait(for: right)
             }
             Log.write(
                 "correction: \"\(written)\" -> \"\(back)\" is a counter-example for"
@@ -3810,6 +3812,50 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return false
         }
         return true
+    }
+
+    /// Builds a term's portrait now, because its uses just changed.
+    ///
+    /// `TermPortrait.summary` caches under a fingerprint of the term's stored
+    /// uses, so recording one invalidates it and the *next* dictation naming
+    /// that term pays the rebuild — one embedding pass per use and per
+    /// counter-example, up to `TermUses.keep` of each.
+    ///
+    /// A correction is the moment the uses changed and the moment nobody is
+    /// waiting, so the work moves here. Nothing waits on it and nothing reads
+    /// the result: if it fails, or the app quits first, the next dictation
+    /// rebuilds exactly as it does today. Calling `summary` and dropping the
+    /// answer *is* the rebuild — it is the same call the dictation would make,
+    /// and it writes the same cache.
+    ///
+    /// **How much this is worth is not measured.** The mechanism is certain —
+    /// the fingerprint changes here and the rebuild lands there — but the size
+    /// is not. It cannot be measured from the CLI: `SentenceGate.settle` stands
+    /// aside whenever the word vectors are not loaded, and in a one-shot
+    /// process they never are, so no `--pipeline` run reaches a portrait at
+    /// all. The archive's 26 slow dictations of 957 arrive in bursts that look
+    /// like a session of corrections, which is the reason to think this
+    /// matters, and `gate_ms` on a running app is what would settle it.
+    ///
+    /// Only with the sentence gate on. `SentenceGate` is the only thing that
+    /// reads a portrait, and with it off this would fetch 335 MB of word
+    /// vectors to answer a question nobody asks.
+    private func rebuildPortrait(for term: String) {
+        guard config.vocabulary.gateSentence else { return }
+        guard #available(macOS 14, *) else { return }
+        Task.detached(priority: .background) {
+            let started = Date()
+            // Nil covers both "too few uses to describe" and "it threw", and
+            // neither is worth a line: nothing was built either way.
+            guard (try? await TermPortrait.shared.summary(for: term)) != nil else { return }
+            // Not "rebuilt". The fingerprint decides whether there was work to
+            // do, and the time says which happened — a rebuild is seconds, a
+            // portrait that was already good is instant.
+            Log.write(String(
+                format: "portrait: %@ is current in %.1fs, so the next dictation does not wait",
+                term, Date().timeIntervalSince(started)
+            ))
+        }
     }
 
     /// The vocabulary term this word is, ignoring case and any possessive.
@@ -4864,9 +4910,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 // portrait is built from, and this is the only moment the app
                 // knows a sentence is right.
                 do {
-                    try TermUses.record(
-                        term: rule.corrected, said: corrected, span: rule.corrected
-                    )
+                    // The vocabulary's own spelling, not the one that was
+                    // typed. Matching is case-insensitive everywhere else, so
+                    // saving `praisy` against an existing `Praisy` would file
+                    // the sentence under a second key and build a portrait
+                    // there — while the gate goes on reading `Praisy` and finds
+                    // neither. Nil is a term the vocabulary has not got yet,
+                    // and then what was typed is the name.
+                    //
+                    // The span stays as typed. It has to be the word standing
+                    // in the sentence, and the sentence holds what was written.
+                    let term = existingTerm(named: rule.corrected) ?? rule.corrected
+                    try TermUses.record(term: term, said: corrected, span: rule.corrected)
+                    rebuildPortrait(for: term)
                 } catch {
                     // A portrait that missed one sentence is worth less than a
                     // correction that refused to save over it.

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -272,6 +272,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         owner: NSRunningApplication?, landing: Correction.Landing
     )?
 
+    /// Where each run's clip went, so a hand edit is filed beside the
+    /// dictation it is about. `output_dir` can change between the two — see
+    /// `Trace.record` — and the global would file them apart.
+    private var clipDirectories: [Int: URL] = [:]
+
     /// The focused element's text as it was at the press, for an app that gave
     /// no caret. What changed in it afterwards is where the words went.
     ///
@@ -2145,6 +2150,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 // The trace is opened around the whole chain, not just the
                 // decoder: the stages that follow write into the same record,
                 // and the line is appended even if one of them throws.
+                self?.clipDirectories[press.run] = recording.url.deletingLastPathComponent()
+                self?.clipDirectories = self?.clipDirectories.filter { $0.key > press.run - 8 } ?? [:]
                 let text = try await Trace.record(
                     wav: recording.url.lastPathComponent, source: .live,
                     app: app.map { Trace.App(name: $0.name, bundleID: $0.bundleID) },
@@ -3715,6 +3722,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// panel about it would be noise on every dictation.
     private func offerToLearn(_ changes: [EditWatch.Change]) {
         let sentence = changes.first?.sentence ?? ""
+        // Every change is written down first, whatever the panel does with
+        // it. A word changed to a word both lists know is not offered, and it
+        // is the one label a misheard-word stage cannot get any other way.
+        for change in changes where !EditWatch.onlyPunctuation(change) {
+            let heard = EditWatch.asHeard(change)
+            Trace.edit(
+                heard: change.was, corrected: change.now,
+                text: heard.text, range: heard.range,
+                lang: DictationLanguage.forCorrection(
+                    transcript: heard.text, allowed: config.transcription.languages
+                ),
+                app: lastDictated?.owner?.localizedName,
+                after: Date().timeIntervalSince(edits.startedAt),
+                beside: lastDictated.flatMap { clipDirectories[$0.run] }
+            )
+        }
         // The counters first. A change that runs the other way is not a rule
         // to weigh, and `teaches` would drop half of them — `BetterStack` put
         // back to `better stack` lands on two ordinary words.
@@ -3871,48 +3894,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// Is this correction about a name, or about English?
-    ///
-    /// The panel used to show every one-word change, which is every typo and
-    /// every reword. Distance does not separate them — measured on this
-    /// speaker's own `heard:` lists against ordinary edits, `its -> it\'s`
-    /// scores 1.000 and `Prezi -> Praisy` scores 0.304, so any floor drawn
-    /// through spelling keeps the noise and drops the names.
-    ///
-    /// What separates them is the word the correction lands *on*. Measured on
-    /// the same two sets: the two word lists call 8 of 9 real corrections
-    /// unknown and all 10 of the ordinary ones known. `Sentry` is the miss, and
-    /// it is capitalised, so the second half catches it.
-    ///
-    /// An `or`, which is also the answer to why this was left out before: the
-    /// day `Vercel` enters a dictionary, the capital still offers it.
+    /// Is this correction about a name, or about English? The decision is
+    /// `EditWatch.refusal`, which has a case set; this only says why in the log.
     private func teaches(_ change: EditWatch.Change) -> Bool {
-        let letters = { (s: String) in String(s.filter { $0.isLetter || $0.isNumber }) }
-        // Punctuation or case alone is not a pronunciation. Spacing is: gluing
-        // two words into one is most of this vocabulary — `Red Rock` to
-        // `Redrock`, `Better Stack` to `BetterStack`, `Ghost T` to `Ghostty` —
-        // so the test that ignores punctuation must not ignore the space, or it
-        // throws away the commonest correction there is.
-        let spaced = { (s: String) in
-            String(s.filter { $0.isLetter || $0.isNumber || $0.isWhitespace }).lowercased()
-        }
-        guard spaced(change.was) != spaced(change.now) else {
-            Log.write("correction: \"\(change.was)\" -> \"\(change.now)\" is punctuation,"
-                + " not a name; not offered")
-            return false
-        }
-        if Vocabulary.unseenWord(letters(change.now)) { return true }
-        // A capital that is not the one every sentence starts with.
-        // A capital that is not the one every sentence starts with.
-        //
-        // The first word of the *line* was not the right test. A line holds
-        // several sentences, and every one of them opens with a capital:
-        // correcting `Fais` to `Et` at the start of a sentence mid-line read
-        // as a name because of it, and a French grammar fix was offered as a
-        // vocabulary rule.
-        let opens = EditWatch.opensSentence(in: change.sentence, at: change.nowAt)
-        if change.now.first?.isUppercase == true, !opens { return true }
-        Log.write("correction: \"\(change.was)\" -> \"\(change.now)\" is ordinary English;"
+        guard let refusal = EditWatch.refusal(for: change) else { return true }
+        Log.write("correction: \"\(change.was)\" -> \"\(change.now)\" is \(refusal);"
             + " not offered")
         return false
     }
@@ -4904,7 +4890,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
             do {
                 try ConfigWriter.addVocabularyPronunciation(
-                    term: rule.corrected, heard: rule.heard, kind: rule.kind
+                    term: rule.corrected, heard: rule.heard
                 )
                 // The sentence too, not only the mapping. It is what a term's
                 // portrait is built from, and this is the only moment the app
@@ -5513,7 +5499,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             for rule in rules {
                 do {
                     try ConfigWriter.addVocabularyPronunciation(
-                        term: rule.corrected, heard: rule.heard, kind: rule.kind
+                        term: rule.corrected, heard: rule.heard
                     )
                     Log.write("learned pronunciation: \(rule.heard) -> \(rule.corrected)")
                     Trace.correction(

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2289,6 +2289,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 Log.write(String(
                     format: "transcriber: warmed up in %.1fs", Date().timeIntervalSince(started)
                 ))
+                // Loaded is not the same as run. See `warmDecode`.
+                await transcriber.warmDecode()
             } catch {
                 // Nothing else is worth fetching. Without speech the app
                 // cannot transcribe at all, so 700 MB more buys nothing, and
@@ -2305,11 +2307,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             await transcriber.warmSentenceModel()
             // 81 MB, and the sound pass is on by default.
             Task.detached(priority: .background) {
-                guard await !NeuralPhonemes.isReady() else { return }
-                do { try await NeuralPhonemes.download() } catch {
-                    Log.write("sound model: \(error.localizedDescription); the next"
-                        + " dictation that needs it tries again")
+                if await !NeuralPhonemes.isReady() {
+                    do { try await NeuralPhonemes.download() } catch {
+                        Log.write("sound model: \(error.localizedDescription); the next"
+                            + " dictation that needs it tries again")
+                        return
+                    }
                 }
+                // What the model said last time, read here rather than by the
+                // first dictation. After the fetch, not before: the table is
+                // keyed on a hash of the weights, so with no weights on disk
+                // there is nothing to check it against and it would be dropped
+                // on the one launch that installed them.
+                NeuralPhonemes.warmCache()
             }
             // 335 MB, and only the sentence gate reads them. Someone who turns
             // the gate off should not pay for it.

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -2189,8 +2189,9 @@ struct Config: Decodable, Equatable {
         /// swallows something real.
         var speechGate: Bool = true
         /// Decode the clip a second time beside the first, with silence at
-        /// both ends, and keep that decode when it reaches further. Off by
-        /// default: it recovers a rare failure and costs a second decode.
+        /// both ends, and keep that decode when it reaches further. On by
+        /// default: the arms decode beside the first pass rather than after
+        /// it, so the dictation waits on the slowest one, not on all three.
         ///
         /// The failure is Parakeet skipping frames it never looks at. It
         /// predicts a token and a skip of up to 4 frames of 80ms together, so

--- a/Sources/ParrotFlow/CorrectionPanel.swift
+++ b/Sources/ParrotFlow/CorrectionPanel.swift
@@ -4,8 +4,8 @@ import SwiftUI
 
 /// Teach me the words I got wrong.
 ///
-/// A table: what was heard, what it should be, what kind of thing it names. The
-/// rows are proposed by the spell check rather than typed from nothing — see
+/// A table: what was heard and what it should be. The rows are proposed by the
+/// spell check rather than typed from nothing — see
 /// `VocabularySuggest` for what it finds and what it cannot.
 ///
 /// Visually a sibling of the pill: near-black at 95%, the same plumage rim.
@@ -173,9 +173,8 @@ enum CorrectionMetrics {
     static let heardWidth: CGFloat = 165
     static let arrowWidth: CGFloat = 12
     static let correctedWidth: CGFloat = 185
-    static let kindWidth: CGFloat = 96
-    /// The three columns, the arrow, the ✕, and the gaps between them.
-    static let width: CGFloat = 572
+    /// The two columns, the arrow, the ✕, and the gaps between them.
+    static let width: CGFloat = 482
     static let rowHeight: CGFloat = 40
     static let maxRows = 7
     /// Title, column labels, the add-a-word row, and the buttons. Measured

--- a/Sources/ParrotFlow/CorrectionTable.swift
+++ b/Sources/ParrotFlow/CorrectionTable.swift
@@ -1,16 +1,10 @@
 import Foundation
 import SwiftUI
 
-/// One thing the panel taught: what was heard, what it should be, and what kind
-/// of thing it names.
-///
-/// `kind` is optional because most callers have no opinion. Only the panel
-/// fills it in, and only a filled-in one is written to `vocabulary.yaml` — a
-/// default written as if it were a decision is worse than no line at all.
+/// One thing the panel taught: what was heard and what it should be.
 struct TaughtRule: Equatable {
     var heard: String
     var corrected: String
-    var kind: WordKind?
 }
 
 /// One row of the panel.
@@ -21,7 +15,6 @@ struct CorrectionRow: Identifiable, Equatable {
     /// the whole reason it is a field and not a label.
     var heard: String
     var corrected: String = ""
-    var kind: WordKind = .word
     /// Proposed by the spell check rather than typed. Only used to decide
     /// where the caret starts.
     var suggested: Bool = false
@@ -46,7 +39,7 @@ final class CorrectionModel: ObservableObject {
             let heard = row.heard.trimmingCharacters(in: .whitespacesAndNewlines)
             let corrected = row.corrected.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !heard.isEmpty, !corrected.isEmpty, heard != corrected else { return nil }
-            return TaughtRule(heard: heard, corrected: corrected, kind: row.kind)
+            return TaughtRule(heard: heard, corrected: corrected)
         }
     }
 
@@ -77,7 +70,7 @@ final class CorrectionModel: ObservableObject {
     func load(sentence: String, language: String? = nil) {
         self.sentence = sentence
         rows = VocabularySuggest.rows(in: sentence, language: language).map {
-            CorrectionRow(heard: $0.heard, kind: $0.kind, suggested: true)
+            CorrectionRow(heard: $0.heard, suggested: true)
         }
         if rows.isEmpty { rows = [CorrectionRow(heard: "")] }
         focusFirstRow()
@@ -89,19 +82,8 @@ final class CorrectionModel: ObservableObject {
     /// More than one row when the utterance carried more than one correction:
     /// "Tasmeen spells T A S M E E N and Mick spells M I K" is two rules, and
     /// splitting them across two panels would mean saying it twice.
-    ///
-    /// The kind is still proposed from the tag, because a rule that arrived
-    /// this way has a heard word like any other.
     func load(rules proposed: [(heard: String, corrected: String)], over sentence: String = "") {
         self.sentence = sentence
-        // What the vocabulary already says about this term beats what a tagger
-        // guesses about the word. A term you have already labelled is labelled,
-        // and offering a different answer for it invites you to disagree with
-        // yourself one row at a time.
-        let known = ((try? ConfigStore.load())?.vocabulary.terms ?? [:])
-            .reduce(into: [String: WordKind]()) { out, entry in
-                if let kind = entry.value.kind { out[entry.key.lowercased()] = kind }
-            }
         rows = proposed.map { proposal in
             // The possessive belongs to the sentence, not to the name. Saved as
             // it stands, `Precey's -> Praizy's` teaches a term called `Praizy's`
@@ -113,14 +95,7 @@ final class CorrectionModel: ObservableObject {
                 rule.corrected = String(rule.corrected.dropLast(mine.suffix.count))
                 rule.heard = String(rule.heard.dropLast(theirs.suffix.count))
             }
-            let word = rule.corrected.trimmingCharacters(in: .punctuationCharacters)
-            if let already = known[word.lowercased()] {
-                return CorrectionRow(heard: rule.heard, corrected: rule.corrected, kind: already)
-            }
-            let tag = Tagger.tokens(in: rule.corrected, language: nil).first?.tag
-            return CorrectionRow(
-                heard: rule.heard, corrected: rule.corrected, kind: .from(tag: tag)
-            )
+            return CorrectionRow(heard: rule.heard, corrected: rule.corrected)
         }
         if rows.isEmpty { rows = [CorrectionRow(heard: "")] }
         focusFirstRow()
@@ -150,10 +125,9 @@ final class CorrectionModel: ObservableObject {
 
     // MARK: - Focus
 
-    enum Column: Hashable { case heard, corrected, kind }
+    enum Column: Hashable { case heard, corrected }
 
-    /// One editable thing on the panel. The type menu is one of them: it is a
-    /// third of what a row says, so Tab has to reach it.
+    /// One editable thing on the panel.
     struct Cell: Hashable {
         let row: UUID
         let column: Column
@@ -169,8 +143,7 @@ final class CorrectionModel: ObservableObject {
     private var ring: [Cell] {
         rows.flatMap { row in
             [Cell(row: row.id, column: .heard),
-             Cell(row: row.id, column: .corrected),
-             Cell(row: row.id, column: .kind)]
+             Cell(row: row.id, column: .corrected)]
         }
     }
 

--- a/Sources/ParrotFlow/CorrectionTableView.swift
+++ b/Sources/ParrotFlow/CorrectionTableView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// The teach-a-word panel: one row per word, mapping what ParrotFlow wrote to
-/// what it should have written, and what kind of thing that is.
+/// what it should have written.
 ///
 /// The rows are proposed rather than enumerated. An earlier version put one row
 /// per word of the selection, which is a wall of rows to read on a long
@@ -72,7 +72,6 @@ struct CorrectionView: View {
             Color.clear.frame(width: CorrectionMetrics.arrowWidth)
             Text("SHOULD BE")
                 .frame(width: CorrectionMetrics.correctedWidth, alignment: .leading)
-            Text("TYPE")
             Spacer()
         }
         .font(.system(size: 11, weight: .semibold, design: .rounded))
@@ -107,8 +106,6 @@ struct CorrectionView: View {
                 .parrotField(focused: focused == cell(id, .corrected))
                 .frame(width: CorrectionMetrics.correctedWidth)
 
-            kindPicker(row.kind, id: id)
-
             Button {
                 model.remove(id)
             } label: {
@@ -123,28 +120,6 @@ struct CorrectionView: View {
         }
         .font(.system(size: 15, weight: .medium, design: .monospaced))
         .frame(height: CorrectionMetrics.rowHeight)
-    }
-
-    /// A menu rather than four segments. The proposal is right most of the time,
-    /// so the common case is reading one word and moving on; four segments would
-    /// spend the width of the panel on a control nobody touches.
-    private func kindPicker(_ kind: Binding<WordKind>, id: UUID) -> some View {
-        Menu {
-            ForEach(WordKind.allCases, id: \.self) { option in
-                Button(option.label) { kind.wrappedValue = option }
-            }
-        } label: {
-            Text(kind.wrappedValue.label)
-                .font(.system(size: 13, weight: .medium, design: .rounded))
-        }
-        .menuStyle(.borderlessButton)
-        .frame(width: CorrectionMetrics.kindWidth - 18)
-        // A menu is not in the tab ring unless it asks to be, and macOS only
-        // tabs to non-text controls when Full Keyboard Access is on. The panel
-        // catches Tab itself, so the ring here is ours either way.
-        .focusable()
-        .focused($focused, equals: cell(id, .kind))
-        .parrotField(focused: focused == cell(id, .kind))
     }
 
     private func cell(_ id: UUID, _ column: CorrectionModel.Column) -> CorrectionModel.Cell {

--- a/Sources/ParrotFlow/EditDiffCommand.swift
+++ b/Sources/ParrotFlow/EditDiffCommand.swift
@@ -5,10 +5,11 @@ import Foundation
 ///     ParrotFlow --edit-diff "the Vercel Castle is closed" "the Versailles Castle is closed"
 ///     Vercel -> Versailles
 ///
-/// `EditWatch.change` decides whether a field that no longer says what was
+/// `EditWatch.changes` decides whether a field that no longer says what was
 /// dictated holds a correction or a rewrite, and a rewrite read as a correction
-/// teaches a term the wrong sentence. It is a pure function with no
-/// accessibility and no timing behind it, so it has a set.
+/// teaches a term the wrong sentence. `EditWatch.refusal` then decides whether
+/// the correction is about a name. Neither has accessibility or timing behind
+/// it, so both have a set.
 enum EditDiffCommand {
     static func run(before: String, now: String) -> Int32 {
         let changes = EditWatch.changes(from: before, to: now)
@@ -23,6 +24,17 @@ enum EditDiffCommand {
             // sentence, where every word is capitalised and the capital says
             // nothing about the word.
             print("  opens: \(EditWatch.opensSentence(in: change.sentence, at: change.nowAt))")
+            // Whether the panel would offer it. The two word lists are the
+            // real ones, so the answer is this machine's.
+            if let refusal = EditWatch.refusal(for: change) {
+                print("  offer: no, \(refusal)")
+            } else {
+                print("  offer: yes")
+            }
+            // What `trace.jsonl` would keep: the window as heard and where
+            // the heard word stands in it.
+            let heard = EditWatch.asHeard(change)
+            print("  heard: \(heard.range.lowerBound)..<\(heard.range.upperBound) in \"\(heard.text)\"")
         }
         print("  in: \(changes[0].sentence)")
         return 0

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -343,13 +343,40 @@ final class EditWatch {
             // of it was meant.
             guard left >= 1, right >= 1, left <= 2, right <= 2, left + right <= 3
             else { continue }
-            let pair = Self.trimmed(
+            let candidate = Self.trimmed(
                 was: old[fromI ..< i].joined(separator: " "),
                 now: new[fromJ ..< j].joined(separator: " ")
             )
+            // Words added beside a word are not a correction of it.
+            guard !Self.added(was: candidate.was, now: candidate.now) else { continue }
+            let pair = candidate
             found.append(Change(was: pair.was, now: pair.now, sentence: now, at: fromI, nowAt: fromJ))
         }
         return found
+    }
+
+    /// Whether one reading is the other with more words added beside it.
+    ///
+    /// Typing a name after a word, or pasting into the line, is not a
+    /// correction of anything. `morning` became `morning Tasmeen` and
+    /// `dictation.` became `dictation.[Image #17]`, and both were offered as
+    /// vocabulary rules.
+    ///
+    /// The test is a whole word, not a prefix. `Ghost` to `Ghostty` extends the
+    /// word itself and is a real correction; `Praisy` to `Praisy's` likewise.
+    /// What is refused is one reading standing whole at the start or end of the
+    /// other with a separate word beside it — which is why the longer side has
+    /// to hold a space for this to fire at all.
+    static func added(was: String, now: String) -> Bool {
+        let (short, long) = was.count < now.count ? (was, now) : (now, was)
+        guard short != long, long.contains(where: \.isWhitespace) else { return false }
+        guard long.hasPrefix(short) || long.hasSuffix(short) else { return false }
+        // The rest has to begin or end on a boundary, or `Ghost D` would read
+        // as `Ghost` with a word added.
+        let rest = long.hasPrefix(short)
+            ? long.dropFirst(short.count) : long.dropLast(short.count)
+        return rest.first?.isWhitespace == true || rest.last?.isWhitespace == true
+            || rest.contains(where: \.isWhitespace)
     }
 
     /// The two readings with the punctuation they share taken off both.

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -45,6 +45,11 @@ final class EditWatch {
         /// words into one or splits one into two, so anything reading
         /// `sentence` by index has to use this one.
         let nowAt: Int
+        /// The line as it was written, which `at` indexes. What a scorer
+        /// needs is the text as heard, and `sentence` already has the fix in.
+        let written: String
+        /// How many words of `written` the change covers, from `at`.
+        let span: Int
     }
 
     /// Every correction of one settling, handed over at once.
@@ -77,6 +82,10 @@ final class EditWatch {
     /// and keying by the word lost one of `versal is not versal` corrected to
     /// `Vercel is not Versailles`.
     private var seen: [Int: Change] = [:]
+    /// What has been handed over already. The pending read in `stop` finds
+    /// the same diff for as long as the line stands, and a correction declined
+    /// at one press was offered again at the next.
+    private var told: Set<String> = []
     private var lastLook = Date.distantPast
     /// The read waiting for you to stop typing. Cancelled and replaced by every
     /// key, so it only ever runs once the field has been still.
@@ -103,6 +112,11 @@ final class EditWatch {
 
     var isRunning: Bool { !monitors.isEmpty }
 
+    /// When the dictation this watch is about landed. A change two seconds
+    /// later is most likely a mishearing being fixed; five minutes later it
+    /// is more likely a change of mind. Recorded, not decided on.
+    private(set) var startedAt = Date()
+
     /// Watch the field the dictation just landed in.
     ///
     /// `snapshot` is the whole field as it stands now, not the dictation alone.
@@ -110,11 +124,13 @@ final class EditWatch {
     /// anybody is still editing.
     func start(dictated words: String, in element: AXUIElement?) {
         generation += 1
+        startedAt = Date()
         before = nil
         dictated = words
         field = element
         reported = []
         seen = [:]
+        told = []
         keysSeen = 0
         guard Permissions.accessibility == .granted else {
             Log.write("edit watch: accessibility is not granted; corrections cannot be seen")
@@ -237,7 +253,14 @@ final class EditWatch {
     private func tell() {
         guard !seen.isEmpty else { return }
         let changes = seen.values.sorted { $0.at < $1.at }
+            .filter { told.insert("\($0.at)\u{1}\($0.now)").inserted }
         seen = [:]
+        guard !changes.isEmpty else { return }
+        // Both lines whole, so the log says what the diff ran over and not
+        // only what it found. A 60-character prefix could not explain
+        // `prone.maybe` becoming `prone point.maybe`.
+        Log.write("edit watch: was \"\(before ?? "")\"")
+        Log.write("edit watch: now \"\(changes[0].sentence)\"")
         for change in changes {
             Log.write("edit watch: \"\(change.was)\" became \"\(change.now)\"")
         }
@@ -347,7 +370,10 @@ final class EditWatch {
                 was: old[fromI ..< i].joined(separator: " "),
                 now: new[fromJ ..< j].joined(separator: " ")
             )
-            found.append(Change(was: pair.was, now: pair.now, sentence: now, at: fromI, nowAt: fromJ))
+            found.append(Change(
+                was: pair.was, now: pair.now, sentence: now, at: fromI, nowAt: fromJ,
+                written: before, span: i - fromI
+            ))
         }
         return found
     }
@@ -362,6 +388,10 @@ final class EditWatch {
     /// Only punctuation is cut, never letters. `Prizzy -> Praizy` shares "Pr"
     /// and "zy" and must survive whole; cutting shared letters would offer
     /// "iz -> aiz", which is not a word anybody said.
+    ///
+    /// The same at the tail. `prone.maybe` became `prone point.maybe`: the
+    /// two share `.maybe`, and the second sentence is not part of the
+    /// correction. It comes off from the first mark of the shared suffix.
     static func trimmed(was: String, now: String) -> (was: String, now: String) {
         let a = Array(was), b = Array(now)
         func plain(_ c: Character) -> Bool { c.isLetter || c.isNumber }
@@ -371,16 +401,104 @@ final class EditWatch {
         var head = 0
         for i in 0 ..< shared where !plain(a[i]) { head = i + 1 }
 
-        var tail = 0
-        while tail < a.count - head, tail < b.count - head,
-              a[a.count - 1 - tail] == b[b.count - 1 - tail],
-              !plain(a[a.count - 1 - tail]) {
-            tail += 1
+        var sharedTail = 0
+        while sharedTail < a.count - head, sharedTail < b.count - head,
+              a[a.count - 1 - sharedTail] == b[b.count - 1 - sharedTail] {
+            sharedTail += 1
         }
+        var tail = 0
+        for i in 0 ..< sharedTail where !plain(a[a.count - 1 - i]) { tail = i + 1 }
 
         guard head + tail > 0, a.count - head - tail > 0, b.count - head - tail > 0
         else { return (was, now) }
         return (String(a[head ..< (a.count - tail)]), String(b[head ..< (b.count - tail)]))
+    }
+
+    /// The line as heard around the change, and where `was` stands in it.
+    ///
+    /// Twelve words either side, clipped to the line. That is the window the
+    /// scorers read; the whole line is a terminal's input box and may hold
+    /// several dictations. The words are joined with single spaces, so a row
+    /// that wrapped comes back as one line, and the range is in characters
+    /// of the text returned.
+    static func asHeard(_ change: Change, margin: Int = 12) -> (text: String, range: Range<Int>) {
+        let said = words(of: change.written)
+        let end = min(said.count, change.at + change.span)
+        guard change.at < end else { return (change.was, 0 ..< change.was.count) }
+        let from = max(0, change.at - margin)
+        let to = min(said.count, end + margin)
+        let text = said[from ..< to].joined(separator: " ")
+        let run = said[change.at ..< end].joined(separator: " ")
+        let head = said[from ..< change.at].reduce(0) { $0 + $1.count + 1 }
+        let inner = run.range(of: change.was).map { run.distance(from: run.startIndex, to: $0.lowerBound) } ?? 0
+        let start = head + inner
+        return (text, start ..< start + change.was.count)
+    }
+
+    // MARK: - the offer
+
+    /// Why a change is not worth a panel.
+    enum Refusal: CustomStringConvertible {
+        /// Punctuation or case alone. Not a pronunciation.
+        case punctuation
+        /// Every word it lands on is one the word lists know.
+        case ordinary
+
+        var description: String {
+            switch self {
+            case .punctuation: return "punctuation, not a name"
+            case .ordinary: return "ordinary English"
+            }
+        }
+    }
+
+    /// Punctuation or case alone, which is not a pronunciation. Spacing is:
+    /// gluing two words into one is most of this vocabulary — `Red Rock` to
+    /// `Redrock`, `Ghost T` to `Ghostty` — so the test that ignores
+    /// punctuation must not ignore the space.
+    static func onlyPunctuation(_ change: Change) -> Bool {
+        let spaced = { (s: String) in
+            String(s.filter { $0.isLetter || $0.isNumber || $0.isWhitespace }).lowercased()
+        }
+        return spaced(change.was) == spaced(change.now)
+    }
+
+    /// Is this correction about a name, or about English?
+    ///
+    /// Spelling distance does not separate them. Measured on this speaker's
+    /// own `heard:` lists against ordinary edits, `its -> it's` scores 1.000
+    /// and `Prezi -> Praisy` 0.304, so any floor drawn through spelling keeps
+    /// the noise and drops the names.
+    ///
+    /// The word the correction lands *on* does. On the same two sets the two
+    /// word lists call 8 of 9 real corrections unknown and all 10 ordinary ones
+    /// known. `Sentry` is the miss, and it is capitalised, so the capital is
+    /// the second test — an `or`, so the day `Vercel` enters a dictionary it is
+    /// still offered.
+    ///
+    /// Word by word. `prone -> prone point` was glued to `pronepoint` before it
+    /// was looked up, and no list knows that, so a sentence being repaired was
+    /// offered as a term. One name in the span is enough to offer it.
+    static func refusal(
+        for change: Change, unseen: (String) -> Bool = Vocabulary.unseenWord
+    ) -> Refusal? {
+        let letters = { (s: String) in String(s.filter { $0.isLetter || $0.isNumber }) }
+        guard !onlyPunctuation(change) else { return .punctuation }
+        let said = change.now.split(whereSeparator: { $0.isWhitespace }).map(String.init)
+        for (offset, word) in said.enumerated() {
+            let bare = letters(word)
+            guard !bare.isEmpty else { continue }
+            if unseen(bare) { return nil }
+            // A capital that is not the one every sentence starts with. The
+            // first word of the *line* was not the right test: a line holds
+            // several sentences, and correcting `Fais` to `Et` at the start of
+            // one mid-line read as a name because of it.
+            if bare.first?.isUppercase == true,
+               !opensSentence(in: change.sentence, at: change.nowAt + offset) {
+                return nil
+            }
+        }
+        return .ordinary
     }
 
     /// The words of a line, punctuation kept: `Vercel.` and `Vercel` are not the

--- a/Sources/ParrotFlow/InventedTailCommand.swift
+++ b/Sources/ParrotFlow/InventedTailCommand.swift
@@ -1,0 +1,203 @@
+import FluidAudio
+import Foundation
+import Yams
+
+/// `--invented-tail` — the endings Parakeet writes over silence, scored against
+/// real decodes.
+///
+/// Every case is a word array taken from `trace.jsonl`, so what is scored is
+/// what the decoder actually returned on a clip somebody dictated. The words
+/// are turned back into token timings and handed to the real
+/// `Transcriber.withoutInventedTail`, which means the text trim is scored too
+/// — the half that can go wrong quietly, because `ASRResult.text` and the
+/// timings are two different objects and only one of them reaches the screen.
+///
+/// The set is meant to be read in both directions. A rule that drops an
+/// invention nobody said is worth nothing if it also drops "Kim?" off the end
+/// of a question, so the cases that must survive outnumber the ones that must
+/// go.
+enum InventedTailCommand {
+
+    private struct Case {
+        let name: String
+        let speechEnd: Double?
+        let text: String
+        let words: [Trace.Word]
+        /// The text that must survive. Equal to `text` when nothing goes.
+        let keeps: String
+        /// `burst`, `after speech`, or nil when nothing may be dropped.
+        let reason: String?
+        /// What `decodedNothing` must say, when the case asks.
+        let nothing: Bool?
+    }
+
+    static func run(casesPath: String?) -> Int32 {
+        let path = casesPath ?? FileManager.default.currentDirectoryPath
+            + "/tests/invented-tail-cases.yaml"
+        let cases: [Case]
+        do {
+            cases = try loadCases(at: path)
+        } catch {
+            print("✗ cases: \(error.localizedDescription)")
+            return 1
+        }
+
+        var failures = 0
+        for testCase in cases {
+            failures += check(testCase) ? 0 : 1
+        }
+        print("")
+        print("  \(cases.count - failures)/\(cases.count)")
+        return failures == 0 ? 0 : 1
+    }
+
+    private static func check(_ testCase: Case) -> Bool {
+        let result = decode(testCase)
+        let trimmed = Transcriber.withoutInventedTail(result, speechEnd: testCase.speechEnd)
+        let found = Transcriber.inventedTail(words: testCase.words, speechEnd: testCase.speechEnd)
+
+        var problems: [String] = []
+        if trimmed.text != testCase.keeps {
+            problems.append("kept \"\(trimmed.text)\", expected \"\(testCase.keeps)\"")
+        }
+        if found?.reason != testCase.reason {
+            problems.append("read it as \(found?.reason ?? "speech"), "
+                + "expected \(testCase.reason ?? "speech")")
+        }
+        // The timings have to lose exactly the words the text lost, or the HUD
+        // and the trace describe different sentences.
+        let lostTimings = testCase.words.count - Trace.words(from: trimmed.tokenTimings ?? []).count
+        let lostText = words(in: testCase.text) - words(in: trimmed.text)
+        if lostTimings != lostText {
+            problems.append("\(lostTimings) word(s) of timing dropped against \(lostText) of text")
+        }
+        // The aggregate has to describe the words that survive, as the
+        // decoder would have scored them on their own: the mean, clamped to
+        // 0.1...1.
+        let survivors = Array(testCase.words.prefix(testCase.words.count - lostText))
+        if !survivors.isEmpty {
+            let mean = survivors.map(\.confidence).reduce(0, +) / Float(survivors.count)
+            let expected = lostText == 0 ? result.confidence : max(0.1, min(1, mean))
+            if abs(trimmed.confidence - expected) > 0.0005 {
+                problems.append(String(
+                    format: "confidence %.3f after the trim, expected %.3f from the kept words",
+                    trimmed.confidence, expected
+                ))
+            }
+        }
+        if let wanted = testCase.nothing {
+            let gate = Transcriber.SpeechGate(
+                samples: [], segments: [(start: 0, end: testCase.speechEnd ?? 1)], decodable: true
+            )
+            let got = Transcriber.decodedNothing(result, gate: gate)
+            if got != wanted {
+                problems.append("decodedNothing said \(got), expected \(wanted)")
+            }
+        }
+
+        guard problems.isEmpty else {
+            print("  ✗ \(testCase.name)")
+            for problem in problems { print("      \(problem)") }
+            return false
+        }
+        print("  ✓ \(testCase.name) — \(describe(found, kept: trimmed.text, of: testCase))")
+        return true
+    }
+
+    private static func words(in text: String) -> Int {
+        text.split(whereSeparator: \.isWhitespace).count
+    }
+
+    private static func describe(
+        _ found: (count: Int, reason: String)?, kept: String, of testCase: Case
+    ) -> String {
+        guard let found else { return "kept whole" }
+        guard kept != testCase.text else { return "\(found.reason), and the trim refused" }
+        return "dropped \(found.count) (\(found.reason)), left \"\(kept)\""
+    }
+
+    /// The case as the decoder would have handed it over: one token per word,
+    /// marked the way SentencePiece marks a word's first piece, so
+    /// `Trace.words` gives the case's own words back. The aggregate is the
+    /// mean, which is what FluidAudio puts there.
+    private static func decode(_ testCase: Case) -> ASRResult {
+        let mean = testCase.words.map(\.confidence).reduce(0, +)
+            / Float(max(testCase.words.count, 1))
+        return ASRResult(
+            text: testCase.text,
+            confidence: max(0.1, min(1, mean)),
+            duration: testCase.words.last?.end ?? 0,
+            processingTime: 0,
+            tokenTimings: testCase.words.map {
+                TokenTiming(
+                    token: "\u{2581}" + $0.word,
+                    tokenId: 0,
+                    startTime: $0.start,
+                    endTime: $0.end,
+                    confidence: $0.confidence
+                )
+            }
+        )
+    }
+
+    private static func loadCases(at path: String) throws -> [Case] {
+        let text = try String(contentsOfFile: path, encoding: .utf8)
+        let raw = try YAMLDecoder().decode([RawCase].self, from: text)
+        return try raw.map { one in
+            let words = try one.words.map(word)
+            let text = one.text ?? words.map(\.word).joined(separator: " ")
+            return Case(
+                name: one.name,
+                speechEnd: one.speechEnd,
+                text: text,
+                words: words,
+                keeps: one.keeps ?? text,
+                reason: one.reason,
+                nothing: one.nothing
+            )
+        }
+    }
+
+    /// `<word> <start> <end> <confidence>`. Read from the right, so a word
+    /// that is itself a number is still a word.
+    private static func word(_ line: String) throws -> Trace.Word {
+        let fields = line.split(whereSeparator: \.isWhitespace).map(String.init)
+        guard fields.count >= 4, let start = Double(fields[fields.count - 3]),
+            let end = Double(fields[fields.count - 2]),
+            let confidence = Float(fields[fields.count - 1])
+        else {
+            throw CaseError.word(line)
+        }
+        return Trace.Word(
+            word: fields[0..<(fields.count - 3)].joined(separator: " "),
+            start: start, end: end, confidence: confidence
+        )
+    }
+
+    private enum CaseError: LocalizedError {
+        case word(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .word(let line):
+                return "a word needs \"<word> <start> <end> <confidence>\", got \"\(line)\""
+            }
+        }
+    }
+
+    private struct RawCase: Decodable {
+        let name: String
+        let speechEnd: Double?
+        let text: String?
+        let words: [String]
+        let keeps: String?
+        let reason: String?
+        let nothing: Bool?
+
+        enum CodingKeys: String, CodingKey {
+            case name
+            case speechEnd = "speech_end"
+            case text, words, keeps, reason, nothing
+        }
+    }
+}

--- a/Sources/ParrotFlow/NeuralPhonemes.swift
+++ b/Sources/ParrotFlow/NeuralPhonemes.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import FluidAudio
 
@@ -66,8 +67,204 @@ enum NeuralPhonemes {
         try await MultilingualG2PModel.shared.ensureModelsAvailable()
     }
 
-    private static var cache: [String: String] = [:]
+    // MARK: - what the model has already said
+
+    /// The answers so far, by language and then by word, kept between launches.
+    ///
+    /// The sound pass asks about every 1- and 2-word window of the sentence,
+    /// and each miss is one sequence-to-sequence call. Held only in memory this
+    /// table started empty at every launch, so every session paid for its own
+    /// warm-up. Warmed on 1211 English dictations from the archive and asked
+    /// the next 135, 51.5% of windows were already known: 6.7 model calls a
+    /// dictation instead of 13.7.
+    ///
+    /// No cap. Those 1211 dictations produce 10305 entries, about 460 KB, and
+    /// an entry is a word and a short string of IPA.
+    private static var cache: [String: [String: String]] = [:]
+    private static var loadedFromDisk = false
+    private static var savePending = false
+    /// Worked out once per launch. The files do not move under a running app.
+    private static var weights: String?
     private static let cacheLock = NSLock()
+    private static let saveQueue = DispatchQueue(label: "com.parrotflow.phonemes")
+
+    /// Named for the model. The name says which model wrote the table and
+    /// nothing about which weights, which is what `weightsFingerprint` is for.
+    private static var cacheURL: URL {
+        AppVariant.supportDirectory
+            .appendingPathComponent("phonemes-multilingual-g2p.json")
+    }
+
+    /// The weights on disk, hashed. Every byte of both G2P bundles, each file
+    /// preceded by its path under the cache root so a file moving counts too.
+    ///
+    /// The table has to be thrown away when the model changes, and there is
+    /// nothing cheaper to hang that on. FluidAudio publishes no version for
+    /// these models, `ModelNames.MultilingualG2P` is two file names and no
+    /// revision, and the download leaves no manifest — the `config.json` beside
+    /// the bundles is `{}`. The bytes are the only identity there is.
+    ///
+    /// Path, size and modification date were tried first and are not enough:
+    /// weights can be replaced with different bytes of the same size and the
+    /// dates put back, and the table would then be kept against a model that no
+    /// longer agrees with it. The damage is a mixed table rather than an old
+    /// one — a window read by the new model scored against a term read by the
+    /// old one over a 0.85 floor, with neither reading wrong on its own.
+    ///
+    /// One pass over 79 MB, once per launch — the answer is held in `weights`
+    /// for the life of the process. It is cheaper than it sounds because the
+    /// files are in the page cache by the time anything asks: the model has
+    /// just been loaded. `--sound` end to end is 0.37-0.44s with this and was
+    /// 0.43s without it, which is inside the noise. A genuinely cold read costs
+    /// about a second, and `AppDelegate` pays it on the same background task
+    /// that fetches the model, so a dictation waits on it only if one is
+    /// started before that task gets there.
+    ///
+    /// Streamed in 1 MB chunks. The point is a digest, not 79 MB resident.
+    ///
+    /// Nil when both bundles are not there to read, and then nothing is
+    /// written: a table that cannot be keyed cannot be trusted next launch.
+    private static func weightsFingerprint() -> String? {
+        cacheLock.lock()
+        let known = weights
+        cacheLock.unlock()
+        if let known { return known }
+
+        guard let root = try? TtsCacheDirectory.ensure() else { return nil }
+        let wanted = ModelNames.MultilingualG2P.requiredModels
+        let manager = FileManager.default
+        guard let walk = manager.enumerator(
+            at: root, includingPropertiesForKeys: nil
+        ) else { return nil }
+
+        var seen: Set<String> = []
+        var files: [URL] = []
+        for case let url as URL in walk where wanted.contains(url.lastPathComponent) {
+            walk.skipDescendants()
+            seen.insert(url.lastPathComponent)
+            guard let inside = manager.enumerator(
+                at: url, includingPropertiesForKeys: nil
+            ) else { return nil }
+            for case let file as URL in inside {
+                var directory: ObjCBool = false
+                guard manager.fileExists(atPath: file.path, isDirectory: &directory),
+                      !directory.boolValue
+                else { continue }
+                files.append(file)
+            }
+        }
+        guard seen == wanted, !files.isEmpty else { return nil }
+
+        var hasher = SHA256()
+        // Sorted, so the digest does not depend on the order the enumerator
+        // happened to walk in. The path goes in with the bytes: both bundles
+        // hold a `model.mil` and a `weights/weight.bin`.
+        for file in files.sorted(by: { $0.path < $1.path }) {
+            hasher.update(data: Data(file.path.dropFirst(root.path.count).utf8))
+            guard let handle = try? FileHandle(forReadingFrom: file) else { return nil }
+            defer { try? handle.close() }
+            while let chunk = try? handle.read(upToCount: 1 << 20), !chunk.isEmpty {
+                hasher.update(data: chunk)
+            }
+        }
+        let mark = String(
+            hasher.finalize().compactMap { String(format: "%02x", $0) }.joined().prefix(16)
+        )
+        cacheLock.lock()
+        weights = mark
+        cacheLock.unlock()
+        return mark
+    }
+
+    /// Reads the table now, so the first dictation of the session does not.
+    ///
+    /// Safe to call from anywhere and safe to call twice. Called at launch and
+    /// again at the top of `of`, for the run where the launch call has not
+    /// landed yet.
+    static func warmCache() {
+        cacheLock.lock()
+        let already = loadedFromDisk
+        cacheLock.unlock()
+        guard !already else { return }
+
+        let disk = readCache()
+        cacheLock.lock()
+        if !loadedFromDisk {
+            // Anything computed while the file was being read wins. It came
+            // from the same weights and it is the later answer.
+            for (language, words) in disk {
+                cache[language] = words.merging(cache[language] ?? [:]) { _, live in live }
+            }
+            loadedFromDisk = true
+        }
+        cacheLock.unlock()
+    }
+
+    /// Writes the table back, off the caller's thread and one write at a time.
+    ///
+    /// A dictation adds a handful of entries and the whole table is re-encoded,
+    /// so this must not run on the path it exists to shorten. A second request
+    /// arriving while one is queued is dropped rather than queued behind it:
+    /// the block reads the table when it runs, so it already carries whatever
+    /// the second caller added.
+    private static func scheduleSave() {
+        cacheLock.lock()
+        let pending = savePending
+        savePending = true
+        cacheLock.unlock()
+        guard !pending else { return }
+
+        saveQueue.async {
+            cacheLock.lock()
+            savePending = false
+            let snapshot = cache
+            cacheLock.unlock()
+            writeCache(snapshot)
+        }
+    }
+
+    /// Waits for a queued write to land.
+    ///
+    /// For a process that ends: a CLI command, or the app quitting. Without it
+    /// a `--sound` run asks the model for words it will ask for again next
+    /// time, because it exits before the write does.
+    static func flushCache() {
+        saveQueue.sync {}
+    }
+
+    /// The file: the weights that wrote the table, and the table.
+    private struct Stored: Codable {
+        let weights: String
+        let words: [String: [String: String]]
+    }
+
+    private static func readCache() -> [String: [String: String]] {
+        guard let here = weightsFingerprint(),
+              let data = try? Data(contentsOf: cacheURL),
+              let stored = try? JSONDecoder().decode(Stored.self, from: data)
+        else { return [:] }
+        guard stored.weights == here else {
+            Log.write("phonemes: the sound model has changed since these"
+                + " pronunciations were saved; starting again")
+            return [:]
+        }
+        return stored.words
+    }
+
+    private static func writeCache(_ table: [String: [String: String]]) {
+        guard let here = weightsFingerprint() else { return }
+        do {
+            try FileManager.default.createDirectory(
+                at: cacheURL.deletingLastPathComponent(), withIntermediateDirectories: true
+            )
+            try JSONEncoder().encode(Stored(weights: here, words: table))
+                .write(to: cacheURL, options: .atomic)
+        } catch {
+            // The table is still in memory for this run and the next run asks
+            // the model again. Not worth failing a dictation over.
+            Log.write("phonemes: could not cache (\(error.localizedDescription))")
+        }
+    }
 
     /// The IPA of every word given. Absent from the result means the model had
     /// nothing to say about it.
@@ -75,18 +272,20 @@ enum NeuralPhonemes {
     /// One word per call by construction — the model is sequence to sequence
     /// and takes one string — so this is the slower of the two ears. The cache
     /// is what makes that affordable: an ordinary dictation asks about words
-    /// it has asked about before.
+    /// it has asked about before, this launch or a previous one.
     static func of(
         _ words: [String], language: MultilingualG2PLanguage
     ) async -> [String: String] {
         guard await isReady() else { return [:] }
+        warmCache()
+        let table = language.rawValue
         var answer: [String: String] = [:]
+        var added = false
         for word in words {
             let clean = Phonemes.cleaned(word)
             guard !clean.isEmpty else { continue }
-            let key = "\(language.rawValue)\u{0}\(clean)"
             cacheLock.lock()
-            let known = cache[key]
+            let known = cache[table]?[clean]
             cacheLock.unlock()
             if let known {
                 if !known.isEmpty { answer[word] = known }
@@ -98,17 +297,28 @@ enum NeuralPhonemes {
                     .phonemize(word: clean, language: language)?
                     .joined() ?? ""
             } catch {
-                said = ""
+                // Not an answer, so it is not written down. A call that threw
+                // is a model that was busy or half-loaded, and the table now
+                // outlives the process: caching its silence would hide this
+                // word from the sound pass at every future launch as well.
+                // `nil` above is the other case — the model saying it has
+                // nothing for this word — and that is worth keeping.
+                continue
             }
             // Stress and length go, exactly as they do for espeak — the two
             // scores are compared against one floor, so they have to be the
             // same kind of string.
             let clipped = Phonemes.clip(said)
             cacheLock.lock()
-            cache[key] = clipped
+            // Empty is an answer and it is kept. A word the model has nothing
+            // to say about costs a call to find out, and it costs the same
+            // call every time it is asked again.
+            cache[table, default: [:]][clean] = clipped
             cacheLock.unlock()
+            added = true
             if !clipped.isEmpty { answer[word] = clipped }
         }
+        if added { scheduleSave() }
         return answer
     }
 }

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -237,15 +237,14 @@ enum PanelsCommand {
         // the case the table has to be able to hold.
         let rule = CorrectionModel()
         rule.load(sentence: "we deployed on Ver Sal")
-        rule.rows = [CorrectionRow(heard: "Ver Sal", corrected: "Vercel",
-                                   kind: .organization)]
+        rule.rows = [CorrectionRow(heard: "Ver Sal", corrected: "Vercel")]
         // The rows were replaced wholesale, so the focus `load` left points at
         // a row that no longer exists.
         rule.focus = CorrectionModel.Cell(row: rule.rows[0].id, column: .corrected)
 
-        // Two rows, so the picker is drawn twice against different words. The
-        // sheet cannot show a focus ring on any of them: it renders offscreen,
-        // in no key window, and SwiftUI grants focus to neither.
+        // Two rows. The sheet cannot show a focus ring on any of them: it
+        // renders offscreen, in no key window, and SwiftUI grants focus to
+        // neither.
         let several = CorrectionModel()
         several.load(sentence: "Olama runs polyma for Tasmine")
 

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -970,12 +970,21 @@ struct Pipeline: Equatable, Codable {
         // near miss has to raise this or that stage never runs.
         var nearMisses = 0
         var bySound = 0
+        // Where this stage's time goes, split at its two model calls. The
+        // stage's own `ms` is one number for all of it, so it cannot tell a
+        // pronunciation the model has never been asked for from a term
+        // portrait being rebuilt. Those are the two things that put a
+        // dictation past a second here.
+        var soundSeconds = 0.0
+        var gateSeconds = 0.0
         func result(_ text: String, _ vars: [String: Scope.Value]) -> StageResult {
             let wrote: [String: Scope.Value] = [
                 "count": .int(exact.count + nearMisses + bySound),
                 "changes": .string(exact.changes),
                 "before": .string(handed),
                 "protected": .string(exact.protected),
+                "sound_ms": .int(Int((soundSeconds * 1000).rounded())),
+                "gate_ms": .int(Int((gateSeconds * 1000).rounded())),
             ]
             return StageResult(text: text, vars: wrote.merging(vars) { _, new in new })
         }
@@ -1021,10 +1030,12 @@ struct Pipeline: Equatable, Codable {
         // measured over 20891 dictations — see `phonemeParts` for what fires
         // and what it costs.
         if step.bySound ?? true, Pipeline.language(of: text, config: config) == "en" {
+            let askedAt = Date()
             let heard = await VocabularyJudge.phonemeParts(
                 in: text, sounds: config.vocabularySounds, voice: "en-us",
                 language: "en", floor: config.vocabulary.soundBelow, claimed: parts
             )
+            soundSeconds = Date().timeIntervalSince(askedAt)
             bySound = heard.count
             parts += heard
         }
@@ -1064,6 +1075,7 @@ struct Pipeline: Equatable, Codable {
         //
         // `taught` wins over the gate, because a spelling lesson is settled by
         // a rule that is 4/4 where the models measured were 0/4.
+        let gatedAt = Date()
         let settled = (step.gate ?? true)
             ? VocabularyJudge.settle(
                 changes, in: text, by: [.sound: .full, .rule: .lists],
@@ -1076,6 +1088,7 @@ struct Pipeline: Equatable, Codable {
         if config.vocabulary.gateSentence, #available(macOS 14, *) {
             decided = await SentenceGate.settle(changes, in: text, given: decided)
         }
+        gateSeconds = Date().timeIntervalSince(gatedAt)
 
         let gated = decided.enumerated().filter { $0.element != nil && !taught[$0.offset] }.count
         if gated > 0 {

--- a/Sources/ParrotFlow/TermPortrait.swift
+++ b/Sources/ParrotFlow/TermPortrait.swift
@@ -174,6 +174,10 @@ actor TermPortrait {
     private var cache: [String: Summary] = [:]
     private var loadedFromDisk = false
 
+    /// The build running for a term, and the uses it was started for. See
+    /// `summary` for why an actor alone does not stop two of them.
+    private var building: [String: (mark: String, task: Task<Summary, Error>)] = [:]
+
     /// Keyed by the model, because the numbers are only comparable within one
     /// set of weights. A model change invalidates every summary and no
     /// sentence.
@@ -293,7 +297,34 @@ actor TermPortrait {
         if !loadedFromDisk { cache = Self.readCache(); loadedFromDisk = true }
         if let held = cache[term], held.fingerprint == mark { return held }
 
-        let built = try await Self.build(uses, against: counters, fingerprint: mark)
+        // A build already running for this same fingerprint is the build this
+        // caller wants, so join it rather than start a second one.
+        //
+        // Actor isolation is not enough on its own. `build` awaits a vector per
+        // use, and an actor lets another call in at every one of those
+        // suspensions — so two callers can both find the cache stale on either
+        // side of the same await and both do the whole thing. That is exactly
+        // the pair this stage now creates: the rebuild a correction starts, and
+        // the dictation that names the term while it is still running. Without
+        // this the dictation waits for a full build anyway, and the machine
+        // does the work twice. Same shape as `Transcriber.loadingModels` and
+        // `WordVectors.loading`.
+        //
+        // Keyed on the fingerprint too, because a build in flight for older
+        // uses is the wrong answer for this caller — another correction may
+        // have landed since it started.
+        if let running = building[term], running.mark == mark {
+            return try await running.task.value
+        }
+
+        let task = Task { try await Self.build(uses, against: counters, fingerprint: mark) }
+        building[term] = (mark: mark, task: task)
+        // Only if it is still ours. A correction arriving mid-build starts its
+        // own task under this key, and clearing that one would let a third
+        // caller start a duplicate of it.
+        defer { if building[term]?.mark == mark { building[term] = nil } }
+
+        let built = try await task.value
         cache[term] = built
         Self.writeCache(cache)
         return built

--- a/Sources/ParrotFlow/Trace.swift
+++ b/Sources/ParrotFlow/Trace.swift
@@ -50,6 +50,7 @@ enum Trace {
     enum Kind: String {
         case dictation
         case correction
+        case edit
     }
 
     /// The app a dictation was spoken into.
@@ -249,6 +250,24 @@ enum Trace {
         )
     }
 
+    /// Writes down a word changed by hand. See `Edit`.
+    /// - Parameter beside: the directory holding the dictation's clip, so the
+    ///   edit and the dictation it is about are in one file. See `record`.
+    static func edit(
+        heard: String, corrected: String, text: String, range: Range<Int>,
+        lang: String, app: String?, after: TimeInterval, beside: URL? = nil
+    ) {
+        append(
+            Edit(
+                v: version, kind: Kind.edit.rawValue, at: stamp(),
+                heard: heard, corrected: corrected, text: text,
+                range: [range.lowerBound, range.upperBound], lang: lang, app: app,
+                after: (after * 10).rounded() / 10
+            ),
+            to: beside ?? directory
+        )
+    }
+
     private static let queue = DispatchQueue(label: "com.parrotflow.trace")
 
     /// Waits for queued writes to reach the file. Same reason as `Log.flush` —
@@ -400,11 +419,8 @@ enum Trace {
     /// got a word wrong and what the right one was. It cannot be reconstructed
     /// afterwards from anything else on disk.
     ///
-    /// These are the corrections ParrotFlow already mediates — the panel, an
-    /// inline instruction, `--learn` — and nothing more. Watching the field
-    /// after the text lands would catch more of them, and would mean reading
-    /// another app's content back out through Accessibility after we have given
-    /// focus away. That is a different thing to be, and not one this file needs.
+    /// These are the corrections ParrotFlow mediates — the panel, an inline
+    /// instruction, `--learn`. A change made by hand in the field is `Edit`.
     fileprivate struct Correction: Encodable {
         let v: Int
         let kind: String
@@ -412,6 +428,40 @@ enum Trace {
         let heard: String
         let corrected: String
         let via: String
+    }
+
+    /// A word changed by hand in the field after the dictation landed.
+    ///
+    /// Every one the watch sees, not only the ones the panel opens on. A
+    /// misheard ordinary word — `backgrounds` for `bigrams` — is refused by
+    /// the panel because both sides are words the lists know, and it is
+    /// exactly the label a misheard-word stage would need. Rewords are kept
+    /// too: at record time nothing can tell `hear -> say` from `drew -> few`,
+    /// since real mishearings score 0.20 to 0.43 on the sound measure and
+    /// unrelated words in the same slot score the same. Sound is a question
+    /// for whoever reads the file.
+    ///
+    /// `text` is the line **as heard**, before the change, and `range` is
+    /// where `heard` stands in it, in characters. A sentence with the fix
+    /// already in it is worse than none: the term portrait was once scored
+    /// on text after the rule had written the term in, and 4 of 4 cases
+    /// flipped when scored as heard.
+    ///
+    /// This stores the person's own sentences. That is the point of it: a
+    /// count table keeps statistics and drops the context, and the context is
+    /// what a scorer needs. `docs/corrections.md` says so.
+    fileprivate struct Edit: Encodable {
+        let v: Int
+        let kind: String
+        let at: String
+        let heard: String
+        let corrected: String
+        let text: String
+        let range: [Int]
+        let lang: String
+        let app: String?
+        /// Seconds between the dictation landing and the change.
+        let after: Double
     }
 
     fileprivate struct ASR: Encodable {

--- a/Sources/ParrotFlow/Trace.swift
+++ b/Sources/ParrotFlow/Trace.swift
@@ -336,21 +336,32 @@ enum Trace {
     /// confidence: a name that came through as one solid piece and one shaky
     /// one is a shaky name, and averaging hides exactly that.
     static func words(from timings: [TokenTiming]) -> [Word] {
-        var words: [Word] = []
+        grouped(from: timings).map(\.word)
+    }
+
+    /// The same grouping, with the tokens each word was built from.
+    ///
+    /// One implementation, because a caller that cuts words off a decode has to
+    /// cut the tokens the same way. A second copy of this loop would drift.
+    static func grouped(from timings: [TokenTiming]) -> [(word: Word, tokens: Range<Int>)] {
+        var words: [(word: Word, tokens: Range<Int>)] = []
         var text = ""
         var start = 0.0
         var end = 0.0
         var confidence = Float.greatestFiniteMagnitude
+        var first = 0
+        var last = 0
 
         func flush() {
             let trimmed = text.trimmingCharacters(in: .whitespaces)
             guard !trimmed.isEmpty else { return }
-            words.append(
-                Word(word: trimmed, start: start, end: end, confidence: confidence)
-            )
+            words.append((
+                Word(word: trimmed, start: start, end: end, confidence: confidence),
+                first..<(last + 1)
+            ))
         }
 
-        for timing in timings {
+        for (index, timing) in timings.enumerated() {
             let token = timing.token
             if token.isEmpty || token == "<blank>" || token == "<pad>" { continue }
 
@@ -361,11 +372,13 @@ enum Trace {
                 text = token.replacingOccurrences(of: "\u{2581}", with: "")
                 start = timing.startTime
                 confidence = timing.confidence
+                first = index
             } else {
                 text += token
                 confidence = min(confidence, timing.confidence)
             }
             end = timing.endTime
+            last = index
         }
         flush()
         return words

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -98,6 +98,37 @@ actor Transcriber {
         return try await task.value
     }
 
+    /// One decode of silence, so the first real clip does not pay for the
+    /// graph being run for the first time.
+    ///
+    /// `prepare` loads the weights and stops there. Core ML compiles and lays
+    /// out its kernels on the first inference, and over the archive that shows
+    /// up as the first dictation after a gap being slower: 0.074s of processing
+    /// per second of audio on the 20 dictations that opened a session, against
+    /// 0.046s on the other 849, and 0.30s on the worst one.
+    ///
+    /// A second of silence rather than a real clip. The encoder is the part
+    /// that compiles and it runs on whatever it is given; the decoder runs its
+    /// frames too and commits nothing, which is the point.
+    ///
+    /// Nothing waits on this and nothing reads its result. A failure is logged
+    /// and dropped: the first dictation is then as slow as it is today.
+    func warmDecode() async {
+        guard let models else { return }
+        let started = Date()
+        let asr = AsrManager(models: models)
+        var state = await TdtDecoderState.make(decoderLayers: asr.decoderLayerCount)
+        let silence = [Float](repeating: 0, count: Int(Self.sampleRate))
+        do {
+            _ = try await asr.transcribe(silence, decoderState: &state)
+            Log.write(String(
+                format: "transcriber: warm decode in %.2fs", Date().timeIntervalSince(started)
+            ))
+        } catch {
+            Log.write("transcriber: warm decode failed — \(error.localizedDescription)")
+        }
+    }
+
     private var lastReportedPercent: Int = -1
 
     private func reportDownload(_ label: String, _ progress: DownloadProgress) {

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -333,6 +333,14 @@ actor Transcriber {
         // returned empty.
         var result = try await asr.transcribe(url, decoderState: &decoderState)
 
+        // Here rather than after the retries below, because an invented ending
+        // is clamped to the end of the clip and every check downstream reads
+        // that as the decoder having reached the end: `droppedTail` stops
+        // firing, and no padded arm can reach further than a first pass that
+        // already claims the last frame.
+        let speechEnd = gated.map(Self.lastSpeechEnd)
+        result = Self.withoutInventedTail(result, speechEnd: speechEnd)
+
         // Closing the pause up and decoding again puts those words in a window
         // with speech either side of them. It is a retry rather than the first
         // thing tried, because moving the windows is not free: done to every
@@ -344,7 +352,11 @@ actor Transcriber {
         if let gated, Self.droppedTail(result, gate: gated), let closed = Self.closeLongPauses(gated) {
             var retryState = await TdtDecoderState.make(decoderLayers: asr.decoderLayerCount)
             let raw = try await asr.transcribe(closed.samples, decoderState: &retryState)
-            let retried = Self.restoreTimings(raw, closed: closed, seconds: gated.seconds)
+            let retried = Self.withoutInventedTail(
+                Self.restoreTimings(raw, closed: closed, seconds: gated.seconds),
+                speechEnd: speechEnd,
+                note: "long-pause retry: "
+            )
             if Self.lastWordEnd(retried) > Self.lastWordEnd(result), Self.extends(result, by: retried) {
                 Log.write(String(
                     format: "decoder stopped %.2fs before the speech did; "
@@ -383,8 +395,14 @@ actor Transcriber {
         // Separate from the retry above, which needs words to measure a
         // dropped tail against and so cannot reach this case at all:
         // `droppedTail` is false on an empty decode by definition.
+        //
+        // One unsure "Yeah." is the same failure wearing a word, and goes the
+        // same way — see `decodedOnlyYeah`.
         if let gated, Self.decodedNothing(result, gate: gated) {
             let speech = Self.speechSeconds(gated)
+            let wrote = Self.decodedOnlyYeah(result)
+                ? "only \"\(result.text.trimmingCharacters(in: .whitespacesAndNewlines))\""
+                : "nothing"
             var recovered: (pad: Double, result: ASRResult)?
             if opinions.isEmpty {
                 for pad in Self.silenceRetryPads where recovered == nil {
@@ -414,16 +432,16 @@ actor Transcriber {
             }
             if let recovered {
                 Log.write(String(
-                    format: "decoder returned nothing for %.2fs of speech; "
+                    format: "decoder returned %@ for %.2fs of speech; "
                         + "%.0fms of silence either side recovered it",
-                    speech, recovered.pad * 1000
+                    wrote, speech, recovered.pad * 1000
                 ))
                 result = recovered.result
             } else {
                 Log.write(String(
-                    format: "decoder returned nothing for %.2fs of speech, "
+                    format: "decoder returned %@ for %.2fs of speech, "
                         + "and no padded retry returned anything either",
-                    speech
+                    wrote, speech
                 ))
             }
         } else if !opinions.isEmpty {
@@ -582,7 +600,16 @@ actor Transcriber {
         guard let padded = paddedWithSilence(gate, pad: pad) else { return nil }
         var state = await TdtDecoderState.make(decoderLayers: asr.decoderLayerCount)
         let raw = try await asr.transcribe(padded, decoderState: &state)
-        return unpadTimings(raw, by: pad, seconds: gate.seconds)
+        // Before the arm is compared with anything. An arm whose only addition
+        // is an invented run then adds nothing, and loses on the guards that
+        // are already there. Unpadding clamps a word running past the end of
+        // the clip back to the clip's length, so those words land on one point
+        // on the clock and the burst rule sees them.
+        return withoutInventedTail(
+            unpadTimings(raw, by: pad, seconds: gate.seconds),
+            speechEnd: lastSpeechEnd(gate),
+            note: String(format: "second opinion at %.0fms: ", pad * 1000)
+        )
     }
 
     /// Starts one padded decode per rung of `silenceRetryPads`, running now.
@@ -858,6 +885,163 @@ actor Transcriber {
         return lastSpeechEnd(gate) - lastWordEnd(result) > droppedTailSeconds
     }
 
+    // MARK: - Endings the decoder invented
+
+    /// Two words are at the same place on the clock. Half the length of one
+    /// encoder frame, so nothing the decoder can actually separate lands here.
+    private static let sameTimeSeconds = 0.005
+
+    /// How far past the last speech the gate heard a word has to start before
+    /// it is read as invented. On top of the VAD's own 0.75s hangover, so the
+    /// boundary this measures against is already generous.
+    static let inventedTailMargin = 0.3
+
+    /// A word at or above this is left alone by the after-speech rule. The one
+    /// thing that separates an invented ending from a real late clause: "C'est
+    /// le signal qu'on ne peut pas savoir." decodes its last five words after
+    /// the gate's last segment, at 0.94 to 1.00.
+    static let inventedTailConfidence: Float = 0.8
+
+    /// The trailing words the decoder wrote over silence, and which rule found
+    /// them. Nil when the decode ends in speech.
+    ///
+    /// Two shapes, measured over 7315 first-pass decodes and checked against
+    /// Whisper large-v3-turbo on every clip that still had a wav.
+    ///
+    /// A burst is two or more trailing words sharing one start and one end.
+    /// The decoder emitted them at a single point on the clock, which speech
+    /// never is. 45 clips, and Whisper heard none of the dropped words on the
+    /// 41 that had a wav — including bursts holding a word scored 0.9 and
+    /// above, which is why there is no confidence test on this half.
+    ///
+    /// After the speech is two or more trailing words that start at least
+    /// `inventedTailMargin` past the gate's last segment, none of them
+    /// confident. Together the two fire on 56 of the 7315, with no false
+    /// positive found.
+    ///
+    /// `speechEnd` is nil when there was no gate, which turns the second rule
+    /// off — it has nothing to measure against.
+    nonisolated static func inventedTail(
+        words: [Trace.Word], speechEnd: Double?
+    ) -> (count: Int, reason: String)? {
+        guard words.count >= 2 else { return nil }
+
+        var first = words.count - 1
+        while first > 0, sameTime(words[first], words[first - 1]) { first -= 1 }
+        let burst = words.count - first >= 2 ? words.count - first : 0
+
+        var after = 0
+        if let speechEnd {
+            var late = words.count
+            while late > 0, words[late - 1].start >= speechEnd + inventedTailMargin {
+                late -= 1
+            }
+            let run = words[late...]
+            if run.count >= 2, run.allSatisfy({ $0.confidence < inventedTailConfidence }) {
+                after = run.count
+            }
+        }
+
+        if burst > 0, burst >= after { return (burst, "burst") }
+        if after > 0 { return (after, "after speech") }
+        return nil
+    }
+
+    private nonisolated static func sameTime(_ one: Trace.Word, _ other: Trace.Word) -> Bool {
+        abs(one.start - other.start) < sameTimeSeconds
+            && abs(one.end - other.end) < sameTimeSeconds
+    }
+
+    /// The decode without the ending it invented, text and timings together.
+    ///
+    /// Both or neither. `ASRResult.text` is a separate string from the
+    /// timings, so trimming one and not the other leaves the HUD, the trace
+    /// and the pipeline disagreeing about what was said. The two agreed on the
+    /// word count in all 22136 trace records that carry both, so the text is
+    /// cut back word by word from its end and the original spacing of what
+    /// survives is left as it was. A decode where they ever disagree is kept
+    /// whole: a wrong cut is worse than a kept invention.
+    nonisolated static func withoutInventedTail(
+        _ result: ASRResult, speechEnd: Double?, note: String = ""
+    ) -> ASRResult {
+        let timings = result.tokenTimings ?? []
+        let grouped = Trace.grouped(from: timings)
+        guard let tail = inventedTail(words: grouped.map(\.word), speechEnd: speechEnd) else {
+            return result
+        }
+        let keep = grouped.count - tail.count
+        guard let text = trimmedText(result.text, dropping: tail.count, of: grouped.count) else {
+            Log.write(
+                "\(note)\(tail.count) trailing word(s) look invented, but the text and the "
+                    + "timings do not line up; keeping the decode as it is"
+            )
+            return result
+        }
+        let dropped = grouped[keep...].map(\.word.word).joined(separator: " ")
+        Log.write(
+            "\(note)dropped \(tail.count) invented trailing word(s), "
+                + "\(tail.reason): \"\(dropped)\""
+        )
+        let kept = Array(timings[0..<(keep > 0 ? grouped[keep - 1].tokens.upperBound : 0)])
+        return ASRResult(
+            text: text,
+            confidence: confidence(of: kept) ?? result.confidence,
+            duration: result.duration,
+            processingTime: result.processingTime,
+            tokenTimings: kept,
+            performanceMetrics: result.performanceMetrics,
+            ctcDetectedTerms: result.ctcDetectedTerms,
+            ctcAppliedTerms: result.ctcAppliedTerms
+        )
+    }
+
+    /// The aggregate the decoder would have reported for these tokens alone:
+    /// FluidAudio's `calculateConfidence`, the mean token confidence clamped
+    /// to 0.1...1. Recomputed after a trim so the low-confidence warning and
+    /// `asr.confidence` conditions read the words that were delivered, not the
+    /// ones that were cut. Nil with no tokens.
+    private nonisolated static func confidence(of timings: [TokenTiming]) -> Float? {
+        guard !timings.isEmpty else { return nil }
+        let mean = timings.map(\.confidence).reduce(0, +) / Float(timings.count)
+        return max(0.1, min(1, mean))
+    }
+
+    /// `text` without its last `dropping` whitespace-separated words, or nil
+    /// when it does not hold exactly `of` of them.
+    nonisolated static func trimmedText(
+        _ text: String, dropping: Int, of words: Int
+    ) -> String? {
+        guard text.split(whereSeparator: \.isWhitespace).count == words else { return nil }
+        var end = text.endIndex
+        for _ in 0..<dropping {
+            while end > text.startIndex, text[text.index(before: end)].isWhitespace {
+                end = text.index(before: end)
+            }
+            while end > text.startIndex, !text[text.index(before: end)].isWhitespace {
+                end = text.index(before: end)
+            }
+        }
+        while end > text.startIndex, text[text.index(before: end)].isWhitespace {
+            end = text.index(before: end)
+        }
+        return String(text[text.startIndex..<end])
+    }
+
+    /// A word this unsure, on its own, is not a word.
+    static let loneYeahConfidence: Float = 0.6
+
+    /// True when the whole decode is one unsure "Yeah." — a failed alignment
+    /// rather than something somebody said.
+    ///
+    /// Measured on 24 such clips: Whisper heard "yeah" in none of them, and a
+    /// padded decode returned real words on 19 of the 23 it could read. So it
+    /// is handed to the empty-decode recovery rather than deleted.
+    nonisolated static func decodedOnlyYeah(_ result: ASRResult) -> Bool {
+        let words = Trace.words(from: result.tokenTimings ?? [])
+        guard words.count == 1, words[0].confidence < loneYeahConfidence else { return false }
+        return words[0].word.lowercased().filter(\.isLetter) == "yeah"
+    }
+
     /// How much silence the empty-decode retry puts either side of the clip,
     /// tried in order until one of them decodes to something.
     ///
@@ -880,14 +1064,16 @@ actor Transcriber {
         gate.segments.reduce(0) { $0 + ($1.end - $1.start) }
     }
 
-    /// True when the gate heard speech and the decoder wrote nothing at all.
+    /// True when the gate heard speech and the decoder wrote nothing worth
+    /// keeping — no text at all, or one unsure "Yeah."
     ///
     /// The text, not the timings: a decode with no words is the thing being
     /// caught, and whether it also carried an empty timing array is a detail
     /// of the decoder rather than the symptom.
     nonisolated static func decodedNothing(_ result: ASRResult, gate: SpeechGate) -> Bool {
         guard !gate.segments.isEmpty else { return false }
-        return result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        if result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return true }
+        return decodedOnlyYeah(result)
     }
 
     /// The clip with `pad` seconds of silence at each end, or nil when the

--- a/Sources/ParrotFlow/WarmModelsCommand.swift
+++ b/Sources/ParrotFlow/WarmModelsCommand.swift
@@ -1,13 +1,15 @@
 import Foundation
 
 /// `--warm-models` — downloads Parakeet (and the voice detector, if the
-/// config asks for one) without waiting for a first dictation.
+/// config asks for one) and runs one decode, without waiting for a first
+/// dictation.
 ///
-/// `Transcriber.prepare` already does this lazily, on the first real
-/// transcription. This command calls the same method and nothing else, so
-/// `install.sh` — or anyone else scripting a setup — can trigger the
-/// download on its own schedule instead of the user's first attempt to
-/// dictate.
+/// `Transcriber.prepare` already downloads lazily, on the first real
+/// transcription. This command calls the same method, so `install.sh` — or
+/// anyone else scripting a setup — can trigger the download on its own
+/// schedule instead of the user's first attempt to dictate. `warmDecode`
+/// then runs the graph once, which is the other half of the first dictation's
+/// cost and the half `prepare` does not cover.
 enum WarmModelsCommand {
 
     static func run() -> Int32 {
@@ -36,6 +38,10 @@ enum WarmModelsCommand {
             }
             do {
                 try await transcriber.prepare(config: config)
+                // Downloaded and loaded is not run. `install.sh` calls this so
+                // the first dictation waits for nothing, and the Core ML
+                // compile is part of what it would otherwise wait for.
+                await transcriber.warmDecode()
                 print("\r\u{1B}[K✓ models ready")
             } catch {
                 print("\r\u{1B}[K✗ \(error.localizedDescription)")

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -94,6 +94,13 @@ if arguments.contains("--audio-recovery") {
     exit(AudioRecoveryCommand.run(casesPath: casesPath))
 }
 
+if arguments.contains("--invented-tail") {
+    let casesPath = arguments.firstIndex(of: "--cases").flatMap {
+        arguments.indices.contains($0 + 1) ? arguments[$0 + 1] : nil
+    }
+    exit(InventedTailCommand.run(casesPath: casesPath))
+}
+
 if let index = arguments.firstIndex(of: "--set-key") {
     guard arguments.indices.contains(index + 1) else {
         print("usage: ParrotFlow --set-key <model> [--forget]")

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -15,7 +15,7 @@ let arguments = CommandLine.arguments
 // flush and the rest did not, so `--replace` was dropping the very lines that
 // explain what the pipeline did — a stage saying it skipped, and why. Doing it
 // here covers every path, including the ones added later.
-atexit { Log.flush(); Trace.flush() }
+atexit { Log.flush(); Trace.flush(); NeuralPhonemes.flushCache() }
 
 // First, and above the config: this is the handshake that says which code you
 // are running, and it must answer even when the config is broken or missing.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -844,6 +844,15 @@ jq -r '.stages[]? | select(.seconds) | [.name, .seconds] | @tsv' trace.jsonl |
   awk '{n[$1]++; s[$1]+=$2} END {for (k in n) printf "%-28s %6.3fs  ×%d\n", k, s[k]/n[k], n[k]}' |
   sort -k2 -rn
 
+# Where the vocabulary stage's time goes. It has two halves that call a model
+# and the stage's own `seconds` covers both: `sound_ms` is the sound pass
+# asking the G2P model for pronunciations, `gate_ms` is the word lists, the
+# slot and the sentence gate deciding. A dictation past a second here is
+# almost always one of the two, and this says which.
+jq -r '.stages[]? | select(.name == "vocabulary" and .vars.gate_ms) |
+       [.seconds, .vars.sound_ms, .vars.gate_ms, .vars.slots] | @tsv' trace.jsonl |
+  sort -rn | head -20
+
 # Every dictation a prompt stage rewrote, and into what.
 jq -r '.stages[]? | select(.before and .before != .after) |
        [.name, .before, .after] | @tsv' trace.jsonl

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -729,6 +729,7 @@ scripts/check-tokenizer.sh         # the hand-written BPE against HuggingFace's 
 scripts/check-sentence-probe.sh    # the boundary score against coremltools (needs the model)
 scripts/check-slot-gate.sh         # where a name proposal is routed (needs the model)
 scripts/check-sentence-case.sh     # the capital after a period the join removes
+scripts/check-invented-tail.sh     # the endings the decoder wrote over silence
 scripts/check-sentence-join.sh     # the two tiers of the sentence join (needs the model)
 
 PF_VIEWPORT=Ghostty scripts/check-inplace.sh   # the same set, in another terminal

--- a/docs/corrections.md
+++ b/docs/corrections.md
@@ -6,14 +6,14 @@ colleagues' names all day. A rule you teach once is written to your
 
 When a name comes out wrong, select it in whatever app you're in, hold the
 hotkey and say **"hey parrot"**. A panel opens with a row for each word that
-looks wrong: what it heard, what it should be, and what kind of thing that is.
+looks wrong: what it heard and what it should be.
 
     VOCABULARY  TEACH A WORD
 
-    HEARD AS            SHOULD BE          TYPE
+    HEARD AS            SHOULD BE
 
-    [ Tasmin        ] → [ Tasmeen      ]   Person ⌄   ✕
-    [ Versal        ] → [ Vercel       ]   Org ⌄      ✕
+    [ Tasmin        ] → [ Tasmeen      ]   ✕
+    [ Versal        ] → [ Vercel       ]   ✕
     + Add a word
 
     2 rules to save              Cancel esc    Save ↩
@@ -32,10 +32,17 @@ in two — "red crawl" for Redcrawl arrives as two ordinary words and no proposa
 can join them. Type over the left field to widen the row to the span you meant,
 and the rule taught is `red crawl => Redcrawl`, which leaves the colour alone.
 
-**The type column** is proposed from the macOS word tagger and is often wrong
-about products: it calls Vercel a place. Change it with the menu. It is written
-to the term as `kind:` and nothing reads it yet — it is recorded now so the
-stages that will need it have something to read.
+**Every word you change by hand is written down**, whether or not the panel
+opens on it. One line per change in `trace.jsonl` beside your recordings,
+with `kind: "edit"`: the word as heard, what you typed, the twelve words
+either side as they were before you changed them, and where the heard word
+stands in that text. A misheard ordinary word — `backgrounds` for `bigrams` —
+is never a vocabulary rule, and this is the only record of it. The file holds
+your own sentences, and that is deliberate: a count without its context is
+no use to anything that would put the right word back. The same file holds
+your dictation records, so to forget the edits alone keep the other lines:
+
+    jq -c 'select(.kind != "edit")' trace.jsonl > kept.jsonl
 
 Saving writes one rule per row to `vocabulary.yaml` — comments and your other
 settings untouched — and puts the corrected sentence back where it came from.

--- a/scripts/check-edit-diff.sh
+++ b/scripts/check-edit-diff.sh
@@ -3,11 +3,16 @@
 #
 #   scripts/check-edit-diff.sh
 #
-# `EditWatch.change` decides whether a field that no longer says what was
+# `EditWatch.changes` decides whether a field that no longer says what was
 # dictated holds a correction worth learning from. A rewrite read as a
 # correction teaches a vocabulary term the wrong sentence, and that sentence
 # then decides other dictations — so the strict half of this is the half that
 # matters. No accessibility, no timing, no model.
+#
+# A case with `offer:` also checks `EditWatch.refusal`, which says whether the
+# panel opens on the correction. That half asks the spell checker and the
+# word-piece list, so it is this machine's answer. A case with `heard:` checks
+# the window and range `EditWatch.asHeard` writes to the trace.
 set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BIN=""
@@ -19,10 +24,17 @@ done
 
 failed=0
 seen=0
-while IFS=$'\t' read -r written now want; do
+while IFS=$'\t' read -r written now want offer heard; do
   seen=$((seen + 1))
-  got="$("$BIN" --edit-diff "$written" "$now" 2>/dev/null | grep -vE "^  (in|opens): " \
-    | paste -sd '|' - | sed 's/|/ | /g')"
+  out="$("$BIN" --edit-diff "$written" "$now" 2>/dev/null)"
+  got="$(grep -vE "^  (in|opens|offer|heard): " <<<"$out" | paste -sd '|' - | sed 's/|/ | /g')"
+  if [ "$heard" != "-" ]; then
+    gotHeard="$(grep -E "^  heard: " <<<"$out" | sed 's/^  heard: //' | paste -sd '|' - | sed 's/|/ | /g')"
+    if [ "$gotHeard" != "$heard" ]; then
+      printf '  ✗ %s: heard "%s", expected "%s"\n' "${written:0:34}" "$gotHeard" "$heard"
+      failed=1
+    fi
+  fi
   [ "$want" = "none" ] && want="no single change"
   if [ "$got" = "$want" ]; then
     printf '  ✓ %s\n' "$got"
@@ -30,10 +42,18 @@ while IFS=$'\t' read -r written now want; do
     printf '  ✗ %s: got "%s", expected "%s"\n' "${written:0:34}" "$got" "$want"
     failed=1
   fi
+  [ "$offer" = "-" ] && continue
+  gotOffer="$(grep -E "^  offer: " <<<"$out" | sed 's/^  offer: //' | paste -sd '|' - | sed 's/|/ | /g')"
+  if [ "$gotOffer" = "$offer" ]; then
+    printf '    offer: %s\n' "$gotOffer"
+  else
+    printf '  ✗ %s: offer "%s", expected "%s"\n' "${written:0:34}" "$gotOffer" "$offer"
+    failed=1
+  fi
 done < <(python3 -c '
 import sys, yaml
 for c in yaml.safe_load(open(sys.argv[1]))["cases"]:
-    print("\t".join([c["written"], c["now"], str(c["expect"])]))
+    print("\t".join([c["written"], c["now"], str(c["expect"]), str(c.get("offer", "-")), str(c.get("heard", "-"))]))
 ' "$ROOT/tests/edit-diff-cases.yaml")
 
 if [ "$seen" -eq 0 ]; then echo "Failed: edit-diff — no case was read"; exit 1; fi

--- a/scripts/check-invented-tail.sh
+++ b/scripts/check-invented-tail.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Endings the decoder wrote over silence, and endings it really heard.
+#
+#   scripts/check-invented-tail.sh
+#
+# The cases are in tests/invented-tail-cases.yaml, and every one of them is a
+# decode taken out of trace.jsonl. No audio and no model: the words, their
+# timings and their confidences are what the decoder returned, and the rule
+# reads nothing else.
+#
+# Both halves of the trim are scored. `ASRResult.text` is a separate string
+# from the token timings, so a run dropped from one and not the other leaves
+# the screen and the trace describing different sentences — and nothing would
+# say so.
+#
+# The config is a scratch one. `audio.output_dir` decides where clips and the
+# trace go, so a run against the real config would write into the recordings
+# folder.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/release/ParrotFlow"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/parrotflow-invented-tail.XXXXXX")"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+mkdir -p "$SCRATCH/config" "$SCRATCH/clips"
+cat > "$SCRATCH/config/config.yaml" <<YAML
+# Written by scripts/check-invented-tail.sh. Nothing reads it but this run.
+audio:
+  output_dir: $SCRATCH/clips
+transcription:
+  enabled: false
+YAML
+
+cd "$ROOT" || exit 1
+PARROTFLOW_CONFIG_DIR="$SCRATCH/config" "$BIN" --invented-tail \
+  --cases "$ROOT/tests/invented-tail-cases.yaml"

--- a/tests/edit-diff-cases.yaml
+++ b/tests/edit-diff-cases.yaml
@@ -111,6 +111,30 @@ cases:
     now:     "we run Node.js and Qwen"
     expect:  "Gwen -> Qwen"
 
+  # Typing a name after a word is not a correction of that word. `morning`
+  # became `morning Tasmeen` and it was offered as a vocabulary rule.
+  - written: "I said it this morning."
+    now:     "I said it this morning Tasmeen."
+    expect:  none
+
+  - written: "said morning, and left"
+    now:     "said morning Tasmeen, and left"
+    expect:  none
+
+  # Nor is pasting into the line. This one glues to the word before it, so it
+  # is one word becoming one word and looks like a correction.
+  - written: "a word in the dictation."
+    now:     "a word in the dictation.[Image #17]"
+    expect:  none
+
+  # But a word that grows is still a correction, and so is one that splits.
+  - written: "it is Ghost here"
+    now:     "it is Ghostty here"
+    expect:  "Ghost -> Ghostty"
+
+  - written: "ask Praisy today"
+    now:     "ask Praisy's today"
+    expect:  "Praisy -> Praisy's"
 
 # Not here: the input box between two rules, and a line wrapped onto a second
 # row. Both are several lines of screen, and this set carries one case per line.

--- a/tests/edit-diff-cases.yaml
+++ b/tests/edit-diff-cases.yaml
@@ -2,6 +2,9 @@
 #
 # expect: "<was> -> <now>"   the one span that changed
 # expect: none               a rewrite, two edits, or nothing worth learning
+# offer:  yes | no, <why>    whether the panel opens on it; optional, and one
+#                            per span when there are several
+# heard:  <a>..<b> in "…"    the window and range written to the trace; optional
 #
 # The strict half matters more than the generous one. A rewrite read as a
 # correction teaches a term a sentence nobody meant, and a portrait built on
@@ -90,6 +93,7 @@ cases:
   - written: "I like it.Ghost T is my terminal"
     now:     "I like it.Ghostty is my terminal"
     expect:  "Ghost T -> Ghostty"
+    heard:   '10..<17 in "I like it.Ghost T is my terminal"'
 
   # The same at the other end.
   - written: "the ghostly, terminal"
@@ -110,6 +114,92 @@ cases:
   - written: "we run Node.js and Gwen"
     now:     "we run Node.js and Qwen"
     expect:  "Gwen -> Qwen"
+    offer:   "yes"
+
+  # From the log, 2026-09-02. Two dictations ran together, and the first was
+  # repaired by putting a word back. The shared tail `.maybe` is the next
+  # sentence, not the correction; and what is left lands on two ordinary
+  # words, which the glued-together lookup `pronepoint` used to call a name.
+  - written: "❯ It is error prone.maybe it is fine"
+    now:     "❯ It is error prone point.maybe it is fine"
+    expect:  "prone -> prone point"
+    offer:   "no, ordinary English"
+
+  # Punctuation alone. Both from the log.
+  - written: "keep the diff small."
+    now:     "keep the diff small"
+    expect:  "small. -> small"
+    offer:   "no, punctuation, not a name"
+
+  - written: "(before offering vocabulary options."
+    now:     "(before offering vocabulary options.)"
+    expect:  "options. -> options.)"
+    offer:   "no, punctuation, not a name"
+
+  # Two corrections in one line, one onto a name and one onto a word the
+  # lists know.
+  - written: "We have e speak and we have a fluid audio model."
+    now:     "We have espeak and we have a FluidAudio model."
+    expect:  "e speak -> espeak | fluid audio -> FluidAudio"
+    offer:   "yes | yes"
+
+  - written: "the idiots are detected before submitting"
+    now:     "the edits are detected before submitting"
+    expect:  "idiots -> edits"
+    offer:   "no, ordinary English"
+
+  - written: "say point instead"
+    now:     "say dot instead"
+    expect:  "point -> dot"
+    offer:   "no, ordinary English"
+
+  - written: "we compare Ribrovent with Dorselex"
+    now:     "we compare Rybrevant with Darzalex"
+    expect:  "Ribrovent -> Rybrevant | Dorselex -> Darzalex"
+    offer:   "yes | yes"
+
+  # A word the dictionary knows, made a name by its capital mid-sentence.
+  - written: "errors go to century"
+    now:     "errors go to Sentry"
+    expect:  "century -> Sentry"
+    offer:   "yes"
+
+  # The capital that opens a sentence says nothing about the word.
+  - written: "Fais attention. Fais le maintenant"
+    now:     "Fais attention. Et le maintenant"
+    expect:  "Fais -> Et"
+    offer:   "no, ordinary English"
+
+  # One name in the span is enough.
+  - written: "I met Prezi yesterday"
+    now:     "I met Praisy Dupont yesterday"
+    expect:  "Prezi -> Praisy Dupont"
+    offer:   "yes"
+
+  # A reword, 2026-09-03: two words put in for one. Glued to `forinstance`
+  # no list knew it, and the panel offered it as a name.
+  - written: "a thing to see or two"
+    now:     "a thing to, see for instance. two"
+    expect:  "to -> to, | or -> for instance."
+    offer:   "no, punctuation, not a name | no, ordinary English"
+
+  - written: "the model can hear what Drew said"
+    now:     "the model can say what a drew said"
+    expect:  "hear -> say | Drew -> a drew"
+    offer:   "no, ordinary English | no, ordinary English"
+
+  - written: "we count BRAM"
+    now:     "we count bigram"
+    expect:  "BRAM -> bigram"
+    offer:   "no, ordinary English"
+
+  # The window is twelve words either side, clipped to the line, and the
+  # prompt is not a word. The range is the heard word in that window.
+  - written: "❯ one two three four five six seven eight nine ten eleven twelve thirteen the backgrounds are, counted here and more"
+    now:     "❯ one two three four five six seven eight nine ten eleven twelve thirteen the bigrams are, counted here and more"
+    expect:  "backgrounds -> bigrams"
+    offer:   "no, ordinary English"
+    heard:   '68..<79 in "three four five six seven eight nine ten eleven twelve thirteen the backgrounds are, counted here and more"'
 
 
 # Not here: the input box between two rules, and a line wrapped onto a second

--- a/tests/invented-tail-cases.yaml
+++ b/tests/invented-tail-cases.yaml
@@ -1,0 +1,252 @@
+# Endings Parakeet wrote over silence, and endings it really heard.
+#
+# Run with scripts/check-invented-tail.sh. Every case is a decode taken from
+# trace.jsonl — the words, their timings and their confidences exactly as the
+# decoder returned them on a clip somebody dictated. Nothing here is invented
+# by hand, because the whole question is what the decoder does, and a made-up
+# word array can be made to prove anything.
+#
+#   speech_end  where the gate's last speech segment ended. Absent means there
+#               was no gate, which turns the after-speech rule off.
+#   words       "<word> <start> <end> <confidence>", in order.
+#   text        what the decoder wrote. Absent means the words joined by
+#               spaces, which is what the trace shows on all but one record.
+#   keeps       the text that must survive. Absent means all of it.
+#   reason      burst | after speech. Absent means nothing may be dropped.
+#   nothing     what `decodedNothing` must say about the decode.
+#
+# The must-not-fire half is the half that matters. A dictation that loses a
+# real last word loses it silently, and the word most at risk is a name — the
+# thing the decoder is least sure of and the speaker most wants.
+
+# ---------------------------------------------------------------- must fire
+
+- name: three words at one point on the clock, 6s after the speech stopped
+  # B3813269. Whisper heard "Because you could look for" and nothing after it.
+  speech_end: 2.404
+  text: "Because you could look for the first time."
+  words:
+    - Because  0.76 1.08 0.907
+    - you      1.08 1.24 0.996
+    - could    1.24 1.56 0.994
+    - look     1.56 1.88 0.996
+    - for      1.88 2.20 1.000
+    - the      8.09 8.09 0.152
+    - first    8.09 8.09 0.038
+    - time.    8.09 8.09 0.192
+  keeps: "Because you could look for"
+  reason: burst
+
+- name: a burst that is also after the speech
+  # D5D66F4A. Both rules find the same four words. The burst is reported,
+  # because it is the stronger evidence: no confidence had to be read.
+  speech_end: 2.148
+  text: "And if you ask it, you can see it."
+  words:
+    - And   0.72 0.96 0.529
+    - if    0.96 1.20 0.948
+    - you   1.20 1.36 0.962
+    - ask   1.36 1.76 0.971
+    - it,   1.76 3.76 0.160
+    - you   3.76 3.84 0.141
+    - can   3.76 3.84 0.281
+    - see   3.76 3.84 0.110
+    - it.   3.76 3.84 0.200
+  keeps: "And if you ask it,"
+  reason: burst
+
+- name: two words at the very end of a clip that is all speech
+  # 33B103E7. The gate heard speech to the last sample, so only the burst can
+  # find this one.
+  speech_end: 2.277
+  text: "Sorry, back to the first time."
+  words:
+    - Sorry,   0.24 0.72 0.533
+    - back     0.72 0.96 0.944
+    - to       0.96 1.28 0.987
+    - the      1.28 1.52 0.981
+    - first    2.16 2.24 0.036
+    - time.    2.16 2.24 0.125
+  keeps: "Sorry, back to the"
+  reason: burst
+
+- name: a burst holding a word scored 0.82
+  # 402455DD. "It's not just" is what was said. The invented ending carries
+  # "bit" at 0.823, which is why the burst rule reads no confidence at all.
+  speech_end: 1.371
+  text: "It's not just a little bit"
+  words:
+    - It's   0.00 0.36 0.553
+    - not    0.36 0.68 0.999
+    - just   0.68 1.00 0.993
+    - a      1.37 1.37 0.234
+    - little 1.37 1.37 0.093
+    - bit    1.37 1.37 0.823
+  keeps: "It's not just"
+  reason: burst
+
+- name: six words repeating themselves, two of them scored above 0.8
+  # 0F0910EC. Same shape, longer, and the repetition is the tell a confidence
+  # test would have to ignore anyway.
+  speech_end: 3.878
+  text: "Can you use a little bit of a little bit"
+  words:
+    - Can    2.00 2.32 0.653
+    - you    2.32 2.56 0.983
+    - use    2.56 2.88 0.976
+    - a      2.88 3.12 0.550
+    - little 3.76 3.84 0.060
+    - bit    3.76 3.84 0.819
+    - of     3.76 3.84 0.329
+    - a      3.76 3.84 0.240
+    - little 3.76 3.84 0.053
+    - bit    3.76 3.84 0.833
+  keeps: "Can you use a"
+  reason: burst
+
+- name: four words after the speech, none of them at the same time
+  # 58D2647D. No burst to find: the four have four different timings. They
+  # start 2.6s past the gate's last segment, and one of them scores 0.75 —
+  # which is what the 0.8 floor is for.
+  speech_end: 5.732
+  text: "It should have been found by the comments of the U.S."
+  words:
+    - It       0.56 0.80 0.553
+    - should   0.80 1.12 0.947
+    - have     1.12 1.28 0.980
+    - been     1.28 1.52 0.996
+    - found    3.92 4.48 0.904
+    - by       4.48 4.80 0.991
+    - the      4.80 5.12 0.976
+    - comments 8.32 8.64 0.136
+    - of       8.80 8.88 0.324
+    - the      8.88 8.96 0.750
+    - U.S.     9.84 9.92 0.028
+  keeps: "It should have been found by the"
+  reason: after speech
+
+- name: a lone unsure Yeah is not a word
+  # DB189782. Whisper heard no "yeah" on any of the 24 clips like this one.
+  speech_end: 0.931
+  words:
+    - Yeah. 0.72 0.88 0.467
+  nothing: true
+
+- name: and the same at 0.52
+  # A096B2F3.
+  speech_end: 1.771
+  words:
+    - Yeah. 1.44 1.60 0.523
+  nothing: true
+
+# ------------------------------------------------------------ must not fire
+
+- name: an unsure name at the end of a question
+  # 67C849E2. "Kim?" scores 0.458 and is the word the speaker cared about.
+  speech_end: 1.181
+  text: "What do you think, Kim?"
+  words:
+    - What    0.12 0.36 0.945
+    - do      0.36 0.44 0.993
+    - you     0.44 0.52 0.994
+    - think,  0.52 0.68 0.497
+    - Kim?    0.76 1.08 0.458
+
+- name: an unsure product name at the end of a list
+  # 462679BD. "WordPress." at 0.338, real, and inside the speech.
+  speech_end: 7.927
+  text: "In Slack, in web forms, in WordPress."
+  words:
+    - In          0.44 0.76 0.797
+    - Slack,      0.76 2.36 0.748
+    - in          2.36 2.68 0.981
+    - web         2.68 2.84 0.781
+    - forms,      3.16 5.24 0.866
+    - in          5.24 5.56 0.978
+    - WordPress.  6.84 7.93 0.338
+
+- name: two invented-sounding names in one sentence, both said
+  # 97CE83D3. 0.167 and 0.212, and the second is the last word.
+  speech_end: 7.586
+  text: "But why were search terms recoverable in Ribrovent and not in Dorselex?"
+  words:
+    - But         0.62 0.94 0.973
+    - why         0.94 1.34 1.000
+    - were        1.34 1.66 0.999
+    - search      1.66 2.06 0.745
+    - terms       2.06 2.70 0.900
+    - recoverable 2.70 3.66 1.000
+    - in          3.98 4.30 1.000
+    - Ribrovent   4.54 5.50 0.167
+    - and         5.66 5.90 1.000
+    - not         5.90 6.14 1.000
+    - in          6.14 6.30 0.952
+    - Dorselex?   6.46 7.59 0.212
+
+- name: counting in French, close together and unsure
+  # 44B479DD. "Un," scores 0.439 and the three words run end to end.
+  speech_end: 1.942
+  text: "Prisonniers en France. Un, deux, trois."
+  words:
+    - Prisonniers 0.00 0.30 0.503
+    - en          0.38 0.46 0.979
+    - France.     0.46 0.70 0.532
+    - Un,         0.86 1.10 0.439
+    - deux,       1.10 1.34 0.971
+    - trois.      1.34 1.94 0.831
+
+- name: five words after the gate's last segment, all confident
+  # 422E0A9E. The rule-B shape exactly: the gate stopped at 0.868 and the
+  # speaker carried on at 3.76. The confidences are 0.94 to 1.00, so the
+  # 0.8 floor is the only thing keeping this sentence whole.
+  speech_end: 0.868
+  text: "C'est le signal qu'on ne peut pas savoir."
+  words:
+    - C'est    0.00 0.40 0.636
+    - le       0.40 0.64 0.999
+    - signal   0.64 1.28 1.000
+    - qu'on    3.76 4.08 0.939
+    - ne       4.08 4.24 0.994
+    - peut     4.24 4.40 0.997
+    - pas      4.40 4.64 0.999
+    - savoir.  4.64 5.84 0.723
+
+- name: a lone Yes below the Yeah floor
+  # 2026-08-10T21-20-59, at 0.565. The rule is about the word, not about the
+  # confidence: an unsure "Yes." is an answer somebody gave.
+  speech_end: 1.686
+  words:
+    - Yes. 0.72 1.28 0.565
+  nothing: false
+
+- name: an ordinary sentence, nothing to drop
+  # 402455DD's opening on its own, so the same words score both ways.
+  speech_end: 1.371
+  text: "It's not just"
+  words:
+    - It's 0.00 0.36 0.553
+    - not  0.36 0.68 0.999
+    - just 0.68 1.00 0.993
+  nothing: false
+
+# ------------------------------------------------------------------ the trim
+
+- name: a text whose words do not line up with the timings is kept whole
+  # The same burst as B3813269, with the ending written as one word. The rule
+  # still sees three invented words; the trim refuses, because it cannot say
+  # which letters they are. On the archive this never happens — the two counts
+  # agreed on all 22136 records that carry both — and if it ever does, a kept
+  # invention beats a sentence cut in the wrong place.
+  speech_end: 2.404
+  text: "Because you could look for the-first-time."
+  words:
+    - Because  0.76 1.08 0.907
+    - you      1.08 1.24 0.996
+    - could    1.24 1.56 0.994
+    - look     1.56 1.88 0.996
+    - for      1.88 2.20 1.000
+    - the      8.09 8.09 0.152
+    - first    8.09 8.09 0.038
+    - time.    8.09 8.09 0.192
+  keeps: "Because you could look for the-first-time."
+  reason: burst


### PR DESCRIPTION
Typing a name after a word, or pasting into the line, was offered as a vocabulary rule. Both happened in one dictation: `morning` → `morning Tasmeen`, and `dictation.` → `dictation.[Image #17]`. Neither is a correction of anything — the first adds a name after a word that was heard correctly, and the second is a paste.

The panel now never sees them. `EditWatch.added` refuses a pair where one reading stands whole at the start or end of the other with a separate word beside it.

Reviewers: the whole change is `EditWatch.added` and the one `guard` that calls it. The interesting part is what it must **not** refuse.

<details>
<summary>Why "one is a prefix of the other" is the wrong test</summary>

`Ghost` → `Ghostty` is a real correction and `Ghostty` starts with `Ghost`. So a prefix test would throw away the commonest kind of name fix there is.

What separates an addition from a growth is whether a **whole separate word** appeared. So the longer reading has to hold a space before this fires at all, and what is left after removing the shorter one has to hold whitespace.

```
  morning.     -> morning Tasmeen.       rest is " Tasmeen"      refused
  dictation.   -> dictation.[Image #17]  rest has a space        refused
  Ghost        -> Ghostty                no space anywhere       kept
  Praisy       -> Praisy's               no space anywhere       kept
  Ghost E.     -> Ghostty.               not a prefix either way kept
```

</details>

<details>
<summary>Why it is asked before the trim</summary>

`added` takes the two readings **as they stood**, not what `trimmed` hands back, and takes off only the punctuation both end on.

#259 landed `prone.maybe` → `prone point.maybe`, which has to read as `prone -> prone point` and is turned away later, at the offer, as ordinary English. That is a word added beside another word, exactly like `morning` → `morning Tasmeen`. On the trimmed readings the two are the same shape and `added` cannot tell them apart.

On the readings as they stood it can. `trimmed` cuts the shared `.maybe` — the next sentence, not the correction — and only after that cut does `prone point.maybe` look like a word appended. Before it, `prone.maybe` stands at neither end of `prone point.maybe`, because the word went *inside* the run.

</details>

<details>
<summary>Why the paste looked like a correction at all</summary>

`EditWatch` splits a line on whitespace. `[Image #17]` pasted straight after `dictation.` with no space between them, so the word `dictation.` became the word `dictation.[Image` — one word for one, which is exactly the shape of a mangled name.

It is caught because the pasted text carries its own space, so the pair as a whole holds one.

A paste with no space in it at all would still get through. That is a narrower hole than the one being closed and it is not fixed here.

</details>

<details>
<summary>Five cases, three of which are the ones that must survive</summary>

```
  ✓ no single change      "…this morning."     -> "…this morning Tasmeen."
  ✓ no single change      "said morning, and"  -> "said morning Tasmeen, and"
  ✓ no single change      "…the dictation."    -> "…the dictation.[Image #17]"
  ✓ Ghost -> Ghostty      the word grows
  ✓ Praisy -> Praisy's    a possessive
```

`Ghost E. -> Ghostty.`, `prone -> prone point` and the rest of the set still pass — 39 of 39 in `tests/edit-diff-cases.yaml`.

`scripts/check-edit-diff.sh` is not one of the steps in `.github/workflows/checks.yml`, so the green tick on this pull request is the build, SwiftLint and the other sets, not this case file. Run `make test` to score it.

</details>
