### PR TITLE
fix: a correction rebuilds the term's portrait, not the next dictation

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -4910,10 +4910,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 // portrait is built from, and this is the only moment the app
                 // knows a sentence is right.
                 do {
-                    try TermUses.record(
-                        term: rule.corrected, said: corrected, span: rule.corrected
-                    )
-                    rebuildPortrait(for: rule.corrected)
+                    // The vocabulary's own spelling, not the one that was
+                    // typed. Matching is case-insensitive everywhere else, so
+                    // saving `praisy` against an existing `Praisy` would file
+                    // the sentence under a second key and build a portrait
+                    // there — while the gate goes on reading `Praisy` and finds
+                    // neither. Nil is a term the vocabulary has not got yet,
+                    // and then what was typed is the name.
+                    //
+                    // The span stays as typed. It has to be the word standing
+                    // in the sentence, and the sentence holds what was written.
+                    let term = existingTerm(named: rule.corrected) ?? rule.corrected
+                    try TermUses.record(term: term, said: corrected, span: rule.corrected)
+                    rebuildPortrait(for: term)
                 } catch {
                     // A portrait that missed one sentence is worth less than a
                     // correction that refused to save over it.

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3795,11 +3795,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let ours = heard.contains { $0.caseInsensitiveCompare(back) == .orderedSame }
         do {
             try TermUses.record(term: term, said: sentence, span: back, counter: true)
+            rebuildPortrait(for: term)
             // One term corrected into another — `Praizy` into `Praisy` — says
             // two things at once, and both are worth keeping: the first does
             // not live here and the second does.
             if let right = existingTerm(named: back) {
                 try TermUses.record(term: right, said: sentence, span: back)
+                rebuildPortrait(for: right)
             }
             Log.write(
                 "correction: \"\(written)\" -> \"\(back)\" is a counter-example for"
@@ -3810,6 +3812,50 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return false
         }
         return true
+    }
+
+    /// Builds a term's portrait now, because its uses just changed.
+    ///
+    /// `TermPortrait.summary` caches under a fingerprint of the term's stored
+    /// uses, so recording one invalidates it and the *next* dictation naming
+    /// that term pays the rebuild — one embedding pass per use and per
+    /// counter-example, up to `TermUses.keep` of each.
+    ///
+    /// A correction is the moment the uses changed and the moment nobody is
+    /// waiting, so the work moves here. Nothing waits on it and nothing reads
+    /// the result: if it fails, or the app quits first, the next dictation
+    /// rebuilds exactly as it does today. Calling `summary` and dropping the
+    /// answer *is* the rebuild — it is the same call the dictation would make,
+    /// and it writes the same cache.
+    ///
+    /// **How much this is worth is not measured.** The mechanism is certain —
+    /// the fingerprint changes here and the rebuild lands there — but the size
+    /// is not. It cannot be measured from the CLI: `SentenceGate.settle` stands
+    /// aside whenever the word vectors are not loaded, and in a one-shot
+    /// process they never are, so no `--pipeline` run reaches a portrait at
+    /// all. The archive's 26 slow dictations of 957 arrive in bursts that look
+    /// like a session of corrections, which is the reason to think this
+    /// matters, and `gate_ms` on a running app is what would settle it.
+    ///
+    /// Only with the sentence gate on. `SentenceGate` is the only thing that
+    /// reads a portrait, and with it off this would fetch 335 MB of word
+    /// vectors to answer a question nobody asks.
+    private func rebuildPortrait(for term: String) {
+        guard config.vocabulary.gateSentence else { return }
+        guard #available(macOS 14, *) else { return }
+        Task.detached(priority: .background) {
+            let started = Date()
+            // Nil covers both "too few uses to describe" and "it threw", and
+            // neither is worth a line: nothing was built either way.
+            guard (try? await TermPortrait.shared.summary(for: term)) != nil else { return }
+            // Not "rebuilt". The fingerprint decides whether there was work to
+            // do, and the time says which happened — a rebuild is seconds, a
+            // portrait that was already good is instant.
+            Log.write(String(
+                format: "portrait: %@ is current in %.1fs, so the next dictation does not wait",
+                term, Date().timeIntervalSince(started)
+            ))
+        }
     }
 
     /// The vocabulary term this word is, ignoring case and any possessive.
@@ -4867,6 +4913,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     try TermUses.record(
                         term: rule.corrected, said: corrected, span: rule.corrected
                     )
+                    rebuildPortrait(for: rule.corrected)
                 } catch {
                     // A portrait that missed one sentence is worth less than a
                     // correction that refused to save over it.

--- a/Sources/ParrotFlow/TermPortrait.swift
+++ b/Sources/ParrotFlow/TermPortrait.swift
@@ -174,6 +174,10 @@ actor TermPortrait {
     private var cache: [String: Summary] = [:]
     private var loadedFromDisk = false
 
+    /// The build running for a term, and the uses it was started for. See
+    /// `summary` for why an actor alone does not stop two of them.
+    private var building: [String: (mark: String, task: Task<Summary, Error>)] = [:]
+
     /// Keyed by the model, because the numbers are only comparable within one
     /// set of weights. A model change invalidates every summary and no
     /// sentence.
@@ -293,7 +297,34 @@ actor TermPortrait {
         if !loadedFromDisk { cache = Self.readCache(); loadedFromDisk = true }
         if let held = cache[term], held.fingerprint == mark { return held }
 
-        let built = try await Self.build(uses, against: counters, fingerprint: mark)
+        // A build already running for this same fingerprint is the build this
+        // caller wants, so join it rather than start a second one.
+        //
+        // Actor isolation is not enough on its own. `build` awaits a vector per
+        // use, and an actor lets another call in at every one of those
+        // suspensions — so two callers can both find the cache stale on either
+        // side of the same await and both do the whole thing. That is exactly
+        // the pair this stage now creates: the rebuild a correction starts, and
+        // the dictation that names the term while it is still running. Without
+        // this the dictation waits for a full build anyway, and the machine
+        // does the work twice. Same shape as `Transcriber.loadingModels` and
+        // `WordVectors.loading`.
+        //
+        // Keyed on the fingerprint too, because a build in flight for older
+        // uses is the wrong answer for this caller — another correction may
+        // have landed since it started.
+        if let running = building[term], running.mark == mark {
+            return try await running.task.value
+        }
+
+        let task = Task { try await Self.build(uses, against: counters, fingerprint: mark) }
+        building[term] = (mark: mark, task: task)
+        // Only if it is still ours. A correction arriving mid-build starts its
+        // own task under this key, and clearing that one would let a third
+        // caller start a duplicate of it.
+        defer { if building[term]?.mark == mark { building[term] = nil } }
+
+        let built = try await task.value
         cache[term] = built
         Self.writeCache(cache)
         return built


### PR DESCRIPTION
A term's portrait goes stale the moment a correction is recorded, and nothing rebuilt it there — the next dictation naming that term did, on its own time. This moves the rebuild to the correction, where nobody is waiting. Behaviour is unchanged: the same call, writing the same cache, at a different moment.

It only runs with `gate_sentence` on, which is the default.

Read the "what is not measured" toggle before approving. The mechanism is certain but the size is not, and the commit deliberately does not claim one.

<details>
<summary>What a portrait is, and what a rebuild costs</summary>

Two centroids per term: one over the sentences where the term was confirmed, one over the counter-examples where it does not belong. `SentenceGate` compares a dictation against both to decide whether this sentence is a place the term lives.

`TermPortrait.summary` caches it on disk under a fingerprint of the term's stored sentences. Recording one changes the fingerprint, so the cached portrait is invalid from that moment.

Rebuilding is one embedding pass through Qwen3-Embedding per use and per counter-example, capped at `TermUses.keep` (40) of each.

</details>

<details>
<summary>Where it now happens</summary>

All three places the app calls `TermUses.record`:

- `recordCounter`, for the term the sentence is a counter-example for
- `recordCounter` again, for the term the correction wrote, when one word was corrected into another
- the spoken-command path that learns a pronunciation and keeps the sentence with it

Calling `summary` and dropping the answer *is* the rebuild — it is the same call the dictation would have made, and it writes the same cache. There is no second code path to keep in step.

`--learn` is deliberately not hooked. It seeds in bulk and the process exits immediately, so a background task there would be killed before it finished and would fire once per seeded row on the way.

</details>

<details>
<summary>What happens when it does not finish</summary>

Nothing waits on it and nothing reads the result. If it throws, or the term has fewer than `TermPortrait.minimum` sentences to describe it, or the app quits first, the next dictation rebuilds exactly as it does today. This can only remove work from the dictation path, never add it.

A correction followed straight away by a dictation of the same term joins the rebuild already running and waits only for what is left of it.

That did not work at first and is the second commit here. An actor is not enough on its own: `build` awaits a vector per use, and an actor admits another call at every one of those suspensions, so both callers found the cache stale and both built. The change could therefore double the embedding work in the exact case it exists to improve. A build in flight is now held per term, keyed on the fingerprint too, and joined — the same shape as `Transcriber.loadingModels` and `WordVectors.loading`.

The log line says `is current`, not `rebuilt` — the fingerprint decides whether there was work to do, and the time tells you which happened.

</details>

<details>
<summary>What is not measured, and why the CLI cannot measure it</summary>

**The size of this win is unknown, and this PR does not claim one.**

`SentenceGate.settle` stands aside whenever the word vectors are not loaded:

```swift
guard await WordVectors.shared.isLoaded else {
    await WordVectors.shared.warm()
    Log.write("sentence gate: the word vectors are not loaded yet; skipped")
    return settled
}
```

`warm()` only starts the load. In a one-shot CLI process the vectors are never loaded by the time the gate runs, so **no `--pipeline` run reaches a portrait at all**. Confirmed directly: with the portrait cache deleted, three consecutive runs read 224, 197 and 201 ms and the cache file was never written.

This also corrects a number in #255. The `gate_ms` 8931 quoted there as evidence of portrait rebuilds was ModernBERT's first Core ML compile inside `Vocabulary.shared.slotGate()` → `SentenceProbe.load()`, which is why the next process read 260 ms — the compiled model had been cached on disk. Portraits were never involved.

What actually supports this change is the archive: 26 English dictations of 957 spent over a second in the vocabulary stage, arriving in two bursts on one day, which is what a session of correcting one term looks like from the inside. That is a reason to suspect portraits, not proof.

`gate_ms` on a running app is what would settle it. A further split, separating portrait work from model loading inside the gate, would settle it precisely — worth doing if these numbers turn out to matter.

</details>

<details>
<summary>Checks</summary>

- `swift build` clean, no new warnings.
- `make test` — 31 suites, exit 0, no failures.
- Behaviour verified by reading, not by measurement, for the reason in the toggle above.
- The coalescing is not reproduced concurrently: there is no test target and `--portrait` builds one term at a time. What is checked is that `build` suspends per use and that the sequential path still passes.

</details>
