### PR TITLE
fix: a dictation no longer ends with words nobody said

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -259,3 +259,10 @@ jobs:
       # scripts/check-sentence-join.sh, is run by hand.
       - name: The capital after a period the join removes
         run: scripts/check-sentence-case.sh
+
+      # Endings Parakeet writes over silence. Word arrays out of trace.jsonl,
+      # so no audio and no model — and the half that can go wrong quietly is
+      # scored too: the text is a separate string from the token timings, and
+      # a run dropped from one and not the other is invisible.
+      - name: Endings the decoder invented
+        run: scripts/check-invented-tail.sh

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,8 @@ release-certificate:
 CHECKS := numbers replacements pipeline pipeline-config wake split dotted dates keyed \
           transform-folders eval audio-recovery possessive word-gate suggest input join \
           profiles span-rule clipboard default-config vocabulary-config learn \
-          signing-identity no-voice sound tokenizer sentence-case term-uses edit-diff sentence-open
+          signing-identity no-voice sound tokenizer sentence-case term-uses edit-diff sentence-open \
+          invented-tail
 
 test:
 	@swift build -c release

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -2189,8 +2189,9 @@ struct Config: Decodable, Equatable {
         /// swallows something real.
         var speechGate: Bool = true
         /// Decode the clip a second time beside the first, with silence at
-        /// both ends, and keep that decode when it reaches further. Off by
-        /// default: it recovers a rare failure and costs a second decode.
+        /// both ends, and keep that decode when it reaches further. On by
+        /// default: the arms decode beside the first pass rather than after
+        /// it, so the dictation waits on the slowest one, not on all three.
         ///
         /// The failure is Parakeet skipping frames it never looks at. It
         /// predicts a token and a skip of up to 4 frames of 80ms together, so

--- a/Sources/ParrotFlow/InventedTailCommand.swift
+++ b/Sources/ParrotFlow/InventedTailCommand.swift
@@ -1,0 +1,186 @@
+import FluidAudio
+import Foundation
+import Yams
+
+/// `--invented-tail` — the endings Parakeet writes over silence, scored against
+/// real decodes.
+///
+/// Every case is a word array taken from `trace.jsonl`, so what is scored is
+/// what the decoder actually returned on a clip somebody dictated. The words
+/// are turned back into token timings and handed to the real
+/// `Transcriber.withoutInventedTail`, which means the text trim is scored too
+/// — the half that can go wrong quietly, because `ASRResult.text` and the
+/// timings are two different objects and only one of them reaches the screen.
+///
+/// The set is meant to be read in both directions. A rule that drops an
+/// invention nobody said is worth nothing if it also drops "Kim?" off the end
+/// of a question, so the cases that must survive outnumber the ones that must
+/// go.
+enum InventedTailCommand {
+
+    private struct Case {
+        let name: String
+        let speechEnd: Double?
+        let text: String
+        let words: [Trace.Word]
+        /// The text that must survive. Equal to `text` when nothing goes.
+        let keeps: String
+        /// `burst`, `after speech`, or nil when nothing may be dropped.
+        let reason: String?
+        /// What `decodedNothing` must say, when the case asks.
+        let nothing: Bool?
+    }
+
+    static func run(casesPath: String?) -> Int32 {
+        let path = casesPath ?? FileManager.default.currentDirectoryPath
+            + "/tests/invented-tail-cases.yaml"
+        let cases: [Case]
+        do {
+            cases = try loadCases(at: path)
+        } catch {
+            print("✗ cases: \(error.localizedDescription)")
+            return 1
+        }
+
+        var failures = 0
+        for testCase in cases {
+            failures += check(testCase) ? 0 : 1
+        }
+        print("")
+        print("  \(cases.count - failures)/\(cases.count)")
+        return failures == 0 ? 0 : 1
+    }
+
+    private static func check(_ testCase: Case) -> Bool {
+        let result = decode(testCase)
+        let trimmed = Transcriber.withoutInventedTail(result, speechEnd: testCase.speechEnd)
+        let found = Transcriber.inventedTail(words: testCase.words, speechEnd: testCase.speechEnd)
+
+        var problems: [String] = []
+        if trimmed.text != testCase.keeps {
+            problems.append("kept \"\(trimmed.text)\", expected \"\(testCase.keeps)\"")
+        }
+        if found?.reason != testCase.reason {
+            problems.append("read it as \(found?.reason ?? "speech"), "
+                + "expected \(testCase.reason ?? "speech")")
+        }
+        // The timings have to lose exactly the words the text lost, or the HUD
+        // and the trace describe different sentences.
+        let lostTimings = testCase.words.count - Trace.words(from: trimmed.tokenTimings ?? []).count
+        let lostText = words(in: testCase.text) - words(in: trimmed.text)
+        if lostTimings != lostText {
+            problems.append("\(lostTimings) word(s) of timing dropped against \(lostText) of text")
+        }
+        if let wanted = testCase.nothing {
+            let gate = Transcriber.SpeechGate(
+                samples: [], segments: [(start: 0, end: testCase.speechEnd ?? 1)], decodable: true
+            )
+            let got = Transcriber.decodedNothing(result, gate: gate)
+            if got != wanted {
+                problems.append("decodedNothing said \(got), expected \(wanted)")
+            }
+        }
+
+        guard problems.isEmpty else {
+            print("  ✗ \(testCase.name)")
+            for problem in problems { print("      \(problem)") }
+            return false
+        }
+        print("  ✓ \(testCase.name) — \(describe(found, kept: trimmed.text, of: testCase))")
+        return true
+    }
+
+    private static func words(in text: String) -> Int {
+        text.split(whereSeparator: \.isWhitespace).count
+    }
+
+    private static func describe(
+        _ found: (count: Int, reason: String)?, kept: String, of testCase: Case
+    ) -> String {
+        guard let found else { return "kept whole" }
+        guard kept != testCase.text else { return "\(found.reason), and the trim refused" }
+        return "dropped \(found.count) (\(found.reason)), left \"\(kept)\""
+    }
+
+    /// The case as the decoder would have handed it over: one token per word,
+    /// marked the way SentencePiece marks a word's first piece, so
+    /// `Trace.words` gives the case's own words back.
+    private static func decode(_ testCase: Case) -> ASRResult {
+        ASRResult(
+            text: testCase.text,
+            confidence: testCase.words.map(\.confidence).min() ?? 0,
+            duration: testCase.words.last?.end ?? 0,
+            processingTime: 0,
+            tokenTimings: testCase.words.map {
+                TokenTiming(
+                    token: "\u{2581}" + $0.word,
+                    tokenId: 0,
+                    startTime: $0.start,
+                    endTime: $0.end,
+                    confidence: $0.confidence
+                )
+            }
+        )
+    }
+
+    private static func loadCases(at path: String) throws -> [Case] {
+        let text = try String(contentsOfFile: path, encoding: .utf8)
+        let raw = try YAMLDecoder().decode([RawCase].self, from: text)
+        return try raw.map { one in
+            let words = try one.words.map(word)
+            let text = one.text ?? words.map(\.word).joined(separator: " ")
+            return Case(
+                name: one.name,
+                speechEnd: one.speechEnd,
+                text: text,
+                words: words,
+                keeps: one.keeps ?? text,
+                reason: one.reason,
+                nothing: one.nothing
+            )
+        }
+    }
+
+    /// `<word> <start> <end> <confidence>`. Read from the right, so a word
+    /// that is itself a number is still a word.
+    private static func word(_ line: String) throws -> Trace.Word {
+        let fields = line.split(whereSeparator: \.isWhitespace).map(String.init)
+        guard fields.count >= 4, let start = Double(fields[fields.count - 3]),
+            let end = Double(fields[fields.count - 2]),
+            let confidence = Float(fields[fields.count - 1])
+        else {
+            throw CaseError.word(line)
+        }
+        return Trace.Word(
+            word: fields[0..<(fields.count - 3)].joined(separator: " "),
+            start: start, end: end, confidence: confidence
+        )
+    }
+
+    private enum CaseError: LocalizedError {
+        case word(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .word(let line):
+                return "a word needs \"<word> <start> <end> <confidence>\", got \"\(line)\""
+            }
+        }
+    }
+
+    private struct RawCase: Decodable {
+        let name: String
+        let speechEnd: Double?
+        let text: String?
+        let words: [String]
+        let keeps: String?
+        let reason: String?
+        let nothing: Bool?
+
+        enum CodingKeys: String, CodingKey {
+            case name
+            case speechEnd = "speech_end"
+            case text, words, keeps, reason, nothing
+        }
+    }
+}

--- a/Sources/ParrotFlow/InventedTailCommand.swift
+++ b/Sources/ParrotFlow/InventedTailCommand.swift
@@ -71,6 +71,20 @@ enum InventedTailCommand {
         if lostTimings != lostText {
             problems.append("\(lostTimings) word(s) of timing dropped against \(lostText) of text")
         }
+        // The aggregate has to describe the words that survive, as the
+        // decoder would have scored them on their own: the mean, clamped to
+        // 0.1...1.
+        let survivors = Array(testCase.words.prefix(testCase.words.count - lostText))
+        if !survivors.isEmpty {
+            let mean = survivors.map(\.confidence).reduce(0, +) / Float(survivors.count)
+            let expected = lostText == 0 ? result.confidence : max(0.1, min(1, mean))
+            if abs(trimmed.confidence - expected) > 0.0005 {
+                problems.append(String(
+                    format: "confidence %.3f after the trim, expected %.3f from the kept words",
+                    trimmed.confidence, expected
+                ))
+            }
+        }
         if let wanted = testCase.nothing {
             let gate = Transcriber.SpeechGate(
                 samples: [], segments: [(start: 0, end: testCase.speechEnd ?? 1)], decodable: true
@@ -104,11 +118,14 @@ enum InventedTailCommand {
 
     /// The case as the decoder would have handed it over: one token per word,
     /// marked the way SentencePiece marks a word's first piece, so
-    /// `Trace.words` gives the case's own words back.
+    /// `Trace.words` gives the case's own words back. The aggregate is the
+    /// mean, which is what FluidAudio puts there.
     private static func decode(_ testCase: Case) -> ASRResult {
-        ASRResult(
+        let mean = testCase.words.map(\.confidence).reduce(0, +)
+            / Float(max(testCase.words.count, 1))
+        return ASRResult(
             text: testCase.text,
-            confidence: testCase.words.map(\.confidence).min() ?? 0,
+            confidence: max(0.1, min(1, mean)),
             duration: testCase.words.last?.end ?? 0,
             processingTime: 0,
             tokenTimings: testCase.words.map {

--- a/Sources/ParrotFlow/Trace.swift
+++ b/Sources/ParrotFlow/Trace.swift
@@ -336,21 +336,32 @@ enum Trace {
     /// confidence: a name that came through as one solid piece and one shaky
     /// one is a shaky name, and averaging hides exactly that.
     static func words(from timings: [TokenTiming]) -> [Word] {
-        var words: [Word] = []
+        grouped(from: timings).map(\.word)
+    }
+
+    /// The same grouping, with the tokens each word was built from.
+    ///
+    /// One implementation, because a caller that cuts words off a decode has to
+    /// cut the tokens the same way. A second copy of this loop would drift.
+    static func grouped(from timings: [TokenTiming]) -> [(word: Word, tokens: Range<Int>)] {
+        var words: [(word: Word, tokens: Range<Int>)] = []
         var text = ""
         var start = 0.0
         var end = 0.0
         var confidence = Float.greatestFiniteMagnitude
+        var first = 0
+        var last = 0
 
         func flush() {
             let trimmed = text.trimmingCharacters(in: .whitespaces)
             guard !trimmed.isEmpty else { return }
-            words.append(
-                Word(word: trimmed, start: start, end: end, confidence: confidence)
-            )
+            words.append((
+                Word(word: trimmed, start: start, end: end, confidence: confidence),
+                first..<(last + 1)
+            ))
         }
 
-        for timing in timings {
+        for (index, timing) in timings.enumerated() {
             let token = timing.token
             if token.isEmpty || token == "<blank>" || token == "<pad>" { continue }
 
@@ -361,11 +372,13 @@ enum Trace {
                 text = token.replacingOccurrences(of: "\u{2581}", with: "")
                 start = timing.startTime
                 confidence = timing.confidence
+                first = index
             } else {
                 text += token
                 confidence = min(confidence, timing.confidence)
             }
             end = timing.endTime
+            last = index
         }
         flush()
         return words

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -926,17 +926,17 @@ actor Transcriber {
     ) -> (count: Int, reason: String)? {
         guard words.count >= 2 else { return nil }
 
-        var index = words.count - 1
-        while index > 0, sameTime(words[index], words[index - 1]) { index -= 1 }
-        let burst = words.count - index >= 2 ? words.count - index : 0
+        var first = words.count - 1
+        while first > 0, sameTime(words[first], words[first - 1]) { first -= 1 }
+        let burst = words.count - first >= 2 ? words.count - first : 0
 
         var after = 0
         if let speechEnd {
-            var index = words.count
-            while index > 0, words[index - 1].start >= speechEnd + inventedTailMargin {
-                index -= 1
+            var late = words.count
+            while late > 0, words[late - 1].start >= speechEnd + inventedTailMargin {
+                late -= 1
             }
-            let run = words[index...]
+            let run = words[late...]
             if run.count >= 2, run.allSatisfy({ $0.confidence < inventedTailConfidence }) {
                 after = run.count
             }

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -333,6 +333,14 @@ actor Transcriber {
         // returned empty.
         var result = try await asr.transcribe(url, decoderState: &decoderState)
 
+        // Here rather than after the retries below, because an invented ending
+        // is clamped to the end of the clip and every check downstream reads
+        // that as the decoder having reached the end: `droppedTail` stops
+        // firing, and no padded arm can reach further than a first pass that
+        // already claims the last frame.
+        let speechEnd = gated.map(Self.lastSpeechEnd)
+        result = Self.withoutInventedTail(result, speechEnd: speechEnd)
+
         // Closing the pause up and decoding again puts those words in a window
         // with speech either side of them. It is a retry rather than the first
         // thing tried, because moving the windows is not free: done to every
@@ -344,7 +352,11 @@ actor Transcriber {
         if let gated, Self.droppedTail(result, gate: gated), let closed = Self.closeLongPauses(gated) {
             var retryState = await TdtDecoderState.make(decoderLayers: asr.decoderLayerCount)
             let raw = try await asr.transcribe(closed.samples, decoderState: &retryState)
-            let retried = Self.restoreTimings(raw, closed: closed, seconds: gated.seconds)
+            let retried = Self.withoutInventedTail(
+                Self.restoreTimings(raw, closed: closed, seconds: gated.seconds),
+                speechEnd: speechEnd,
+                note: "long-pause retry: "
+            )
             if Self.lastWordEnd(retried) > Self.lastWordEnd(result), Self.extends(result, by: retried) {
                 Log.write(String(
                     format: "decoder stopped %.2fs before the speech did; "
@@ -383,8 +395,14 @@ actor Transcriber {
         // Separate from the retry above, which needs words to measure a
         // dropped tail against and so cannot reach this case at all:
         // `droppedTail` is false on an empty decode by definition.
+        //
+        // One unsure "Yeah." is the same failure wearing a word, and goes the
+        // same way — see `decodedOnlyYeah`.
         if let gated, Self.decodedNothing(result, gate: gated) {
             let speech = Self.speechSeconds(gated)
+            let wrote = Self.decodedOnlyYeah(result)
+                ? "only \"\(result.text.trimmingCharacters(in: .whitespacesAndNewlines))\""
+                : "nothing"
             var recovered: (pad: Double, result: ASRResult)?
             if opinions.isEmpty {
                 for pad in Self.silenceRetryPads where recovered == nil {
@@ -414,16 +432,16 @@ actor Transcriber {
             }
             if let recovered {
                 Log.write(String(
-                    format: "decoder returned nothing for %.2fs of speech; "
+                    format: "decoder returned %@ for %.2fs of speech; "
                         + "%.0fms of silence either side recovered it",
-                    speech, recovered.pad * 1000
+                    wrote, speech, recovered.pad * 1000
                 ))
                 result = recovered.result
             } else {
                 Log.write(String(
-                    format: "decoder returned nothing for %.2fs of speech, "
+                    format: "decoder returned %@ for %.2fs of speech, "
                         + "and no padded retry returned anything either",
-                    speech
+                    wrote, speech
                 ))
             }
         } else if !opinions.isEmpty {
@@ -582,7 +600,16 @@ actor Transcriber {
         guard let padded = paddedWithSilence(gate, pad: pad) else { return nil }
         var state = await TdtDecoderState.make(decoderLayers: asr.decoderLayerCount)
         let raw = try await asr.transcribe(padded, decoderState: &state)
-        return unpadTimings(raw, by: pad, seconds: gate.seconds)
+        // Before the arm is compared with anything. An arm whose only addition
+        // is an invented run then adds nothing, and loses on the guards that
+        // are already there. Unpadding clamps a word running past the end of
+        // the clip back to the clip's length, so those words land on one point
+        // on the clock and the burst rule sees them.
+        return withoutInventedTail(
+            unpadTimings(raw, by: pad, seconds: gate.seconds),
+            speechEnd: lastSpeechEnd(gate),
+            note: String(format: "second opinion at %.0fms: ", pad * 1000)
+        )
     }
 
     /// Starts one padded decode per rung of `silenceRetryPads`, running now.
@@ -858,6 +885,151 @@ actor Transcriber {
         return lastSpeechEnd(gate) - lastWordEnd(result) > droppedTailSeconds
     }
 
+    // MARK: - Endings the decoder invented
+
+    /// Two words are at the same place on the clock. Half the length of one
+    /// encoder frame, so nothing the decoder can actually separate lands here.
+    private static let sameTimeSeconds = 0.005
+
+    /// How far past the last speech the gate heard a word has to start before
+    /// it is read as invented. On top of the VAD's own 0.75s hangover, so the
+    /// boundary this measures against is already generous.
+    static let inventedTailMargin = 0.3
+
+    /// A word at or above this is left alone by the after-speech rule. The one
+    /// thing that separates an invented ending from a real late clause: "C'est
+    /// le signal qu'on ne peut pas savoir." decodes its last five words after
+    /// the gate's last segment, at 0.94 to 1.00.
+    static let inventedTailConfidence: Float = 0.8
+
+    /// The trailing words the decoder wrote over silence, and which rule found
+    /// them. Nil when the decode ends in speech.
+    ///
+    /// Two shapes, measured over 7315 first-pass decodes and checked against
+    /// Whisper large-v3-turbo on every clip that still had a wav.
+    ///
+    /// A burst is two or more trailing words sharing one start and one end.
+    /// The decoder emitted them at a single point on the clock, which speech
+    /// never is. 45 clips, and Whisper heard none of the dropped words on the
+    /// 41 that had a wav — including bursts holding a word scored 0.9 and
+    /// above, which is why there is no confidence test on this half.
+    ///
+    /// After the speech is two or more trailing words that start at least
+    /// `inventedTailMargin` past the gate's last segment, none of them
+    /// confident. Together the two fire on 56 of the 7315, with no false
+    /// positive found.
+    ///
+    /// `speechEnd` is nil when there was no gate, which turns the second rule
+    /// off — it has nothing to measure against.
+    nonisolated static func inventedTail(
+        words: [Trace.Word], speechEnd: Double?
+    ) -> (count: Int, reason: String)? {
+        guard words.count >= 2 else { return nil }
+
+        var index = words.count - 1
+        while index > 0, sameTime(words[index], words[index - 1]) { index -= 1 }
+        let burst = words.count - index >= 2 ? words.count - index : 0
+
+        var after = 0
+        if let speechEnd {
+            var index = words.count
+            while index > 0, words[index - 1].start >= speechEnd + inventedTailMargin {
+                index -= 1
+            }
+            let run = words[index...]
+            if run.count >= 2, run.allSatisfy({ $0.confidence < inventedTailConfidence }) {
+                after = run.count
+            }
+        }
+
+        if burst > 0, burst >= after { return (burst, "burst") }
+        if after > 0 { return (after, "after speech") }
+        return nil
+    }
+
+    private nonisolated static func sameTime(_ one: Trace.Word, _ other: Trace.Word) -> Bool {
+        abs(one.start - other.start) < sameTimeSeconds
+            && abs(one.end - other.end) < sameTimeSeconds
+    }
+
+    /// The decode without the ending it invented, text and timings together.
+    ///
+    /// Both or neither. `ASRResult.text` is a separate string from the
+    /// timings, so trimming one and not the other leaves the HUD, the trace
+    /// and the pipeline disagreeing about what was said. The two agreed on the
+    /// word count in all 22136 trace records that carry both, so the text is
+    /// cut back word by word from its end and the original spacing of what
+    /// survives is left as it was. A decode where they ever disagree is kept
+    /// whole: a wrong cut is worse than a kept invention.
+    nonisolated static func withoutInventedTail(
+        _ result: ASRResult, speechEnd: Double?, note: String = ""
+    ) -> ASRResult {
+        let timings = result.tokenTimings ?? []
+        let grouped = Trace.grouped(from: timings)
+        guard let tail = inventedTail(words: grouped.map(\.word), speechEnd: speechEnd) else {
+            return result
+        }
+        let keep = grouped.count - tail.count
+        guard let text = trimmedText(result.text, dropping: tail.count, of: grouped.count) else {
+            Log.write(
+                "\(note)\(tail.count) trailing word(s) look invented, but the text and the "
+                    + "timings do not line up; keeping the decode as it is"
+            )
+            return result
+        }
+        let dropped = grouped[keep...].map(\.word.word).joined(separator: " ")
+        Log.write(
+            "\(note)dropped \(tail.count) invented trailing word(s), "
+                + "\(tail.reason): \"\(dropped)\""
+        )
+        return ASRResult(
+            text: text,
+            confidence: result.confidence,
+            duration: result.duration,
+            processingTime: result.processingTime,
+            tokenTimings: Array(timings[0..<(keep > 0 ? grouped[keep - 1].tokens.upperBound : 0)]),
+            performanceMetrics: result.performanceMetrics,
+            ctcDetectedTerms: result.ctcDetectedTerms,
+            ctcAppliedTerms: result.ctcAppliedTerms
+        )
+    }
+
+    /// `text` without its last `dropping` whitespace-separated words, or nil
+    /// when it does not hold exactly `of` of them.
+    nonisolated static func trimmedText(
+        _ text: String, dropping: Int, of words: Int
+    ) -> String? {
+        guard text.split(whereSeparator: \.isWhitespace).count == words else { return nil }
+        var end = text.endIndex
+        for _ in 0..<dropping {
+            while end > text.startIndex, text[text.index(before: end)].isWhitespace {
+                end = text.index(before: end)
+            }
+            while end > text.startIndex, !text[text.index(before: end)].isWhitespace {
+                end = text.index(before: end)
+            }
+        }
+        while end > text.startIndex, text[text.index(before: end)].isWhitespace {
+            end = text.index(before: end)
+        }
+        return String(text[text.startIndex..<end])
+    }
+
+    /// A word this unsure, on its own, is not a word.
+    static let loneYeahConfidence: Float = 0.6
+
+    /// True when the whole decode is one unsure "Yeah." — a failed alignment
+    /// rather than something somebody said.
+    ///
+    /// Measured on 24 such clips: Whisper heard "yeah" in none of them, and a
+    /// padded decode returned real words on 19 of the 23 it could read. So it
+    /// is handed to the empty-decode recovery rather than deleted.
+    nonisolated static func decodedOnlyYeah(_ result: ASRResult) -> Bool {
+        let words = Trace.words(from: result.tokenTimings ?? [])
+        guard words.count == 1, words[0].confidence < loneYeahConfidence else { return false }
+        return words[0].word.lowercased().filter(\.isLetter) == "yeah"
+    }
+
     /// How much silence the empty-decode retry puts either side of the clip,
     /// tried in order until one of them decodes to something.
     ///
@@ -880,14 +1052,16 @@ actor Transcriber {
         gate.segments.reduce(0) { $0 + ($1.end - $1.start) }
     }
 
-    /// True when the gate heard speech and the decoder wrote nothing at all.
+    /// True when the gate heard speech and the decoder wrote nothing worth
+    /// keeping — no text at all, or one unsure "Yeah."
     ///
     /// The text, not the timings: a decode with no words is the thing being
     /// caught, and whether it also carried an empty timing array is a detail
     /// of the decoder rather than the symptom.
     nonisolated static func decodedNothing(_ result: ASRResult, gate: SpeechGate) -> Bool {
         guard !gate.segments.isEmpty else { return false }
-        return result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        if result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return true }
+        return decodedOnlyYeah(result)
     }
 
     /// The clip with `pad` seconds of silence at each end, or nil when the

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -982,16 +982,28 @@ actor Transcriber {
             "\(note)dropped \(tail.count) invented trailing word(s), "
                 + "\(tail.reason): \"\(dropped)\""
         )
+        let kept = Array(timings[0..<(keep > 0 ? grouped[keep - 1].tokens.upperBound : 0)])
         return ASRResult(
             text: text,
-            confidence: result.confidence,
+            confidence: confidence(of: kept) ?? result.confidence,
             duration: result.duration,
             processingTime: result.processingTime,
-            tokenTimings: Array(timings[0..<(keep > 0 ? grouped[keep - 1].tokens.upperBound : 0)]),
+            tokenTimings: kept,
             performanceMetrics: result.performanceMetrics,
             ctcDetectedTerms: result.ctcDetectedTerms,
             ctcAppliedTerms: result.ctcAppliedTerms
         )
+    }
+
+    /// The aggregate the decoder would have reported for these tokens alone:
+    /// FluidAudio's `calculateConfidence`, the mean token confidence clamped
+    /// to 0.1...1. Recomputed after a trim so the low-confidence warning and
+    /// `asr.confidence` conditions read the words that were delivered, not the
+    /// ones that were cut. Nil with no tokens.
+    private nonisolated static func confidence(of timings: [TokenTiming]) -> Float? {
+        guard !timings.isEmpty else { return nil }
+        let mean = timings.map(\.confidence).reduce(0, +) / Float(timings.count)
+        return max(0.1, min(1, mean))
     }
 
     /// `text` without its last `dropping` whitespace-separated words, or nil

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -94,6 +94,13 @@ if arguments.contains("--audio-recovery") {
     exit(AudioRecoveryCommand.run(casesPath: casesPath))
 }
 
+if arguments.contains("--invented-tail") {
+    let casesPath = arguments.firstIndex(of: "--cases").flatMap {
+        arguments.indices.contains($0 + 1) ? arguments[$0 + 1] : nil
+    }
+    exit(InventedTailCommand.run(casesPath: casesPath))
+}
+
 if let index = arguments.firstIndex(of: "--set-key") {
     guard arguments.indices.contains(index + 1) else {
         print("usage: ParrotFlow --set-key <model> [--forget]")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -729,6 +729,7 @@ scripts/check-tokenizer.sh         # the hand-written BPE against HuggingFace's 
 scripts/check-sentence-probe.sh    # the boundary score against coremltools (needs the model)
 scripts/check-slot-gate.sh         # where a name proposal is routed (needs the model)
 scripts/check-sentence-case.sh     # the capital after a period the join removes
+scripts/check-invented-tail.sh     # the endings the decoder wrote over silence
 scripts/check-sentence-join.sh     # the two tiers of the sentence join (needs the model)
 
 PF_VIEWPORT=Ghostty scripts/check-inplace.sh   # the same set, in another terminal

--- a/scripts/check-invented-tail.sh
+++ b/scripts/check-invented-tail.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Endings the decoder wrote over silence, and endings it really heard.
+#
+#   scripts/check-invented-tail.sh
+#
+# The cases are in tests/invented-tail-cases.yaml, and every one of them is a
+# decode taken out of trace.jsonl. No audio and no model: the words, their
+# timings and their confidences are what the decoder returned, and the rule
+# reads nothing else.
+#
+# Both halves of the trim are scored. `ASRResult.text` is a separate string
+# from the token timings, so a run dropped from one and not the other leaves
+# the screen and the trace describing different sentences — and nothing would
+# say so.
+#
+# The config is a scratch one. `audio.output_dir` decides where clips and the
+# trace go, so a run against the real config would write into the recordings
+# folder.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/release/ParrotFlow"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/parrotflow-invented-tail.XXXXXX")"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+mkdir -p "$SCRATCH/config" "$SCRATCH/clips"
+cat > "$SCRATCH/config/config.yaml" <<YAML
+# Written by scripts/check-invented-tail.sh. Nothing reads it but this run.
+audio:
+  output_dir: $SCRATCH/clips
+transcription:
+  enabled: false
+YAML
+
+cd "$ROOT" || exit 1
+PARROTFLOW_CONFIG_DIR="$SCRATCH/config" "$BIN" --invented-tail \
+  --cases "$ROOT/tests/invented-tail-cases.yaml"

--- a/tests/invented-tail-cases.yaml
+++ b/tests/invented-tail-cases.yaml
@@ -1,0 +1,252 @@
+# Endings Parakeet wrote over silence, and endings it really heard.
+#
+# Run with scripts/check-invented-tail.sh. Every case is a decode taken from
+# trace.jsonl — the words, their timings and their confidences exactly as the
+# decoder returned them on a clip somebody dictated. Nothing here is invented
+# by hand, because the whole question is what the decoder does, and a made-up
+# word array can be made to prove anything.
+#
+#   speech_end  where the gate's last speech segment ended. Absent means there
+#               was no gate, which turns the after-speech rule off.
+#   words       "<word> <start> <end> <confidence>", in order.
+#   text        what the decoder wrote. Absent means the words joined by
+#               spaces, which is what the trace shows on all but one record.
+#   keeps       the text that must survive. Absent means all of it.
+#   reason      burst | after speech. Absent means nothing may be dropped.
+#   nothing     what `decodedNothing` must say about the decode.
+#
+# The must-not-fire half is the half that matters. A dictation that loses a
+# real last word loses it silently, and the word most at risk is a name — the
+# thing the decoder is least sure of and the speaker most wants.
+
+# ---------------------------------------------------------------- must fire
+
+- name: three words at one point on the clock, 6s after the speech stopped
+  # B3813269. Whisper heard "Because you could look for" and nothing after it.
+  speech_end: 2.404
+  text: "Because you could look for the first time."
+  words:
+    - Because  0.76 1.08 0.907
+    - you      1.08 1.24 0.996
+    - could    1.24 1.56 0.994
+    - look     1.56 1.88 0.996
+    - for      1.88 2.20 1.000
+    - the      8.09 8.09 0.152
+    - first    8.09 8.09 0.038
+    - time.    8.09 8.09 0.192
+  keeps: "Because you could look for"
+  reason: burst
+
+- name: a burst that is also after the speech
+  # D5D66F4A. Both rules find the same four words. The burst is reported,
+  # because it is the stronger evidence: no confidence had to be read.
+  speech_end: 2.148
+  text: "And if you ask it, you can see it."
+  words:
+    - And   0.72 0.96 0.529
+    - if    0.96 1.20 0.948
+    - you   1.20 1.36 0.962
+    - ask   1.36 1.76 0.971
+    - it,   1.76 3.76 0.160
+    - you   3.76 3.84 0.141
+    - can   3.76 3.84 0.281
+    - see   3.76 3.84 0.110
+    - it.   3.76 3.84 0.200
+  keeps: "And if you ask it,"
+  reason: burst
+
+- name: two words at the very end of a clip that is all speech
+  # 33B103E7. The gate heard speech to the last sample, so only the burst can
+  # find this one.
+  speech_end: 2.277
+  text: "Sorry, back to the first time."
+  words:
+    - Sorry,   0.24 0.72 0.533
+    - back     0.72 0.96 0.944
+    - to       0.96 1.28 0.987
+    - the      1.28 1.52 0.981
+    - first    2.16 2.24 0.036
+    - time.    2.16 2.24 0.125
+  keeps: "Sorry, back to the"
+  reason: burst
+
+- name: a burst holding a word scored 0.82
+  # 402455DD. "It's not just" is what was said. The invented ending carries
+  # "bit" at 0.823, which is why the burst rule reads no confidence at all.
+  speech_end: 1.371
+  text: "It's not just a little bit"
+  words:
+    - It's   0.00 0.36 0.553
+    - not    0.36 0.68 0.999
+    - just   0.68 1.00 0.993
+    - a      1.37 1.37 0.234
+    - little 1.37 1.37 0.093
+    - bit    1.37 1.37 0.823
+  keeps: "It's not just"
+  reason: burst
+
+- name: six words repeating themselves, two of them scored above 0.8
+  # 0F0910EC. Same shape, longer, and the repetition is the tell a confidence
+  # test would have to ignore anyway.
+  speech_end: 3.878
+  text: "Can you use a little bit of a little bit"
+  words:
+    - Can    2.00 2.32 0.653
+    - you    2.32 2.56 0.983
+    - use    2.56 2.88 0.976
+    - a      2.88 3.12 0.550
+    - little 3.76 3.84 0.060
+    - bit    3.76 3.84 0.819
+    - of     3.76 3.84 0.329
+    - a      3.76 3.84 0.240
+    - little 3.76 3.84 0.053
+    - bit    3.76 3.84 0.833
+  keeps: "Can you use a"
+  reason: burst
+
+- name: four words after the speech, none of them at the same time
+  # 58D2647D. No burst to find: the four have four different timings. They
+  # start 2.6s past the gate's last segment, and one of them scores 0.75 —
+  # which is what the 0.8 floor is for.
+  speech_end: 5.732
+  text: "It should have been found by the comments of the U.S."
+  words:
+    - It       0.56 0.80 0.553
+    - should   0.80 1.12 0.947
+    - have     1.12 1.28 0.980
+    - been     1.28 1.52 0.996
+    - found    3.92 4.48 0.904
+    - by       4.48 4.80 0.991
+    - the      4.80 5.12 0.976
+    - comments 8.32 8.64 0.136
+    - of       8.80 8.88 0.324
+    - the      8.88 8.96 0.750
+    - U.S.     9.84 9.92 0.028
+  keeps: "It should have been found by the"
+  reason: after speech
+
+- name: a lone unsure Yeah is not a word
+  # DB189782. Whisper heard no "yeah" on any of the 24 clips like this one.
+  speech_end: 0.931
+  words:
+    - Yeah. 0.72 0.88 0.467
+  nothing: true
+
+- name: and the same at 0.52
+  # A096B2F3.
+  speech_end: 1.771
+  words:
+    - Yeah. 1.44 1.60 0.523
+  nothing: true
+
+# ------------------------------------------------------------ must not fire
+
+- name: an unsure name at the end of a question
+  # 67C849E2. "Kim?" scores 0.458 and is the word the speaker cared about.
+  speech_end: 1.181
+  text: "What do you think, Kim?"
+  words:
+    - What    0.12 0.36 0.945
+    - do      0.36 0.44 0.993
+    - you     0.44 0.52 0.994
+    - think,  0.52 0.68 0.497
+    - Kim?    0.76 1.08 0.458
+
+- name: an unsure product name at the end of a list
+  # 462679BD. "WordPress." at 0.338, real, and inside the speech.
+  speech_end: 7.927
+  text: "In Slack, in web forms, in WordPress."
+  words:
+    - In          0.44 0.76 0.797
+    - Slack,      0.76 2.36 0.748
+    - in          2.36 2.68 0.981
+    - web         2.68 2.84 0.781
+    - forms,      3.16 5.24 0.866
+    - in          5.24 5.56 0.978
+    - WordPress.  6.84 7.93 0.338
+
+- name: two invented-sounding names in one sentence, both said
+  # 97CE83D3. 0.167 and 0.212, and the second is the last word.
+  speech_end: 7.586
+  text: "But why were search terms recoverable in Ribrovent and not in Dorselex?"
+  words:
+    - But         0.62 0.94 0.973
+    - why         0.94 1.34 1.000
+    - were        1.34 1.66 0.999
+    - search      1.66 2.06 0.745
+    - terms       2.06 2.70 0.900
+    - recoverable 2.70 3.66 1.000
+    - in          3.98 4.30 1.000
+    - Ribrovent   4.54 5.50 0.167
+    - and         5.66 5.90 1.000
+    - not         5.90 6.14 1.000
+    - in          6.14 6.30 0.952
+    - Dorselex?   6.46 7.59 0.212
+
+- name: counting in French, close together and unsure
+  # 44B479DD. "Un," scores 0.439 and the three words run end to end.
+  speech_end: 1.942
+  text: "Prisonniers en France. Un, deux, trois."
+  words:
+    - Prisonniers 0.00 0.30 0.503
+    - en          0.38 0.46 0.979
+    - France.     0.46 0.70 0.532
+    - Un,         0.86 1.10 0.439
+    - deux,       1.10 1.34 0.971
+    - trois.      1.34 1.94 0.831
+
+- name: five words after the gate's last segment, all confident
+  # 422E0A9E. The rule-B shape exactly: the gate stopped at 0.868 and the
+  # speaker carried on at 3.76. The confidences are 0.94 to 1.00, so the
+  # 0.8 floor is the only thing keeping this sentence whole.
+  speech_end: 0.868
+  text: "C'est le signal qu'on ne peut pas savoir."
+  words:
+    - C'est    0.00 0.40 0.636
+    - le       0.40 0.64 0.999
+    - signal   0.64 1.28 1.000
+    - qu'on    3.76 4.08 0.939
+    - ne       4.08 4.24 0.994
+    - peut     4.24 4.40 0.997
+    - pas      4.40 4.64 0.999
+    - savoir.  4.64 5.84 0.723
+
+- name: a lone Yes below the Yeah floor
+  # 2026-08-10T21-20-59, at 0.565. The rule is about the word, not about the
+  # confidence: an unsure "Yes." is an answer somebody gave.
+  speech_end: 1.686
+  words:
+    - Yes. 0.72 1.28 0.565
+  nothing: false
+
+- name: an ordinary sentence, nothing to drop
+  # 402455DD's opening on its own, so the same words score both ways.
+  speech_end: 1.371
+  text: "It's not just"
+  words:
+    - It's 0.00 0.36 0.553
+    - not  0.36 0.68 0.999
+    - just 0.68 1.00 0.993
+  nothing: false
+
+# ------------------------------------------------------------------ the trim
+
+- name: a text whose words do not line up with the timings is kept whole
+  # The same burst as B3813269, with the ending written as one word. The rule
+  # still sees three invented words; the trim refuses, because it cannot say
+  # which letters they are. On the archive this never happens — the two counts
+  # agreed on all 22136 records that carry both — and if it ever does, a kept
+  # invention beats a sentence cut in the wrong place.
+  speech_end: 2.404
+  text: "Because you could look for the-first-time."
+  words:
+    - Because  0.76 1.08 0.907
+    - you      1.08 1.24 0.996
+    - could    1.24 1.56 0.994
+    - look     1.56 1.88 0.996
+    - for      1.88 2.20 1.000
+    - the      8.09 8.09 0.152
+    - first    8.09 8.09 0.038
+    - time.    8.09 8.09 0.192
+  keeps: "Because you could look for the-first-time."
+  reason: burst


### PR DESCRIPTION
Parakeet sometimes writes a sentence over the silence at the end of a clip. "Because you could look for" came back as "Because you could look for the first time.", and nothing in the transcript says which half was said. This drops those words before anything downstream sees them, on two shapes measured over 7315 first-pass decodes: a burst of trailing words sharing one point on the clock, and a run of unsure words starting well after the last speech the gate heard. A lone unsure "Yeah." is the same failure with a word attached, and now goes to the empty-decode recovery instead of being written out.

No setting. The rules run on every dictation, with `audio.second_opinion` on or off.

Start the review at `Transcriber.inventedTail` and at the text trim below it — cutting the words out of `ASRResult.text` and out of the token timings has to be one act, and that is the part that can go wrong quietly.

<details>
<summary>Why the decoder does this, and how the two rules find it</summary>

Parakeet predicts a token and a frame skip together, and over trailing silence it keeps predicting. What it produces has a shape that speech does not.

**A burst.** Two or more trailing words that share one start and one end, to 5ms. The decoder emitted them at a single point on the clock. Measured: 45 clips of 7315. Whisper large-v3-turbo heard none of those words on the 41 that still had a wav — including bursts holding a word scored 0.9 and above, which is why this rule reads no confidence at all. `It's not just` came back as `It's not just a little bit`, with "bit" at 0.823.

**After the speech.** Two or more trailing words starting at least 0.3s past the gate's last speech segment, none of them scoring 0.8 or more. The boundary is the VAD's own last segment, which already carries a 0.75s hangover, so it is generous on purpose. The 0.8 floor is what keeps a real late clause: "C'est le signal qu'on ne peut pas savoir." decodes its last five words after the gate's last segment, at 0.94 to 1.00.

Together: 56 clips of 7315, no false positive found.

The rules run on the first pass, on the long-pause retry, and on each second-opinion arm before it is compared with anything. That last one is the point of putting it there: an arm whose only addition is an invented run now adds nothing, and loses on the guards that were already there.

</details>

<details>
<summary>The text and the timings are two objects, and the trim had to cut both — 22136 records say how</summary>

`ASRResult.text` is a separate string from `tokenTimings`. Trimming one and not the other leaves the HUD, the trace and the pipeline describing different sentences, and nothing would report it.

Two ways to do it, checked against the 22136 trace records that carry both `asr.text` and `asr.words`:

| approach | exact on the archive |
|---|---|
| cut the last N whitespace-separated words off `text` | 22136 of 22136 |
| rebuild `text` by joining the surviving words | 22135 of 22136 |

The word counts agreed on every record, so the cut is exact. The rejoin is not: one record holds a double space inside `asr.text`, and joining flattens it. So the text is cut from its end, character by character, and the spacing of what survives is left exactly as it was.

The cut is guarded: if the whitespace word count ever disagrees with `Trace.words`, the decode is kept whole and the log says so. A kept invention beats a sentence cut in the wrong place.

The aggregate confidence is recomputed too, the way FluidAudio computes it: the mean of the retained token probabilities, clamped to 0.1...1. Leaving the decoder's number in place would describe words that are no longer in the sentence, and the default warning fires below 0.80 — "Sorry, back to the first time." scored 0.68 with the invented ending and scores 0.86 without it, so the repair would have warned about the sentence it had just repaired. Found in review.

The timings lose the tokens of the same words. `Trace.words` was refactored onto `Trace.grouped`, which returns each word with the token range it was built from — one grouping loop, not two.

</details>

<details>
<summary>A lone "Yeah." is not a word — 0 of 24, and a pad recovers 19 of 23</summary>

24 clips in the archive decoded to a single word "Yeah." with the word scoring under 0.6. Whisper heard "yeah" in none of them. A padded decode returned the real words on 19 of the 23 that had a wav: "The Versailles Castle.", "I don't get it.", "Thank you so much, Jess."

So it is treated like an empty decode — fed to the recovery that was already there, which takes a padded arm as it stands and keeps the first pass when every arm is empty. It works with `second_opinion` off too, through `silenceRetryPads`.

The floor is on the word, not on the decode: an unsure "Yes." at 0.565 is an answer somebody gave, and is kept. In the whole archive no lone "yeah" ever scored 0.6 or more, so the floor has never had to keep one.

</details>

<details>
<summary>Verified on real audio with the built binary — 52 of 52, and 100 random clips unchanged</summary>

`.build/release/ParrotFlow --transcribe <wav> --no-vocab`, against a scratch config so nothing touched the recordings folder. `second_opinion: true` unless stated.

| set | result |
|---|---|
| the 52 fired clips that still have a wav | the invented run is gone on 52, the rest of each text unchanged |
| the same 52 with `second_opinion: false` | the same: 52 of 52 |
| the 24 lone-yeah clips | 18 recovered to real words, the same 18 with `second_opinion` off |
| 100 random clips dictated since 2026-08-25 | text identical to the live trace on 100 of 100 |
| the 12 clips the retry sweep changed | the 6 recoveries intact, the 5 inventions gone |

On the 24 lone-yeah clips: a padded arm returned text on 20, and on 18 of those the text was real words. On 2 the arm returned "Yeah." again and it was taken as it stands, which is what the recovery does. On the other 4 every arm came back empty and the first pass was kept. DB189782 is one of the 2 whose arm said "Yeah." again.

The 6 recoveries that had to survive: "Go ahead and try it.", "Je ne comprends rien de ce que tu dis. Dans un kilomètre.", "In Slack, in web forms, in WordPress." (WordPress at 0.338), "Prisonniers en France. Un, deux, trois.", "Don't join her.", "But why were search terms recoverable in Ribrovent and not in Dorselex?" (0.167 and 0.212).

The 5 inventions that had to go: "Let's get back to the first time." → "Let's get back to"; "Because you could look for the first time." → "Because you could look for"; "…very hard to get a little." → "…very hard to get."; "Can you check this artifact with the first?" → "Can you check this artifact with"; "I went until the first time." → "I went until."

"What do you think, Kim?" is kept whole, with "Kim?" at 0.458 inside the speech. That is the known miss of the retry sweep and it stays a miss here — deliberately, because it is also the case the rules must never fire on.

</details>

<details>
<summary>New behaviour to watch: a trimmed first pass lets a padded arm win, on 5 of 188 clips</summary>

An invented ending is clamped to the end of the clip, so before this change the first pass claimed the last frame and no arm could ever "reach further". Trimming it opens that comparison. On the 188 clips run above, 51 had a first-pass drop, an arm won on 12, and on 5 of them both happened — arm wins that could not have happened before:

| clip | first pass, after the drop | what the arm added |
|---|---|---|
| 22-07-51 | "…to tackle this as" (dropped "a little bit.") | "a" |
| AC943CA8 | "…the prompt and" (dropped "Israel vendredi on the eye") | "on" |
| BB416705 | "J'allais mettre un jour qui est" (dropped "un peu plus tard") | "une." |
| A57DCF98 | "Je n'ai pas encore de" (dropped "la vie.") | "la" |
| B888703B | "…but only if" (dropped "you have a") | "we" |

Each is a single word, so no rule here can judge it: both rules need two. Listed as observed behaviour, not fixed.

The count is 51 first-pass drops, not 52, because B3813269 does not reproduce its invention when the wav is decoded again — it invented live and decodes clean from the file. The arm still invented and was still trimmed.

The arms end in real silence, so they are the most likely place for an invention. They are not a noisy one: on the 100 random clips, an arm dropped a run on 1 clip and the first pass on none, so an ordinary dictation adds no line to the log.

</details>

<details>
<summary>The check — `--invented-tail`, 16 decodes taken out of the trace</summary>

`scripts/check-invented-tail.sh`, in `make test` and in CI. No audio and no model: every case is the word array, the timings and the confidences the decoder actually returned on a clip somebody dictated, and the words are turned back into token timings and handed to the real `withoutInventedTail`. So the text trim is scored too, not only the rule.

Eight cases must fire, eight must not. The must-not half is the half that matters: an unsure name at the end of a question ("Kim?" 0.458), an unsure product name at the end of a list ("WordPress." 0.338), two invented-sounding names that were said ("Ribrovent" 0.167, "Dorselex?" 0.212), French counting, the rule-B shape with confident words, a lone "Yes." at 0.565, and a text whose words do not line up with its timings, which must be kept whole.

`make test` passes, including the new check at 16/16.

</details>

<details>
<summary>Also in here: the `second_opinion` docstring said "off by default" and the default is true</summary>

One docstring in `Config.swift`. The default has been `true`; the comment above it still said off. Nothing else.

</details>

