### PR TITLE
feat: hand edits are kept, and the popup opens only on names

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3715,6 +3715,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// panel about it would be noise on every dictation.
     private func offerToLearn(_ changes: [EditWatch.Change]) {
         let sentence = changes.first?.sentence ?? ""
+        // Every change is written down first, whatever the panel does with
+        // it. A word changed to a word both lists know is not offered, and it
+        // is the one label a misheard-word stage cannot get any other way.
+        for change in changes where !EditWatch.onlyPunctuation(change) {
+            let heard = EditWatch.asHeard(change)
+            Trace.edit(
+                heard: change.was, corrected: change.now,
+                text: heard.text, range: heard.range,
+                lang: DictationLanguage.forCorrection(
+                    transcript: heard.text, allowed: config.transcription.languages
+                ),
+                app: lastDictated?.owner?.localizedName,
+                after: Date().timeIntervalSince(edits.startedAt)
+            )
+        }
         // The counters first. A change that runs the other way is not a rule
         // to weigh, and `teaches` would drop half of them — `BetterStack` put
         // back to `better stack` lands on two ordinary words.

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -272,6 +272,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         owner: NSRunningApplication?, landing: Correction.Landing
     )?
 
+    /// Where each run's clip went, so a hand edit is filed beside the
+    /// dictation it is about. `output_dir` can change between the two — see
+    /// `Trace.record` — and the global would file them apart.
+    private var clipDirectories: [Int: URL] = [:]
+
     /// The focused element's text as it was at the press, for an app that gave
     /// no caret. What changed in it afterwards is where the words went.
     ///
@@ -2145,6 +2150,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 // The trace is opened around the whole chain, not just the
                 // decoder: the stages that follow write into the same record,
                 // and the line is appended even if one of them throws.
+                self?.clipDirectories[press.run] = recording.url.deletingLastPathComponent()
+                self?.clipDirectories = self?.clipDirectories.filter { $0.key > press.run - 8 } ?? [:]
                 let text = try await Trace.record(
                     wav: recording.url.lastPathComponent, source: .live,
                     app: app.map { Trace.App(name: $0.name, bundleID: $0.bundleID) },
@@ -3727,7 +3734,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     transcript: heard.text, allowed: config.transcription.languages
                 ),
                 app: lastDictated?.owner?.localizedName,
-                after: Date().timeIntervalSince(edits.startedAt)
+                after: Date().timeIntervalSince(edits.startedAt),
+                beside: lastDictated.flatMap { clipDirectories[$0.run] }
             )
         }
         // The counters first. A change that runs the other way is not a rule

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -4904,7 +4904,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
             do {
                 try ConfigWriter.addVocabularyPronunciation(
-                    term: rule.corrected, heard: rule.heard, kind: rule.kind
+                    term: rule.corrected, heard: rule.heard
                 )
                 // The sentence too, not only the mapping. It is what a term's
                 // portrait is built from, and this is the only moment the app
@@ -5513,7 +5513,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             for rule in rules {
                 do {
                     try ConfigWriter.addVocabularyPronunciation(
-                        term: rule.corrected, heard: rule.heard, kind: rule.kind
+                        term: rule.corrected, heard: rule.heard
                     )
                     Log.write("learned pronunciation: \(rule.heard) -> \(rule.corrected)")
                     Trace.correction(

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3871,48 +3871,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// Is this correction about a name, or about English?
-    ///
-    /// The panel used to show every one-word change, which is every typo and
-    /// every reword. Distance does not separate them — measured on this
-    /// speaker's own `heard:` lists against ordinary edits, `its -> it\'s`
-    /// scores 1.000 and `Prezi -> Praisy` scores 0.304, so any floor drawn
-    /// through spelling keeps the noise and drops the names.
-    ///
-    /// What separates them is the word the correction lands *on*. Measured on
-    /// the same two sets: the two word lists call 8 of 9 real corrections
-    /// unknown and all 10 of the ordinary ones known. `Sentry` is the miss, and
-    /// it is capitalised, so the second half catches it.
-    ///
-    /// An `or`, which is also the answer to why this was left out before: the
-    /// day `Vercel` enters a dictionary, the capital still offers it.
+    /// Is this correction about a name, or about English? The decision is
+    /// `EditWatch.refusal`, which has a case set; this only says why in the log.
     private func teaches(_ change: EditWatch.Change) -> Bool {
-        let letters = { (s: String) in String(s.filter { $0.isLetter || $0.isNumber }) }
-        // Punctuation or case alone is not a pronunciation. Spacing is: gluing
-        // two words into one is most of this vocabulary — `Red Rock` to
-        // `Redrock`, `Better Stack` to `BetterStack`, `Ghost T` to `Ghostty` —
-        // so the test that ignores punctuation must not ignore the space, or it
-        // throws away the commonest correction there is.
-        let spaced = { (s: String) in
-            String(s.filter { $0.isLetter || $0.isNumber || $0.isWhitespace }).lowercased()
-        }
-        guard spaced(change.was) != spaced(change.now) else {
-            Log.write("correction: \"\(change.was)\" -> \"\(change.now)\" is punctuation,"
-                + " not a name; not offered")
-            return false
-        }
-        if Vocabulary.unseenWord(letters(change.now)) { return true }
-        // A capital that is not the one every sentence starts with.
-        // A capital that is not the one every sentence starts with.
-        //
-        // The first word of the *line* was not the right test. A line holds
-        // several sentences, and every one of them opens with a capital:
-        // correcting `Fais` to `Et` at the start of a sentence mid-line read
-        // as a name because of it, and a French grammar fix was offered as a
-        // vocabulary rule.
-        let opens = EditWatch.opensSentence(in: change.sentence, at: change.nowAt)
-        if change.now.first?.isUppercase == true, !opens { return true }
-        Log.write("correction: \"\(change.was)\" -> \"\(change.now)\" is ordinary English;"
+        guard let refusal = EditWatch.refusal(for: change) else { return true }
+        Log.write("correction: \"\(change.was)\" -> \"\(change.now)\" is \(refusal);"
             + " not offered")
         return false
     }

--- a/Sources/ParrotFlow/CorrectionPanel.swift
+++ b/Sources/ParrotFlow/CorrectionPanel.swift
@@ -4,8 +4,8 @@ import SwiftUI
 
 /// Teach me the words I got wrong.
 ///
-/// A table: what was heard, what it should be, what kind of thing it names. The
-/// rows are proposed by the spell check rather than typed from nothing — see
+/// A table: what was heard and what it should be. The rows are proposed by the
+/// spell check rather than typed from nothing — see
 /// `VocabularySuggest` for what it finds and what it cannot.
 ///
 /// Visually a sibling of the pill: near-black at 95%, the same plumage rim.
@@ -173,9 +173,8 @@ enum CorrectionMetrics {
     static let heardWidth: CGFloat = 165
     static let arrowWidth: CGFloat = 12
     static let correctedWidth: CGFloat = 185
-    static let kindWidth: CGFloat = 96
-    /// The three columns, the arrow, the ✕, and the gaps between them.
-    static let width: CGFloat = 572
+    /// The two columns, the arrow, the ✕, and the gaps between them.
+    static let width: CGFloat = 482
     static let rowHeight: CGFloat = 40
     static let maxRows = 7
     /// Title, column labels, the add-a-word row, and the buttons. Measured

--- a/Sources/ParrotFlow/CorrectionTable.swift
+++ b/Sources/ParrotFlow/CorrectionTable.swift
@@ -1,16 +1,10 @@
 import Foundation
 import SwiftUI
 
-/// One thing the panel taught: what was heard, what it should be, and what kind
-/// of thing it names.
-///
-/// `kind` is optional because most callers have no opinion. Only the panel
-/// fills it in, and only a filled-in one is written to `vocabulary.yaml` — a
-/// default written as if it were a decision is worse than no line at all.
+/// One thing the panel taught: what was heard and what it should be.
 struct TaughtRule: Equatable {
     var heard: String
     var corrected: String
-    var kind: WordKind?
 }
 
 /// One row of the panel.
@@ -21,7 +15,6 @@ struct CorrectionRow: Identifiable, Equatable {
     /// the whole reason it is a field and not a label.
     var heard: String
     var corrected: String = ""
-    var kind: WordKind = .word
     /// Proposed by the spell check rather than typed. Only used to decide
     /// where the caret starts.
     var suggested: Bool = false
@@ -46,7 +39,7 @@ final class CorrectionModel: ObservableObject {
             let heard = row.heard.trimmingCharacters(in: .whitespacesAndNewlines)
             let corrected = row.corrected.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !heard.isEmpty, !corrected.isEmpty, heard != corrected else { return nil }
-            return TaughtRule(heard: heard, corrected: corrected, kind: row.kind)
+            return TaughtRule(heard: heard, corrected: corrected)
         }
     }
 
@@ -77,7 +70,7 @@ final class CorrectionModel: ObservableObject {
     func load(sentence: String, language: String? = nil) {
         self.sentence = sentence
         rows = VocabularySuggest.rows(in: sentence, language: language).map {
-            CorrectionRow(heard: $0.heard, kind: $0.kind, suggested: true)
+            CorrectionRow(heard: $0.heard, suggested: true)
         }
         if rows.isEmpty { rows = [CorrectionRow(heard: "")] }
         focusFirstRow()
@@ -89,19 +82,8 @@ final class CorrectionModel: ObservableObject {
     /// More than one row when the utterance carried more than one correction:
     /// "Tasmeen spells T A S M E E N and Mick spells M I K" is two rules, and
     /// splitting them across two panels would mean saying it twice.
-    ///
-    /// The kind is still proposed from the tag, because a rule that arrived
-    /// this way has a heard word like any other.
     func load(rules proposed: [(heard: String, corrected: String)], over sentence: String = "") {
         self.sentence = sentence
-        // What the vocabulary already says about this term beats what a tagger
-        // guesses about the word. A term you have already labelled is labelled,
-        // and offering a different answer for it invites you to disagree with
-        // yourself one row at a time.
-        let known = ((try? ConfigStore.load())?.vocabulary.terms ?? [:])
-            .reduce(into: [String: WordKind]()) { out, entry in
-                if let kind = entry.value.kind { out[entry.key.lowercased()] = kind }
-            }
         rows = proposed.map { proposal in
             // The possessive belongs to the sentence, not to the name. Saved as
             // it stands, `Precey's -> Praizy's` teaches a term called `Praizy's`
@@ -113,14 +95,7 @@ final class CorrectionModel: ObservableObject {
                 rule.corrected = String(rule.corrected.dropLast(mine.suffix.count))
                 rule.heard = String(rule.heard.dropLast(theirs.suffix.count))
             }
-            let word = rule.corrected.trimmingCharacters(in: .punctuationCharacters)
-            if let already = known[word.lowercased()] {
-                return CorrectionRow(heard: rule.heard, corrected: rule.corrected, kind: already)
-            }
-            let tag = Tagger.tokens(in: rule.corrected, language: nil).first?.tag
-            return CorrectionRow(
-                heard: rule.heard, corrected: rule.corrected, kind: .from(tag: tag)
-            )
+            return CorrectionRow(heard: rule.heard, corrected: rule.corrected)
         }
         if rows.isEmpty { rows = [CorrectionRow(heard: "")] }
         focusFirstRow()
@@ -150,10 +125,9 @@ final class CorrectionModel: ObservableObject {
 
     // MARK: - Focus
 
-    enum Column: Hashable { case heard, corrected, kind }
+    enum Column: Hashable { case heard, corrected }
 
-    /// One editable thing on the panel. The type menu is one of them: it is a
-    /// third of what a row says, so Tab has to reach it.
+    /// One editable thing on the panel.
     struct Cell: Hashable {
         let row: UUID
         let column: Column
@@ -169,8 +143,7 @@ final class CorrectionModel: ObservableObject {
     private var ring: [Cell] {
         rows.flatMap { row in
             [Cell(row: row.id, column: .heard),
-             Cell(row: row.id, column: .corrected),
-             Cell(row: row.id, column: .kind)]
+             Cell(row: row.id, column: .corrected)]
         }
     }
 

--- a/Sources/ParrotFlow/CorrectionTableView.swift
+++ b/Sources/ParrotFlow/CorrectionTableView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// The teach-a-word panel: one row per word, mapping what ParrotFlow wrote to
-/// what it should have written, and what kind of thing that is.
+/// what it should have written.
 ///
 /// The rows are proposed rather than enumerated. An earlier version put one row
 /// per word of the selection, which is a wall of rows to read on a long
@@ -72,7 +72,6 @@ struct CorrectionView: View {
             Color.clear.frame(width: CorrectionMetrics.arrowWidth)
             Text("SHOULD BE")
                 .frame(width: CorrectionMetrics.correctedWidth, alignment: .leading)
-            Text("TYPE")
             Spacer()
         }
         .font(.system(size: 11, weight: .semibold, design: .rounded))
@@ -107,8 +106,6 @@ struct CorrectionView: View {
                 .parrotField(focused: focused == cell(id, .corrected))
                 .frame(width: CorrectionMetrics.correctedWidth)
 
-            kindPicker(row.kind, id: id)
-
             Button {
                 model.remove(id)
             } label: {
@@ -123,28 +120,6 @@ struct CorrectionView: View {
         }
         .font(.system(size: 15, weight: .medium, design: .monospaced))
         .frame(height: CorrectionMetrics.rowHeight)
-    }
-
-    /// A menu rather than four segments. The proposal is right most of the time,
-    /// so the common case is reading one word and moving on; four segments would
-    /// spend the width of the panel on a control nobody touches.
-    private func kindPicker(_ kind: Binding<WordKind>, id: UUID) -> some View {
-        Menu {
-            ForEach(WordKind.allCases, id: \.self) { option in
-                Button(option.label) { kind.wrappedValue = option }
-            }
-        } label: {
-            Text(kind.wrappedValue.label)
-                .font(.system(size: 13, weight: .medium, design: .rounded))
-        }
-        .menuStyle(.borderlessButton)
-        .frame(width: CorrectionMetrics.kindWidth - 18)
-        // A menu is not in the tab ring unless it asks to be, and macOS only
-        // tabs to non-text controls when Full Keyboard Access is on. The panel
-        // catches Tab itself, so the ring here is ours either way.
-        .focusable()
-        .focused($focused, equals: cell(id, .kind))
-        .parrotField(focused: focused == cell(id, .kind))
     }
 
     private func cell(_ id: UUID, _ column: CorrectionModel.Column) -> CorrectionModel.Cell {

--- a/Sources/ParrotFlow/EditDiffCommand.swift
+++ b/Sources/ParrotFlow/EditDiffCommand.swift
@@ -31,6 +31,10 @@ enum EditDiffCommand {
             } else {
                 print("  offer: yes")
             }
+            // What `trace.jsonl` would keep: the window as heard and where
+            // the heard word stands in it.
+            let heard = EditWatch.asHeard(change)
+            print("  heard: \(heard.range.lowerBound)..<\(heard.range.upperBound) in \"\(heard.text)\"")
         }
         print("  in: \(changes[0].sentence)")
         return 0

--- a/Sources/ParrotFlow/EditDiffCommand.swift
+++ b/Sources/ParrotFlow/EditDiffCommand.swift
@@ -5,10 +5,11 @@ import Foundation
 ///     ParrotFlow --edit-diff "the Vercel Castle is closed" "the Versailles Castle is closed"
 ///     Vercel -> Versailles
 ///
-/// `EditWatch.change` decides whether a field that no longer says what was
+/// `EditWatch.changes` decides whether a field that no longer says what was
 /// dictated holds a correction or a rewrite, and a rewrite read as a correction
-/// teaches a term the wrong sentence. It is a pure function with no
-/// accessibility and no timing behind it, so it has a set.
+/// teaches a term the wrong sentence. `EditWatch.refusal` then decides whether
+/// the correction is about a name. Neither has accessibility or timing behind
+/// it, so both have a set.
 enum EditDiffCommand {
     static func run(before: String, now: String) -> Int32 {
         let changes = EditWatch.changes(from: before, to: now)
@@ -23,6 +24,13 @@ enum EditDiffCommand {
             // sentence, where every word is capitalised and the capital says
             // nothing about the word.
             print("  opens: \(EditWatch.opensSentence(in: change.sentence, at: change.nowAt))")
+            // Whether the panel would offer it. The two word lists are the
+            // real ones, so the answer is this machine's.
+            if let refusal = EditWatch.refusal(for: change) {
+                print("  offer: no, \(refusal)")
+            } else {
+                print("  offer: yes")
+            }
         }
         print("  in: \(changes[0].sentence)")
         return 0

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -45,6 +45,11 @@ final class EditWatch {
         /// words into one or splits one into two, so anything reading
         /// `sentence` by index has to use this one.
         let nowAt: Int
+        /// The line as it was written, which `at` indexes. What a scorer
+        /// needs is the text as heard, and `sentence` already has the fix in.
+        let written: String
+        /// How many words of `written` the change covers, from `at`.
+        let span: Int
     }
 
     /// Every correction of one settling, handed over at once.
@@ -107,6 +112,11 @@ final class EditWatch {
 
     var isRunning: Bool { !monitors.isEmpty }
 
+    /// When the dictation this watch is about landed. A change two seconds
+    /// later is most likely a mishearing being fixed; five minutes later it
+    /// is more likely a change of mind. Recorded, not decided on.
+    private(set) var startedAt = Date()
+
     /// Watch the field the dictation just landed in.
     ///
     /// `snapshot` is the whole field as it stands now, not the dictation alone.
@@ -114,6 +124,7 @@ final class EditWatch {
     /// anybody is still editing.
     func start(dictated words: String, in element: AXUIElement?) {
         generation += 1
+        startedAt = Date()
         before = nil
         dictated = words
         field = element
@@ -359,7 +370,10 @@ final class EditWatch {
                 was: old[fromI ..< i].joined(separator: " "),
                 now: new[fromJ ..< j].joined(separator: " ")
             )
-            found.append(Change(was: pair.was, now: pair.now, sentence: now, at: fromI, nowAt: fromJ))
+            found.append(Change(
+                was: pair.was, now: pair.now, sentence: now, at: fromI, nowAt: fromJ,
+                written: before, span: i - fromI
+            ))
         }
         return found
     }
@@ -400,6 +414,27 @@ final class EditWatch {
         return (String(a[head ..< (a.count - tail)]), String(b[head ..< (b.count - tail)]))
     }
 
+    /// The line as heard around the change, and where `was` stands in it.
+    ///
+    /// Twelve words either side, clipped to the line. That is the window the
+    /// scorers read; the whole line is a terminal's input box and may hold
+    /// several dictations. The words are joined with single spaces, so a row
+    /// that wrapped comes back as one line, and the range is in characters
+    /// of the text returned.
+    static func asHeard(_ change: Change, margin: Int = 12) -> (text: String, range: Range<Int>) {
+        let said = words(of: change.written)
+        let end = min(said.count, change.at + change.span)
+        guard change.at < end else { return (change.was, 0 ..< change.was.count) }
+        let from = max(0, change.at - margin)
+        let to = min(said.count, end + margin)
+        let text = said[from ..< to].joined(separator: " ")
+        let run = said[change.at ..< end].joined(separator: " ")
+        let head = said[from ..< change.at].reduce(0) { $0 + $1.count + 1 }
+        let inner = run.range(of: change.was).map { run.distance(from: run.startIndex, to: $0.lowerBound) } ?? 0
+        let start = head + inner
+        return (text, start ..< start + change.was.count)
+    }
+
     // MARK: - the offer
 
     /// Why a change is not worth a panel.
@@ -415,6 +450,17 @@ final class EditWatch {
             case .ordinary: return "ordinary English"
             }
         }
+    }
+
+    /// Punctuation or case alone, which is not a pronunciation. Spacing is:
+    /// gluing two words into one is most of this vocabulary — `Red Rock` to
+    /// `Redrock`, `Ghost T` to `Ghostty` — so the test that ignores
+    /// punctuation must not ignore the space.
+    static func onlyPunctuation(_ change: Change) -> Bool {
+        let spaced = { (s: String) in
+            String(s.filter { $0.isLetter || $0.isNumber || $0.isWhitespace }).lowercased()
+        }
+        return spaced(change.was) == spaced(change.now)
     }
 
     /// Is this correction about a name, or about English?
@@ -437,14 +483,7 @@ final class EditWatch {
         for change: Change, unseen: (String) -> Bool = Vocabulary.unseenWord
     ) -> Refusal? {
         let letters = { (s: String) in String(s.filter { $0.isLetter || $0.isNumber }) }
-        // Punctuation or case alone is not a pronunciation. Spacing is: gluing
-        // two words into one is most of this vocabulary — `Red Rock` to
-        // `Redrock`, `Ghost T` to `Ghostty` — so the test that ignores
-        // punctuation must not ignore the space.
-        let spaced = { (s: String) in
-            String(s.filter { $0.isLetter || $0.isNumber || $0.isWhitespace }).lowercased()
-        }
-        guard spaced(change.was) != spaced(change.now) else { return .punctuation }
+        guard !onlyPunctuation(change) else { return .punctuation }
         let said = change.now.split(whereSeparator: { $0.isWhitespace }).map(String.init)
         for (offset, word) in said.enumerated() {
             let bare = letters(word)

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -77,6 +77,10 @@ final class EditWatch {
     /// and keying by the word lost one of `versal is not versal` corrected to
     /// `Vercel is not Versailles`.
     private var seen: [Int: Change] = [:]
+    /// What has been handed over already. The pending read in `stop` finds
+    /// the same diff for as long as the line stands, and a correction declined
+    /// at one press was offered again at the next.
+    private var told: Set<String> = []
     private var lastLook = Date.distantPast
     /// The read waiting for you to stop typing. Cancelled and replaced by every
     /// key, so it only ever runs once the field has been still.
@@ -115,6 +119,7 @@ final class EditWatch {
         field = element
         reported = []
         seen = [:]
+        told = []
         keysSeen = 0
         guard Permissions.accessibility == .granted else {
             Log.write("edit watch: accessibility is not granted; corrections cannot be seen")
@@ -237,7 +242,14 @@ final class EditWatch {
     private func tell() {
         guard !seen.isEmpty else { return }
         let changes = seen.values.sorted { $0.at < $1.at }
+            .filter { told.insert("\($0.at)\u{1}\($0.now)").inserted }
         seen = [:]
+        guard !changes.isEmpty else { return }
+        // Both lines whole, so the log says what the diff ran over and not
+        // only what it found. A 60-character prefix could not explain
+        // `prone.maybe` becoming `prone point.maybe`.
+        Log.write("edit watch: was \"\(before ?? "")\"")
+        Log.write("edit watch: now \"\(changes[0].sentence)\"")
         for change in changes {
             Log.write("edit watch: \"\(change.was)\" became \"\(change.now)\"")
         }
@@ -362,6 +374,10 @@ final class EditWatch {
     /// Only punctuation is cut, never letters. `Prizzy -> Praizy` shares "Pr"
     /// and "zy" and must survive whole; cutting shared letters would offer
     /// "iz -> aiz", which is not a word anybody said.
+    ///
+    /// The same at the tail. `prone.maybe` became `prone point.maybe`: the
+    /// two share `.maybe`, and the second sentence is not part of the
+    /// correction. It comes off from the first mark of the shared suffix.
     static func trimmed(was: String, now: String) -> (was: String, now: String) {
         let a = Array(was), b = Array(now)
         func plain(_ c: Character) -> Bool { c.isLetter || c.isNumber }
@@ -371,16 +387,79 @@ final class EditWatch {
         var head = 0
         for i in 0 ..< shared where !plain(a[i]) { head = i + 1 }
 
-        var tail = 0
-        while tail < a.count - head, tail < b.count - head,
-              a[a.count - 1 - tail] == b[b.count - 1 - tail],
-              !plain(a[a.count - 1 - tail]) {
-            tail += 1
+        var sharedTail = 0
+        while sharedTail < a.count - head, sharedTail < b.count - head,
+              a[a.count - 1 - sharedTail] == b[b.count - 1 - sharedTail] {
+            sharedTail += 1
         }
+        var tail = 0
+        for i in 0 ..< sharedTail where !plain(a[a.count - 1 - i]) { tail = i + 1 }
 
         guard head + tail > 0, a.count - head - tail > 0, b.count - head - tail > 0
         else { return (was, now) }
         return (String(a[head ..< (a.count - tail)]), String(b[head ..< (b.count - tail)]))
+    }
+
+    // MARK: - the offer
+
+    /// Why a change is not worth a panel.
+    enum Refusal: CustomStringConvertible {
+        /// Punctuation or case alone. Not a pronunciation.
+        case punctuation
+        /// Every word it lands on is one the word lists know.
+        case ordinary
+
+        var description: String {
+            switch self {
+            case .punctuation: return "punctuation, not a name"
+            case .ordinary: return "ordinary English"
+            }
+        }
+    }
+
+    /// Is this correction about a name, or about English?
+    ///
+    /// Spelling distance does not separate them. Measured on this speaker's
+    /// own `heard:` lists against ordinary edits, `its -> it's` scores 1.000
+    /// and `Prezi -> Praisy` 0.304, so any floor drawn through spelling keeps
+    /// the noise and drops the names.
+    ///
+    /// The word the correction lands *on* does. On the same two sets the two
+    /// word lists call 8 of 9 real corrections unknown and all 10 ordinary ones
+    /// known. `Sentry` is the miss, and it is capitalised, so the capital is
+    /// the second test — an `or`, so the day `Vercel` enters a dictionary it is
+    /// still offered.
+    ///
+    /// Word by word. `prone -> prone point` was glued to `pronepoint` before it
+    /// was looked up, and no list knows that, so a sentence being repaired was
+    /// offered as a term. One name in the span is enough to offer it.
+    static func refusal(
+        for change: Change, unseen: (String) -> Bool = Vocabulary.unseenWord
+    ) -> Refusal? {
+        let letters = { (s: String) in String(s.filter { $0.isLetter || $0.isNumber }) }
+        // Punctuation or case alone is not a pronunciation. Spacing is: gluing
+        // two words into one is most of this vocabulary — `Red Rock` to
+        // `Redrock`, `Ghost T` to `Ghostty` — so the test that ignores
+        // punctuation must not ignore the space.
+        let spaced = { (s: String) in
+            String(s.filter { $0.isLetter || $0.isNumber || $0.isWhitespace }).lowercased()
+        }
+        guard spaced(change.was) != spaced(change.now) else { return .punctuation }
+        let said = change.now.split(whereSeparator: { $0.isWhitespace }).map(String.init)
+        for (offset, word) in said.enumerated() {
+            let bare = letters(word)
+            guard !bare.isEmpty else { continue }
+            if unseen(bare) { return nil }
+            // A capital that is not the one every sentence starts with. The
+            // first word of the *line* was not the right test: a line holds
+            // several sentences, and correcting `Fais` to `Et` at the start of
+            // one mid-line read as a name because of it.
+            if bare.first?.isUppercase == true,
+               !opensSentence(in: change.sentence, at: change.nowAt + offset) {
+                return nil
+            }
+        }
+        return .ordinary
     }
 
     /// The words of a line, punctuation kept: `Vercel.` and `Vercel` are not the

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -237,15 +237,14 @@ enum PanelsCommand {
         // the case the table has to be able to hold.
         let rule = CorrectionModel()
         rule.load(sentence: "we deployed on Ver Sal")
-        rule.rows = [CorrectionRow(heard: "Ver Sal", corrected: "Vercel",
-                                   kind: .organization)]
+        rule.rows = [CorrectionRow(heard: "Ver Sal", corrected: "Vercel")]
         // The rows were replaced wholesale, so the focus `load` left points at
         // a row that no longer exists.
         rule.focus = CorrectionModel.Cell(row: rule.rows[0].id, column: .corrected)
 
-        // Two rows, so the picker is drawn twice against different words. The
-        // sheet cannot show a focus ring on any of them: it renders offscreen,
-        // in no key window, and SwiftUI grants focus to neither.
+        // Two rows. The sheet cannot show a focus ring on any of them: it
+        // renders offscreen, in no key window, and SwiftUI grants focus to
+        // neither.
         let several = CorrectionModel()
         several.load(sentence: "Olama runs polyma for Tasmine")
 

--- a/Sources/ParrotFlow/Trace.swift
+++ b/Sources/ParrotFlow/Trace.swift
@@ -251,9 +251,11 @@ enum Trace {
     }
 
     /// Writes down a word changed by hand. See `Edit`.
+    /// - Parameter beside: the directory holding the dictation's clip, so the
+    ///   edit and the dictation it is about are in one file. See `record`.
     static func edit(
         heard: String, corrected: String, text: String, range: Range<Int>,
-        lang: String, app: String?, after: TimeInterval
+        lang: String, app: String?, after: TimeInterval, beside: URL? = nil
     ) {
         append(
             Edit(
@@ -262,7 +264,7 @@ enum Trace {
                 range: [range.lowerBound, range.upperBound], lang: lang, app: app,
                 after: (after * 10).rounded() / 10
             ),
-            to: directory
+            to: beside ?? directory
         )
     }
 

--- a/Sources/ParrotFlow/Trace.swift
+++ b/Sources/ParrotFlow/Trace.swift
@@ -50,6 +50,7 @@ enum Trace {
     enum Kind: String {
         case dictation
         case correction
+        case edit
     }
 
     /// The app a dictation was spoken into.
@@ -249,6 +250,22 @@ enum Trace {
         )
     }
 
+    /// Writes down a word changed by hand. See `Edit`.
+    static func edit(
+        heard: String, corrected: String, text: String, range: Range<Int>,
+        lang: String, app: String?, after: TimeInterval
+    ) {
+        append(
+            Edit(
+                v: version, kind: Kind.edit.rawValue, at: stamp(),
+                heard: heard, corrected: corrected, text: text,
+                range: [range.lowerBound, range.upperBound], lang: lang, app: app,
+                after: (after * 10).rounded() / 10
+            ),
+            to: directory
+        )
+    }
+
     private static let queue = DispatchQueue(label: "com.parrotflow.trace")
 
     /// Waits for queued writes to reach the file. Same reason as `Log.flush` —
@@ -400,11 +417,8 @@ enum Trace {
     /// got a word wrong and what the right one was. It cannot be reconstructed
     /// afterwards from anything else on disk.
     ///
-    /// These are the corrections ParrotFlow already mediates — the panel, an
-    /// inline instruction, `--learn` — and nothing more. Watching the field
-    /// after the text lands would catch more of them, and would mean reading
-    /// another app's content back out through Accessibility after we have given
-    /// focus away. That is a different thing to be, and not one this file needs.
+    /// These are the corrections ParrotFlow mediates — the panel, an inline
+    /// instruction, `--learn`. A change made by hand in the field is `Edit`.
     fileprivate struct Correction: Encodable {
         let v: Int
         let kind: String
@@ -412,6 +426,40 @@ enum Trace {
         let heard: String
         let corrected: String
         let via: String
+    }
+
+    /// A word changed by hand in the field after the dictation landed.
+    ///
+    /// Every one the watch sees, not only the ones the panel opens on. A
+    /// misheard ordinary word — `backgrounds` for `bigrams` — is refused by
+    /// the panel because both sides are words the lists know, and it is
+    /// exactly the label a misheard-word stage would need. Rewords are kept
+    /// too: at record time nothing can tell `hear -> say` from `drew -> few`,
+    /// since real mishearings score 0.20 to 0.43 on the sound measure and
+    /// unrelated words in the same slot score the same. Sound is a question
+    /// for whoever reads the file.
+    ///
+    /// `text` is the line **as heard**, before the change, and `range` is
+    /// where `heard` stands in it, in characters. A sentence with the fix
+    /// already in it is worse than none: the term portrait was once scored
+    /// on text after the rule had written the term in, and 4 of 4 cases
+    /// flipped when scored as heard.
+    ///
+    /// This stores the person's own sentences. That is the point of it: a
+    /// count table keeps statistics and drops the context, and the context is
+    /// what a scorer needs. `docs/corrections.md` says so.
+    fileprivate struct Edit: Encodable {
+        let v: Int
+        let kind: String
+        let at: String
+        let heard: String
+        let corrected: String
+        let text: String
+        let range: [Int]
+        let lang: String
+        let app: String?
+        /// Seconds between the dictation landing and the change.
+        let after: Double
     }
 
     fileprivate struct ASR: Encodable {

--- a/docs/corrections.md
+++ b/docs/corrections.md
@@ -6,14 +6,14 @@ colleagues' names all day. A rule you teach once is written to your
 
 When a name comes out wrong, select it in whatever app you're in, hold the
 hotkey and say **"hey parrot"**. A panel opens with a row for each word that
-looks wrong: what it heard, what it should be, and what kind of thing that is.
+looks wrong: what it heard and what it should be.
 
     VOCABULARY  TEACH A WORD
 
-    HEARD AS            SHOULD BE          TYPE
+    HEARD AS            SHOULD BE
 
-    [ Tasmin        ] → [ Tasmeen      ]   Person ⌄   ✕
-    [ Versal        ] → [ Vercel       ]   Org ⌄      ✕
+    [ Tasmin        ] → [ Tasmeen      ]   ✕
+    [ Versal        ] → [ Vercel       ]   ✕
     + Add a word
 
     2 rules to save              Cancel esc    Save ↩
@@ -31,11 +31,6 @@ a word the dictionary knows, so no row is proposed and you type it yourself.
 in two — "red crawl" for Redcrawl arrives as two ordinary words and no proposal
 can join them. Type over the left field to widen the row to the span you meant,
 and the rule taught is `red crawl => Redcrawl`, which leaves the colour alone.
-
-**The type column** is proposed from the macOS word tagger and is often wrong
-about products: it calls Vercel a place. Change it with the menu. It is written
-to the term as `kind:` and nothing reads it yet — it is recorded now so the
-stages that will need it have something to read.
 
 Saving writes one rule per row to `vocabulary.yaml` — comments and your other
 settings untouched — and puts the corrected sentence back where it came from.

--- a/docs/corrections.md
+++ b/docs/corrections.md
@@ -32,6 +32,18 @@ in two — "red crawl" for Redcrawl arrives as two ordinary words and no proposa
 can join them. Type over the left field to widen the row to the span you meant,
 and the rule taught is `red crawl => Redcrawl`, which leaves the colour alone.
 
+**Every word you change by hand is written down**, whether or not the panel
+opens on it. One line per change in `trace.jsonl` beside your recordings,
+with `kind: "edit"`: the word as heard, what you typed, the twelve words
+either side as they were before you changed them, and where the heard word
+stands in that text. A misheard ordinary word — `backgrounds` for `bigrams` —
+is never a vocabulary rule, and this is the only record of it. The file holds
+your own sentences, and that is deliberate: a count without its context is
+no use to anything that would put the right word back. The same file holds
+your dictation records, so to forget the edits alone keep the other lines:
+
+    jq -c 'select(.kind != "edit")' trace.jsonl > kept.jsonl
+
 Saving writes one rule per row to `vocabulary.yaml` — comments and your other
 settings untouched — and puts the corrected sentence back where it came from.
 A row with a blank right-hand side is skipped, so the words you did not come to

--- a/scripts/check-edit-diff.sh
+++ b/scripts/check-edit-diff.sh
@@ -11,7 +11,8 @@
 #
 # A case with `offer:` also checks `EditWatch.refusal`, which says whether the
 # panel opens on the correction. That half asks the spell checker and the
-# word-piece list, so it is this machine's answer.
+# word-piece list, so it is this machine's answer. A case with `heard:` checks
+# the window and range `EditWatch.asHeard` writes to the trace.
 set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BIN=""
@@ -23,10 +24,17 @@ done
 
 failed=0
 seen=0
-while IFS=$'\t' read -r written now want offer; do
+while IFS=$'\t' read -r written now want offer heard; do
   seen=$((seen + 1))
   out="$("$BIN" --edit-diff "$written" "$now" 2>/dev/null)"
-  got="$(grep -vE "^  (in|opens|offer): " <<<"$out" | paste -sd '|' - | sed 's/|/ | /g')"
+  got="$(grep -vE "^  (in|opens|offer|heard): " <<<"$out" | paste -sd '|' - | sed 's/|/ | /g')"
+  if [ "$heard" != "-" ]; then
+    gotHeard="$(grep -E "^  heard: " <<<"$out" | sed 's/^  heard: //' | paste -sd '|' - | sed 's/|/ | /g')"
+    if [ "$gotHeard" != "$heard" ]; then
+      printf '  ✗ %s: heard "%s", expected "%s"\n' "${written:0:34}" "$gotHeard" "$heard"
+      failed=1
+    fi
+  fi
   [ "$want" = "none" ] && want="no single change"
   if [ "$got" = "$want" ]; then
     printf '  ✓ %s\n' "$got"
@@ -45,7 +53,7 @@ while IFS=$'\t' read -r written now want offer; do
 done < <(python3 -c '
 import sys, yaml
 for c in yaml.safe_load(open(sys.argv[1]))["cases"]:
-    print("\t".join([c["written"], c["now"], str(c["expect"]), str(c.get("offer", "-"))]))
+    print("\t".join([c["written"], c["now"], str(c["expect"]), str(c.get("offer", "-")), str(c.get("heard", "-"))]))
 ' "$ROOT/tests/edit-diff-cases.yaml")
 
 if [ "$seen" -eq 0 ]; then echo "Failed: edit-diff — no case was read"; exit 1; fi

--- a/scripts/check-edit-diff.sh
+++ b/scripts/check-edit-diff.sh
@@ -3,11 +3,15 @@
 #
 #   scripts/check-edit-diff.sh
 #
-# `EditWatch.change` decides whether a field that no longer says what was
+# `EditWatch.changes` decides whether a field that no longer says what was
 # dictated holds a correction worth learning from. A rewrite read as a
 # correction teaches a vocabulary term the wrong sentence, and that sentence
 # then decides other dictations — so the strict half of this is the half that
 # matters. No accessibility, no timing, no model.
+#
+# A case with `offer:` also checks `EditWatch.refusal`, which says whether the
+# panel opens on the correction. That half asks the spell checker and the
+# word-piece list, so it is this machine's answer.
 set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BIN=""
@@ -19,10 +23,10 @@ done
 
 failed=0
 seen=0
-while IFS=$'\t' read -r written now want; do
+while IFS=$'\t' read -r written now want offer; do
   seen=$((seen + 1))
-  got="$("$BIN" --edit-diff "$written" "$now" 2>/dev/null | grep -vE "^  (in|opens): " \
-    | paste -sd '|' - | sed 's/|/ | /g')"
+  out="$("$BIN" --edit-diff "$written" "$now" 2>/dev/null)"
+  got="$(grep -vE "^  (in|opens|offer): " <<<"$out" | paste -sd '|' - | sed 's/|/ | /g')"
   [ "$want" = "none" ] && want="no single change"
   if [ "$got" = "$want" ]; then
     printf '  ✓ %s\n' "$got"
@@ -30,10 +34,18 @@ while IFS=$'\t' read -r written now want; do
     printf '  ✗ %s: got "%s", expected "%s"\n' "${written:0:34}" "$got" "$want"
     failed=1
   fi
+  [ "$offer" = "-" ] && continue
+  gotOffer="$(grep -E "^  offer: " <<<"$out" | sed 's/^  offer: //' | paste -sd '|' - | sed 's/|/ | /g')"
+  if [ "$gotOffer" = "$offer" ]; then
+    printf '    offer: %s\n' "$gotOffer"
+  else
+    printf '  ✗ %s: offer "%s", expected "%s"\n' "${written:0:34}" "$gotOffer" "$offer"
+    failed=1
+  fi
 done < <(python3 -c '
 import sys, yaml
 for c in yaml.safe_load(open(sys.argv[1]))["cases"]:
-    print("\t".join([c["written"], c["now"], str(c["expect"])]))
+    print("\t".join([c["written"], c["now"], str(c["expect"]), str(c.get("offer", "-"))]))
 ' "$ROOT/tests/edit-diff-cases.yaml")
 
 if [ "$seen" -eq 0 ]; then echo "Failed: edit-diff — no case was read"; exit 1; fi

--- a/tests/edit-diff-cases.yaml
+++ b/tests/edit-diff-cases.yaml
@@ -4,6 +4,7 @@
 # expect: none               a rewrite, two edits, or nothing worth learning
 # offer:  yes | no, <why>    whether the panel opens on it; optional, and one
 #                            per span when there are several
+# heard:  <a>..<b> in "…"    the window and range written to the trace; optional
 #
 # The strict half matters more than the generous one. A rewrite read as a
 # correction teaches a term a sentence nobody meant, and a portrait built on
@@ -92,6 +93,7 @@ cases:
   - written: "I like it.Ghost T is my terminal"
     now:     "I like it.Ghostty is my terminal"
     expect:  "Ghost T -> Ghostty"
+    heard:   '10..<17 in "I like it.Ghost T is my terminal"'
 
   # The same at the other end.
   - written: "the ghostly, terminal"
@@ -190,6 +192,14 @@ cases:
     now:     "we count bigram"
     expect:  "BRAM -> bigram"
     offer:   "no, ordinary English"
+
+  # The window is twelve words either side, clipped to the line, and the
+  # prompt is not a word. The range is the heard word in that window.
+  - written: "❯ one two three four five six seven eight nine ten eleven twelve thirteen the backgrounds are, counted here and more"
+    now:     "❯ one two three four five six seven eight nine ten eleven twelve thirteen the bigrams are, counted here and more"
+    expect:  "backgrounds -> bigrams"
+    offer:   "no, ordinary English"
+    heard:   '68..<79 in "three four five six seven eight nine ten eleven twelve thirteen the backgrounds are, counted here and more"'
 
 
 # Not here: the input box between two rules, and a line wrapped onto a second

--- a/tests/edit-diff-cases.yaml
+++ b/tests/edit-diff-cases.yaml
@@ -2,6 +2,8 @@
 #
 # expect: "<was> -> <now>"   the one span that changed
 # expect: none               a rewrite, two edits, or nothing worth learning
+# offer:  yes | no, <why>    whether the panel opens on it; optional, and one
+#                            per span when there are several
 #
 # The strict half matters more than the generous one. A rewrite read as a
 # correction teaches a term a sentence nobody meant, and a portrait built on
@@ -110,6 +112,84 @@ cases:
   - written: "we run Node.js and Gwen"
     now:     "we run Node.js and Qwen"
     expect:  "Gwen -> Qwen"
+    offer:   "yes"
+
+  # From the log, 2026-09-02. Two dictations ran together, and the first was
+  # repaired by putting a word back. The shared tail `.maybe` is the next
+  # sentence, not the correction; and what is left lands on two ordinary
+  # words, which the glued-together lookup `pronepoint` used to call a name.
+  - written: "❯ It is error prone.maybe it is fine"
+    now:     "❯ It is error prone point.maybe it is fine"
+    expect:  "prone -> prone point"
+    offer:   "no, ordinary English"
+
+  # Punctuation alone. Both from the log.
+  - written: "keep the diff small."
+    now:     "keep the diff small"
+    expect:  "small. -> small"
+    offer:   "no, punctuation, not a name"
+
+  - written: "(before offering vocabulary options."
+    now:     "(before offering vocabulary options.)"
+    expect:  "options. -> options.)"
+    offer:   "no, punctuation, not a name"
+
+  # Two corrections in one line, one onto a name and one onto a word the
+  # lists know.
+  - written: "We have e speak and we have a fluid audio model."
+    now:     "We have espeak and we have a FluidAudio model."
+    expect:  "e speak -> espeak | fluid audio -> FluidAudio"
+    offer:   "yes | yes"
+
+  - written: "the idiots are detected before submitting"
+    now:     "the edits are detected before submitting"
+    expect:  "idiots -> edits"
+    offer:   "no, ordinary English"
+
+  - written: "say point instead"
+    now:     "say dot instead"
+    expect:  "point -> dot"
+    offer:   "no, ordinary English"
+
+  - written: "we compare Ribrovent with Dorselex"
+    now:     "we compare Rybrevant with Darzalex"
+    expect:  "Ribrovent -> Rybrevant | Dorselex -> Darzalex"
+    offer:   "yes | yes"
+
+  # A word the dictionary knows, made a name by its capital mid-sentence.
+  - written: "errors go to century"
+    now:     "errors go to Sentry"
+    expect:  "century -> Sentry"
+    offer:   "yes"
+
+  # The capital that opens a sentence says nothing about the word.
+  - written: "Fais attention. Fais le maintenant"
+    now:     "Fais attention. Et le maintenant"
+    expect:  "Fais -> Et"
+    offer:   "no, ordinary English"
+
+  # One name in the span is enough.
+  - written: "I met Prezi yesterday"
+    now:     "I met Praisy Dupont yesterday"
+    expect:  "Prezi -> Praisy Dupont"
+    offer:   "yes"
+
+  # A reword, 2026-09-03: two words put in for one. Glued to `forinstance`
+  # no list knew it, and the panel offered it as a name.
+  - written: "a thing to see or two"
+    now:     "a thing to, see for instance. two"
+    expect:  "to -> to, | or -> for instance."
+    offer:   "no, punctuation, not a name | no, ordinary English"
+
+  - written: "the model can hear what Drew said"
+    now:     "the model can say what a drew said"
+    expect:  "hear -> say | Drew -> a drew"
+    offer:   "no, ordinary English | no, ordinary English"
+
+  - written: "we count BRAM"
+    now:     "we count bigram"
+    expect:  "BRAM -> bigram"
+    offer:   "no, ordinary English"
 
 
 # Not here: the input box between two rules, and a line wrapped onto a second


### PR DESCRIPTION
Every word changed by hand after a dictation is now written to `trace.jsonl` as `kind: "edit"`, panel or no panel, so a misheard ordinary word like `backgrounds -> bigrams` is kept for the misheard-word work. The vocabulary popup opened on hand edits that were not names: `prone.maybe -> prone point.maybe` and `or -> for instance.` were both offered as rules, and a declined offer came back at the next hotkey press. Three defects in `EditWatch`, all read off the log. The type column is gone from the panel, since nothing reads it.

The decision that opens the panel now lives in `EditWatch.refusal` and is scored: `scripts/check-edit-diff.sh` runs 34 cases, 14 of them taken from the log of 2026-09-02 and 03, and every one passes. The log also prints the baseline line and the current line whole when a correction is handed over, so the next bad offer can be explained from the log alone.

The record holds the twelve words either side **as heard**, the range of the heard word in that text, the language, the app, and the seconds since the dictation landed. This stores the user's own sentences on purpose, and `docs/corrections.md` says so and how to drop those lines. It is not behind a setting; `vocabulary-uses.yaml` already keeps sentences the same way, and the unfiled `logging.text` follow-up from #247 is the place to decide both together.

A reviewer should check `EditWatch.trimmed` (the new tail rule) and `EditWatch.refusal` (the per-word check). The once-only fix is stateful and has no case; the first declined panel after install is its test. The Dev app still runs the old code until it is reinstalled.

Related: #258, the `dotted` rule that ate "point" and made the hand repair necessary.

<details>
<summary>Why the three offers were wrong</summary>

**The trim stopped at the tail.** `trimmed(was:now:)` took a shared prefix off up to its last punctuation mark, but only bare punctuation off the tail. `prone.maybe` and `prone point.maybe` share `.maybe`, which is the next sentence. It now comes off from the first mark of the shared suffix, and only punctuation is ever the cut point, so `Prizzy -> Praizy` still survives whole.

**The name check glued the words.** `teaches` stripped the whole span to letters before asking the word lists: `prone point` became `pronepoint`, `for instance.` became `forinstance`, and no list knows those. It now asks word by word. One unseen word, or one capital that does not open a sentence, is enough to offer the span.

**A declined offer was told again.** `tell()` cleared `seen`, but the pending read in `stop()` found the same diff at the next press and refilled it. `told` keeps what was handed over until the next dictation starts.

</details>

<details>
<summary>The case set now scores the offer, not only the diff</summary>

`tests/edit-diff-cases.yaml` gains an optional `offer:` per case: `yes`, or `no, <why>`. `--edit-diff` prints the verdict and the script compares it. The verdict asks the real spell checker and word-piece list, so it is this machine's answer.

From the log:

| written | now | offer |
|---|---|---|
| prone.maybe | prone point.maybe | no, ordinary English |
| or | for instance. | no, ordinary English |
| small. | small | no, punctuation |
| e speak / fluid audio | espeak / FluidAudio | yes / yes |
| Ribrovent / Dorselex | Rybrevant / Darzalex | yes / yes |
| Drew | a drew | no, ordinary English |
| BRAM | bigram | no, ordinary English |

Before this change the binary returned `prone.maybe -> prone point.maybe` for the first row.

One caveat. The app logged `e speak -> espeak` as ordinary English on 2026-09-02, and the CLI on the same machine says yes. The word-piece list is present in the installed bundle, so the cause is elsewhere and is not settled here.

</details>

<details>
<summary>What the edit record keeps, and why rewords stay in</summary>

One JSON line per change, appended with the same `O_APPEND` writer the dictation trace uses. Punctuation-only and case-only changes are skipped. Nothing else is filtered: at record time nothing can tell `hear -> say` from `drew -> few`, since real mishearings score 0.20 to 0.43 on `Phonemes.similarity` and unrelated words in the same slot score the same. Rewords also serve as negatives for whoever reads the file. Sound is computed at use time.

```json
{"v":2,"kind":"edit","at":"…","heard":"backgrounds","corrected":"bigrams",
 "text":"… the backgrounds are, counted here …","range":[68,79],"lang":"en","app":"Ghostty","after":4.2}
```

`after` is seconds since the dictation landed: a fix two seconds later is likely a mishearing, five minutes later a change of mind. Recorded, not decided on. `text` is the line before the change, never after. The term portrait was once scored on text with the rule already applied, and 4 of 4 cases flipped when scored as heard. The consumer is the misheard-word work in progress; it has no store of its own and asked for exactly these fields.

</details>

<details>
<summary>What this does not change</summary>

The watch still reads the whole input box, so repairing an earlier sentence in the same box is still seen. That is by design: today's `prone` case is refused by the trim and the per-word check, not by narrowing what is watched.

`kind:` stays in the vocabulary format and in `--learn`. Only the panel stops asking for it.

</details>
