### PR TITLE
feat: a lone capital after a pause is read as a sentence boundary

### DIFF
--- a/Sources/ParrotFlow/SentenceJoin.swift
+++ b/Sources/ParrotFlow/SentenceJoin.swift
@@ -184,7 +184,8 @@ actor SentenceJoin {
             // A single space, and a letter or a digit before it: anything else
             // is a mark, a bracket or a line break, and none of those is this
             // shape.
-            guard text.index(after: previous.upperBound) == range.lowerBound,
+            guard previous.upperBound < text.endIndex,
+                  text.index(after: previous.upperBound) == range.lowerBound,
                   let last = text[previous].last, last.isLetter || last.isNumber
             else { continue }
             guard !opens(previous), n + 1 == words.count || !opens(words[n + 1]) else {
@@ -259,7 +260,7 @@ actor SentenceJoin {
     /// Measured over 621 candidates from one speaker's dictation: refusing
     /// every class but these removes 93% of the capitals that must not be
     /// touched, and costs 9 repairs of which 4 were reachable at all.
-    static let readable: Set<String> = [
+    static let readableClasses: Set<String> = [
         "Conjunction", "Determiner", "Pronoun", "Adverb",
         "Preposition", "Particle", "Interjection", "Verb",
     ]
@@ -282,7 +283,7 @@ actor SentenceJoin {
         tagger.string = joined
         tagger.setLanguage(.english, range: joined.startIndex..<joined.endIndex)
         let tag = tagger.tag(at: from, unit: .word, scheme: .nameTypeOrLexicalClass).0?.rawValue
-        return Self.readable.contains(tag ?? "")
+        return Self.readableClasses.contains(tag ?? "")
     }
 
     /// The whole text with one mark taken out, and where the word after it

--- a/Sources/ParrotFlow/SentenceJoin.swift
+++ b/Sources/ParrotFlow/SentenceJoin.swift
@@ -23,8 +23,15 @@ import NaturalLanguage
 /// A pause is written `word? Capital` or `word? lowercase` about a quarter as
 /// often as `word. Capital`, so question marks are scanned as well. A period
 /// followed by a lowercase word is not: the transcriber did not start a
-/// sentence there, and the shape has never been measured. A capital with no
-/// mark in front of it is not either — it does not separate (AUC 0.750).
+/// sentence there, and the shape has never been measured.
+///
+/// A capital with no mark at all is scanned, with a fourth reading — the text
+/// as decoded — because there is no mark to take out and "leave it alone" has
+/// to be a candidate rather than a default. Half of those capitals are correct,
+/// so `bareBoundaries` and `readable` refuse a run of capitals, a capital
+/// inside the word and every part of speech but the ones that open a clause.
+/// 64% of the spurious ones lowercased over 110 hand-labelled candidates, no
+/// correct capital touched, none of 15 real sentence starts joined.
 ///
 /// English only. The reading is scored by an English base model, and the mark
 /// set is English: French wants `:` where English does not.
@@ -74,9 +81,13 @@ actor SentenceJoin {
     /// One boundary: where the mark is, which mark it is, and the word after
     /// it. The mark travels with the boundary so the readings, the log line
     /// and the change all name the one the transcriber wrote.
+    ///
+    /// `mark` is nil for a capital the transcriber wrote with nothing in front
+    /// of it, and `at` is then the first letter of that word rather than a
+    /// character to remove.
     struct Boundary {
         let at: String.Index
-        let mark: Character
+        let mark: Character?
         let next: Range<String.Index>
     }
 
@@ -137,6 +148,53 @@ actor SentenceJoin {
         return found
     }
 
+    /// Every capitalised word the transcriber wrote with no mark in front of
+    /// it: `imports name definitions And all the things`.
+    ///
+    /// A pause does not always make the transcriber write a mark, and this
+    /// shape is about a third as common as `word. Capital`. The word before it
+    /// has to end in a letter or a digit, so a capital that already follows a
+    /// mark, a bracket or a quote is the shape above and is not visited twice.
+    ///
+    /// Two capitals in a row are left alone. Over 621 candidates from one
+    /// speaker, a run of two or more is 53% names — `Better Stack`,
+    /// `Hugging Face`, `Red Crawl` — and 13% boundaries, so reading one asks
+    /// the wrong question. Whether a run is a name is its own problem.
+    static func bareBoundaries(in text: String) -> [Boundary] {
+        var found: [Boundary] = []
+        var words: [Range<String.Index>] = []
+        var cursor = text.startIndex
+        while cursor < text.endIndex {
+            while cursor < text.endIndex, text[cursor].isWhitespace {
+                cursor = text.index(after: cursor)
+            }
+            guard cursor < text.endIndex else { break }
+            let end = text[cursor...].firstIndex(where: \.isWhitespace) ?? text.endIndex
+            words.append(cursor..<end)
+            cursor = end
+        }
+
+        func opens(_ range: Range<String.Index>) -> Bool {
+            guard let first = text[range].first else { return false }
+            return first.isUppercase
+        }
+
+        for (n, range) in words.enumerated() where n > 0 && opens(range) {
+            let previous = words[n - 1]
+            // A single space, and a letter or a digit before it: anything else
+            // is a mark, a bracket or a line break, and none of those is this
+            // shape.
+            guard text.index(after: previous.upperBound) == range.lowerBound,
+                  let last = text[previous].last, last.isLetter || last.isNumber
+            else { continue }
+            guard !opens(previous), n + 1 == words.count || !opens(words[n + 1]) else {
+                continue
+            }
+            found.append(Boundary(at: range.lowerBound, mark: nil, next: range))
+        }
+        return found
+    }
+
     // MARK: - The capital, once the period is gone
 
     /// The next word as it should be written with no period in front of it.
@@ -189,14 +247,86 @@ actor SentenceJoin {
         return word.prefix(1).lowercased() + word.dropFirst()
     }
 
+    /// Classes a capital with no mark in front of it may be read in.
+    ///
+    /// `written` decides how to write the word after a mark that is already
+    /// there, where a capital that is right is rare. Here it is half the
+    /// input, so the same rules are asked first and the part of speech is
+    /// asked as well. A noun or an adjective in this position is a name, a
+    /// product or a title — `Slack`, `English`, `Friday`, `TypeScript` — and
+    /// lowercasing it writes something nobody said.
+    ///
+    /// Measured over 621 candidates from one speaker's dictation: refusing
+    /// every class but these removes 93% of the capitals that must not be
+    /// touched, and costs 9 repairs of which 4 were reachable at all.
+    static let readable: Set<String> = [
+        "Conjunction", "Determiner", "Pronoun", "Adverb",
+        "Preposition", "Particle", "Interjection", "Verb",
+    ]
+
+    /// Whether a bare capital may be read at all. `written` first, then this.
+    ///
+    /// A capital after the first letter says name whatever the sentence says:
+    /// `WhatsApp`, `TypeScript`, `OpenAI`. `written` only refuses a word in
+    /// capitals throughout, so this is the case it does not see.
+    ///
+    /// The tagger is built with the scheme set `written` uses. Asking for
+    /// `.lexicalClass` alongside changes the answer on 3 of the same 621.
+    static func readable(_ word: String, in joined: String, at offset: Int) -> Bool {
+        let bare = String(word.prefix { $0.isLetter })
+        guard !bare.dropFirst().contains(where: \.isUppercase) else { return false }
+        guard let from = joined.index(
+            joined.startIndex, offsetBy: offset, limitedBy: joined.endIndex
+        ) else { return false }
+        let tagger = NLTagger(tagSchemes: [.nameTypeOrLexicalClass, .lemma])
+        tagger.string = joined
+        tagger.setLanguage(.english, range: joined.startIndex..<joined.endIndex)
+        let tag = tagger.tag(at: from, unit: .word, scheme: .nameTypeOrLexicalClass).0?.rawValue
+        return Self.readable.contains(tag ?? "")
+    }
+
     /// The whole text with one mark taken out, and where the word after it
     /// then starts. Both halves of what `written` needs to tag.
     static func joining(_ text: String, at boundary: Boundary) -> (text: String, offset: Int) {
+        let start = text.distance(from: text.startIndex, to: boundary.next.lowerBound)
+        guard boundary.mark != nil else { return (text, start) }
         var joined = text
         joined.remove(at: boundary.at)
         // The mark sits before the word, so removing it moves the word one
         // character left and nothing else moves at all.
-        return (joined, text.distance(from: text.startIndex, to: boundary.next.lowerBound) - 1)
+        return (joined, start - 1)
+    }
+
+    /// A bare capital is only read when the speaker paused this long in front
+    /// of it. Seconds.
+    ///
+    /// This is a latency cut, not a safety one. The readings answer these
+    /// boundaries correctly with or without it — 0 wrong writes either way on
+    /// 110 labelled candidates — but a pause is what makes the transcriber
+    /// write the capital in the first place, so a capital with no pause in
+    /// front of it is rarely the shape this stage repairs. Skipping those
+    /// spends no forward pass on them.
+    static let paused: Double = 1.0
+
+    /// Seconds of silence in front of each word, keyed by where that word
+    /// starts in the text.
+    ///
+    /// The decoder's words joined by single spaces are the text, so a word's
+    /// offset is a running length. `Transcriber.swift` runs this stage before
+    /// the pipeline for exactly that reason — every text stage after it
+    /// rewrites words the timings index. Words that do not rebuild the text
+    /// give no gate rather than a wrong one.
+    static func pauses(in text: String, words: [Trace.Word]) -> [Int: Double] {
+        guard words.map(\.word).joined(separator: " ") == text else { return [:] }
+        var out: [Int: Double] = [:]
+        var offset = 0
+        var previous: Trace.Word?
+        for word in words {
+            if let previous { out[offset] = word.start - previous.end }
+            offset += word.word.count + 1
+            previous = word
+        }
+        return out
     }
 
     // MARK: - The pass
@@ -210,12 +340,19 @@ actor SentenceJoin {
     /// Nothing here waits for the model. A dictation that arrives before the
     /// weights are in memory keeps its boundaries and starts the load, so the
     /// first dictation after a launch pays nothing and the second is repaired.
-    func apply(to text: String, config: Config) async -> Outcome {
+    /// `words` are the decoder's own, for the pause gate. Without them every
+    /// candidate is read, which is what `--sentence-join` and the tests do.
+    func apply(
+        to text: String, config: Config, words: [Trace.Word] = []
+    ) async -> Outcome {
         let settings = config.transcription.sentences
         guard settings.enabled else { return .unchanged(text) }
         let language = Pipeline.language(of: text, config: config)
         let marks = config.transcription.marks(for: language)
-        let found = Self.boundaries(in: text, scanning: Self.scanned(marks))
+        let found = (
+            Self.boundaries(in: text, scanning: Self.scanned(marks))
+            + Self.bareBoundaries(in: text)
+        ).sorted { $0.next.lowerBound < $1.next.lowerBound }
         guard !found.isEmpty else { return .unchanged(text) }
         guard await SentenceReadings.shared.isLoaded else {
             await SentenceReadings.shared.warm()
@@ -224,19 +361,32 @@ actor SentenceJoin {
             return .unchanged(text)
         }
         let terms = Array(config.vocabulary.terms.keys)
+        let pauses = words.isEmpty ? [:] : Self.pauses(in: text, words: words)
 
         var readings: [Reading] = []
         var rebuilt = ""
         var cursor = text.startIndex
         for boundary in found {
             let word = String(text[boundary.next])
+            let (whole, offset) = Self.joining(text, at: boundary)
+            let now = Self.written(word, in: whole, at: offset, terms: terms)
+            // A bare capital is filtered before it is read, never after. Half
+            // of them are a name the transcriber was right about, and a name
+            // must not reach a reading that could vote to lowercase it.
+            if boundary.mark == nil,
+               now == word || !Self.readable(word, in: whole, at: offset) {
+                continue
+            }
+            if boundary.mark == nil, let gap = pauses[offset], gap < Self.paused {
+                continue
+            }
             let started = DispatchTime.now().uptimeNanoseconds
             let scores: [SentenceReadings.Score]
             do {
                 scores = try await SentenceReadings.shared.read(
                     left: String(text[..<boundary.at]),
                     right: String(text[boundary.next.lowerBound...]),
-                    found: String(boundary.mark),
+                    found: boundary.mark.map(String.init) ?? "",
                     marks: marks
                 )
             } catch {
@@ -248,12 +398,14 @@ actor SentenceJoin {
             }
             let milliseconds = Double(DispatchTime.now().uptimeNanoseconds - started) / 1e6
             guard let best = Self.winner(of: scores) else { continue }
-            let (whole, offset) = Self.joining(text, at: boundary)
-            let now = Self.written(word, in: whole, at: offset, terms: terms)
+            // With no mark, `at` is the word itself and the text before it ends
+            // in the space that separates them.
             let before = String(
-                text[..<boundary.at].reversed().prefix { !$0.isWhitespace }.reversed()
+                text[..<boundary.at].reversed()
+                    .drop { $0.isWhitespace }.prefix { !$0.isWhitespace }.reversed()
             )
-            let change = "\(before)\(boundary.mark) \(word) -> \(before) \(now)"
+            let mark = boundary.mark.map(String.init) ?? ""
+            let change = "\(before)\(mark) \(word) -> \(before) \(now)"
             let listed = scores
                 .map { String(format: "%@ %.2f", $0.key, $0.mean) }
                 .joined(separator: "  ")
@@ -265,7 +417,8 @@ actor SentenceJoin {
 
             if best.key == SentenceReadings.join {
                 rebuilt += text[cursor..<boundary.at]
-                rebuilt += text[text.index(after: boundary.at)..<boundary.next.lowerBound]
+                let after = boundary.mark == nil ? boundary.at : text.index(after: boundary.at)
+                rebuilt += text[after..<boundary.next.lowerBound]
                 rebuilt += now
                 cursor = boundary.next.upperBound
             }

--- a/Sources/ParrotFlow/SentenceJoinCommand.swift
+++ b/Sources/ParrotFlow/SentenceJoinCommand.swift
@@ -30,10 +30,19 @@ enum SentenceJoinCommand {
         if caseOnly {
             let terms = Array(config.vocabulary.terms.keys)
             let scan = SentenceJoin.scanned(config.transcription.sentences.marks)
-            for boundary in SentenceJoin.boundaries(in: text, scanning: scan) {
+            let found = (
+                SentenceJoin.boundaries(in: text, scanning: scan)
+                + SentenceJoin.bareBoundaries(in: text)
+            ).sorted { $0.next.lowerBound < $1.next.lowerBound }
+            for boundary in found {
                 let (whole, offset) = SentenceJoin.joining(text, at: boundary)
                 let word = String(text[boundary.next])
-                let now = SentenceJoin.written(word, in: whole, at: offset, terms: terms)
+                var now = SentenceJoin.written(word, in: whole, at: offset, terms: terms)
+                // A bare capital that the filter refuses is never read, so the
+                // word it would be written as is the word itself.
+                if boundary.mark == nil, !SentenceJoin.readable(word, in: whole, at: offset) {
+                    now = word
+                }
                 print("  next       \(word) -> \(now)")
             }
             return 0
@@ -65,7 +74,7 @@ enum SentenceJoinCommand {
         for reading in outcome.readings {
             print("  boundary   \(reading.change)")
             for score in reading.scores {
-                let key = score.key.padding(toLength: 8, withPad: " ", startingAt: 0)
+                let key = score.key.padding(toLength: 10, withPad: " ", startingAt: 0)
                 print(String(format: "  reading    %@ %8.4f  %d",
                              key, score.mean, score.tokens))
             }

--- a/Sources/ParrotFlow/SentenceProbeCommand.swift
+++ b/Sources/ParrotFlow/SentenceProbeCommand.swift
@@ -16,6 +16,10 @@ import MLX
 ///       reading   join      -4.5571  4
 ///       winner    join
 ///
+/// `--bare` reads the boundary as a capital the transcriber wrote with nothing
+/// in front of it: four readings instead of three, the extra one being the text
+/// exactly as decoded. A `"mark": ""` row in a bench file is the same thing.
+///
 /// `--bench <cases.json> --out <scores.json>` scores a whole file in one loaded
 /// process — `[{"left": …, "right": …}]` in, one row of scores out, with the
 /// milliseconds each decision took. A row may carry `"mark": "?"` where the
@@ -36,13 +40,17 @@ enum SentenceProbeCommand {
         return marks.first { SentenceReadings.enders.contains($0) } ?? "."
     }
 
-    static func run(left: String, right: String) -> Int32 {
+    static func run(left: String, right: String, bare: Bool = false) -> Int32 {
         var exitCode: Int32 = 0
         let done = DispatchSemaphore(value: 0)
         // English: this is the English boundary probe, and the stage it stands
         // in runs in no other language.
         let marks = ((try? ConfigStore.load()) ?? Config()).transcription.marks(for: "en")
-        let mark = found(in: left, marks: marks)
+        // `--bare`: the transcriber wrote the capital with no mark at all, so
+        // the text as decoded is a reading of its own. A left half with no mark
+        // is otherwise read as a period, which is what it writes most of the
+        // time.
+        let mark = bare ? "" : found(in: left, marks: marks)
 
         Task {
             do {

--- a/Sources/ParrotFlow/SentenceProbeCommand.swift
+++ b/Sources/ParrotFlow/SentenceProbeCommand.swift
@@ -61,7 +61,7 @@ enum SentenceProbeCommand {
                 for score in scores {
                     // `%@` ignores a width on this platform, so the column
                     // is padded here.
-                    let key = score.key.padding(toLength: 8, withPad: " ", startingAt: 0)
+                    let key = score.key.padding(toLength: 10, withPad: " ", startingAt: 0)
                     print(String(
                         format: "  reading   %@ %8.4f  %d%@",
                         key, score.mean, score.tokens,

--- a/Sources/ParrotFlow/SentenceReadings.swift
+++ b/Sources/ParrotFlow/SentenceReadings.swift
@@ -13,7 +13,9 @@ import MLXLMCommon
 ///     ", the vocabulary is slower"     it is really a comma
 ///
 /// The first reading is the mark the transcriber actually wrote, so a
-/// `word? Capital` boundary is read `"? Word"`, `", word"` and `" word"`.
+/// `word? Capital` boundary is read `"? Word"`, `", word"` and `" word"`. A
+/// boundary with no mark is read four ways — see `bare` — because the text as
+/// decoded is then a candidate rather than what happens by default.
 /// Reading every configured ender at every boundary was measured too and is
 /// worse: 259 of 325 question cuts repaired against 265, for a fourth forward
 /// pass.
@@ -67,6 +69,9 @@ actor SentenceReadings {
     /// The key of the reading that removes the period.
     static let join = "join"
 
+    /// The key of the reading that leaves a bare capital exactly as decoded.
+    static let asDecoded = "as-decoded"
+
     /// Marks after which the next word keeps its capital.
     static let enders: Set<String> = [".", "?", "!"]
 
@@ -117,9 +122,31 @@ actor SentenceReadings {
     /// The other enders are left out. A boundary already carries one, and
     /// swapping a period for a question mark is not a repair this stage makes.
     static func readings(found: String, marks: [String]) -> [Reading] {
-        ([found] + marks.filter { !enders.contains($0) && $0 != found })
+        guard !found.isEmpty else { return bare(marks: marks) }
+        return ([found] + marks.filter { !enders.contains($0) && $0 != found })
             .map { Reading(key: $0, mark: $0, capital: enders.contains($0)) }
             + [Reading(key: join, mark: "", capital: false)]
+    }
+
+    /// The readings of a boundary that holds no mark at all — a capital the
+    /// transcriber wrote after a pause, with nothing in front of it.
+    ///
+    /// Four, not three. The text as decoded is a reading of its own here: with
+    /// no mark to remove, "leave it alone" is a real candidate rather than the
+    /// thing that happens when a mark wins. Only `join` writes anything.
+    ///
+    /// One ender, not every configured one. Which sentence mark belongs here is
+    /// a question this stage does not answer — it never inserts one — so a
+    /// second ender would buy a fifth forward pass and no decision.
+    static func bare(marks: [String]) -> [Reading] {
+        (marks.first { enders.contains($0) }.map {
+            [Reading(key: $0, mark: $0, capital: true)]
+        } ?? [])
+        + [Reading(key: asDecoded, mark: "", capital: true)]
+        + marks.filter { !enders.contains($0) }.map {
+            Reading(key: $0, mark: $0, capital: false)
+        }
+        + [Reading(key: join, mark: "", capital: false)]
     }
 
     /// The shared prefix and one continuation per reading.

--- a/Sources/ParrotFlow/SentenceReadings.swift
+++ b/Sources/ParrotFlow/SentenceReadings.swift
@@ -14,8 +14,8 @@ import MLXLMCommon
 ///
 /// The first reading is the mark the transcriber actually wrote, so a
 /// `word? Capital` boundary is read `"? Word"`, `", word"` and `" word"`. A
-/// boundary with no mark is read four ways — see `bare` — because the text as
-/// decoded is then a candidate rather than what happens by default.
+/// boundary with no mark is read four ways — see `bareReadings` — because the
+/// text as decoded is then a candidate rather than what happens by default.
 /// Reading every configured ender at every boundary was measured too and is
 /// worse: 259 of 325 question cuts repaired against 265, for a fourth forward
 /// pass.
@@ -122,7 +122,7 @@ actor SentenceReadings {
     /// The other enders are left out. A boundary already carries one, and
     /// swapping a period for a question mark is not a repair this stage makes.
     static func readings(found: String, marks: [String]) -> [Reading] {
-        guard !found.isEmpty else { return bare(marks: marks) }
+        guard !found.isEmpty else { return bareReadings(marks: marks) }
         return ([found] + marks.filter { !enders.contains($0) && $0 != found })
             .map { Reading(key: $0, mark: $0, capital: enders.contains($0)) }
             + [Reading(key: join, mark: "", capital: false)]
@@ -138,7 +138,7 @@ actor SentenceReadings {
     /// One ender, not every configured one. Which sentence mark belongs here is
     /// a question this stage does not answer — it never inserts one — so a
     /// second ender would buy a fifth forward pass and no decision.
-    static func bare(marks: [String]) -> [Reading] {
+    private static func bareReadings(marks: [String]) -> [Reading] {
         (marks.first { enders.contains($0) }.map {
             [Reading(key: $0, mark: $0, capital: true)]
         } ?? [])

--- a/Sources/ParrotFlow/Trace.swift
+++ b/Sources/ParrotFlow/Trace.swift
@@ -495,7 +495,7 @@ enum Trace {
         }
     }
 
-    struct Word: Encodable {
+    struct Word: Encodable, Sendable {
         let word: String
         let start: Double
         let end: Double

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -517,7 +517,10 @@ actor Transcriber {
             // only thing able to match them.
             if !config.vocabularySounds.isEmpty { warmSoundModel() }
             if #available(macOS 14, *) {
-                let joins = await SentenceJoin.shared.apply(to: text, config: config)
+                let joins = await SentenceJoin.shared.apply(
+                    to: text, config: config,
+                    words: Trace.words(from: result.tokenTimings ?? [])
+                )
                 text = joins.text
                 joinedSentences = joins.count(.join)
             }

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -165,13 +165,18 @@ if let at = arguments.firstIndex(of: "--sentence-probe") {
             cases: arguments[bench + 1], out: out, vectors: arguments.contains("--vectors")
         ))
     }
-    guard arguments.indices.contains(at + 2) else {
-        print("usage: ParrotFlow --sentence-probe \"<left half>\" \"<right half>\"")
+    let halves = arguments[(at + 1)...].filter { !$0.hasPrefix("--") }
+    guard halves.count >= 2 else {
+        print("usage: ParrotFlow --sentence-probe [--bare] \"<left half>\" \"<right half>\"")
         print("       ParrotFlow --sentence-probe --bench <cases.json>"
               + " [--out <scores.json>] [--vectors]")
         exit(2)
     }
-    exit(SentenceProbeCommand.run(left: arguments[at + 1], right: arguments[at + 2]))
+    exit(SentenceProbeCommand.run(
+        left: halves[halves.startIndex],
+        right: halves[halves.index(after: halves.startIndex)],
+        bare: arguments.contains("--bare")
+    ))
 }
 
 if let at = arguments.firstIndex(of: "--sentence-join") {

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -165,18 +165,26 @@ if let at = arguments.firstIndex(of: "--sentence-probe") {
             cases: arguments[bench + 1], out: out, vectors: arguments.contains("--vectors")
         ))
     }
-    let halves = arguments[(at + 1)...].filter { !$0.hasPrefix("--") }
-    guard halves.count >= 2 else {
+    // Only `--bare` is taken as an option, and only the first one. Everything
+    // else is transcript, including a half that starts with a dash.
+    var bare = false
+    var halves: [String] = []
+    var index = at + 1
+    while index < arguments.count, halves.count < 2 {
+        if arguments[index] == "--bare", !bare {
+            bare = true
+        } else {
+            halves.append(arguments[index])
+        }
+        index += 1
+    }
+    guard halves.count == 2 else {
         print("usage: ParrotFlow --sentence-probe [--bare] \"<left half>\" \"<right half>\"")
         print("       ParrotFlow --sentence-probe --bench <cases.json>"
               + " [--out <scores.json>] [--vectors]")
         exit(2)
     }
-    exit(SentenceProbeCommand.run(
-        left: halves[halves.startIndex],
-        right: halves[halves.index(after: halves.startIndex)],
-        bare: arguments.contains("--bare")
-    ))
+    exit(SentenceProbeCommand.run(left: halves[0], right: halves[1], bare: bare))
 }
 
 if let at = arguments.firstIndex(of: "--sentence-join") {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -463,6 +463,7 @@ reason for the swap.
 ```sh
 $PF --sentence-model                                       # fetch the model the readings need
 $PF --sentence-probe "<left half>" "<right half>"          # read one boundary
+$PF --sentence-probe --bare "<left half>" "<right half>"   # a capital with no mark
 $PF --sentence-probe --bench <cases.json> --out <out.json> # a whole file, one loaded process
 ```
 
@@ -475,6 +476,20 @@ threshold.
 
 End the left half with `?` to read a question boundary. With no mark there it
 is read as a period.
+
+`--bare` reads it as a capital the transcriber wrote with nothing in front of
+it. That shape gets a fourth reading, the text exactly as decoded, because
+there is no mark to take out and leaving it alone has to be a candidate of its
+own rather than what happens when a mark wins.
+
+```
+$PF --sentence-probe --bare "…the dot and the word app" "And decide which one is bigger"
+  reading   .           -4.9574  7
+  reading   as-decoded  -5.3883  6
+  reading   ,           -4.2416  7
+  reading   join        -4.3177  6
+  winner    ,
+```
 
 ```
 $PF --sentence-probe "…the first usage of the LLM with." "The vocabulary is slower"
@@ -492,7 +507,8 @@ sequences do this.
 
 `--bench` reads `[{"left": …, "right": …}]` and writes one row of scores per
 boundary, with the mark it read and the milliseconds each decision took. A row
-may carry `"mark": "?"` where the left half does not end with the mark itself.
+may carry `"mark": "?"` where the left half does not end with the mark itself,
+and `"mark": ""` for the bare-capital shape.
 It loads the model once, so it is the only way to get a latency number;
 `--vectors` loads the word vectors as well, so the memory line describes the
 process the app runs.

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -511,8 +511,55 @@ A question mark counts even when the next word is lowercase. Of 19 such lines
 in one speaker's dictation, 7 hold a mark that should go and 12 a real
 question, so the reading has to decide. A period followed by a lowercase word is
 left alone: the transcriber did not start a sentence there and the shape has
-never been measured. A capital with no mark in front of it is left alone too —
-it does not separate (AUC 0.750 over 26 hand-labelled cases).
+never been measured.
+
+### A capital with no mark in front of it
+
+A pause does not always make the transcriber write the mark. It writes
+`imports name definitions And all the things`, and that shape is about a third
+as common as `word. Capital`. It is scanned too, with a **fourth reading**: the
+text exactly as it was decoded.
+
+```
+". A before section B"     the sentence really ended
+" A before section B"      as decoded, a capital that belongs
+" a before section B"      a pause cut one sentence in two
+", a before section B"     it is really a comma
+```
+
+The fourth reading exists because there is no mark to take out. Everywhere else
+"leave it alone" is what happens when a mark wins; here it is a candidate of its
+own, and it is the one that saves `paste it into Outlook and the other apps`.
+Only the third writes anything. The period is never inserted — where a mark
+wins, the text is left as it was decoded and the decision is logged.
+
+Half of these capitals are correct and must not be touched: `Slack`, `English`,
+`Friday`, `TypeScript`, `Google Cloud`. Four rules refuse a candidate before any
+reading, on top of the ones that decide the word after a joined period:
+
+- a **run of two or more** capitals is never a candidate. Over 621 candidates
+  from one speaker it is 53% names — `Better Stack`, `Hugging Face` — and 13%
+  boundaries, so it is a different question and is left for one.
+- a **capital inside the word**: `WhatsApp`, `TypeScript`, `OpenAI`.
+- the **part of speech**, from the tag the lowercasing rule already asks for.
+  Only a conjunction, determiner, pronoun, adverb, preposition, particle,
+  interjection or verb goes on. A noun or an adjective here is a name, a
+  product or a title.
+- a **pause shorter than a second** in front of the capital, when the decoder's
+  word timings are there. This one is for latency, not safety: it removes 13%
+  of the candidates that reach the model. `--sentence-join` has no audio and
+  applies no gate.
+
+Measured over 7659 English dictations from one speaker. 2433 bare capitals,
+1645 refused by the lowercasing rules, and 236 of the rest reach the readings —
+**3.1 per 100 dictations, 2.7 after the pause gate**. On 110 hand-labelled
+candidates: **64% of the spurious capitals lowercased, no correct capital
+touched, and none of 15 real sentence starts joined.** The fourth reading is
+what makes the second number hold; without it four correct capitals are
+lowercased and not one repair is gained.
+
+#256 measured this shape at AUC 0.750 and dropped it. That was the threshold
+probe on ModernBERT, which has since been replaced.
 
 Three things are load-bearing. Per token, not summed: on summed
 log-probability the joined reading wins by being shortest, which repairs 97% of

--- a/scripts/check-sentence-case.sh
+++ b/scripts/check-sentence-case.sh
@@ -41,7 +41,15 @@ fi
 pass=0; total=0
 while IFS= read -r text && IFS= read -r want && IFS= read -r why; do
   total=$((total + 1))
-  got="$("$BIN" --sentence-join --case "$text" 2>/dev/null | awk '$1 == "next" { print $4; exit }')"
+  # The line for this case's own boundary, not the first one printed. A text
+  # can hold several — "what I meant. Which one" has a bare "I" before the
+  # period — and only one of them is what the case is about.
+  got="$("$BIN" --sentence-join --case "$text" 2>/dev/null | awk -v w="$want" '
+    $1 == "next" {
+      a = tolower(substr($2, 1, 1)) substr($2, 2)
+      b = tolower(substr(w, 1, 1)) substr(w, 2)
+      if (a == b) { print $4; exit }
+    }')"
   if [ "$got" = "$want" ]; then
     pass=$((pass + 1))
     printf '  ✓  %-12s %s\n' "$got" "$why"

--- a/scripts/check-sentence-join.sh
+++ b/scripts/check-sentence-join.sh
@@ -4,7 +4,9 @@
 #   scripts/check-sentence-join.sh
 #
 # Half the cases are real sentence endings and half are pauses that cut one
-# sentence in two, in both the period and the question-mark shape. Two numbers
+# sentence in two, in both the period and the question-mark shape. A third
+# shape, a capital with no mark in front of it, carries its four readings and
+# is checked on drift alone: it has no real/cut pair. Two numbers
 # decide per shape: how many cuts were repaired, and how many real endings were
 # joined by mistake. A joined real ending is a sentence nobody wrote, with
 # nothing on screen to say so, so one of those fails the run.
@@ -77,7 +79,8 @@ def block_of(out, case):
 
 DRIFT = 0.05
 tally = {name: {} for name in
-         ("en_real.json", "en_cuts.json", "enq_real.json", "enq_cuts_hard.json")}
+         ("en_real.json", "en_cuts.json", "enq_real.json", "enq_cuts_hard.json",
+          "bare-capitals")}
 drifted = []
 
 for case in cases:
@@ -90,7 +93,7 @@ for case in cases:
         print("  ✗ the measured boundary was not found in: " + text_of(case))
         sys.exit(1)
     winner = block["winner"]
-    counts = tally[case["set"]]
+    counts = tally.setdefault(case["set"], {})
     counts[winner] = counts.get(winner, 0) + 1
     gap = max(abs(block["mean"].get(k, 0) - v) for k, v in case["mean"].items())
     mark = " "
@@ -125,6 +128,12 @@ for shape, cut_key, real_key in shapes:
     print("  %d%% of %s cuts repaired, %.1f false joins per 100 real endings" % (
         round(100 * cuts.get("join", 0) / cut_total), shape,
         100 * wrong / real_total))
+    print()
+
+bare, bare_total = row("bare capitals", "bare-capitals")
+if bare_total:
+    print("  %d read as the join, %d left as decoded" % (
+        bare.get("join", 0), bare_total - bare.get("join", 0)))
     print()
 
 if drifted:

--- a/tests/sentence-boundary-cases.json
+++ b/tests/sentence-boundary-cases.json
@@ -718,5 +718,70 @@
    "?": -6.9357,
    "join": -3.8142
   }
+ },
+ {
+  "set": "bare-capitals",
+  "mark": "",
+  "left": "This one does not rely on um the harness we can construct",
+  "right": "A test set inspired from a couple of crawl files of HCP",
+  "winner": "join",
+  "mean": {
+   ",": -6.2126,
+   ".": -6.2656,
+   "as-decoded": -6.5784,
+   "join": -5.9801
+  }
+ },
+ {
+  "set": "bare-capitals",
+  "mark": "",
+  "left": "name of the people they interact with and all the jargon from",
+  "right": "The main channels they communicate into We feed it and then from",
+  "winner": "join",
+  "mean": {
+   ",": -6.2038,
+   ".": -6.4045,
+   "as-decoded": -6.5457,
+   "join": -6.0074
+  }
+ },
+ {
+  "set": "bare-capitals",
+  "mark": "",
+  "left": "with and all the jargon from The main channels they communicate into",
+  "right": "We feed it and then from that we identify the terms that",
+  "winner": ",",
+  "mean": {
+   ",": -4.5055,
+   ".": -4.5627,
+   "as-decoded": -5.1056,
+   "join": -4.6273
+  }
+ },
+ {
+  "set": "bare-capitals",
+  "mark": "",
+  "left": "technical terms and acronyms from the code base and from Slack conversations",
+  "right": "And the people I interacted with the last thirty days so a",
+  "winner": ",",
+  "mean": {
+   ",": -4.0813,
+   ".": -4.2839,
+   "as-decoded": -4.5694,
+   "join": -4.1349
+  }
+ },
+ {
+  "set": "bare-capitals",
+  "mark": "",
+  "left": "example if it heard a dot b then it substitution would be",
+  "right": "A dot B and A dot B would be part of the",
+  "winner": "as-decoded",
+  "mean": {
+   ",": -2.8468,
+   ".": -3.1882,
+   "as-decoded": -2.3563,
+   "join": -2.4674
+  }
  }
 ]

--- a/tests/sentence-case-cases.json
+++ b/tests/sentence-case-cases.json
@@ -1,197 +1,41 @@
 [
- {
-  "text": "I will ask him. Nathan knows the answer.",
-  "want": "Nathan",
-  "why": "a personal name"
- },
- {
-  "text": "we can send it to her. Sarah is already on it.",
-  "want": "Sarah",
-  "why": "a personal name"
- },
- {
-  "text": "I booked the tickets. Paris is expensive in June.",
-  "want": "Paris",
-  "why": "a place name"
- },
- {
-  "text": "he lives there now. London was cheaper then.",
-  "want": "London",
-  "why": "a place name"
- },
- {
-  "text": "I sent the invoice. Google has not paid it yet.",
-  "want": "Google",
-  "why": "an organization name"
- },
- {
-  "text": "we merged it yesterday. Greptile said nothing about it.",
-  "want": "Greptile",
-  "why": "an organization name"
- },
- {
-  "text": "we should ship it. Redcrawl is the one that breaks.",
-  "want": "Redcrawl",
-  "why": "a project name the tagger does not know"
- },
- {
-  "text": "I looked at the log. ParrotFlow wrote it twice.",
-  "want": "ParrotFlow",
-  "why": "the tagger calls it a plain noun, and it has no lemma"
- },
- {
-  "text": "it ran all night. Ollama was not even started.",
-  "want": "Ollama",
-  "why": "a tool name with no lemma"
- },
- {
-  "text": "we lost the thread. Compass was the one that broke.",
-  "want": "Compass",
-  "why": "a vocabulary term that is also an English word"
- },
- {
-  "text": "you should see a parrot. At the top right of your screen.",
-  "want": "at",
-  "why": "a preposition"
- },
- {
-  "text": "the release notes are not bigger than the height. Another feature is missing.",
-  "want": "another",
-  "why": "a determiner"
- },
- {
-  "text": "they look great now. But I still do not see the prompt.",
-  "want": "but",
-  "why": "a conjunction"
- },
- {
-  "text": "we can do that. If there is more than two fixes.",
-  "want": "if",
-  "why": "a conjunction"
- },
- {
-  "text": "it is not working. Because the first usage is slow.",
-  "want": "because",
-  "why": "a conjunction"
- },
- {
-  "text": "I wanted to go one by one. The vocabulary is slower.",
-  "want": "the",
-  "why": "a determiner"
- },
- {
-  "text": "that is not what I meant. Which one did you pick?",
-  "want": "which",
-  "why": "a pronoun"
- },
- {
-  "text": "we have to do it. That works well.",
-  "want": "that",
-  "why": "a pronoun"
- },
- {
-  "text": "he said he would come. When the build is done.",
-  "want": "when",
-  "why": "an adverb"
- },
- {
-  "text": "I will look at it. So we can move on.",
-  "want": "so",
-  "why": "a conjunction"
- },
- {
-  "text": "let me check the config. There is nothing in it.",
-  "want": "there",
-  "why": "an adverb"
- },
- {
-  "text": "put it in the folder. Then run the script again.",
-  "want": "then",
-  "why": "an adverb"
- },
- {
-  "text": "he did not answer. Everybody was waiting.",
-  "want": "everybody",
-  "why": "a pronoun"
- },
- {
-  "text": "we tried it twice. Nothing changed.",
-  "want": "nothing",
-  "why": "a pronoun"
- },
- {
-  "text": "I read the page. Every line was wrong.",
-  "want": "every",
-  "why": "a determiner"
- },
- {
-  "text": "you can skip it. Most people do.",
-  "want": "most",
-  "why": "a determiner"
- },
- {
-  "text": "she will call back. Around four o'clock.",
-  "want": "around",
-  "why": "a preposition"
- },
- {
-  "text": "no but that is not what I wanted. I wanted to go one by one.",
-  "want": "I",
-  "why": "the pronoun I"
- },
- {
-  "text": "she asked for it. I'll send it tonight.",
-  "want": "I'll",
-  "why": "a contraction of I"
- },
- {
-  "text": "we changed the endpoint. API keys are in the keychain.",
-  "want": "API",
-  "why": "capitals throughout"
- },
- {
-  "text": "the model is cached. CI has no business downloading it.",
-  "want": "CI",
-  "why": "capitals throughout"
- },
- {
-  "text": "imports name definitions And all the things we said",
-  "want": "and",
-  "why": "no mark in front of it, a conjunction"
- },
- {
-  "text": "we should think about it So the next step is clear",
-  "want": "so",
-  "why": "no mark in front of it, an adverb"
- },
- {
-  "text": "I asked whether the caret moves However the field was empty",
-  "want": "however",
-  "why": "no mark in front of it, a pronoun to the tagger"
- },
- {
-  "text": "the sound pass reads it in Slack for the moment",
-  "want": "Slack",
-  "why": "no mark in front of it, a noun is a name here"
- },
- {
-  "text": "we are writing it in English for the other reviewers",
-  "want": "English",
-  "why": "no mark in front of it, the lexicon knows this noun"
- },
- {
-  "text": "I want to paste it into WhatsApp and the other apps",
-  "want": "WhatsApp",
-  "why": "no mark in front of it, a capital inside the word"
- },
- {
-  "text": "the release goes out on Friday if the checks are green",
-  "want": "Friday",
-  "why": "no mark in front of it, a weekday is a noun"
- },
- {
-  "text": "we can format the functions in TypeScript for that case",
-  "want": "TypeScript",
-  "why": "no mark in front of it, a capital inside the word"
- }
+ { "text": "I will ask him. Nathan knows the answer.", "want": "Nathan", "why": "a personal name" },
+ { "text": "we can send it to her. Sarah is already on it.", "want": "Sarah", "why": "a personal name" },
+ { "text": "I booked the tickets. Paris is expensive in June.", "want": "Paris", "why": "a place name" },
+ { "text": "he lives there now. London was cheaper then.", "want": "London", "why": "a place name" },
+ { "text": "I sent the invoice. Google has not paid it yet.", "want": "Google", "why": "an organization name" },
+ { "text": "we merged it yesterday. Greptile said nothing about it.", "want": "Greptile", "why": "an organization name" },
+ { "text": "we should ship it. Redcrawl is the one that breaks.", "want": "Redcrawl", "why": "a project name the tagger does not know" },
+ { "text": "I looked at the log. ParrotFlow wrote it twice.", "want": "ParrotFlow", "why": "the tagger calls it a plain noun, and it has no lemma" },
+ { "text": "it ran all night. Ollama was not even started.", "want": "Ollama", "why": "a tool name with no lemma" },
+ { "text": "we lost the thread. Compass was the one that broke.", "want": "Compass", "why": "a vocabulary term that is also an English word" },
+ { "text": "you should see a parrot. At the top right of your screen.", "want": "at", "why": "a preposition" },
+ { "text": "the release notes are not bigger than the height. Another feature is missing.", "want": "another", "why": "a determiner" },
+ { "text": "they look great now. But I still do not see the prompt.", "want": "but", "why": "a conjunction" },
+ { "text": "we can do that. If there is more than two fixes.", "want": "if", "why": "a conjunction" },
+ { "text": "it is not working. Because the first usage is slow.", "want": "because", "why": "a conjunction" },
+ { "text": "I wanted to go one by one. The vocabulary is slower.", "want": "the", "why": "a determiner" },
+ { "text": "that is not what I meant. Which one did you pick?", "want": "which", "why": "a pronoun" },
+ { "text": "we have to do it. That works well.", "want": "that", "why": "a pronoun" },
+ { "text": "he said he would come. When the build is done.", "want": "when", "why": "an adverb" },
+ { "text": "I will look at it. So we can move on.", "want": "so", "why": "a conjunction" },
+ { "text": "let me check the config. There is nothing in it.", "want": "there", "why": "an adverb" },
+ { "text": "put it in the folder. Then run the script again.", "want": "then", "why": "an adverb" },
+ { "text": "he did not answer. Everybody was waiting.", "want": "everybody", "why": "a pronoun" },
+ { "text": "we tried it twice. Nothing changed.", "want": "nothing", "why": "a pronoun" },
+ { "text": "I read the page. Every line was wrong.", "want": "every", "why": "a determiner" },
+ { "text": "you can skip it. Most people do.", "want": "most", "why": "a determiner" },
+ { "text": "she will call back. Around four o'clock.", "want": "around", "why": "a preposition" },
+ { "text": "no but that is not what I wanted. I wanted to go one by one.", "want": "I", "why": "the pronoun I" },
+ { "text": "she asked for it. I'll send it tonight.", "want": "I'll", "why": "a contraction of I" },
+ { "text": "we changed the endpoint. API keys are in the keychain.", "want": "API", "why": "capitals throughout" },
+ { "text": "the model is cached. CI has no business downloading it.", "want": "CI", "why": "capitals throughout" },
+ { "text": "imports name definitions And all the things we said", "want": "and", "why": "no mark in front of it, a conjunction" },
+ { "text": "we should think about it So the next step is clear", "want": "so", "why": "no mark in front of it, an adverb" },
+ { "text": "I asked whether the caret moves However the field was empty", "want": "however", "why": "no mark in front of it, a pronoun to the tagger" },
+ { "text": "the sound pass reads it in Slack for the moment", "want": "Slack", "why": "no mark in front of it, a noun is a name here" },
+ { "text": "we are writing it in English for the other reviewers", "want": "English", "why": "no mark in front of it, the lexicon knows this noun" },
+ { "text": "I want to paste it into WhatsApp and the other apps", "want": "WhatsApp", "why": "no mark in front of it, a capital inside the word" },
+ { "text": "the release goes out on Friday if the checks are green", "want": "Friday", "why": "no mark in front of it, a weekday is a noun" },
+ { "text": "we can format the functions in TypeScript for that case", "want": "TypeScript", "why": "no mark in front of it, a capital inside the word" }
 ]

--- a/tests/sentence-case-cases.json
+++ b/tests/sentence-case-cases.json
@@ -1,33 +1,197 @@
 [
- { "text": "I will ask him. Nathan knows the answer.", "want": "Nathan", "why": "a personal name" },
- { "text": "we can send it to her. Sarah is already on it.", "want": "Sarah", "why": "a personal name" },
- { "text": "I booked the tickets. Paris is expensive in June.", "want": "Paris", "why": "a place name" },
- { "text": "he lives there now. London was cheaper then.", "want": "London", "why": "a place name" },
- { "text": "I sent the invoice. Google has not paid it yet.", "want": "Google", "why": "an organization name" },
- { "text": "we merged it yesterday. Greptile said nothing about it.", "want": "Greptile", "why": "an organization name" },
- { "text": "we should ship it. Redcrawl is the one that breaks.", "want": "Redcrawl", "why": "a project name the tagger does not know" },
- { "text": "I looked at the log. ParrotFlow wrote it twice.", "want": "ParrotFlow", "why": "the tagger calls it a plain noun, and it has no lemma" },
- { "text": "it ran all night. Ollama was not even started.", "want": "Ollama", "why": "a tool name with no lemma" },
- { "text": "we lost the thread. Compass was the one that broke.", "want": "Compass", "why": "a vocabulary term that is also an English word" },
- { "text": "you should see a parrot. At the top right of your screen.", "want": "at", "why": "a preposition" },
- { "text": "the release notes are not bigger than the height. Another feature is missing.", "want": "another", "why": "a determiner" },
- { "text": "they look great now. But I still do not see the prompt.", "want": "but", "why": "a conjunction" },
- { "text": "we can do that. If there is more than two fixes.", "want": "if", "why": "a conjunction" },
- { "text": "it is not working. Because the first usage is slow.", "want": "because", "why": "a conjunction" },
- { "text": "I wanted to go one by one. The vocabulary is slower.", "want": "the", "why": "a determiner" },
- { "text": "that is not what I meant. Which one did you pick?", "want": "which", "why": "a pronoun" },
- { "text": "we have to do it. That works well.", "want": "that", "why": "a pronoun" },
- { "text": "he said he would come. When the build is done.", "want": "when", "why": "an adverb" },
- { "text": "I will look at it. So we can move on.", "want": "so", "why": "a conjunction" },
- { "text": "let me check the config. There is nothing in it.", "want": "there", "why": "an adverb" },
- { "text": "put it in the folder. Then run the script again.", "want": "then", "why": "an adverb" },
- { "text": "he did not answer. Everybody was waiting.", "want": "everybody", "why": "a pronoun" },
- { "text": "we tried it twice. Nothing changed.", "want": "nothing", "why": "a pronoun" },
- { "text": "I read the page. Every line was wrong.", "want": "every", "why": "a determiner" },
- { "text": "you can skip it. Most people do.", "want": "most", "why": "a determiner" },
- { "text": "she will call back. Around four o'clock.", "want": "around", "why": "a preposition" },
- { "text": "no but that is not what I wanted. I wanted to go one by one.", "want": "I", "why": "the pronoun I" },
- { "text": "she asked for it. I'll send it tonight.", "want": "I'll", "why": "a contraction of I" },
- { "text": "we changed the endpoint. API keys are in the keychain.", "want": "API", "why": "capitals throughout" },
- { "text": "the model is cached. CI has no business downloading it.", "want": "CI", "why": "capitals throughout" }
+ {
+  "text": "I will ask him. Nathan knows the answer.",
+  "want": "Nathan",
+  "why": "a personal name"
+ },
+ {
+  "text": "we can send it to her. Sarah is already on it.",
+  "want": "Sarah",
+  "why": "a personal name"
+ },
+ {
+  "text": "I booked the tickets. Paris is expensive in June.",
+  "want": "Paris",
+  "why": "a place name"
+ },
+ {
+  "text": "he lives there now. London was cheaper then.",
+  "want": "London",
+  "why": "a place name"
+ },
+ {
+  "text": "I sent the invoice. Google has not paid it yet.",
+  "want": "Google",
+  "why": "an organization name"
+ },
+ {
+  "text": "we merged it yesterday. Greptile said nothing about it.",
+  "want": "Greptile",
+  "why": "an organization name"
+ },
+ {
+  "text": "we should ship it. Redcrawl is the one that breaks.",
+  "want": "Redcrawl",
+  "why": "a project name the tagger does not know"
+ },
+ {
+  "text": "I looked at the log. ParrotFlow wrote it twice.",
+  "want": "ParrotFlow",
+  "why": "the tagger calls it a plain noun, and it has no lemma"
+ },
+ {
+  "text": "it ran all night. Ollama was not even started.",
+  "want": "Ollama",
+  "why": "a tool name with no lemma"
+ },
+ {
+  "text": "we lost the thread. Compass was the one that broke.",
+  "want": "Compass",
+  "why": "a vocabulary term that is also an English word"
+ },
+ {
+  "text": "you should see a parrot. At the top right of your screen.",
+  "want": "at",
+  "why": "a preposition"
+ },
+ {
+  "text": "the release notes are not bigger than the height. Another feature is missing.",
+  "want": "another",
+  "why": "a determiner"
+ },
+ {
+  "text": "they look great now. But I still do not see the prompt.",
+  "want": "but",
+  "why": "a conjunction"
+ },
+ {
+  "text": "we can do that. If there is more than two fixes.",
+  "want": "if",
+  "why": "a conjunction"
+ },
+ {
+  "text": "it is not working. Because the first usage is slow.",
+  "want": "because",
+  "why": "a conjunction"
+ },
+ {
+  "text": "I wanted to go one by one. The vocabulary is slower.",
+  "want": "the",
+  "why": "a determiner"
+ },
+ {
+  "text": "that is not what I meant. Which one did you pick?",
+  "want": "which",
+  "why": "a pronoun"
+ },
+ {
+  "text": "we have to do it. That works well.",
+  "want": "that",
+  "why": "a pronoun"
+ },
+ {
+  "text": "he said he would come. When the build is done.",
+  "want": "when",
+  "why": "an adverb"
+ },
+ {
+  "text": "I will look at it. So we can move on.",
+  "want": "so",
+  "why": "a conjunction"
+ },
+ {
+  "text": "let me check the config. There is nothing in it.",
+  "want": "there",
+  "why": "an adverb"
+ },
+ {
+  "text": "put it in the folder. Then run the script again.",
+  "want": "then",
+  "why": "an adverb"
+ },
+ {
+  "text": "he did not answer. Everybody was waiting.",
+  "want": "everybody",
+  "why": "a pronoun"
+ },
+ {
+  "text": "we tried it twice. Nothing changed.",
+  "want": "nothing",
+  "why": "a pronoun"
+ },
+ {
+  "text": "I read the page. Every line was wrong.",
+  "want": "every",
+  "why": "a determiner"
+ },
+ {
+  "text": "you can skip it. Most people do.",
+  "want": "most",
+  "why": "a determiner"
+ },
+ {
+  "text": "she will call back. Around four o'clock.",
+  "want": "around",
+  "why": "a preposition"
+ },
+ {
+  "text": "no but that is not what I wanted. I wanted to go one by one.",
+  "want": "I",
+  "why": "the pronoun I"
+ },
+ {
+  "text": "she asked for it. I'll send it tonight.",
+  "want": "I'll",
+  "why": "a contraction of I"
+ },
+ {
+  "text": "we changed the endpoint. API keys are in the keychain.",
+  "want": "API",
+  "why": "capitals throughout"
+ },
+ {
+  "text": "the model is cached. CI has no business downloading it.",
+  "want": "CI",
+  "why": "capitals throughout"
+ },
+ {
+  "text": "imports name definitions And all the things we said",
+  "want": "and",
+  "why": "no mark in front of it, a conjunction"
+ },
+ {
+  "text": "we should think about it So the next step is clear",
+  "want": "so",
+  "why": "no mark in front of it, an adverb"
+ },
+ {
+  "text": "I asked whether the caret moves However the field was empty",
+  "want": "however",
+  "why": "no mark in front of it, a pronoun to the tagger"
+ },
+ {
+  "text": "the sound pass reads it in Slack for the moment",
+  "want": "Slack",
+  "why": "no mark in front of it, a noun is a name here"
+ },
+ {
+  "text": "we are writing it in English for the other reviewers",
+  "want": "English",
+  "why": "no mark in front of it, the lexicon knows this noun"
+ },
+ {
+  "text": "I want to paste it into WhatsApp and the other apps",
+  "want": "WhatsApp",
+  "why": "no mark in front of it, a capital inside the word"
+ },
+ {
+  "text": "the release goes out on Friday if the checks are green",
+  "want": "Friday",
+  "why": "no mark in front of it, a weekday is a noun"
+ },
+ {
+  "text": "we can format the functions in TypeScript for that case",
+  "want": "TypeScript",
+  "why": "no mark in front of it, a capital inside the word"
+ }
 ]


### PR DESCRIPTION
A pause does not always make the transcriber write the mark. It writes `imports name definitions And all the things`, and `SentenceJoin.boundaries()` only ever started a boundary at a period or a question mark, so that capital shipped. It is scanned now.

The shape needs a **fourth reading**: the text exactly as it was decoded. Everywhere else "leave it alone" is what happens when a mark wins; here there is no mark to take out, so it has to be a candidate of its own. Half of these capitals are correct — `Slack`, `English`, `Friday`, `TypeScript` — so four rules refuse a candidate before any reading, and the fourth reading catches what they miss.

Measured over 7659 English dictations: **3.1 candidates per 100 dictations reach the model, 2.7 after the pause gate. On 110 hand-labelled candidates, 64% of the spurious capitals are lowercased, no correct capital is touched, and none of 15 real sentence starts is joined.** The period is never inserted; where a mark wins the text is left as decoded and the decision is logged. The period and question shapes are byte-identical — `written()` is untouched.

Reviewers: start at `SentenceJoin.bareBoundaries` and `SentenceJoin.readable`. The risky part is the rebuild when there is no mark to remove.

Closes #273.

<details>
<summary>The four readings, and why the fourth is the one that matters</summary>

```
". A before section B"     the sentence really ended
" A before section B"      as decoded, a capital that belongs
" a before section B"      a pause cut one sentence in two
", a before section B"     it is really a comma
```

Argmax per token, as today, and `join` is last so an exact tie leaves the text alone. Only the third reading writes anything.

One ender, not every configured mark. Which sentence mark belongs here is a question this stage does not answer, so a second ender buys a fifth forward pass and no decision. Scored with `?` in the set as well, it won 12 of 621 boundaries and changed nothing, because an ender win means "leave as decoded" either way.

The fourth reading is worth 4 wrong writes and costs nothing:

| readings | filter | wrong writes | repaired |
|---|---|---:|---:|
| three | none | 28 | 46/75 (61%) |
| **four** | none | **9** | 46/75 (61%) |
| three | the rules below | 4 | 44/69 (64%) |
| **four** | **the rules below** | **0** | **44/69 (64%)** |

It took 19 cases off `join` without the filter and 4 with it. **Every one of them is a capital that was correct, and not one repair was lost.** The four it saves:

```
A         as-decoded -3.461 > join -3.639   ...what's in common between section A...
A         as-decoded -3.348 > join -3.781   ...can the stage return a list of terms...
A         as-decoded -3.790 > join -4.181   ...the difference between A and B...
Outlook   as-decoded -4.376 > join -4.565   ...difficult to paste into Outlook...
```

</details>

<details>
<summary>Four rules refuse a candidate before any reading — half of them are names</summary>

`written()` decides how to write the word after a mark that is already there, where a capital that is right is rare. Here it is half the input. Over 621 candidates that survive `written()`, hand-labelled in a random sample of 120: **50% are a capital that must not be touched**, 32% a spurious capital, 7% a real sentence start, 12% a stutter.

On top of the existing rules (`I`, capitals throughout, a vocabulary term, a name tag, no lemma):

| rule | catches | why |
|---|---|---|
| a run of two or more capitals | `Better Stack`, `Hugging Face`, `Red Crawl` | 53% names and 13% boundaries — a different question |
| a capital inside the word | `WhatsApp`, `TypeScript`, `OpenAI` | `written()` only refuses capitals *throughout* |
| the part of speech | `Slack`, `English`, `Friday` | a noun or adjective here is a name, a product or a title |
| a pause under a second | — | latency, see below |

The part of speech comes from `.nameTypeOrLexicalClass`, **the tag `written()` already asks for**. Over the same 621 it gives the same class as `.lexicalClass` on 618 and the same filter decision on 620, so this is one `guard` on a value the tagger already produced, not a second pass. Asking for both schemes on one tagger changes the answer on 3 of the 621, so `readable()` builds the tagger the way `written()` builds it.

The class filter alone removes 93% of the capitals that must not be touched, and costs 9 repairs of which only 4 were reachable at all.

</details>

<details>
<summary>The pause gate is for latency, not safety — 13% fewer Qwen calls</summary>

`apply(to:config:words:)` takes the decoder's words and skips a bare capital with less than 1.0 s of silence in front of it.

| | per 100 dictations |
|---|---:|
| survive `written()` today | 8.1 |
| pass this PR's candidate shape | **3.1** |
| and the 1.0 s gate | **2.7** |

**13% of the candidates never reach the model.** At 52 ms a reading that is 0.21 ms per dictation on average, and a whole 52 ms saved on the 13% of dictations that would have paid it.

It is not the safety mechanism, and the PR body should not be read that way: with the filter and the four readings it is **0 wrong writes with the gate and 0 without**, and 44/69 repaired either way. It also *shrinks* the evidence — it removes 5 of the 19 labelled break+keep cases, taking the 95% bound from 0.08 to 0.09 wrong writes per 100 dictations. Its whole value is the forward passes it does not spend.

The alignment is safe. `Transcriber.swift:479` is `var text = result.text` and its comment says why that point was chosen: "the last point where the words still line up with the audio they came from." Nothing rewrites `text` between there and the join at `:520`. All three decode paths keep text and timings together — the first pass, the long-pause retry (`restoreTimings` maps every timestamp back to the original timeline) and `audio.second_opinion` (`unpadTimings` takes the pad off). `pauses(in:words:)` rebuilds the text from the words and returns no gate at all if they do not match, so a caller with words from somewhere else gets every candidate read rather than the wrong one skipped.

`--sentence-join` and `--sentence-probe` pass no words and apply no gate, so the harness and the tests see every candidate.

</details>

<details>
<summary>What was measured — 7659 dictations, 200 hand labels</summary>

Corpus: 31525 trace records, deduped by `wav`, English only, mined from `asr.text` — the raw decode this stage runs on, not `final`.

| | n | per 100 dictations |
|---|---:|---:|
| English dictations | 7659 | |
| bare capitals, 4 words each side | 2433 | 31.8 |
| refused by `written()` | 1645 | 21.5 |
| survive it | 621 | 8.1 |
| **pass this PR's candidate shape** | **236** | **3.1** |
| and the pause gate | 205 | 2.7 |

200 candidates hand-labelled into four piles — 120 drawn at random from the 621 and 80 more from what the class filter passes. With the filter and the four readings, on the 110 that are this PR's shape:

| pile | n | join | as-decoded | `,` | `.` |
|---|---:|---:|---:|---:|---:|
| join — spurious capital | 69 | **44 (64%)** | 0 | 23 | 2 |
| break — real sentence start | 15 | **0** | 0 | 11 | 4 |
| keep — the capital is correct | 4 | **0** | 4 | 0 | 0 |
| other — stutter or restart | 22 | 4 | 0 | 14 | 4 |

**0 wrong writes. 95% upper bound 0.08 per 100 dictations, against 1.2 repairs.**

Latency: 52.3 ms median per boundary, p95 68.5 ms, against 52.2 / 60.3 for three readings. The fourth reading goes into the same padded batch.

</details>

<details>
<summary>What was tried and left out</summary>

**A one-letter rule** (skip `section A`, `A dot B`). It caught 3 wrong writes and cost 6 repairs. The fourth reading handles all three of those cases and costs nothing, so the rule is not here.

**The comma as a repair.** On this shape `,` also lowercases, so "lowercase unless `.` wins" is a real option: it repairs 92% instead of 64%. It is out because the break pile never picks `join` but picks `,` 11 times of 15 — it would lowercase 11 real sentence starts.

**Inserting the period** where the `.` reading wins. 4 of the 15 break cases would have gained a correct period. That is a separate decision and this PR never inserts a mark.

**A world-knowledge arbiter for the run of capitals** — score the rest of the sentence with the capitals against without them, argmax, no threshold. It reads `Better Stack` the monitoring product correctly and lowercases `the Cloed Design Project`. It scored 16 of 16 on the decisive labelled runs, but two of its three original errors were relabelled after it was scored, so that number is not earned. The run shape is left for its own issue.

**Widening the vocabulary guard** to match a term with its spaces removed. `BetterStack`, `RedCrawl` and `RedRock` are one word in the vocabulary and two in the decode, and `written()` compares one word, so it misses them — 8 of 82 runs. Left out deliberately: `Better Stack` is genuinely ambiguous between the product and "a better stack", and no spelling rule settles it. `written()`'s handling of the word after a joined period is unchanged.

**Not measured.** The bench was mined with at least 4 words either side, so a bare capital with less context than that is unmeasured. The existing period shape has the same property. Also out of scope: a capital that starts a clip and continues a sentence already typed (`such that | The boilerplate`) — that needs the captured input field.

</details>

<details>
<summary>Review notes — where the risk is</summary>

**`Boundary.mark` is now optional.** nil means a bare capital, and `at` is then the first letter of the word rather than a character to remove. Two places branch on it:

- `joining()` returns the text unchanged and the word's own offset.
- the rebuild in `apply()` steps over `at` only when there is a mark there.

**The order of the scan.** `bareBoundaries()` is merged with `boundaries()` and sorted by `next.lowerBound`, so boundaries are still visited in text order and `cursor` never goes backwards.

**No double-visiting.** A bare candidate requires the previous word to end in a letter or a digit, so a capital that already follows a mark, a bracket or a quote belongs to the existing shape only.

**The filter runs before the read, never after** — a name must not reach a reading that could vote to lowercase it. `written()` moved above the `read()` call for that. It is pure, so the period path is unaffected.

**`--sentence-probe --bare`** reads a boundary as this shape from the command line, so the four readings are debuggable without a bench file. `"mark": ""` in a bench row is the same thing. `docs/cli.md` has both.

**Tests.** `tests/sentence-case-cases.json` gains 8 model-free cases for the new refusals and runs in CI. `tests/sentence-boundary-cases.json` gains 5 bare boundaries with their four stored readings; `check-sentence-probe.sh` and `check-sentence-join.sh` both read them. `check-sentence-case.sh` now picks the line for the case's own boundary rather than the first printed — `what I meant. Which one` holds a bare `I` before the period.

`make test`: every check passes, and the period and question rows are unchanged at 0 false joins.

</details>
