### PR TITLE
feat: the vocabulary gate reads French at its own floor

### DIFF
--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -98,11 +98,13 @@ enum CheckConfigCommand {
                 .map { "\"\($0)\"" }.joined(separator: ", ")
             emit("  · wake phrase       \(listed.isEmpty ? "none — spoken commands are off" : listed)")
             emit("  · rewrite line      \(transcription.rewriteLine ? "on" : "off (terminals can't be edited without it)")")
-            // The floor is not the same in two languages, so it is printed per
-            // language rather than once.
+            // Neither setting is the same in two languages, so both are printed
+            // per language rather than once.
             emit("  · languages         \(transcription.languages.joined(separator: ", "))")
             for language in transcription.languages {
-                emit("      \(language)  slot floor"
+                emit("      \(language)  marks"
+                    + " \(transcription.marks(for: language).joined(separator: " "))"
+                    + "  slot floor"
                     + " \(String(format: "%.2f", transcription.slotFloor(for: language)))")
             }
             // The pipeline, because "why was this not converted" is a question

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -98,6 +98,13 @@ enum CheckConfigCommand {
                 .map { "\"\($0)\"" }.joined(separator: ", ")
             emit("  · wake phrase       \(listed.isEmpty ? "none — spoken commands are off" : listed)")
             emit("  · rewrite line      \(transcription.rewriteLine ? "on" : "off (terminals can't be edited without it)")")
+            // The floor is not the same in two languages, so it is printed per
+            // language rather than once.
+            emit("  · languages         \(transcription.languages.joined(separator: ", "))")
+            for language in transcription.languages {
+                emit("      \(language)  slot floor"
+                    + " \(String(format: "%.2f", transcription.slotFloor(for: language)))")
+            }
             // The pipeline, because "why was this not converted" is a question
             // about the order and not about a setting any more.
             let pipeline = Pipeline.resolved(config: config)

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1767,10 +1767,11 @@ struct Config: Decodable, Equatable {
 
             /// What each language gets with nothing in the file.
             ///
-            /// French gaps are compressed by about a third, so the English
-            /// floor refuses correct French rewrites. No single value serves
-            /// both: 0.40 is free in both and costs the English gate 35 of the
-            /// 55 wrong rewrites it catches.
+            /// French gaps are compressed by about a third. On a 201-case
+            /// French bench the English floor wrongly refuses 7 correct
+            /// rewrites of 84 and 0.30 refuses 2. No single value serves both:
+            /// 0.40 is free in both and costs the English gate 35 of the 55
+            /// wrong rewrites it catches.
             static let builtIn: [String: Language] = [
                 "en": Language(marks: defaultMarks, slotFloor: defaultSlotFloor),
                 "fr": Language(marks: defaultMarks, slotFloor: 0.30),

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1671,11 +1671,18 @@ struct Config: Decodable, Equatable {
         /// There is no threshold; the reading the model scores highest is the
         /// one that is written. `;` and `:` were measured and never changed a
         /// decision in English, so they are not in the default.
+        ///
+        /// The marks live in `per_language` now. `marks:` here is still read
+        /// and still answers for English — see `marks(for:)`.
         var sentences: Sentences = Sentences()
 
         struct Sentences: Decodable, Equatable {
             var enabled = true
-            var marks: [String] = [".", ",", "?"]
+            /// The old home of the mark set. Read through
+            /// `Transcription.marks(for:)`, which prefers `per_language`;
+            /// `marksWritten` says the file set this one.
+            var marks: [String] = Language.defaultMarks
+            var marksWritten = false
 
             /// Keys still read and no longer acted on, for `notices()`.
             var legacy: [String] = []
@@ -1700,44 +1707,10 @@ struct Config: Decodable, Equatable {
                 }
                 let c = try decoder.container(keyedBy: CodingKeys.self)
                 if let written = try c.decodeIfPresent([String].self, forKey: .marks) {
-                    let kept = written
-                        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                        .filter { !$0.isEmpty }
-                    // With no mark the join is the only reading, so it wins
-                    // every boundary and every period in the transcript goes.
-                    guard !kept.isEmpty else {
-                        throw ConfigError.invalidValue(
-                            key: "transcription.sentences.marks",
-                            value: "an empty list",
-                            expected: "at least one mark — with none, joining is the only"
-                                + " reading and every period would be removed"
-                        )
-                    }
-                    // The enders in the list are where a boundary is looked
-                    // for. With none the stage finds nothing and does nothing,
-                    // which is what `sentences: false` is for.
-                    guard kept.contains(where: { SentenceReadings.enders.contains($0) }) else {
-                        throw ConfigError.invalidValue(
-                            key: "transcription.sentences.marks",
-                            value: kept.map { "`\($0)`" }.joined(separator: ", "),
-                            expected: "at least one of `.`, `?` or `!` — those are where a"
-                                + " boundary is looked for, so with none the stage never runs."
-                                + " Use `sentences: false` to turn it off"
-                        )
-                    }
-                    // A mark is one punctuation character. Any word here would
-                    // be written into the sentence as if it were punctuation,
-                    // and the word `join` is the name of the reading that
-                    // removes the period, so it would remove one.
-                    let wrong = kept.filter { $0.count != 1 || !($0.first?.isPunctuation ?? false) }
-                    guard wrong.isEmpty else {
-                        throw ConfigError.invalidValue(
-                            key: "transcription.sentences.marks",
-                            value: wrong.map { "`\($0)`" }.joined(separator: ", "),
-                            expected: "one punctuation character each — `[\".\", \",\"]`"
-                        )
-                    }
-                    marks = kept
+                    marks = try Language.checked(
+                        marks: written, key: "transcription.sentences.marks"
+                    )
+                    marksWritten = true
                 }
                 let old = try decoder.container(keyedBy: LegacyKeys.self)
                 for key in [LegacyKeys.joinBelow, .offerBelow]
@@ -1755,11 +1728,23 @@ struct Config: Decodable, Equatable {
         ///       per_language:
         ///         fr:
         ///           slot_floor: 0.30
+        ///           marks: [".", ",", "?"]
         ///
         /// An entry overrides only the keys it names. Everything else keeps the
         /// built-in value for that language, and a language with no entry keeps
         /// English's.
         var perLanguage: [String: Language] = [:]
+
+        /// The marks the sentence stage tries beside removing the period.
+        ///
+        /// `transcription.sentences.marks` is the old home of the same set. It
+        /// is still read, and it answers for English only: that stage has never
+        /// run in another language.
+        func marks(for language: String) -> [String] {
+            if let written = perLanguage[language]?.marks { return written }
+            if language == "en", sentences.marksWritten { return sentences.marks }
+            return Language.builtIn[language]?.marks ?? Language.defaultMarks
+        }
 
         /// How far the heard word must win by before the vocabulary gate
         /// refuses a rewrite — see `SlotReference`.
@@ -1772,8 +1757,10 @@ struct Config: Decodable, Equatable {
         /// What one language sets. Every key is optional: naming a language to
         /// change one of them must not silently reset the others.
         struct Language: Decodable, Equatable {
+            var marks: [String]?
             var slotFloor: Double?
 
+            static let defaultMarks = [".", ",", "?"]
             /// English's floor. Ordinary words sit at -0.30 to -0.43 and
             /// correct rewrites at -0.02 to -0.18, and nothing lands between.
             static let defaultSlotFloor = 0.20
@@ -1785,15 +1772,17 @@ struct Config: Decodable, Equatable {
             /// both: 0.40 is free in both and costs the English gate 35 of the
             /// 55 wrong rewrites it catches.
             static let builtIn: [String: Language] = [
-                "en": Language(slotFloor: defaultSlotFloor),
-                "fr": Language(slotFloor: 0.30),
+                "en": Language(marks: defaultMarks, slotFloor: defaultSlotFloor),
+                "fr": Language(marks: defaultMarks, slotFloor: 0.30),
             ]
 
-            init(slotFloor: Double? = nil) {
+            init(marks: [String]? = nil, slotFloor: Double? = nil) {
+                self.marks = marks
                 self.slotFloor = slotFloor
             }
 
             enum CodingKeys: String, CodingKey {
+                case marks
                 case slotFloor = "slot_floor"
             }
 
@@ -1802,6 +1791,9 @@ struct Config: Decodable, Equatable {
                 let path = "transcription.per_language"
                     + (named.isEmpty ? "" : ".\(named)")
                 let c = try decoder.container(keyedBy: CodingKeys.self)
+                if let written = try c.decodeIfPresent([String].self, forKey: .marks) {
+                    marks = try Self.checked(marks: written, key: "\(path).marks")
+                }
                 if let written = try c.decodeIfPresent(Double.self, forKey: .slotFloor) {
                     // The gap is one cosine minus another, so it never goes
                     // below -2 and a floor of 2 refuses nothing. At 0 or less
@@ -1816,6 +1808,45 @@ struct Config: Decodable, Equatable {
                     }
                     slotFloor = written
                 }
+            }
+
+            /// A mark is one punctuation character. Any word here would be
+            /// written into the sentence as if it were punctuation.
+            static func checked(marks written: [String], key: String) throws -> [String] {
+                let kept = written
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .filter { !$0.isEmpty }
+                // With no mark the join is the only reading, so it wins every
+                // boundary and every period in the transcript goes.
+                guard !kept.isEmpty else {
+                    throw ConfigError.invalidValue(
+                        key: key,
+                        value: "an empty list",
+                        expected: "at least one mark — with none, joining is the only"
+                            + " reading and every period would be removed"
+                    )
+                }
+                // The enders in the list are where a boundary is looked for.
+                // With none the stage finds nothing and does nothing, which is
+                // what `sentences: false` is for.
+                guard kept.contains(where: { SentenceReadings.enders.contains($0) }) else {
+                    throw ConfigError.invalidValue(
+                        key: key,
+                        value: kept.map { "`\($0)`" }.joined(separator: ", "),
+                        expected: "at least one of `.`, `?` or `!` — those are where a"
+                            + " boundary is looked for, so with none the stage never runs."
+                            + " Use `sentences: false` to turn it off"
+                    )
+                }
+                let wrong = kept.filter { $0.count != 1 || !($0.first?.isPunctuation ?? false) }
+                guard wrong.isEmpty else {
+                    throw ConfigError.invalidValue(
+                        key: key,
+                        value: wrong.map { "`\($0)`" }.joined(separator: ", "),
+                        expected: "one punctuation character each — `[\".\", \",\", \"?\"]`"
+                    )
+                }
+                return kept
             }
         }
 
@@ -2855,6 +2886,13 @@ struct Config: Decodable, Equatable {
         // file-level key and nothing else.
         said += vocabulary.legacy.map { "vocabulary: \($0)" }
         said += transcription.sentences.legacy.map { "sentences: \($0)" }
+        // Still read, and still English's set. It moved because the slot floor
+        // keys off the language too, and two settings keyed the same way belong
+        // in one block.
+        if transcription.sentences.marksWritten, transcription.perLanguage["en"]?.marks == nil {
+            said.append("sentences: `marks:` now lives at"
+                + " `transcription.per_language.en.marks`. Yours is still read")
+        }
         return said
     }
 

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1749,6 +1749,76 @@ struct Config: Decodable, Equatable {
             }
         }
 
+        /// The settings that key off which language you dictated in.
+        ///
+        ///     transcription:
+        ///       per_language:
+        ///         fr:
+        ///           slot_floor: 0.30
+        ///
+        /// An entry overrides only the keys it names. Everything else keeps the
+        /// built-in value for that language, and a language with no entry keeps
+        /// English's.
+        var perLanguage: [String: Language] = [:]
+
+        /// How far the heard word must win by before the vocabulary gate
+        /// refuses a rewrite — see `SlotReference`.
+        func slotFloor(for language: String) -> Double {
+            perLanguage[language]?.slotFloor
+                ?? Language.builtIn[language]?.slotFloor
+                ?? Language.defaultSlotFloor
+        }
+
+        /// What one language sets. Every key is optional: naming a language to
+        /// change one of them must not silently reset the others.
+        struct Language: Decodable, Equatable {
+            var slotFloor: Double?
+
+            /// English's floor. Ordinary words sit at -0.30 to -0.43 and
+            /// correct rewrites at -0.02 to -0.18, and nothing lands between.
+            static let defaultSlotFloor = 0.20
+
+            /// What each language gets with nothing in the file.
+            ///
+            /// French gaps are compressed by about a third, so the English
+            /// floor refuses correct French rewrites. No single value serves
+            /// both: 0.40 is free in both and costs the English gate 35 of the
+            /// 55 wrong rewrites it catches.
+            static let builtIn: [String: Language] = [
+                "en": Language(slotFloor: defaultSlotFloor),
+                "fr": Language(slotFloor: 0.30),
+            ]
+
+            init(slotFloor: Double? = nil) {
+                self.slotFloor = slotFloor
+            }
+
+            enum CodingKeys: String, CodingKey {
+                case slotFloor = "slot_floor"
+            }
+
+            init(from decoder: Decoder) throws {
+                let named = decoder.codingPath.last?.stringValue ?? ""
+                let path = "transcription.per_language"
+                    + (named.isEmpty ? "" : ".\(named)")
+                let c = try decoder.container(keyedBy: CodingKeys.self)
+                if let written = try c.decodeIfPresent(Double.self, forKey: .slotFloor) {
+                    // The gap is one cosine minus another, so it never goes
+                    // below -2 and a floor of 2 refuses nothing. At 0 or less
+                    // the faintest lean against the term refuses it.
+                    guard written > 0, written <= 2 else {
+                        throw ConfigError.invalidValue(
+                            key: "\(path).slot_floor",
+                            value: "\(written)",
+                            expected: "a number above 0 and at most 2 — 0.20 in English,"
+                                + " 0.30 in French"
+                        )
+                    }
+                    slotFloor = written
+                }
+            }
+        }
+
         enum InsertMode: String, Codable, Equatable {
             case paste
             case clipboard
@@ -1756,6 +1826,7 @@ struct Config: Decodable, Equatable {
 
         enum CodingKeys: String, CodingKey {
             case enabled, replacements, pipeline, languages, sentences
+            case perLanguage = "per_language"
             case insertMode = "insert_mode"
             case activationPhrases = "activation_phrases"
             case activationPhrase = "activation_phrase"
@@ -2074,6 +2145,31 @@ struct Config: Decodable, Equatable {
                     key: "transcription.sentences",
                     value: "not a sentence setting",
                     expected: "`false`, or `marks:` as a list of punctuation marks"
+                )
+            }
+            // Not `try?` either, and for the same reason: a floor the file got
+            // wrong must not leave the gate running on a stock one.
+            do {
+                if let written = try c.decodeIfPresent(
+                    [String: Language].self, forKey: .perLanguage
+                ) {
+                    let unknown = written.keys.filter { !DictationLanguage.supported.contains($0) }
+                    guard unknown.isEmpty else {
+                        throw ConfigError.invalidValue(
+                            key: "transcription.per_language",
+                            value: unknown.sorted().map { "`\($0)`" }.joined(separator: ", "),
+                            expected: "one of \(DictationLanguage.supported.joined(separator: ", "))"
+                        )
+                    }
+                    perLanguage = written
+                }
+            } catch let bad as ConfigError {
+                throw bad
+            } catch {
+                throw ConfigError.invalidValue(
+                    key: "transcription.per_language",
+                    value: "not a language block",
+                    expected: "a language code, then `marks:` or `slot_floor:` under it"
                 )
             }
             // Wrapped, as `replacements:` is below and for the same reason.

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -1088,7 +1088,9 @@ struct Pipeline: Equatable, Codable {
         if config.vocabulary.gateSentence, #available(macOS 14, *) {
             decided = await SentenceGate.settle(
                 changes, in: text, given: decided,
-                language: Pipeline.language(of: text, config: config)
+                floor: config.transcription.slotFloor(
+                    for: Pipeline.language(of: text, config: config)
+                )
             )
         }
         gateSeconds = Date().timeIntervalSince(gatedAt)

--- a/Sources/ParrotFlow/PipelineCommand.swift
+++ b/Sources/ParrotFlow/PipelineCommand.swift
@@ -29,6 +29,10 @@ enum PipelineCommand {
     /// A fixture is a config with everything irrelevant left out.
     private struct Fixture: Decodable {
         var languages: [String] = ["en"]
+        /// The floor the vocabulary gate reads and the marks the sentence
+        /// stage tries. A fixture that cannot state its floor cannot say what
+        /// the gate was scored at.
+        var perLanguage: [String: Config.Transcription.Language] = [:]
         var replacements: [String: [String]] = [:]
         var pipeline: [Config.Transcription.PipelineEntry] = []
         /// Its own `transforms:`, decoded by `Config` rather than re-read here,
@@ -50,11 +54,15 @@ enum PipelineCommand {
 
         enum CodingKeys: String, CodingKey {
             case languages, replacements, pipeline, transforms, vocabulary, lists, models
+            case perLanguage = "per_language"
         }
 
         init(from decoder: Decoder) throws {
             let c = try decoder.container(keyedBy: CodingKeys.self)
             if let v = try c.decodeIfPresent([String].self, forKey: .languages) { languages = v }
+            if let v = try c.decodeIfPresent(
+                [String: Config.Transcription.Language].self, forKey: .perLanguage
+            ) { perLanguage = v }
             if let v = try c.decodeIfPresent([String: [String]].self, forKey: .replacements) {
                 replacements = v
             }
@@ -137,6 +145,7 @@ enum PipelineCommand {
         let pipeline = Pipeline(steps: steps)
         var config = Config()
         config.transcription.languages = fixture.languages
+        config.transcription.perLanguage = fixture.perLanguage
         config.transcription.replacements = fixture.replacements
         config.transcription.pipeline = pipeline
         config.transforms = fixture.transforms

--- a/Sources/ParrotFlow/SentenceGate.swift
+++ b/Sources/ParrotFlow/SentenceGate.swift
@@ -33,9 +33,13 @@ enum SentenceGate {
     /// `settled` carries one entry per change: `true` writes the term, `false`
     /// keeps what was heard, `nil` is still open. Only the open ones are asked
     /// about, so a place the word lists already settled costs nothing.
+    ///
+    /// `floor` is how far the heard word must win by before `SlotReference`
+    /// refuses. It keys off the language of the transcript — see
+    /// `Config.Transcription.slotFloor(for:)`.
     static func settle(
         _ changes: [VocabularyJudge.Change], in text: String, given settled: [Bool?],
-        language: String
+        floor: Double
     ) async -> [Bool?] {
         // Never on the dictation's time. The word vectors are 400 MB and the
         // first MLX call warms Metal; waiting for that with the pill on screen
@@ -116,7 +120,7 @@ enum SentenceGate {
                 let gap = try await SlotReference.gap(
                     term: change.now, heard: change.was, at: change.range, in: text
                 )
-                refuses = gap < -SlotReference.floor(for: language)
+                refuses = gap < -floor
             } catch {
                 // A place the slot cannot read is a place this stage has no
                 // opinion about, not one to guess at.

--- a/Sources/ParrotFlow/SentenceJoin.swift
+++ b/Sources/ParrotFlow/SentenceJoin.swift
@@ -213,7 +213,9 @@ actor SentenceJoin {
     func apply(to text: String, config: Config) async -> Outcome {
         let settings = config.transcription.sentences
         guard settings.enabled else { return .unchanged(text) }
-        let found = Self.boundaries(in: text, scanning: Self.scanned(settings.marks))
+        let language = Pipeline.language(of: text, config: config)
+        let marks = config.transcription.marks(for: language)
+        let found = Self.boundaries(in: text, scanning: Self.scanned(marks))
         guard !found.isEmpty else { return .unchanged(text) }
         guard await SentenceReadings.shared.isLoaded else {
             await SentenceReadings.shared.warm()
@@ -235,7 +237,7 @@ actor SentenceJoin {
                     left: String(text[..<boundary.at]),
                     right: String(text[boundary.next.lowerBound...]),
                     found: String(boundary.mark),
-                    marks: settings.marks
+                    marks: marks
                 )
             } catch {
                 Log.write(

--- a/Sources/ParrotFlow/SentenceProbeCommand.swift
+++ b/Sources/ParrotFlow/SentenceProbeCommand.swift
@@ -39,7 +39,7 @@ enum SentenceProbeCommand {
     static func run(left: String, right: String) -> Int32 {
         var exitCode: Int32 = 0
         let done = DispatchSemaphore(value: 0)
-        let marks = ((try? ConfigStore.load()) ?? Config()).transcription.sentences.marks
+        let marks = ((try? ConfigStore.load()) ?? Config()).transcription.marks(for: "en")
         let mark = found(in: left, marks: marks)
 
         Task {
@@ -90,7 +90,7 @@ enum SentenceProbeCommand {
         }
         var exitCode: Int32 = 0
         let done = DispatchSemaphore(value: 0)
-        let marks = ((try? ConfigStore.load()) ?? Config()).transcription.sentences.marks
+        let marks = ((try? ConfigStore.load()) ?? Config()).transcription.marks(for: "en")
 
         Task {
             do {

--- a/Sources/ParrotFlow/SentenceProbeCommand.swift
+++ b/Sources/ParrotFlow/SentenceProbeCommand.swift
@@ -39,6 +39,8 @@ enum SentenceProbeCommand {
     static func run(left: String, right: String) -> Int32 {
         var exitCode: Int32 = 0
         let done = DispatchSemaphore(value: 0)
+        // English: this is the English boundary probe, and the stage it stands
+        // in runs in no other language.
         let marks = ((try? ConfigStore.load()) ?? Config()).transcription.marks(for: "en")
         let mark = found(in: left, marks: marks)
 

--- a/Sources/ParrotFlow/SlotGapCommand.swift
+++ b/Sources/ParrotFlow/SlotGapCommand.swift
@@ -10,12 +10,15 @@ import Foundation
 /// they are printed because they explain the number: a slot whose ten words are
 /// pronouns cannot tell two names apart, and the gap comes out near zero.
 ///
+/// `--lang fr` reads the verdict at the French floor. The gap itself is the
+/// same number in every language; only the line it is compared against moves.
+///
 /// This is what `scripts/check-slot-gap.sh` scores, so a case set runs against
 /// the shipped path rather than a copy of it.
 @available(macOS 14, *)
 enum SlotGapCommand {
 
-    static func run(sentence: String, heard: String, term: String) -> Int32 {
+    static func run(sentence: String, heard: String, term: String, language: String) -> Int32 {
         let outcome = Blocking.run { () async -> Result<(Double, [String]), Error> in
             do {
                 guard let found = sentence.range(of: heard) else {
@@ -39,8 +42,9 @@ enum SlotGapCommand {
             return 1
         case .success(let (gap, words)):
             print("expected  \(words.joined(separator: " "))")
-            // English, which is the only language the gate runs in.
-            let verdict = gap < -SlotReference.floor(for: "en") ? "refuse" : "no opinion"
+            let floor = ((try? ConfigStore.load()) ?? Config())
+                .transcription.slotFloor(for: language)
+            let verdict = gap < -floor ? "refuse" : "no opinion"
             print("gap       \(String(format: "%+.3f", gap))   \(verdict)")
             return 0
         }

--- a/Sources/ParrotFlow/SlotReference.swift
+++ b/Sources/ParrotFlow/SlotReference.swift
@@ -27,28 +27,18 @@ import Foundation
 /// to write. `TermPortrait` is the half that authorises.
 ///
 /// Measured on 59 hand-labelled proposals and on 35 more from fresh dictation,
-/// at `floor`: no correct rewrite refused, no ordinary word overwritten.
+/// at the English floor: no correct rewrite refused, no ordinary word
+/// overwritten.
+///
+/// **The floor is per language and it lives in the config**, at
+/// `transcription.per_language.<code>.slot_floor` — 0.20 in English, 0.30 in
+/// French. It is the raw difference of two cosines, not divided by anything.
+/// Dividing by the spread of the ten words looks like it should help and does
+/// the opposite: a sentence holding a rare name makes the ten words collapse
+/// together, the spread goes to 0.002, and the ratio explodes on exactly the
+/// cases that should be written.
 @available(macOS 14, *)
 enum SlotReference {
-
-    /// How far the heard word must win by before the rewrite is refused.
-    ///
-    /// The raw difference of two cosines, not divided by anything. Dividing by
-    /// the spread of the ten words looks like it should help and does the
-    /// opposite: a sentence holding a rare name makes the ten words collapse
-    /// together, the spread goes to 0.002, and the ratio explodes on exactly
-    /// the cases that should be written.
-    ///
-    /// 0.20 holds on three sets, two of them chosen after it was fixed.
-    /// Ordinary words sit at -0.30 to -0.43 and correct rewrites at -0.02 to
-    /// -0.18, and nothing lands between.
-    ///
-    /// Per language, because the value does not transfer. Only English is in
-    /// the table: the gate runs on nothing else yet.
-    static func floor(for language: String) -> Double { floors[language] ?? english }
-
-    private static let english = 0.20
-    private static let floors: [String: Double] = ["en": english]
 
     /// How many words the reference is built from, and how deep to look for
     /// them. Ten is what every measurement used.

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -491,20 +491,24 @@ actor Transcriber {
         // downloads at once halve the bandwidth of the one somebody is
         // watching.
         //
-        // English only, and the sentence pass below shares that gate: the
-        // readings are scored by an English base model and the mark set is
-        // English.
+        // The vocabulary gate's two models, in any language: mmBERT-small
+        // answers in French and so do the word vectors.
+        //
+        // Fetched at launch too. This is the retry: a fetch that failed clears
+        // itself, and the next dictation tries again.
+        warmSlotModel()
+        if config.vocabulary.gateSentence, #available(macOS 14, *) {
+            Task { await WordVectors.shared.warm() }
+        }
+
+        // The sentence pass is English only: the readings are scored by an
+        // English base model and the mark set is English. So is the sound pass
+        // — espeak's letter-to-sound answers for French words and the answer is
+        // noise.
         var joinedSentences = 0
         if Pipeline.language(of: text, config: config) == "en" {
-            // Fetched at launch now. This is the retry: a fetch that failed
-            // clears itself, and the next English dictation is the next chance
-            // to try again.
-            warmSlotModel()
             if #available(macOS 14, *), config.transcription.sentences.enabled {
                 Task { await SentenceReadings.shared.warm() }
-            }
-            if config.vocabulary.gateSentence, #available(macOS 14, *) {
-                Task { await WordVectors.shared.warm() }
             }
             // The set the sound pass actually reads, not the shorter one the
             // audio search needed. `vocabularyTerms` drops anything under five

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -476,7 +476,10 @@ if let index = arguments.firstIndex(of: "--slot-gap") {
     let slotGapLanguage: String
     if arguments.contains("--lang") {
         let listed = languageList(arguments) ?? []
-        guard listed.count == 1, let only = listed.first,
+        // `languageList` reads the first `--lang` and ignores a second one, so
+        // the count is checked here rather than there.
+        guard arguments.filter({ $0 == "--lang" }).count == 1,
+              listed.count == 1, let only = listed.first,
               DictationLanguage.supported.contains(only) else {
             print("✗ --lang wants one of"
                 + " \(DictationLanguage.supported.joined(separator: ", "))"

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -470,12 +470,21 @@ if let index = arguments.firstIndex(of: "--slot-gap") {
         print("usage: ParrotFlow --slot-gap \"<sentence>\" <heard> <term> [--lang <code>]")
         exit(2)
     }
+    // Refused rather than defaulted. An unknown code takes English's floor, so
+    // `--lang eng` would print a confident verdict about a language nobody asked
+    // about.
+    let slotGapLanguage = languageList(arguments)?.first ?? "en"
+    guard DictationLanguage.supported.contains(slotGapLanguage) else {
+        print("✗ --lang \(slotGapLanguage): the gate knows a floor for"
+            + " \(DictationLanguage.supported.joined(separator: ", ")) only")
+        exit(2)
+    }
     exit(
         SlotGapCommand.run(
             sentence: arguments[index + 1],
             heard: arguments[index + 2],
             term: arguments[index + 3],
-            language: languageList(arguments)?.first ?? "en"
+            language: slotGapLanguage
         )
     )
 }

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -467,14 +467,15 @@ if let index = arguments.firstIndex(of: "--slot-gap") {
         exit(1)
     }
     guard arguments.indices.contains(index + 3) else {
-        print("usage: ParrotFlow --slot-gap \"<sentence>\" <heard> <term>")
+        print("usage: ParrotFlow --slot-gap \"<sentence>\" <heard> <term> [--lang <code>]")
         exit(2)
     }
     exit(
         SlotGapCommand.run(
             sentence: arguments[index + 1],
             heard: arguments[index + 2],
-            term: arguments[index + 3]
+            term: arguments[index + 3],
+            language: languageList(arguments)?.first ?? "en"
         )
     )
 }

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -470,14 +470,22 @@ if let index = arguments.firstIndex(of: "--slot-gap") {
         print("usage: ParrotFlow --slot-gap \"<sentence>\" <heard> <term> [--lang <code>]")
         exit(2)
     }
-    // Refused rather than defaulted. An unknown code takes English's floor, so
-    // `--lang eng` would print a confident verdict about a language nobody asked
-    // about.
-    let slotGapLanguage = languageList(arguments)?.first ?? "en"
-    guard DictationLanguage.supported.contains(slotGapLanguage) else {
-        print("✗ --lang \(slotGapLanguage): the gate knows a floor for"
-            + " \(DictationLanguage.supported.joined(separator: ", ")) only")
-        exit(2)
+    // Refused rather than defaulted, and one code only. The verdict is read at
+    // that language's floor, so `--lang eng` or `--lang en,fr` would answer
+    // about a language nobody asked about.
+    let slotGapLanguage: String
+    if arguments.contains("--lang") {
+        let listed = languageList(arguments) ?? []
+        guard listed.count == 1, let only = listed.first,
+              DictationLanguage.supported.contains(only) else {
+            print("✗ --lang wants one of"
+                + " \(DictationLanguage.supported.joined(separator: ", "))"
+                + " — the gate knows a floor for those only")
+            exit(2)
+        }
+        slotGapLanguage = only
+    } else {
+        slotGapLanguage = "en"
     }
     exit(
         SlotGapCommand.run(

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -90,6 +90,15 @@ transcription:
   # sentences:
   #   marks: [".", ",", "?"]  # `.` and `?` are scanned, `,` is read beside them
 
+  # The settings that differ from one language to the next. `slot_floor` is
+  # how far the heard word must win by before the vocabulary gate refuses a
+  # rewrite: 0.20 in English, 0.30 in French, where the gaps are a third
+  # narrower.
+  #
+  # per_language:
+  #   en: {slot_floor: 0.20}
+  #   fr: {slot_floor: 0.30}
+
   # What a transcript runs through, in order. Remove a line to skip that
   # stage. One list for every language: a step that should only run in one
   # takes `when: language == "fr"`. See docs/pipelines.md.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -87,17 +87,17 @@ transcription:
   # model scores highest is written. On by default, and only where the model is
   # already on disk. `sentences: false` turns it off.
   #
-  # sentences:
-  #   marks: [".", ",", "?"]  # `.` and `?` are scanned, `,` is read beside them
+  # sentences: false
 
-  # The settings that differ from one language to the next. `slot_floor` is
-  # how far the heard word must win by before the vocabulary gate refuses a
+  # The settings that differ from one language to the next. `marks` is the
+  # list above: `.` and `?` are scanned, `,` is read beside them. `slot_floor`
+  # is how far the heard word must win by before the vocabulary gate refuses a
   # rewrite: 0.20 in English, 0.30 in French, where the gaps are a third
   # narrower.
   #
   # per_language:
-  #   en: {slot_floor: 0.20}
-  #   fr: {slot_floor: 0.30}
+  #   en: {marks: [".", ",", "?"], slot_floor: 0.20}
+  #   fr: {marks: [".", ",", "?"], slot_floor: 0.30}
 
   # What a transcript runs through, in order. Remove a line to skip that
   # stage. One list for every language: a step that should only run in one

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -425,7 +425,7 @@ $PF --transcribe /tmp/t.wav
 $PF --slot-model                                           # fetch, compile and load mmBERT-small
 $PF --slot-probe "<left half>" "<right half>"              # the ten words the slot expects, and the time
 $PF --slot-probe --encode "<text>"                         # the tokenizer alone, no model
-$PF --slot-gap "<sentence>" <heard> <term>                 # what the slot says about a rewrite
+$PF --slot-gap "<sentence>" <heard> <term> [--lang fr]     # what the slot says about a rewrite
 ```
 
 The vocabulary pass proposes a rewrite from spelling and sound alone. The slot
@@ -438,8 +438,11 @@ $PF --slot-gap "The old house looked ghostly in the fog." ghostly Ghostty
   gap       -0.243   refuse
 ```
 
-`gap` is `cos(term, centre) − cos(heard, centre)`. Below −0.20 the rewrite is
-refused; above it the slot has no opinion. It only ever refuses — a term is
+`gap` is `cos(term, centre) − cos(heard, centre)`. Below the floor for the
+language the rewrite is refused; above it the slot has no opinion. The floor is
+`transcription.per_language.<code>.slot_floor`, 0.20 in English and 0.30 in
+French, and `--lang` picks which one the verdict is read at. The gap itself is
+the same number either way. It only ever refuses — a term is
 unknown to the tokenizer by construction, so it can never win this comparison.
 The ten words are printed because they explain the number: a slot whose ten
 words are pronouns cannot tell two names apart, and the gap comes out near zero.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -528,9 +528,10 @@ $PF --sentence-join "…the first usage of the LLM with. The vocabulary is slowe
 ```
 
 The mark is removed where `join` wins, and left alone otherwise. Which marks are
-scanned, and which are read beside them, is `transcription.sentences.marks` in
-`config.yaml` — the sentence enders in that list are scanned, the rest are
-readings. `scripts/check-sentence-join.sh` scores the decisions against
+scanned, and which are read beside them, is
+`transcription.per_language.<code>.marks` in `config.yaml` — the sentence enders
+in that list are scanned, the rest are readings.
+`scripts/check-sentence-join.sh` scores the decisions against
 tests/sentence-boundary-cases.json, in both shapes; it needs the model, so it is
 run by hand.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,7 @@ transcription:
   languages: [en]       # en and fr are the supported values
   rewrite_line: true
   sentences: …          # or false — joining a sentence a pause cut in two
+  per_language: …       # the settings that differ from one language to the next
   pipeline: …           # see pipelines.md
   transforms: …         # see pipelines.md
 
@@ -445,6 +446,32 @@ language. One entry means no detection runs at all.
 
 Most spoken first: the first entry is the fallback for transcripts too short to
 judge, under four words. Supported values are `en` and `fr`.
+
+## `transcription.per_language`
+
+The settings that differ from one language to the next, in one block keyed by
+language code.
+
+```yaml
+transcription:
+  per_language:
+    en: {slot_floor: 0.20}
+    fr: {slot_floor: 0.30}
+```
+
+Those are the defaults, so an empty block changes nothing. An entry overrides
+only the keys it names. A language with no entry gets English's values.
+
+`slot_floor` is how far the word you were heard to say must beat a vocabulary
+term by before the gate refuses to write the term. The number is a difference of
+two cosines, so it must be above 0 and at most 2. It does not carry between
+languages: French gaps are about a third narrower, so the English 0.20 refuses
+correct French rewrites where 0.30 does not. No single value works for both —
+0.40 is free in both and costs the English gate 35 of the 55 wrong rewrites it
+catches. The gate only ever refuses, so a floor set too tight costs a name you
+have to type, never a wrong word in your text.
+
+`--check-config` prints the floor for every language you listed.
 
 ## `transcription.activation_phrases`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -470,11 +470,12 @@ the sentence as punctuation.
 `slot_floor` is how far the word you were heard to say must beat a vocabulary
 term by before the gate refuses to write the term. The number is a difference of
 two cosines, so it must be above 0 and at most 2. It does not carry between
-languages: French gaps are about a third narrower, so the English 0.20 refuses
-correct French rewrites where 0.30 does not. No single value works for both —
-0.40 is free in both and costs the English gate 35 of the 55 wrong rewrites it
-catches. The gate only ever refuses, so a floor set too tight costs a name you
-have to type, never a wrong word in your text.
+languages: French gaps are about a third narrower. On a 201-case French bench,
+0.20 wrongly refuses 7 correct rewrites of 84 and 0.30 refuses 2, at a cost of
+19 of the 117 wrong rewrites caught. No single value works for both — 0.40 is
+free in both and costs the English gate 35 of the 55 wrong rewrites it catches.
+The gate only ever refuses, so a floor set too tight costs a name you have to
+type, never a wrong word in your text.
 
 `--check-config` prints both values for every language you listed.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -455,12 +455,17 @@ language code.
 ```yaml
 transcription:
   per_language:
-    en: {slot_floor: 0.20}
-    fr: {slot_floor: 0.30}
+    en: {marks: [".", ","], slot_floor: 0.20}
+    fr: {marks: [".", ","], slot_floor: 0.30}
 ```
 
 Those are the defaults, so an empty block changes nothing. An entry overrides
 only the keys it names. A language with no entry gets English's values.
+
+`marks` are the punctuation the sentence stage tries beside removing the period
+— see [`transcription.sentences`](#transcriptionsentences). Each entry is one
+punctuation character; anything else is refused, because a mark is written into
+the sentence as punctuation.
 
 `slot_floor` is how far the word you were heard to say must beat a vocabulary
 term by before the gate refuses to write the term. The number is a difference of
@@ -471,7 +476,7 @@ correct French rewrites where 0.30 does not. No single value works for both —
 catches. The gate only ever refuses, so a floor set too tight costs a name you
 have to type, never a wrong word in your text.
 
-`--check-config` prints the floor for every language you listed.
+`--check-config` prints both values for every language you listed.
 
 ## `transcription.activation_phrases`
 
@@ -503,13 +508,9 @@ and capitalise the next word, so one sentence becomes two. Every such boundary
 in an English transcript is read several ways and the reading the model likes
 best wins.
 
-```yaml
-transcription:
-  sentences:
-    marks: [".", ",", "?"]    # what a boundary can be written
-```
-
-`sentences: false` turns the whole stage off.
+`sentences: false` turns the whole stage off. The marks it works with are
+[`transcription.per_language`](#transcriptionper_language), default
+`[".", ",", "?"]`.
 
 One list, two jobs. The sentence enders in it — `.` and `?` — are **where a
 boundary is looked for**. Everything else in it — the comma — is a **reading
@@ -531,10 +532,12 @@ real period joined, and 82% of 325 question cuts repaired at one wrong join in
 they no longer do anything.
 
 `;` and `:` were measured and never changed a decision in English, so they are
-not in the default. The set is a setting because it is language-dependent. Each
-entry is one punctuation character, and at least one must end a sentence;
-anything else is refused, because a mark is written into the sentence as
-punctuation.
+not in the default. Each entry is one punctuation character, and at least one
+must end a sentence; anything else is refused, because a mark is written into
+the sentence as punctuation. The set is a setting because it is
+language-dependent, which is why it lives in the language block. `marks:` under
+`sentences:` is still read and still answers for English; `--check-config` says
+where it moved.
 
 A word after a question mark does not have to be capitalised. Of 19 lines where
 the transcriber wrote `word? lowercase`, 7 hold a mark that should go and 12 a

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -433,9 +433,9 @@ refused 14 and left 24 on the same set, also with no error; mmBERT-small
 replaced it because it covers French, at no cost in English.
 
 The model is never waited for. Until it is on disk, every place this tier would
-judge is simply left open, which is the behaviour before this tier. The gate is
-still reached on English dictation only: mmBERT-small answers in French too, and
-turning that on needs its own floor, which is a change of its own.
+judge is simply left open, which is the behaviour before this tier. This tier
+runs in every language and was measured in English only. Its error direction is
+the same cheap one: it refuses, so its mistake costs a name you type yourself.
 
 **What the slot cannot settle, the term itself can.** Every sentence you
 confirm a term in is kept in `vocabulary-uses.yaml`, and from three of them the

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -497,9 +497,9 @@ three ways and scored by a small causal language model
 
 Each reading is the log-probability of its continuation divided by its token
 count, and the highest wins. Nothing is compared to a threshold, so there is
-nothing to calibrate. The marks are `transcription.sentences.marks`, default
-`[".", ",", "?"]`; `;` and `:` were measured and never changed a decision in
-English.
+nothing to calibrate. The marks are `transcription.per_language.<code>.marks`,
+default `[".", ",", "?"]`; `;` and `:` were measured and never changed a
+decision in English.
 
 The list does two jobs. `.` and `?` are where a boundary is looked for; the
 comma is a reading tried at one. The first reading is always the mark the

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -433,9 +433,9 @@ refused 14 and left 24 on the same set, also with no error; mmBERT-small
 replaced it because it covers French, at no cost in English.
 
 The model is never waited for. Until it is on disk, every place this tier would
-judge is simply left open, which is the behaviour before this tier. This tier
-runs in every language and was measured in English only. Its error direction is
-the same cheap one: it refuses, so its mistake costs a name you type yourself.
+judge is simply left open, which is the behaviour before this tier. This tier is
+reached only from the sound pass, and that pass is English only, so it was
+measured in English only and runs nowhere else.
 
 **What the slot cannot settle, the term itself can.** Every sentence you
 confirm a term in is kept in `vocabulary-uses.yaml`, and from three of them the

--- a/scripts/check-slot-gap.sh
+++ b/scripts/check-slot-gap.sh
@@ -9,7 +9,10 @@
 #
 # tests/slot-gap-cases.yaml scores the decision, not the number: the gap moves
 # with the model and with its Core ML conversion, and every case here sits clear
-# of the line — a refusal below -0.30, a no-opinion above -0.05.
+# of the line.
+#
+# The floor is per language, so each case carries `lang:` and it is passed to
+# the binary. English cases sit clear of -0.20, French ones clear of -0.30.
 #
 # Not in `make test`: it needs the 269 MB slot model and the 400 MB
 # word-vector model, which CI has no business downloading. Run it by hand after
@@ -26,12 +29,17 @@ done
 [ -n "$BIN" ] || { echo "build first: swift build"; exit 1; }
 
 CASES="$ROOT/tests/slot-gap-cases.yaml"
+# A scratch config, so a `per_language:` floor on this machine cannot change the
+# verdicts. The floors the cases were picked against are the built-in ones.
+WORK="$(mktemp -d -t parrotflow-slot-gap)"
+trap 'rm -rf "$WORK"' EXIT
+export PARROTFLOW_CONFIG_DIR="$WORK"
 failed=0
 seen=0
 
-while IFS=$'\t' read -r said heard term expect; do
+while IFS=$'\t' read -r said heard term expect lang; do
   seen=$((seen + 1))
-  out="$("$BIN" --slot-gap "$said" "$heard" "$term" 2>/dev/null | tail -1)"
+  out="$("$BIN" --slot-gap "$said" "$heard" "$term" --lang "$lang" 2>/dev/null | tail -1)"
   gap="$(printf '%s' "$out" | sed -n 's/^gap  *\([+-][0-9.]*\).*/\1/p')"
   got="$(printf '%s' "$out" | sed -n 's/^gap  *[+-][0-9.]*  *\(.*\)$/\1/p')"
 
@@ -39,15 +47,16 @@ while IFS=$'\t' read -r said heard term expect; do
     printf '  ✗ %s -> %s: no gap (%s)\n' "$heard" "$term" "${out:-no output}"
     failed=1
   elif [ "$got" != "$expect" ]; then
-    printf '  ✗ %s -> %s: %s at %s, expected %s\n' "$heard" "$term" "$got" "$gap" "$expect"
+    printf '  ✗ [%s] %s -> %s: %s at %s, expected %s\n' \
+      "$lang" "$heard" "$term" "$got" "$gap" "$expect"
     failed=1
   else
-    printf '  ✓ %-13s -> %-13s %s   %s\n' "$heard" "$term" "$gap" "$got"
+    printf '  ✓ [%s] %-13s -> %-13s %s   %s\n' "$lang" "$heard" "$term" "$gap" "$got"
   fi
 done < <(python3 -c '
 import sys, yaml
 for c in yaml.safe_load(open(sys.argv[1]))["cases"]:
-    print("\t".join([c["said"], c["heard"], c["term"], c["expect"]]))
+    print("\t".join([c["said"], c["heard"], c["term"], c["expect"], c.get("lang", "en")]))
 ' "$CASES")
 
 if [ "$seen" -eq 0 ]; then

--- a/tests/slot-gap-cases.yaml
+++ b/tests/slot-gap-cases.yaml
@@ -1,11 +1,17 @@
 # What the slot says about a rewrite, on cases from tests/judge-cases.yaml.
 #
-# expect: refuse      the heard word wins by more than SlotReference.floor
+# expect: refuse      the heard word wins by more than the floor
 # expect: no opinion  the two readings are too close to settle
+# lang:               which floor to read the gap at; en when it is missing
 #
 # The numbers move with the model and with its Core ML conversion, so this scores
 # the decision and not the number. Cases were picked well clear of the line:
-# a refusal here sits below -0.30 and a no-opinion above -0.05.
+# in English a refusal sits below -0.30 and a no-opinion above -0.05, against a
+# floor of 0.20; in French below -0.42 and above -0.12, against 0.30.
+#
+# The French cases come in pairs on the same two words, because that is the
+# whole claim of this stage: `vers celle` is Vercel in one sentence and two
+# ordinary words in the next, and only the sentence separates them.
 
 cases:
 - said: The team deserves praise for how quickly they shipped a Ruxby.
@@ -44,3 +50,47 @@ cases:
   heard: Tasmin
   term: Tasmeen
   expect: no opinion
+
+# French, from the 201-case bench in issue #262. Five terms of the same
+# vocabulary, against the French words they collide with.
+- said: On se dirige vers celle qui parle le plus fort.
+  heard: vers celle
+  term: Vercel
+  expect: refuse
+  lang: fr
+- said: J'ai une erreur sur vers celle en ce moment.
+  heard: vers celle
+  term: Vercel
+  expect: no opinion
+  lang: fr
+- said: Le but de la réunion est centré sur les chiffres.
+  heard: centré
+  term: Sentry
+  expect: refuse
+  lang: fr
+- said: On a configuré centré pour le monitoring.
+  heard: centré
+  term: Sentry
+  expect: no opinion
+  lang: fr
+- said: J'aime quand ta mine est détendue et sereine.
+  heard: ta mine
+  term: Tasmeen
+  expect: refuse
+  lang: fr
+- said: Nous recherchons un terme précis pour ce cas.
+  heard: précis
+  term: Praisy
+  expect: refuse
+  lang: fr
+- said: Un nouveau service de stockage sera implémenté via super base.
+  heard: super base
+  term: Supabase
+  expect: no opinion
+  lang: fr
+- said: Mais donc pour revenir à Versal, ce nom n'est dans aucun dictionnaire, ça devrait être
+    remplacé sans juge.
+  heard: Versal
+  term: Vercel
+  expect: no opinion
+  lang: fr


### PR DESCRIPTION
The vocabulary gate's slot test reads mmBERT-small since #268, which answers in
French. What was wrong in French was the floor, not the model: 0.20 is
calibrated on English, French gaps are about a third narrower, and at 0.20 the
stage refuses correct French rewrites. The floor is a setting now, in one block
keyed by language — `transcription.per_language.<code>.slot_floor`, 0.20 in
English and 0.30 in French. The sentence stage's mark set moves into the same
block as `marks:`, with no change in behaviour — including #269's `?` and its
two jobs; `transcription.sentences.marks` is still read and `--check-config`
says once where it went. Measured through the
shipped binary on the 201-case French bench: at 0.30, 2 of 84 correct rewrites
wrongly refused and 47 of 117 wrong ones caught, against 7 and 66 at 0.20.

**One thing in the issue is wrong and it changes what this PR is.** The gate was
already running on French dictation, at the English floor. `Pipeline` calls
`SentenceGate.settle` with no language check, and `AppDelegate.warmModels` warms
the slot model and the word vectors at launch whatever you speak. The `"en"`
block in `Transcriber.swift` only held the per-dictation retry warm.
So this is not "turn a stage on" — it is "stop that stage losing French names",
and the split of the retry warm is what makes it survive a failed fetch.

Start the review at `Config.Transcription.Language`. The rest is call sites.

Closes #262.

<details>

<summary>The French bench through the shipped binary — 47 of 117 caught, 2 of 84 lost</summary>

`~/Documents/parrotflow-scratch/sentence-join/french-slot/cases_fr.json`, 201
cases, 84 approve and 117 decline. Scored with `--slot-gap` one case per
process, so this is the shipped path with the 4-bit MLX Qwen, not the harness.

| floor | wrong rewrites caught | correct rewrites wrongly refused |
|---|---:|---:|
| 0.20 (English) | 66 / 117 | 7 / 84 |
| **0.30 (shipped)** | **47 / 117** | **2 / 84** |
| 0.40 | 16 / 117 | 0 / 84 |

AUC 0.783 on the 135-case honest subset — the 44 cases where the heard word *is*
the term and the 22 name-against-name cases taken out. The issue predicted 47
and 1 for mmBERT-small; the binary agrees on the first and finds one more wrong
refusal.

The two the floor still costs are cases 172 (`Mirza <- mise à`, -0.319) and 181
(`Tasmeen <- ta mine`, -0.312). Five more sit in the band the change moves
(-0.30 to -0.20): 148, 180, 182, 183 are approves the old floor refused, and 18
declines the old floor caught.

**The number is provisional.** 184 of the 201 cases are invented and only 2 are
real declines. The labels are unchecked: they are waiting at
`~/Documents/parrotflow-scratch/label-french-slots.txt`, every one still
`verdict: ?`, and cases 148, 151, 180 and the five from `mise à` and `ta mine`
are exactly the ones that pin the floor. Labelling them moves the number, not
whether the stage works.

</details>

<details>

<summary>Every language gate on the vocabulary path, and the one that moved</summary>

Found by `grep` for `"en"` and `language(of`:

| where | what it gates | what happened |
|---|---|---|
| the `"en"` block in `Transcriber.swift` | slot model warm, word-vector warm | **moved out** — the gate's own models, warmed in any language |
| the same block | `SentenceReadings.warm`, `warmSoundModel`, `SentenceJoin.apply` | stays English |
| the `bySound` guard in `Pipeline.swift` | the sound pass | stays English — the phoneme model is English |
| the `SentenceGate.settle` call in `Pipeline.swift` | nothing | no gate. The language only ever picked the floor, and now it picks it from the config |
| `AppDelegate.warmModels` | nothing | the launch warm was never language-gated |
| `SlotGapCommand` | the printed verdict, hardcoded `en` | now `--lang`, and a code it does not know is refused |
| `SentenceJoinCommand` and `WordGateCommand` | CLI output | stay |

**`SlotGate`, the part-of-speech decline, has no language check and still never
runs in French.** `VocabularyJudge.settle` only reaches it for a proposal with
`.full` standing, the policy gives `.full` to `.sound` alone, and the sound pass
is English. So it is English by its input, not by a guard, and it stays measured
on the 50 English cases only. `docs/transcription.md` said it was gated; that
line is corrected here.

**`TermPortrait` and the counter-portrait have no language gate and do run in
French.** They read `Qwen3-Embedding`, which #262 measured in French: synonym
margin +0.259, translation-against-random 10/10, accents surviving the
tokenizer. Nothing here changes them.

</details>

<details>

<summary>Four French sentences end to end, and one that is still wrong</summary>

`--pipeline` with `languages: [en, fr]` and a small vocabulary — Vercel with
`heard: [Versal, vers celle, Versailles]`, Praisy with `heard: [précise]`.

```
On se dirige vers celle qui parle le plus fort.
  sentence gate: "vers celle" kept — it belongs here
  out: On se dirige vers celle qui parle le plus fort.

J'ai une erreur sur vers celle en ce moment.
  out: J'ai une erreur sur Vercel en ce moment.

Mais donc pour revenir à Versal, ce nom n'est dans aucun dictionnaire.
  vocabulary gate: "Versal" -> "Vercel" is in neither word list — written, not asked
  out: Mais donc pour revenir à Vercel, ce nom n'est dans aucun dictionnaire.
```

Same two words, opposite answers, and the sentence is what decides. That pair is
in `tests/slot-gap-cases.yaml` now.

The floor is what makes the difference, on the same binary:

```
Il faut parler à précise rapidement.
  slot_floor 0.30   out: Il faut parler à Praisy rapidement.
  slot_floor 0.20   sentence gate: "précise" kept — it belongs here
                    out: Il faut parler à précise rapidement.
```

**`Versailles` is still written over.** `Nous avons visité le château de
Versailles avec toute la famille.` comes out as `château de Vercel`. That is the
name-against-name hole #261 measured — both encoders refuse 2 of 17 such cases —
and nothing here touches it.

</details>

<details>

<summary>Nothing English moved: five scripts, same numbers as #268 recorded</summary>

| script | result |
|---|---|
| `check-slot-gap.sh` | 16/16, the 8 English cases at the same gaps |
| `check-slot-gate.sh` | applied 12, declined 15, judge 23, 0 errors |
| `check-portrait.sh` | every check passed |
| `check-counter-portrait.sh` | 20 right, 0 wrong, 0 quiet held out |
| `check-sentence-join.sh` | 95% of cuts repaired, 0.0 false joins per 100 real periods |

`check-word-gate.sh` and `check-sentence-open.sh` run in `make test`, which
passes. Rebased onto #269 and #270, and rerun after both: `check-sentence-join.sh`
is 95% of period cuts and 80% of question cuts repaired with 0 false joins on
either, and `check-sentence-probe.sh` is 60/60 — the numbers #269 recorded.

`--slot-gap` takes one language code it knows, or refuses. On the release
binary at head:

```
--lang eng               exit=2  ✗ --lang wants one of en, fr — the gate knows a floor for those only
--lang en,fr             exit=2  ✗ ...
--lang fr --lang en      exit=2  ✗ ...
--lang                   exit=2  ✗ ...
--lang fr                exit=0  gap  -0.428   refuse
--lang en                exit=0  gap  -0.428   refuse
```

The French fixture is eight cases in `tests/slot-gap-cases.yaml`, each carrying
`lang: fr`, and `scripts/check-slot-gap.sh` passes it to `--lang`. They sit
clear of the line the way the English ones do: refusals below -0.42, no-opinions
above -0.12, against a floor of 0.30. The script runs against a scratch
`PARROTFLOW_CONFIG_DIR` now, so a `per_language:` floor on the machine cannot
change its verdicts.

</details>

<details>

<summary>The block: what it holds, what it refuses, what `--check-config` prints</summary>

```yaml
transcription:
  per_language:
    en: {marks: [".", ",", "?"], slot_floor: 0.20}
    fr: {marks: [".", ",", "?"], slot_floor: 0.30}
```

Those are the built-in defaults, so an empty block changes nothing. An entry
overrides only the keys it names, and a language with no entry gets English's
values.

```
  · languages         en, fr
      en  marks . , ?  slot floor 0.20
      fr  marks . , ?  slot floor 0.30
```

Refused, each with the key named: a language that is not `en` or `fr`, a
`slot_floor` at or below 0 or above 2 (the gap is one cosine minus another, so
it never reaches -2), a mark that is not one punctuation character, and an empty
mark list.

A config that still writes `transcription.sentences.marks` keeps working and
gets one notice naming the new key. It answers for English only, which is the
only language the sentence stage runs in — `fr.marks` is inert today and is
there for the day that stage is turned on.

`--pipeline` fixtures can set `per_language:` now. Without it no fixture could
say which floor it was scored at, and the demo above could not have been run.

</details>

- [x] `make test` passes.
- [x] A prompt or pattern change is scored, and the numbers are above.
- [x] Every commit is signed off — `git commit -s`. See [CONTRIBUTING.md](../CONTRIBUTING.md).
