### PR TITLE
feat: a pause that wrote a question mark is repaired too

### DIFF
--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1652,26 +1652,30 @@ struct Config: Decodable, Equatable {
         /// at all.
         var languages: [String] = ["en"]
 
-        /// When a period the transcriber wrote is taken out again — see
+        /// When a mark the transcriber wrote is taken out again — see
         /// `SentenceJoin`.
         ///
-        ///     sentences: false          never look at a boundary
+        ///     sentences: false               never look at a boundary
         ///     sentences:
-        ///       marks: [".", ","]       the marks tried beside the join
+        ///       marks: [".", ",", "?"]       what a boundary can be written
         ///
         /// Two spellings, like `review:` on a pipeline step: a bare `false`
         /// turns the stage off, anything else says what it runs with.
         ///
-        /// There is no threshold. Every boundary is read as many ways as there
-        /// are marks, plus once with no mark at all, and the reading the model
-        /// scores highest is the one that is written. `;` and `:` were measured
-        /// and never changed a decision in English, so the default is the two
-        /// that do.
+        /// One list, two jobs. The sentence enders in it — `.` and `?` — are
+        /// where a boundary is looked for. Everything else in it — the comma —
+        /// is a reading tried at every boundary. So a boundary is read three
+        /// ways: the mark it carries, the comma, and no mark at all. Drop `?`
+        /// from the list and question marks stop being scanned.
+        ///
+        /// There is no threshold; the reading the model scores highest is the
+        /// one that is written. `;` and `:` were measured and never changed a
+        /// decision in English, so they are not in the default.
         var sentences: Sentences = Sentences()
 
         struct Sentences: Decodable, Equatable {
             var enabled = true
-            var marks: [String] = [".", ","]
+            var marks: [String] = [".", ",", "?"]
 
             /// Keys still read and no longer acted on, for `notices()`.
             var legacy: [String] = []
@@ -1707,6 +1711,18 @@ struct Config: Decodable, Equatable {
                             value: "an empty list",
                             expected: "at least one mark — with none, joining is the only"
                                 + " reading and every period would be removed"
+                        )
+                    }
+                    // The enders in the list are where a boundary is looked
+                    // for. With none the stage finds nothing and does nothing,
+                    // which is what `sentences: false` is for.
+                    guard kept.contains(where: { SentenceReadings.enders.contains($0) }) else {
+                        throw ConfigError.invalidValue(
+                            key: "transcription.sentences.marks",
+                            value: kept.map { "`\($0)`" }.joined(separator: ", "),
+                            expected: "at least one of `.`, `?` or `!` — those are where a"
+                                + " boundary is looked for, so with none the stage never runs."
+                                + " Use `sentences: false` to turn it off"
                         )
                     }
                     // A mark is one punctuation character. Any word here would

--- a/Sources/ParrotFlow/SentenceJoin.swift
+++ b/Sources/ParrotFlow/SentenceJoin.swift
@@ -9,15 +9,22 @@ import NaturalLanguage
 ///     said     "you should see a parrot at the top right of your screen"
 ///     written  "You should see a parrot. At the top right of your screen."
 ///
-/// Every `word. Capital` boundary in the finished transcript is read three
-/// ways by `SentenceReadings` — with a period, with a comma, and with nothing
-/// at all — and the reading the language model scores highest is the one that
-/// is written. Nothing is compared to a threshold, so there is nothing to
-/// calibrate. Where the joined reading wins, the period is removed and the
-/// word after it is lowercased.
+/// Every boundary in the finished transcript is read three ways by
+/// `SentenceReadings` — with the mark the transcriber wrote, with a comma, and
+/// with nothing at all — and the reading the language model scores highest is
+/// the one that is written. Nothing is compared to a threshold, so there is
+/// nothing to calibrate. Where the joined reading wins, the mark is removed
+/// and the word after it is lowercased.
 ///
 /// The thresholds this used to carry repaired 26% of the cuts. The choice
-/// repairs 81%, and joins none of 172 real sentence endings.
+/// repairs 81% of the period cuts and joins none of 172 real sentence endings,
+/// and 82% of the question cuts at one wrong join in 111 real questions.
+///
+/// A pause is written `word? Capital` or `word? lowercase` about a quarter as
+/// often as `word. Capital`, so question marks are scanned as well. A period
+/// followed by a lowercase word is not: the transcriber did not start a
+/// sentence there, and the shape has never been measured. A capital with no
+/// mark in front of it is not either — it does not separate (AUC 0.750).
 ///
 /// English only. The reading is scored by an English base model, and the mark
 /// set is English: French wants `:` where English does not.
@@ -43,7 +50,8 @@ actor SentenceJoin {
         }
     }
 
-    /// One boundary, read every way. `change` reads `parrot. At -> parrot at`.
+    /// One boundary, read every way. `change` reads `parrot. At -> parrot at`,
+    /// with the mark the transcriber wrote.
     struct Reading: Sendable {
         let change: String
         let scores: [SentenceReadings.Score]
@@ -63,41 +71,67 @@ actor SentenceJoin {
         }
     }
 
-    /// One `word. Capital` boundary: the period, and the word after it.
+    /// One boundary: where the mark is, which mark it is, and the word after
+    /// it. The mark travels with the boundary so the readings, the log line
+    /// and the change all name the one the transcriber wrote.
     struct Boundary {
-        let period: String.Index
+        let at: String.Index
+        let mark: Character
         let next: Range<String.Index>
     }
 
-    /// Tags a capital must survive. A name stays a name once the period goes.
+    /// Marks that only start a boundary in front of a capital.
+    ///
+    /// `word? lowercase` is a boundary: of 19 such lines in the user's
+    /// dictation, 7 hold a spurious mark and 12 a real question, so the reading
+    /// has to decide and no rule can. `word. lowercase` is left alone, because
+    /// that shape has never been measured.
+    static let capitalOnly: Set<Character> = ["."]
+
+    /// Where a boundary is looked for: the sentence enders in the configured
+    /// mark list. The rest of the list — the comma — is a reading tried at a
+    /// boundary, not a place to find one.
+    static func scanned(_ marks: [String]) -> Set<Character> {
+        Set(marks.filter { SentenceReadings.enders.contains($0) }.compactMap(\.first))
+    }
+
+    /// Tags a capital must survive. A name stays a name once the mark goes.
     static let names: Set<String> = ["PersonalName", "PlaceName", "OrganizationName"]
 
     // MARK: - Finding the boundaries
 
-    /// Every place a period is followed by a capitalised word.
+    /// Every place one of `marks` is followed by a word.
     ///
-    /// Three things that look like one and are not. A period inside a run of
-    /// them is an ellipsis. A period after a single letter is an initial —
-    /// "J. Smith". A period after anything but a letter or a digit is closing
-    /// something rather than ending a sentence.
-    static func boundaries(in text: String) -> [Boundary] {
+    /// Three things that look like a boundary and are not. A mark inside a run
+    /// of them is an ellipsis or a stutter. A mark after a single letter is an
+    /// initial — "J. Smith". A mark after anything but a letter or a digit is
+    /// closing something rather than ending a sentence.
+    static func boundaries(in text: String, scanning marks: Set<Character>) -> [Boundary] {
         var found: [Boundary] = []
         var cursor = text.startIndex
-        while let period = text[cursor...].firstIndex(of: ".") {
-            cursor = text.index(after: period)
-            guard period > text.startIndex, cursor < text.endIndex, text[cursor] != "." else {
+        while let at = text[cursor...].firstIndex(where: { marks.contains($0) }) {
+            let mark = text[at]
+            cursor = text.index(after: at)
+            guard at > text.startIndex, cursor < text.endIndex, text[cursor] != mark else {
                 continue
             }
-            let word = text[..<period].reversed().prefix { $0.isLetter || $0.isNumber }
+            let word = text[..<at].reversed().prefix { $0.isLetter || $0.isNumber }
             guard word.count > 1 else { continue }
 
             var start = cursor
             while start < text.endIndex, text[start].isWhitespace {
                 start = text.index(after: start)
             }
-            guard start > cursor, start < text.endIndex, text[start].isUppercase else { continue }
-            let end = text[start...].firstIndex(where: \.isWhitespace) ?? text.endIndex
-            found.append(Boundary(period: period, next: start..<end))
+            guard start > cursor, start < text.endIndex, text[start].isLetter else { continue }
+            guard text[start].isUppercase || !capitalOnly.contains(mark) else { continue }
+            // The next word can carry the mark of the boundary after it —
+            // "…the format. Right? We have". The word stops before that mark,
+            // so the scan reaches it instead of stepping over it.
+            var end = text[start...].firstIndex(where: \.isWhitespace) ?? text.endIndex
+            while end > start, marks.contains(text[text.index(before: end)]) {
+                end = text.index(before: end)
+            }
+            found.append(Boundary(at: at, mark: mark, next: start..<end))
             cursor = end
         }
         return found
@@ -155,22 +189,22 @@ actor SentenceJoin {
         return word.prefix(1).lowercased() + word.dropFirst()
     }
 
-    /// The whole text with one period taken out, and where the word after it
+    /// The whole text with one mark taken out, and where the word after it
     /// then starts. Both halves of what `written` needs to tag.
     static func joining(_ text: String, at boundary: Boundary) -> (text: String, offset: Int) {
         var joined = text
-        joined.remove(at: boundary.period)
-        // The period sits before the word, so removing it moves the word one
+        joined.remove(at: boundary.at)
+        // The mark sits before the word, so removing it moves the word one
         // character left and nothing else moves at all.
         return (joined, text.distance(from: text.startIndex, to: boundary.next.lowerBound) - 1)
     }
 
     // MARK: - The pass
 
-    /// The transcript with the false periods taken out.
+    /// The transcript with the false sentence marks taken out.
     ///
     /// Every boundary is scored against the text as it arrived, not against
-    /// the text as it is being rebuilt. A join only removes a period, so the
+    /// the text as it is being rebuilt. A join only removes a mark, so the
     /// window a later boundary reads is the same words either way.
     ///
     /// Nothing here waits for the model. A dictation that arrives before the
@@ -179,7 +213,7 @@ actor SentenceJoin {
     func apply(to text: String, config: Config) async -> Outcome {
         let settings = config.transcription.sentences
         guard settings.enabled else { return .unchanged(text) }
-        let found = Self.boundaries(in: text)
+        let found = Self.boundaries(in: text, scanning: Self.scanned(settings.marks))
         guard !found.isEmpty else { return .unchanged(text) }
         guard await SentenceReadings.shared.isLoaded else {
             await SentenceReadings.shared.warm()
@@ -198,8 +232,9 @@ actor SentenceJoin {
             let scores: [SentenceReadings.Score]
             do {
                 scores = try await SentenceReadings.shared.read(
-                    left: String(text[..<boundary.period]),
+                    left: String(text[..<boundary.at]),
                     right: String(text[boundary.next.lowerBound...]),
+                    found: String(boundary.mark),
                     marks: settings.marks
                 )
             } catch {
@@ -214,9 +249,9 @@ actor SentenceJoin {
             let (whole, offset) = Self.joining(text, at: boundary)
             let now = Self.written(word, in: whole, at: offset, terms: terms)
             let before = String(
-                text[..<boundary.period].reversed().prefix { !$0.isWhitespace }.reversed()
+                text[..<boundary.at].reversed().prefix { !$0.isWhitespace }.reversed()
             )
-            let change = "\(before). \(word) -> \(before) \(now)"
+            let change = "\(before)\(boundary.mark) \(word) -> \(before) \(now)"
             let listed = scores
                 .map { String(format: "%@ %.2f", $0.key, $0.mean) }
                 .joined(separator: "  ")
@@ -227,8 +262,8 @@ actor SentenceJoin {
             readings.append(Reading(change: change, scores: scores, winner: best.key))
 
             if best.key == SentenceReadings.join {
-                rebuilt += text[cursor..<boundary.period]
-                rebuilt += text[text.index(after: boundary.period)..<boundary.next.lowerBound]
+                rebuilt += text[cursor..<boundary.at]
+                rebuilt += text[text.index(after: boundary.at)..<boundary.next.lowerBound]
                 rebuilt += now
                 cursor = boundary.next.upperBound
             }

--- a/Sources/ParrotFlow/SentenceJoinCommand.swift
+++ b/Sources/ParrotFlow/SentenceJoinCommand.swift
@@ -29,7 +29,8 @@ enum SentenceJoinCommand {
         let config = (try? ConfigStore.load()) ?? Config()
         if caseOnly {
             let terms = Array(config.vocabulary.terms.keys)
-            for boundary in SentenceJoin.boundaries(in: text) {
+            let scan = SentenceJoin.scanned(config.transcription.sentences.marks)
+            for boundary in SentenceJoin.boundaries(in: text, scanning: scan) {
                 let (whole, offset) = SentenceJoin.joining(text, at: boundary)
                 let word = String(text[boundary.next])
                 let now = SentenceJoin.written(word, in: whole, at: offset, terms: terms)

--- a/Sources/ParrotFlow/SentenceProbeCommand.swift
+++ b/Sources/ParrotFlow/SentenceProbeCommand.swift
@@ -4,10 +4,10 @@ import MLX
 /// `--sentence-probe` — is this period real, or did a pause cut one sentence
 /// in two?
 ///
-/// The two halves of the boundary, left then right. The period on the left is
-/// optional; the capital on the right is expected, because that is what the
-/// transcriber writes. Every reading of the boundary is scored, per token of
-/// the continuation, and the highest wins.
+/// The two halves of the boundary, left then right. The mark on the left says
+/// which boundary this is — end the left half with `?` to read a question, and
+/// with nothing or a period to read a period. Every reading of the boundary is
+/// scored, per token of the continuation, and the highest wins.
 ///
 ///     ParrotFlow --sentence-probe "…the LLM with." "The vocabulary is slower"
 ///       prefix    the first usage of the LLM with
@@ -22,17 +22,29 @@ import MLX
 ///
 /// `--bench <cases.json> --out <scores.json>` scores a whole file in one loaded
 /// process — `[{"left": …, "right": …}]` in, one row of scores out, with the
-/// milliseconds each decision took. One process per boundary would pay the 1.3s
+/// milliseconds each decision took. A row may carry `"mark": "?"` where the
+/// left half does not end with the mark itself. One process per boundary would pay the 1.3s
 /// load every time, so this is the only way to get a latency number. `--vectors`
 /// loads the word vectors as well, so the memory line describes the process the
 /// app actually runs, with both MLX models in it.
 @available(macOS 14, *)
 enum SentenceProbeCommand {
 
+    /// The mark the boundary carries, taken from the end of the left half. With
+    /// nothing there it is a period, which is what the transcriber writes most
+    /// of the time.
+    static func found(in left: String, marks: [String]) -> String {
+        if let last = left.last, SentenceJoin.scanned(marks).contains(last) {
+            return String(last)
+        }
+        return marks.first { SentenceReadings.enders.contains($0) } ?? "."
+    }
+
     static func run(left: String, right: String) -> Int32 {
         var exitCode: Int32 = 0
         let done = DispatchSemaphore(value: 0)
         let marks = ((try? ConfigStore.load()) ?? Config()).transcription.sentences.marks
+        let mark = found(in: left, marks: marks)
 
         Task {
             do {
@@ -42,11 +54,11 @@ enum SentenceProbeCommand {
                 }
                 print("\r\u{1B}[K", terminator: "")
                 guard let built = SentenceReadings.build(
-                    left: left, right: right, marks: marks
+                    left: left, right: right, found: mark, marks: marks
                 ) else { throw SentenceReadings.Failure.empty }
                 print("  prefix    \(built.prefix)")
                 let scores = try await SentenceReadings.shared.read(
-                    left: left, right: right, marks: marks
+                    left: left, right: right, found: mark, marks: marks
                 )
                 for score in scores {
                     // `%@` ignores a width on this platform, so the column
@@ -72,7 +84,14 @@ enum SentenceProbeCommand {
 
     /// Every boundary in a file, scored in one loaded process.
     static func bench(cases path: String, out: String?, vectors: Bool) -> Int32 {
-        struct Row: Decodable { let left: String; let right: String }
+        struct Row: Decodable {
+            let left: String
+            let right: String
+            /// The mark the boundary carries, where the left half does not end
+            /// with it. `enq_real.json` is mined by splitting on the mark, so
+            /// its left halves have none.
+            let mark: String?
+        }
         var exitCode: Int32 = 0
         let done = DispatchSemaphore(value: 0)
         let marks = ((try? ConfigStore.load()) ?? Config()).transcription.sentences.marks
@@ -88,8 +107,9 @@ enum SentenceProbeCommand {
                 var times: [Double] = []
                 for (i, row) in rows.enumerated() {
                     let start = DispatchTime.now().uptimeNanoseconds
+                    let mark = row.mark ?? found(in: row.left, marks: marks)
                     guard let scores = try? await SentenceReadings.shared.read(
-                        left: row.left, right: row.right, marks: marks
+                        left: row.left, right: row.right, found: mark, marks: marks
                     ) else { continue }
                     let winner = SentenceJoin.winner(of: scores)?.key ?? "none"
                     let elapsed = Double(
@@ -105,7 +125,7 @@ enum SentenceProbeCommand {
                     }
                     results.append([
                         "i": i, "mean": means, "n": tokens, "winner": winner,
-                        "ms": elapsed,
+                        "mark": mark, "ms": elapsed,
                         "retokenised": scores.contains(where: \.retokenised),
                     ])
                 }

--- a/Sources/ParrotFlow/SentenceProbeCommand.swift
+++ b/Sources/ParrotFlow/SentenceProbeCommand.swift
@@ -1,8 +1,8 @@
 import Foundation
 import MLX
 
-/// `--sentence-probe` — is this period real, or did a pause cut one sentence
-/// in two?
+/// `--sentence-probe` — is this sentence mark real, or did a pause cut one
+/// sentence in two?
 ///
 /// The two halves of the boundary, left then right. The mark on the left says
 /// which boundary this is — end the left half with `?` to read a question, and
@@ -23,10 +23,10 @@ import MLX
 /// `--bench <cases.json> --out <scores.json>` scores a whole file in one loaded
 /// process — `[{"left": …, "right": …}]` in, one row of scores out, with the
 /// milliseconds each decision took. A row may carry `"mark": "?"` where the
-/// left half does not end with the mark itself. One process per boundary would pay the 1.3s
-/// load every time, so this is the only way to get a latency number. `--vectors`
-/// loads the word vectors as well, so the memory line describes the process the
-/// app actually runs, with both MLX models in it.
+/// left half does not end with the mark itself. One process per boundary would
+/// pay the 1.3s load every time, so this is the only way to get a latency
+/// number. `--vectors` loads the word vectors as well, so the memory line
+/// describes the process the app actually runs, with both MLX models in it.
 @available(macOS 14, *)
 enum SentenceProbeCommand {
 

--- a/Sources/ParrotFlow/SentenceReadings.swift
+++ b/Sources/ParrotFlow/SentenceReadings.swift
@@ -3,14 +3,20 @@ import MLX
 import MLXLLM
 import MLXLMCommon
 
-/// Reads one `word. Capital` boundary three ways and says which reading the
-/// language model prefers.
+/// Reads one boundary three ways and says which reading the language model
+/// prefers.
 ///
 /// For `…the LLM with. The vocabulary is slower` the three readings are
 ///
 ///     ". The vocabulary is slower"     the period is real
 ///     " the vocabulary is slower"      the pause cut one sentence in two
 ///     ", the vocabulary is slower"     it is really a comma
+///
+/// The first reading is the mark the transcriber actually wrote, so a
+/// `word? Capital` boundary is read `"? Word"`, `", word"` and `" word"`.
+/// Reading every configured ender at every boundary was measured too and is
+/// worse: 259 of 325 question cuts repaired against 265, for a fourth forward
+/// pass.
 ///
 /// Each is scored as `sum of log P(token | everything before it)` over the
 /// continuation, **divided by the token count**, and the highest wins. There is
@@ -103,24 +109,29 @@ actor SentenceReadings {
         let retokenised: Bool
     }
 
-    /// The readings, in the order the winner is picked from: the marks as
-    /// configured, then the join. First past the post, so an exact tie leaves
-    /// the boundary alone.
-    static func readings(marks: [String]) -> [Reading] {
-        marks.map { Reading(key: $0, mark: $0, capital: enders.contains($0)) }
+    /// The readings, in the order the winner is picked from: the mark found in
+    /// the text, then the configured marks that do not end a sentence, then
+    /// the join. First past the post, so an exact tie leaves the boundary
+    /// alone.
+    ///
+    /// The other enders are left out. A boundary already carries one, and
+    /// swapping a period for a question mark is not a repair this stage makes.
+    static func readings(found: String, marks: [String]) -> [Reading] {
+        ([found] + marks.filter { !enders.contains($0) && $0 != found })
+            .map { Reading(key: $0, mark: $0, capital: enders.contains($0)) }
             + [Reading(key: join, mark: "", capital: false)]
     }
 
     /// The shared prefix and one continuation per reading.
     ///
-    /// The left side loses its trailing period, so a caller that kept it and
-    /// one that did not build the same window.
+    /// The left side loses its trailing mark, so a caller that kept it and one
+    /// that did not build the same window.
     static func build(
-        left: String, right: String, marks: [String]
+        left: String, right: String, found: String, marks: [String]
     ) -> (prefix: String, continuations: [String])? {
-        let leftWords = left
-            .replacingOccurrences(of: "\\.+$", with: "", options: .regularExpression)
-            .split(whereSeparator: \.isWhitespace).map(String.init)
+        var bare = left
+        while let last = bare.last, enders.contains(String(last)) { bare.removeLast() }
+        let leftWords = bare.split(whereSeparator: \.isWhitespace).map(String.init)
         let rightWords = right.split(whereSeparator: \.isWhitespace).map(String.init)
         guard !leftWords.isEmpty, !rightWords.isEmpty else { return nil }
         let prefix = leftWords.suffix(radius).joined(separator: " ")
@@ -130,7 +141,7 @@ actor SentenceReadings {
         let rest = rightWords.count > 1
             ? Array(rightWords[1 ..< min(radius, rightWords.count)]) : []
         let tail = rest.isEmpty ? "" : " " + rest.joined(separator: " ")
-        let continuations = readings(marks: marks).map {
+        let continuations = readings(found: found, marks: marks).map {
             "\($0.mark) \($0.capital ? up : lo)\(tail)"
         }
         return (prefix, continuations)
@@ -209,8 +220,12 @@ actor SentenceReadings {
     // MARK: - scoring
 
     /// The three readings of one boundary, scored.
-    func read(left: String, right: String, marks: [String]) async throws -> [Score] {
-        guard let built = Self.build(left: left, right: right, marks: marks) else {
+    func read(
+        left: String, right: String, found: String, marks: [String]
+    ) async throws -> [Score] {
+        guard let built = Self.build(
+            left: left, right: right, found: found, marks: marks
+        ) else {
             throw Failure.empty
         }
         let context = try await context()
@@ -219,7 +234,7 @@ actor SentenceReadings {
         }
         return Self.score(
             prefix: built.prefix, continuations: built.continuations,
-            keys: Self.readings(marks: marks).map(\.key),
+            keys: Self.readings(found: found, marks: marks).map(\.key),
             model: model, tokenizer: context.tokenizer
         )
     }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -81,14 +81,14 @@ transcription:
   languages: [en, fr]
 
   # A pause mid-sentence makes the transcriber write a period and capitalise
-  # the next word. English dictations are checked for that and the period is
-  # taken out again. Every boundary is read once per mark and once with no
-  # mark at all, and the reading the model scores highest is written. On by
-  # default, and only where the model is already on disk. `sentences: false`
-  # turns it off.
+  # the next word, or writes a question mark. English dictations are checked
+  # for that and the mark is taken out again. Each boundary is read three ways
+  # — the mark it carries, the comma, and no mark at all — and the reading the
+  # model scores highest is written. On by default, and only where the model is
+  # already on disk. `sentences: false` turns it off.
   #
   # sentences:
-  #   marks: [".", ","]  # the marks tried beside removing the period
+  #   marks: [".", ",", "?"]  # `.` and `?` are scanned, `,` is read beside them
 
   # What a transcript runs through, in order. Remove a line to skip that
   # stage. One list for every language: a step that should only run in one

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -455,7 +455,7 @@ covers 1,800 languages, where ModernBERT is English-only. It is not cheaper —
 the same cache size, and 18 ms per pass against 11, because its head is five
 times wider. Multilingual is the whole reason for the swap.
 
-## Is this period real
+## Is this sentence mark real
 
 ```sh
 $PF --sentence-model                                       # fetch both sentence models
@@ -464,11 +464,15 @@ $PF --sentence-probe --encode "<text>"                     # the masked tokenize
 $PF --sentence-probe --bench <cases.json> --out <out.json> # a whole file, one loaded process
 ```
 
-A pause in the middle of a sentence makes the transcriber write a period. The
-probe builds one reading of the boundary per mark and one with no mark at all,
-and scores each with `mlx-community/Qwen3-0.6B-Base-4bit`. The score is the
-log-probability of the continuation divided by its token count. The highest
-wins, and there is no threshold.
+A pause in the middle of a sentence makes the transcriber write a period or a
+question mark. The probe builds three readings of the boundary — the mark on
+the left half, the comma, and no mark at all — and scores each with
+`mlx-community/Qwen3-0.6B-Base-4bit`. The score is the log-probability of the
+continuation divided by its token count. The highest wins, and there is no
+threshold.
+
+End the left half with `?` to read a question boundary. With no mark there it
+is read as a period.
 
 ```
 $PF --sentence-probe "…the first usage of the LLM with." "The vocabulary is slower"
@@ -485,9 +489,11 @@ reading is scored from the first token that actually differs — 2 of 972 bench
 sequences do this.
 
 `--bench` reads `[{"left": …, "right": …}]` and writes one row of scores per
-boundary, with the milliseconds each decision took. It loads the model once, so
-it is the only way to get a latency number; `--vectors` loads the word vectors
-as well, so the memory line describes the process the app runs.
+boundary, with the mark it read and the milliseconds each decision took. A row
+may carry `"mark": "?"` where the left half does not end with the mark itself.
+It loads the model once, so it is the only way to get a latency number;
+`--vectors` loads the word vectors as well, so the memory line describes the
+process the app runs.
 
 `--encode` prints ModernBERT's ids and loads no model, which is what
 `scripts/check-tokenizer.sh` compares against HuggingFace's own tokenizer.
@@ -500,7 +506,7 @@ with, and ModernBERT, which no stage reads any more. The slot gate moved to
 mmBERT-small, so ModernBERT is now a download with nothing behind it, and a
 follow-up takes it out.
 
-## Which periods a pause put there
+## Which sentence marks a pause put there
 
 ```sh
 $PF --sentence-join "<text>"            # read every boundary, and join what wins
@@ -508,7 +514,9 @@ $PF --sentence-join --case "<text>"     # the lowercasing alone, no model
 ```
 
 `--sentence-join` is the pass the app runs, on the text you give it. One block
-per `word. Capital` boundary, then the text it hands on.
+per boundary, then the text it hands on. A boundary is a `.` or a `?` followed
+by a word — a capital after a period, a capital or a lowercase word after a
+question mark.
 
 ```
 $PF --sentence-join "…the first usage of the LLM with. The vocabulary is slower"
@@ -521,12 +529,14 @@ $PF --sentence-join "…the first usage of the LLM with. The vocabulary is slowe
   text       …the first usage of the LLM with the vocabulary is slower
 ```
 
-The period is removed where `join` wins, and left alone otherwise. The marks
-tried are `transcription.sentences.marks` in `config.yaml`.
-`scripts/check-sentence-join.sh` scores the decisions against
-tests/sentence-boundary-cases.json; it needs the model, so it is run by hand.
+The mark is removed where `join` wins, and left alone otherwise. Which marks are
+scanned, and which are read beside them, is `transcription.sentences.marks` in
+`config.yaml` — the sentence enders in that list are scanned, the rest are
+readings. `scripts/check-sentence-join.sh` scores the decisions against
+tests/sentence-boundary-cases.json, in both shapes; it needs the model, so it is
+run by hand.
 
-`--case` answers only what the capitalised word becomes once the period is
+`--case` answers only what the capitalised word becomes once the mark is
 gone. `NLTagger` and your vocabulary decide that, so no model is loaded and
 `scripts/check-sentence-case.sh` runs in CI. See `SentenceJoin`.
 
@@ -772,8 +782,8 @@ scripts/check-slot-tokenizer.sh    # the slot tokenizer against HuggingFace's ow
 scripts/check-sentence-probe.sh    # the three readings of a boundary (needs the model)
 scripts/check-slot-gate.sh         # where a name proposal is routed (needs the model)
 scripts/check-slot-gap.sh          # what the slot says about a rewrite (needs both models)
-scripts/check-sentence-case.sh     # the capital after a period the join removes
-scripts/check-sentence-join.sh     # which periods the join removes (needs the model)
+scripts/check-sentence-case.sh     # the capital after a mark the join removes
+scripts/check-sentence-join.sh     # which sentence marks the join removes (needs the model)
 
 PF_VIEWPORT=Ghostty scripts/check-inplace.sh   # the same set, in another terminal
 $PF --peek 3 --via-copy                        # what Select All + Copy hands back

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -471,35 +471,48 @@ end of what was still there.
 
 ## `transcription.sentences`
 
-A pause mid-sentence makes the transcriber write a period and capitalise the
-next word, so one sentence becomes two. Every `word. Capital` boundary in an
-English transcript is read several ways and the reading the model likes best
-wins.
+A pause mid-sentence makes the transcriber write a period or a question mark,
+and capitalise the next word, so one sentence becomes two. Every such boundary
+in an English transcript is read several ways and the reading the model likes
+best wins.
 
 ```yaml
 transcription:
   sentences:
-    marks: [".", ","]    # the marks tried beside removing the period
+    marks: [".", ",", "?"]    # what a boundary can be written
 ```
 
 `sentences: false` turns the whole stage off.
 
-There is no threshold. For a `word. Capital` boundary the stage builds one
-reading per mark — `". The vocabulary is slower"`, `", the vocabulary is
-slower"` — and one with no mark at all, scores each with a small causal
-language model, and writes the winner. A score is the log-probability of the
-continuation divided by its token count. Where the reading with no mark wins,
-the period is removed and the next word is lowercased.
+One list, two jobs. The sentence enders in it — `.` and `?` — are **where a
+boundary is looked for**. Everything else in it — the comma — is a **reading
+tried at a boundary**. So each boundary is read three ways: the mark it
+carries, the comma, and no mark at all. Take `?` out of the list and question
+marks stop being scanned; take `.` out and periods do.
 
-Measured over 172 real periods and 140 cuts of one speaker's dictation: 81% of
-the cuts repaired and no real period joined. The two thresholds this used to
-take, `join_below:` and `offer_below:`, repaired 26%. They are still read, and
-`--check-config` says they no longer do anything.
+There is no threshold. The stage builds those three readings — `". The
+vocabulary is slower"`, `", the vocabulary is slower"`, `" the vocabulary is
+slower"` — scores each with a small causal language model, and writes the
+winner. A score is the log-probability of the continuation divided by its token
+count. Where the reading with no mark wins, the mark is removed and the next
+word is lowercased.
 
-`;` and `:` were measured and never changed a decision in English, so the
-default is the two marks that do. The set is a setting because it is
-language-dependent. Each entry is one punctuation character; anything else is
-refused, because a mark is written into the sentence as punctuation.
+Measured over one speaker's dictation: 81% of 140 period cuts repaired with no
+real period joined, and 82% of 325 question cuts repaired at one wrong join in
+111 real questions. The two thresholds this used to take, `join_below:` and
+`offer_below:`, repaired 26%. They are still read, and `--check-config` says
+they no longer do anything.
+
+`;` and `:` were measured and never changed a decision in English, so they are
+not in the default. The set is a setting because it is language-dependent. Each
+entry is one punctuation character, and at least one must end a sentence;
+anything else is refused, because a mark is written into the sentence as
+punctuation.
+
+A word after a question mark does not have to be capitalised. Of 19 lines where
+the transcriber wrote `word? lowercase`, 7 hold a mark that should go and 12 a
+real question, so the reading decides and no rule could. A word after a *period*
+does have to be: that shape has never been measured, so it is left alone.
 
 English only, and only where the model is already on disk. Nothing is
 downloaded for this and nothing waits: with no model the transcript arrives as

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -485,8 +485,8 @@ said     "you should see a parrot at the top right of your screen"
 written  "You should see a parrot. At the top right of your screen."
 ```
 
-After the vocabulary pass, every `word. Capital` boundary in an English
-transcript is read three ways and scored by a small causal language model
+After the vocabulary pass, every such boundary in an English transcript is read
+three ways and scored by a small causal language model
 (`mlx-community/Qwen3-0.6B-Base-4bit`, 320 MB):
 
 ```
@@ -498,8 +498,21 @@ transcript is read three ways and scored by a small causal language model
 Each reading is the log-probability of its continuation divided by its token
 count, and the highest wins. Nothing is compared to a threshold, so there is
 nothing to calibrate. The marks are `transcription.sentences.marks`, default
-`[".", ","]`; `;` and `:` were measured and never changed a decision in
+`[".", ",", "?"]`; `;` and `:` were measured and never changed a decision in
 English.
+
+The list does two jobs. `.` and `?` are where a boundary is looked for; the
+comma is a reading tried at one. The first reading is always the mark the
+transcriber wrote, so a `word? Capital` boundary is read `"? Word"`, `", word"`
+and `" word"`. Reading every ender at every boundary was measured too and is
+worse: 259 of 325 question cuts repaired against 265, for a fourth forward pass.
+
+A question mark counts even when the next word is lowercase. Of 19 such lines
+in one speaker's dictation, 7 hold a mark that should go and 12 a real
+question, so the reading has to decide. A period followed by a lowercase word is
+left alone: the transcriber did not start a sentence there and the shape has
+never been measured. A capital with no mark in front of it is left alone too —
+it does not separate (AUC 0.750 over 26 hand-labelled cases).
 
 Three things are load-bearing. Per token, not summed: on summed
 log-probability the joined reading wins by being shortest, which repairs 97% of
@@ -509,14 +522,28 @@ the join. And the three readings go into one padded forward pass, which costs
 50 ms against 70 ms for three passes; a shared KV cache for the prefix is
 slower still.
 
-Measured over 172 real periods and 140 cuts of one speaker's dictation: 81% of
-the cuts repaired, no real period joined. The two thresholds this stage used to
-carry repaired 26%, and the higher one could not be raised — it was set by the
-single lowest-scoring real ending.
+Measured over one speaker's dictation. Periods: 81% of 140 cuts repaired, none
+of 172 real periods joined. Question marks: 82% of 325 cuts repaired, and **one
+wrong join in 111 real questions**. The two thresholds this stage used to carry
+repaired 26% of the period cuts, and the higher one could not be raised — it was
+set by the single lowest-scoring real ending.
 
-Joining removes the period and lowercases the word after it. Not every capital
+The question shape is not silent-safe the way the period shape is. One wrong
+join in 111 bounds the true rate at 4.9 per 100 with 95% confidence, against 1.7
+for the period shape. The wrong join is a real question ending, and it loses to
+the join by 0.045 of a log-probability:
+
+```
+said     ... what's the best grammatical model we can use? For now part flow
+         is open source so doesn't make a big issue.
+written  ... what's the best grammatical model we can use for now part flow
+         is open source so doesn't make a big issue.
+```
+
+Joining removes the mark and lowercases the word after it. Not every capital
 there is because of the period: "I will ask him. Nathan knows the answer" must
 not become "ask him nathan knows". So the rule asks for a reason to lowercase.
+A word that was already lowercase is left as it is.
 `I` and its contractions keep the capital, so does a word in capitals
 throughout, so does a `PersonalName`, `PlaceName` or `OrganizationName` from
 `NLTagger`, and so does a word `NLTagger` gives no lemma for — the lexicon has

--- a/scripts/check-sentence-join.sh
+++ b/scripts/check-sentence-join.sh
@@ -3,10 +3,11 @@
 #
 #   scripts/check-sentence-join.sh
 #
-# Half the cases are real periods and half are pauses that cut one sentence in
-# two. Two numbers decide: how many cuts were repaired, and how many real
-# periods were joined by mistake. A joined real period is a sentence nobody
-# wrote, with nothing on screen to say so, so one of those fails the run.
+# Half the cases are real sentence endings and half are pauses that cut one
+# sentence in two, in both the period and the question-mark shape. Two numbers
+# decide per shape: how many cuts were repaired, and how many real endings were
+# joined by mistake. A joined real ending is a sentence nobody wrote, with
+# nothing on screen to say so, so one of those fails the run.
 #
 # Each case also carries the readings measured when the set was built. This
 # compares the binary's against them. That is what says the app reads a boundary
@@ -38,10 +39,14 @@ binary = root / ".build/release/ParrotFlow"
 cases = json.load(open(root / "tests/sentence-boundary-cases.json"))
 
 # The set stores the two halves already windowed to twelve words each, which is
-# the window the app builds. Glued back into one text, the boundary the app
-# finds is the one the set is about.
+# the window the app builds. Glued back into one text with the case's own mark,
+# the boundary the app finds is the one the set is about.
+def mark_of(case):
+    return case.get("mark", ".")
+
+
 def text_of(case):
-    return case["left"].rstrip(".") + ". " + case["right"]
+    return case["left"].rstrip(".?!") + mark_of(case) + " " + case["right"]
 
 
 # The boundary this case is about, not the first one printed. Several of the
@@ -49,7 +54,8 @@ def text_of(case):
 # boundaries in the glued text and only one of them is the measured one. It is
 # named by the word each side of it.
 def block_of(out, case):
-    wanted = "%s. %s ->" % (case["left"].rstrip(".").split()[-1], case["right"].split()[0])
+    wanted = "%s%s %s ->" % (
+        case["left"].rstrip(".?!").split()[-1], mark_of(case), case["right"].split()[0])
     block, mine = None, None
     for line in out.splitlines():
         parts = line.split(None, 1)
@@ -70,7 +76,8 @@ def block_of(out, case):
     return None
 
 DRIFT = 0.05
-tally = {"en_real.json": {}, "en_cuts.json": {}}
+tally = {name: {} for name in
+         ("en_real.json", "en_cuts.json", "enq_real.json", "enq_cuts_hard.json")}
 drifted = []
 
 for case in cases:
@@ -90,30 +97,35 @@ for case in cases:
     if gap > DRIFT:
         drifted.append((text_of(case), case["winner"], winner, gap))
         mark = "✗"
-    print("  %s  %-5s %-5s stored %-5s  gap %.4f  %s" % (
-        mark, case["set"].removeprefix("en_").removesuffix(".json"),
-        winner, case["winner"], gap, case["left"][:48]))
+    print("  %s  %-10s %-5s stored %-5s  gap %.4f  %s" % (
+        mark, case["set"].removeprefix("en").removeprefix("_").removesuffix(".json"),
+        winner, case["winner"], gap, case["left"][:44]))
 
 def row(name, key):
     counts = tally[key]
     total = sum(counts.values())
     listed = ", ".join("%d %s" % (n, k) for k, n in sorted(counts.items()))
-    print("  %-13s %s  (of %d)" % (name, listed, total))
+    print("  %-16s %s  (of %d)" % (name, listed, total))
     return counts, total
 
 print()
-cuts, cut_total = row("cuts", "en_cuts.json")
-real, real_total = row("real periods", "en_real.json")
-
-if not cut_total or not real_total:
-    print("  ✗ no cases read from tests/sentence-boundary-cases.json")
-    sys.exit(1)
-
-joined = cuts.get("join", 0)
-false_joins = real.get("join", 0)
-print()
-print("  %d%% of cuts repaired, %.1f false joins per 100 real periods" % (
-    round(100 * joined / cut_total), 100 * false_joins / real_total))
+shapes = (
+    ("period", "en_cuts.json", "en_real.json"),
+    ("question", "enq_cuts_hard.json", "enq_real.json"),
+)
+false_joins = 0
+for shape, cut_key, real_key in shapes:
+    cuts, cut_total = row(shape + " cuts", cut_key)
+    real, real_total = row(shape + " real", real_key)
+    if not cut_total or not real_total:
+        print("  ✗ no %s cases read from tests/sentence-boundary-cases.json" % shape)
+        sys.exit(1)
+    wrong = real.get("join", 0)
+    false_joins += wrong
+    print("  %d%% of %s cuts repaired, %.1f false joins per 100 real endings" % (
+        round(100 * cuts.get("join", 0) / cut_total), shape,
+        100 * wrong / real_total))
+    print()
 
 if drifted:
     print()

--- a/scripts/check-sentence-probe.sh
+++ b/scripts/check-sentence-probe.sh
@@ -3,15 +3,16 @@
 #
 #   scripts/check-sentence-probe.sh [tolerance]
 #
-# tests/sentence-boundary-cases.json holds 40 boundaries from a scored set of
-# the user's own dictation, half real periods and half pauses that cut one
-# sentence in two, with the per-token score of every reading and the winner.
-# This answers "does this build still read a boundary the same way": the window,
-# the three continuations, the padded batch, the log-softmax and the argmax.
-# Regenerate it with scripts/sentence-probe-reference.py readings.
+# tests/sentence-boundary-cases.json holds 60 boundaries from a scored set of
+# the user's own dictation: 40 written with a period and 20 with a question
+# mark, half of each real and half pauses that cut one sentence in two, with
+# the per-token score of every reading and the winner. This answers "does this
+# build still read a boundary the same way": the window, the three
+# continuations, the padded batch, the log-softmax and the argmax. Regenerate it
+# with scripts/sentence-probe-reference.py readings.
 #
-# One loaded process for all 40, through `--sentence-probe --bench`. A process
-# per case would pay the 1.3s model load forty times.
+# One loaded process for all 60, through `--sentence-probe --bench`. A process
+# per case would pay the 1.3s model load sixty times.
 #
 # Not in `make test`: it needs the 320 MB model, which CI has no business
 # downloading. Run it by hand after touching SentenceReadings.
@@ -29,7 +30,9 @@ export PARROTFLOW_CONFIG_DIR="$WORK/config"
 python3 -c '
 import json, sys
 cases = json.load(open(sys.argv[1]))
-json.dump([{"left": c["left"], "right": c["right"]} for c in cases], open(sys.argv[2], "w"))
+json.dump([
+    {"left": c["left"], "right": c["right"], "mark": c.get("mark", ".")} for c in cases
+], open(sys.argv[2], "w"))
 ' "$ROOT/tests/sentence-boundary-cases.json" "$WORK/cases.json" || {
   echo "  ✗ tests/sentence-boundary-cases.json could not be read"; exit 1; }
 
@@ -56,7 +59,8 @@ for i, case in enumerate(cases):
     if gap <= tolerance and row["winner"] == case["winner"]:
         passed += 1
     else:
-        print("  ✗ %s. %s" % (case["left"].rstrip("."), case["right"].split()[0]))
+        print("  ✗ %s%s %s" % (
+            case["left"].rstrip(".?!"), case.get("mark", "."), case["right"].split()[0]))
         print("      winner %s, stored %s   gap %.4f" % (
             row["winner"], case["winner"], gap))
 

--- a/scripts/sentence-probe-reference.py
+++ b/scripts/sentence-probe-reference.py
@@ -14,6 +14,10 @@ came back, so the fixture is by construction what the binary produces. Point
 --data at the bench directory; its files hold `left` and `right` already
 windowed to +-12 words, which is the window the app builds.
 
+Four sets, two marks. --count rows come from the period pair and --questions
+rows from the question pair, so raising one does not resample the other. Each
+row carries the mark its boundary is written with.
+
 Real endings carrying a hand label are left out. `join` means the period is
 wrong, `drop` that the row is not a dictation, and `tie` that both readings are
 right — none of the three is a real ending a join would spoil.
@@ -83,14 +87,22 @@ def readings(args):
         for key in ("join", "drop", "tie"):
             labelled |= set(labels.get(key, []))
 
+    sets = (
+        ("en_real.json", ".", labelled, args.count // 2),
+        ("en_cuts.json", ".", set(), args.count // 2),
+        ("enq_real.json", "?", set(), args.questions // 2),
+        ("enq_cuts_hard.json", "?", set(), args.questions // 2),
+    )
+
     out = []
-    for name, skip in (("en_real.json", labelled), ("en_cuts.json", set())):
+    for name, mark, skip, take in sets:
         entries = json.load(open(os.path.join(args.data, name)))
         wanted = [i for i in range(len(entries)) if i not in skip]
-        step = max(1, len(wanted) // (args.count // 2))
-        wanted = wanted[::step][: args.count // 2]
+        step = max(1, len(wanted) // take)
+        wanted = wanted[::step][:take]
         rows = [
-            {"left": entries[i]["left"], "right": entries[i]["right"]} for i in wanted
+            {"left": entries[i]["left"], "right": entries[i]["right"], "mark": mark}
+            for i in wanted
         ]
         with tempfile.TemporaryDirectory(dir=os.environ.get("TMPDIR")) as work:
             cases = os.path.join(work, "cases.json")
@@ -103,6 +115,7 @@ def readings(args):
             for row in json.load(open(scored)):
                 out.append({
                     "set": name,
+                    "mark": mark,
                     "left": rows[row["i"]]["left"],
                     "right": rows[row["i"]]["right"],
                     "winner": row["winner"],
@@ -124,6 +137,7 @@ parser.add_argument("--tokenizer", default=TOKENIZER)
 parser.add_argument("--data", default=".")
 parser.add_argument("--binary", default=os.path.join(HERE, ".build/release/ParrotFlow"))
 parser.add_argument("--count", type=int, default=40)
+parser.add_argument("--questions", type=int, default=20)
 parser.add_argument("--out")
 args = parser.parse_args()
 (tokens if args.what == "tokens" else readings)(args)

--- a/tests/sentence-boundary-cases.json
+++ b/tests/sentence-boundary-cases.json
@@ -1,6 +1,7 @@
 [
  {
   "set": "en_real.json",
+  "mark": ".",
   "left": "if it's because the release notes are not bigger than the height",
   "right": "Another features. If there is more than two fixes then there is",
   "winner": ",",
@@ -12,6 +13,7 @@
  },
  {
   "set": "en_real.json",
+  "mark": ".",
   "left": "what we're doing anymore.I thought we had a success with audio clips",
   "right": "We had a discussion about whether they make a different Vercel's rules",
   "winner": ".",
@@ -23,6 +25,7 @@
  },
  {
   "set": "en_real.json",
+  "mark": ".",
   "left": "though is that I didn't actually have the the bar fully filled",
   "right": "It just there's a little space between the end and the where",
   "winner": ",",
@@ -34,6 +37,7 @@
  },
  {
   "set": "en_real.json",
+  "mark": ".",
   "left": "with E4B? The yes-no?Also, if I understand correctly, the sequential doesn't hurt",
   "right": "It's the same score. Right? For example, in sentences with only one",
   "winner": ",",
@@ -45,6 +49,7 @@
  },
  {
   "set": "en_real.json",
+  "mark": ".",
   "left": "word and every LLM prompt receives the result of the previous one",
   "right": "So for example, if the first word was resolved. Then it is",
   "winner": ".",
@@ -56,6 +61,7 @@
  },
  {
   "set": "en_real.json",
+  "mark": ".",
   "left": "would just use Python for everything. I would drop Ollama in Swift",
   "right": "It's not necessarily it's not necessary.I would just implement a pipeline runner",
   "winner": ".",
@@ -67,6 +73,7 @@
  },
  {
   "set": "en_real.json",
+  "mark": ".",
   "left": "go to A remote AI provider.Here a feature is it's using parakeet",
   "right": "Blazing fast. local Transcription. Model.",
   "winner": ".",
@@ -78,6 +85,7 @@
  },
  {
   "set": "en_real.json",
+  "mark": ".",
   "left": "They can be selected with arrows left, right, and enter",
   "right": "And of course, the focus is there. When the hood appears. Show",
   "winner": ".",
@@ -89,6 +97,7 @@
  },
  {
   "set": "en_real.json",
+  "mark": ".",
   "left": "hesitations, mumbling, and hesitations and back and forth like For example this",
   "right": "I was with Peter, not with Peter, with James. And uh we",
   "winner": ".",
@@ -100,6 +109,7 @@
  },
  {
   "set": "en_real.json",
+  "mark": ".",
   "left": "recognize. For example, in my case it would be French and English",
   "right": "And then all the prompts would be localized. So instead of trying",
   "winner": ",",
@@ -111,6 +121,7 @@
  },
  {
   "set": "en_real.json",
+  "mark": ".",
   "left": "want. I want a tail. So I want a C L command",
   "right": "So it would be like a Swift script or a Python one.",
   "winner": ".",
@@ -122,6 +133,7 @@
  },
  {
   "set": "en_real.json",
+  "mark": ".",
   "left": "also I want a panel showing up when the appis laucnching",
   "right": "It seems like when you open the app, the only visible effect",
   "winner": ".",
@@ -133,6 +145,7 @@
  },
  {
   "set": "en_real.json",
+  "mark": ".",
   "left": "of the seven terms with none — that puts 23 rows back",
   "right": "Do not ship MFCC + DTW; it was chosen to be cheap,",
   "winner": ".",
@@ -144,6 +157,7 @@
  },
  {
   "set": "en_real.json",
+  "mark": ".",
   "left": "and the one sentence definition. At the beginning it could be mind",
   "right": "It could be mind from slack. With a good prompt in the",
   "winner": ".",
@@ -155,6 +169,7 @@
  },
  {
   "set": "en_real.json",
+  "mark": ".",
   "left": "so the point was to ed to iterate on the dictating pill",
   "right": "So the HUD we see while dictating.Can you make a few suggestions?We",
   "winner": ",",
@@ -166,6 +181,7 @@
  },
  {
   "set": "en_real.json",
+  "mark": ".",
   "left": "But there can be a replacement",
   "right": "Why can't we count it?",
   "winner": ",",
@@ -177,6 +193,7 @@
  },
  {
   "set": "en_real.json",
+  "mark": ".",
   "left": "So I was prompted but declined before I dictated anything",
   "right": "Then I dictated something, asked to fix grammar. And nothing happened.",
   "winner": ".",
@@ -188,6 +205,7 @@
  },
  {
   "set": "en_real.json",
+  "mark": ".",
   "left": "it For claude code for now so we can have an idea",
   "right": "Make it a system pipeline stage similarly to numbers replacements or fuzzy.",
   "winner": ".",
@@ -199,6 +217,7 @@
  },
  {
   "set": "en_real.json",
+  "mark": ".",
   "left": "use a reject transform and add simple date transformation for the script",
   "right": "For the pipeline you want to add the grammar check only on",
   "winner": ".",
@@ -210,6 +229,7 @@
  },
  {
   "set": "en_real.json",
+  "mark": ".",
   "left": "Then mention Ollama setup. So if the model is there, fine",
   "right": "If Ollama is there but not the model, just say you're download",
   "winner": ".",
@@ -221,6 +241,7 @@
  },
  {
   "set": "en_cuts.json",
+  "mark": ".",
   "left": "alive is not working because the first usage of the LLM with.",
   "right": "The vocabulary is slower",
   "winner": "join",
@@ -232,6 +253,7 @@
  },
  {
   "set": "en_cuts.json",
+  "mark": ".",
   "left": "So okay, sure, let's rebase let's get.",
   "right": "In your the scratch pad",
   "winner": "join",
@@ -243,6 +265,7 @@
  },
  {
   "set": "en_cuts.json",
+  "mark": ".",
   "left": "A local, fast and programmable dictation tool shaped around.",
   "right": "Your voice and your work",
   "winner": "join",
@@ -254,6 +277,7 @@
  },
  {
   "set": "en_cuts.json",
+  "mark": ".",
   "left": "I mean, can we use Olama as an.",
   "right": "Interface for commercial models",
   "winner": "join",
@@ -265,6 +289,7 @@
  },
  {
   "set": "en_cuts.json",
+  "mark": ".",
   "left": "I want to do all this in.",
   "right": "Another in a subsequent one",
   "winner": "join",
@@ -276,6 +301,7 @@
  },
  {
   "set": "en_cuts.json",
+  "mark": ".",
   "left": "and btw when pressing Enter to submit the text the hud.",
   "right": "Should also vanish immediatly and stop decaying",
   "winner": "join",
@@ -287,6 +313,7 @@
  },
  {
   "set": "en_cuts.json",
+  "mark": ".",
   "left": "Context could be the dictation before or.",
   "right": "After, or what was on the screen",
   "winner": "join",
@@ -298,6 +325,7 @@
  },
  {
   "set": "en_cuts.json",
+  "mark": ".",
   "left": "The script has not changed, the permissions were still there, and.",
   "right": "Parakeet was immediately available",
   "winner": "join",
@@ -309,6 +337,7 @@
  },
  {
   "set": "en_cuts.json",
+  "mark": ".",
   "left": "before the judge and only let the judge decide between what was.",
   "right": "Heard by the decoder and what the decoder found similar",
   "winner": "join",
@@ -320,6 +349,7 @@
  },
  {
   "set": "en_cuts.json",
+  "mark": ".",
   "left": "I've done plenty I've.",
   "right": "Done it plenty of times now",
   "winner": "join",
@@ -331,6 +361,7 @@
  },
  {
   "set": "en_cuts.json",
+  "mark": ".",
   "left": "Do a grammar check on the selected text.",
   "right": "And also write a section about what's gonna be installed succinctly",
   "winner": ",",
@@ -342,6 +373,7 @@
  },
  {
   "set": "en_cuts.json",
+  "mark": ".",
   "left": "pinned row could clear a newer.",
   "right": "Prompt after focus advances",
   "winner": "join",
@@ -353,6 +385,7 @@
  },
  {
   "set": "en_cuts.json",
+  "mark": ".",
   "left": "Mira and Mira were on.",
   "right": "Vacation and have visited Versailles Castle while the app was being deployed",
   "winner": "join",
@@ -364,6 +397,7 @@
  },
  {
   "set": "en_cuts.json",
+  "mark": ".",
   "left": "I'd like to use some sort of.",
   "right": "Object programming, interface and implementation classes on top",
   "winner": "join",
@@ -375,6 +409,7 @@
  },
  {
   "set": "en_cuts.json",
+  "mark": ".",
   "left": "So how would you.",
   "right": "Use in practice a negative example",
   "winner": "join",
@@ -386,6 +421,7 @@
  },
  {
   "set": "en_cuts.json",
+  "mark": ".",
   "left": "Can you give me an.",
   "right": "Example so that I understand visually",
   "winner": "join",
@@ -397,6 +433,7 @@
  },
  {
   "set": "en_cuts.json",
+  "mark": ".",
   "left": "ordinary word, however much.",
   "right": "It looks like one of them",
   "winner": "join",
@@ -408,6 +445,7 @@
  },
  {
   "set": "en_cuts.json",
+  "mark": ".",
   "left": "Can you make the.",
   "right": "Type menu more visible because it seems like it's very small compared",
   "winner": "join",
@@ -419,6 +457,7 @@
  },
  {
   "set": "en_cuts.json",
+  "mark": ".",
   "left": "Okay, the same happened but there was another still window.",
   "right": "From a maybe a previous process still open",
   "winner": "join",
@@ -430,6 +469,7 @@
  },
  {
   "set": "en_cuts.json",
+  "mark": ".",
   "left": "As usual, check Greptile reviews, address comments, and continue.",
   "right": "Until Greptile is happy",
   "winner": "join",
@@ -437,6 +477,246 @@
    ",": -3.2308,
    ".": -4.3363,
    "join": -2.7409
+  }
+ },
+ {
+  "set": "enq_real.json",
+  "mark": "?",
+  "left": "But that is not the evaluation format. Right",
+  "right": "We have a markdown format generated with a script from the thermal",
+  "winner": "?",
+  "mean": {
+   ",": -5.0898,
+   "?": -5.0011,
+   "join": -5.4792
+  }
+ },
+ {
+  "set": "enq_real.json",
+  "mark": "?",
+  "left": "What is enabled for?Can we just enable them by default",
+  "right": "What would it change?Also is there a better place to put router",
+  "winner": ",",
+  "mean": {
+   ",": -3.9177,
+   "?": -3.9834,
+   "join": -4.1526
+  }
+ },
+ {
+  "set": "enq_real.json",
+  "mark": "?",
+  "left": "we don't have audio calibration, can you simplify the Claude onboarding procedure",
+  "right": "Give me the main steps that the Claude onboarding procedure will do.",
+  "winner": "?",
+  "mean": {
+   ",": -3.294,
+   "?": -3.2426,
+   "join": -3.6342
+  }
+ },
+ {
+  "set": "enq_real.json",
+  "mark": "?",
+  "left": "Again about ordering. Where is the ordering there",
+  "right": "And I don't understand where the 25000 pairs come from so you",
+  "winner": "?",
+  "mean": {
+   ",": -3.1406,
+   "?": -3.0329,
+   "join": -3.2182
+  }
+ },
+ {
+  "set": "enq_real.json",
+  "mark": "?",
+  "left": "So what happened here",
+  "right": "How many times did the prompt run?",
+  "winner": "?",
+  "mean": {
+   ",": -4.2509,
+   "?": -4.1002,
+   "join": -4.9657
+  }
+ },
+ {
+  "set": "enq_real.json",
+  "mark": "?",
+  "left": "we land this to prod? What is the magnitude of the change",
+  "right": "How many PRs would we have to ship?",
+  "winner": "?",
+  "mean": {
+   ",": -4.2028,
+   "?": -4.0261,
+   "join": -4.6543
+  }
+ },
+ {
+  "set": "enq_real.json",
+  "mark": "?",
+  "left": "things we have tried. where does spelling candidate come from? text rules",
+  "right": "And btw how do accoustic similarity is measured.",
+  "winner": ",",
+  "mean": {
+   ",": -5.9919,
+   "?": -6.2055,
+   "join": -6.3905
+  }
+ },
+ {
+  "set": "enq_real.json",
+  "mark": "?",
+  "left": "So audio clips are still in",
+  "right": "I thought all the experiments we made were in f favor of",
+  "winner": ",",
+  "mean": {
+   ",": -6.2287,
+   "?": -6.3328,
+   "join": -6.5318
+  }
+ },
+ {
+  "set": "enq_real.json",
+  "mark": "?",
+  "left": "So if we could combine transforms into transforms, wouldn't it be easier",
+  "right": "We could have groups. Use the AI to identify the first name",
+  "winner": "?",
+  "mean": {
+   ",": -4.9373,
+   "?": -4.7363,
+   "join": -5.4272
+  }
+ },
+ {
+  "set": "enq_real.json",
+  "mark": "?",
+  "left": "Can you implement some basic formatting rules",
+  "right": "Again a Python transform, I suppose, but for example if I dictate",
+  "winner": "?",
+  "mean": {
+   ",": -5.2356,
+   "?": -4.9798,
+   "join": -5.6493
+  }
+ },
+ {
+  "set": "enq_cuts_hard.json",
+  "mark": "?",
+  "left": "Does the latest release include the changes?",
+  "right": "In the config example",
+  "winner": "join",
+  "mean": {
+   ",": -6.5446,
+   "?": -6.7433,
+   "join": -5.504
+  }
+ },
+ {
+  "set": "enq_cuts_hard.json",
+  "mark": "?",
+  "left": "Are you testing against that?",
+  "right": "Same plant we use in GPT Luna that does pretty much everything",
+  "winner": "join",
+  "mean": {
+   ",": -5.9797,
+   "?": -6.1438,
+   "join": -5.9056
+  }
+ },
+ {
+  "set": "enq_cuts_hard.json",
+  "mark": "?",
+  "left": "But what is a rule?",
+  "right": "If it's not a substitution",
+  "winner": ",",
+  "mean": {
+   ",": -3.7699,
+   "?": -4.0366,
+   "join": -4.1886
+  }
+ },
+ {
+  "set": "enq_cuts_hard.json",
+  "mark": "?",
+  "left": "And what if you?",
+  "right": "Have several words in a sentence",
+  "winner": "join",
+  "mean": {
+   ",": -4.6872,
+   "?": -5.1829,
+   "join": -3.5982
+  }
+ },
+ {
+  "set": "enq_cuts_hard.json",
+  "mark": "?",
+  "left": "So if we could combine?",
+  "right": "Transforms into transforms, wouldn't it be easier",
+  "winner": "join",
+  "mean": {
+   ",": -4.3884,
+   "?": -4.7321,
+   "join": -3.7069
+  }
+ },
+ {
+  "set": "enq_cuts_hard.json",
+  "mark": "?",
+  "left": "what is the command for the llm?",
+  "right": "Vocab judge in the config",
+  "winner": "?",
+  "mean": {
+   ",": -7.0322,
+   "?": -6.7963,
+   "join": -7.2856
+  }
+ },
+ {
+  "set": "enq_cuts_hard.json",
+  "mark": "?",
+  "left": "How does a prompt work when several vocabulary terms?",
+  "right": "Are in the same transcription",
+  "winner": "join",
+  "mean": {
+   ",": -5.7768,
+   "?": -6.9,
+   "join": -3.7899
+  }
+ },
+ {
+  "set": "enq_cuts_hard.json",
+  "mark": "?",
+  "left": "When I open the post-dictation?",
+  "right": "Menu with the buttons, hotkeys won't work",
+  "winner": "join",
+  "mean": {
+   ",": -4.7084,
+   "?": -5.444,
+   "join": -4.1
+  }
+ },
+ {
+  "set": "enq_cuts_hard.json",
+  "mark": "?",
+  "left": "have the probability of the dot lower than the next word that?",
+  "right": "Don't make sense as a new sentence",
+  "winner": "join",
+  "mean": {
+   ",": -4.7908,
+   "?": -5.395,
+   "join": -3.7754
+  }
+ },
+ {
+  "set": "enq_cuts_hard.json",
+  "mark": "?",
+  "left": "I mean if we had someone speak for longer, would?",
+  "right": "It give better results",
+  "winner": "join",
+  "mean": {
+   ",": -5.9299,
+   "?": -6.9357,
+   "join": -3.8142
   }
  }
 ]


### PR DESCRIPTION
A pause does not always make the transcriber write a period. It often writes a
question mark, and the sentence-break scan never looked at those, so about a
quarter of the split boundaries in the user's own dictation were left split. A
boundary now carries the mark it was written with, and its first reading is
that mark: a question boundary is read `"? Word"`, `", word"` and `" word"`, a
period boundary reads exactly what it read before. `transcription.sentences.marks`
now defaults to `[".", ",", "?"]` and does two jobs — the sentence enders in it
are where a boundary is looked for, the rest are readings tried at one — and
`sentences: false` still turns the stage off.

**This shape is not silent-safe the way the period shape is.** It repairs 82%
of 325 question cuts and joins 1 of 111 real question endings. The period
bench is unchanged: 81% of 140 cuts, 0 wrong joins of 172. The accepted cost is
one sentence in a hundred that was a real question and is written as one
sentence instead, with nothing on screen to say so.

Start the review at `SentenceJoin.boundaries()`. Two things there: a lowercase
word after `?` is a boundary and after `.` is not, and the next word now stops
before a mark of its own so `…format. Right? We have` finds both boundaries
instead of stepping over the second.

Closes #256.

<details>
<summary>The wrong join, in full — a real question ending, lost by 0.045</summary>

`enq_real.json` index 15. Run through `--sentence-join` on the same ±12-word
window the app builds:

```
said     ... what's the best grammatical model we can use? For now part flow
         is open source so doesn't make a big issue.
written  ... what's the best grammatical model we can use for now part flow
         is open source so doesn't make a big issue.

  boundary   use? For -> use for
  reading    ?         -5.2515  14
  reading    ,         -5.1720  14
  reading    join      -5.1273  13
  winner     join
```

It is not a tie and not a labelling miss. Nothing rules it out: adding a `.`
reading does not, and adding `;` and `:` does not either.

1 of 111 is 0.9%, with a 95% upper bound near 4.9 per 100. The period shape is
0 of 172, upper bound 1.7. Issue #256 already notes that even 0 of 111 would
only bound this shape at 2.7, so a bigger real-question set is the only thing
that would settle it.

The period zero is not an artefact of curation. With no hand labels applied at
all, the stage joins 2 of the raw 194 real period endings, and both are already
labelled `join`, `drop` or `tie`.

</details>

<details>
<summary>Both designs, both benches — B repairs 6 more cuts with one reading fewer</summary>

Scored through `--sentence-probe --bench`, which is this stage's own code, on
`~/Documents/parrotflow-scratch/sentence-join/harness/`: `en_real_nf.json` and
`en_cuts_nf.json` with `en_real_labels.json` applied, `enq_real.json` (111 hand
-checked real question endings), `enq_cuts_hard.json` (325 cuts inside sentences
that are themselves questions) and `enq_cuts.json` (130 easy cuts).

- **A** — every boundary reads every configured mark plus join, so a boundary
  gets `.`, `,`, `?` and join.
- **B** — a boundary reads the mark found in the text, the comma and join.
  **This is what ships.**

| | period real | period cuts | q real | q hard cuts | q easy cuts | readings | median |
|---|---|---|---|---|---|---|---|
| before this PR | 0 / 172 | 114 / 140 (81%) | – | – | – | 3 | 51 ms |
| A | 0 / 172 | 114 / 140 (81%) | 1 / 111 | 259 / 325 (80%) | 112 / 130 (86%) | 4 | 50–67 ms |
| **B** | 0 / 172 | **114 / 140 (81%)** | **1 / 111** | **265 / 325 (82%)** | 113 / 130 (87%) | 3 | 37–51 ms |

B leaves the period columns identical by construction: a period boundary still
reads `.`, `,` and join. A's period columns were re-measured and did not move
either, so the choice between them is only about the question shape and the
fourth forward pass.

The 40 period rows in `tests/sentence-boundary-cases.json` were regenerated with
the shipped binary and came back byte-identical apart from the new `mark` field:
280 insertions, 0 deletions.

</details>

<details>
<summary>`word? lowercase` is scanned, and the reading almost always leaves it</summary>

Of the 19 lines in the user's dictation matching `[?!]\s+[a-z]`, 7 hold a mark
that should go and 12 a real question. No rule can separate those, so the shape
is scanned and the reading decides.

All 19 lines through `--sentence-join` end to end: **1 line changed**, and it is
one of the 7 spurious marks.

```
in   But wait, what about that conversation about? clustering audio clips and
     how that scale better than rules
out  But wait, what about that conversation about clustering audio clips and
     how that scale better than rules
```

None of the 12 real questions was touched. The `!` line is left alone: `!` is
not in the default mark list, and its run of `!!!!!` fails the run guard anyway.

The live case from the issue is repaired:

```
in   Could we have a quick chat? to onboard me on the analytics and data breaks
out  Could we have a quick chat to onboard me on the analytics and data breaks
```

Under the old threshold stage that one scored +2.21 against a safe line of
+0.44 — it was in the hardest 14% of the shape and could not be repaired.

</details>

<details>
<summary>What is not built — the bare capital, and any threshold</summary>

**No bare-capital repair.** A capital with no mark in front of it does not
separate: AUC 0.750 over 26 hand-labelled cases, 10% caught at zero errors, and
the live example is the second-worst case in the set. Issue #256 says so and
this PR does not touch it.

**No threshold.** The only ways to take the question shape to zero wrong joins
were a threshold or a smaller repair rate. The stage has no threshold and does
not gain one.

**`!` is not scanned.** One line in 1878 has the shape. It can be added to
`marks` by hand; the scan and the readings already handle it.

**A period followed by a lowercase word is still not a boundary.** That shape
has never been measured, so it is left exactly as it was.

</details>

<details>
<summary>Run by hand, since the model-backed checks are not in CI</summary>

```
scripts/check-sentence-probe.sh    60/60 within 0.05, worst gap 0.0000
scripts/check-sentence-join.sh     95% of period cuts repaired, 0.0 false joins per 100
                                   80% of question cuts repaired, 0.0 false joins per 100
scripts/check-sentence-case.sh     31/31   (in CI, no model)
scripts/check-sentence-open.sh     every check passed
make test                          every check passed
```

`tests/sentence-boundary-cases.json` grew from 40 rows to 60: the 40 period rows
unchanged, plus 10 real question endings and 10 question cuts, each row carrying
its mark. Regenerate with `scripts/sentence-probe-reference.py readings`, which
now takes `--questions` beside `--count` so raising one does not resample the
other.

Config was checked by hand under a scratch `PARROTFLOW_CONFIG_DIR`:
`sentences: false` still turns the stage off, `marks: [".", ","]` stops question
marks being scanned, and `marks: [","]` is refused with a message naming the
enders.

</details>

- [x] `make test` passes.
- [x] A prompt or pattern change is scored, and the numbers are above.
- [x] Every commit is signed off — `git commit -s`. See [CONTRIBUTING.md](../CONTRIBUTING.md).
