### PR TITLE
perf: the sound model's answers are kept between launches

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2289,6 +2289,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 Log.write(String(
                     format: "transcriber: warmed up in %.1fs", Date().timeIntervalSince(started)
                 ))
+                // Loaded is not the same as run. See `warmDecode`.
+                await transcriber.warmDecode()
             } catch {
                 // Nothing else is worth fetching. Without speech the app
                 // cannot transcribe at all, so 700 MB more buys nothing, and
@@ -2305,6 +2307,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             await transcriber.warmSentenceModel()
             // 81 MB, and the sound pass is on by default.
             Task.detached(priority: .background) {
+                // What the model said last time, before anything asks it. Reads
+                // a file the first dictation would otherwise read itself, and
+                // it is worth doing whether or not the download below runs.
+                NeuralPhonemes.warmCache()
                 guard await !NeuralPhonemes.isReady() else { return }
                 do { try await NeuralPhonemes.download() } catch {
                     Log.write("sound model: \(error.localizedDescription); the next"

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2307,15 +2307,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             await transcriber.warmSentenceModel()
             // 81 MB, and the sound pass is on by default.
             Task.detached(priority: .background) {
-                // What the model said last time, before anything asks it. Reads
-                // a file the first dictation would otherwise read itself, and
-                // it is worth doing whether or not the download below runs.
-                NeuralPhonemes.warmCache()
-                guard await !NeuralPhonemes.isReady() else { return }
-                do { try await NeuralPhonemes.download() } catch {
-                    Log.write("sound model: \(error.localizedDescription); the next"
-                        + " dictation that needs it tries again")
+                if await !NeuralPhonemes.isReady() {
+                    do { try await NeuralPhonemes.download() } catch {
+                        Log.write("sound model: \(error.localizedDescription); the next"
+                            + " dictation that needs it tries again")
+                        return
+                    }
                 }
+                // What the model said last time, read here rather than by the
+                // first dictation. After the fetch, not before: the table is
+                // keyed on a hash of the weights, so with no weights on disk
+                // there is nothing to check it against and it would be dropped
+                // on the one launch that installed them.
+                NeuralPhonemes.warmCache()
             }
             // 335 MB, and only the sentence gate reads them. Someone who turns
             // the gate off should not pay for it.

--- a/Sources/ParrotFlow/NeuralPhonemes.swift
+++ b/Sources/ParrotFlow/NeuralPhonemes.swift
@@ -66,8 +66,107 @@ enum NeuralPhonemes {
         try await MultilingualG2PModel.shared.ensureModelsAvailable()
     }
 
-    private static var cache: [String: String] = [:]
+    // MARK: - what the model has already said
+
+    /// The answers so far, by language and then by word, kept between launches.
+    ///
+    /// The sound pass asks about every 1- and 2-word window of the sentence,
+    /// and each miss is one sequence-to-sequence call. Held only in memory this
+    /// table started empty at every launch, so every session paid for its own
+    /// warm-up. Warmed on 1211 English dictations from the archive and asked
+    /// the next 135, 51.5% of windows were already known: 6.7 model calls a
+    /// dictation instead of 13.7.
+    ///
+    /// No cap. Those 1211 dictations produce 10305 entries, about 460 KB, and
+    /// an entry is a word and a short string of IPA.
+    private static var cache: [String: [String: String]] = [:]
+    private static var loadedFromDisk = false
+    private static var savePending = false
     private static let cacheLock = NSLock()
+    private static let saveQueue = DispatchQueue(label: "com.parrotflow.phonemes")
+
+    /// Keyed by the model, because an entry is only right for the weights that
+    /// wrote it.
+    private static var cacheURL: URL {
+        AppVariant.supportDirectory
+            .appendingPathComponent("phonemes-multilingual-g2p.json")
+    }
+
+    /// Reads the table now, so the first dictation of the session does not.
+    ///
+    /// Safe to call from anywhere and safe to call twice. Called at launch and
+    /// again at the top of `of`, for the run where the launch call has not
+    /// landed yet.
+    static func warmCache() {
+        cacheLock.lock()
+        let already = loadedFromDisk
+        cacheLock.unlock()
+        guard !already else { return }
+
+        let disk = readCache()
+        cacheLock.lock()
+        if !loadedFromDisk {
+            // Anything computed while the file was being read wins. It came
+            // from the same weights and it is the later answer.
+            for (language, words) in disk {
+                cache[language] = words.merging(cache[language] ?? [:]) { _, live in live }
+            }
+            loadedFromDisk = true
+        }
+        cacheLock.unlock()
+    }
+
+    /// Writes the table back, off the caller's thread and one write at a time.
+    ///
+    /// A dictation adds a handful of entries and the whole table is re-encoded,
+    /// so this must not run on the path it exists to shorten. A second request
+    /// arriving while one is queued is dropped rather than queued behind it:
+    /// the block reads the table when it runs, so it already carries whatever
+    /// the second caller added.
+    private static func scheduleSave() {
+        cacheLock.lock()
+        let pending = savePending
+        savePending = true
+        cacheLock.unlock()
+        guard !pending else { return }
+
+        saveQueue.async {
+            cacheLock.lock()
+            savePending = false
+            let snapshot = cache
+            cacheLock.unlock()
+            writeCache(snapshot)
+        }
+    }
+
+    /// Waits for a queued write to land.
+    ///
+    /// For a process that ends: a CLI command, or the app quitting. Without it
+    /// a `--sound` run asks the model for words it will ask for again next
+    /// time, because it exits before the write does.
+    static func flushCache() {
+        saveQueue.sync {}
+    }
+
+    private static func readCache() -> [String: [String: String]] {
+        guard let data = try? Data(contentsOf: cacheURL),
+              let decoded = try? JSONDecoder().decode([String: [String: String]].self, from: data)
+        else { return [:] }
+        return decoded
+    }
+
+    private static func writeCache(_ table: [String: [String: String]]) {
+        do {
+            try FileManager.default.createDirectory(
+                at: cacheURL.deletingLastPathComponent(), withIntermediateDirectories: true
+            )
+            try JSONEncoder().encode(table).write(to: cacheURL, options: .atomic)
+        } catch {
+            // The table is still in memory for this run and the next run asks
+            // the model again. Not worth failing a dictation over.
+            Log.write("phonemes: could not cache (\(error.localizedDescription))")
+        }
+    }
 
     /// The IPA of every word given. Absent from the result means the model had
     /// nothing to say about it.
@@ -75,18 +174,20 @@ enum NeuralPhonemes {
     /// One word per call by construction — the model is sequence to sequence
     /// and takes one string — so this is the slower of the two ears. The cache
     /// is what makes that affordable: an ordinary dictation asks about words
-    /// it has asked about before.
+    /// it has asked about before, this launch or a previous one.
     static func of(
         _ words: [String], language: MultilingualG2PLanguage
     ) async -> [String: String] {
         guard await isReady() else { return [:] }
+        warmCache()
+        let table = language.rawValue
         var answer: [String: String] = [:]
+        var added = false
         for word in words {
             let clean = Phonemes.cleaned(word)
             guard !clean.isEmpty else { continue }
-            let key = "\(language.rawValue)\u{0}\(clean)"
             cacheLock.lock()
-            let known = cache[key]
+            let known = cache[table]?[clean]
             cacheLock.unlock()
             if let known {
                 if !known.isEmpty { answer[word] = known }
@@ -98,17 +199,28 @@ enum NeuralPhonemes {
                     .phonemize(word: clean, language: language)?
                     .joined() ?? ""
             } catch {
-                said = ""
+                // Not an answer, so it is not written down. A call that threw
+                // is a model that was busy or half-loaded, and the table now
+                // outlives the process: caching its silence would hide this
+                // word from the sound pass at every future launch as well.
+                // `nil` above is the other case — the model saying it has
+                // nothing for this word — and that is worth keeping.
+                continue
             }
             // Stress and length go, exactly as they do for espeak — the two
             // scores are compared against one floor, so they have to be the
             // same kind of string.
             let clipped = Phonemes.clip(said)
             cacheLock.lock()
-            cache[key] = clipped
+            // Empty is an answer and it is kept. A word the model has nothing
+            // to say about costs a call to find out, and it costs the same
+            // call every time it is asked again.
+            cache[table, default: [:]][clean] = clipped
             cacheLock.unlock()
+            added = true
             if !clipped.isEmpty { answer[word] = clipped }
         }
+        if added { scheduleSave() }
         return answer
     }
 }

--- a/Sources/ParrotFlow/NeuralPhonemes.swift
+++ b/Sources/ParrotFlow/NeuralPhonemes.swift
@@ -95,25 +95,34 @@ enum NeuralPhonemes {
             .appendingPathComponent("phonemes-multilingual-g2p.json")
     }
 
-    /// What the weights on disk look like: every file inside the two G2P model
-    /// bundles, by path, size and modification date, hashed.
+    /// The weights on disk, hashed. Every byte of both G2P bundles, each file
+    /// preceded by its path under the cache root so a file moving counts too.
     ///
     /// The table has to be thrown away when the model changes, and there is
-    /// nothing to hang that on. FluidAudio publishes no version for these
-    /// models and `ModelNames.MultilingualG2P` is two file names and no
-    /// revision, so the file name cannot carry it. The files themselves are the
-    /// identity: new weights are a new download, and a download rewrites them.
+    /// nothing cheaper to hang that on. FluidAudio publishes no version for
+    /// these models, `ModelNames.MultilingualG2P` is two file names and no
+    /// revision, and the download leaves no manifest — the `config.json` beside
+    /// the bundles is `{}`. The bytes are the only identity there is.
     ///
-    /// Sizes and dates rather than contents. The weights are 81 MB and this
-    /// answers a question that is almost always "unchanged". What that allows
-    /// is a re-download of the same weights invalidating a table that was fine,
-    /// which costs one session of warm-up. What it cannot allow is the other
-    /// way round: weights the model reads differently, with the files the same.
+    /// Path, size and modification date were tried first and are not enough:
+    /// weights can be replaced with different bytes of the same size and the
+    /// dates put back, and the table would then be kept against a model that no
+    /// longer agrees with it. The damage is a mixed table rather than an old
+    /// one — a window read by the new model scored against a term read by the
+    /// old one over a 0.85 floor, with neither reading wrong on its own.
     ///
-    /// The walk is the whole FluidAudio cache, which is 28 files here, and it
-    /// stops descending as soon as it has a bundle.
+    /// One pass over 79 MB, once per launch — the answer is held in `weights`
+    /// for the life of the process. It is cheaper than it sounds because the
+    /// files are in the page cache by the time anything asks: the model has
+    /// just been loaded. `--sound` end to end is 0.37-0.44s with this and was
+    /// 0.43s without it, which is inside the noise. A genuinely cold read costs
+    /// about a second, and `AppDelegate` pays it on the same background task
+    /// that fetches the model, so a dictation waits on it only if one is
+    /// started before that task gets there.
     ///
-    /// Nil when both bundles are not there to look at, and then nothing is
+    /// Streamed in 1 MB chunks. The point is a digest, not 79 MB resident.
+    ///
+    /// Nil when both bundles are not there to read, and then nothing is
     /// written: a table that cannot be keyed cannot be trusted next launch.
     private static func weightsFingerprint() -> String? {
         cacheLock.lock()
@@ -124,36 +133,47 @@ enum NeuralPhonemes {
         guard let root = try? TtsCacheDirectory.ensure() else { return nil }
         let wanted = ModelNames.MultilingualG2P.requiredModels
         let manager = FileManager.default
-        let keys: Set<URLResourceKey> = [.fileSizeKey, .contentModificationDateKey]
         guard let walk = manager.enumerator(
-            at: root, includingPropertiesForKeys: Array(keys)
+            at: root, includingPropertiesForKeys: nil
         ) else { return nil }
 
         var seen: Set<String> = []
-        var lines: [String] = []
+        var files: [URL] = []
         for case let url as URL in walk where wanted.contains(url.lastPathComponent) {
             walk.skipDescendants()
             seen.insert(url.lastPathComponent)
             guard let inside = manager.enumerator(
-                at: url, includingPropertiesForKeys: Array(keys)
+                at: url, includingPropertiesForKeys: nil
             ) else { return nil }
             for case let file as URL in inside {
-                let values = try? file.resourceValues(forKeys: keys)
-                let stamp = values?.contentModificationDate?.timeIntervalSince1970 ?? -1
-                // The path from the cache root, not the file name: both bundles
-                // hold a `model.mil` and a `weights/weight.bin`.
-                lines.append("\(file.path.dropFirst(root.path.count))\u{1}"
-                    + "\(values?.fileSize ?? -1)\u{1}\(Int(stamp))")
+                var directory: ObjCBool = false
+                guard manager.fileExists(atPath: file.path, isDirectory: &directory),
+                      !directory.boolValue
+                else { continue }
+                files.append(file)
             }
         }
-        guard seen == wanted, !lines.isEmpty else { return nil }
+        guard seen == wanted, !files.isEmpty else { return nil }
 
-        let digest = SHA256.hash(data: Data(lines.sorted().joined(separator: "\u{2}").utf8))
-        let mark = digest.compactMap { String(format: "%02x", $0) }.joined().prefix(16)
+        var hasher = SHA256()
+        // Sorted, so the digest does not depend on the order the enumerator
+        // happened to walk in. The path goes in with the bytes: both bundles
+        // hold a `model.mil` and a `weights/weight.bin`.
+        for file in files.sorted(by: { $0.path < $1.path }) {
+            hasher.update(data: Data(file.path.dropFirst(root.path.count).utf8))
+            guard let handle = try? FileHandle(forReadingFrom: file) else { return nil }
+            defer { try? handle.close() }
+            while let chunk = try? handle.read(upToCount: 1 << 20), !chunk.isEmpty {
+                hasher.update(data: chunk)
+            }
+        }
+        let mark = String(
+            hasher.finalize().compactMap { String(format: "%02x", $0) }.joined().prefix(16)
+        )
         cacheLock.lock()
-        weights = String(mark)
+        weights = mark
         cacheLock.unlock()
-        return String(mark)
+        return mark
     }
 
     /// Reads the table now, so the first dictation of the session does not.

--- a/Sources/ParrotFlow/NeuralPhonemes.swift
+++ b/Sources/ParrotFlow/NeuralPhonemes.swift
@@ -82,14 +82,68 @@ enum NeuralPhonemes {
     private static var cache: [String: [String: String]] = [:]
     private static var loadedFromDisk = false
     private static var savePending = false
+    /// The languages `verifyCache` has already settled this launch.
+    private static var verified: Set<String> = []
     private static let cacheLock = NSLock()
     private static let saveQueue = DispatchQueue(label: "com.parrotflow.phonemes")
 
-    /// Keyed by the model, because an entry is only right for the weights that
-    /// wrote it.
+    /// Named for the model, which is as far as a name gets here. FluidAudio
+    /// publishes no version for these weights and `ModelNames.MultilingualG2P`
+    /// carries no revision, so an updated model arrives under the same two file
+    /// names. `verifyCache` is what actually decides the table is still valid.
     private static var cacheURL: URL {
         AppVariant.supportDirectory
             .appendingPathComponent("phonemes-multilingual-g2p.json")
+    }
+
+    /// Asks the model to confirm a few entries it wrote, and drops the whole
+    /// table if it will not.
+    ///
+    /// A name cannot answer this. New weights land under the same file names,
+    /// and the table under them is then from the model before. The damage is a
+    /// mixed table rather than an old one: a window read by the new model is
+    /// scored against a term read by the old one, over a 0.85 floor, and
+    /// neither reading is wrong on its own.
+    ///
+    /// So three entries per language are asked again, on the first dictation of
+    /// each launch. Three calls, against a table that saves about seven a
+    /// dictation. A disagreement drops everything rather than trying to work
+    /// out which entries are stale, because there is no way to tell: a word the
+    /// two models agree on looks exactly like a word only the new one has seen.
+    ///
+    /// A call that throws decides nothing, same as in `of`. It is a busy model,
+    /// not a different one, and it must not cost a table that is fine.
+    private static func verifyCache(language: MultilingualG2PLanguage) async {
+        let table = language.rawValue
+        cacheLock.lock()
+        let checked = verified.contains(table)
+        let canaries = checked ? [] : (cache[table] ?? [:])
+            .filter { !$0.value.isEmpty }
+            .sorted { $0.key < $1.key }
+            .prefix(3)
+            .map { ($0.key, $0.value) }
+        if !checked { verified.insert(table) }
+        cacheLock.unlock()
+        guard !canaries.isEmpty else { return }
+
+        for (word, was) in canaries {
+            let now: String
+            do {
+                now = try await MultilingualG2PModel.shared
+                    .phonemize(word: word, language: language)?
+                    .joined() ?? ""
+            } catch {
+                return
+            }
+            guard Phonemes.clip(now) != was else { continue }
+            Log.write("phonemes: the model no longer reads \(word) the same way;"
+                + " the saved pronunciations are from other weights and are dropped")
+            cacheLock.lock()
+            cache = [:]
+            cacheLock.unlock()
+            scheduleSave()
+            return
+        }
     }
 
     /// Reads the table now, so the first dictation of the session does not.
@@ -180,6 +234,7 @@ enum NeuralPhonemes {
     ) async -> [String: String] {
         guard await isReady() else { return [:] }
         warmCache()
+        await verifyCache(language: language)
         let table = language.rawValue
         var answer: [String: String] = [:]
         var added = false

--- a/Sources/ParrotFlow/NeuralPhonemes.swift
+++ b/Sources/ParrotFlow/NeuralPhonemes.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import FluidAudio
 
@@ -82,68 +83,77 @@ enum NeuralPhonemes {
     private static var cache: [String: [String: String]] = [:]
     private static var loadedFromDisk = false
     private static var savePending = false
-    /// The languages `verifyCache` has already settled this launch.
-    private static var verified: Set<String> = []
+    /// Worked out once per launch. The files do not move under a running app.
+    private static var weights: String?
     private static let cacheLock = NSLock()
     private static let saveQueue = DispatchQueue(label: "com.parrotflow.phonemes")
 
-    /// Named for the model, which is as far as a name gets here. FluidAudio
-    /// publishes no version for these weights and `ModelNames.MultilingualG2P`
-    /// carries no revision, so an updated model arrives under the same two file
-    /// names. `verifyCache` is what actually decides the table is still valid.
+    /// Named for the model. The name says which model wrote the table and
+    /// nothing about which weights, which is what `weightsFingerprint` is for.
     private static var cacheURL: URL {
         AppVariant.supportDirectory
             .appendingPathComponent("phonemes-multilingual-g2p.json")
     }
 
-    /// Asks the model to confirm a few entries it wrote, and drops the whole
-    /// table if it will not.
+    /// What the weights on disk look like: every file inside the two G2P model
+    /// bundles, by path, size and modification date, hashed.
     ///
-    /// A name cannot answer this. New weights land under the same file names,
-    /// and the table under them is then from the model before. The damage is a
-    /// mixed table rather than an old one: a window read by the new model is
-    /// scored against a term read by the old one, over a 0.85 floor, and
-    /// neither reading is wrong on its own.
+    /// The table has to be thrown away when the model changes, and there is
+    /// nothing to hang that on. FluidAudio publishes no version for these
+    /// models and `ModelNames.MultilingualG2P` is two file names and no
+    /// revision, so the file name cannot carry it. The files themselves are the
+    /// identity: new weights are a new download, and a download rewrites them.
     ///
-    /// So three entries per language are asked again, on the first dictation of
-    /// each launch. Three calls, against a table that saves about seven a
-    /// dictation. A disagreement drops everything rather than trying to work
-    /// out which entries are stale, because there is no way to tell: a word the
-    /// two models agree on looks exactly like a word only the new one has seen.
+    /// Sizes and dates rather than contents. The weights are 81 MB and this
+    /// answers a question that is almost always "unchanged". What that allows
+    /// is a re-download of the same weights invalidating a table that was fine,
+    /// which costs one session of warm-up. What it cannot allow is the other
+    /// way round: weights the model reads differently, with the files the same.
     ///
-    /// A call that throws decides nothing, same as in `of`. It is a busy model,
-    /// not a different one, and it must not cost a table that is fine.
-    private static func verifyCache(language: MultilingualG2PLanguage) async {
-        let table = language.rawValue
+    /// The walk is the whole FluidAudio cache, which is 28 files here, and it
+    /// stops descending as soon as it has a bundle.
+    ///
+    /// Nil when both bundles are not there to look at, and then nothing is
+    /// written: a table that cannot be keyed cannot be trusted next launch.
+    private static func weightsFingerprint() -> String? {
         cacheLock.lock()
-        let checked = verified.contains(table)
-        let canaries = checked ? [] : (cache[table] ?? [:])
-            .filter { !$0.value.isEmpty }
-            .sorted { $0.key < $1.key }
-            .prefix(3)
-            .map { ($0.key, $0.value) }
-        if !checked { verified.insert(table) }
+        let known = weights
         cacheLock.unlock()
-        guard !canaries.isEmpty else { return }
+        if let known { return known }
 
-        for (word, was) in canaries {
-            let now: String
-            do {
-                now = try await MultilingualG2PModel.shared
-                    .phonemize(word: word, language: language)?
-                    .joined() ?? ""
-            } catch {
-                return
+        guard let root = try? TtsCacheDirectory.ensure() else { return nil }
+        let wanted = ModelNames.MultilingualG2P.requiredModels
+        let manager = FileManager.default
+        let keys: Set<URLResourceKey> = [.fileSizeKey, .contentModificationDateKey]
+        guard let walk = manager.enumerator(
+            at: root, includingPropertiesForKeys: Array(keys)
+        ) else { return nil }
+
+        var seen: Set<String> = []
+        var lines: [String] = []
+        for case let url as URL in walk where wanted.contains(url.lastPathComponent) {
+            walk.skipDescendants()
+            seen.insert(url.lastPathComponent)
+            guard let inside = manager.enumerator(
+                at: url, includingPropertiesForKeys: Array(keys)
+            ) else { return nil }
+            for case let file as URL in inside {
+                let values = try? file.resourceValues(forKeys: keys)
+                let stamp = values?.contentModificationDate?.timeIntervalSince1970 ?? -1
+                // The path from the cache root, not the file name: both bundles
+                // hold a `model.mil` and a `weights/weight.bin`.
+                lines.append("\(file.path.dropFirst(root.path.count))\u{1}"
+                    + "\(values?.fileSize ?? -1)\u{1}\(Int(stamp))")
             }
-            guard Phonemes.clip(now) != was else { continue }
-            Log.write("phonemes: the model no longer reads \(word) the same way;"
-                + " the saved pronunciations are from other weights and are dropped")
-            cacheLock.lock()
-            cache = [:]
-            cacheLock.unlock()
-            scheduleSave()
-            return
         }
+        guard seen == wanted, !lines.isEmpty else { return nil }
+
+        let digest = SHA256.hash(data: Data(lines.sorted().joined(separator: "\u{2}").utf8))
+        let mark = digest.compactMap { String(format: "%02x", $0) }.joined().prefix(16)
+        cacheLock.lock()
+        weights = String(mark)
+        cacheLock.unlock()
+        return String(mark)
     }
 
     /// Reads the table now, so the first dictation of the session does not.
@@ -202,19 +212,33 @@ enum NeuralPhonemes {
         saveQueue.sync {}
     }
 
+    /// The file: the weights that wrote the table, and the table.
+    private struct Stored: Codable {
+        let weights: String
+        let words: [String: [String: String]]
+    }
+
     private static func readCache() -> [String: [String: String]] {
-        guard let data = try? Data(contentsOf: cacheURL),
-              let decoded = try? JSONDecoder().decode([String: [String: String]].self, from: data)
+        guard let here = weightsFingerprint(),
+              let data = try? Data(contentsOf: cacheURL),
+              let stored = try? JSONDecoder().decode(Stored.self, from: data)
         else { return [:] }
-        return decoded
+        guard stored.weights == here else {
+            Log.write("phonemes: the sound model has changed since these"
+                + " pronunciations were saved; starting again")
+            return [:]
+        }
+        return stored.words
     }
 
     private static func writeCache(_ table: [String: [String: String]]) {
+        guard let here = weightsFingerprint() else { return }
         do {
             try FileManager.default.createDirectory(
                 at: cacheURL.deletingLastPathComponent(), withIntermediateDirectories: true
             )
-            try JSONEncoder().encode(table).write(to: cacheURL, options: .atomic)
+            try JSONEncoder().encode(Stored(weights: here, words: table))
+                .write(to: cacheURL, options: .atomic)
         } catch {
             // The table is still in memory for this run and the next run asks
             // the model again. Not worth failing a dictation over.
@@ -234,7 +258,6 @@ enum NeuralPhonemes {
     ) async -> [String: String] {
         guard await isReady() else { return [:] }
         warmCache()
-        await verifyCache(language: language)
         let table = language.rawValue
         var answer: [String: String] = [:]
         var added = false

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -970,12 +970,21 @@ struct Pipeline: Equatable, Codable {
         // near miss has to raise this or that stage never runs.
         var nearMisses = 0
         var bySound = 0
+        // Where this stage's time goes, split at its two model calls. The
+        // stage's own `ms` is one number for all of it, so it cannot tell a
+        // pronunciation the model has never been asked for from a term
+        // portrait being rebuilt. Those are the two things that put a
+        // dictation past a second here.
+        var soundSeconds = 0.0
+        var gateSeconds = 0.0
         func result(_ text: String, _ vars: [String: Scope.Value]) -> StageResult {
             let wrote: [String: Scope.Value] = [
                 "count": .int(exact.count + nearMisses + bySound),
                 "changes": .string(exact.changes),
                 "before": .string(handed),
                 "protected": .string(exact.protected),
+                "sound_ms": .int(Int((soundSeconds * 1000).rounded())),
+                "gate_ms": .int(Int((gateSeconds * 1000).rounded())),
             ]
             return StageResult(text: text, vars: wrote.merging(vars) { _, new in new })
         }
@@ -1021,10 +1030,12 @@ struct Pipeline: Equatable, Codable {
         // measured over 20891 dictations — see `phonemeParts` for what fires
         // and what it costs.
         if step.bySound ?? true, Pipeline.language(of: text, config: config) == "en" {
+            let askedAt = Date()
             let heard = await VocabularyJudge.phonemeParts(
                 in: text, sounds: config.vocabularySounds, voice: "en-us",
                 language: "en", floor: config.vocabulary.soundBelow, claimed: parts
             )
+            soundSeconds = Date().timeIntervalSince(askedAt)
             bySound = heard.count
             parts += heard
         }
@@ -1064,6 +1075,7 @@ struct Pipeline: Equatable, Codable {
         //
         // `taught` wins over the gate, because a spelling lesson is settled by
         // a rule that is 4/4 where the models measured were 0/4.
+        let gatedAt = Date()
         let settled = (step.gate ?? true)
             ? VocabularyJudge.settle(
                 changes, in: text, by: [.sound: .full, .rule: .lists],
@@ -1076,6 +1088,7 @@ struct Pipeline: Equatable, Codable {
         if config.vocabulary.gateSentence, #available(macOS 14, *) {
             decided = await SentenceGate.settle(changes, in: text, given: decided)
         }
+        gateSeconds = Date().timeIntervalSince(gatedAt)
 
         let gated = decided.enumerated().filter { $0.element != nil && !taught[$0.offset] }.count
         if gated > 0 {

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -98,6 +98,37 @@ actor Transcriber {
         return try await task.value
     }
 
+    /// One decode of silence, so the first real clip does not pay for the
+    /// graph being run for the first time.
+    ///
+    /// `prepare` loads the weights and stops there. Core ML compiles and lays
+    /// out its kernels on the first inference, and over the archive that shows
+    /// up as the first dictation after a gap being slower: 0.074s of processing
+    /// per second of audio on the 20 dictations that opened a session, against
+    /// 0.046s on the other 849, and 0.30s on the worst one.
+    ///
+    /// A second of silence rather than a real clip. The encoder is the part
+    /// that compiles and it runs on whatever it is given; the decoder runs its
+    /// frames too and commits nothing, which is the point.
+    ///
+    /// Nothing waits on this and nothing reads its result. A failure is logged
+    /// and dropped: the first dictation is then as slow as it is today.
+    func warmDecode() async {
+        guard let models else { return }
+        let started = Date()
+        let asr = AsrManager(models: models)
+        var state = await TdtDecoderState.make(decoderLayers: asr.decoderLayerCount)
+        let silence = [Float](repeating: 0, count: Int(Self.sampleRate))
+        do {
+            _ = try await asr.transcribe(silence, decoderState: &state)
+            Log.write(String(
+                format: "transcriber: warm decode in %.2fs", Date().timeIntervalSince(started)
+            ))
+        } catch {
+            Log.write("transcriber: warm decode failed — \(error.localizedDescription)")
+        }
+    }
+
     private var lastReportedPercent: Int = -1
 
     private func reportDownload(_ label: String, _ progress: DownloadProgress) {

--- a/Sources/ParrotFlow/WarmModelsCommand.swift
+++ b/Sources/ParrotFlow/WarmModelsCommand.swift
@@ -1,13 +1,15 @@
 import Foundation
 
 /// `--warm-models` — downloads Parakeet (and the voice detector, if the
-/// config asks for one) without waiting for a first dictation.
+/// config asks for one) and runs one decode, without waiting for a first
+/// dictation.
 ///
-/// `Transcriber.prepare` already does this lazily, on the first real
-/// transcription. This command calls the same method and nothing else, so
-/// `install.sh` — or anyone else scripting a setup — can trigger the
-/// download on its own schedule instead of the user's first attempt to
-/// dictate.
+/// `Transcriber.prepare` already downloads lazily, on the first real
+/// transcription. This command calls the same method, so `install.sh` — or
+/// anyone else scripting a setup — can trigger the download on its own
+/// schedule instead of the user's first attempt to dictate. `warmDecode`
+/// then runs the graph once, which is the other half of the first dictation's
+/// cost and the half `prepare` does not cover.
 enum WarmModelsCommand {
 
     static func run() -> Int32 {
@@ -36,6 +38,10 @@ enum WarmModelsCommand {
             }
             do {
                 try await transcriber.prepare(config: config)
+                // Downloaded and loaded is not run. `install.sh` calls this so
+                // the first dictation waits for nothing, and the Core ML
+                // compile is part of what it would otherwise wait for.
+                await transcriber.warmDecode()
                 print("\r\u{1B}[K✓ models ready")
             } catch {
                 print("\r\u{1B}[K✗ \(error.localizedDescription)")

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -15,7 +15,7 @@ let arguments = CommandLine.arguments
 // flush and the rest did not, so `--replace` was dropping the very lines that
 // explain what the pipeline did — a stage saying it skipped, and why. Doing it
 // here covers every path, including the ones added later.
-atexit { Log.flush(); Trace.flush() }
+atexit { Log.flush(); Trace.flush(); NeuralPhonemes.flushCache() }
 
 // First, and above the config: this is the handshake that says which code you
 // are running, and it must answer even when the config is broken or missing.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -844,6 +844,15 @@ jq -r '.stages[]? | select(.seconds) | [.name, .seconds] | @tsv' trace.jsonl |
   awk '{n[$1]++; s[$1]+=$2} END {for (k in n) printf "%-28s %6.3fs  ×%d\n", k, s[k]/n[k], n[k]}' |
   sort -k2 -rn
 
+# Where the vocabulary stage's time goes. It has two halves that call a model
+# and the stage's own `seconds` covers both: `sound_ms` is the sound pass
+# asking the G2P model for pronunciations, `gate_ms` is the word lists, the
+# slot and the sentence gate deciding. A dictation past a second here is
+# almost always one of the two, and this says which.
+jq -r '.stages[]? | select(.name == "vocabulary" and .vars.gate_ms) |
+       [.seconds, .vars.sound_ms, .vars.gate_ms, .vars.slots] | @tsv' trace.jsonl |
+  sort -rn | head -20
+
 # Every dictation a prompt stage rewrote, and into what.
 jq -r '.stages[]? | select(.before and .before != .after) |
        [.name, .before, .after] | @tsv' trace.jsonl


### PR DESCRIPTION
Three changes, all about paying for a model once instead of once per session. The sound model's answers are now kept on disk between launches, the speech model runs one decode of silence at launch so the first dictation does not pay the Core ML compile, and the vocabulary stage reports its time as two numbers instead of one. Nothing changes what the app decides — the same words come out, sooner.

Review the phoneme cache first. It is the only change that keeps state, and the question to ask of it is what happens when the model does not answer.

<details>
<summary>Why the sound pass was slow — one model call per window, and the table started empty every launch</summary>

`VocabularyJudge.phonemeParts` builds a window for every 1- and 2-word span of the sentence, then asks both ears for a pronunciation. `NeuralPhonemes.of` is the model ear, and its own comment says what it costs: "One word per call by construction — the model is sequence to sequence and takes one string." It is a `for` loop, one awaited Core ML call per miss.

The table that made this affordable was `private static var cache`, in memory only. Every launch started with nothing, so every session paid for its own warm-up, and a sentence of ten words could be nineteen sequential model calls.

Measured on the archive: warmed on 1211 English dictations and asked the next 135, **51.5% of windows were already known**. That is 6.7 model calls a dictation instead of 13.7.

Measured on the binary: `--sound` runs in **0.43s against 4.15s**, and answers 13/13 either way.

</details>

<details>
<summary>What the cache file is, and why it has no size limit</summary>

`~/Library/Application Support/ParrotFlow/phonemes-multilingual-g2p.json`, beside the term portraits. The name says which model wrote the table; which *weights* wrote it is a digest of their bytes stored inside the file, and the toggle below is about that.

Nested by language, then by word. Flat keys would have needed a separator inside a JSON key; two levels needs neither.

No cap. Those 1211 dictations produce 10305 entries, about 460 KB, and an entry is a word and a short string of IPA. The trace file this repo already keeps unbounded is larger.

Writes are coalesced onto a background queue — one at a time, and a request arriving while one is queued is dropped rather than queued behind it, because the queued block reads the table when it runs. `atexit` waits for a write to land, beside the `Log.flush()` and `Trace.flush()` already there. Without that a `--sound` run would exit before its own write and ask the model again next time.

</details>

<details>
<summary>A call that throws is not written down — the one behaviour change worth arguing about</summary>

`of` collapsed two things into an empty string: `phonemize` returning nil, and `phonemize` throwing. Both were cached.

That was harmless while the table died with the process. It is not harmless now. A model that is busy or half-loaded throws, and a persisted empty string would hide that word from the sound pass at every future launch, with nothing to clear it.

So the `catch` now `continue`s without caching. `nil` still caches: that is the model saying it has nothing for this word, it is deterministic, and finding it out costs a call.

</details>

<details>
<summary>How the table knows the model has not changed under it</summary>

A table that outlives the process has to be thrown away when the weights
change, and there is nothing obvious to hang that on: FluidAudio publishes no
version for these models and `ModelNames.MultilingualG2P` is two file names and
no revision. The damage from getting it wrong is a *mixed* table, not an old
one — a window read by the new model scored against a term read by the old one
over a 0.85 floor, with neither reading wrong on its own.

The download leaves no manifest either — the `config.json` beside the bundles is
`{}` — so the bytes are the only identity there is. The file carries a digest of
them: both G2P bundles, every file, each preceded by its path under the cache
root so a file moving counts too, streamed in 1 MB chunks. A different digest on
read drops the table whole.

Path, size and modification date were tried first and are not enough. All three
can be preserved while the bytes change, and the table would then be kept
against a model that no longer agrees with it.

79 MB is cheaper than it sounds, because the files are in the page cache by the
time anything asks — the model has just been loaded. `--sound` end to end is
0.37-0.44s with the digest and was 0.43s with the dates, inside the noise. A
genuinely cold read costs about a second, paid once per launch on the same
background task that fetches the model.

That ordering changed with it: `AppDelegate` reads the table *after* fetching
the model rather than before. With the key coming from the weights there is
nothing to check against until they exist, and the old order would have dropped
the table on the very launch that installed them.

A launch that cannot find both bundles writes nothing: a table that cannot be
keyed cannot be trusted next launch.

Checked with the case that breaks the metadata version — one byte flipped in the
middle of `weight.bin`, size and mtime put back with `os.utime`, metadata
verified identical. The key moves from `d8d7ec18c345d70b` to `68bea5397e8159e2`,
and returns to `d8d7ec18c345d70b` once the file is restored.

</details>

<details>
<summary>The warm decode — 0.15-0.22s off the first dictation, and no more than that</summary>

`Transcriber.prepare` downloads and loads the weights. It never runs the graph, and Core ML compiles and lays out its kernels on the first inference.

`warmDecode` pushes one second of silence through `AsrManager` right after `prepare` succeeds. Nothing waits on it and nothing reads its result; a failure is logged and dropped.

Measured on three fresh processes: 0.22s, 0.15s, 0.17s for the first decode, against nothing like it for later ones in the same process. So this is worth 0.15-0.22s on the first dictation of a session, not seconds.

`--warm-models` calls it too, so `install.sh` covers it for a fresh install.

</details>

<details>
<summary>Splitting the vocabulary timer — and what it said the first time it ran</summary>

The stage's `seconds` was one number for the whole stage. Over 957 English dictations in the archive, 26 spent more than a second here, with a maximum of 8.48s, and nothing in the trace said which half it was.

Two new vars: `sound_ms` for the sound pass, `gate_ms` for the word lists, the slot and the sentence gate. `docs/cli.md` carries the `jq` query.

The first cold profile through `--pipeline` reads **713 / 8931**. The tail is the gate, not the sound pass — the term portrait being built. The next run in a fresh process reads 57 / 260, because `TermPortrait` caches to disk too. So the multi-second vocabulary dictations are portrait rebuilds, which happen when a correction adds a use and changes the fingerprint. That is a separate fix (build the portrait when the correction is recorded), and this PR is what makes it measurable.

</details>

<details>
<summary>What this does not fix</summary>

**Two processes writing the cache.** The app and a `--transcribe` sweep both write the whole file atomically, so a concurrent write loses the other's new entries, never the file. A lost entry costs one model call to recompute. `trace.jsonl` needed `O_APPEND` because a torn write there loses a dictation permanently; there is nothing here worth the same machinery.

**The gate tail.** 713/8931 says where it is. It is not touched here.

**Press to recording.** Still about 175 ms, and nothing in this PR is about the capture path.

</details>

<details>
<summary>Checks</summary>

- `swift build` clean, no new warnings in the changed files.
- `make test` — 31 suites, exit 0, no failures.
- `--sound` 13/13 cold and warm.
- `--warm-models` prints the warm decode line and exits 0.
- Cache file inspected: 79 entries after `--sound`, correct IPA (`parrot` → `pɛɹət`).
- Weights digest: a byte flipped with size and mtime preserved moves the key and drops the table; restoring the file returns the key to its original value.

</details>
