### PR TITLE
feat: a false sentence break is repaired by choosing between readings

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2314,8 +2314,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             await transcriber.warmSentenceModel()
             // The boundary readings. 320 MB and a 1.3s load, and a dictation
             // never waits for either: without this the first few dictations of
-            // a launch keep the periods a pause put in.
-            if #available(macOS 14, *) {
+            // a launch keep the periods a pause put in. Not fetched at all when
+            // the stage is off — nothing else reads them.
+            if #available(macOS 14, *), config.transcription.sentences.enabled {
                 Task.detached(priority: .background) {
                     await SentenceReadings.shared.warm()
                 }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2312,6 +2312,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // dictation: the stages that read them stand aside until they are
             // in memory.
             await transcriber.warmSentenceModel()
+            // The boundary readings. 320 MB and a 1.3s load, and a dictation
+            // never waits for either: without this the first few dictations of
+            // a launch keep the periods a pause put in.
+            if #available(macOS 14, *) {
+                Task.detached(priority: .background) {
+                    await SentenceReadings.shared.warm()
+                }
+            }
             // 81 MB, and the sound pass is on by default.
             Task.detached(priority: .background) {
                 if await !NeuralPhonemes.isReady() {

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1709,6 +1709,18 @@ struct Config: Decodable, Equatable {
                                 + " reading and every period would be removed"
                         )
                     }
+                    // A mark is one punctuation character. Any word here would
+                    // be written into the sentence as if it were punctuation,
+                    // and the word `join` is the name of the reading that
+                    // removes the period, so it would remove one.
+                    let wrong = kept.filter { $0.count != 1 || !($0.first?.isPunctuation ?? false) }
+                    guard wrong.isEmpty else {
+                        throw ConfigError.invalidValue(
+                            key: "transcription.sentences.marks",
+                            value: wrong.map { "`\($0)`" }.joined(separator: ", "),
+                            expected: "one punctuation character each — `[\".\", \",\"]`"
+                        )
+                    }
                     marks = kept
                 }
                 let old = try decoder.container(keyedBy: LegacyKeys.self)

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1655,26 +1655,34 @@ struct Config: Decodable, Equatable {
         /// When a period the transcriber wrote is taken out again — see
         /// `SentenceJoin`.
         ///
-        ///     sentences: false        never look at a boundary
+        ///     sentences: false          never look at a boundary
         ///     sentences:
-        ///       join_below: -4.0      remove the period, say nothing
-        ///       offer_below: -2.0     offer the join, do not write it
+        ///       marks: [".", ","]       the marks tried beside the join
         ///
         /// Two spellings, like `review:` on a pipeline step: a bare `false`
         /// turns the stage off, anything else says what it runs with.
         ///
-        /// The defaults are where the score was measured, over 194 real
-        /// periods and 130 synthetic cuts of this speaker's own dictation. -4
-        /// repaired 32% of the cuts and joined no real period; -2 repaired 55%
-        /// and joined 1.2 per 100. So -4 writes and -2 asks.
+        /// There is no threshold. Every boundary is read as many ways as there
+        /// are marks, plus once with no mark at all, and the reading the model
+        /// scores highest is the one that is written. `;` and `:` were measured
+        /// and never changed a decision in English, so the default is the two
+        /// that do.
         var sentences: Sentences = Sentences()
 
         struct Sentences: Decodable, Equatable {
             var enabled = true
-            var joinBelow: Double = -4
-            var offerBelow: Double = -2
+            var marks: [String] = [".", ","]
+
+            /// Keys still read and no longer acted on, for `notices()`.
+            var legacy: [String] = []
 
             enum CodingKeys: String, CodingKey {
+                case marks
+            }
+
+            /// The two thresholds the argmax replaced. Read only so that a
+            /// config still setting them can be told they do nothing.
+            private enum LegacyKeys: String, CodingKey {
                 case joinBelow = "join_below"
                 case offerBelow = "offer_below"
             }
@@ -1687,17 +1695,28 @@ struct Config: Decodable, Equatable {
                     return
                 }
                 let c = try decoder.container(keyedBy: CodingKeys.self)
-                joinBelow = try c.decodeIfPresent(Double.self, forKey: .joinBelow) ?? joinBelow
-                offerBelow = try c.decodeIfPresent(Double.self, forKey: .offerBelow) ?? offerBelow
-                // Read in this order, so the two swapped make every offer a
-                // silent join instead of refusing the file.
-                guard joinBelow < offerBelow else {
-                    throw ConfigError.invalidValue(
-                        key: "transcription.sentences.join_below",
-                        value: "\(joinBelow), against offer_below \(offerBelow)",
-                        expected: "a number below offer_below — joining is the surer tier,"
-                            + " so its threshold is the lower one"
-                    )
+                if let written = try c.decodeIfPresent([String].self, forKey: .marks) {
+                    let kept = written
+                        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                        .filter { !$0.isEmpty }
+                    // With no mark the join is the only reading, so it wins
+                    // every boundary and every period in the transcript goes.
+                    guard !kept.isEmpty else {
+                        throw ConfigError.invalidValue(
+                            key: "transcription.sentences.marks",
+                            value: "an empty list",
+                            expected: "at least one mark — with none, joining is the only"
+                                + " reading and every period would be removed"
+                        )
+                    }
+                    marks = kept
+                }
+                let old = try decoder.container(keyedBy: LegacyKeys.self)
+                for key in [LegacyKeys.joinBelow, .offerBelow]
+                where ((try? old.decodeIfPresent(Double.self, forKey: key)) ?? nil) != nil {
+                    legacy.append("`\(key.stringValue):` was a threshold on a score."
+                        + " The boundary is settled by which reading the model scores"
+                        + " highest now, so there is nothing left to set")
                 }
             }
         }
@@ -2026,7 +2045,7 @@ struct Config: Decodable, Equatable {
                 throw ConfigError.invalidValue(
                     key: "transcription.sentences",
                     value: "not a sentence setting",
-                    expected: "`false`, or `join_below:` and `offer_below:` as numbers"
+                    expected: "`false`, or `marks:` as a list of punctuation marks"
                 )
             }
             // Wrapped, as `replacements:` is below and for the same reason.
@@ -2711,6 +2730,7 @@ struct Config: Decodable, Equatable {
         // Said whether or not there are terms: a file can carry the old
         // file-level key and nothing else.
         said += vocabulary.legacy.map { "vocabulary: \($0)" }
+        said += transcription.sentences.legacy.map { "sentences: \($0)" }
         return said
     }
 

--- a/Sources/ParrotFlow/MLXModelCache.swift
+++ b/Sources/ParrotFlow/MLXModelCache.swift
@@ -1,0 +1,152 @@
+import Foundation
+import MLXLMCommon
+@preconcurrency import Tokenizers
+
+/// One MLX model in the application support directory, and the fetch that puts
+/// it there.
+///
+/// Two models are loaded this way — the word vectors and the sentence readings
+/// — and the download is the part with the traps in it: a lock so two
+/// ParrotFlow processes do not fetch the same weights at once, a staging
+/// directory so a half-written cache never loads, and a file list rather than a
+/// whole-repository mirror.
+///
+/// The file list is per model and it is not the whole repository.
+/// `model.safetensors.index.json` is absent from these repositories — the
+/// weights are one file — and listing it would fail the download on `unlisted`.
+struct MLXModelCache: Sendable {
+
+    /// The Hugging Face repository, `owner/name`.
+    let repository: String
+    /// Every file that has to be on disk before the model loads.
+    let files: [String]
+    /// Where they end up.
+    let directory: URL
+    /// Beside the cache directory, not inside it, so a fetch that clears the
+    /// cache does not delete a lock somebody is holding.
+    let lockURL: URL
+    /// What a progress line calls this model — "word vectors 43%".
+    let label: String
+
+    enum Failure: LocalizedError {
+        case busy(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .busy(let label):
+                return "another ParrotFlow process is fetching the \(label) model"
+            }
+        }
+    }
+
+    var isCached: Bool {
+        files.allSatisfy {
+            FileManager.default.fileExists(atPath: directory.appendingPathComponent($0).path)
+        }
+    }
+
+    /// Downloads the files unless they are all already there.
+    ///
+    /// `progress` gets a label shaped like "word vectors 43%", already
+    /// de-duplicated.
+    func ensure(progress: (@Sendable (String) -> Void)? = nil) async throws {
+        guard !isCached else { return }
+        try await underLock { try await fetch(progress: progress) }
+    }
+
+    private func underLock(_ body: () async throws -> Void) async throws {
+        try FileManager.default.createDirectory(
+            at: lockURL.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        let handle = open(lockURL.path, O_CREAT | O_RDWR, 0o644)
+        guard handle >= 0 else { throw Failure.busy(label) }
+        defer { close(handle) }
+        guard flock(handle, LOCK_EX | LOCK_NB) == 0 else { throw Failure.busy(label) }
+        try await body()
+    }
+
+    /// Fetches into a staging directory and moves the result into place, so a
+    /// half-written cache never loads. Staging sits inside `directory` to keep
+    /// the move a rename on one volume.
+    private func fetch(progress: (@Sendable (String) -> Void)?) async throws {
+        let manager = FileManager.default
+        try manager.createDirectory(at: directory, withIntermediateDirectories: true)
+        let left = try? manager.contentsOfDirectory(atPath: directory.path)
+        for name in left ?? [] where name.hasPrefix(".staging-") {
+            try? manager.removeItem(at: directory.appendingPathComponent(name))
+        }
+        let staging = directory
+            .appendingPathComponent(".staging-\(UUID().uuidString)", isDirectory: true)
+        try manager.createDirectory(at: staging, withIntermediateDirectories: true)
+        defer { try? manager.removeItem(at: staging) }
+
+        let reported = Reported()
+        let label = label
+        try await HubDownload.fetch(repo: repository, paths: files, into: staging) { fraction in
+            guard let progress else { return }
+            let percent = Int((fraction * 100).rounded())
+            guard reported.advanced(to: percent) else { return }
+            progress("\(label) \(percent)%")
+        }
+        for name in files {
+            let target = directory.appendingPathComponent(name)
+            try? manager.removeItem(at: target)
+            try manager.moveItem(at: staging.appendingPathComponent(name), to: target)
+        }
+    }
+
+    /// The percentage last reported. A class because the progress closure is
+    /// `@Sendable` and escapes.
+    private final class Reported: @unchecked Sendable {
+        private var last = -1
+        private let lock = NSLock()
+
+        func advanced(to percent: Int) -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            guard percent > last else { return false }
+            last = percent
+            return true
+        }
+    }
+}
+
+/// `AutoTokenizer` over a folder, as the one protocol `loadModel` needs.
+///
+/// `MLXHuggingFace` provides this behind a macro, and swift-syntax with it.
+/// This is the whole of what that macro expands to for the loading path.
+@available(macOS 14, *)
+struct FolderTokenizer: TokenizerLoader {
+    func load(from directory: URL) async throws -> any MLXLMCommon.Tokenizer {
+        Adapter(try await AutoTokenizer.from(modelFolder: directory))
+    }
+
+    private struct Adapter: MLXLMCommon.Tokenizer, @unchecked Sendable {
+        let upstream: any Tokenizers.Tokenizer
+
+        init(_ upstream: any Tokenizers.Tokenizer) { self.upstream = upstream }
+
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+            upstream.encode(text: text, addSpecialTokens: addSpecialTokens)
+        }
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+            upstream.decode(tokens: tokenIds, skipSpecialTokens: skipSpecialTokens)
+        }
+        func convertTokenToId(_ token: String) -> Int? { upstream.convertTokenToId(token) }
+        func convertIdToToken(_ id: Int) -> String? { upstream.convertIdToToken(id) }
+
+        var bosToken: String? { upstream.bosToken }
+        var eosToken: String? { upstream.eosToken }
+        var unknownToken: String? { upstream.unknownToken }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] {
+            // Nothing here holds a conversation. One stage sends a sentence and
+            // reads the states back; the other scores a sequence it built.
+            []
+        }
+    }
+}

--- a/Sources/ParrotFlow/MLXModelCache.swift
+++ b/Sources/ParrotFlow/MLXModelCache.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MLX
 import MLXLMCommon
 @preconcurrency import Tokenizers
 
@@ -37,6 +38,16 @@ struct MLXModelCache: Sendable {
                 return "another ParrotFlow process is fetching the \(label) model"
             }
         }
+    }
+
+    /// Caps the MLX buffer pool, which is process-wide.
+    ///
+    /// It grows with the variety of shapes it has seen: 1.0 GB after one pass
+    /// over the boundary bench and 2.0 GB after four. Measured with both models
+    /// resident, 256 MB gives the same 36 ms median as 2 GB and holds 620 MB
+    /// less. Called on every model load; setting it twice costs nothing.
+    static func limitBufferPool() {
+        MLX.GPU.set(cacheLimit: 256 * 1024 * 1024)
     }
 
     var isCached: Bool {

--- a/Sources/ParrotFlow/SentenceJoin.swift
+++ b/Sources/ParrotFlow/SentenceJoin.swift
@@ -9,35 +9,29 @@ import NaturalLanguage
 ///     said     "you should see a parrot at the top right of your screen"
 ///     written  "You should see a parrot. At the top right of your screen."
 ///
-/// Every `word. Capital` boundary in the finished transcript is scored by
-/// `SentenceProbe` — one masked position, `log P(".") - log P(" <next word>")`
-/// — and two thresholds decide:
+/// Every `word. Capital` boundary in the finished transcript is read three
+/// ways by `SentenceReadings` — with a period, with a comma, and with nothing
+/// at all — and the reading the language model scores highest is the one that
+/// is written. Nothing is compared to a threshold, so there is nothing to
+/// calibrate. Where the joined reading wins, the period is removed and the
+/// word after it is lowercased.
 ///
-///     score < join_below                    join, and say nothing
-///     join_below <= score < offer_below     offer the join, do not write it
-///     score >= offer_below                  leave it alone
+/// The thresholds this used to carry repaired 26% of the cuts. The choice
+/// repairs 82%, and joins none of 172 real sentence endings.
 ///
-/// Joining removes the period and lowercases the word after it.
+/// English only. The reading is scored by an English base model, and the mark
+/// set is English: French wants `:` where English does not.
 ///
-/// English only. The model is English-only, and the same probe measured on
-/// `cservan/french-modernbert-large` and `-base` scores near chance — 0.67 and
-/// 0.58 AUC against 0.96 for English. There is no French model to switch to.
-///
-/// Fails open everywhere. No cached model, a probe that throws, a boundary it
-/// cannot read: the text arrives as it was. A sentence in two halves is a
-/// worse transcript; a rewrite nobody asked for costs the words themselves.
+/// Fails open everywhere. A model still downloading, a load that threw, a
+/// boundary it cannot read: the text arrives as it was. A sentence in two
+/// halves is a worse transcript; a rewrite nobody asked for costs the words
+/// themselves.
 @available(macOS 14, *)
 actor SentenceJoin {
 
     static let shared = SentenceJoin()
 
     /// What one pass did, for the pipeline to read.
-    ///
-    /// `offer` is the tier that does not write. It is a log line and a count
-    /// today: the vocabulary pass's `proposals` road is keyed by term and ends
-    /// at a judge that argues about names, and the pill's offer is a row of
-    /// transform chips. Neither carries a boundary, so this publishes the
-    /// count and waits for a consumer rather than forcing one.
     struct Outcome: Sendable {
         let text: String
         let readings: [Reading]
@@ -49,11 +43,24 @@ actor SentenceJoin {
         }
     }
 
-    /// One boundary, scored. `change` reads `parrot. At -> parrot at`.
+    /// One boundary, read every way. `change` reads `parrot. At -> parrot at`.
     struct Reading: Sendable {
         let change: String
-        let score: Double
-        let tier: Tier
+        let scores: [SentenceReadings.Score]
+        let winner: String
+
+        var tier: Tier { winner == SentenceReadings.join ? .join : .leave }
+    }
+
+    /// The reading with the highest per-token score, or nil if there is none.
+    ///
+    /// First past the post over the order `SentenceReadings.readings` builds —
+    /// the marks, then the join — so an exact tie leaves the boundary alone.
+    static func winner(of scores: [SentenceReadings.Score]) -> SentenceReadings.Score? {
+        scores.reduce(nil) { best, score in
+            guard let best else { return score }
+            return score.mean > best.mean ? score : best
+        }
     }
 
     /// One `word. Capital` boundary: the period, and the word after it.
@@ -160,43 +167,26 @@ actor SentenceJoin {
 
     // MARK: - The pass
 
-    /// The masked language model, once per process, and only if it is already
-    /// on disk. `Transcriber.warmSentenceModel` fetches it in the background
-    /// after the first English dictation; nothing here waits for that.
-    private var loaded: SentenceProbe?
-
-    /// When a failed load may be tried again. A held `flock` on the model cache
-    /// is the failure this exists for: another process is fetching, and the
-    /// next dictation would otherwise never look again. Not a latch — but not
-    /// every dictation either, because a damaged cache makes `load` re-fetch
-    /// 300 MB.
-    private var retryAfter: Date?
-    private static let backoff: TimeInterval = 300
-
-    private func probe() async -> SentenceProbe? {
-        if let loaded { return loaded }
-        if let retryAfter, Date() < retryAfter { return nil }
-        guard SentenceModel.isCached else { return nil }
-        do {
-            loaded = try await SentenceProbe.load()
-            retryAfter = nil
-        } catch {
-            retryAfter = Date().addingTimeInterval(Self.backoff)
-            Log.write("sentences: no probe (\(error.localizedDescription)); left as decoded")
-        }
-        return loaded
-    }
-
     /// The transcript with the false periods taken out.
     ///
     /// Every boundary is scored against the text as it arrived, not against
     /// the text as it is being rebuilt. A join only removes a period, so the
     /// window a later boundary reads is the same words either way.
+    ///
+    /// Nothing here waits for the model. A dictation that arrives before the
+    /// weights are in memory keeps its boundaries and starts the load, so the
+    /// first dictation after a launch pays nothing and the second is repaired.
     func apply(to text: String, config: Config) async -> Outcome {
         let settings = config.transcription.sentences
         guard settings.enabled else { return .unchanged(text) }
         let found = Self.boundaries(in: text)
-        guard !found.isEmpty, let probe = await probe() else { return .unchanged(text) }
+        guard !found.isEmpty else { return .unchanged(text) }
+        guard await SentenceReadings.shared.isLoaded else {
+            await SentenceReadings.shared.warm()
+            Log.write("sentences: \(found.count) boundary(s) left as decoded;"
+                + " the model is not in memory yet")
+            return .unchanged(text)
+        }
         let terms = Array(config.vocabulary.terms.keys)
 
         var readings: [Reading] = []
@@ -204,12 +194,14 @@ actor SentenceJoin {
         var cursor = text.startIndex
         for boundary in found {
             let word = String(text[boundary.next])
-            let score: Double
+            let started = DispatchTime.now().uptimeNanoseconds
+            let scores: [SentenceReadings.Score]
             do {
-                score = try probe.read(
+                scores = try await SentenceReadings.shared.read(
                     left: String(text[..<boundary.period]),
-                    right: String(text[boundary.next.lowerBound...])
-                ).score
+                    right: String(text[boundary.next.lowerBound...]),
+                    marks: settings.marks
+                )
             } catch {
                 Log.write(
                     "sentences: \(word.debugDescription) could not be read"
@@ -217,17 +209,24 @@ actor SentenceJoin {
                 )
                 continue
             }
+            let milliseconds = Double(DispatchTime.now().uptimeNanoseconds - started) / 1e6
+            guard let best = Self.winner(of: scores) else { continue }
             let (whole, offset) = Self.joining(text, at: boundary)
             let now = Self.written(word, in: whole, at: offset, terms: terms)
             let before = String(
                 text[..<boundary.period].reversed().prefix { !$0.isWhitespace }.reversed()
             )
-            let tier = Tier(of: score, by: settings)
             let change = "\(before). \(word) -> \(before) \(now)"
-            Log.write(String(format: "sentences: %@ %.2f %@", change, score, tier.rawValue))
-            readings.append(Reading(change: change, score: score, tier: tier))
+            let listed = scores
+                .map { String(format: "%@ %.2f", $0.key, $0.mean) }
+                .joined(separator: "  ")
+            Log.write(String(
+                format: "sentences: %@ %@ [%@] %.0fms",
+                change, best.key, listed, milliseconds
+            ))
+            readings.append(Reading(change: change, scores: scores, winner: best.key))
 
-            if tier == .join {
+            if best.key == SentenceReadings.join {
                 rebuilt += text[cursor..<boundary.period]
                 rebuilt += text[text.index(after: boundary.period)..<boundary.next.lowerBound]
                 rebuilt += now
@@ -237,18 +236,9 @@ actor SentenceJoin {
         return Outcome(text: rebuilt + text[cursor...], readings: readings)
     }
 
-    /// Which of the three a score falls in.
+    /// What a boundary came to. There is no middle tier: an argmax has no
+    /// threshold to hedge with, so a boundary is either joined or left.
     enum Tier: String {
-        case join, offer, leave
-
-        init(of score: Double, by settings: Config.Transcription.Sentences) {
-            if score < settings.joinBelow {
-                self = .join
-            } else if score < settings.offerBelow {
-                self = .offer
-            } else {
-                self = .leave
-            }
-        }
+        case join, leave
     }
 }

--- a/Sources/ParrotFlow/SentenceJoin.swift
+++ b/Sources/ParrotFlow/SentenceJoin.swift
@@ -17,7 +17,7 @@ import NaturalLanguage
 /// word after it is lowercased.
 ///
 /// The thresholds this used to carry repaired 26% of the cuts. The choice
-/// repairs 82%, and joins none of 172 real sentence endings.
+/// repairs 81%, and joins none of 172 real sentence endings.
 ///
 /// English only. The reading is scored by an English base model, and the mark
 /// set is English: French wants `:` where English does not.

--- a/Sources/ParrotFlow/SentenceJoinCommand.swift
+++ b/Sources/ParrotFlow/SentenceJoinCommand.swift
@@ -5,14 +5,16 @@ import Foundation
 ///     ParrotFlow --sentence-join "You should see a parrot. At the top right."
 ///       language   en
 ///       boundary   parrot. At -> parrot at
-///       score      -5.07
-///       tier       join
+///       reading    .         -7.2669  5
+///       reading    ,         -6.5327  5
+///       reading    join      -4.5571  4
+///       winner     join
 ///       text       You should see a parrot at the top right.
 ///
-/// One `boundary`/`score`/`tier` block per boundary, in order, then the text
-/// the stage hands on. `scripts/check-sentence-join.sh` scores the two tiers
-/// with this. Nothing is downloaded: with no cached model the text comes back
-/// untouched and the run says so, which is what the app does.
+/// One block per boundary, in order, then the text the stage hands on.
+/// `scripts/check-sentence-join.sh` scores the decisions with this. Nothing is
+/// downloaded: with no cached model the text comes back untouched and the run
+/// says so.
 ///
 /// `--case` asks the lowercasing question alone and loads no model, so it runs
 /// on a machine that has never dictated. `scripts/check-sentence-case.sh` is
@@ -42,8 +44,8 @@ enum SentenceJoinCommand {
             print("  text       \(text)")
             return 0
         }
-        guard SentenceModel.isCached else {
-            print("  probe      not cached")
+        guard SentenceReadings.isCached else {
+            print("  model      not cached")
             print("  text       \(text)")
             return 0
         }
@@ -51,6 +53,9 @@ enum SentenceJoinCommand {
         var outcome = SentenceJoin.Outcome.unchanged(text)
         let done = DispatchSemaphore(value: 0)
         Task {
+            // The app never waits for this load; a run from the shell has to,
+            // or every case comes back untouched.
+            try? await SentenceReadings.shared.prepare()
             outcome = await SentenceJoin.shared.apply(to: text, config: config)
             done.signal()
         }
@@ -58,8 +63,12 @@ enum SentenceJoinCommand {
 
         for reading in outcome.readings {
             print("  boundary   \(reading.change)")
-            print(String(format: "  score      %.4f", reading.score))
-            print("  tier       \(reading.tier.rawValue)")
+            for score in reading.scores {
+                let key = score.key.padding(toLength: 8, withPad: " ", startingAt: 0)
+                print(String(format: "  reading    %@ %8.4f  %d",
+                             key, score.mean, score.tokens))
+            }
+            print("  winner     \(reading.winner)")
         }
         print("  text       \(outcome.text)")
         return 0

--- a/Sources/ParrotFlow/SentenceModelCommand.swift
+++ b/Sources/ParrotFlow/SentenceModelCommand.swift
@@ -1,15 +1,22 @@
 import CoreML
 import Foundation
 
-/// `--sentence-model` — fetches, compiles and loads ModernBERT, then says what
-/// it got and how long it took.
+/// `--sentence-model` — fetches both models the sentence stages read, then
+/// says what it got and how long it took.
 ///
 ///     ParrotFlow --sentence-model
-///       sentence model 43%…
-///     ✓ sentence model ready in 41.2s
+///       sentence readings 43%…
+///     ✓ sentence readings ready in 22.4s (downloaded)
+///       cache   ~/Library/Application Support/ParrotFlow/models/qwen3-0.6b-base-4bit
+///     ✓ sentence model ready in 41.2s (downloaded and compiled)
 ///       cache   ~/Library/Application Support/ParrotFlow/models/modernbert-base-64
 ///       inputs  input_ids [1, 64]
 ///       outputs logits [1, 64, 50368]
+///
+/// Two models, because two stages read them. Qwen scores the readings that
+/// decide a boundary; ModernBERT is what the vocabulary slot gate fills a
+/// masked slot with, and it is still fetched here so one command leaves a
+/// machine ready.
 ///
 /// The same call the first English dictation makes, without a microphone. Run
 /// it twice: the second run skips the download and the 7s compile, which is
@@ -22,6 +29,24 @@ enum SentenceModelCommand {
         let done = DispatchSemaphore(value: 0)
 
         Task {
+            let readingsStarted = Date()
+            let readingsCached = SentenceReadings.isCached
+            do {
+                try await SentenceReadings.shared.prepare { label in
+                    print("\r  \(label)…", terminator: "")
+                    fflush(stdout)
+                }
+                print(String(
+                    format: "\r\u{1B}[K✓ sentence readings ready in %.1fs (%@)",
+                    Date().timeIntervalSince(readingsStarted),
+                    readingsCached ? "cached" : "downloaded"
+                ))
+                print("  cache   \(tilde(SentenceReadings.directory.path))")
+            } catch {
+                print("\r\u{1B}[K✗ \(error.localizedDescription)")
+                exitCode = 1
+            }
+
             let started = Date()
             let cached = SentenceModel.isCached
             do {

--- a/Sources/ParrotFlow/SentenceProbe.swift
+++ b/Sources/ParrotFlow/SentenceProbe.swift
@@ -1,33 +1,26 @@
 import CoreML
 import Foundation
 
-/// Is this period real, or did a pause cut one sentence in two?
+/// What does ModernBERT put in a masked slot?
 ///
-/// Put a `[MASK]` where the period is, lowercase the word after it, and ask
-/// ModernBERT what belongs in the slot:
+/// Put a `[MASK]` where a word is, and read the distribution over the whole
+/// vocabulary at that one position. `SlotGate` and `SlotReference` read it to
+/// decide whether the word a vocabulary term would replace belongs where it
+/// stands.
 ///
-///     score = log P(".") - log P(" <next word>")
-///
-/// One forward pass reads both. Below the threshold, the period is false and
-/// the two halves are one sentence. Measured over 194 real periods and 130
-/// synthetic cuts of this user's own dictation:
-///
-///     -4    32% of cuts repaired    0.0 false joins per 100 real periods
-///     -2    55%                     1.2
-///      0    82%                     6.1
-///
-/// `SentenceJoin` is the consumer: -4 writes, -2 offers.
+/// It used to answer the sentence-boundary question too — a mask where the
+/// period is, `log P(".") - log P(" <next word>")`, against a threshold. That
+/// repaired 26% of the cuts. `SentenceJoin` chooses between whole readings of
+/// the sentence now; see `SentenceReadings`.
 @available(macOS 14, *)
 struct SentenceProbe {
 
     enum Failure: LocalizedError {
         case shape(String)
-        case empty
 
         var errorDescription: String? {
             switch self {
             case .shape(let what): return "sentence probe: \(what)"
-            case .empty: return "sentence probe: no word after the boundary"
             }
         }
     }
@@ -52,58 +45,13 @@ struct SentenceProbe {
 
     let tokenizer: BPETokenizer
     private let model: MLModel
-    private let period: Int
 
     static func load(progress: (@Sendable (String) -> Void)? = nil) async throws -> SentenceProbe {
         let model = try await SentenceModel.shared.prepare(progress: progress)
         // The tokenizer runs `assertBoundaryIDs` as it parses, so one that
         // would score the wrong ids throws here rather than answering.
         let tokenizer = try await SentenceModel.shared.tokenizer(at: tokenizerURL)
-        guard let period = tokenizer.firstID(of: ".") else {
-            throw Failure.shape("\".\" does not encode")
-        }
-        return SentenceProbe(tokenizer: tokenizer, model: model, period: period)
-    }
-
-    // MARK: - One boundary
-
-    struct Reading {
-        /// `log P(".") - log P(" <next word>")`. Below the threshold, the
-        /// period is false.
-        let score: Double
-        let periodLogProbability: Double
-        let nextLogProbability: Double
-        /// The next word with its leading space, as the model reads it.
-        let next: String
-        let top: [Prediction]
-        /// The masked text the model was given, for a caller checking its work.
-        let text: String
-    }
-
-    func read(left: String, right: String) throws -> Reading {
-        // The period under test is dropped before the words are counted, so a
-        // caller that kept it and one that did not get the same window.
-        let kept = String(left.reversed().drop { $0 == "." }.reversed())
-        let before = kept.split(whereSeparator: \.isWhitespace).suffix(Self.radius).map(String.init)
-        let tail = right.split(whereSeparator: \.isWhitespace).map(String.init)
-        guard var next = tail.first else { throw Failure.empty }
-        next = next.prefix(1).lowercased() + next.dropFirst()
-        let after = ([next] + tail.dropFirst()).prefix(Self.radius).joined(separator: " ")
-
-        guard let nextID = tokenizer.firstID(of: " " + next) else {
-            throw Failure.shape("\((" " + next).debugDescription) does not encode")
-        }
-        let slot = try at(left: before.joined(separator: " "), right: " " + after)
-        let periodLogProbability = slot.logProbability(of: period)
-        let nextLogProbability = slot.logProbability(of: nextID)
-        return Reading(
-            score: periodLogProbability - nextLogProbability,
-            periodLogProbability: periodLogProbability,
-            nextLogProbability: nextLogProbability,
-            next: " " + next,
-            top: slot.top(5),
-            text: before.joined(separator: " ") + " [MASK] " + after
-        )
+        return SentenceProbe(tokenizer: tokenizer, model: model)
     }
 
     // MARK: - One forward pass

--- a/Sources/ParrotFlow/SentenceProbeCommand.swift
+++ b/Sources/ParrotFlow/SentenceProbeCommand.swift
@@ -1,50 +1,64 @@
 import Foundation
+import MLX
 
 /// `--sentence-probe` — is this period real, or did a pause cut one sentence
 /// in two?
 ///
 /// The two halves of the boundary, left then right. The period on the left is
 /// optional; the capital on the right is expected, because that is what the
-/// transcriber writes.
+/// transcriber writes. Every reading of the boundary is scored, per token of
+/// the continuation, and the highest wins.
 ///
-///     ParrotFlow --sentence-probe "we have to do it." "That works well"
-///       boundary  "." 15   " ." 964   "That" 2773   " That" 2064  ✓
-///       text      we have to do it [MASK] that works well
-///       score      -2.63          ← below -4 means the period is false
-///       period     -5.71   "."
-///       next       -3.08   " that"
-///       top        " that" -3.08   " which" -4.10   " it" -4.87
+///     ParrotFlow --sentence-probe "…the LLM with." "The vocabulary is slower"
+///       prefix    the first usage of the LLM with
+///       reading   .         -7.2669  5
+///       reading   ,         -6.5327  5
+///       reading   join      -4.5571  4
+///       winner    join
 ///
-/// `--encode "<text>"` prints the ids alone and loads no model, which is what
-/// `scripts/check-tokenizer.sh` compares against the reference tokenizer.
+/// `--encode "<text>"` prints ModernBERT's ids and loads no model, which is
+/// what `scripts/check-tokenizer.sh` compares against the reference tokenizer.
+/// That tokenizer is the vocabulary slot gate's, not this stage's.
+///
+/// `--bench <cases.json> --out <scores.json>` scores a whole file in one loaded
+/// process — `[{"left": …, "right": …}]` in, one row of scores out, with the
+/// milliseconds each decision took. One process per boundary would pay the 1.3s
+/// load every time, so this is the only way to get a latency number. `--vectors`
+/// loads the word vectors as well, so the memory line describes the process the
+/// app actually runs, with both MLX models in it.
 @available(macOS 14, *)
 enum SentenceProbeCommand {
 
     static func run(left: String, right: String) -> Int32 {
         var exitCode: Int32 = 0
         let done = DispatchSemaphore(value: 0)
+        let marks = ((try? ConfigStore.load()) ?? Config()).transcription.sentences.marks
 
         Task {
             do {
-                let probe = try await SentenceProbe.load { label in
+                try await SentenceReadings.shared.prepare { label in
                     print("\r  \(label)…", terminator: "")
                     fflush(stdout)
                 }
                 print("\r\u{1B}[K", terminator: "")
-                let listed = probe.tokenizer.boundaryIDs
-                    .map { "\($0.token.debugDescription) \($0.id)" }
-                    .joined(separator: "   ")
-                print("  boundary  \(listed)  ✓")
-
-                let reading = try probe.read(left: left, right: right)
-                print("  text      \(reading.text)")
-                print(row("score", reading.score, ""))
-                print(row("period", reading.periodLogProbability, "\".\""))
-                print(row("next", reading.nextLogProbability, reading.next.debugDescription))
-                let top = reading.top
-                    .map { "\($0.word.debugDescription) \(format($0.logProbability))" }
-                    .joined(separator: "   ")
-                print("  top       \(top)")
+                guard let built = SentenceReadings.build(
+                    left: left, right: right, marks: marks
+                ) else { throw SentenceReadings.Failure.empty }
+                print("  prefix    \(built.prefix)")
+                let scores = try await SentenceReadings.shared.read(
+                    left: left, right: right, marks: marks
+                )
+                for score in scores {
+                    // `%@` ignores a width on this platform, so the column
+                    // is padded here.
+                    let key = score.key.padding(toLength: 8, withPad: " ", startingAt: 0)
+                    print(String(
+                        format: "  reading   %@ %8.4f  %d%@",
+                        key, score.mean, score.tokens,
+                        score.retokenised ? "  retokenised" : ""
+                    ))
+                }
+                print("  winner    \(SentenceJoin.winner(of: scores)?.key ?? "none")")
             } catch {
                 print("\r\u{1B}[K✗ \(error.localizedDescription)")
                 exitCode = 1
@@ -56,8 +70,77 @@ enum SentenceProbeCommand {
         return exitCode
     }
 
-    /// The tokenizer on its own. No model, so this answers on a machine that
-    /// has never run a dictation.
+    /// Every boundary in a file, scored in one loaded process.
+    static func bench(cases path: String, out: String?, vectors: Bool) -> Int32 {
+        struct Row: Decodable { let left: String; let right: String }
+        var exitCode: Int32 = 0
+        let done = DispatchSemaphore(value: 0)
+        let marks = ((try? ConfigStore.load()) ?? Config()).transcription.sentences.marks
+
+        Task {
+            do {
+                let rows = try JSONDecoder().decode(
+                    [Row].self, from: Data(contentsOf: URL(fileURLWithPath: path))
+                )
+                if vectors { try await WordVectors.shared.prepare() }
+                try await SentenceReadings.shared.prepare()
+                var results: [[String: Any]] = []
+                var times: [Double] = []
+                for (i, row) in rows.enumerated() {
+                    let start = DispatchTime.now().uptimeNanoseconds
+                    guard let scores = try? await SentenceReadings.shared.read(
+                        left: row.left, right: row.right, marks: marks
+                    ) else { continue }
+                    let winner = SentenceJoin.winner(of: scores)?.key ?? "none"
+                    let elapsed = Double(
+                        DispatchTime.now().uptimeNanoseconds - start
+                    ) / 1e6
+                    // The first decision pays the Metal kernel compile.
+                    if i > 0 { times.append(elapsed) }
+                    var means: [String: Double] = [:]
+                    var tokens: [String: Int] = [:]
+                    for score in scores {
+                        means[score.key] = score.mean
+                        tokens[score.key] = score.tokens
+                    }
+                    results.append([
+                        "i": i, "mean": means, "n": tokens, "winner": winner,
+                        "ms": elapsed,
+                        "retokenised": scores.contains(where: \.retokenised),
+                    ])
+                }
+                let data = try JSONSerialization.data(
+                    withJSONObject: results, options: [.prettyPrinted, .sortedKeys]
+                )
+                if let out {
+                    try data.write(to: URL(fileURLWithPath: out))
+                } else {
+                    FileHandle.standardOutput.write(data)
+                }
+                times.sort()
+                if !times.isEmpty {
+                    print(String(
+                        format: "  %d boundaries   median %.1f ms   p95 %.1f ms",
+                        results.count, times[times.count / 2],
+                        times[min(times.count - 1, Int(Double(times.count) * 0.95))]
+                    ))
+                }
+                print("  MLX active \(MLX.GPU.activeMemory / 1_048_576) MB"
+                    + "   cache \(MLX.GPU.cacheMemory / 1_048_576) MB"
+                    + "   peak \(MLX.GPU.peakMemory / 1_048_576) MB")
+            } catch {
+                print("✗ \(error.localizedDescription)")
+                exitCode = 1
+            }
+            done.signal()
+        }
+
+        done.wait()
+        return exitCode
+    }
+
+    /// The tokenizer of the masked model the vocabulary slot gate reads. No
+    /// model, so this answers on a machine that has never run a dictation.
     static func encode(_ text: String) -> Int32 {
         do {
             let tokenizer = try BPETokenizer.load(contentsOf: SentenceProbe.tokenizerURL)
@@ -69,15 +152,5 @@ enum SentenceProbeCommand {
             print("✗ \(error.localizedDescription)")
             return 1
         }
-    }
-
-    private static func row(_ name: String, _ value: Double, _ note: String) -> String {
-        let padded = name + String(repeating: " ", count: max(0, 9 - name.count))
-        return "  \(padded) \(format(value))   \(note)"
-    }
-
-    /// `%@` ignores a width on this platform, so the column is padded here.
-    private static func format(_ value: Double) -> String {
-        String(format: "%7.2f", value)
     }
 }

--- a/Sources/ParrotFlow/SentenceReadings.swift
+++ b/Sources/ParrotFlow/SentenceReadings.swift
@@ -1,0 +1,287 @@
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+
+/// Reads one `word. Capital` boundary three ways and says which reading the
+/// language model prefers.
+///
+/// For `…the LLM with. The vocabulary is slower` the three readings are
+///
+///     ". The vocabulary is slower"     the period is real
+///     " the vocabulary is slower"      the pause cut one sentence in two
+///     ", the vocabulary is slower"     it is really a comma
+///
+/// Each is scored as `sum of log P(token | everything before it)` over the
+/// continuation, **divided by the token count**, and the highest wins. There is
+/// no threshold and nothing to calibrate. On summed log-probability instead of
+/// per-token the joined reading wins by being shortest — 97% of cuts repaired
+/// and 33 real endings destroyed.
+///
+/// The comma is a reading, not a term in a subtraction. 26% of real sentence
+/// endings pick it, and that is why none of them picks `join`. Scoring
+/// `max(mark) - log P(next)` instead gives 64% against this shape's 82%.
+///
+/// `mlx-community/Qwen3-0.6B-Base-4bit`, not the DWQ checkpoint: despite the
+/// name that one is a quant of the *instruct* model and repairs 76%.
+///
+/// The three readings go into one padded batch, which reads the weights once:
+/// 50 ms against 70 ms for three separate passes. A shared KV cache for the
+/// prefix is slower still — one forward costs 23 ms whatever the length at
+/// 0.6B, so caching the prefix adds a fourth pass and saves nothing.
+@available(macOS 14, *)
+actor SentenceReadings {
+
+    static let shared = SentenceReadings()
+
+    /// `model.safetensors.index.json` is absent from this repository — the
+    /// weights are one file — and listing it would fail the fetch.
+    static let cache = MLXModelCache(
+        repository: "mlx-community/Qwen3-0.6B-Base-4bit",
+        files: [
+            "config.json",
+            "model.safetensors",
+            "tokenizer.json",
+            "tokenizer_config.json",
+            "special_tokens_map.json",
+            "added_tokens.json",
+            "vocab.json",
+            "merges.txt",
+        ],
+        directory: AppVariant.supportDirectory
+            .appendingPathComponent("models/qwen3-0.6b-base-4bit", isDirectory: true),
+        lockURL: AppVariant.supportDirectory
+            .appendingPathComponent("models/qwen3-0.6b-base.lock"),
+        label: "sentence readings"
+    )
+
+    static var directory: URL { cache.directory }
+    static var isCached: Bool { cache.isCached }
+
+    /// The key of the reading that removes the period.
+    static let join = "join"
+
+    /// Marks after which the next word keeps its capital.
+    static let enders: Set<String> = [".", "?", "!"]
+
+    /// Words kept either side of the boundary, the next word counting as the
+    /// first on the right. The measurement was made at 12.
+    static let radius = 12
+
+    /// The MLX buffer pool grows with the variety of shapes it has seen: 1.0 GB
+    /// after one pass over the bench and 2.0 GB after four. Three models share
+    /// this process, and the limit is process-wide, so it is set once here.
+    static let cacheLimit = 256 * 1024 * 1024
+
+    enum Failure: LocalizedError {
+        case notQwen(String)
+        case empty
+
+        var errorDescription: String? {
+            switch self {
+            case .notQwen(let kind):
+                return "the sentence model loaded as \(kind), not Qwen3"
+            case .empty:
+                return "sentence readings: nothing either side of the boundary"
+            }
+        }
+    }
+
+    // MARK: - the three readings
+
+    /// One reading of the boundary: the mark written there, and whether the
+    /// word after it keeps its capital.
+    struct Reading: Sendable {
+        let key: String
+        let mark: String
+        let capital: Bool
+    }
+
+    /// One reading, scored.
+    struct Score: Sendable {
+        let key: String
+        /// Log-probability per token of the continuation.
+        let mean: Double
+        let tokens: Int
+        /// True when the boundary character merged into the last prefix token,
+        /// so the score starts at the first token that actually differs.
+        let retokenised: Bool
+    }
+
+    /// The readings, in the order the winner is picked from: the marks as
+    /// configured, then the join. First past the post, so an exact tie leaves
+    /// the boundary alone.
+    static func readings(marks: [String]) -> [Reading] {
+        marks.map { Reading(key: $0, mark: $0, capital: enders.contains($0)) }
+            + [Reading(key: join, mark: "", capital: false)]
+    }
+
+    /// The shared prefix and one continuation per reading.
+    ///
+    /// The left side loses its trailing period, so a caller that kept it and
+    /// one that did not build the same window.
+    static func build(
+        left: String, right: String, marks: [String]
+    ) -> (prefix: String, continuations: [String])? {
+        let leftWords = left
+            .replacingOccurrences(of: "\\.+$", with: "", options: .regularExpression)
+            .split(whereSeparator: \.isWhitespace).map(String.init)
+        let rightWords = right.split(whereSeparator: \.isWhitespace).map(String.init)
+        guard !leftWords.isEmpty, !rightWords.isEmpty else { return nil }
+        let prefix = leftWords.suffix(radius).joined(separator: " ")
+        let first = rightWords[0]
+        let up = first.prefix(1).uppercased() + first.dropFirst()
+        let lo = first.prefix(1).lowercased() + first.dropFirst()
+        let rest = rightWords.count > 1
+            ? Array(rightWords[1 ..< min(radius, rightWords.count)]) : []
+        let tail = rest.isEmpty ? "" : " " + rest.joined(separator: " ")
+        let continuations = readings(marks: marks).map {
+            "\($0.mark) \($0.capital ? up : lo)\(tail)"
+        }
+        return (prefix, continuations)
+    }
+
+    // MARK: - loading
+
+    private var loaded: ModelContext?
+
+    /// The load in flight, if any. Actor isolation stops a torn read of
+    /// `loaded`, not two callers both finding it nil across the same `await`.
+    private var loading: Task<ModelContext, Error>?
+
+    /// True once the weights are in memory.
+    ///
+    /// The stage asks before it runs. A dictation must never wait on a 320 MB
+    /// download and a 1.3 s load: the boundaries of that one dictation are left
+    /// alone and the warm starts instead.
+    var isLoaded: Bool { loaded != nil }
+
+    /// When a failed load may be tried again. A held `flock` on the model cache
+    /// is the failure this exists for: another process is fetching, and the
+    /// next dictation would otherwise never look again. Not a latch — but not
+    /// every dictation either, because a damaged cache makes the load re-fetch
+    /// 320 MB.
+    private var retryAfter: Date?
+    private static let backoff: TimeInterval = 300
+
+    /// Starts the load if nothing is doing it, and returns at once.
+    func warm() {
+        guard loaded == nil, loading == nil else { return }
+        if let retryAfter, Date() < retryAfter { return }
+        Task { [weak self] in
+            do { try await self?.prepare() } catch {
+                await self?.hold(after: error)
+            }
+        }
+    }
+
+    private func hold(after error: Error) {
+        retryAfter = Date().addingTimeInterval(Self.backoff)
+        Log.write("sentence readings: \(error.localizedDescription);"
+            + " boundaries are left as decoded until they load")
+    }
+
+    func prepare(progress: (@Sendable (String) -> Void)? = nil) async throws {
+        _ = try await context(progress: progress)
+    }
+
+    private func context(
+        progress: (@Sendable (String) -> Void)? = nil
+    ) async throws -> ModelContext {
+        if let loaded { return loaded }
+        if let loading { return try await loading.value }
+
+        let task = Task<ModelContext, Error> { try await Self.build(progress: progress) }
+        loading = task
+        defer { loading = nil }
+        let built = try await task.value
+        loaded = built
+        return built
+    }
+
+    private static func build(
+        progress: (@Sendable (String) -> Void)?
+    ) async throws -> ModelContext {
+        try await cache.ensure(progress: progress)
+        let context = try await loadModel(from: cache.directory, using: FolderTokenizer())
+        guard context.model is Qwen3Model else {
+            throw Failure.notQwen(String(describing: type(of: context.model)))
+        }
+        MLX.GPU.set(cacheLimit: cacheLimit)
+        return context
+    }
+
+    // MARK: - scoring
+
+    /// The three readings of one boundary, scored.
+    func read(left: String, right: String, marks: [String]) async throws -> [Score] {
+        guard let built = Self.build(left: left, right: right, marks: marks) else {
+            throw Failure.empty
+        }
+        let context = try await context()
+        guard let model = context.model as? Qwen3Model else {
+            throw Failure.notQwen(String(describing: type(of: context.model)))
+        }
+        return Self.score(
+            prefix: built.prefix, continuations: built.continuations,
+            keys: Self.readings(marks: marks).map(\.key),
+            model: model, tokenizer: context.tokenizer
+        )
+    }
+
+    /// Every reading padded into one batch and scored in one forward pass.
+    ///
+    /// Right-padded with the prefix's last token, causal attention, and the pad
+    /// columns are never scored, so the padding cannot reach a score.
+    ///
+    /// The prefix does not always tokenize the same inside the full sequence:
+    /// on 2 of 972 bench sequences the boundary character merges into the last
+    /// prefix token — the case is a left side ending `names).`. Slicing the
+    /// continuation at the prefix's length would then score the wrong tokens,
+    /// so the scored span starts at the first token that actually differs.
+    private static func score(
+        prefix: String, continuations: [String], keys: [String],
+        model: Qwen3Model, tokenizer: any MLXLMCommon.Tokenizer
+    ) -> [Score] {
+        let prefixIds = tokenizer.encode(text: prefix, addSpecialTokens: false)
+        let p = prefixIds.count
+        let fulls = continuations.map {
+            tokenizer.encode(text: prefix + $0, addSpecialTokens: false)
+        }
+        let width = fulls.map(\.count).max() ?? 0
+        guard width > 0, p > 0 else { return [] }
+
+        let pad = Int32(prefixIds.last ?? 0)
+        var flat: [Int32] = []
+        flat.reserveCapacity(width * fulls.count)
+        for full in fulls {
+            flat.append(contentsOf: full.map { Int32($0) })
+            flat.append(contentsOf: Array(repeating: pad, count: width - full.count))
+        }
+        let logits = model(MLXArray(flat, [fulls.count, width]), cache: nil)
+
+        var starts: [Int] = []
+        var totals: [MLXArray] = []
+        for (b, full) in fulls.enumerated() {
+            let shared = zip(full, prefixIds).prefix { $0.0 == $0.1 }.count
+            let from = max(1, min(shared, full.count - 1))
+            starts.append(from)
+            let n = full.count - from
+            let slice = logits[b, (from - 1) ..< (full.count - 1)].asType(.float32)
+            let targets = MLXArray(full[from...].map { Int32($0) }, [n, 1])
+            let picked = takeAlong(slice, targets, axis: 1)
+            totals.append((picked - logSumExp(slice, axis: 1, keepDims: true)).sum())
+        }
+        let stackedTotals = stacked(totals)
+        stackedTotals.eval()
+        let sums = stackedTotals.asArray(Float.self)
+
+        return keys.indices.map { i in
+            let n = fulls[i].count - starts[i]
+            return Score(
+                key: keys[i], mean: Double(sums[i]) / Double(n), tokens: n,
+                retokenised: starts[i] != p
+            )
+        }
+    }
+}

--- a/Sources/ParrotFlow/SentenceReadings.swift
+++ b/Sources/ParrotFlow/SentenceReadings.swift
@@ -20,7 +20,7 @@ import MLXLMCommon
 ///
 /// The comma is a reading, not a term in a subtraction. 26% of real sentence
 /// endings pick it, and that is why none of them picks `join`. Scoring
-/// `max(mark) - log P(next)` instead gives 64% against this shape's 82%.
+/// `max(mark) - log P(next)` instead gives 64% against this shape's 81%.
 ///
 /// `mlx-community/Qwen3-0.6B-Base-4bit`, not the DWQ checkpoint: despite the
 /// name that one is a quant of the *instruct* model and repairs 76%.
@@ -67,11 +67,6 @@ actor SentenceReadings {
     /// Words kept either side of the boundary, the next word counting as the
     /// first on the right. The measurement was made at 12.
     static let radius = 12
-
-    /// The MLX buffer pool grows with the variety of shapes it has seen: 1.0 GB
-    /// after one pass over the bench and 2.0 GB after four. Three models share
-    /// this process, and the limit is process-wide, so it is set once here.
-    static let cacheLimit = 256 * 1024 * 1024
 
     enum Failure: LocalizedError {
         case notQwen(String)
@@ -207,7 +202,7 @@ actor SentenceReadings {
         guard context.model is Qwen3Model else {
             throw Failure.notQwen(String(describing: type(of: context.model)))
         }
-        MLX.GPU.set(cacheLimit: cacheLimit)
+        MLXModelCache.limitBufferPool()
         return context
     }
 

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -505,7 +505,7 @@ actor Transcriber {
             // that failed clears itself, and the next English dictation is the
             // next chance to try again.
             warmSentenceModel()
-            if #available(macOS 14, *) {
+            if #available(macOS 14, *), config.transcription.sentences.enabled {
                 Task { await SentenceReadings.shared.warm() }
             }
             if config.vocabulary.gateSentence, #available(macOS 14, *) {

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -152,10 +152,10 @@ actor Transcriber {
 
     /// Starts the sentence model download and does not wait for it.
     ///
-    /// Nothing reads the model yet, so awaiting it would park the first
-    /// English dictation behind 300 MB for no gain. It reports progress but
-    /// never `.failed`: a model no stage consumes must not put "Model error"
-    /// in the menu bar.
+    /// The vocabulary slot gate reads it, and that gate stands aside until the
+    /// weights are there, so awaiting it would park the first English dictation
+    /// behind 300 MB for no gain. It reports progress but never `.failed`: a
+    /// stage that stands aside must not put "Model error" in the menu bar.
     func warmSentenceModel() {
         guard sentenceModelFetch == nil else { return }
         sentenceModelRunning = true
@@ -497,14 +497,17 @@ actor Transcriber {
         // watching.
         //
         // English only, and the sentence pass below shares that gate: the
-        // masked model is English-only and scores near chance on French.
+        // readings are scored by an English base model and the mark set is
+        // English.
         var joinedSentences = 0
-        var offeredSentences = 0
         if Pipeline.language(of: text, config: config) == "en" {
             // Both are fetched at launch now. These are the retry: a fetch
             // that failed clears itself, and the next English dictation is the
             // next chance to try again.
             warmSentenceModel()
+            if #available(macOS 14, *) {
+                Task { await SentenceReadings.shared.warm() }
+            }
             if config.vocabulary.gateSentence, #available(macOS 14, *) {
                 Task { await WordVectors.shared.warm() }
             }
@@ -518,7 +521,6 @@ actor Transcriber {
                 let joins = await SentenceJoin.shared.apply(to: text, config: config)
                 text = joins.text
                 joinedSentences = joins.count(.join)
-                offeredSentences = joins.count(.offer)
             }
         }
 
@@ -555,11 +557,8 @@ actor Transcriber {
                 // pipeline can read rather than an error about a missing path.
                 "vocabulary.count": .int(vocabularyCount),
                 "vocabulary.changes": .string(vocabularyChanges),
-                // The periods a pause put in and this run took out, and the
-                // ones it would only offer to take out. Nothing shows the
-                // offer yet — see `SentenceJoin.Outcome`.
+                // The periods a pause put in and this run took out.
                 "sentences.joined": .int(joinedSentences),
-                "sentences.offered": .int(offeredSentences),
         ])
         // Only when there is one. Absent says "no press", which is the honest
         // answer off the hotkey path and the one `input` declines on.

--- a/Sources/ParrotFlow/WordVectors.swift
+++ b/Sources/ParrotFlow/WordVectors.swift
@@ -27,42 +27,36 @@ actor WordVectors {
 
     static let shared = WordVectors()
 
-    private static let repository = "mlx-community/Qwen3-Embedding-0.6B-4bit-DWQ"
+    /// The cache and its download. The file list is not the whole repository:
+    /// `model.safetensors.index.json` is absent from it, and listing a file
+    /// that is not there fails the fetch on `unlisted`.
+    static let cache = MLXModelCache(
+        repository: "mlx-community/Qwen3-Embedding-0.6B-4bit-DWQ",
+        files: [
+            "config.json",
+            "model.safetensors",
+            "tokenizer.json",
+            "tokenizer_config.json",
+            "special_tokens_map.json",
+            "added_tokens.json",
+            "vocab.json",
+            "merges.txt",
+        ],
+        directory: AppVariant.supportDirectory
+            .appendingPathComponent("models/qwen3-embedding-0.6b-4bit", isDirectory: true),
+        lockURL: AppVariant.supportDirectory
+            .appendingPathComponent("models/qwen3-embedding.lock"),
+        label: "word vectors"
+    )
 
-    /// `model.safetensors.index.json` is not in the repository — the weights
-    /// are one file. Listing it would fail the download on `unlisted`.
-    private static let files = [
-        "config.json",
-        "model.safetensors",
-        "tokenizer.json",
-        "tokenizer_config.json",
-        "special_tokens_map.json",
-        "added_tokens.json",
-        "vocab.json",
-        "merges.txt",
-    ]
-
-    static var directory: URL {
-        AppVariant.supportDirectory
-            .appendingPathComponent("models/qwen3-embedding-0.6b-4bit", isDirectory: true)
-    }
-
-    /// Beside the cache directory, not inside it, so a fetch that clears the
-    /// cache does not delete a lock somebody is holding.
-    private static var lockURL: URL {
-        directory.deletingLastPathComponent()
-            .appendingPathComponent("qwen3-embedding.lock")
-    }
+    static var directory: URL { cache.directory }
 
     enum Failure: LocalizedError {
-        case busy
         case notQwen(String)
         case spanNotFound(word: String, in: String)
 
         var errorDescription: String? {
             switch self {
-            case .busy:
-                return "another ParrotFlow process is fetching the word-vector model"
             case .notQwen(let kind):
                 return "the word-vector model loaded as \(kind), not Qwen3"
             case .spanNotFound(let word, let sentence):
@@ -71,11 +65,7 @@ actor WordVectors {
         }
     }
 
-    static var isCached: Bool {
-        files.allSatisfy {
-            FileManager.default.fileExists(atPath: directory.appendingPathComponent($0).path)
-        }
-    }
+    static var isCached: Bool { cache.isCached }
 
     private var loaded: ModelContext?
 
@@ -127,52 +117,12 @@ actor WordVectors {
     private static func build(
         progress: (@Sendable (String) -> Void)?
     ) async throws -> ModelContext {
-        if !isCached { try await underLock { try await fetch(progress: progress) } }
-        let context = try await loadModel(from: directory, using: FolderTokenizer())
+        try await cache.ensure(progress: progress)
+        let context = try await loadModel(from: cache.directory, using: FolderTokenizer())
         guard context.model is Qwen3Model else {
             throw Failure.notQwen(String(describing: type(of: context.model)))
         }
         return context
-    }
-
-    private static func underLock(_ body: () async throws -> Void) async throws {
-        try FileManager.default.createDirectory(
-            at: lockURL.deletingLastPathComponent(), withIntermediateDirectories: true
-        )
-        let handle = open(lockURL.path, O_CREAT | O_RDWR, 0o644)
-        guard handle >= 0 else { throw Failure.busy }
-        defer { close(handle) }
-        guard flock(handle, LOCK_EX | LOCK_NB) == 0 else { throw Failure.busy }
-        try await body()
-    }
-
-    /// Fetches into a staging directory and moves the result into place, so a
-    /// half-written cache never loads. Staging sits inside `directory` to keep
-    /// the move a rename on one volume.
-    private static func fetch(progress: (@Sendable (String) -> Void)?) async throws {
-        let manager = FileManager.default
-        try manager.createDirectory(at: directory, withIntermediateDirectories: true)
-        let left = try? manager.contentsOfDirectory(atPath: directory.path)
-        for name in left ?? [] where name.hasPrefix(".staging-") {
-            try? manager.removeItem(at: directory.appendingPathComponent(name))
-        }
-        let staging = directory
-            .appendingPathComponent(".staging-\(UUID().uuidString)", isDirectory: true)
-        try manager.createDirectory(at: staging, withIntermediateDirectories: true)
-        defer { try? manager.removeItem(at: staging) }
-
-        let reported = Reported()
-        try await HubDownload.fetch(repo: repository, paths: files, into: staging) { fraction in
-            guard let progress else { return }
-            let percent = Int((fraction * 100).rounded())
-            guard reported.advanced(to: percent) else { return }
-            progress("word vectors \(percent)%")
-        }
-        for name in files {
-            let target = directory.appendingPathComponent(name)
-            try? manager.removeItem(at: target)
-            try manager.moveItem(at: staging.appendingPathComponent(name), to: target)
-        }
     }
 
     // MARK: - the two vectors
@@ -262,58 +212,4 @@ actor WordVectors {
         return first ..< (last + 1)
     }
 
-    /// The percentage last reported. A class because the progress closure is
-    /// `@Sendable` and escapes.
-    private final class Reported: @unchecked Sendable {
-        private var last = -1
-        private let lock = NSLock()
-
-        func advanced(to percent: Int) -> Bool {
-            lock.lock()
-            defer { lock.unlock() }
-            guard percent > last else { return false }
-            last = percent
-            return true
-        }
-    }
-}
-
-/// `AutoTokenizer` over a folder, as the one protocol `loadModel` needs.
-///
-/// `MLXHuggingFace` provides this behind a macro, and swift-syntax with it.
-/// This is the whole of what that macro expands to for the loading path.
-@available(macOS 14, *)
-private struct FolderTokenizer: TokenizerLoader {
-    func load(from directory: URL) async throws -> any MLXLMCommon.Tokenizer {
-        Adapter(try await AutoTokenizer.from(modelFolder: directory))
-    }
-
-    private struct Adapter: MLXLMCommon.Tokenizer, @unchecked Sendable {
-        let upstream: any Tokenizers.Tokenizer
-
-        init(_ upstream: any Tokenizers.Tokenizer) { self.upstream = upstream }
-
-        func encode(text: String, addSpecialTokens: Bool) -> [Int] {
-            upstream.encode(text: text, addSpecialTokens: addSpecialTokens)
-        }
-        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
-            upstream.decode(tokens: tokenIds, skipSpecialTokens: skipSpecialTokens)
-        }
-        func convertTokenToId(_ token: String) -> Int? { upstream.convertTokenToId(token) }
-        func convertIdToToken(_ id: Int) -> String? { upstream.convertIdToToken(id) }
-
-        var bosToken: String? { upstream.bosToken }
-        var eosToken: String? { upstream.eosToken }
-        var unknownToken: String? { upstream.unknownToken }
-
-        func applyChatTemplate(
-            messages: [[String: any Sendable]],
-            tools: [[String: any Sendable]]?,
-            additionalContext: [String: any Sendable]?
-        ) throws -> [Int] {
-            // Nothing here holds a conversation. The vocabulary stage sends one
-            // sentence and reads the states back.
-            []
-        }
-    }
 }

--- a/Sources/ParrotFlow/WordVectors.swift
+++ b/Sources/ParrotFlow/WordVectors.swift
@@ -122,6 +122,7 @@ actor WordVectors {
         guard context.model is Qwen3Model else {
             throw Failure.notQwen(String(describing: type(of: context.model)))
         }
+        MLXModelCache.limitBufferPool()
         return context
     }
 

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -136,9 +136,19 @@ if let at = arguments.firstIndex(of: "--sentence-probe") {
     if let encode = arguments.firstIndex(of: "--encode"), arguments.indices.contains(encode + 1) {
         exit(SentenceProbeCommand.encode(arguments[encode + 1]))
     }
+    if let bench = arguments.firstIndex(of: "--bench"), arguments.indices.contains(bench + 1) {
+        let out = arguments.firstIndex(of: "--out").flatMap {
+            arguments.indices.contains($0 + 1) ? arguments[$0 + 1] : nil
+        }
+        exit(SentenceProbeCommand.bench(
+            cases: arguments[bench + 1], out: out, vectors: arguments.contains("--vectors")
+        ))
+    }
     guard arguments.indices.contains(at + 2) else {
         print("usage: ParrotFlow --sentence-probe \"<left half>\" \"<right half>\"")
         print("       ParrotFlow --sentence-probe --encode \"<text>\"")
+        print("       ParrotFlow --sentence-probe --bench <cases.json>"
+              + " [--out <scores.json>] [--vectors]")
         exit(2)
     }
     exit(SentenceProbeCommand.run(left: arguments[at + 1], right: arguments[at + 2]))

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -82,12 +82,13 @@ transcription:
 
   # A pause mid-sentence makes the transcriber write a period and capitalise
   # the next word. English dictations are checked for that and the period is
-  # taken out again. On by default, and only where the sentence model is
-  # already on disk. `sentences: false` turns it off.
+  # taken out again. Every boundary is read once per mark and once with no
+  # mark at all, and the reading the model scores highest is written. On by
+  # default, and only where the model is already on disk. `sentences: false`
+  # turns it off.
   #
   # sentences:
-  #   join_below: -4.0   # remove the period and say nothing
-  #   offer_below: -2.0  # offer the join, do not write it
+  #   marks: [".", ","]  # the marks tried beside removing the period
 
   # What a transcript runs through, in order. Remove a line to skip that
   # stage. One list for every language: a step that should only run in one

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -422,48 +422,52 @@ $PF --transcribe /tmp/t.wav
 ## Is this period real
 
 ```sh
-$PF --sentence-model                                       # fetch, compile and load ModernBERT
-$PF --sentence-probe "<left half>" "<right half>"          # score one boundary
-$PF --sentence-probe --encode "<text>"                     # the tokenizer alone, no model
+$PF --sentence-model                                       # fetch both sentence models
+$PF --sentence-probe "<left half>" "<right half>"          # read one boundary
+$PF --sentence-probe --encode "<text>"                     # the masked tokenizer, no model
+$PF --sentence-probe --bench <cases.json> --out <out.json> # a whole file, one loaded process
 ```
 
 A pause in the middle of a sentence makes the transcriber write a period. The
-probe asks ModernBERT what belongs where that period is:
-`score = log P(".") − log P(" <next word>")`, both read at one masked position.
-A low score means the period is false and the two halves are one sentence.
-Measured over 194 real periods and 130 synthetic cuts of dictation:
-
-| threshold | cuts repaired | false joins per 100 real periods |
-|---:|---:|---:|
-| −4 | 32% | 0.0 |
-| −2 | 55% | 1.2 |
-| 0 | 82% | 6.1 |
+probe builds one reading of the boundary per mark and one with no mark at all,
+and scores each with `mlx-community/Qwen3-0.6B-Base-4bit`. The score is the
+log-probability of the continuation divided by its token count. The highest
+wins, and there is no threshold.
 
 ```
-$PF --sentence-probe "we have to do it." "That works well"
-  boundary  "." 15   " ." 964   "That" 2773   " That" 2064  ✓
-  text      we have to do it [MASK] that works well
-  score        1.45
-  period      -4.12   "."
-  next        -5.57   " that"
-  top       " and"   -1.54   ","   -2.36   " something"   -2.93
+$PF --sentence-probe "…the first usage of the LLM with." "The vocabulary is slower"
+  prefix    the first usage of the LLM with
+  reading   .        -7.2669  5
+  reading   ,        -6.5327  5
+  reading   join     -4.5571  4
+  winner    join
 ```
 
-The `boundary` line is the tokenizer checking itself against a real
-tokenization. A word after another word carries its leading space, so `" That"`
-is 2064 and `"That"` is 2773 — comparing against the second scores nothing at
-every threshold and raises no error. If that check fails the probe refuses to
-answer.
+The number after the score is how many tokens it was divided by. `retokenised`
+on a line means the mark merged into the last token of the prefix, so that
+reading is scored from the first token that actually differs — 2 of 972 bench
+sequences do this.
 
-`--encode` prints ids and loads no model, which is what
-`scripts/check-tokenizer.sh` compares against HuggingFace's own tokenizer.
-`scripts/check-sentence-probe.sh` goes further and compares the scores;
-it needs the model, so it is not in `make test`.
+`--bench` reads `[{"left": …, "right": …}]` and writes one row of scores per
+boundary, with the milliseconds each decision took. It loads the model once, so
+it is the only way to get a latency number; `--vectors` loads the word vectors
+as well, so the memory line describes the process the app runs.
+
+`--encode` prints ModernBERT's ids and loads no model, which is what
+`scripts/check-tokenizer.sh` compares against HuggingFace's own tokenizer. That
+tokenizer belongs to the vocabulary slot gate, not to this stage.
+`scripts/check-sentence-probe.sh` compares the readings against
+tests/sentence-boundary-cases.json; it needs the model, so it is not in
+`make test`.
+
+`--sentence-model` fetches both: the Qwen base model the readings are scored
+with, and ModernBERT, which the vocabulary slot gate still fills a masked slot
+with.
 
 ## Which periods a pause put there
 
 ```sh
-$PF --sentence-join "<text>"            # score every boundary, and join what is below
+$PF --sentence-join "<text>"            # read every boundary, and join what wins
 $PF --sentence-join --case "<text>"     # the lowercasing alone, no model
 ```
 
@@ -474,14 +478,16 @@ per `word. Capital` boundary, then the text it hands on.
 $PF --sentence-join "…the first usage of the LLM with. The vocabulary is slower"
   language   en
   boundary   with. The -> with the
-  score      -5.0664
-  tier       join
+  reading    .         -7.2669  5
+  reading    ,         -6.5327  5
+  reading    join      -4.5571  4
+  winner     join
   text       …the first usage of the LLM with the vocabulary is slower
 ```
 
-`tier` is `join` below `join_below`, `offer` below `offer_below`, and `leave`
-above it. Both thresholds are `transcription.sentences` in `config.yaml`.
-`scripts/check-sentence-join.sh` scores the two tiers against
+The period is removed where `join` wins, and left alone otherwise. The marks
+tried are `transcription.sentences.marks` in `config.yaml`.
+`scripts/check-sentence-join.sh` scores the decisions against
 tests/sentence-boundary-cases.json; it needs the model, so it is run by hand.
 
 `--case` answers only what the capitalised word becomes once the period is
@@ -726,10 +732,10 @@ scripts/check-clipboard.sh         # when a rewrite may go to the clipboard, and
 scripts/check-span-rule.sh         # which range a rewrite is written as, before any app sees it
 scripts/check-bug-report.sh        # what a bug report carries, and that it carries no home path
 scripts/check-tokenizer.sh         # the hand-written BPE against HuggingFace's own
-scripts/check-sentence-probe.sh    # the boundary score against coremltools (needs the model)
+scripts/check-sentence-probe.sh    # the three readings of a boundary (needs the model)
 scripts/check-slot-gate.sh         # where a name proposal is routed (needs the model)
 scripts/check-sentence-case.sh     # the capital after a period the join removes
-scripts/check-sentence-join.sh     # the two tiers of the sentence join (needs the model)
+scripts/check-sentence-join.sh     # which periods the join removes (needs the model)
 
 PF_VIEWPORT=Ghostty scripts/check-inplace.sh   # the same set, in another terminal
 $PF --peek 3 --via-copy                        # what Select All + Copy hands back

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -473,25 +473,34 @@ end of what was still there.
 
 A pause mid-sentence makes the transcriber write a period and capitalise the
 next word, so one sentence becomes two. Every `word. Capital` boundary in an
-English transcript is scored, and two thresholds decide what happens.
+English transcript is read several ways and the reading the model likes best
+wins.
 
 ```yaml
 transcription:
   sentences:
-    join_below: -4.0     # remove the period and say nothing
-    offer_below: -2.0    # offer the join, do not write it
+    marks: [".", ","]    # the marks tried beside removing the period
 ```
 
 `sentences: false` turns the whole stage off.
 
-The score is `log P(".") − log P(" <next word>")`, read from a masked language
-model at the position of the period. It is negative when the model would rather
-see the next word there than a full stop. Measured over 194 real periods and
-130 synthetic cuts of one speaker's dictation, −4 repaired 32% of the cuts and
-joined no real period; −2 repaired 55% and joined 1.2 per 100. So −4 writes and
-−2 asks. Nothing shows the offer yet.
+There is no threshold. For a `word. Capital` boundary the stage builds one
+reading per mark — `". The vocabulary is slower"`, `", the vocabulary is
+slower"` — and one with no mark at all, scores each with a small causal
+language model, and writes the winner. A score is the log-probability of the
+continuation divided by its token count. Where the reading with no mark wins,
+the period is removed and the next word is lowercased.
 
-English only, and only where the sentence model is already on disk. Nothing is
+Measured over 172 real periods and 140 cuts of one speaker's dictation: 81% of
+the cuts repaired and no real period joined. The two thresholds this used to
+take, `join_below:` and `offer_below:`, repaired 26%. They are still read, and
+`--check-config` says they no longer do anything.
+
+`;` and `:` were measured and never changed a decision in English, so the
+default is the two marks that do. The set is a setting because it is
+language-dependent.
+
+English only, and only where the model is already on disk. Nothing is
 downloaded for this and nothing waits: with no model the transcript arrives as
 it was. See [transcription.md](transcription.md).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -498,7 +498,8 @@ take, `join_below:` and `offer_below:`, repaired 26%. They are still read, and
 
 `;` and `:` were measured and never changed a decision in English, so the
 default is the two marks that do. The set is a setting because it is
-language-dependent.
+language-dependent. Each entry is one punctuation character; anything else is
+refused, because a mark is written into the sentence as punctuation.
 
 English only, and only where the model is already on disk. Nothing is
 downloaded for this and nothing waits: with no model the transcript arrives as

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -483,20 +483,33 @@ written  "You should see a parrot. At the top right of your screen."
 ```
 
 After the vocabulary pass, every `word. Capital` boundary in an English
-transcript is scored by the same masked language model the slot gate uses:
-`score = log P(".") − log P(" <next word>")` at one masked position, ±12
-words. Two thresholds decide, both under `transcription.sentences`:
+transcript is read three ways and scored by a small causal language model
+(`mlx-community/Qwen3-0.6B-Base-4bit`, 320 MB):
 
-| score | what happens |
-|---|---|
-| below `join_below`, default −4 | the period is removed and nothing is said |
-| below `offer_below`, default −2 | the join is offered, not written |
-| above it | left alone |
+```
+". The vocabulary is slower"     the period is real
+" the vocabulary is slower"      a pause cut one sentence in two
+", the vocabulary is slower"     it is really a comma
+```
 
-Measured over 194 real periods and 130 synthetic cuts of one speaker's
-dictation, −4 repaired 32% of the cuts and joined no real period; −2 repaired
-55% and joined 1.2 per 100. A silent rewrite that is wrong costs the words
-themselves, so the writing tier sits where nothing was joined by mistake.
+Each reading is the log-probability of its continuation divided by its token
+count, and the highest wins. Nothing is compared to a threshold, so there is
+nothing to calibrate. The marks are `transcription.sentences.marks`, default
+`[".", ","]`; `;` and `:` were measured and never changed a decision in
+English.
+
+Three things are load-bearing. Per token, not summed: on summed
+log-probability the joined reading wins by being shortest, which repairs 97% of
+the cuts and destroys 33 real endings. The comma is a reading and not a term in
+a subtraction: 26% of real endings pick it, and that is why none of them picks
+the join. And the three readings go into one padded forward pass, which costs
+50 ms against 70 ms for three passes; a shared KV cache for the prefix is
+slower still.
+
+Measured over 172 real periods and 140 cuts of one speaker's dictation: 81% of
+the cuts repaired, no real period joined. The two thresholds this stage used to
+carry repaired 26%, and the higher one could not be raised — it was set by the
+single lowest-scoring real ending.
 
 Joining removes the period and lowercases the word after it. Not every capital
 there is because of the period: "I will ask him. Nathan knows the answer" must
@@ -508,14 +521,15 @@ never seen it, which is what a name it has not been told about looks like. A
 term in your `vocabulary.yaml` is asked first, because a name that is also an
 English word is the one case the lemma rule cannot see.
 
-English only. The model is English-only, and the same probe measured on
-`cservan/french-modernbert-large` and `-base` scores near chance. Nothing is
-waited for: with no cached model, a probe that throws or a boundary it cannot
-read, the text arrives as it was.
+English only. The readings are scored by an English base model, and the mark
+set is English: French uses `:` where English does not. Nothing is waited for:
+with no cached model, a load that threw or a boundary it cannot read, the text
+arrives as it was. A dictation that arrives before the weights are in memory
+keeps its boundaries and starts the load.
 
-`scripts/check-sentence-join.sh` scores the two tiers and needs the model.
+`scripts/check-sentence-join.sh` scores the decisions and needs the model.
 `scripts/check-sentence-case.sh` scores the lowercasing and needs none, so it
-runs in CI. See `SentenceJoin`.
+runs in CI. See `SentenceJoin` and `SentenceReadings`.
 
 ## Voice corrections
 

--- a/scripts/check-sentence-join.sh
+++ b/scripts/check-sentence-join.sh
@@ -1,27 +1,25 @@
 #!/usr/bin/env bash
-# Scores the two tiers of the sentence join, against
-# tests/sentence-boundary-cases.json.
+# Scores the sentence join against tests/sentence-boundary-cases.json.
 #
 #   scripts/check-sentence-join.sh
 #
 # Half the cases are real periods and half are pauses that cut one sentence in
-# two. Three numbers decide: how many cuts were repaired with nothing asked,
-# how many real periods were joined by mistake, and how many cuts the offer
-# tier would have caught. The false joins are the ones that matter — a silent
-# rewrite that is wrong is worse than a stage that does nothing.
+# two. Two numbers decide: how many cuts were repaired, and how many real
+# periods were joined by mistake. A joined real period is a sentence nobody
+# wrote, with nothing on screen to say so, so one of those fails the run.
 #
-# Each case also carries the score the probe measured when the set was built.
-# This compares the binary's score against it. That is what says the app reads
-# a boundary the same way the measurement did; without it the tier counts
-# describe some other pipeline.
+# Each case also carries the readings measured when the set was built. This
+# compares the binary's against them. That is what says the app reads a boundary
+# the same way the measurement did; without it the counts describe some other
+# pipeline.
 #
-# Not in `make test` and not in CI: it needs the 300 MB sentence model, which
-# CI has no business downloading. Run it by hand after touching `SentenceJoin`
-# or the thresholds. Nothing is downloaded here either — with no cached model
-# every case comes back untouched and the run says so.
+# Not in `make test` and not in CI: it needs the 320 MB model, which CI has no
+# business downloading. Run it by hand after touching `SentenceJoin`. Nothing is
+# downloaded here either — with no cached model every case comes back untouched
+# and the run says so.
 #
-# Runs against a scratch PARROTFLOW_CONFIG_DIR, so the thresholds are the
-# shipped defaults rather than whatever this machine is tuned to.
+# Runs against a scratch PARROTFLOW_CONFIG_DIR, so the marks are the shipped
+# defaults rather than whatever this machine is tuned to.
 set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 [ -x "$ROOT/.build/release/ParrotFlow" ] || {
@@ -40,8 +38,8 @@ binary = root / ".build/release/ParrotFlow"
 cases = json.load(open(root / "tests/sentence-boundary-cases.json"))
 
 # The set stores the two halves already windowed to twelve words each, which is
-# what `SentenceProbe.radius` keeps. Glued back into one text, the boundary the
-# app finds is the one the set is about.
+# the window the app builds. Glued back into one text, the boundary the app
+# finds is the one the set is about.
 def text_of(case):
     return case["left"].rstrip(".") + ". " + case["right"]
 
@@ -50,20 +48,26 @@ def text_of(case):
 # left halves carry a period of their own, so the app finds two or three
 # boundaries in the glued text and only one of them is the measured one. It is
 # named by the word each side of it.
-def reading(out, case):
+def block_of(out, case):
     wanted = "%s. %s ->" % (case["left"].rstrip(".").split()[-1], case["right"].split()[0])
-    block = {}
+    block, mine = None, None
     for line in out.splitlines():
         parts = line.split(None, 1)
         if len(parts) != 2:
             continue
         if parts[0] == "boundary":
-            block = {"boundary": parts[1].strip()}
-        elif block:
-            block[parts[0]] = parts[1].strip()
-        if block.get("boundary", "").startswith(wanted) and "tier" in block:
-            return block
-    return {}
+            block = {"boundary": parts[1].strip(), "mean": {}}
+            mine = block if parts[1].strip().startswith(wanted) else None
+        elif block is None:
+            continue
+        elif parts[0] == "reading":
+            key, mean, _ = parts[1].split()
+            block["mean"][key] = float(mean)
+        elif parts[0] == "winner":
+            block["winner"] = parts[1].strip()
+            if mine is not None:
+                return mine
+    return None
 
 DRIFT = 0.05
 tally = {"en_real.json": {}, "en_cuts.json": {}}
@@ -74,28 +78,27 @@ for case in cases:
         [binary, "--sentence-join", text_of(case)],
         capture_output=True, text=True,
     ).stdout
-    block = reading(out, case)
+    block = block_of(out, case)
     if not block:
         print("  ✗ the measured boundary was not found in: " + text_of(case))
         sys.exit(1)
-    tier, score = block["tier"], block["score"]
+    winner = block["winner"]
     counts = tally[case["set"]]
-    counts[tier] = counts.get(tier, 0) + 1
-    delta = float(score) - case["score"]
+    counts[winner] = counts.get(winner, 0) + 1
+    gap = max(abs(block["mean"].get(k, 0) - v) for k, v in case["mean"].items())
     mark = " "
-    if abs(delta) > DRIFT:
-        drifted.append((text_of(case), case["score"], float(score)))
+    if gap > DRIFT:
+        drifted.append((text_of(case), case["winner"], winner, gap))
         mark = "✗"
-    print("  %s  %-9s %8.3f  %-5s  stored %8.3f" % (
+    print("  %s  %-5s %-5s stored %-5s  gap %.4f  %s" % (
         mark, case["set"].removeprefix("en_").removesuffix(".json"),
-        float(score), tier, case["score"]))
+        winner, case["winner"], gap, case["left"][:48]))
 
 def row(name, key):
     counts = tally[key]
     total = sum(counts.values())
-    print("  %-13s %2d joined, %2d offered, %2d left alone  (of %d)" % (
-        name, counts.get("join", 0), counts.get("offer", 0),
-        counts.get("leave", 0), total))
+    listed = ", ".join("%d %s" % (n, k) for k, n in sorted(counts.items()))
+    print("  %-13s %s  (of %d)" % (name, listed, total))
     return counts, total
 
 print()
@@ -107,21 +110,16 @@ if not cut_total or not real_total:
     sys.exit(1)
 
 joined = cuts.get("join", 0)
-offered = cuts.get("offer", 0)
 false_joins = real.get("join", 0)
 print()
-print("  join tier      %d%% of cuts repaired, %.1f false joins per 100 real periods" % (
+print("  %d%% of cuts repaired, %.1f false joins per 100 real periods" % (
     round(100 * joined / cut_total), 100 * false_joins / real_total))
-print("  offer tier     %d%% more cuts caught, %.1f per 100 real periods offered" % (
-    round(100 * offered / cut_total), 100 * real.get("offer", 0) / real_total))
 
 if drifted:
     print()
-    print("  ✗ %d case(s) scored differently from the stored measurement:" % len(drifted))
-    for text, want, got in drifted:
-        print("      want %8.3f  got %8.3f   %s" % (want, got, text))
+    print("  ✗ %d case(s) read differently from the stored measurement:" % len(drifted))
+    for text, want, got, gap in drifted:
+        print("      stored %-5s got %-5s gap %.4f   %s" % (want, got, gap, text))
 
-# A joined real period is a sentence nobody wrote, with nothing on screen to
-# say so. It fails the run on its own.
 sys.exit(1 if drifted or false_joins else 0)
 PY

--- a/scripts/check-sentence-probe.sh
+++ b/scripts/check-sentence-probe.sh
@@ -1,74 +1,68 @@
 #!/usr/bin/env bash
-# Compares the Swift probe's scores against the reference, case by case.
+# Compares the Swift readings against the stored ones, case by case.
 #
 #   scripts/check-sentence-probe.sh [tolerance]
 #
-# The tokenizer check answers "are the ids right". This answers "is the whole
-# thing right": the window, the lowercased next word, the padding, the row read
-# out of the logits, and the log-softmax over it.
-#
 # tests/sentence-boundary-cases.json holds 40 boundaries from a scored set of
-# the user's own dictation, half real periods and half synthetic cuts, with the
-# scores coremltools gets from the same .mlpackage. Same weights, same runtime,
-# so a disagreement is Swift's packing and nothing else. Regenerate it with
-# scripts/sentence-probe-reference.py.
+# the user's own dictation, half real periods and half pauses that cut one
+# sentence in two, with the per-token score of every reading and the winner.
+# This answers "does this build still read a boundary the same way": the window,
+# the three continuations, the padded batch, the log-softmax and the argmax.
+# Regenerate it with scripts/sentence-probe-reference.py readings.
 #
-# Not in `make test`: it needs the 300 MB model, which CI has no business
-# downloading. Run it by hand after touching the tokenizer or the probe.
+# One loaded process for all 40, through `--sentence-probe --bench`. A process
+# per case would pay the 1.3s model load forty times.
+#
+# Not in `make test`: it needs the 320 MB model, which CI has no business
+# downloading. Run it by hand after touching SentenceReadings.
 set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BIN="$ROOT/.build/release/ParrotFlow"
 [ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
 
 TOLERANCE="${1:-0.05}"
-CASES="$ROOT/tests/sentence-boundary-cases.json"
 WORK="$(mktemp -d -t parrotflow-sentence-probe)"
 trap 'rm -rf "$WORK"' EXIT
+# The shipped marks, not whatever this machine is tuned to.
+export PARROTFLOW_CONFIG_DIR="$WORK/config"
 
-# left, right and the three reference numbers, one field per line, so a case
-# holding a quote arrives whole.
 python3 -c '
 import json, sys
-for case in json.load(open(sys.argv[1])):
-    print(json.dumps(case["left"]))
-    print(json.dumps(case["right"]))
-    print("%s %s %s" % (case["score"], case["period"], case["next"]))
-' "$CASES" > "$WORK/cases" || { echo "  ✗ $CASES could not be read"; exit 1; }
+cases = json.load(open(sys.argv[1]))
+json.dump([{"left": c["left"], "right": c["right"]} for c in cases], open(sys.argv[2], "w"))
+' "$ROOT/tests/sentence-boundary-cases.json" "$WORK/cases.json" || {
+  echo "  ✗ tests/sentence-boundary-cases.json could not be read"; exit 1; }
 
-unquote() { python3 -c 'import json,sys; sys.stdout.write(json.loads(sys.argv[1]))' "$1"; }
+"$BIN" --sentence-probe --bench "$WORK/cases.json" --out "$WORK/scored.json" \
+  || { echo "  ✗ the binary could not score the cases"; exit 1; }
 
-pass=0; total=0; worst=0; worst_case=""
-while IFS= read -r left && IFS= read -r right && IFS= read -r want; do
-  total=$((total + 1))
-  out="$("$BIN" --sentence-probe "$(unquote "$left")" "$(unquote "$right")" 2>/dev/null)"
-  got="$(printf '%s\n' "$out" | awk '$1 == "score" || $1 == "period" || $1 == "next" { print $1, $2 }')"
-  read -r verdict <<< "$(python3 -c '
-import sys
-want = dict(zip(("score", "period", "next"), (float(x) for x in sys.argv[1].split())))
-got = dict(line.split() for line in sys.argv[2].splitlines() if line)
-if len(got) != 3:
-    print("gone 0.0 the probe printed nothing")
-    raise SystemExit
-gap = max(abs(float(got[k]) - want[k]) for k in want)
-print("%s %.4f score %s want %s" % ("ok" if gap <= float(sys.argv[3]) else "off",
-                                     gap, got["score"], want["score"]))
-' "$want" "$got" "$TOLERANCE")"
-  state="${verdict%% *}"
-  rest="${verdict#* }"
-  gap="${rest%% *}"
-  note="${rest#* }"
-  if [ "$state" = ok ]; then
-    pass=$((pass + 1))
-  else
-    printf '  ✗ %s\n      %s  gap %s\n' "$left" "$note" "$gap"
-  fi
-  if python3 -c "import sys; sys.exit(0 if float('$gap') > float('$worst') else 1)"; then
-    worst="$gap"; worst_case="$left"
-  fi
-done < "$WORK/cases"
+exec python3 - "$ROOT" "$WORK/scored.json" "$TOLERANCE" <<'PY'
+import json, sys
+from pathlib import Path
 
-echo
-[ "$total" -eq 0 ] && { echo "  ✗ no cases read from $CASES"; exit 1; }
-printf '  %d/%d within %s  (tests/sentence-boundary-cases.json)\n' "$pass" "$total" "$TOLERANCE"
-printf '  worst gap %s  %s\n' "$worst" "$worst_case"
-[ "$pass" = "$total" ]
+root, scored, tolerance = Path(sys.argv[1]), sys.argv[2], float(sys.argv[3])
+cases = json.load(open(root / "tests/sentence-boundary-cases.json"))
+got = {row["i"]: row for row in json.load(open(scored))}
+
+passed, worst, worst_case = 0, 0.0, ""
+for i, case in enumerate(cases):
+    row = got.get(i)
+    if row is None:
+        print("  ✗ not scored: " + case["left"])
+        continue
+    gap = max(abs(row["mean"][k] - v) for k, v in case["mean"].items())
+    if gap > worst:
+        worst, worst_case = gap, case["left"]
+    if gap <= tolerance and row["winner"] == case["winner"]:
+        passed += 1
+    else:
+        print("  ✗ %s. %s" % (case["left"].rstrip("."), case["right"].split()[0]))
+        print("      winner %s, stored %s   gap %.4f" % (
+            row["winner"], case["winner"], gap))
+
+print()
+print("  %d/%d within %s  (tests/sentence-boundary-cases.json)" % (
+    passed, len(cases), tolerance))
+print("  worst gap %.4f  %s" % (worst, worst_case))
+sys.exit(0 if passed == len(cases) else 1)
+PY

--- a/scripts/sentence-probe-reference.py
+++ b/scripts/sentence-probe-reference.py
@@ -1,16 +1,22 @@
 #!/usr/bin/env python3
-"""Writes the two fixtures the Swift sentence probe is checked against.
+"""Writes the two fixtures the Swift sentence code is checked against.
 
-    scripts/sentence-probe-reference.py tokens          -> tests/tokenizer-cases.json
-    scripts/sentence-probe-reference.py scores <n>      -> tests/sentence-boundary-cases.json
+    scripts/sentence-probe-reference.py tokens     -> tests/tokenizer-cases.json
+    scripts/sentence-probe-reference.py readings   -> tests/sentence-boundary-cases.json
 
-`tokens` needs the `tokenizers` package and `tokenizer.json`. `scores` also
-needs `coremltools` and the `.mlpackage`, and runs the same weights Swift runs
-so a disagreement is Swift's packing, not a conversion difference.
+`tokens` needs the `tokenizers` package and ModernBERT's `tokenizer.json`. That
+tokenizer belongs to the vocabulary slot gate, which still reads the masked
+model.
 
-Boundaries come from a scored set of the user's own dictation. Point --data at
-its directory; the file holds `left` and `right` already windowed to +-12
-words, which is what `SentenceProbe.read` reproduces.
+`readings` needs the release binary and the Qwen model on disk. It runs
+`--sentence-probe --bench` over a sample of the boundary bench and stores what
+came back, so the fixture is by construction what the binary produces. Point
+--data at the bench directory; its files hold `left` and `right` already
+windowed to +-12 words, which is the window the app builds.
+
+Real endings carrying a hand label are left out. `join` means the period is
+wrong, `drop` that the row is not a dictation, and `tie` that both readings are
+right — none of the three is a real ending a join would spoil.
 """
 import argparse
 import json
@@ -22,7 +28,6 @@ TOKENIZER = os.path.expanduser(
     "~/Library/Application Support/ParrotFlow/models/modernbert-base-64/tokenizer.json"
 )
 LENGTH = 64
-RADIUS = 12
 
 # Every class the Swift tokenizer can get wrong on its own: the byte alphabet,
 # the merge order, the NFC normaliser, the added tokens, and the empty string.
@@ -66,68 +71,43 @@ def tokens(args):
     write(args.out or os.path.join(HERE, "tests/tokenizer-cases.json"), out)
 
 
-def build(tk, left, right):
-    """The text and the two ids, exactly as `SentenceProbe.read` builds them."""
-    words = left.rstrip(".").split()[-RADIUS:]
-    after = right.split()
-    if not after or not words:
-        return None
-    nxt = after[0][0].lower() + after[0][1:]
-    after = ([nxt] + after[1:])[:RADIUS]
-    head = tk.encode(" ".join(words), add_special_tokens=False).ids
-    tail = tk.encode(" " + " ".join(after), add_special_tokens=False).ids
-    while len(head) + len(tail) > LENGTH - 3:
-        if len(head) >= len(tail):
-            head = head[1:]
-        else:
-            tail = tail[:-1]
-    ids = [tk.token_to_id("[CLS]")] + head + [tk.token_to_id("[MASK]")] + tail
-    ids += [tk.token_to_id("[SEP]")]
-    mask_at = 1 + len(head)
-    ids += [tk.token_to_id("[PAD]")] * (LENGTH - len(ids))
-    nid = tk.encode(" " + nxt, add_special_tokens=False).ids
-    if not nid:
-        return None
-    return ids, mask_at, nid[0], " ".join(words) + " [MASK] " + " ".join(after)
+def readings(args):
+    """A sample of the bench, scored by the release binary."""
+    import subprocess
+    import tempfile
 
-
-def scores(args):
-    import coremltools as ct
-    import numpy as np
-
-    tk = load_tokenizer(args.tokenizer)
-    model = ct.models.MLModel(args.package)
-    dot = tk.token_to_id(".")
-
-    data = []
-    for name in ("en_real.json", "en_cuts.json"):
-        entries = json.load(open(os.path.join(args.data, name)))
-        step = max(1, len(entries) // (args.count // 2))
-        data += [(name, e) for e in entries[::step]][: args.count // 2]
+    labelled = set()
+    labels_path = os.path.join(args.data, "en_real_labels.json")
+    if os.path.exists(labels_path):
+        labels = json.load(open(labels_path))
+        for key in ("join", "drop", "tie"):
+            labelled |= set(labels.get(key, []))
 
     out = []
-    for name, entry in data:
-        built = build(tk, entry["left"], entry["right"])
-        if built is None:
-            continue
-        ids, mask_at, nid, text = built
-        logits = model.predict(
-            {"input_ids": np.array([ids], dtype=np.int32)}
-        )["logits"][0, mask_at]
-        logits = logits.astype(np.float64)
-        top = logits.max()
-        norm = top + np.log(np.exp(logits - top).sum())
-        period = float(logits[dot] - norm)
-        following = float(logits[nid] - norm)
-        out.append({
-            "set": name,
-            "left": entry["left"],
-            "right": entry["right"],
-            "text": text,
-            "period": round(period, 4),
-            "next": round(following, 4),
-            "score": round(period - following, 4),
-        })
+    for name, skip in (("en_real.json", labelled), ("en_cuts.json", set())):
+        entries = json.load(open(os.path.join(args.data, name)))
+        wanted = [i for i in range(len(entries)) if i not in skip]
+        step = max(1, len(wanted) // (args.count // 2))
+        wanted = wanted[::step][: args.count // 2]
+        rows = [
+            {"left": entries[i]["left"], "right": entries[i]["right"]} for i in wanted
+        ]
+        with tempfile.TemporaryDirectory(dir=os.environ.get("TMPDIR")) as work:
+            cases = os.path.join(work, "cases.json")
+            scored = os.path.join(work, "scored.json")
+            json.dump(rows, open(cases, "w"))
+            subprocess.run(
+                [args.binary, "--sentence-probe", "--bench", cases, "--out", scored],
+                check=True, stdout=subprocess.DEVNULL,
+            )
+            for row in json.load(open(scored)):
+                out.append({
+                    "set": name,
+                    "left": rows[row["i"]]["left"],
+                    "right": rows[row["i"]]["right"],
+                    "winner": row["winner"],
+                    "mean": {k: round(v, 4) for k, v in sorted(row["mean"].items())},
+                })
     write(args.out or os.path.join(HERE, "tests/sentence-boundary-cases.json"), out)
 
 
@@ -139,11 +119,11 @@ def write(path, rows):
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument("what", choices=("tokens", "scores"))
+parser.add_argument("what", choices=("tokens", "readings"))
 parser.add_argument("--tokenizer", default=TOKENIZER)
-parser.add_argument("--package", default="ModernBERT-base-64.mlpackage")
 parser.add_argument("--data", default=".")
+parser.add_argument("--binary", default=os.path.join(HERE, ".build/release/ParrotFlow"))
 parser.add_argument("--count", type=int, default=40)
 parser.add_argument("--out")
 args = parser.parse_args()
-(tokens if args.what == "tokens" else scores)(args)
+(tokens if args.what == "tokens" else readings)(args)

--- a/tests/sentence-boundary-cases.json
+++ b/tests/sentence-boundary-cases.json
@@ -3,360 +3,440 @@
   "set": "en_real.json",
   "left": "if it's because the release notes are not bigger than the height",
   "right": "Another features. If there is more than two fixes then there is",
-  "text": "if it's because the release notes are not bigger than the height [MASK] another features. If there is more than two fixes then there is",
-  "period": -8.129,
-  "next": -10.6172,
-  "score": 2.4883
+  "winner": ",",
+  "mean": {
+   ",": -4.5424,
+   ".": -4.7232,
+   "join": -4.8348
+  }
  },
  {
   "set": "en_real.json",
-  "left": "because it requires resolving that the negation is corrective rather than contrastive",
-  "right": "It's also where you can lose content or gain content that was",
-  "text": "because it requires resolving that the negation is corrective rather than contrastive [MASK] it's also where you can lose content or gain content that was",
-  "period": -0.6836,
-  "next": -8.9492,
-  "score": 8.2656
+  "left": "what we're doing anymore.I thought we had a success with audio clips",
+  "right": "We had a discussion about whether they make a different Vercel's rules",
+  "winner": ".",
+  "mean": {
+   ",": -4.7733,
+   ".": -4.699,
+   "join": -5.1087
+  }
  },
  {
   "set": "en_real.json",
-  "left": "No but that's not what I wanted",
-  "right": "I wanted to just go one by one. I don't need to",
-  "text": "No but that's not what I wanted [MASK] i wanted to just go one by one. I don't need to",
-  "period": -1.4398,
-  "next": -7.6351,
-  "score": 6.1953
+  "left": "though is that I didn't actually have the the bar fully filled",
+  "right": "It just there's a little space between the end and the where",
+  "winner": ",",
+  "mean": {
+   ",": -3.4374,
+   ".": -3.4649,
+   "join": -3.6519
+  }
  },
  {
   "set": "en_real.json",
-  "left": "They look great now",
-  "right": "But I still don't see the second permission prompt. The one asking",
-  "text": "They look great now [MASK] but I still don't see the second permission prompt. The one asking",
-  "period": -6.4992,
-  "next": -10.9211,
-  "score": 4.4219
+  "left": "with E4B? The yes-no?Also, if I understand correctly, the sequential doesn't hurt",
+  "right": "It's the same score. Right? For example, in sentences with only one",
+  "winner": ",",
+  "mean": {
+   ",": -3.8399,
+   ".": -3.9648,
+   "join": -4.1239
+  }
  },
  {
   "set": "en_real.json",
-  "left": "Yeah, that's how that's what I want. I want a tail",
-  "right": "So I want a C L command. So it would be like",
-  "text": "Yeah, that's how that's what I want. I want a tail [MASK] so I want a C L command. So it would be like",
-  "period": -5.6667,
-  "next": -8.8972,
-  "score": 3.2305
+  "left": "word and every LLM prompt receives the result of the previous one",
+  "right": "So for example, if the first word was resolved. Then it is",
+  "winner": ".",
+  "mean": {
+   ",": -3.3248,
+   ".": -3.2496,
+   "join": -3.6689
+  }
  },
  {
   "set": "en_real.json",
-  "left": "terminal and have the logs or the traces as dictations come in",
-  "right": "And would it be a separate data structure or would it come",
-  "text": "terminal and have the logs or the traces as dictations come in [MASK] and would it be a separate data structure or would it come",
-  "period": -3.9536,
-  "next": -4.5551,
-  "score": 0.6016
+  "left": "would just use Python for everything. I would drop Ollama in Swift",
+  "right": "It's not necessarily it's not necessary.I would just implement a pipeline runner",
+  "winner": ".",
+  "mean": {
+   ",": -4.4803,
+   ".": -4.2846,
+   "join": -4.8066
+  }
  },
  {
   "set": "en_real.json",
-  "left": "Greptile's remaining objection has moved to overlapping completions and an inline-fallback field",
-  "right": "Not acted on, per the standing constraint. Worth noting only that it",
-  "text": "Greptile's remaining objection has moved to overlapping completions and an inline-fallback field [MASK] not acted on, per the standing constraint. Worth noting only that it",
-  "period": -6.9337,
-  "next": -7.8321,
-  "score": 0.8984
+  "left": "go to A remote AI provider.Here a feature is it's using parakeet",
+  "right": "Blazing fast. local Transcription. Model.",
+  "winner": ".",
+  "mean": {
+   ",": -6.4425,
+   ".": -5.8092,
+   "join": -7.0589
+  }
  },
  {
   "set": "en_real.json",
-  "left": "So draft me a quick informal plan",
-  "right": "Make it visual and use scratchml",
-  "text": "So draft me a quick informal plan [MASK] make it visual and use scratchml",
-  "period": -5.5445,
-  "next": -10.0679,
-  "score": 4.5234
+  "left": "They can be selected with arrows left, right, and enter",
+  "right": "And of course, the focus is there. When the hood appears. Show",
+  "winner": ".",
+  "mean": {
+   ",": -4.8708,
+   ".": -4.7668,
+   "join": -5.3261
+  }
  },
  {
   "set": "en_real.json",
-  "left": "The sentence is about cooking",
-  "right": "An accounting system does not go in a sauce.",
-  "text": "The sentence is about cooking [MASK] an accounting system does not go in a sauce.",
-  "period": -5.4783,
-  "next": -8.4158,
-  "score": 2.9375
+  "left": "hesitations, mumbling, and hesitations and back and forth like For example this",
+  "right": "I was with Peter, not with Peter, with James. And uh we",
+  "winner": ".",
+  "mean": {
+   ",": -4.7378,
+   ".": -4.6674,
+   "join": -4.8519
+  }
  },
  {
   "set": "en_real.json",
-  "left": "one transforms I would like you to create",
-  "right": "So if you say PR followed by a number or PR number",
-  "text": "one transforms I would like you to create [MASK] so if you say PR followed by a number or PR number",
-  "period": -2.834,
-  "next": -5.0762,
-  "score": 2.2422
+  "left": "recognize. For example, in my case it would be French and English",
+  "right": "And then all the prompts would be localized. So instead of trying",
+  "winner": ",",
+  "mean": {
+   ",": -3.5624,
+   ".": -3.6951,
+   "join": -3.7934
+  }
  },
  {
   "set": "en_real.json",
-  "left": "merci — on the line above",
-  "right": "If it is anything else — a question, a",
-  "text": "merci — on the line above [MASK] if it is anything else — a question, a",
-  "period": -6.0009,
-  "next": -8.6416,
-  "score": 2.6406
+  "left": "want. I want a tail. So I want a C L command",
+  "right": "So it would be like a Swift script or a Python one.",
+  "winner": ".",
+  "mean": {
+   ",": -3.8735,
+   ".": -3.7349,
+   "join": -4.1465
+  }
  },
  {
   "set": "en_real.json",
-  "left": "that is already punctuated by parakeet.So punctuation need to replace existing punctuation",
-  "right": "For example, if You say to wait exclamation point. This will still",
-  "text": "that is already punctuated by parakeet.So punctuation need to replace existing punctuation [MASK] for example, if You say to wait exclamation point. This will still",
-  "period": -1.1377,
-  "next": -8.8565,
-  "score": 7.7188
+  "left": "also I want a panel showing up when the appis laucnching",
+  "right": "It seems like when you open the app, the only visible effect",
+  "winner": ".",
+  "mean": {
+   ",": -3.4459,
+   ".": -3.2952,
+   "join": -3.6826
+  }
  },
  {
   "set": "en_real.json",
-  "left": "that we want to sing the substitute First names with Slack handles",
-  "right": "But not systematically. For example, I can write a message in Slack",
-  "text": "that we want to sing the substitute First names with Slack handles [MASK] but not systematically. For example, I can write a message in Slack",
-  "period": -6.7232,
-  "next": -8.8755,
-  "score": 2.1523
+  "left": "of the seven terms with none — that puts 23 rows back",
+  "right": "Do not ship MFCC + DTW; it was chosen to be cheap,",
+  "winner": ".",
+  "mean": {
+   ",": -5.6053,
+   ".": -5.3177,
+   "join": -6.0445
+  }
  },
  {
   "set": "en_real.json",
-  "left": "a model name. And spelling and the model name.In the example config",
-  "right": "The model name would be ollma, but commented out.",
-  "text": "a model name. And spelling and the model name.In the example config [MASK] the model name would be ollma, but commented out.",
-  "period": -4.8133,
-  "next": -7.6727,
-  "score": 2.8594
+  "left": "and the one sentence definition. At the beginning it could be mind",
+  "right": "It could be mind from slack. With a good prompt in the",
+  "winner": ".",
+  "mean": {
+   ",": -4.5113,
+   ".": -4.4676,
+   "join": -4.9026
+  }
  },
  {
   "set": "en_real.json",
-  "left": "very marginal improvement, maybe not significant, but at least it seems fine",
-  "right": "So I'd keep it on.",
-  "text": "very marginal improvement, maybe not significant, but at least it seems fine [MASK] so I'd keep it on.",
-  "period": -5.467,
-  "next": -11.3264,
-  "score": 5.8594
+  "left": "so the point was to ed to iterate on the dictating pill",
+  "right": "So the HUD we see while dictating.Can you make a few suggestions?We",
+  "winner": ",",
+  "mean": {
+   ",": -5.5819,
+   ".": -5.6519,
+   "join": -5.8956
+  }
  },
  {
   "set": "en_real.json",
   "left": "But there can be a replacement",
   "right": "Why can't we count it?",
-  "text": "But there can be a replacement [MASK] why can't we count it?",
-  "period": -6.5019,
-  "next": -10.459,
-  "score": 3.957
+  "winner": ",",
+  "mean": {
+   ",": -4.5357,
+   ".": -4.5907,
+   "join": -4.9913
+  }
  },
  {
   "set": "en_real.json",
   "left": "So I was prompted but declined before I dictated anything",
   "right": "Then I dictated something, asked to fix grammar. And nothing happened.",
-  "text": "So I was prompted but declined before I dictated anything [MASK] then I dictated something, asked to fix grammar. And nothing happened.",
-  "period": -3.5358,
-  "next": -9.1686,
-  "score": 5.6328
+  "winner": ".",
+  "mean": {
+   ",": -4.4033,
+   ".": -4.3052,
+   "join": -4.8071
+  }
  },
  {
   "set": "en_real.json",
-  "left": "a nice lettering, that would be cool. Use the front-end design skill",
-  "right": "And we don't need more information, we don't need the models, we",
-  "text": "a nice lettering, that would be cool. Use the front-end design skill [MASK] and we don't need more information, we don't need the models, we",
-  "period": -3.6183,
-  "next": -8.6066,
-  "score": 4.9883
+  "left": "it For claude code for now so we can have an idea",
+  "right": "Make it a system pipeline stage similarly to numbers replacements or fuzzy.",
+  "winner": ".",
+  "mean": {
+   ",": -7.0792,
+   ".": -7.013,
+   "join": -7.5715
+  }
  },
  {
   "set": "en_real.json",
-  "left": "I saw our pop up to ask the permission from the microphone",
-  "right": "I accepted but it was already done so I directly got the",
-  "text": "I saw our pop up to ask the permission from the microphone [MASK] i accepted but it was already done so I directly got the",
-  "period": -4.5669,
-  "next": -10.1138,
-  "score": 5.5469
+  "left": "use a reject transform and add simple date transformation for the script",
+  "right": "For the pipeline you want to add the grammar check only on",
+  "winner": ".",
+  "mean": {
+   ",": -4.3696,
+   ".": -4.332,
+   "join": -4.7515
+  }
  },
  {
   "set": "en_real.json",
-  "left": "But we can verify that the input is empty",
-  "right": "Or maybe the string length.",
-  "text": "But we can verify that the input is empty [MASK] or maybe the string length.",
-  "period": -3.8985,
-  "next": -6.9845,
-  "score": 3.0859
+  "left": "Then mention Ollama setup. So if the model is there, fine",
+  "right": "If Ollama is there but not the model, just say you're download",
+  "winner": ".",
+  "mean": {
+   ",": -2.8632,
+   ".": -2.8385,
+   "join": -3.1508
+  }
  },
  {
   "set": "en_cuts.json",
   "left": "alive is not working because the first usage of the LLM with.",
   "right": "The vocabulary is slower",
-  "text": "alive is not working because the first usage of the LLM with [MASK] the vocabulary is slower",
-  "period": -10.2926,
-  "next": -5.2262,
-  "score": -5.0664
+  "winner": "join",
+  "mean": {
+   ",": -6.5327,
+   ".": -7.2669,
+   "join": -4.5571
+  }
  },
  {
   "set": "en_cuts.json",
   "left": "So okay, sure, let's rebase let's get.",
   "right": "In your the scratch pad",
-  "text": "So okay, sure, let's rebase let's get [MASK] in your the scratch pad",
-  "period": -11.2182,
-  "next": -7.0815,
-  "score": -4.1367
+  "winner": "join",
+  "mean": {
+   ",": -6.8226,
+   ".": -7.1884,
+   "join": -6.4815
+  }
  },
  {
   "set": "en_cuts.json",
   "left": "A local, fast and programmable dictation tool shaped around.",
   "right": "Your voice and your work",
-  "text": "A local, fast and programmable dictation tool shaped around [MASK] your voice and your work",
-  "period": -7.9156,
-  "next": -5.8297,
-  "score": -2.0859
+  "winner": "join",
+  "mean": {
+   ",": -5.3496,
+   ".": -5.549,
+   "join": -4.8613
+  }
  },
  {
   "set": "en_cuts.json",
   "left": "I mean, can we use Olama as an.",
   "right": "Interface for commercial models",
-  "text": "I mean, can we use Olama as an [MASK] interface for commercial models",
-  "period": -12.9462,
-  "next": -4.454,
-  "score": -8.4922
+  "winner": "join",
+  "mean": {
+   ",": -7.9847,
+   ".": -9.042,
+   "join": -6.3771
+  }
  },
  {
   "set": "en_cuts.json",
   "left": "I want to do all this in.",
   "right": "Another in a subsequent one",
-  "text": "I want to do all this in [MASK] another in a subsequent one",
-  "period": -8.7312,
-  "next": -3.9109,
-  "score": -4.8203
+  "winner": "join",
+  "mean": {
+   ",": -7.0436,
+   ".": -7.8443,
+   "join": -6.427
+  }
  },
  {
   "set": "en_cuts.json",
   "left": "and btw when pressing Enter to submit the text the hud.",
   "right": "Should also vanish immediatly and stop decaying",
-  "text": "and btw when pressing Enter to submit the text the hud [MASK] should also vanish immediatly and stop decaying",
-  "period": -9.0805,
-  "next": -8.7641,
-  "score": -0.3164
+  "winner": "join",
+  "mean": {
+   ",": -5.1434,
+   ".": -5.7522,
+   "join": -4.6921
+  }
  },
  {
   "set": "en_cuts.json",
   "left": "Context could be the dictation before or.",
   "right": "After, or what was on the screen",
-  "text": "Context could be the dictation before or [MASK] after, or what was on the screen",
-  "period": -10.3953,
-  "next": -8.1531,
-  "score": -2.2422
+  "winner": "join",
+  "mean": {
+   ",": -4.0757,
+   ".": -4.927,
+   "join": -3.4596
+  }
  },
  {
   "set": "en_cuts.json",
   "left": "The script has not changed, the permissions were still there, and.",
   "right": "Parakeet was immediately available",
-  "text": "The script has not changed, the permissions were still there, and [MASK] parakeet was immediately available",
-  "period": -10.3499,
-  "next": -12.9476,
-  "score": 2.5977
+  "winner": "join",
+  "mean": {
+   ",": -6.6327,
+   ".": -6.4023,
+   "join": -5.9606
+  }
  },
  {
   "set": "en_cuts.json",
   "left": "before the judge and only let the judge decide between what was.",
   "right": "Heard by the decoder and what the decoder found similar",
-  "text": "before the judge and only let the judge decide between what was [MASK] heard by the decoder and what the decoder found similar",
-  "period": -11.2402,
-  "next": -6.3496,
-  "score": -4.8906
+  "winner": "join",
+  "mean": {
+   ",": -4.9563,
+   ".": -5.7212,
+   "join": -4.1484
+  }
  },
  {
   "set": "en_cuts.json",
   "left": "I've done plenty I've.",
   "right": "Done it plenty of times now",
-  "text": "I've done plenty I've [MASK] done it plenty of times now",
-  "period": -7.4716,
-  "next": -3.1278,
-  "score": -4.3438
+  "winner": "join",
+  "mean": {
+   ",": -4.3004,
+   ".": -4.7469,
+   "join": -3.5804
+  }
  },
  {
   "set": "en_cuts.json",
   "left": "Do a grammar check on the selected text.",
   "right": "And also write a section about what's gonna be installed succinctly",
-  "text": "Do a grammar check on the selected text [MASK] and also write a section about what's gonna be installed succinctly",
-  "period": -5.3806,
-  "next": -7.7634,
-  "score": 2.3828
+  "winner": ",",
+  "mean": {
+   ",": -4.5424,
+   ".": -4.7987,
+   "join": -4.9485
+  }
  },
  {
   "set": "en_cuts.json",
   "left": "pinned row could clear a newer.",
   "right": "Prompt after focus advances",
-  "text": "pinned row could clear a newer [MASK] prompt after focus advances",
-  "period": -9.095,
-  "next": -7.509,
-  "score": -1.5859
+  "winner": "join",
+  "mean": {
+   ",": -8.2565,
+   ".": -9.3067,
+   "join": -8.0804
+  }
  },
  {
   "set": "en_cuts.json",
   "left": "Mira and Mira were on.",
   "right": "Vacation and have visited Versailles Castle while the app was being deployed",
-  "text": "Mira and Mira were on [MASK] vacation and have visited Versailles Castle while the app was being deployed",
-  "period": -13.1884,
-  "next": -5.5243,
-  "score": -7.6641
+  "winner": "join",
+  "mean": {
+   ",": -6.1118,
+   ".": -6.4798,
+   "join": -5.2982
+  }
  },
  {
   "set": "en_cuts.json",
   "left": "I'd like to use some sort of.",
   "right": "Object programming, interface and implementation classes on top",
-  "text": "I'd like to use some sort of [MASK] object programming, interface and implementation classes on top",
-  "period": -9.6188,
-  "next": -7.0211,
-  "score": -2.5977
+  "winner": "join",
+  "mean": {
+   ",": -6.0146,
+   ".": -6.7599,
+   "join": -5.713
+  }
  },
  {
   "set": "en_cuts.json",
   "left": "So how would you.",
   "right": "Use in practice a negative example",
-  "text": "So how would you [MASK] use in practice a negative example",
-  "period": -9.0791,
-  "next": -4.9854,
-  "score": -4.0938
+  "winner": "join",
+  "mean": {
+   ",": -6.1502,
+   ".": -7.1025,
+   "join": -5.6097
+  }
  },
  {
   "set": "en_cuts.json",
   "left": "Can you give me an.",
   "right": "Example so that I understand visually",
-  "text": "Can you give me an [MASK] example so that I understand visually",
-  "period": -12.5818,
-  "next": -2.5701,
-  "score": -10.0117
+  "winner": "join",
+  "mean": {
+   ",": -6.1552,
+   ".": -6.9377,
+   "join": -4.7663
+  }
  },
  {
   "set": "en_cuts.json",
   "left": "ordinary word, however much.",
   "right": "It looks like one of them",
-  "text": "ordinary word, however much [MASK] it looks like one of them",
-  "period": -6.7032,
-  "next": -6.8438,
-  "score": 0.1406
+  "winner": "join",
+  "mean": {
+   ",": -4.1409,
+   ".": -4.384,
+   "join": -3.7565
+  }
  },
  {
   "set": "en_cuts.json",
   "left": "Can you make the.",
   "right": "Type menu more visible because it seems like it's very small compared",
-  "text": "Can you make the [MASK] type menu more visible because it seems like it's very small compared",
-  "period": -11.899,
-  "next": -5.9771,
-  "score": -5.9219
+  "winner": "join",
+  "mean": {
+   ",": -5.1884,
+   ".": -5.3842,
+   "join": -4.183
+  }
  },
  {
   "set": "en_cuts.json",
   "left": "Okay, the same happened but there was another still window.",
   "right": "From a maybe a previous process still open",
-  "text": "Okay, the same happened but there was another still window [MASK] from a maybe a previous process still open",
-  "period": -7.2939,
-  "next": -7.7392,
-  "score": 0.4453
+  "winner": "join",
+  "mean": {
+   ",": -6.0344,
+   ".": -6.4879,
+   "join": -5.8647
+  }
  },
  {
   "set": "en_cuts.json",
   "left": "As usual, check Greptile reviews, address comments, and continue.",
   "right": "Until Greptile is happy",
-  "text": "As usual, check Greptile reviews, address comments, and continue [MASK] until Greptile is happy",
-  "period": -8.0153,
-  "next": -8.4684,
-  "score": 0.4531
+  "winner": "join",
+  "mean": {
+   ",": -3.2308,
+   ".": -4.3363,
+   "join": -2.7409
+  }
  }
 ]


### PR DESCRIPTION
A pause mid-sentence makes the transcriber write a period and capitalise the next word. The stage that repairs this scored the boundary with ModernBERT and compared the score to two thresholds. It repaired 26% of the cuts, and the threshold could not be raised: it was set by the single lowest-scoring real sentence ending out of 180. The boundary is a choice now. Every `word. Capital` boundary is read once per mark and once with no mark at all, each reading is scored per token by `mlx-community/Qwen3-0.6B-Base-4bit` (320 MB, new download), and the highest wins. On the user's own dictation that repairs 81% of 140 cuts and joins none of 172 real endings, at 50 ms median per boundary. The new setting is `transcription.sentences.marks`, default `[".", ","]`; `sentences: false` still turns the stage off.

Start the review at `SentenceReadings.swift`. Check three things there: the readings are scored **per token**, not summed; the comma is a reading and not a term in a subtraction; and the guard in `score` that handles a prefix which retokenises inside the full sequence. Then check the fail-open path in `SentenceJoin.apply` — a dictation that arrives before the weights are in memory keeps its boundaries and starts the load, it never waits.

Closes #260.

<details>
<summary>Measured through the binary — 81% of 140 cuts repaired, 0 wrong joins of 172</summary>

Bench: `~/Documents/parrotflow-scratch/sentence-join/harness/en_real_nf.json` (194 real endings) and `en_cuts_nf.json` (130 cuts), with `en_real_labels.json` applied as `qwen-timing/eval_argmax.py` applies it — `join` moves to the cut set, `drop` and `tie` are removed. Run through `--sentence-probe --bench`, which is this PR's own code.

| | repaired | wrong joins |
|---|---|---|
| shipped ModernBERT at `join_below: -4` | 26% | 0 of 172 |
| **this PR, Qwen3-0.6B-Base-4bit, three readings batched** | **114 of 140 (81%)** | **0 of 172** |

**81%, not the issue's 82%.** The issue's headline is the naive arm, which runs one forward pass per reading. This PR batches the three readings into one padded pass, which is 1.4x faster and repairs one cut fewer. `qwen-timing/RESULT.md` §4 records the same: 114 batched against 115 naive, 0 wrong joins either way.

Row-by-row against the reference `swift_qmarks_base4bit.json` `batched` field: 323 of 324 boundaries agree to the last digit (max |delta| 0.00000). The one that differs is `real i=5`, and it differs because of the retokenisation guard — see the block below.

</details>

<details>
<summary>Stripping fillers first buys nothing now — the pipeline order stays</summary>

The issue asked whether the stage should run after the `fillers` step instead of before it. Stripping fillers was worth 14 points to the old threshold, because it moved the safe line. An argmax has no line to move, and the measurement says the value is zero.

Both file pairs scored through the same binary:

| | repaired | wrong joins |
|---|---|---|
| `*_nf.json`, fillers stripped | 114 of 140 (81%) | 0 of 172 |
| `en_real.json` / `en_cuts.json`, fillers kept | 114 of 140 (81%) | 0 of 172 |

5 of 324 decisions differ, and all five are `.` against `,`. Both mean leave the boundary alone, so no text changes. No join decision differs.

Worth knowing why the effect is so small: only 22 of the 324 boundaries have any filler in their ±12-word window at all. The two file pairs are identical text on the other 302.

**Recommendation: leave the order as it is.** Do not move this stage after `fillers` for the sake of the boundary decision.

</details>

<details>
<summary>The retokenisation guard fired on 1 of 324 boundaries, and cost nothing</summary>

`tokenize(prefix + continuation).prefix(p)` is not always `tokenize(prefix)`. On 2 of 972 bench sequences the boundary character merges into the last prefix token. The case is a left side ending `names).`. Slicing the continuation at the prefix's length then scores the wrong tokens.

`SentenceReadings.score` compares each full sequence against the prefix ids and starts the scored span at the first token that actually differs. It fired once, on `real i=5`:

    stored (unguarded)   .  -6.1517   ,  -6.2821   join  -6.6884
    guarded              .  -5.6512   ,  -5.6379   join  -6.6884

The argmax flips from `.` to `,`. Both mean leave the boundary alone, so 0 wrong joins of 172 holds. `join` is unchanged and still loses.

It is belt-and-braces in the app: `SentenceJoin.boundaries(in:)` already skips a period whose preceding character is not a letter or a digit, so `names).` would never reach the scorer. The guard is there because the trap sits under any prefix-sharing optimisation, and the next person to try one should find it handled.

</details>

<details>
<summary>Latency and memory — 50 ms median, and why the buffer pool is capped at 256 MB</summary>

M2 Pro, 32 GB, macOS 27.0. Ollama resident, other agents running on the same machine, so the load average moved between runs and is given with each number. `--sentence-probe --bench`, release build, the first decision dropped because it pays the Metal kernel compile.

| load average | models resident | boundaries | median | p95 |
|---:|---|---:|---:|---:|
| 14.7 | readings only | 194 real | 50.9 ms | 88.1 ms |
| 14.7 | readings only | 130 cuts | 56.0 ms | 87.6 ms |
| 10.9 | readings + word vectors | 130 cuts | 48.8 ms | 85.7 ms |
| 5.6 | readings + word vectors | 130 cuts | 36.1 ms | 50.9 ms |

The reference run measured 50.1 ms median at load 5.5–10, so this reproduces. The p95 is the tail a contended GPU gives.

Memory, both MLX models in one process, after 130 boundaries:

| buffer-pool limit | MLX active | MLX cache | MLX peak | process peak footprint | median |
|---|---:|---:|---:|---:|---:|
| 256 MB (this PR) | 639 MB | 256 MB | 837 MB | 1.25 GB | 36.1 ms |
| 2 GB (effectively none) | 639 MB | 1038 MB | 838 MB | 1.87 GB | 36.1 ms |

256 MB holds 620 MB less and costs nothing measurable. `WordVectors` set no limit before this PR, so the cap now lives in `MLXModelCache.limitBufferPool()` and is applied by whichever MLX model loads first.

Weights on disk 320 MB. Load 1.3 s warm; nothing waits for it.

</details>

<details>
<summary>Deliberate removals, and one that goes beyond the issue</summary>

**The offer tier.** `Tier.offer` is gone. An argmax has no threshold to hedge with, so there is no middle to report. `Tier` is now `join` and `leave`.

**`join_below` and `offer_below`.** Both keys are still parsed, and `--check-config` reports each as a notice:

    · sentences: `join_below:` was a threshold on a score. The boundary is settled
      by which reading the model scores highest now, so there is nothing left to set

The config still loads and the stage still runs. `sentences: false` and `sentences: {…}` are both still valid. Two shapes of `marks:` are refused. An empty list, because with no mark the join is the only reading and every period in the transcript would go. And anything that is not a single punctuation character: a mark is written into the sentence as punctuation, and the word `join` is the name of the reading that removes the period, so `marks: ["join"]` would have removed one.

**`sentences.offered`** is removed from the pipeline scope. Nothing in `docs/`, `tests/` or `scripts/` read it. `sentences.joined` stays.

**Beyond what the issue asked for: `SentenceProbe.read()`, its `Reading` struct, `Failure.empty` and the `period` field are deleted.** They existed only to compute `log P(".") − log P(" next")` for this stage, and nothing called them once `SentenceJoin` stopped. `SentenceProbe.at`, `Slot`, `top`, `SentenceModel`, `BPETokenizer`, the ModernBERT cache directory and `check-tokenizer.sh` are all untouched — `SlotGate` and `SlotReference` still read them, and #261 is what moves that side. Say the word and I will put `read()` back.

**Not changed: `PipelineCommand.swift:196`.** `--pipeline --warm` loads ModernBERT for the vocabulary slot gate, which still needs it. The sentence join is not a pipeline stage, so nothing there wants the readings.

</details>

<details>
<summary>What the fixture and the two check scripts do now</summary>

`tests/sentence-boundary-cases.json` is rebuilt: 40 boundaries, 20 real endings and 20 cuts, each with the per-token score of every reading and the winner. It is generated by `scripts/sentence-probe-reference.py readings`, which runs the release binary's `--sentence-probe --bench` and stores what came back, so the fixture is by construction what the binary produces. Real endings carrying a hand label (`join`, `drop`, `tie`) are left out — none of the three is a real ending a join would spoil.

`scripts/check-sentence-probe.sh` compares the three scores and the winner, case by case, in one loaded process. 40/40, worst gap 0.0000.

`scripts/check-sentence-join.sh` glues each case back into one text, runs `--sentence-join`, and checks the scores and the decisions. 19 of 20 cuts repaired, 0 of 20 real periods joined, worst gap 0.0000. A joined real period fails the run on its own.

Neither is in CI: they need the 320 MB model. Both were run by hand for this PR, along with `check-tokenizer.sh` (19/19), `check-sentence-case.sh` (31/31, and it is in CI) and `check-sentence-open.sh`.

`--sentence-probe --bench <cases.json> --out <scores.json>` is new. One process per boundary pays the 1.3 s load every time, so it is the only way to get a latency number or to score a whole bench. `--vectors` loads the word vectors as well, so the memory line describes the process the app runs.

</details>

<details>
<summary>Review notes: the shared loader, and one flaky local check</summary>

The first commit is a refactor with no behaviour change. `WordVectors` held the download, the `flock`, the staging directory, the de-duplicated progress and the `FolderTokenizer` adapter. Two models need all of that now, so it is `MLXModelCache`. Same repository, same file list, same cache directory, same lock path. `--word-vector` was run before and after.

`make test` passes. One case, `every stage's variables survive the stages after it`, fails about one run in four **on this machine**. The failing dump shows `vocabulary.gate_ms = 186`, so the vocabulary gate's model ran and changed `vocabulary.count`. CI has no models, so the gate stands aside there and the case is deterministic. This PR does not touch the vocabulary gate. Flagging it rather than chasing it; CI is the check that matters.

</details>

- [x] `make test` passes.
- [x] A prompt or pattern change is scored, and the numbers are above.
- [x] Every commit is signed off — `git commit -s`. See [CONTRIBUTING.md](../CONTRIBUTING.md).

