### PR TITLE
feat: the setup window is one screen that names every model it downloads

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -5823,23 +5823,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // After the pill, which writes the label too: this has to hold the
             // token of the last write, or `.ready` never clears the menu bar.
             transcriberLabelToken = labelToken
-            // `what` reads like "speech model 43%" — the number, if this is
-            // the one download that carries one, is the only part worth a
-            // second field for; the rest is already the sentence above.
-            let percent = what.split(separator: " ").last.flatMap { token -> Int? in
-                token.hasSuffix("%") ? Int(token.dropLast()) : nil
-            }
-            // Only for a download that holds dictation up. This row says
-            // whether you can speak yet, and a background fetch does not
-            // change that answer.
-            if blocking { permissions.model.speechModel = .preparing(percent: percent) }
         case .loading:
             setLabel("Loading speech model…")
             if ownsDownloadPill {
                 updateProgress("Loading speech model…", token: dictationProgressToken)
             }
             transcriberLabelToken = labelToken
-            permissions.model.speechModel = .preparing(percent: nil)
         case .failed(let message):
             setLabel("Model error: \(message)")
             transcriberLabelToken = labelToken
@@ -5848,11 +5837,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // run waiting on the model gets it as a thrown error whose catch
             // already hides the pill and puts up the alert. Two endings on
             // screen for one failure is worse than one.
-            // Not surfaced as "preparing" forever: the permissions window
-            // isn't the place a transcription failure gets diagnosed, and a
-            // stuck "downloading" badge there would outlive the one place
-            // that does explain it — this label, and the log.
-            permissions.model.speechModel = .ready
         case .ready, .idle:
             if transcriberLabelToken == labelToken { setLabel(nil) }
             transcriberLabelToken = nil
@@ -5863,7 +5847,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 updateProgress("Transcribing…", token: dictationProgressToken)
             }
             pillDownloadRun = nil
-            permissions.model.speechModel = .ready
         }
     }
 

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2390,6 +2390,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// two background fetches clear themselves when they fail. Rows that
     /// already installed keep saying so.
     private func retryDownloads() {
+        // A damaged copy is bytes on disk that will not load. Every fetch here
+        // skips the download when the files are already there, so re-running
+        // the warm-up would hand the loader the same bytes. The cache goes
+        // first, and only for the rows that said "damaged".
+        let damaged = ModelDownloads.shared.damaged
+        if #available(macOS 14, *) {
+            if damaged.contains(Transcriber.speechDownload.id) {
+                Transcriber.discardSpeechModel()
+            }
+            if damaged.contains(SlotModel.download.id) { SlotModel.discardCache() }
+            if damaged.contains(SentenceReadings.download.id) { SentenceReadings.discardCache() }
+            if damaged.contains(WordVectors.download.id) { WordVectors.discardCache() }
+        }
         ModelDownloads.shared.retrying()
         warmModels()
     }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2410,6 +2410,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             if damaged.contains(WordVectors.download.id) { WordVectors.discardCache() }
         }
         ModelDownloads.shared.retrying()
+        // `SentenceReadings.warm` holds a failed load for five minutes, and
+        // `warmModels` below goes through it. Without this the row would go
+        // back to waiting with nothing fetching it. Pressing the button is
+        // somebody saying try now.
+        if #available(macOS 14, *), config.readsBoundaries {
+            Task { await SentenceReadings.shared.retryNow() }
+        }
         warmModels()
     }
 

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2399,6 +2399,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             if damaged.contains(Transcriber.speechDownload.id) {
                 Transcriber.discardSpeechModel()
             }
+            if damaged.contains(Transcriber.voiceDownload.id) {
+                Transcriber.discardVoiceDetector()
+            }
+            if damaged.contains(NeuralPhonemes.soundDownload.id) {
+                NeuralPhonemes.discardCache()
+            }
             if damaged.contains(SlotModel.download.id) { SlotModel.discardCache() }
             if damaged.contains(SentenceReadings.download.id) { SentenceReadings.discardCache() }
             if damaged.contains(WordVectors.download.id) { WordVectors.discardCache() }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -606,6 +606,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // After the preview flags return. Those launches draw a panel and
         // quit; nothing there transcribes, and fetching 1.47 GB for them
         // is what `warmUpTranscriber` avoided by sitting below this point.
+        // The one button the setup screen offers for a download that did not
+        // arrive. The window reports the fetches; it does not own them.
+        permissions.onRetryDownloads = { [weak self] in self?.retryDownloads() }
         warmModels()
 
 
@@ -2291,6 +2294,31 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard config.transcription.enabled else { return }
         let transcriber = transcriber
         let config = config
+
+        // The launch set, declared by the code that fetches it. Each model
+        // describes itself next to its own download; nothing here holds a list
+        // of what those models are. A row switched off by a setting says so
+        // rather than sitting on "waiting" for a fetch that never starts.
+        let downloads = ModelDownloads.shared
+        downloads.expect(Transcriber.speechDownload)
+        downloads.expect(
+            Transcriber.voiceDownload,
+            off: config.audio.speechGate ? nil : ModelDownload.gateOff
+        )
+        downloads.expect(
+            SlotModel.download,
+            off: config.readsSlots ? nil : ModelDownload.gateOff
+        )
+        downloads.expect(
+            SentenceReadings.download,
+            off: config.readsBoundaries ? nil : ModelDownload.gateOff
+        )
+        downloads.expect(NeuralPhonemes.soundDownload)
+        downloads.expect(
+            WordVectors.download,
+            off: config.readsSentenceGate ? nil : ModelDownload.gateOff
+        )
+
         Task.detached(priority: .background) {
             // Speech first, on its own. Nothing can be transcribed until it
             // lands, and it is the only one somebody is waiting for. Started
@@ -2333,12 +2361,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
             // 81 MB, and the sound pass is on by default.
             Task.detached(priority: .background) {
-                if await !NeuralPhonemes.isReady() {
-                    do { try await NeuralPhonemes.download() } catch {
-                        Log.write("sound model: \(error.localizedDescription); the next"
-                            + " dictation that needs it tries again")
-                        return
-                    }
+                // `download` returns at once when the models are already there,
+                // and reports the row either way.
+                do { try await NeuralPhonemes.download() } catch {
+                    Log.write("sound model: \(error.localizedDescription); the next"
+                        + " dictation that needs it tries again")
+                    return
                 }
                 // What the model said last time, read here rather than by the
                 // first dictation. After the fetch, not before: the table is
@@ -2353,6 +2381,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 Task.detached(priority: .background) { await WordVectors.shared.warm() }
             }
         }
+    }
+
+    /// Runs the launch fetches again, for the button a blocking failure puts
+    /// in the foot of the Downloads step.
+    ///
+    /// Safe: `prepare` converges overlapping callers onto one download, and the
+    /// two background fetches clear themselves when they fail. Rows that
+    /// already installed keep saying so.
+    private func retryDownloads() {
+        ModelDownloads.shared.retrying()
+        warmModels()
     }
 
     /// Keeps the model warm by running one token a minute through it.
@@ -6128,7 +6167,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(settingsItem)
 
         permissionsItem = NSMenuItem(
-            title: "Permissions…",
+            title: "Setup…",
             action: #selector(openPermissions),
             keyEquivalent: ""
         )
@@ -6413,7 +6452,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.orderFrontStandardAboutPanel(options: [
             .applicationName: AppVariant.displayName,
             .applicationVersion: AppVariant.version,
-            .credits: AppVariant.repositoryLink,
+            .credits: AppVariant.credits,
         ])
     }
 

--- a/Sources/ParrotFlow/AppVariant.swift
+++ b/Sources/ParrotFlow/AppVariant.swift
@@ -116,4 +116,78 @@ enum AppVariant {
 
         return NSAttributedString(string: "github.com/znat/parrotflow", attributes: attributes)
     }
+
+    /// What the app contains: the repository line, then every model it fetches
+    /// and every library that fetches or runs one.
+    ///
+    /// The About panel is the one surface that names a program this app did not
+    /// write, and it is the only place the licences are stated. Two paragraph
+    /// styles: the repository line stays centred, and a centred list is
+    /// unreadable, so everything under it goes left.
+    ///
+    /// Only models this build actually fetches are named. eSpeak NG is set
+    /// apart because it is the one name here that is not shipped and not
+    /// downloaded — nothing is distributed, so no GPL source offer applies; it
+    /// is named because the app runs it.
+    static var credits: NSAttributedString {
+        let left = NSMutableParagraphStyle()
+        left.alignment = .natural
+        left.paragraphSpacing = 3
+
+        let credits = NSMutableAttributedString(attributedString: repositoryLink)
+        credits.append(NSAttributedString(string: "\n\n"))
+
+        func line(_ text: String, size: CGFloat = 10.5, bold: Bool = false, dim: Bool = false) {
+            credits.append(NSAttributedString(string: text + "\n", attributes: [
+                .font: bold
+                    ? NSFont.boldSystemFont(ofSize: size) : NSFont.systemFont(ofSize: size),
+                .foregroundColor: dim ? NSColor.tertiaryLabelColor : NSColor.secondaryLabelColor,
+                .paragraphStyle: left,
+            ]))
+        }
+
+        /// A name in bold, then what it does and what it is under.
+        func item(_ name: String, _ role: String) {
+            let entry = NSMutableAttributedString(
+                string: name,
+                attributes: [
+                    .font: NSFont.boldSystemFont(ofSize: 10.5),
+                    .foregroundColor: NSColor.labelColor,
+                    .paragraphStyle: left,
+                ]
+            )
+            entry.append(NSAttributedString(string: " — \(role)\n", attributes: [
+                .font: NSFont.systemFont(ofSize: 10.5),
+                .foregroundColor: NSColor.secondaryLabelColor,
+                .paragraphStyle: left,
+            ]))
+            credits.append(entry)
+        }
+
+        line("BUILT WITH", size: 9, bold: true, dim: true)
+        item("Parakeet TDT 0.6B v3", "speech recognition · CC BY 4.0")
+        item("Silero VAD", "finds where speech is · MIT")
+        item("CharsiuG2P", "pronunciations, for matching your terms by sound")
+        // Two lines because the code and the weights are not under the same
+        // terms, and the weights the app fetches are not the upstream ones.
+        line(
+            "MIT for the code · the Core ML weights it fetches are Apache 2.0;"
+                + " the upstream weights state no licence",
+            size: 10, dim: true
+        )
+        item("ModernBERT", "sentence boundaries · Apache 2.0")
+        item("Qwen3 Embedding 0.6B", "word vectors for the vocabulary gate · Apache 2.0")
+        item("MLX", "runs Qwen3 Embedding · MIT")
+        item("FluidAudio", "fetching and Core ML plumbing · Apache 2.0")
+
+        credits.append(NSAttributedString(string: "\n"))
+        item(
+            "eSpeak NG",
+            "GPL-3.0. Not distributed with ParrotFlow. If you install it yourself,"
+                + " ParrotFlow runs it as a separate program and reads its output."
+        )
+        line("github.com/espeak-ng/espeak-ng", size: 10, dim: true)
+
+        return credits
+    }
 }

--- a/Sources/ParrotFlow/AppVariant.swift
+++ b/Sources/ParrotFlow/AppVariant.swift
@@ -175,9 +175,10 @@ enum AppVariant {
                 + " the upstream weights state no licence",
             size: 10, dim: true
         )
-        item("ModernBERT", "sentence boundaries · Apache 2.0")
+        item("mmBERT-small", "reads the slot a word sits in · MIT")
+        item("Qwen3 0.6B Base", "scores sentence boundaries · Apache 2.0")
         item("Qwen3 Embedding 0.6B", "word vectors for the vocabulary gate · Apache 2.0")
-        item("MLX", "runs Qwen3 Embedding · MIT")
+        item("MLX", "runs both Qwen models · MIT")
         item("FluidAudio", "fetching and Core ML plumbing · Apache 2.0")
 
         credits.append(NSAttributedString(string: "\n"))

--- a/Sources/ParrotFlow/EspeakInstall.swift
+++ b/Sources/ParrotFlow/EspeakInstall.swift
@@ -17,11 +17,16 @@ enum EspeakInstall {
 
     /// The line to run. Without Homebrew its own installer is chained in front,
     /// because `brew install` on a Mac with no brew is an error message.
+    ///
+    /// The second half names the binary by path. Installing Homebrew does not
+    /// put `/opt/homebrew/bin` on the PATH of the shell that just ran the
+    /// installer, so a bare `brew` there exits 127 with Homebrew installed and
+    /// eSpeak NG not.
     static var command: String {
-        guard brew == nil else { return "brew install espeak-ng" }
+        if let brew { return "\(brew) install espeak-ng" }
         return "/bin/bash -c \"$(curl -fsSL"
             + " https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
-            + " && brew install espeak-ng"
+            + " && /opt/homebrew/bin/brew install espeak-ng"
     }
 
     static func copyCommand() {
@@ -35,8 +40,12 @@ enum EspeakInstall {
     /// A script rather than AppleScript's `do script`: telling Terminal what to
     /// run is an Apple Event, and that puts an Automation permission prompt in
     /// front of someone who is still granting the first two.
+    ///
+    /// Returns false when there is nothing to open. `opened` comes later, on
+    /// the main queue, and is false when the launch itself was refused — the
+    /// row has to go back to offering the button, not sit on "Terminal open".
     @discardableResult
-    static func runInTerminal() -> Bool {
+    static func runInTerminal(opened: @escaping (Bool) -> Void = { _ in }) -> Bool {
         guard let terminal = NSWorkspace.shared.urlForApplication(
             withBundleIdentifier: "com.apple.Terminal"
         ) else {
@@ -66,6 +75,7 @@ enum EspeakInstall {
             if let error {
                 Log.write("espeak: Terminal did not open — \(error.localizedDescription)")
             }
+            DispatchQueue.main.async { opened(error == nil) }
         }
         return true
     }

--- a/Sources/ParrotFlow/EspeakInstall.swift
+++ b/Sources/ParrotFlow/EspeakInstall.swift
@@ -29,6 +29,19 @@ enum EspeakInstall {
             + " && /opt/homebrew/bin/brew install espeak-ng"
     }
 
+    /// Whether the answer to "Install eSpeak NG?" was "Not now".
+    ///
+    /// `UserDefaults`, like the microphone notice and the update reminder: this
+    /// is an answer the app already has, not a setting somebody chose, so it
+    /// does not belong in `config.yaml` where it would have to be read past.
+    /// Per bundle identifier, so the two builds ask separately.
+    static var declined: Bool {
+        get { UserDefaults.standard.bool(forKey: declinedKey) }
+        set { UserDefaults.standard.set(newValue, forKey: declinedKey) }
+    }
+
+    private static let declinedKey = "Setup.espeakDeclined"
+
     static func copyCommand() {
         let board = NSPasteboard.general
         board.clearContents()

--- a/Sources/ParrotFlow/EspeakInstall.swift
+++ b/Sources/ParrotFlow/EspeakInstall.swift
@@ -1,0 +1,72 @@
+import AppKit
+import Foundation
+
+/// Installing espeak-ng, which this app never does for you.
+///
+/// It is GPL-3 and a separate program: nothing is bundled and nothing is
+/// fetched. The setup screen offers the one line that installs it and runs
+/// that line in Terminal, where it can be read while it runs. `Phonemes.binary`
+/// is what notices it afterwards.
+enum EspeakInstall {
+
+    /// Homebrew, if it is there. The two places it installs itself.
+    static var brew: String? {
+        ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"]
+            .first { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+
+    /// The line to run. Without Homebrew its own installer is chained in front,
+    /// because `brew install` on a Mac with no brew is an error message.
+    static var command: String {
+        guard brew == nil else { return "brew install espeak-ng" }
+        return "/bin/bash -c \"$(curl -fsSL"
+            + " https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
+            + " && brew install espeak-ng"
+    }
+
+    static func copyCommand() {
+        let board = NSPasteboard.general
+        board.clearContents()
+        board.setString(command, forType: .string)
+    }
+
+    /// Opens Terminal on a script holding the command.
+    ///
+    /// A script rather than AppleScript's `do script`: telling Terminal what to
+    /// run is an Apple Event, and that puts an Automation permission prompt in
+    /// front of someone who is still granting the first two.
+    @discardableResult
+    static func runInTerminal() -> Bool {
+        guard let terminal = NSWorkspace.shared.urlForApplication(
+            withBundleIdentifier: "com.apple.Terminal"
+        ) else {
+            Log.write("espeak: Terminal.app not found")
+            return false
+        }
+
+        let script = AppVariant.supportDirectory
+            .appendingPathComponent("install-espeak-ng.command")
+        do {
+            try FileManager.default.createDirectory(
+                at: AppVariant.supportDirectory, withIntermediateDirectories: true
+            )
+            try "#!/bin/bash\n\(command)\n".write(to: script, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o755], ofItemAtPath: script.path
+            )
+        } catch {
+            Log.write("espeak: could not write the install script — \(error.localizedDescription)")
+            return false
+        }
+
+        NSWorkspace.shared.open(
+            [script], withApplicationAt: terminal,
+            configuration: NSWorkspace.OpenConfiguration()
+        ) { _, error in
+            if let error {
+                Log.write("espeak: Terminal did not open — \(error.localizedDescription)")
+            }
+        }
+        return true
+    }
+}

--- a/Sources/ParrotFlow/MLXModelCache.swift
+++ b/Sources/ParrotFlow/MLXModelCache.swift
@@ -31,6 +31,10 @@ struct MLXModelCache: Sendable {
     let lockURL: URL
     /// What a progress line calls this model — "word vectors 43%".
     let label: String
+    /// The `ModelDownload` row this fetch reports into, so the setup screen
+    /// shows a percentage for a model whose download lives here rather than in
+    /// the model's own file.
+    let downloadID: String
 
     enum Failure: LocalizedError {
         case busy(String)
@@ -96,11 +100,15 @@ struct MLXModelCache: Sendable {
 
         let reported = Reported()
         let label = label
-        try await HubDownload.fetch(repo: repository, revision: revision, paths: files, into: staging) { fraction in
-            guard let progress else { return }
+        let downloadID = downloadID
+        ModelDownloads.report(downloadID, .downloading(percent: nil))
+        try await HubDownload.fetch(
+            repo: repository, revision: revision, paths: files, into: staging
+        ) { fraction in
             let percent = Int((fraction * 100).rounded())
             guard reported.advanced(to: percent) else { return }
-            progress("\(label) \(percent)%")
+            ModelDownloads.report(downloadID, .downloading(percent: percent))
+            progress?("\(label) \(percent)%")
         }
         for name in files {
             let target = directory.appendingPathComponent(name)

--- a/Sources/ParrotFlow/ModelDownloads.swift
+++ b/Sources/ParrotFlow/ModelDownloads.swift
@@ -85,6 +85,10 @@ struct ModelDownload: Identifiable, Equatable {
     /// True when a dictation waits on it. Carried by
     /// `Transcriber.Status.downloading(_, blocking:)` for the two that have it.
     let blocking: Bool
+    /// What is lost while it is not here, as the second half of "X could not be
+    /// downloaded, and …". Only a blocking row's is read, because only a
+    /// blocking row's failure reaches the title.
+    let costOfFailure: String
     var state: State = .waiting
 
     var sizeLabel: String { "\(megabytes) MB" }
@@ -158,10 +162,12 @@ final class ModelDownloads: ObservableObject {
         rows.filter { $0.group == group }
     }
 
-    /// The failure of the first row a dictation is waiting on, if one failed.
-    /// It is the only kind that reaches the foot of the screen.
-    var blockingFailure: ModelDownload.Failure? {
-        rows.first { $0.blocking && $0.state.hasFailed }?.state.failure
+    /// The row a dictation is waiting on that failed, if one did. It is the
+    /// only kind of failure that reaches the title and the foot, and the screen
+    /// names this row rather than the first blocking one — a failed voice
+    /// detector must not be reported as a failed speech model.
+    var blockingFailure: ModelDownload? {
+        rows.first { $0.blocking && $0.state.hasFailed }
     }
 
     /// The rows whose bytes are on disk and will not load. Their repair is to
@@ -172,8 +178,14 @@ final class ModelDownloads: ObservableObject {
 
     /// True when nothing a dictation waits on is still coming. A row a setting
     /// switched off is not coming and nothing waits for it either.
+    ///
+    /// False when there is nothing to wait for at all: `allSatisfy` over no
+    /// rows is true, and that would read as ready to dictate on a launch that
+    /// registered no speech model because it will never transcribe.
     var speechIsIn: Bool {
-        rows.filter(\.blocking).allSatisfy {
+        let blocking = rows.filter(\.blocking)
+        guard !blocking.isEmpty else { return false }
+        return blocking.allSatisfy {
             switch $0.state {
             case .installed, .off: return true
             case .waiting, .downloading, .failed: return false

--- a/Sources/ParrotFlow/ModelDownloads.swift
+++ b/Sources/ParrotFlow/ModelDownloads.swift
@@ -170,20 +170,15 @@ final class ModelDownloads: ObservableObject {
         Set(rows.filter { $0.state.failure == .damaged }.map(\.id))
     }
 
-    var anyDownloading: Bool {
-        rows.contains { if case .downloading = $0.state { return true } else { return false } }
-    }
-
-    /// What the eyebrow says: the size of the set, then what is happening to it.
-    var summary: String {
-        if rows.contains(where: { $0.state.hasFailed }) { return "One did not arrive" }
-        if anyDownloading { return "Downloading" }
-        let wanted = rows.filter { if case .off = $0.state { return false } else { return true } }
-        if !wanted.isEmpty, wanted.allSatisfy({ $0.state == .installed }) {
-            return "Everything is here"
+    /// True when nothing a dictation waits on is still coming. A row a setting
+    /// switched off is not coming and nothing waits for it either.
+    var speechIsIn: Bool {
+        rows.filter(\.blocking).allSatisfy {
+            switch $0.state {
+            case .installed, .off: return true
+            case .waiting, .downloading, .failed: return false
+            }
         }
-        let total = wanted.reduce(0) { $0 + $1.megabytes }
-        return "\(wanted.count) files, \(Self.size(megabytes: total))"
     }
 
     /// A failure turned into the one sentence that says what happened.

--- a/Sources/ParrotFlow/ModelDownloads.swift
+++ b/Sources/ParrotFlow/ModelDownloads.swift
@@ -67,6 +67,15 @@ struct ModelDownload: Identifiable, Equatable {
             if case .failed(let why) = self { return why }
             return nil
         }
+
+        /// Still to come. A row that failed is not pending: it has stopped,
+        /// and the screen says so in its own sentence.
+        var isPending: Bool {
+            switch self {
+            case .waiting, .downloading: return true
+            case .installed, .off, .failed: return false
+            }
+        }
     }
 
     /// What a row says when a setting means it is never fetched. Not a failure

--- a/Sources/ParrotFlow/ModelDownloads.swift
+++ b/Sources/ParrotFlow/ModelDownloads.swift
@@ -112,9 +112,17 @@ final class ModelDownloads: ObservableObject {
     /// Idempotent, and it keeps the order of first registration. A second call
     /// leaves the state alone: that belongs to the fetch, and a retry that put
     /// an installed row back to "waiting" would report work nobody is doing.
+    ///
+    /// The one state a second call does write is `.off`, both ways. `update`
+    /// drops every report for a row a setting switched off, so a row left off
+    /// after the setting came back would never move again.
     func expect(_ model: ModelDownload, off reason: String? = nil) {
         if let at = rows.firstIndex(where: { $0.id == model.id }) {
-            if let reason { rows[at].state = .off(reason) }
+            if let reason {
+                rows[at].state = .off(reason)
+            } else if case .off = rows[at].state {
+                rows[at].state = model.state
+            }
             return
         }
         var row = model
@@ -154,6 +162,12 @@ final class ModelDownloads: ObservableObject {
     /// It is the only kind that reaches the foot of the screen.
     var blockingFailure: ModelDownload.Failure? {
         rows.first { $0.blocking && $0.state.hasFailed }?.state.failure
+    }
+
+    /// The rows whose bytes are on disk and will not load. Their repair is to
+    /// throw the cache away, which the retry does before it fetches again.
+    var damaged: Set<String> {
+        Set(rows.filter { $0.state.failure == .damaged }.map(\.id))
     }
 
     var anyDownloading: Bool {

--- a/Sources/ParrotFlow/ModelDownloads.swift
+++ b/Sources/ParrotFlow/ModelDownloads.swift
@@ -1,0 +1,233 @@
+import FluidAudio
+import Foundation
+
+/// One model the app fetches at launch, and how far it has got.
+///
+/// The description of a model lives beside the code that fetches it — see
+/// `Transcriber.speechDownload`, `Transcriber.voiceDownload`,
+/// `SlotModel.download`, `SentenceReadings.download`, `WordVectors.download`
+/// and `NeuralPhonemes.soundDownload`. No screen keeps a list of models. A
+/// model added later declares itself next to its own fetch and every surface
+/// that draws rows draws it.
+struct ModelDownload: Identifiable, Equatable {
+
+    /// What the model does, which is how the setup screen groups the rows.
+    enum Group: Equatable {
+        case sound
+        case language
+    }
+
+    /// The five ways a fetch ends badly. Each says something different about
+    /// what to do next, which is why they are five sentences and not one.
+    enum Failure: Equatable {
+        case unreachable
+        case stopped
+        case busy
+        case damaged
+        /// The free space the install wanted, as words: "600 MB".
+        case noSpace(String)
+
+        var message: String {
+            switch self {
+            case .unreachable: return "Could not reach the server."
+            case .stopped: return "Download stopped."
+            case .busy: return "Already downloading in another window."
+            case .damaged: return "The installed copy is damaged."
+            case .noSpace(let needs): return "Needs about \(needs) free."
+            }
+        }
+
+        /// What the button offering the repair says, or nil when no button can
+        /// help. The other build holds the lock and lets go on its own.
+        var retryTitle: String? {
+            switch self {
+            case .busy: return nil
+            case .damaged: return "Download again"
+            case .unreachable, .stopped, .noSpace: return "Try again"
+            }
+        }
+    }
+
+    enum State: Equatable {
+        case waiting
+        /// Nil percent for a fetch that reports no fraction.
+        case downloading(percent: Int?)
+        case installed
+        case failed(Failure)
+        /// A setting turned it off. The string is what the row says instead of
+        /// a state — "gate is off".
+        case off(String)
+
+        var hasFailed: Bool {
+            if case .failed = self { return true }
+            return false
+        }
+
+        var failure: Failure? {
+            if case .failed(let why) = self { return why }
+            return nil
+        }
+    }
+
+    /// What a row says when a setting means it is never fetched. Not a failure
+    /// and not a warning: nobody asked for it.
+    static let gateOff = "gate is off"
+
+    let id: String
+    let name: String
+    /// What it takes on disk once installed.
+    let megabytes: Int
+    /// Free space the install needs at its worst moment. The same as
+    /// `megabytes` except for a model that is compiled from a package it then
+    /// deletes, where both exist at once.
+    let peak: Int
+    let group: Group
+    /// True when a dictation waits on it. Carried by
+    /// `Transcriber.Status.downloading(_, blocking:)` for the two that have it.
+    let blocking: Bool
+    var state: State = .waiting
+
+    var sizeLabel: String { "\(megabytes) MB" }
+
+    var peakLabel: String { ModelDownloads.size(megabytes: peak) }
+}
+
+/// Every model this launch is fetching, in the order the launch asks for them.
+///
+/// Not owned by the setup window. The fetches start at launch and outlive any
+/// window, the same rows are drawn by the Downloads step and by the last
+/// screen, and a window that owned a download would take it down with it.
+///
+/// Read and written on the main queue, like `PermissionsModel`. `report` is the
+/// door for the actors that do the fetching.
+final class ModelDownloads: ObservableObject {
+
+    static let shared = ModelDownloads()
+
+    @Published private(set) var rows: [ModelDownload] = []
+
+    /// Declares a model the launch is about to fetch. `off` is the reason a
+    /// setting means it never will be.
+    ///
+    /// Idempotent, and it keeps the order of first registration. A second call
+    /// leaves the state alone: that belongs to the fetch, and a retry that put
+    /// an installed row back to "waiting" would report work nobody is doing.
+    func expect(_ model: ModelDownload, off reason: String? = nil) {
+        if let at = rows.firstIndex(where: { $0.id == model.id }) {
+            if let reason { rows[at].state = .off(reason) }
+            return
+        }
+        var row = model
+        if let reason { row.state = .off(reason) }
+        rows.append(row)
+    }
+
+    /// Puts every failed row back to waiting, for a retry that is about to
+    /// start the fetches again.
+    func retrying() {
+        for at in rows.indices where rows[at].state.hasFailed {
+            rows[at].state = .waiting
+        }
+    }
+
+    func update(_ id: String, to state: ModelDownload.State) {
+        guard let at = rows.firstIndex(where: { $0.id == id }) else { return }
+        // A row a setting switched off is not fetching, so nothing should be
+        // reporting on it. If something does, the setting is still the truth.
+        if case .off = rows[at].state { return }
+        guard rows[at].state != state else { return }
+        rows[at].state = state
+    }
+
+    /// Called from whichever thread the fetch is on.
+    static func report(_ id: String, _ state: ModelDownload.State) {
+        DispatchQueue.main.async { shared.update(id, to: state) }
+    }
+
+    // MARK: - What the screens ask
+
+    func rows(in group: ModelDownload.Group) -> [ModelDownload] {
+        rows.filter { $0.group == group }
+    }
+
+    /// The failure of the first row a dictation is waiting on, if one failed.
+    /// It is the only kind that reaches the foot of the screen.
+    var blockingFailure: ModelDownload.Failure? {
+        rows.first { $0.blocking && $0.state.hasFailed }?.state.failure
+    }
+
+    var anyDownloading: Bool {
+        rows.contains { if case .downloading = $0.state { return true } else { return false } }
+    }
+
+    /// What the eyebrow says: the size of the set, then what is happening to it.
+    var summary: String {
+        if rows.contains(where: { $0.state.hasFailed }) { return "One did not arrive" }
+        if anyDownloading { return "Downloading" }
+        let wanted = rows.filter { if case .off = $0.state { return false } else { return true } }
+        if !wanted.isEmpty, wanted.allSatisfy({ $0.state == .installed }) {
+            return "Everything is here"
+        }
+        let total = wanted.reduce(0) { $0 + $1.megabytes }
+        return "\(wanted.count) files, \(Self.size(megabytes: total))"
+    }
+
+    /// A failure turned into the one sentence that says what happened.
+    ///
+    /// `needs` is the free space to name when the disk is full.
+    @available(macOS 14, *)
+    static func failure(_ error: Error, needs: String) -> ModelDownload.Failure {
+        if error is CancellationError { return .stopped }
+        if let failure = error as? SlotModel.Failure, case .busy = failure { return .busy }
+        if let failure = error as? MLXModelCache.Failure, case .busy = failure { return .busy }
+        // The weights loaded as something that is not Qwen3: the copy on disk
+        // is not the model it is named after. Both MLX models check it.
+        if let failure = error as? WordVectors.Failure, case .notQwen = failure { return .damaged }
+        if let failure = error as? SentenceReadings.Failure, case .notQwen = failure {
+            return .damaged
+        }
+
+        // Parakeet's downloader collapses every reason a transfer failed into
+        // one case with a string, so a dropped connection and a full disk are
+        // the same error here. Only its load and compile failures are told
+        // apart, and those mean the bytes on disk will not open.
+        if let asr = error as? AsrModelsError {
+            switch asr {
+            case .downloadFailed: return .unreachable
+            case .loadingFailed, .modelCompilationFailed, .modelNotFound: return .damaged
+            }
+        }
+
+        if let hub = error as? HubDownload.Failure {
+            switch hub {
+            case .truncated: return .stopped
+            case .http, .unlisted: return .unreachable
+            }
+        }
+
+        let wrapped = error as NSError
+        if wrapped.domain == NSCocoaErrorDomain, wrapped.code == NSFileWriteOutOfSpaceError {
+            return .noSpace(needs)
+        }
+        if wrapped.domain == NSPOSIXErrorDomain, wrapped.code == Int(ENOSPC) {
+            return .noSpace(needs)
+        }
+        // What Core ML throws for a compiled model it will not open. The bytes
+        // are there and re-fetching them is the only repair.
+        if wrapped.domain == "com.apple.CoreML" { return .damaged }
+
+        if let url = error as? URLError {
+            switch url.code {
+            case .cancelled, .networkConnectionLost, .timedOut: return .stopped
+            default: return .unreachable
+            }
+        }
+        return .unreachable
+    }
+
+    /// "1.2 GB", or "461 MB" under a gigabyte.
+    static func size(megabytes: Int) -> String {
+        guard megabytes >= 1000 else { return "\(megabytes) MB" }
+        return String(format: "%.1f GB", Double(megabytes) / 1000)
+    }
+}

--- a/Sources/ParrotFlow/NeuralPhonemes.swift
+++ b/Sources/ParrotFlow/NeuralPhonemes.swift
@@ -35,7 +35,8 @@ enum NeuralPhonemes {
     /// for the job: it is CharsiuG2P, run through FluidAudio's Core ML build.
     static let soundDownload = ModelDownload(
         id: "sound", name: "CharsiuG2P", megabytes: 81, peak: 81,
-        group: .sound, blocking: false
+        group: .sound, blocking: false,
+        costOfFailure: "your terms are matched by spelling until it arrives"
     )
 
     /// The languages the model has, in the app's own terms. Nil for a

--- a/Sources/ParrotFlow/NeuralPhonemes.swift
+++ b/Sources/ParrotFlow/NeuralPhonemes.swift
@@ -31,6 +31,13 @@ import FluidAudio
 /// whole feature.
 enum NeuralPhonemes {
 
+    /// The row the setup screen draws for it. Named for the model rather than
+    /// for the job: it is CharsiuG2P, run through FluidAudio's Core ML build.
+    static let soundDownload = ModelDownload(
+        id: "sound", name: "CharsiuG2P", megabytes: 81, peak: 81,
+        group: .sound, blocking: false
+    )
+
     /// The languages the model has, in the app's own terms. Nil for a
     /// language it does not speak — every other one it would guess at.
     static func language(_ code: String) -> MultilingualG2PLanguage? {
@@ -57,14 +64,29 @@ enum NeuralPhonemes {
     /// that is where `MultilingualG2PModel` looks for them and nothing here
     /// should teach it a second path.
     static func download(progress: (@Sendable (String) -> Void)? = nil) async throws {
-        if await isReady() { return }
+        if await isReady() {
+            ModelDownloads.report(soundDownload.id, .installed)
+            return
+        }
         progress?("sound model")
-        let directory = try TtsCacheDirectory.ensure().appendingPathComponent("Models")
-        try await ModelHub.download(
-            .kokoro, to: directory,
-            additionalModelNames: ModelNames.MultilingualG2P.requiredModels
-        )
-        try await MultilingualG2PModel.shared.ensureModelsAvailable()
+        // No percentage: `ModelHub.download` reports none, and a number nobody
+        // measured is worse than a spinner.
+        ModelDownloads.report(soundDownload.id, .downloading(percent: nil))
+        do {
+            let directory = try TtsCacheDirectory.ensure().appendingPathComponent("Models")
+            try await ModelHub.download(
+                .kokoro, to: directory,
+                additionalModelNames: ModelNames.MultilingualG2P.requiredModels
+            )
+            try await MultilingualG2PModel.shared.ensureModelsAvailable()
+            ModelDownloads.report(soundDownload.id, .installed)
+        } catch {
+            ModelDownloads.report(
+                soundDownload.id,
+                .failed(ModelDownloads.failure(error, needs: soundDownload.peakLabel))
+            )
+            throw error
+        }
     }
 
     // MARK: - what the model has already said

--- a/Sources/ParrotFlow/NeuralPhonemes.swift
+++ b/Sources/ParrotFlow/NeuralPhonemes.swift
@@ -90,6 +90,20 @@ enum NeuralPhonemes {
         }
     }
 
+    /// Deletes the two G2P bundles, so the next `download` fetches them again.
+    ///
+    /// Only those two. They sit in FluidAudio's Kokoro cache beside the voices
+    /// and the lexicons, which this app never fetched and must not remove.
+    static func discardCache() {
+        guard let root = try? TtsCacheDirectory.ensure()
+            .appendingPathComponent("Models")
+            .appendingPathComponent(Repo.kokoro.folderName)
+        else { return }
+        for name in ModelNames.MultilingualG2P.requiredModels {
+            try? FileManager.default.removeItem(at: root.appendingPathComponent(name))
+        }
+    }
+
     // MARK: - what the model has already said
 
     /// The answers so far, by language and then by word, kept between launches.

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -294,6 +294,13 @@ enum PanelsCommand {
         let vadPane = AnyView(PermissionsView()
             .environmentObject(PermissionsModel.showingSetup(vadDidNotArrive, espeak: .found))
             .environmentObject(vadDidNotArrive))
+        // The same screen after "Not now": the card is gone and the line says
+        // what was decided. The alert that asks is a sheet on the window and
+        // cannot be drawn here.
+        let skippedPane = AnyView(PermissionsView()
+            .environmentObject(PermissionsModel.showingSetup(
+                ready, context: .revisiting, espeakDeclined: true))
+            .environmentObject(ready))
 
         // The third element is the appearance to draw in. Every floating
         // surface is dark whatever the system is set to — that is decided in
@@ -333,6 +340,7 @@ enum PanelsCommand {
             (switchedOffPane, setupSize(switchedOffPane), .dark, false),
             (didNotArrivePane, setupSize(didNotArrivePane), .light, false),
             (vadPane, setupSize(vadPane), .dark, false),
+            (skippedPane, setupSize(skippedPane), .light, false),
             (AnyView(PillView().environmentObject(notice)),
              pillSize(notice), .dark, true),
             (AnyView(PillView().environmentObject(thinking)),

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -654,7 +654,13 @@ enum PanelsCommand {
             ticker = Timer.scheduledTimer(withTimeInterval: 0.12, repeats: true) { _ in
                 percent += 1
                 if percent > 100 {
+                    // Parakeet lands first and Silero VAD follows it, which is
+                    // the moment the title has to name the second row rather
+                    // than the first.
                     downloads.update(Transcriber.speechDownload.id, to: .installed)
+                    downloads.update(
+                        Transcriber.voiceDownload.id, to: .downloading(percent: nil)
+                    )
                     downloads.update(SlotModel.download.id, to: .downloading(percent: nil))
                     return
                 }

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -533,7 +533,7 @@ enum PanelsCommand {
     private static func setupSize(_ view: AnyView) -> NSSize {
         let fitting = NSHostingView(rootView: view).fittingSize
         return NSSize(
-            width: PermissionMetrics.width,
+            width: PermissionMetrics.setupWidth,
             height: fitting.height > 0 ? fitting.height : PermissionMetrics.setupHeight
         )
     }

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -265,11 +265,28 @@ enum PanelsCommand {
             after: "I think we should have asked them first — they're going to be annoyed."
         )
 
-        let midDownload = sampleDownloads(speech: .downloading(percent: 62))
-        let failedDownload = sampleDownloads(speech: .failed(.unreachable))
-        let doneDownloads = sampleDownloads(speech: .installed)
-        doneDownloads.update(NeuralPhonemes.soundDownload.id, to: .installed)
-        doneDownloads.update(SlotModel.download.id, to: .installed)
+        // The four states of the one screen, in the order they happen.
+        let almostReady = sampleDownloads(speech: .downloading(percent: 62))
+        let didNotArrive = sampleDownloads(speech: .failed(.unreachable))
+        let ready = sampleDownloads(speech: .installed)
+        ready.update(NeuralPhonemes.soundDownload.id, to: .installed)
+        ready.update(SlotModel.download.id, to: .installed)
+        ready.update(SentenceReadings.download.id, to: .installed)
+
+        let almostReadyPane = AnyView(PermissionsView()
+            .environmentObject(PermissionsModel.showingSetup(almostReady))
+            .environmentObject(almostReady))
+        let readyPane = AnyView(PermissionsView()
+            .environmentObject(PermissionsModel.showingSetup(
+                ready, context: .revisiting, espeak: .found))
+            .environmentObject(ready))
+        let switchedOffPane = AnyView(PermissionsView()
+            .environmentObject(PermissionsModel.showingSetup(
+                ready, axStatus: .notGranted, espeak: .found))
+            .environmentObject(ready))
+        let didNotArrivePane = AnyView(PermissionsView()
+            .environmentObject(PermissionsModel.showingSetup(didNotArrive))
+            .environmentObject(didNotArrive))
 
         // The third element is the appearance to draw in. Every floating
         // surface is dark whatever the system is set to — that is decided in
@@ -301,47 +318,13 @@ enum PanelsCommand {
                     .accessibility, asked: true, context: .revisiting))
                 .environmentObject(ModelDownloads())),
              NSSize(width: PermissionMetrics.width, height: PermissionMetrics.height), .dark, false),
-            // The Downloads step, in the two shapes worth comparing: rows
-            // arriving, and the one row a dictation waits on having failed —
-            // which is the only failure that reaches the foot.
-            (AnyView(PermissionsView()
-                .environmentObject(PermissionsModel.showingDownloads(midDownload))
-                .environmentObject(midDownload)),
-             NSSize(width: PermissionMetrics.width, height: PermissionMetrics.downloadsHeight),
-             .light, false),
-            (AnyView(PermissionsView()
-                .environmentObject(PermissionsModel.showingDownloads(
-                    failedDownload, espeak: .found))
-                .environmentObject(failedDownload)),
-             NSSize(width: PermissionMetrics.width, height: PermissionMetrics.downloadsHeight),
-             .dark, false),
-            // The screen after both are granted, in the shapes it comes in:
-            // the speech model already there, still on its way, there but the
-            // hotkey never bound, and a permission switched off afterwards.
-            (AnyView(PermissionsView()
-                .environmentObject(PermissionsModel.done(downloads: doneDownloads))
-                .environmentObject(doneDownloads)),
-             NSSize(width: PermissionMetrics.width, height: PermissionMetrics.doneHeight),
-             .dark, false),
-            (AnyView(PermissionsView()
-                .environmentObject(PermissionsModel.done(
-                    speechModel: .preparing(percent: 43), downloads: midDownload,
-                    espeak: .missing))
-                .environmentObject(midDownload)),
-             NSSize(width: PermissionMetrics.width, height: PermissionMetrics.doneHeight),
-             .light, false),
-            (AnyView(PermissionsView()
-                .environmentObject(PermissionsModel.done(
-                    hotkeyRegistered: false, downloads: doneDownloads))
-                .environmentObject(doneDownloads)),
-             NSSize(width: PermissionMetrics.width, height: PermissionMetrics.doneHeight),
-             .dark, false),
-            (AnyView(PermissionsView()
-                .environmentObject(PermissionsModel.done(
-                    axStatus: .notGranted, downloads: doneDownloads))
-                .environmentObject(doneDownloads)),
-             NSSize(width: PermissionMetrics.width, height: PermissionMetrics.doneHeight),
-             .dark, false),
+            // The one screen the walk ends on, in its four states. The title
+            // is the state, so this is the only place the four sentences can
+            // be read against each other.
+            (almostReadyPane, setupSize(almostReadyPane), .light, false),
+            (readyPane, setupSize(readyPane), .dark, false),
+            (switchedOffPane, setupSize(switchedOffPane), .dark, false),
+            (didNotArrivePane, setupSize(didNotArrivePane), .light, false),
             (AnyView(PillView().environmentObject(notice)),
              pillSize(notice), .dark, true),
             (AnyView(PillView().environmentObject(thinking)),
@@ -529,6 +512,16 @@ enum PanelsCommand {
         return downloads
     }
 
+    /// The setup screen has no fixed height: it takes the one its content asks
+    /// for, the same way the window does.
+    private static func setupSize(_ view: AnyView) -> NSSize {
+        let fitting = NSHostingView(rootView: view).fittingSize
+        return NSSize(
+            width: PermissionMetrics.width,
+            height: fitting.height > 0 ? fitting.height : PermissionMetrics.setupHeight
+        )
+    }
+
     /// An ordinary titled window. The setup screen is the one surface that is
     /// a window rather than a panel over somebody's words.
     private static func window(for view: AnyView, size: NSSize) -> NSWindow {
@@ -642,17 +635,13 @@ enum PanelsCommand {
         // that cannot be checked from a still.
         case "setup":
             let downloads = sampleDownloads(speech: .downloading(percent: 8))
-            let model = PermissionsModel.showingDownloads(downloads)
-            setupWindow = window(
-                for: AnyView(
-                    PermissionsView()
-                        .environmentObject(model)
-                        .environmentObject(downloads)
-                ),
-                size: NSSize(
-                    width: PermissionMetrics.width, height: PermissionMetrics.downloadsHeight
-                )
+            let model = PermissionsModel.showingSetup(downloads)
+            let pane = AnyView(
+                PermissionsView()
+                    .environmentObject(model)
+                    .environmentObject(downloads)
             )
+            setupWindow = window(for: pane, size: setupSize(pane))
             var percent = 8
             ticker = Timer.scheduledTimer(withTimeInterval: 0.12, repeats: true) { _ in
                 percent += 1

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -272,6 +272,10 @@ enum PanelsCommand {
         ready.update(NeuralPhonemes.soundDownload.id, to: .installed)
         ready.update(SlotModel.download.id, to: .installed)
         ready.update(SentenceReadings.download.id, to: .installed)
+        // The other blocking row. Its failure costs the speech gate rather than
+        // the whole feature, and the sentence has to say which row it is about.
+        let vadDidNotArrive = sampleDownloads(speech: .installed)
+        vadDidNotArrive.update(Transcriber.voiceDownload.id, to: .failed(.stopped))
 
         let almostReadyPane = AnyView(PermissionsView()
             .environmentObject(PermissionsModel.showingSetup(almostReady))
@@ -287,6 +291,9 @@ enum PanelsCommand {
         let didNotArrivePane = AnyView(PermissionsView()
             .environmentObject(PermissionsModel.showingSetup(didNotArrive))
             .environmentObject(didNotArrive))
+        let vadPane = AnyView(PermissionsView()
+            .environmentObject(PermissionsModel.showingSetup(vadDidNotArrive, espeak: .found))
+            .environmentObject(vadDidNotArrive))
 
         // The third element is the appearance to draw in. Every floating
         // surface is dark whatever the system is set to — that is decided in
@@ -325,6 +332,7 @@ enum PanelsCommand {
             (readyPane, setupSize(readyPane), .dark, false),
             (switchedOffPane, setupSize(switchedOffPane), .dark, false),
             (didNotArrivePane, setupSize(didNotArrivePane), .light, false),
+            (vadPane, setupSize(vadPane), .dark, false),
             (AnyView(PillView().environmentObject(notice)),
              pillSize(notice), .dark, true),
             (AnyView(PillView().environmentObject(thinking)),

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -265,6 +265,12 @@ enum PanelsCommand {
             after: "I think we should have asked them first — they're going to be annoyed."
         )
 
+        let midDownload = sampleDownloads(speech: .downloading(percent: 62))
+        let failedDownload = sampleDownloads(speech: .failed(.unreachable))
+        let doneDownloads = sampleDownloads(speech: .installed)
+        doneDownloads.update(NeuralPhonemes.soundDownload.id, to: .installed)
+        doneDownloads.update(SlotModel.download.id, to: .installed)
+
         // The third element is the appearance to draw in. Every floating
         // surface is dark whatever the system is set to — that is decided in
         // `adoptParrotAppearance` and is not a preference. The permissions
@@ -287,24 +293,55 @@ enum PanelsCommand {
             // between them and it is the part worth being able to see: setting
             // up says "Cancel installation", revisiting says "Not now".
             (AnyView(PermissionsView()
-                .environmentObject(PermissionsModel.showing(.microphone))),
+                .environmentObject(PermissionsModel.showing(.microphone))
+                .environmentObject(ModelDownloads())),
              NSSize(width: PermissionMetrics.width, height: PermissionMetrics.height), .light, false),
             (AnyView(PermissionsView()
                 .environmentObject(PermissionsModel.showing(
-                    .accessibility, asked: true, context: .revisiting))),
+                    .accessibility, asked: true, context: .revisiting))
+                .environmentObject(ModelDownloads())),
              NSSize(width: PermissionMetrics.width, height: PermissionMetrics.height), .dark, false),
-            // The screen after both are granted, in the three shapes it comes
-            // in: the speech model already there, still on its way, and there
-            // but the hotkey never bound — the states DonePane's invitation
-            // sentence chooses between.
-            (AnyView(PermissionsView().environmentObject(PermissionsModel.done())),
-             NSSize(width: PermissionMetrics.width, height: PermissionMetrics.height), .dark, false),
+            // The Downloads step, in the two shapes worth comparing: rows
+            // arriving, and the one row a dictation waits on having failed —
+            // which is the only failure that reaches the foot.
             (AnyView(PermissionsView()
-                .environmentObject(PermissionsModel.done(speechModel: .preparing(percent: 43)))),
-             NSSize(width: PermissionMetrics.width, height: PermissionMetrics.height), .dark, false),
+                .environmentObject(PermissionsModel.showingDownloads(midDownload))
+                .environmentObject(midDownload)),
+             NSSize(width: PermissionMetrics.width, height: PermissionMetrics.downloadsHeight),
+             .light, false),
             (AnyView(PermissionsView()
-                .environmentObject(PermissionsModel.done(hotkeyRegistered: false))),
-             NSSize(width: PermissionMetrics.width, height: PermissionMetrics.height), .dark, false),
+                .environmentObject(PermissionsModel.showingDownloads(
+                    failedDownload, espeak: .found))
+                .environmentObject(failedDownload)),
+             NSSize(width: PermissionMetrics.width, height: PermissionMetrics.downloadsHeight),
+             .dark, false),
+            // The screen after both are granted, in the shapes it comes in:
+            // the speech model already there, still on its way, there but the
+            // hotkey never bound, and a permission switched off afterwards.
+            (AnyView(PermissionsView()
+                .environmentObject(PermissionsModel.done(downloads: doneDownloads))
+                .environmentObject(doneDownloads)),
+             NSSize(width: PermissionMetrics.width, height: PermissionMetrics.doneHeight),
+             .dark, false),
+            (AnyView(PermissionsView()
+                .environmentObject(PermissionsModel.done(
+                    speechModel: .preparing(percent: 43), downloads: midDownload,
+                    espeak: .missing))
+                .environmentObject(midDownload)),
+             NSSize(width: PermissionMetrics.width, height: PermissionMetrics.doneHeight),
+             .light, false),
+            (AnyView(PermissionsView()
+                .environmentObject(PermissionsModel.done(
+                    hotkeyRegistered: false, downloads: doneDownloads))
+                .environmentObject(doneDownloads)),
+             NSSize(width: PermissionMetrics.width, height: PermissionMetrics.doneHeight),
+             .dark, false),
+            (AnyView(PermissionsView()
+                .environmentObject(PermissionsModel.done(
+                    axStatus: .notGranted, downloads: doneDownloads))
+                .environmentObject(doneDownloads)),
+             NSSize(width: PermissionMetrics.width, height: PermissionMetrics.doneHeight),
+             .dark, false),
             (AnyView(PillView().environmentObject(notice)),
              pillSize(notice), .dark, true),
             (AnyView(PillView().environmentObject(thinking)),
@@ -476,6 +513,36 @@ enum PanelsCommand {
         return NSWorkspace.shared.icon(forFile: url.path)
     }
 
+    /// A registry with one row in each state it can be in. The real one is
+    /// filled in by the code that fetches — see `AppDelegate.warmModels`.
+    static func sampleDownloads(speech: ModelDownload.State) -> ModelDownloads {
+        let downloads = ModelDownloads()
+        downloads.expect(Transcriber.speechDownload)
+        downloads.update(Transcriber.speechDownload.id, to: speech)
+        downloads.expect(Transcriber.voiceDownload)
+        downloads.update(Transcriber.voiceDownload.id, to: .installed)
+        downloads.expect(NeuralPhonemes.soundDownload)
+        downloads.update(NeuralPhonemes.soundDownload.id, to: .failed(.unreachable))
+        downloads.expect(SlotModel.download)
+        downloads.expect(SentenceReadings.download)
+        downloads.expect(WordVectors.download, off: ModelDownload.gateOff)
+        return downloads
+    }
+
+    /// An ordinary titled window. The setup screen is the one surface that is
+    /// a window rather than a panel over somebody's words.
+    private static func window(for view: AnyView, size: NSSize) -> NSWindow {
+        let hosting = NSHostingController(rootView: view)
+        let window = NSWindow(contentViewController: hosting)
+        window.title = "\(AppVariant.displayName) Setup"
+        window.styleMask = [.titled, .closable]
+        window.setContentSize(size)
+        window.center()
+        NSApp.activate(ignoringOtherApps: true)
+        window.makeKeyAndOrderFront(nil)
+        return window
+    }
+
     static func run(surface: String, seconds: Double) -> Int32 {
         let app = NSApplication.shared
         app.setActivationPolicy(.accessory)
@@ -488,6 +555,7 @@ enum PanelsCommand {
         let micNotice = MicNotice()
         let updatePanel = UpdatePanel()
         var ticker: Timer?
+        var setupWindow: NSWindow?
 
         switch surface {
         case "notice":
@@ -568,6 +636,35 @@ enum PanelsCommand {
                     later: { print("update: later") }
                 )
             )
+        // The setup window, on the step that reports the downloads. A real
+        // registry is empty in this process — nothing here fetches anything —
+        // so it runs on a sample whose percentage climbs, which is the part
+        // that cannot be checked from a still.
+        case "setup":
+            let downloads = sampleDownloads(speech: .downloading(percent: 8))
+            let model = PermissionsModel.showingDownloads(downloads)
+            setupWindow = window(
+                for: AnyView(
+                    PermissionsView()
+                        .environmentObject(model)
+                        .environmentObject(downloads)
+                ),
+                size: NSSize(
+                    width: PermissionMetrics.width, height: PermissionMetrics.downloadsHeight
+                )
+            )
+            var percent = 8
+            ticker = Timer.scheduledTimer(withTimeInterval: 0.12, repeats: true) { _ in
+                percent += 1
+                if percent > 100 {
+                    downloads.update(Transcriber.speechDownload.id, to: .installed)
+                    downloads.update(SlotModel.download.id, to: .downloading(percent: nil))
+                    return
+                }
+                downloads.update(
+                    Transcriber.speechDownload.id, to: .downloading(percent: percent)
+                )
+            }
         case "pill":
             pill.recording(icon: sampleIcon())
             // A meter frozen at zero says nothing about how the meter looks.
@@ -609,12 +706,13 @@ enum PanelsCommand {
         default:
             print("usage: ParrotFlow --panels <notice|caution|failure|thinking|offer"
                 + "|vocabulary|punctuation|rule|dictation|preview|microphone|pill"
-                + "|update|sequence> [seconds]")
+                + "|update|setup|sequence> [seconds]")
             return 2
         }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + seconds) {
             ticker?.invalidate()
+            setupWindow?.close()
             exit(0)
         }
         app.run()

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import SwiftUI
 
 /// The two things macOS will not let this app do without being asked.
@@ -20,6 +21,13 @@ import SwiftUI
 enum PermissionsContext {
     case installing
     case revisiting
+
+    /// Setting up has one way out and it does what it says: the app quits.
+    /// Both permissions are required, and a requirement you can walk past is
+    /// not one. Revisiting has no installation left to cancel.
+    var declineTitle: String {
+        self == .installing ? "Cancel installation" : "Not now"
+    }
 }
 
 enum PermissionStep: CaseIterable {
@@ -57,12 +65,9 @@ enum PermissionStep: CaseIterable {
         }
     }
 
-    /// The same on both screens, and different in the two contexts. Setting up
-    /// has one way out and it does what it says: the app quits. Both
-    /// permissions are required, and a requirement you can walk past is not
-    /// one. Revisiting has no installation left to cancel.
+    /// The same on both screens, and different in the two contexts.
     func declineTitle(in context: PermissionsContext) -> String {
-        context == .installing ? "Cancel installation" : "Not now"
+        context.declineTitle
     }
 
     /// Shown after the ask, while the answer is somewhere else.
@@ -74,6 +79,13 @@ enum PermissionStep: CaseIterable {
             return "Find ParrotFlow in the list and tick it. This window updates itself."
         }
     }
+}
+
+/// A screen in the walk. The permissions are asked for one at a time; the
+/// downloads are one screen that reports on all of them.
+enum SetupStep: Equatable {
+    case permission(PermissionStep)
+    case downloads
 }
 
 final class PermissionsModel: ObservableObject {
@@ -94,6 +106,26 @@ final class PermissionsModel: ObservableObject {
     /// whole job is telling them what to press.
     @Published var hotkeyDisplay: String = "your hotkey"
     @Published var hotkeyRegistered: Bool = true
+    /// Whether espeak-ng is on this Mac. Polled on the same timer as the
+    /// permissions, so a Terminal install lands on the row without a button.
+    @Published var espeak: EspeakPresence = .missing
+
+    /// Every model this launch is fetching. Held so `begin` can tell whether
+    /// there is a Downloads step at all; the panes observe the same object as
+    /// an environment object.
+    let downloads: ModelDownloads
+
+    init(downloads: ModelDownloads = .shared) {
+        self.downloads = downloads
+    }
+
+    enum EspeakPresence: Equatable {
+        case missing
+        /// Terminal has been opened on the command. Nothing to press until it
+        /// lands or does not.
+        case opening
+        case found
+    }
 
     enum SpeechModelProgress: Equatable {
         case ready
@@ -105,13 +137,13 @@ final class PermissionsModel: ObservableObject {
     /// Fixed rather than recomputed so "1 of 2" does not become "1 of 1" under
     /// the reader the moment they grant the first one — a counter that changes
     /// its own total reads as the app losing count.
-    @Published private(set) var steps: [PermissionStep] = []
+    @Published private(set) var steps: [SetupStep] = []
     @Published private(set) var index = 0
     /// The system has been asked and the answer is not here yet.
     @Published private(set) var asked = false
     @Published private(set) var context: PermissionsContext = .installing
 
-    var current: PermissionStep? { steps.indices.contains(index) ? steps[index] : nil }
+    var current: SetupStep? { steps.indices.contains(index) ? steps[index] : nil }
 
     func status(of step: PermissionStep) -> Permissions.Status {
         switch step {
@@ -128,18 +160,27 @@ final class PermissionsModel: ObservableObject {
 
     /// Start the walk. Anything already granted is not a screen — nobody needs
     /// to be told about a permission they have given.
+    ///
+    /// The Downloads step is always the last one, granted permissions or not.
+    /// It reports fetches that started at launch rather than starting them, so
+    /// there is nothing to skip past — except on a launch that fetches nothing
+    /// at all, where the registry is empty and the step would be blank.
     func begin(context: PermissionsContext) {
         self.context = context
         refresh()
-        steps = PermissionStep.allCases.filter { status(of: $0) != .granted }
+        espeak = Phonemes.locate() == nil ? .missing : .found
+        steps = PermissionStep.allCases
+            .filter { status(of: $0) != .granted }
+            .map(SetupStep.permission)
+        if !downloads.rows.isEmpty { steps.append(.downloads) }
         index = 0
         asked = false
     }
 
     func markAsked() { asked = true }
 
-    /// Only reachable when revisiting — during setup the button that would
-    /// call this quits instead.
+    /// The way forward from a step that is not asking for anything: the
+    /// Downloads step's Continue, and the skip a revisit offers.
     func skip() {
         guard index < steps.count else { return }
         index += 1
@@ -153,9 +194,22 @@ final class PermissionsModel: ObservableObject {
     ) -> PermissionsModel {
         let model = PermissionsModel()
         model.context = context
-        model.steps = PermissionStep.allCases
+        model.steps = PermissionStep.allCases.map(SetupStep.permission) + [.downloads]
         model.index = PermissionStep.allCases.firstIndex(of: step) ?? 0
         model.asked = asked
+        return model
+    }
+
+    /// Parked on the Downloads step, for `--panel-sheet` and `--panels setup`.
+    static func showingDownloads(
+        _ downloads: ModelDownloads, context: PermissionsContext = .installing,
+        espeak: EspeakPresence = .missing
+    ) -> PermissionsModel {
+        let model = PermissionsModel(downloads: downloads)
+        model.context = context
+        model.steps = PermissionStep.allCases.map(SetupStep.permission) + [.downloads]
+        model.index = PermissionStep.allCases.count
+        model.espeak = espeak
         return model
     }
 
@@ -164,16 +218,18 @@ final class PermissionsModel: ObservableObject {
     /// `steps`, which nothing outside this file can set directly.
     static func done(
         speechModel: SpeechModelProgress = .ready, hotkeyDisplay: String = "Right ⌥",
-        hotkeyRegistered: Bool = true
+        hotkeyRegistered: Bool = true, axStatus: Permissions.Status = .granted,
+        downloads: ModelDownloads = ModelDownloads(), espeak: EspeakPresence = .found
     ) -> PermissionsModel {
-        let model = PermissionsModel()
+        let model = PermissionsModel(downloads: downloads)
         model.micStatus = .granted
-        model.axStatus = .granted
-        model.steps = PermissionStep.allCases
-        model.index = PermissionStep.allCases.count
+        model.axStatus = axStatus
+        model.steps = PermissionStep.allCases.map(SetupStep.permission) + [.downloads]
+        model.index = model.steps.count
         model.speechModel = speechModel
         model.hotkeyDisplay = hotkeyDisplay
         model.hotkeyRegistered = hotkeyRegistered
+        model.espeak = espeak
         return model
     }
 
@@ -181,10 +237,17 @@ final class PermissionsModel: ObservableObject {
     /// the poll, so the screen advances itself the moment the box is ticked
     /// rather than waiting to be dismissed.
     func advancePastGranted() {
-        while let step = current, status(of: step) == .granted {
+        while case .permission(let step)? = current, status(of: step) == .granted {
             index += 1
             asked = false
         }
+    }
+
+    /// The size the window needs for the screen it is on. The permission
+    /// screens are one instrument and one paragraph; the other two are lists
+    /// that outgrew them.
+    var contentSize: NSSize {
+        NSSize(width: PermissionMetrics.width, height: PermissionMetrics.height(for: current))
     }
 }
 
@@ -200,8 +263,15 @@ final class PermissionsModel: ObservableObject {
 /// menu item opens.
 final class PermissionsWindowController {
     let model = PermissionsModel()
+    /// Re-runs the fetches, for the button a blocking failure puts in the foot.
+    /// Set by `AppDelegate`; the window neither owns nor starts a download.
+    var onRetryDownloads: (() -> Void)?
     private var window: NSWindow?
     private var timer: Timer?
+    private var sizeWatch: AnyCancellable?
+    /// When Terminal was opened on the espeak install, so the row can stop
+    /// saying so.
+    private var openedTerminalAt: Date?
     private var accessibilityObserver: NSObjectProtocol?
     /// The step a fronting attempt is under way for, and how many ticks it
     /// gets to actually land. A step is only worth fighting for the moment it
@@ -253,6 +323,7 @@ final class PermissionsWindowController {
 
     private func poll() {
         model.refresh()
+        pollEspeak()
         model.advancePastGranted()
         guard model.current != nil else { fronting = nil; return }
 
@@ -284,20 +355,59 @@ final class PermissionsWindowController {
         }
     }
 
+    /// No "check again" button. The binary is looked for on the same tick that
+    /// looks for a ticked checkbox, so an install in Terminal lands on its own.
+    private func pollEspeak() {
+        if Phonemes.locate() != nil {
+            if model.espeak != .found { model.espeak = .found }
+            openedTerminalAt = nil
+            return
+        }
+        if model.espeak == .found { model.espeak = .missing }
+        // An install can be cancelled or fail in Terminal, and nothing tells
+        // this window. Without a way back, the one row with a button loses it.
+        if model.espeak == .opening, let opened = openedTerminalAt,
+           Date().timeIntervalSince(opened) > Self.terminalGiveUpSeconds {
+            model.espeak = .missing
+            openedTerminalAt = nil
+        }
+    }
+
+    /// Long enough for `brew install espeak-ng` on a slow connection, and for
+    /// the Homebrew installer in front of it.
+    private static let terminalGiveUpSeconds: TimeInterval = 300
+
     private func build() {
         let view = PermissionsView(
             onAsk: { [weak self] step in self?.ask(step) },
             onDecline: { [weak self] in self?.decline() },
-            onClose: { [weak self] in self?.window?.close() }
-        ).environmentObject(model)
+            onClose: { [weak self] in self?.window?.close() },
+            onContinue: { [weak self] in self?.model.skip() },
+            onRetry: { [weak self] in self?.onRetryDownloads?() },
+            onInstallEspeak: { [weak self] in
+                guard let self else { return }
+                guard EspeakInstall.runInTerminal() else { return }
+                self.model.espeak = .opening
+                self.openedTerminalAt = Date()
+            }
+        )
+        .environmentObject(model)
+        .environmentObject(model.downloads)
 
         let hosting = NSHostingController(rootView: view)
         let window = NSWindow(contentViewController: hosting)
-        window.title = "\(AppVariant.displayName) Permissions"
+        window.title = "\(AppVariant.displayName) Setup"
         window.styleMask = [.titled]
         window.isReleasedWhenClosed = false
-        window.setContentSize(NSSize(width: PermissionMetrics.width, height: PermissionMetrics.height))
+        window.setContentSize(model.contentSize)
         self.window = window
+
+        // The screens are three different heights, and the window is sized to
+        // its content rather than to the tallest of them. `objectWillChange`
+        // fires before the change lands, so the size is read on the next turn.
+        sizeWatch = model.objectWillChange.sink { [weak self] _ in
+            DispatchQueue.main.async { self?.resizeToStep() }
+        }
 
         NotificationCenter.default.addObserver(
             forName: NSWindow.willCloseNotification,
@@ -313,6 +423,16 @@ final class PermissionsWindowController {
     /// installation" that quietly moved to the next screen would be the kind of
     /// wording nobody trusts twice. Revisiting, it is a skip, and the walk ends
     /// on the screen that says what is still missing.
+    /// Only when it actually changed: `setContentSize` on every published
+    /// change would fight a window somebody is looking at.
+    private func resizeToStep() {
+        guard let window else { return }
+        let wanted = model.contentSize
+        guard window.contentLayoutRect.size.height != wanted.height else { return }
+        window.setContentSize(wanted)
+        window.center()
+    }
+
     private func decline() {
         guard model.context == .installing else {
             model.skip()
@@ -345,6 +465,19 @@ final class PermissionsWindowController {
 enum PermissionMetrics {
     static let width: CGFloat = 460
     static let height: CGFloat = 328
+
+    /// The other two screens are lists, and they outgrew the permission
+    /// screens rather than fitting inside them.
+    static let downloadsHeight: CGFloat = 700
+    static let doneHeight: CGFloat = 470
+
+    static func height(for step: SetupStep?) -> CGFloat {
+        switch step {
+        case .permission: return height
+        case .downloads: return downloadsHeight
+        case nil: return doneHeight
+        }
+    }
 }
 
 struct PermissionsView: View {
@@ -353,6 +486,9 @@ struct PermissionsView: View {
     var onAsk: (PermissionStep) -> Void = { _ in }
     var onDecline: () -> Void = {}
     var onClose: () -> Void = {}
+    var onContinue: () -> Void = {}
+    var onRetry: () -> Void = {}
+    var onInstallEspeak: () -> Void = {}
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -370,7 +506,8 @@ struct PermissionsView: View {
             .font(.system(size: 9, weight: .semibold, design: .rounded))
             .kerning(0.9)
 
-            if let step = model.current {
+            switch model.current {
+            case .permission(let step):
                 StepPane(
                     step: step,
                     status: model.status(of: step),
@@ -380,17 +517,29 @@ struct PermissionsView: View {
                     onAsk: { onAsk(step) },
                     onDecline: onDecline
                 )
-            } else {
+            case .downloads:
+                DownloadsPane(
+                    context: model.context,
+                    espeak: model.espeak,
+                    onDecline: onDecline,
+                    onContinue: onContinue,
+                    onRetry: onRetry,
+                    onInstallEspeak: onInstallEspeak
+                )
+            case nil:
                 DonePane(
                     micStatus: model.micStatus, axStatus: model.axStatus,
                     speechModel: model.speechModel, hotkeyDisplay: model.hotkeyDisplay,
-                    hotkeyRegistered: model.hotkeyRegistered,
+                    hotkeyRegistered: model.hotkeyRegistered, espeak: model.espeak,
                     onClose: onClose
                 )
             }
         }
         .padding(28)
-        .frame(width: PermissionMetrics.width, height: PermissionMetrics.height)
+        .frame(
+            width: PermissionMetrics.width,
+            height: PermissionMetrics.height(for: model.current)
+        )
         // Stated rather than inherited. In the app this is the window's own
         // background and setting it changes nothing; drawn on `--panel-sheet`
         // there is no window to inherit from, and without this the pane came
@@ -629,24 +778,52 @@ private struct DonePane: View {
     let speechModel: PermissionsModel.SpeechModelProgress
     let hotkeyDisplay: String
     let hotkeyRegistered: Bool
+    let espeak: PermissionsModel.EspeakPresence
     let onClose: () -> Void
+
+    @EnvironmentObject private var downloads: ModelDownloads
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Spacer(minLength: 20)
+            Spacer(minLength: 16)
 
             Text(title)
                 .font(.system(size: 19, weight: .semibold, design: .rounded))
                 .padding(.bottom, 7)
 
             invitation
-                .padding(.bottom, 18)
+                .padding(.bottom, 12)
 
-            StatusLine(title: "Microphone", text: micStatus.label, color: micStatus.badgeColor)
-            StatusLine(title: "Accessibility", text: axStatus.label, color: axStatus.badgeColor)
-            StatusLine(title: "Speech model", text: speechModel.label, color: speechModel.badgeColor)
+            // Three groups rather than one run of lines, because each is
+            // answered somewhere else: a permission in System Settings, a
+            // download by waiting, and espeak-ng in Terminal.
+            group("Permissions") {
+                SetupLine(glyph: micStatus.glyph, title: "Microphone", trailing: micStatus.note)
+                SetupLine(
+                    glyph: axStatus.glyph, title: "Accessibility", trailing: axStatus.note
+                )
+            }
 
-            Spacer(minLength: 16)
+            if !downloads.rows.isEmpty {
+                group("Downloads") {
+                    ForEach(downloads.rows) { row in
+                        SetupLine(
+                            glyph: row.glyph, title: row.name, trailing: row.doneNote,
+                            trailingIsPercent: row.percent != nil
+                        )
+                    }
+                }
+            }
+
+            group("On your Mac") {
+                SetupLine(
+                    glyph: espeak == .found ? .granted : .absent,
+                    title: "eSpeak NG",
+                    trailing: espeak == .found ? nil : "not found"
+                )
+            }
+
+            Spacer(minLength: 12)
 
             HStack {
                 Spacer()
@@ -655,12 +832,30 @@ private struct DonePane: View {
         }
     }
 
+    @ViewBuilder
+    private func group<Content: View>(
+        _ name: String, @ViewBuilder lines: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(name.uppercased())
+                .font(.system(size: 9, weight: .semibold, design: .rounded))
+                .kerning(0.9)
+                .foregroundStyle(.tertiary)
+                .padding(.bottom, 4)
+            lines()
+        }
+        .padding(.bottom, 12)
+    }
+
     private var everything: Bool { micStatus == .granted && axStatus == .granted }
 
     /// "Ready" oversold it while the model was still on its way in — someone
     /// reads that word, holds the hotkey, and dictates into a download that
     /// has not finished. Only true once both permissions and the model are
     /// all the way there.
+    ///
+    /// Only the speech model counts. The other four can still be coming down
+    /// while you dictate: the stages that read them stand aside.
     private var title: String {
         guard everything else { return "Something was switched off" }
         if case .preparing = speechModel { return "Almost ready" }
@@ -726,6 +921,85 @@ private struct DonePane: View {
     }
 }
 
+/// One line of the last screen: a glyph in a fixed column, a name, and a word
+/// at the right edge only where the glyph cannot say it.
+private struct SetupLine: View {
+    let glyph: SetupGlyph
+    let title: String
+    var trailing: String?
+    var trailingIsPercent: Bool = false
+
+    var body: some View {
+        HStack(spacing: 9) {
+            GlyphView(glyph: glyph)
+            Text(title).font(.system(size: 12))
+            Spacer(minLength: 8)
+            if let trailing {
+                Text(trailing)
+                    .font(.system(size: 11, weight: trailingIsPercent ? .semibold : .regular))
+                    .monospacedDigit()
+                    .foregroundStyle(
+                        trailingIsPercent
+                            ? AnyShapeStyle(Parrot.action) : AnyShapeStyle(.tertiary)
+                    )
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+/// The six states a line can be in, drawn rather than written.
+enum SetupGlyph: Equatable {
+    case granted
+    case switchedOff
+    case downloading
+    case queued
+    case turnedOff
+    case absent
+}
+
+private struct GlyphView: View {
+    let glyph: SetupGlyph
+    @State private var spinning = false
+
+    var body: some View {
+        Group {
+            switch glyph {
+            case .granted:
+                Image(systemName: "checkmark").bold().foregroundStyle(Parrot.leaf)
+            case .switchedOff:
+                Image(systemName: "xmark").bold().foregroundStyle(Parrot.scarlet)
+            case .turnedOff:
+                Image(systemName: "minus").bold().foregroundStyle(.tertiary)
+            case .downloading:
+                Circle()
+                    .trim(from: 0, to: 0.72)
+                    .stroke(Parrot.action, style: StrokeStyle(lineWidth: 1.6, lineCap: .round))
+                    .frame(width: 10, height: 10)
+                    .rotationEffect(.degrees(spinning ? 360 : 0))
+                    .onAppear {
+                        withAnimation(.linear(duration: 0.9).repeatForever(autoreverses: false)) {
+                            spinning = true
+                        }
+                    }
+            case .queued:
+                Circle()
+                    .stroke(
+                        Color.secondary.opacity(0.6),
+                        style: StrokeStyle(lineWidth: 1.2, dash: [2.2, 2.2])
+                    )
+                    .frame(width: 10, height: 10)
+            case .absent:
+                Circle()
+                    .stroke(Parrot.amber, lineWidth: 1.5)
+                    .frame(width: 10, height: 10)
+            }
+        }
+        .font(.system(size: 10, weight: .bold))
+        .frame(width: 14, height: 14)
+    }
+}
+
 /// The same bordered field this window already draws for a key combination
 /// — one mark for "this is a key you press," not two.
 private struct HotkeyBadge: View {
@@ -748,59 +1022,343 @@ private struct HotkeyBadge: View {
     }
 }
 
-private struct StatusLine: View {
-    let title: String
-    let text: String
-    let color: Color
+private extension Permissions.Status {
+    var glyph: SetupGlyph {
+        self == .granted ? .granted : .switchedOff
+    }
 
-    var body: some View {
-        HStack(spacing: 8) {
-            Text(title).font(.system(size: 12))
-            StatusBadge(text: text, color: color)
-            Spacer()
-        }
-        .padding(.vertical, 3)
+    /// Nothing beside a granted permission: the glyph says it.
+    var note: String? {
+        self == .granted ? nil : "switched off"
     }
 }
 
-private struct StatusBadge: View {
+private extension ModelDownload {
+    var glyph: SetupGlyph {
+        switch state {
+        case .installed: return .granted
+        case .downloading: return .downloading
+        case .waiting: return .queued
+        case .off: return .turnedOff
+        // Amber for a fetch the app retries by itself, a cross for one that
+        // holds a dictation up.
+        case .failed: return blocking ? .switchedOff : .absent
+        }
+    }
+
+    var percent: Int? {
+        if case .downloading(let percent) = state { return percent }
+        return nil
+    }
+
+    /// The word at the right edge of the last screen's line, where a glyph
+    /// cannot carry it.
+    var doneNote: String? {
+        switch state {
+        case .downloading(let percent): return percent.map { "\($0)%" }
+        case .off(let reason): return reason
+        case .failed: return "did not arrive"
+        case .installed, .waiting: return nil
+        }
+    }
+}
+
+// MARK: - Downloads
+
+/// What the app is fetching, and the one thing it looks for instead.
+///
+/// Nothing here starts a download. They start at launch, in `warmModels`, and
+/// they carry on whether or not this window is open. The rows report.
+private struct DownloadsPane: View {
+    let context: PermissionsContext
+    let espeak: PermissionsModel.EspeakPresence
+    let onDecline: () -> Void
+    let onContinue: () -> Void
+    let onRetry: () -> Void
+    let onInstallEspeak: () -> Void
+
+    @EnvironmentObject private var downloads: ModelDownloads
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(downloads.summary.uppercased())
+                .font(.system(size: 9, weight: .semibold, design: .rounded))
+                .kerning(0.9)
+                .foregroundStyle(eyebrowColour)
+                .padding(.top, 20)
+                .padding(.bottom, 6)
+
+            Text("Downloads")
+                .font(.system(size: 19, weight: .semibold, design: .rounded))
+                .padding(.bottom, 7)
+
+            Text("ParrotFlow needs the following models to process your dictation on this Mac.")
+                .font(.system(size: 14))
+                .lineSpacing(2)
+                .fixedSize(horizontal: false, vertical: true)
+
+            group(
+                "Speech and sound",
+                "These audio models process your voice, transform it into text and provide"
+                    + " additional cues to correct transcription artifacts.",
+                rows: downloads.rows(in: .sound)
+            )
+
+            group(
+                "Language",
+                "These language models help ParrotFlow apply your vocabulary and correct"
+                    + " transcription artifacts by understanding what you mean.",
+                rows: downloads.rows(in: .language)
+            )
+
+            groupKey("Already on your Mac, or not")
+                .padding(.top, 16)
+                .padding(.bottom, 7)
+            EspeakRow(presence: espeak, onInstall: onInstallEspeak)
+
+            Spacer(minLength: 14)
+
+            HStack(spacing: 10) {
+                // Offered here and not on the permission screens, and it means
+                // what it says: this quits the app. Only while installing —
+                // revisiting, it would say "Not now" beside a Continue that
+                // does the same thing.
+                if context == .installing {
+                    Button(context.declineTitle, action: onDecline)
+                        .buttonStyle(.plain)
+                        .foregroundStyle(.tertiary)
+                        .font(.system(size: 12))
+                }
+
+                Spacer()
+
+                // Never disabled. Nothing on this screen is a condition of
+                // going on: the speech model is the only one a dictation waits
+                // for, and it says so on the screen after this one.
+                Button(primaryTitle, action: primaryAction)
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func group(_ name: String, _ what: String, rows: [ModelDownload]) -> some View {
+        if !rows.isEmpty {
+            VStack(alignment: .leading, spacing: 0) {
+                groupKey(name).padding(.bottom, 3)
+                // The group carries the explanation, so the rows are bare: a
+                // name, a size, a state.
+                Text(what)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.bottom, 7)
+                VStack(spacing: 6) {
+                    ForEach(rows) { DownloadRow(row: $0) }
+                }
+            }
+            .padding(.top, 16)
+        }
+    }
+
+    private func groupKey(_ name: String) -> some View {
+        Text(name.uppercased())
+            .font(.system(size: 9, weight: .semibold, design: .rounded))
+            .kerning(0.9)
+            .foregroundStyle(.tertiary)
+    }
+
+    /// A failure nobody is waiting on stays inside its own row. Only a model a
+    /// dictation waits for reaches the foot.
+    private var primaryTitle: String {
+        downloads.blockingFailure?.retryTitle ?? "Continue"
+    }
+
+    private func primaryAction() {
+        if downloads.blockingFailure?.retryTitle != nil { onRetry() } else { onContinue() }
+    }
+
+    private var eyebrowColour: Color {
+        if downloads.rows.contains(where: { $0.state.hasFailed }) { return Parrot.scarlet }
+        if downloads.anyDownloading { return Parrot.action }
+        if downloads.rows.allSatisfy({ $0.state == .installed }) { return Parrot.leaf }
+        return Parrot.amber
+    }
+}
+
+private struct DownloadRow: View {
+    let row: ModelDownload
+
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 7) {
+                    Text(row.name).font(.system(size: 13, weight: .semibold))
+                    Text(row.sizeLabel).font(.system(size: 11)).foregroundStyle(.tertiary)
+                }
+                // The second line exists only to say why a row failed.
+                if let why = row.state.failure {
+                    Text(sentence(for: why))
+                        .font(.system(size: 11))
+                        .foregroundStyle(row.blocking ? Parrot.scarlet : Parrot.amber)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            Spacer(minLength: 8)
+            state
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color.primary.opacity(0.06))
+        .overlay(alignment: .bottomLeading) { bar }
+        .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
+    }
+
+    /// A model nothing waits on clears its own failed fetch, so the row says
+    /// what happens next rather than asking for a decision.
+    private func sentence(for why: ModelDownload.Failure) -> String {
+        guard !row.blocking else { return why.message }
+        return why.message + " The next dictation that needs it tries again."
+    }
+
+    @ViewBuilder
+    private var state: some View {
+        switch row.state {
+        case .downloading(let percent):
+            if let percent {
+                Text("\(percent)%")
+                    .font(.system(size: 12, weight: .semibold))
+                    .monospacedDigit()
+                    .foregroundStyle(Parrot.action)
+            } else {
+                // No number rather than an invented one: this fetch reports no
+                // fraction.
+                GlyphView(glyph: .downloading)
+            }
+        case .waiting:
+            SetupBadge(text: "Waiting", color: .secondary)
+        case .installed:
+            SetupBadge(text: "Installed", color: Parrot.leaf)
+        case .off(let reason):
+            SetupBadge(text: reason, color: .secondary)
+        case .failed:
+            SetupBadge(
+                text: row.blocking ? "Failed" : "Will retry",
+                color: row.blocking ? Parrot.scarlet : Parrot.amber
+            )
+        }
+    }
+
+    @ViewBuilder
+    private var bar: some View {
+        if let percent = row.percent {
+            GeometryReader { geometry in
+                Rectangle()
+                    .fill(Parrot.action)
+                    .frame(width: geometry.size.width * CGFloat(percent) / 100, height: 2)
+                    .frame(maxHeight: .infinity, alignment: .bottom)
+            }
+        }
+    }
+}
+
+/// The one row no button can fetch, so the one row with controls.
+///
+/// Amber, not scarlet: CharsiuG2P covers the base case, so an absent eSpeak NG
+/// costs some names rather than the feature.
+private struct EspeakRow: View {
+    let presence: PermissionsModel.EspeakPresence
+    let onInstall: () -> Void
+
+    @State private var copied = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack(spacing: 7) {
+                        Text("eSpeak NG").font(.system(size: 13, weight: .semibold))
+                        Text("GPL-3 · a separate program")
+                            .font(.system(size: 10))
+                            .foregroundStyle(.tertiary)
+                    }
+                    Text("Backs up CharsiuG2P on names it misses.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                    if presence != .found {
+                        Text(how)
+                            .font(.system(size: 11))
+                            .foregroundStyle(Parrot.amber)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                Spacer(minLength: 8)
+                switch presence {
+                case .missing:
+                    Button("Run in Terminal", action: onInstall).controlSize(.small)
+                case .opening:
+                    SetupBadge(text: "Terminal open", color: .secondary)
+                case .found:
+                    SetupBadge(text: "Found", color: Parrot.leaf)
+                }
+            }
+
+            // The chained one-liner is 130 characters. Inside a sentence it is
+            // unreadable and unselectable, so it gets a field and a way to copy.
+            if presence != .found {
+                HStack(alignment: .top, spacing: 8) {
+                    Text(EspeakInstall.command)
+                        .font(.system(size: 10, design: .monospaced))
+                        .textSelection(.enabled)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Button(copied ? "Copied" : "Copy") {
+                        EspeakInstall.copyCommand()
+                        copied = true
+                    }
+                    .controlSize(.small)
+                }
+                .padding(.leading, 10)
+                .padding(.trailing, 8)
+                .padding(.vertical, 7)
+                .background(
+                    Color.primary.opacity(0.09),
+                    in: RoundedRectangle(cornerRadius: Parrot.fieldRadius, style: .continuous)
+                )
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .background(
+            Color.primary.opacity(0.06),
+            in: RoundedRectangle(cornerRadius: 9, style: .continuous)
+        )
+    }
+
+    private var how: String {
+        if presence == .opening {
+            return "Terminal is running it now. This row notices on its own when it lands."
+        }
+        if EspeakInstall.brew != nil {
+            return "Not installed. This runs it in Terminal, where you can watch it."
+        }
+        return "Not installed, and neither is Homebrew. This installs Homebrew first,"
+            + " then eSpeak NG."
+    }
+}
+
+private struct SetupBadge: View {
     let text: String
     let color: Color
 
     var body: some View {
-        Text(text)
-            .font(.system(size: 10, weight: .semibold))
-            .padding(.horizontal, 6)
+        Text(text.uppercased())
+            .font(.system(size: 10, weight: .bold))
+            .kerning(0.3)
+            .padding(.horizontal, 7)
             .padding(.vertical, 2)
             .background(color.opacity(0.18), in: Capsule())
             .foregroundStyle(color)
-    }
-}
-
-private extension Permissions.Status {
-    var badgeColor: Color {
-        switch self {
-        case .granted: return Parrot.leaf
-        case .denied: return Parrot.scarlet
-        case .notDetermined, .notGranted: return Parrot.amber
-        }
-    }
-}
-
-private extension PermissionsModel.SpeechModelProgress {
-    var label: String {
-        switch self {
-        case .ready: return "Ready"
-        case .preparing(let percent):
-            guard let percent else { return "Downloading" }
-            return "Downloading \(percent)%"
-        }
-    }
-
-    var badgeColor: Color {
-        switch self {
-        case .ready: return Parrot.leaf
-        case .preparing: return Parrot.amber
-        }
+            .fixedSize()
     }
 }

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -386,7 +386,12 @@ final class PermissionsWindowController {
             onRetry: { [weak self] in self?.onRetryDownloads?() },
             onInstallEspeak: { [weak self] in
                 guard let self else { return }
-                guard EspeakInstall.runInTerminal() else { return }
+                let started = EspeakInstall.runInTerminal { [weak self] opened in
+                    guard let self, !opened, self.model.espeak == .opening else { return }
+                    self.model.espeak = .missing
+                    self.openedTerminalAt = nil
+                }
+                guard started else { return }
                 self.model.espeak = .opening
                 self.openedTerminalAt = Date()
             }

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -848,12 +848,19 @@ private struct SetupPane: View {
         case ready
         case permissionLost
         case somethingDidNotArrive
+        case dictationOff
     }
 
-    /// A permission first: it is the only one of the four that cannot be fixed
-    /// by waiting, and it is fixed somewhere else.
+    /// A permission first: it is the only one of these that cannot be fixed by
+    /// waiting, and it is fixed somewhere else.
+    ///
+    /// An empty registry means `transcription.enabled` is false. `warmModels`
+    /// declares all five rows before this window opens and returns before
+    /// declaring any only on that one setting, so there is nothing else it can
+    /// mean.
     private var moment: Moment {
         if lostPermission != nil { return .permissionLost }
+        if downloads.rows.isEmpty { return .dictationOff }
         if downloads.blockingFailure != nil { return .somethingDidNotArrive }
         return downloads.speechIsIn ? .ready : .almostReady
     }
@@ -864,15 +871,16 @@ private struct SetupPane: View {
         return nil
     }
 
-    /// The model the title is about — the first one a dictation waits on, which
-    /// is the speech model.
-    private var speechName: String {
-        downloads.rows.first { $0.blocking }?.name ?? "The speech model"
+    /// The model still being waited for, which is the one the title is about.
+    private var awaited: ModelDownload? {
+        downloads.rows.first { $0.blocking && !$0.state.hasFailed } ?? downloads.blockingFailure
     }
 
     private var title: String {
         switch moment {
-        case .permissionLost: return "Something was switched off"
+        // A setting that is off is a setting that was switched off, whether
+        // the switch is in System Settings or in config.yaml.
+        case .permissionLost, .dictationOff: return "Something was switched off"
         case .somethingDidNotArrive: return "Something did not arrive"
         case .almostReady: return "Almost ready"
         case .ready: return hotkeyRegistered ? "Ready" : "Almost ready"
@@ -912,15 +920,22 @@ private struct SetupPane: View {
             guard let step = lostPermission else { return nil }
             return "\(step.title) is switched off. Turn it back on in System Settings,"
                 + " and this window updates itself."
+        case .dictationOff:
+            return "Dictation is switched off. Set transcription: enabled: true in"
+                + " config.yaml, then reopen this window."
         case .somethingDidNotArrive:
-            let opening = "\(speechName) could not be downloaded, and nothing transcribes"
-                + " without it."
+            // The row that failed, not the first one a dictation waits on: a
+            // voice detector that did not arrive must not be reported as a
+            // speech model that did not arrive.
+            guard let row = downloads.blockingFailure else { return nil }
+            let opening = "\(row.name) could not be downloaded, and \(row.costOfFailure)."
             // The key line finishes this sentence. Without a hotkey there is no
             // key line, and it would end on "or".
             return hotkeyRegistered ? "\(opening) Try again, or" : "\(opening) Try again"
         case .almostReady:
             guard hotkeyRegistered else { return unregisteredHotkey }
-            return "\(speechName) is still coming down. Once it is here,"
+            guard let row = awaited else { return nil }
+            return "\(row.name) is still coming down. Once it is here,"
         case .ready:
             return hotkeyRegistered ? nil : unregisteredHotkey
         }
@@ -936,7 +951,7 @@ private struct SetupPane: View {
 
     private var keySentence: (String, String)? {
         switch moment {
-        case .permissionLost: return nil
+        case .permissionLost, .dictationOff: return nil
         case .somethingDidNotArrive: return ("hold", "later and it tries again on its own.")
         case .almostReady: return ("hold", "and start dictating.")
         case .ready: return ("Hold", "and start dictating.")
@@ -947,11 +962,12 @@ private struct SetupPane: View {
     /// dictation waits for reaches the foot.
     private var primaryTitle: String {
         guard moment == .somethingDidNotArrive else { return "Done" }
-        return downloads.blockingFailure?.retryTitle ?? "Done"
+        return downloads.blockingFailure?.state.failure?.retryTitle ?? "Done"
     }
 
     private func primaryAction() {
-        if moment == .somethingDidNotArrive, downloads.blockingFailure?.retryTitle != nil {
+        if moment == .somethingDidNotArrive,
+           downloads.blockingFailure?.state.failure?.retryTitle != nil {
             onRetry()
         } else {
             onClose()

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -872,8 +872,11 @@ private struct SetupPane: View {
     }
 
     /// The model still being waited for, which is the one the title is about.
+    ///
+    /// Not the first blocking row: Parakeet lands before Silero VAD starts, and
+    /// naming it then would say an installed model is still coming down.
     private var awaited: ModelDownload? {
-        downloads.rows.first { $0.blocking && !$0.state.hasFailed } ?? downloads.blockingFailure
+        downloads.rows.first { $0.blocking && $0.state.isPending }
     }
 
     private var title: String {

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -103,6 +103,9 @@ final class PermissionsModel: ObservableObject {
     /// Whether espeak-ng is on this Mac. Polled on the same timer as the
     /// permissions, so a Terminal install lands on the row without a button.
     @Published var espeak: EspeakPresence = .missing
+    /// "Not now" was pressed, this launch or an earlier one. Leaving without
+    /// eSpeak NG should be a decision, and a decision is only asked for once.
+    @Published var espeakDeclined: Bool = EspeakInstall.declined
 
     /// Every model this launch is fetching. Held so `begin` can tell whether
     /// there is a Downloads step at all; the panes observe the same object as
@@ -157,6 +160,7 @@ final class PermissionsModel: ObservableObject {
         self.context = context
         refresh()
         espeak = Phonemes.locate() == nil ? .missing : .found
+        espeakDeclined = EspeakInstall.declined
         steps = PermissionStep.allCases
             .filter { status(of: $0) != .granted }
             .map(SetupStep.permission)
@@ -193,7 +197,8 @@ final class PermissionsModel: ObservableObject {
     static func showingSetup(
         _ downloads: ModelDownloads, context: PermissionsContext = .installing,
         axStatus: Permissions.Status = .granted, hotkeyDisplay: String = "Right ⌥",
-        hotkeyRegistered: Bool = true, espeak: EspeakPresence = .missing
+        hotkeyRegistered: Bool = true, espeak: EspeakPresence = .missing,
+        espeakDeclined: Bool = false
     ) -> PermissionsModel {
         let model = PermissionsModel(downloads: downloads)
         model.context = context
@@ -204,6 +209,7 @@ final class PermissionsModel: ObservableObject {
         model.hotkeyDisplay = hotkeyDisplay
         model.hotkeyRegistered = hotkeyRegistered
         model.espeak = espeak
+        model.espeakDeclined = espeakDeclined
         return model
     }
 
@@ -354,19 +360,9 @@ final class PermissionsWindowController {
         let view = PermissionsView(
             onAsk: { [weak self] step in self?.ask(step) },
             onDecline: { [weak self] in self?.decline() },
-            onClose: { [weak self] in self?.window?.close() },
+            onClose: { [weak self] in self?.finish() },
             onRetry: { [weak self] in self?.onRetryDownloads?() },
-            onInstallEspeak: { [weak self] in
-                guard let self else { return }
-                let started = EspeakInstall.runInTerminal { [weak self] opened in
-                    guard let self, !opened, self.model.espeak == .opening else { return }
-                    self.model.espeak = .missing
-                    self.openedTerminalAt = nil
-                }
-                guard started else { return }
-                self.model.espeak = .opening
-                self.openedTerminalAt = Date()
-            }
+            onInstallEspeak: { [weak self] in self?.installEspeak() }
         )
         .environmentObject(model)
         .environmentObject(model.downloads)
@@ -399,6 +395,60 @@ final class PermissionsWindowController {
         ) { [weak self] _ in
             self?.timer?.invalidate()
             self?.timer = nil
+        }
+    }
+
+    private func installEspeak() {
+        let started = EspeakInstall.runInTerminal { [weak self] opened in
+            guard let self, !opened, self.model.espeak == .opening else { return }
+            self.model.espeak = .missing
+            self.openedTerminalAt = nil
+        }
+        guard started else { return }
+        model.espeak = .opening
+        openedTerminalAt = Date()
+    }
+
+    /// Done. It stops once, and only once: leaving without eSpeak NG should be
+    /// a decision rather than something nobody read.
+    ///
+    /// Not on the failed-download screen — that button says Try again and does
+    /// something else — and not after the question has been answered, this
+    /// launch or an earlier one.
+    private func finish() {
+        guard let window else { return }
+        guard model.espeak == .missing, !model.espeakDeclined else {
+            window.close()
+            return
+        }
+        askAboutEspeak(on: window)
+    }
+
+    private func askAboutEspeak(on window: NSWindow) {
+        let alert = NSAlert()
+        alert.messageText = "Install eSpeak NG?"
+        alert.informativeText = "Without it, ParrotFlow misses some of the names in your"
+            + " vocabulary. It is a separate program, so it installs in Terminal and takes"
+            + " about a minute."
+        // The real app icon, the same file System Settings reads. `NSAlert`
+        // finds it by itself in the app; running the bare binary it does not.
+        if let url = Bundle.main.url(forResource: "AppIcon", withExtension: "icns"),
+           let icon = NSImage(contentsOf: url) {
+            alert.icon = icon
+        }
+        alert.addButton(withTitle: "Install it")
+        alert.addButton(withTitle: "Not now")
+        alert.beginSheetModal(for: window) { [weak self] answer in
+            guard let self else { return }
+            guard answer == .alertFirstButtonReturn else {
+                self.model.espeakDeclined = true
+                EspeakInstall.declined = true
+                window.close()
+                return
+            }
+            // The window stays open, so the line can show Terminal opening and
+            // then the binary landing.
+            self.installEspeak()
         }
     }
 
@@ -518,6 +568,7 @@ struct PermissionsView: View {
                     hotkeyDisplay: model.hotkeyDisplay,
                     hotkeyRegistered: model.hotkeyRegistered,
                     context: model.context, espeak: model.espeak,
+                    espeakDeclined: model.espeakDeclined,
                     onDecline: onDecline, onClose: onClose, onRetry: onRetry,
                     onInstallEspeak: onInstallEspeak
                 )
@@ -784,6 +835,7 @@ private struct SetupPane: View {
     let hotkeyRegistered: Bool
     let context: PermissionsContext
     let espeak: PermissionsModel.EspeakPresence
+    let espeakDeclined: Bool
     let onDecline: () -> Void
     let onClose: () -> Void
     let onRetry: () -> Void
@@ -1024,35 +1076,143 @@ private struct SetupPane: View {
         }
     }
 
-    /// The one line the app cannot fetch, so the one line with a button.
+    /// The one thing here the app cannot fetch, so the one thing that asks for
+    /// a decision — and the only thing on the screen drawn as a card.
     ///
     /// Amber, not scarlet: CharsiuG2P covers the base case, so an absent eSpeak
     /// NG costs some names rather than the feature.
     @ViewBuilder
     private var espeakLines: some View {
         SetupLine(
-            glyph: espeak == .found ? .granted : (espeak == .opening ? .downloading : .absent),
+            glyph: espeakGlyph,
             title: "eSpeak NG",
             detail: "GPL-3 · a separate program",
-            note: espeak == .opening ? "Terminal open" : nil,
-            button: espeak == .missing ? ("Run in Terminal", onInstallEspeak) : nil
+            note: espeakNote
         )
-        if espeak != .found {
-            SetupNote(text: espeakHow, tone: Parrot.amber)
-            CommandField()
+        switch espeakState {
+        case .found:
+            EmptyView()
+        case .opening:
+            SetupNote(
+                text: "Terminal is running it now. This line notices on its own when it lands.",
+                tone: Parrot.amber
+            )
+        case .skipped:
+            SetupNote(
+                text: "Skipped. Install it any time from Setup… in the menu bar.",
+                tone: Parrot.amber
+            )
+        case .missing:
+            EspeakCard(onInstall: onInstallEspeak)
         }
     }
 
-    private var espeakHow: String {
-        if espeak == .opening {
-            return "Terminal is running it now. This line notices on its own when it lands."
+    /// Four ways the line reads. "Skipped" is missing plus an answer already
+    /// given, which is not the same thing as missing and unanswered.
+    private enum EspeakState {
+        case found
+        case opening
+        case missing
+        case skipped
+    }
+
+    private var espeakState: EspeakState {
+        switch espeak {
+        case .found: return .found
+        case .opening: return .opening
+        case .missing: return espeakDeclined ? .skipped : .missing
         }
-        let backs = "Backs up CharsiuG2P on names it misses."
+    }
+
+    private var espeakGlyph: SetupGlyph {
+        switch espeakState {
+        case .found: return .granted
+        case .opening: return .downloading
+        case .missing, .skipped: return .absent
+        }
+    }
+
+    private var espeakNote: String? {
+        switch espeakState {
+        case .found: return nil
+        case .opening: return "Terminal open"
+        case .missing: return "not installed"
+        case .skipped: return "skipped"
+        }
+    }
+}
+
+/// What is lost without eSpeak NG, what it is, and the two ways to install it.
+///
+/// A card because it is the one thing on this screen that asks for a decision.
+/// Amber because the decision is not urgent: an absent eSpeak costs some names,
+/// not the feature.
+private struct EspeakCard: View {
+    let onInstall: () -> Void
+
+    @State private var copied = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text("Not installed. Some of your names will be missed without it.")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(Parrot.amber)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text(what)
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            // The chained one-liner is 140 characters. Inside a sentence it is
+            // unreadable and unselectable, so it gets a field of its own.
+            Text(EspeakInstall.command)
+                .font(.system(size: 10, design: .monospaced))
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 6)
+                .background(
+                    Color.primary.opacity(0.08),
+                    in: RoundedRectangle(cornerRadius: Parrot.fieldRadius, style: .continuous)
+                )
+                .padding(.vertical, 1)
+
+            HStack(spacing: 10) {
+                Button("Run in Terminal", action: onInstall)
+                    .buttonStyle(.borderedProminent)
+                Button(copied ? "Copied" : "Copy the command") {
+                    EspeakInstall.copyCommand()
+                    copied = true
+                }
+            }
+            .controlSize(.small)
+            .padding(.top, 2)
+        }
+        .padding(.horizontal, 10)
+        .padding(.top, 8)
+        .padding(.bottom, 9)
+        .background(
+            Parrot.amber.opacity(0.11),
+            in: RoundedRectangle(cornerRadius: 9, style: .continuous)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
+                .strokeBorder(Parrot.amber.opacity(0.38), lineWidth: 1)
+        }
+        .padding(.leading, SetupMetrics.indent)
+        .padding(.top, 2)
+    }
+
+    private var what: String {
+        let backs = "It backs up CharsiuG2P on the names it misses. It is a separate program"
+            + " under GPL-3, so ParrotFlow cannot install it for you."
         if EspeakInstall.brew != nil {
-            return "\(backs) Not installed. This runs it in Terminal, where you can watch it."
+            return "\(backs) This runs the install in Terminal, where you can watch it."
         }
-        return "\(backs) Not installed, and neither is Homebrew. This installs Homebrew first,"
-            + " then eSpeak NG."
+        return "\(backs) Homebrew is missing too, so this installs Homebrew first, then"
+            + " eSpeak NG, in Terminal."
     }
 }
 
@@ -1120,36 +1280,6 @@ private struct SetupNote: View {
             .fixedSize(horizontal: false, vertical: true)
             .padding(.leading, SetupMetrics.indent)
             .padding(.bottom, 4)
-    }
-}
-
-/// The chained one-liner is 140 characters. Inside a sentence it is unreadable
-/// and unselectable, so it gets a field and a way to copy.
-private struct CommandField: View {
-    @State private var copied = false
-
-    var body: some View {
-        HStack(alignment: .top, spacing: 8) {
-            Text(EspeakInstall.command)
-                .font(.system(size: 10, design: .monospaced))
-                .textSelection(.enabled)
-                .fixedSize(horizontal: false, vertical: true)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            Button(copied ? "Copied" : "Copy") {
-                EspeakInstall.copyCommand()
-                copied = true
-            }
-            .controlSize(.small)
-        }
-        .padding(.leading, 10)
-        .padding(.trailing, 8)
-        .padding(.vertical, 6)
-        .background(
-            Color.primary.opacity(0.08),
-            in: RoundedRectangle(cornerRadius: Parrot.fieldRadius, style: .continuous)
-        )
-        .padding(.leading, SetupMetrics.indent)
-        .padding(.bottom, 2)
     }
 }
 

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -467,7 +467,9 @@ final class PermissionsWindowController {
         guard let window, let content = window.contentViewController?.view else { return }
         let fitting = content.fittingSize
         guard fitting.height > 0 else { return }
-        let wanted = NSSize(width: PermissionMetrics.width, height: fitting.height)
+        let wanted = NSSize(
+            width: PermissionMetrics.width(for: model.current), height: fitting.height
+        )
         guard abs(window.contentLayoutRect.height - wanted.height) > 0.5 else { return }
 
         let top = window.frame.maxY
@@ -509,6 +511,25 @@ final class PermissionsWindowController {
 
 enum PermissionMetrics {
     static let width: CGFloat = 460
+
+    /// The setup screen is drawn a quarter larger than the permission screens
+    /// — every size on it, including this one. See `SetupMetrics.scale`.
+    static var setupWidth: CGFloat { SetupMetrics.at(width) }
+
+    static func width(for step: SetupStep) -> CGFloat {
+        switch step {
+        case .permission: return width
+        case .setup: return setupWidth
+        }
+    }
+
+    /// The margin around the pane, on the same scale as what it holds.
+    static func padding(for step: SetupStep) -> CGFloat {
+        switch step {
+        case .permission: return 28
+        case .setup: return SetupMetrics.at(28)
+        }
+    }
     static let height: CGFloat = 328
 
     /// The permission screens are one instrument and one paragraph, and that
@@ -535,10 +556,16 @@ struct PermissionsView: View {
     var onRetry: () -> Void = {}
     var onInstallEspeak: () -> Void = {}
 
+    /// The header belongs to whichever screen is under it, so it is drawn on
+    /// that screen's scale.
+    private func header(_ points: CGFloat) -> CGFloat {
+        model.current == .setup ? SetupMetrics.at(points) : points
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            HStack(spacing: 8) {
-                PlumageMark()
+            HStack(spacing: header(8)) {
+                PlumageMark(size: header(13))
                 Text(AppVariant.displayName.uppercased())
                     .foregroundStyle(Parrot.action)
                 Spacer()
@@ -548,8 +575,8 @@ struct PermissionsView: View {
                         .foregroundStyle(.tertiary)
                 }
             }
-            .font(.system(size: 9, weight: .semibold, design: .rounded))
-            .kerning(0.9)
+            .font(.system(size: header(9), weight: .semibold, design: .rounded))
+            .kerning(header(0.9))
 
             switch model.current {
             case .permission(let step):
@@ -574,8 +601,8 @@ struct PermissionsView: View {
                 )
             }
         }
-        .padding(28)
-        .frame(width: PermissionMetrics.width)
+        .padding(PermissionMetrics.padding(for: model.current))
+        .frame(width: PermissionMetrics.width(for: model.current))
         .frame(height: PermissionMetrics.height(for: model.current))
         // Stated rather than inherited. In the app this is the window's own
         // background and setting it changes nothing; drawn on `--panel-sheet`
@@ -811,12 +838,26 @@ private struct StepPane: View {
 
 // MARK: - The setup screen
 
-/// Where the glyph column ends and the text column begins, so a note under a
-/// line and the bar under it both start where the name does.
+/// Every size on the setup screen, on one scale.
+///
+/// The screen was drawn at the width of the permission screens and reads a
+/// quarter larger than it did there — a list of eleven lines is not a paragraph
+/// and a paragraph's type size is too small for it. One factor rather than a
+/// second set of numbers, so the whole screen stays in proportion and there is
+/// one thing to change.
 enum SetupMetrics {
-    static let glyph: CGFloat = 14
-    static let gap: CGFloat = 9
+    static let scale: CGFloat = 1.25
+
+    static func at(_ points: CGFloat) -> CGFloat { points * scale }
+
+    /// Where the glyph column ends and the text column begins, so a note under
+    /// a line and the bar under it both start where the name does.
+    static var glyph: CGFloat { at(14) }
+    static var gap: CGFloat { at(9) }
     static var indent: CGFloat { glyph + gap }
+    /// The corner the card and the code field are cut with.
+    static var radius: CGFloat { at(9) }
+    static var fieldRadius: CGFloat { at(Parrot.fieldRadius) }
 }
 
 /// One screen: what was granted, what is being fetched, and what is on this
@@ -843,12 +884,14 @@ private struct SetupPane: View {
 
     @EnvironmentObject private var downloads: ModelDownloads
 
+    private func at(_ points: CGFloat) -> CGFloat { SetupMetrics.at(points) }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text(title)
-                .font(.system(size: 19, weight: .semibold, design: .rounded))
-                .padding(.top, 20)
-                .padding(.bottom, 7)
+                .font(.system(size: at(19), weight: .semibold, design: .rounded))
+                .padding(.top, at(20))
+                .padding(.bottom, at(7))
 
             invitation
 
@@ -873,22 +916,23 @@ private struct SetupPane: View {
 
             group("Other") { espeakLines }
 
-            Spacer(minLength: 12)
+            Spacer(minLength: at(12))
 
-            HStack(spacing: 10) {
+            HStack(spacing: at(10)) {
                 // It means what it says: during setup this quits the app.
                 // Revisiting, there is no installation left to cancel.
                 if context == .installing {
                     Button(context.declineTitle, action: onDecline)
                         .buttonStyle(.plain)
                         .foregroundStyle(.tertiary)
-                        .font(.system(size: 12))
+                        .font(.system(size: at(12)))
                 }
 
                 Spacer()
 
                 Button(primaryTitle, action: primaryAction)
                     .keyboardShortcut(.defaultAction)
+                    .controlSize(.large)
             }
         }
     }
@@ -923,14 +967,6 @@ private struct SetupPane: View {
         return nil
     }
 
-    /// The model still being waited for, which is the one the title is about.
-    ///
-    /// Not the first blocking row: Parakeet lands before Silero VAD starts, and
-    /// naming it then would say an installed model is still coming down.
-    private var awaited: ModelDownload? {
-        downloads.rows.first { $0.blocking && $0.state.isPending }
-    }
-
     private var title: String {
         switch moment {
         // A setting that is off is a setting that was switched off, whether
@@ -949,24 +985,24 @@ private struct SetupPane: View {
     /// it. It breaks where the key starts instead.
     @ViewBuilder
     private var invitation: some View {
-        VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: at(6)) {
             if let lead {
                 Text(lead)
-                    .font(.system(size: 12))
+                    .font(.system(size: at(12)))
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
             if let (before, after) = keySentence, hotkeyRegistered {
-                HStack(spacing: 5) {
+                HStack(spacing: at(5)) {
                     Text(before)
                     HotkeyBadge(text: hotkeyDisplay)
                     Text(after)
                 }
-                .font(.system(size: 12))
+                .font(.system(size: at(12)))
                 .foregroundStyle(.secondary)
             }
         }
-        .padding(.bottom, 4)
+        .padding(.bottom, at(4))
     }
 
     private var lead: String? {
@@ -988,9 +1024,9 @@ private struct SetupPane: View {
             // key line, and it would end on "or".
             return hotkeyRegistered ? "\(opening) Try again, or" : "\(opening) Try again"
         case .almostReady:
-            guard hotkeyRegistered else { return unregisteredHotkey }
-            guard let row = awaited else { return nil }
-            return "\(row.name) is still coming down. Once it is here,"
+            // Nothing under the title. The line for the model that is still
+            // coming down is a few lines below, with its own percentage.
+            return hotkeyRegistered ? nil : unregisteredHotkey
         case .ready:
             return hotkeyRegistered ? nil : unregisteredHotkey
         }
@@ -1006,9 +1042,8 @@ private struct SetupPane: View {
 
     private var keySentence: (String, String)? {
         switch moment {
-        case .permissionLost, .dictationOff: return nil
+        case .permissionLost, .dictationOff, .almostReady: return nil
         case .somethingDidNotArrive: return ("hold", "later and it tries again on its own.")
-        case .almostReady: return ("hold", "and start dictating.")
         case .ready: return ("Hold", "and start dictating.")
         }
     }
@@ -1037,22 +1072,22 @@ private struct SetupPane: View {
     ) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             Text(name.uppercased())
-                .font(.system(size: 9, weight: .semibold, design: .rounded))
-                .kerning(0.9)
+                .font(.system(size: at(9), weight: .semibold, design: .rounded))
+                .kerning(at(0.9))
                 .foregroundStyle(.tertiary)
-                .padding(.bottom, 4)
+                .padding(.bottom, at(4))
             // The group carries the explanation, so the lines are bare: a
             // glyph, a name, a size.
             if let blurb {
                 Text(blurb)
-                    .font(.system(size: 11))
+                    .font(.system(size: at(11)))
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
-                    .padding(.bottom, 5)
+                    .padding(.bottom, at(5))
             }
             lines()
         }
-        .padding(.top, 14)
+        .padding(.top, at(14))
     }
 
     @ViewBuilder
@@ -1153,33 +1188,35 @@ private struct EspeakCard: View {
     @State private var copied = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 5) {
+        VStack(alignment: .leading, spacing: SetupMetrics.at(5)) {
             Text("Not installed. Some of your names will be missed without it.")
-                .font(.system(size: 12, weight: .semibold))
+                .font(.system(size: SetupMetrics.at(12), weight: .semibold))
                 .foregroundStyle(Parrot.amber)
                 .fixedSize(horizontal: false, vertical: true)
 
             Text(what)
-                .font(.system(size: 11))
+                .font(.system(size: SetupMetrics.at(11)))
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
 
             // The chained one-liner is 140 characters. Inside a sentence it is
             // unreadable and unselectable, so it gets a field of its own.
             Text(EspeakInstall.command)
-                .font(.system(size: 10, design: .monospaced))
+                .font(.system(size: SetupMetrics.at(10), design: .monospaced))
                 .textSelection(.enabled)
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 6)
+                .padding(.horizontal, SetupMetrics.at(8))
+                .padding(.vertical, SetupMetrics.at(6))
                 .background(
                     Color.primary.opacity(0.08),
-                    in: RoundedRectangle(cornerRadius: Parrot.fieldRadius, style: .continuous)
+                    in: RoundedRectangle(
+                        cornerRadius: SetupMetrics.fieldRadius, style: .continuous
+                    )
                 )
-                .padding(.vertical, 1)
+                .padding(.vertical, SetupMetrics.at(1))
 
-            HStack(spacing: 10) {
+            HStack(spacing: SetupMetrics.at(10)) {
                 Button("Run in Terminal", action: onInstall)
                     .buttonStyle(.borderedProminent)
                 Button(copied ? "Copied" : "Copy the command") {
@@ -1187,22 +1224,21 @@ private struct EspeakCard: View {
                     copied = true
                 }
             }
-            .controlSize(.small)
-            .padding(.top, 2)
+            .padding(.top, SetupMetrics.at(2))
         }
-        .padding(.horizontal, 10)
-        .padding(.top, 8)
-        .padding(.bottom, 9)
+        .padding(.horizontal, SetupMetrics.at(10))
+        .padding(.top, SetupMetrics.at(8))
+        .padding(.bottom, SetupMetrics.at(9))
         .background(
             Parrot.amber.opacity(0.11),
-            in: RoundedRectangle(cornerRadius: 9, style: .continuous)
+            in: RoundedRectangle(cornerRadius: SetupMetrics.radius, style: .continuous)
         )
         .overlay {
-            RoundedRectangle(cornerRadius: 9, style: .continuous)
-                .strokeBorder(Parrot.amber.opacity(0.38), lineWidth: 1)
+            RoundedRectangle(cornerRadius: SetupMetrics.radius, style: .continuous)
+                .strokeBorder(Parrot.amber.opacity(0.38), lineWidth: SetupMetrics.at(1))
         }
         .padding(.leading, SetupMetrics.indent)
-        .padding(.top, 2)
+        .padding(.top, SetupMetrics.at(2))
     }
 
     private var what: String {
@@ -1231,14 +1267,19 @@ private struct SetupLine: View {
     var body: some View {
         HStack(spacing: SetupMetrics.gap) {
             GlyphView(glyph: glyph)
-            Text(title).font(.system(size: 12))
+            Text(title).font(.system(size: SetupMetrics.at(12)))
             if let detail {
-                Text(detail).font(.system(size: 11)).foregroundStyle(.tertiary)
+                Text(detail)
+                    .font(.system(size: SetupMetrics.at(11)))
+                    .foregroundStyle(.tertiary)
             }
-            Spacer(minLength: 8)
+            Spacer(minLength: SetupMetrics.at(8))
             if let note {
                 Text(note)
-                    .font(.system(size: 11, weight: noteIsPercent ? .semibold : .regular))
+                    .font(.system(
+                        size: SetupMetrics.at(11),
+                        weight: noteIsPercent ? .semibold : .regular
+                    ))
                     .monospacedDigit()
                     .foregroundStyle(
                         noteIsPercent
@@ -1246,10 +1287,10 @@ private struct SetupLine: View {
                     )
             }
             if let button {
-                Button(button.title, action: button.action).controlSize(.small)
+                Button(button.title, action: button.action)
             }
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, SetupMetrics.at(4))
         .overlay(alignment: .bottomLeading) { bar }
     }
 
@@ -1260,7 +1301,7 @@ private struct SetupLine: View {
                 let room = max(0, geometry.size.width - SetupMetrics.indent)
                 Rectangle()
                     .fill(Parrot.action)
-                    .frame(width: room * CGFloat(percent) / 100, height: 2)
+                    .frame(width: room * CGFloat(percent) / 100, height: SetupMetrics.at(2))
                     .offset(x: SetupMetrics.indent)
                     .frame(maxHeight: .infinity, alignment: .bottom)
             }
@@ -1275,11 +1316,11 @@ private struct SetupNote: View {
 
     var body: some View {
         Text(text)
-            .font(.system(size: 11))
+            .font(.system(size: SetupMetrics.at(11)))
             .foregroundStyle(tone)
             .fixedSize(horizontal: false, vertical: true)
             .padding(.leading, SetupMetrics.indent)
-            .padding(.bottom, 4)
+            .padding(.bottom, SetupMetrics.at(4))
     }
 }
 
@@ -1309,8 +1350,11 @@ private struct GlyphView: View {
             case .downloading:
                 Circle()
                     .trim(from: 0, to: 0.72)
-                    .stroke(Parrot.action, style: StrokeStyle(lineWidth: 1.6, lineCap: .round))
-                    .frame(width: 10, height: 10)
+                    .stroke(
+                        Parrot.action,
+                        style: StrokeStyle(lineWidth: SetupMetrics.at(1.6), lineCap: .round)
+                    )
+                    .frame(width: SetupMetrics.at(10), height: SetupMetrics.at(10))
                     .rotationEffect(.degrees(spinning ? 360 : 0))
                     .onAppear {
                         withAnimation(.linear(duration: 0.9).repeatForever(autoreverses: false)) {
@@ -1321,16 +1365,19 @@ private struct GlyphView: View {
                 Circle()
                     .stroke(
                         Color.secondary.opacity(0.6),
-                        style: StrokeStyle(lineWidth: 1.2, dash: [2.2, 2.2])
+                        style: StrokeStyle(
+                            lineWidth: SetupMetrics.at(1.2),
+                            dash: [SetupMetrics.at(2.2), SetupMetrics.at(2.2)]
+                        )
                     )
-                    .frame(width: 10, height: 10)
+                    .frame(width: SetupMetrics.at(10), height: SetupMetrics.at(10))
             case .absent:
                 Circle()
-                    .stroke(Parrot.amber, lineWidth: 1.5)
-                    .frame(width: 10, height: 10)
+                    .stroke(Parrot.amber, lineWidth: SetupMetrics.at(1.5))
+                    .frame(width: SetupMetrics.at(10), height: SetupMetrics.at(10))
             }
         }
-        .font(.system(size: 10, weight: .bold))
+        .font(.system(size: SetupMetrics.at(10), weight: .bold))
         .frame(width: SetupMetrics.glyph, height: SetupMetrics.glyph)
     }
 }
@@ -1342,17 +1389,17 @@ private struct HotkeyBadge: View {
 
     var body: some View {
         Text(text)
-            .font(.system(size: 12, weight: .medium, design: .rounded))
+            .font(.system(size: SetupMetrics.at(12), weight: .medium, design: .rounded))
             .foregroundStyle(.primary)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 2)
+            .padding(.horizontal, SetupMetrics.at(8))
+            .padding(.vertical, SetupMetrics.at(2))
             .background(
                 Color.primary.opacity(0.07),
-                in: RoundedRectangle(cornerRadius: Parrot.fieldRadius, style: .continuous)
+                in: RoundedRectangle(cornerRadius: SetupMetrics.fieldRadius, style: .continuous)
             )
             .overlay {
-                RoundedRectangle(cornerRadius: Parrot.fieldRadius, style: .continuous)
-                    .strokeBorder(Parrot.action.opacity(0.55), lineWidth: 1.5)
+                RoundedRectangle(cornerRadius: SetupMetrics.fieldRadius, style: .continuous)
+                    .strokeBorder(Parrot.action.opacity(0.55), lineWidth: SetupMetrics.at(1.5))
             }
     }
 }

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -81,24 +81,18 @@ enum PermissionStep: CaseIterable {
     }
 }
 
-/// A screen in the walk. The permissions are asked for one at a time; the
-/// downloads are one screen that reports on all of them.
+/// A screen in the walk. The permissions are asked for one at a time, and then
+/// there is one screen for everything: what was granted, what is downloading,
+/// and what is on this Mac already.
 enum SetupStep: Equatable {
     case permission(PermissionStep)
-    case downloads
+    case setup
 }
 
 final class PermissionsModel: ObservableObject {
     @Published var micStatus: Permissions.Status = .notDetermined
     @Published var axStatus: Permissions.Status = .notGranted
     @Published var axBlocker: String?
-    /// Pushed from AppDelegate.handleTranscriberStatus, not polled — nothing
-    /// in this file can ask the transcriber actor anything, and this window
-    /// is not the one place that needs to know. Defaults to `.ready` rather
-    /// than an "unknown" third case: a launch that never touches the
-    /// transcriber (transcription disabled) should not sit on a
-    /// "downloading" message forever for a download that will never start.
-    @Published var speechModel: SpeechModelProgress = .ready
     /// Pushed from AppDelegate.updateUI, but only the name of a hotkey that
     /// actually registered — the menu bar's own fallback text (the
     /// *configured* key, shown even when registration failed) would tell
@@ -127,11 +121,6 @@ final class PermissionsModel: ObservableObject {
         case found
     }
 
-    enum SpeechModelProgress: Equatable {
-        case ready
-        case preparing(percent: Int?)
-    }
-
     /// What is left to ask for, fixed when the window opens.
     ///
     /// Fixed rather than recomputed so "1 of 2" does not become "1 of 1" under
@@ -143,7 +132,7 @@ final class PermissionsModel: ObservableObject {
     @Published private(set) var asked = false
     @Published private(set) var context: PermissionsContext = .installing
 
-    var current: SetupStep? { steps.indices.contains(index) ? steps[index] : nil }
+    var current: SetupStep { steps.indices.contains(index) ? steps[index] : .setup }
 
     func status(of step: PermissionStep) -> Permissions.Status {
         switch step {
@@ -161,10 +150,9 @@ final class PermissionsModel: ObservableObject {
     /// Start the walk. Anything already granted is not a screen — nobody needs
     /// to be told about a permission they have given.
     ///
-    /// The Downloads step is always the last one, granted permissions or not.
-    /// It reports fetches that started at launch rather than starting them, so
-    /// there is nothing to skip past — except on a launch that fetches nothing
-    /// at all, where the registry is empty and the step would be blank.
+    /// The setup screen is always the last step, and it is where the walk ends.
+    /// It reports the fetches that started at launch rather than starting them,
+    /// so there is nothing to wait for on it and nothing after it.
     func begin(context: PermissionsContext) {
         self.context = context
         refresh()
@@ -172,17 +160,18 @@ final class PermissionsModel: ObservableObject {
         steps = PermissionStep.allCases
             .filter { status(of: $0) != .granted }
             .map(SetupStep.permission)
-        if !downloads.rows.isEmpty { steps.append(.downloads) }
+        steps.append(.setup)
         index = 0
         asked = false
     }
 
     func markAsked() { asked = true }
 
-    /// The way forward from a step that is not asking for anything: the
-    /// Downloads step's Continue, and the skip a revisit offers.
+    /// The skip a revisit offers on a permission screen. It cannot walk past
+    /// the setup screen: that is the end of the walk, and its button closes
+    /// the window rather than advancing.
     func skip() {
-        guard index < steps.count else { return }
+        guard index + 1 < steps.count else { return }
         index += 1
         asked = false
     }
@@ -194,39 +183,24 @@ final class PermissionsModel: ObservableObject {
     ) -> PermissionsModel {
         let model = PermissionsModel()
         model.context = context
-        model.steps = PermissionStep.allCases.map(SetupStep.permission) + [.downloads]
+        model.steps = PermissionStep.allCases.map(SetupStep.permission) + [.setup]
         model.index = PermissionStep.allCases.firstIndex(of: step) ?? 0
         model.asked = asked
         return model
     }
 
-    /// Parked on the Downloads step, for `--panel-sheet` and `--panels setup`.
-    static func showingDownloads(
+    /// Parked on the setup screen, for `--panel-sheet` and `--panels setup`.
+    static func showingSetup(
         _ downloads: ModelDownloads, context: PermissionsContext = .installing,
-        espeak: EspeakPresence = .missing
+        axStatus: Permissions.Status = .granted, hotkeyDisplay: String = "Right ⌥",
+        hotkeyRegistered: Bool = true, espeak: EspeakPresence = .missing
     ) -> PermissionsModel {
         let model = PermissionsModel(downloads: downloads)
         model.context = context
-        model.steps = PermissionStep.allCases.map(SetupStep.permission) + [.downloads]
-        model.index = PermissionStep.allCases.count
-        model.espeak = espeak
-        return model
-    }
-
-    /// Past every step, for `--panel-sheet` — `showing(_:)` always parks on
-    /// one, and DonePane is only ever reached by walking off the end of
-    /// `steps`, which nothing outside this file can set directly.
-    static func done(
-        speechModel: SpeechModelProgress = .ready, hotkeyDisplay: String = "Right ⌥",
-        hotkeyRegistered: Bool = true, axStatus: Permissions.Status = .granted,
-        downloads: ModelDownloads = ModelDownloads(), espeak: EspeakPresence = .found
-    ) -> PermissionsModel {
-        let model = PermissionsModel(downloads: downloads)
         model.micStatus = .granted
         model.axStatus = axStatus
-        model.steps = PermissionStep.allCases.map(SetupStep.permission) + [.downloads]
-        model.index = model.steps.count
-        model.speechModel = speechModel
+        model.steps = PermissionStep.allCases.map(SetupStep.permission) + [.setup]
+        model.index = PermissionStep.allCases.count
         model.hotkeyDisplay = hotkeyDisplay
         model.hotkeyRegistered = hotkeyRegistered
         model.espeak = espeak
@@ -237,17 +211,11 @@ final class PermissionsModel: ObservableObject {
     /// the poll, so the screen advances itself the moment the box is ticked
     /// rather than waiting to be dismissed.
     func advancePastGranted() {
-        while case .permission(let step)? = current, status(of: step) == .granted {
+        while case .permission(let step) = current, status(of: step) == .granted,
+              index + 1 < steps.count {
             index += 1
             asked = false
         }
-    }
-
-    /// The size the window needs for the screen it is on. The permission
-    /// screens are one instrument and one paragraph; the other two are lists
-    /// that outgrew them.
-    var contentSize: NSSize {
-        NSSize(width: PermissionMetrics.width, height: PermissionMetrics.height(for: current))
     }
 }
 
@@ -269,6 +237,9 @@ final class PermissionsWindowController {
     private var window: NSWindow?
     private var timer: Timer?
     private var sizeWatch: AnyCancellable?
+    /// Set once the window has been centred, so a later resize can keep the
+    /// title bar where it is instead of jumping back to the middle.
+    private var centred = false
     /// When Terminal was opened on the espeak install, so the row can stop
     /// saying so.
     private var openedTerminalAt: Date?
@@ -311,7 +282,9 @@ final class PermissionsWindowController {
         window?.styleMask = context == .installing ? [.titled] : [.titled, .closable]
         NSApp.activate(ignoringOtherApps: true)
         window?.makeKeyAndOrderFront(nil)
+        resizeToContent()
         window?.center()
+        centred = true
         fronting = nil
         succeededIndex = model.index
 
@@ -382,7 +355,6 @@ final class PermissionsWindowController {
             onAsk: { [weak self] step in self?.ask(step) },
             onDecline: { [weak self] in self?.decline() },
             onClose: { [weak self] in self?.window?.close() },
-            onContinue: { [weak self] in self?.model.skip() },
             onRetry: { [weak self] in self?.onRetryDownloads?() },
             onInstallEspeak: { [weak self] in
                 guard let self else { return }
@@ -404,15 +376,21 @@ final class PermissionsWindowController {
         window.title = "\(AppVariant.displayName) Setup"
         window.styleMask = [.titled]
         window.isReleasedWhenClosed = false
-        window.setContentSize(model.contentSize)
         self.window = window
+        resizeToContent()
 
-        // The screens are three different heights, and the window is sized to
-        // its content rather than to the tallest of them. `objectWillChange`
-        // fires before the change lands, so the size is read on the next turn.
-        sizeWatch = model.objectWillChange.sink { [weak self] _ in
-            DispatchQueue.main.async { self?.resizeToStep() }
-        }
+        // Two screens of different shapes, and the setup screen's own height
+        // moves as rows settle, a failure appears, or eSpeak NG turns up. Both
+        // publishers fire before the change lands, so the size is read on the
+        // next turn of the run loop.
+        //
+        // Debounced rather than hopped to the next turn: the poll writes to the
+        // model once a second and a download reports every percent, and each
+        // one of those would otherwise cost a layout pass to find out the
+        // height has not changed.
+        sizeWatch = Publishers.Merge(model.objectWillChange, model.downloads.objectWillChange)
+            .debounce(for: .milliseconds(100), scheduler: DispatchQueue.main)
+            .sink { [weak self] _ in self?.resizeToContent() }
 
         NotificationCenter.default.addObserver(
             forName: NSWindow.willCloseNotification,
@@ -428,14 +406,26 @@ final class PermissionsWindowController {
     /// installation" that quietly moved to the next screen would be the kind of
     /// wording nobody trusts twice. Revisiting, it is a skip, and the walk ends
     /// on the screen that says what is still missing.
-    /// Only when it actually changed: `setContentSize` on every published
-    /// change would fight a window somebody is looking at.
-    private func resizeToStep() {
-        guard let window else { return }
-        let wanted = model.contentSize
-        guard window.contentLayoutRect.size.height != wanted.height else { return }
+    /// The window takes the height its content asks for.
+    ///
+    /// Only when it actually changed: setting the size on every published
+    /// change would fight a window somebody is looking at. The top edge is put
+    /// back afterwards, because `setContentSize` keeps the bottom-left corner
+    /// and a window that grows upward moves its own title bar out from under
+    /// the pointer.
+    private func resizeToContent() {
+        guard let window, let content = window.contentViewController?.view else { return }
+        let fitting = content.fittingSize
+        guard fitting.height > 0 else { return }
+        let wanted = NSSize(width: PermissionMetrics.width, height: fitting.height)
+        guard abs(window.contentLayoutRect.height - wanted.height) > 0.5 else { return }
+
+        let top = window.frame.maxY
         window.setContentSize(wanted)
-        window.center()
+        guard centred else { return }
+        var frame = window.frame
+        frame.origin.y = top - frame.height
+        window.setFrame(frame, display: true)
     }
 
     private func decline() {
@@ -471,16 +461,17 @@ enum PermissionMetrics {
     static let width: CGFloat = 460
     static let height: CGFloat = 328
 
-    /// The other two screens are lists, and they outgrew the permission
-    /// screens rather than fitting inside them.
-    static let downloadsHeight: CGFloat = 700
-    static let doneHeight: CGFloat = 470
+    /// The permission screens are one instrument and one paragraph, and that
+    /// is a fixed shape. The setup screen is four lists whose length depends on
+    /// what is installed, what failed and whether eSpeak NG is here, so it is
+    /// measured rather than declared — see `resizeToContent`. This is the size
+    /// the sheet draws it at when it has no window to ask.
+    static let setupHeight: CGFloat = 740
 
-    static func height(for step: SetupStep?) -> CGFloat {
+    static func height(for step: SetupStep) -> CGFloat? {
         switch step {
         case .permission: return height
-        case .downloads: return downloadsHeight
-        case nil: return doneHeight
+        case .setup: return nil
         }
     }
 }
@@ -491,7 +482,6 @@ struct PermissionsView: View {
     var onAsk: (PermissionStep) -> Void = { _ in }
     var onDecline: () -> Void = {}
     var onClose: () -> Void = {}
-    var onContinue: () -> Void = {}
     var onRetry: () -> Void = {}
     var onInstallEspeak: () -> Void = {}
 
@@ -502,8 +492,8 @@ struct PermissionsView: View {
                 Text(AppVariant.displayName.uppercased())
                     .foregroundStyle(Parrot.action)
                 Spacer()
-                if model.steps.count > 1, let step = model.current,
-                   let position = model.steps.firstIndex(of: step) {
+                if model.steps.count > 1,
+                   let position = model.steps.firstIndex(of: model.current) {
                     Text("\(position + 1) of \(model.steps.count)".uppercased())
                         .foregroundStyle(.tertiary)
                 }
@@ -522,29 +512,20 @@ struct PermissionsView: View {
                     onAsk: { onAsk(step) },
                     onDecline: onDecline
                 )
-            case .downloads:
-                DownloadsPane(
-                    context: model.context,
-                    espeak: model.espeak,
-                    onDecline: onDecline,
-                    onContinue: onContinue,
-                    onRetry: onRetry,
-                    onInstallEspeak: onInstallEspeak
-                )
-            case nil:
-                DonePane(
+            case .setup:
+                SetupPane(
                     micStatus: model.micStatus, axStatus: model.axStatus,
-                    speechModel: model.speechModel, hotkeyDisplay: model.hotkeyDisplay,
-                    hotkeyRegistered: model.hotkeyRegistered, espeak: model.espeak,
-                    onClose: onClose
+                    hotkeyDisplay: model.hotkeyDisplay,
+                    hotkeyRegistered: model.hotkeyRegistered,
+                    context: model.context, espeak: model.espeak,
+                    onDecline: onDecline, onClose: onClose, onRetry: onRetry,
+                    onInstallEspeak: onInstallEspeak
                 )
             }
         }
         .padding(28)
-        .frame(
-            width: PermissionMetrics.width,
-            height: PermissionMetrics.height(for: model.current)
-        )
+        .frame(width: PermissionMetrics.width)
+        .frame(height: PermissionMetrics.height(for: model.current))
         // Stated rather than inherited. In the app this is the window's own
         // background and setting it changes nothing; drawn on `--panel-sheet`
         // there is no window to inherit from, and without this the pane came
@@ -777,69 +758,211 @@ private struct StepPane: View {
     }
 }
 
-private struct DonePane: View {
+// MARK: - The setup screen
+
+/// Where the glyph column ends and the text column begins, so a note under a
+/// line and the bar under it both start where the name does.
+enum SetupMetrics {
+    static let glyph: CGFloat = 14
+    static let gap: CGFloat = 9
+    static var indent: CGFloat { glyph + gap }
+}
+
+/// One screen: what was granted, what is being fetched, and what is on this
+/// Mac already.
+///
+/// The title is the state and the glyphs are the detail. Only the permissions
+/// and the models a dictation waits on can change the title. The other three
+/// arrive in their own time and say so on their own line.
+///
+/// Nothing here starts a download. They start at launch in `warmModels` and
+/// carry on with the window closed, which is why Done never waits.
+private struct SetupPane: View {
     let micStatus: Permissions.Status
     let axStatus: Permissions.Status
-    let speechModel: PermissionsModel.SpeechModelProgress
     let hotkeyDisplay: String
     let hotkeyRegistered: Bool
+    let context: PermissionsContext
     let espeak: PermissionsModel.EspeakPresence
+    let onDecline: () -> Void
     let onClose: () -> Void
+    let onRetry: () -> Void
+    let onInstallEspeak: () -> Void
 
     @EnvironmentObject private var downloads: ModelDownloads
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Spacer(minLength: 16)
-
             Text(title)
                 .font(.system(size: 19, weight: .semibold, design: .rounded))
+                .padding(.top, 20)
                 .padding(.bottom, 7)
 
             invitation
-                .padding(.bottom, 12)
 
-            // Three groups rather than one run of lines, because each is
-            // answered somewhere else: a permission in System Settings, a
-            // download by waiting, and espeak-ng in Terminal.
             group("Permissions") {
-                SetupLine(glyph: micStatus.glyph, title: "Microphone", trailing: micStatus.note)
-                SetupLine(
-                    glyph: axStatus.glyph, title: "Accessibility", trailing: axStatus.note
-                )
+                SetupLine(glyph: micStatus.glyph, title: "Microphone", note: micStatus.note)
+                SetupLine(glyph: axStatus.glyph, title: "Accessibility", note: axStatus.note)
             }
 
-            if !downloads.rows.isEmpty {
-                group("Downloads") {
-                    ForEach(downloads.rows) { row in
-                        SetupLine(
-                            glyph: row.glyph, title: row.name, trailing: row.doneNote,
-                            trailingIsPercent: row.percent != nil
-                        )
-                    }
-                }
-            }
+            models(
+                "Speech and sound",
+                "These audio models process your voice, transform it into text and provide"
+                    + " additional cues to correct transcription artifacts.",
+                in: .sound
+            )
 
-            group("On your Mac") {
-                SetupLine(
-                    glyph: espeak == .found ? .granted : .absent,
-                    title: "eSpeak NG",
-                    trailing: espeak == .found ? nil : "not found"
-                )
-            }
+            models(
+                "Language",
+                "These language models help ParrotFlow apply your vocabulary and correct"
+                    + " transcription artifacts by understanding what you mean.",
+                in: .language
+            )
+
+            group("Other") { espeakLines }
 
             Spacer(minLength: 12)
 
-            HStack {
+            HStack(spacing: 10) {
+                // It means what it says: during setup this quits the app.
+                // Revisiting, there is no installation left to cancel.
+                if context == .installing {
+                    Button(context.declineTitle, action: onDecline)
+                        .buttonStyle(.plain)
+                        .foregroundStyle(.tertiary)
+                        .font(.system(size: 12))
+                }
+
                 Spacer()
-                Button("Done", action: onClose).keyboardShortcut(.defaultAction)
+
+                Button(primaryTitle, action: primaryAction)
+                    .keyboardShortcut(.defaultAction)
             }
         }
     }
 
+    // MARK: What the screen is saying
+
+    private enum Moment {
+        case almostReady
+        case ready
+        case permissionLost
+        case somethingDidNotArrive
+    }
+
+    /// A permission first: it is the only one of the four that cannot be fixed
+    /// by waiting, and it is fixed somewhere else.
+    private var moment: Moment {
+        if lostPermission != nil { return .permissionLost }
+        if downloads.blockingFailure != nil { return .somethingDidNotArrive }
+        return downloads.speechIsIn ? .ready : .almostReady
+    }
+
+    private var lostPermission: PermissionStep? {
+        if micStatus != .granted { return .microphone }
+        if axStatus != .granted { return .accessibility }
+        return nil
+    }
+
+    /// The model the title is about — the first one a dictation waits on, which
+    /// is the speech model.
+    private var speechName: String {
+        downloads.rows.first { $0.blocking }?.name ?? "The speech model"
+    }
+
+    private var title: String {
+        switch moment {
+        case .permissionLost: return "Something was switched off"
+        case .somethingDidNotArrive: return "Something did not arrive"
+        case .almostReady: return "Almost ready"
+        case .ready: return hotkeyRegistered ? "Ready" : "Almost ready"
+        }
+    }
+
+    /// The sentence under the title, and the key it ends on.
+    ///
+    /// The key is a bordered field rather than a word, so it cannot be read
+    /// past — which means the sentence cannot be one `Text` that wraps around
+    /// it. It breaks where the key starts instead.
+    @ViewBuilder
+    private var invitation: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if let lead {
+                Text(lead)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            if let (before, after) = keySentence, hotkeyRegistered {
+                HStack(spacing: 5) {
+                    Text(before)
+                    HotkeyBadge(text: hotkeyDisplay)
+                    Text(after)
+                }
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.bottom, 4)
+    }
+
+    private var lead: String? {
+        switch moment {
+        case .permissionLost:
+            guard let step = lostPermission else { return nil }
+            return "\(step.title) is switched off. Turn it back on in System Settings,"
+                + " and this window updates itself."
+        case .somethingDidNotArrive:
+            let opening = "\(speechName) could not be downloaded, and nothing transcribes"
+                + " without it."
+            // The key line finishes this sentence. Without a hotkey there is no
+            // key line, and it would end on "or".
+            return hotkeyRegistered ? "\(opening) Try again, or" : "\(opening) Try again"
+        case .almostReady:
+            guard hotkeyRegistered else { return unregisteredHotkey }
+            return "\(speechName) is still coming down. Once it is here,"
+        case .ready:
+            return hotkeyRegistered ? nil : unregisteredHotkey
+        }
+    }
+
+    /// Both permissions are granted and the model is in, but the configured key
+    /// never bound — another app already holds it, most likely. Naming the key
+    /// it wanted would tell someone to press a key that does nothing.
+    private var unregisteredHotkey: String {
+        "ParrotFlow's hotkey isn't registered. Check hotkey.key in config.yaml, "
+            + "then reopen this window from the menu bar."
+    }
+
+    private var keySentence: (String, String)? {
+        switch moment {
+        case .permissionLost: return nil
+        case .somethingDidNotArrive: return ("hold", "later and it tries again on its own.")
+        case .almostReady: return ("hold", "and start dictating.")
+        case .ready: return ("Hold", "and start dictating.")
+        }
+    }
+
+    /// A failure nobody is waiting on stays on its own line. Only a model a
+    /// dictation waits for reaches the foot.
+    private var primaryTitle: String {
+        guard moment == .somethingDidNotArrive else { return "Done" }
+        return downloads.blockingFailure?.retryTitle ?? "Done"
+    }
+
+    private func primaryAction() {
+        if moment == .somethingDidNotArrive, downloads.blockingFailure?.retryTitle != nil {
+            onRetry()
+        } else {
+            onClose()
+        }
+    }
+
+    // MARK: The groups
+
     @ViewBuilder
     private func group<Content: View>(
-        _ name: String, @ViewBuilder lines: () -> Content
+        _ name: String, blurb: String? = nil, @ViewBuilder lines: () -> Content
     ) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             Text(name.uppercased())
@@ -847,109 +970,167 @@ private struct DonePane: View {
                 .kerning(0.9)
                 .foregroundStyle(.tertiary)
                 .padding(.bottom, 4)
+            // The group carries the explanation, so the lines are bare: a
+            // glyph, a name, a size.
+            if let blurb {
+                Text(blurb)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.bottom, 5)
+            }
             lines()
         }
-        .padding(.bottom, 12)
+        .padding(.top, 14)
     }
 
-    private var everything: Bool { micStatus == .granted && axStatus == .granted }
-
-    /// "Ready" oversold it while the model was still on its way in — someone
-    /// reads that word, holds the hotkey, and dictates into a download that
-    /// has not finished. Only true once both permissions and the model are
-    /// all the way there.
-    ///
-    /// Only the speech model counts. The other four can still be coming down
-    /// while you dictate: the stages that read them stand aside.
-    private var title: String {
-        guard everything else { return "Something was switched off" }
-        if case .preparing = speechModel { return "Almost ready" }
-        if !hotkeyRegistered { return "Almost ready" }
-        return "Ready"
-    }
-
-    /// Both permissions granted is the gate for reaching this screen at all
-    /// (see `PermissionsModel.begin`'s step filter) — what is still open past
-    /// that is only ever the speech model, and only ever a matter of time,
-    /// not a decision to make. So the two states get their own sentence
-    /// rather than a status line read in silence: one says dictate now, the
-    /// other says what to wait for and then dictate.
-    ///
-    /// The hotkey is a key someone presses, not a word in a sentence — plain
-    /// prose let it blend into "Hold Right Option and start dictating." and
-    /// read past. Its own line, in the same bordered mark this window
-    /// already uses for a key combination, is what makes it the one thing to
-    /// notice here.
     @ViewBuilder
-    private var invitation: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            switch speechModel {
-            case .ready:
-                EmptyView()
-            case .preparing:
-                Text("The speech model is still downloading.")
-                    .font(.system(size: 12))
-                    .foregroundStyle(.secondary)
-            }
-
-            if everything, hotkeyRegistered {
-                HStack(spacing: 6) {
-                    Text(holdVerb)
-                    HotkeyBadge(text: hotkeyDisplay)
-                    Text("and start dictating.")
+    private func models(
+        _ name: String, _ blurb: String, in group: ModelDownload.Group
+    ) -> some View {
+        let rows = downloads.rows(in: group)
+        if !rows.isEmpty {
+            self.group(name, blurb: blurb) {
+                ForEach(rows) { row in
+                    SetupLine(
+                        glyph: row.glyph, title: row.name, detail: row.sizeLabel,
+                        note: row.note, noteIsPercent: row.percent != nil,
+                        percent: row.percent
+                    )
+                    if let why = row.why {
+                        SetupNote(text: why, tone: row.blocking ? Parrot.scarlet : Parrot.amber)
+                    }
                 }
-                .font(.system(size: 12))
-                .foregroundStyle(.secondary)
-            } else if everything {
-                // hotkeyRegistered is false here: both permissions are
-                // granted, but the configured key never bound — another app
-                // already holds it, most likely. Naming the key it wanted
-                // would tell someone to press a key that does nothing.
-                Text("ParrotFlow's hotkey isn't registered. Check hotkey.key in config.yaml, "
-                    + "then reopen this window from the menu bar.")
-                    .font(.system(size: 12))
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            } else {
-                Text("ParrotFlow needs both. Reopen this window from the menu bar when you want to "
-                    + "finish, or check what is missing below.")
-                    .font(.system(size: 12))
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
             }
         }
     }
 
-    private var holdVerb: String {
-        if case .preparing = speechModel { return "Once it's done, hold" }
-        return "Hold"
+    /// The one line the app cannot fetch, so the one line with a button.
+    ///
+    /// Amber, not scarlet: CharsiuG2P covers the base case, so an absent eSpeak
+    /// NG costs some names rather than the feature.
+    @ViewBuilder
+    private var espeakLines: some View {
+        SetupLine(
+            glyph: espeak == .found ? .granted : (espeak == .opening ? .downloading : .absent),
+            title: "eSpeak NG",
+            detail: "GPL-3 · a separate program",
+            note: espeak == .opening ? "Terminal open" : nil,
+            button: espeak == .missing ? ("Run in Terminal", onInstallEspeak) : nil
+        )
+        if espeak != .found {
+            SetupNote(text: espeakHow, tone: Parrot.amber)
+            CommandField()
+        }
+    }
+
+    private var espeakHow: String {
+        if espeak == .opening {
+            return "Terminal is running it now. This line notices on its own when it lands."
+        }
+        let backs = "Backs up CharsiuG2P on names it misses."
+        if EspeakInstall.brew != nil {
+            return "\(backs) Not installed. This runs it in Terminal, where you can watch it."
+        }
+        return "\(backs) Not installed, and neither is Homebrew. This installs Homebrew first,"
+            + " then eSpeak NG."
     }
 }
 
-/// One line of the last screen: a glyph in a fixed column, a name, and a word
-/// at the right edge only where the glyph cannot say it.
+/// One line: a glyph in a fixed column, a name, what it costs, and a word at
+/// the right edge only where the glyph cannot say it.
 private struct SetupLine: View {
     let glyph: SetupGlyph
     let title: String
-    var trailing: String?
-    var trailingIsPercent: Bool = false
+    var detail: String?
+    var note: String?
+    var noteIsPercent = false
+    /// Draws a 2 px bar under this line and no other.
+    var percent: Int?
+    var button: (title: String, action: () -> Void)?
 
     var body: some View {
-        HStack(spacing: 9) {
+        HStack(spacing: SetupMetrics.gap) {
             GlyphView(glyph: glyph)
             Text(title).font(.system(size: 12))
+            if let detail {
+                Text(detail).font(.system(size: 11)).foregroundStyle(.tertiary)
+            }
             Spacer(minLength: 8)
-            if let trailing {
-                Text(trailing)
-                    .font(.system(size: 11, weight: trailingIsPercent ? .semibold : .regular))
+            if let note {
+                Text(note)
+                    .font(.system(size: 11, weight: noteIsPercent ? .semibold : .regular))
                     .monospacedDigit()
                     .foregroundStyle(
-                        trailingIsPercent
+                        noteIsPercent
                             ? AnyShapeStyle(Parrot.action) : AnyShapeStyle(.tertiary)
                     )
             }
+            if let button {
+                Button(button.title, action: button.action).controlSize(.small)
+            }
         }
-        .padding(.vertical, 2)
+        .padding(.vertical, 4)
+        .overlay(alignment: .bottomLeading) { bar }
+    }
+
+    @ViewBuilder
+    private var bar: some View {
+        if let percent {
+            GeometryReader { geometry in
+                let room = max(0, geometry.size.width - SetupMetrics.indent)
+                Rectangle()
+                    .fill(Parrot.action)
+                    .frame(width: room * CGFloat(percent) / 100, height: 2)
+                    .offset(x: SetupMetrics.indent)
+                    .frame(maxHeight: .infinity, alignment: .bottom)
+            }
+        }
+    }
+}
+
+/// The one line under a name that says why it failed, or what to do about it.
+private struct SetupNote: View {
+    let text: String
+    let tone: Color
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 11))
+            .foregroundStyle(tone)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.leading, SetupMetrics.indent)
+            .padding(.bottom, 4)
+    }
+}
+
+/// The chained one-liner is 140 characters. Inside a sentence it is unreadable
+/// and unselectable, so it gets a field and a way to copy.
+private struct CommandField: View {
+    @State private var copied = false
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text(EspeakInstall.command)
+                .font(.system(size: 10, design: .monospaced))
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Button(copied ? "Copied" : "Copy") {
+                EspeakInstall.copyCommand()
+                copied = true
+            }
+            .controlSize(.small)
+        }
+        .padding(.leading, 10)
+        .padding(.trailing, 8)
+        .padding(.vertical, 6)
+        .background(
+            Color.primary.opacity(0.08),
+            in: RoundedRectangle(cornerRadius: Parrot.fieldRadius, style: .continuous)
+        )
+        .padding(.leading, SetupMetrics.indent)
+        .padding(.bottom, 2)
     }
 }
 
@@ -1001,7 +1182,7 @@ private struct GlyphView: View {
             }
         }
         .font(.system(size: 10, weight: .bold))
-        .frame(width: 14, height: 14)
+        .frame(width: SetupMetrics.glyph, height: SetupMetrics.glyph)
     }
 }
 
@@ -1015,7 +1196,7 @@ private struct HotkeyBadge: View {
             .font(.system(size: 12, weight: .medium, design: .rounded))
             .foregroundStyle(.primary)
             .padding(.horizontal, 8)
-            .padding(.vertical, 3)
+            .padding(.vertical, 2)
             .background(
                 Color.primary.opacity(0.07),
                 in: RoundedRectangle(cornerRadius: Parrot.fieldRadius, style: .continuous)
@@ -1056,314 +1237,21 @@ private extension ModelDownload {
         return nil
     }
 
-    /// The word at the right edge of the last screen's line, where a glyph
-    /// cannot carry it.
-    var doneNote: String? {
+    /// The word at the right edge, where a glyph cannot carry it.
+    var note: String? {
         switch state {
         case .downloading(let percent): return percent.map { "\($0)%" }
         case .off(let reason): return reason
-        case .failed: return "did not arrive"
-        case .installed, .waiting: return nil
-        }
-    }
-}
-
-// MARK: - Downloads
-
-/// What the app is fetching, and the one thing it looks for instead.
-///
-/// Nothing here starts a download. They start at launch, in `warmModels`, and
-/// they carry on whether or not this window is open. The rows report.
-private struct DownloadsPane: View {
-    let context: PermissionsContext
-    let espeak: PermissionsModel.EspeakPresence
-    let onDecline: () -> Void
-    let onContinue: () -> Void
-    let onRetry: () -> Void
-    let onInstallEspeak: () -> Void
-
-    @EnvironmentObject private var downloads: ModelDownloads
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text(downloads.summary.uppercased())
-                .font(.system(size: 9, weight: .semibold, design: .rounded))
-                .kerning(0.9)
-                .foregroundStyle(eyebrowColour)
-                .padding(.top, 20)
-                .padding(.bottom, 6)
-
-            Text("Downloads")
-                .font(.system(size: 19, weight: .semibold, design: .rounded))
-                .padding(.bottom, 7)
-
-            Text("ParrotFlow needs the following models to process your dictation on this Mac.")
-                .font(.system(size: 14))
-                .lineSpacing(2)
-                .fixedSize(horizontal: false, vertical: true)
-
-            group(
-                "Speech and sound",
-                "These audio models process your voice, transform it into text and provide"
-                    + " additional cues to correct transcription artifacts.",
-                rows: downloads.rows(in: .sound)
-            )
-
-            group(
-                "Language",
-                "These language models help ParrotFlow apply your vocabulary and correct"
-                    + " transcription artifacts by understanding what you mean.",
-                rows: downloads.rows(in: .language)
-            )
-
-            groupKey("Already on your Mac, or not")
-                .padding(.top, 16)
-                .padding(.bottom, 7)
-            EspeakRow(presence: espeak, onInstall: onInstallEspeak)
-
-            Spacer(minLength: 14)
-
-            HStack(spacing: 10) {
-                // Offered here and not on the permission screens, and it means
-                // what it says: this quits the app. Only while installing —
-                // revisiting, it would say "Not now" beside a Continue that
-                // does the same thing.
-                if context == .installing {
-                    Button(context.declineTitle, action: onDecline)
-                        .buttonStyle(.plain)
-                        .foregroundStyle(.tertiary)
-                        .font(.system(size: 12))
-                }
-
-                Spacer()
-
-                // Never disabled. Nothing on this screen is a condition of
-                // going on: the speech model is the only one a dictation waits
-                // for, and it says so on the screen after this one.
-                Button(primaryTitle, action: primaryAction)
-                    .keyboardShortcut(.defaultAction)
-            }
+        case .installed, .waiting, .failed: return nil
         }
     }
 
-    @ViewBuilder
-    private func group(_ name: String, _ what: String, rows: [ModelDownload]) -> some View {
-        if !rows.isEmpty {
-            VStack(alignment: .leading, spacing: 0) {
-                groupKey(name).padding(.bottom, 3)
-                // The group carries the explanation, so the rows are bare: a
-                // name, a size, a state.
-                Text(what)
-                    .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .padding(.bottom, 7)
-                VStack(spacing: 6) {
-                    ForEach(rows) { DownloadRow(row: $0) }
-                }
-            }
-            .padding(.top, 16)
-        }
-    }
-
-    private func groupKey(_ name: String) -> some View {
-        Text(name.uppercased())
-            .font(.system(size: 9, weight: .semibold, design: .rounded))
-            .kerning(0.9)
-            .foregroundStyle(.tertiary)
-    }
-
-    /// A failure nobody is waiting on stays inside its own row. Only a model a
-    /// dictation waits for reaches the foot.
-    private var primaryTitle: String {
-        downloads.blockingFailure?.retryTitle ?? "Continue"
-    }
-
-    private func primaryAction() {
-        if downloads.blockingFailure?.retryTitle != nil { onRetry() } else { onContinue() }
-    }
-
-    private var eyebrowColour: Color {
-        if downloads.rows.contains(where: { $0.state.hasFailed }) { return Parrot.scarlet }
-        if downloads.anyDownloading { return Parrot.action }
-        if downloads.rows.allSatisfy({ $0.state == .installed }) { return Parrot.leaf }
-        return Parrot.amber
-    }
-}
-
-private struct DownloadRow: View {
-    let row: ModelDownload
-
-    var body: some View {
-        HStack(spacing: 12) {
-            VStack(alignment: .leading, spacing: 3) {
-                HStack(spacing: 7) {
-                    Text(row.name).font(.system(size: 13, weight: .semibold))
-                    Text(row.sizeLabel).font(.system(size: 11)).foregroundStyle(.tertiary)
-                }
-                // The second line exists only to say why a row failed.
-                if let why = row.state.failure {
-                    Text(sentence(for: why))
-                        .font(.system(size: 11))
-                        .foregroundStyle(row.blocking ? Parrot.scarlet : Parrot.amber)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-            }
-            Spacer(minLength: 8)
-            state
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-        .background(Color.primary.opacity(0.06))
-        .overlay(alignment: .bottomLeading) { bar }
-        .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
-    }
-
-    /// A model nothing waits on clears its own failed fetch, so the row says
-    /// what happens next rather than asking for a decision.
-    private func sentence(for why: ModelDownload.Failure) -> String {
-        guard !row.blocking else { return why.message }
-        return why.message + " The next dictation that needs it tries again."
-    }
-
-    @ViewBuilder
-    private var state: some View {
-        switch row.state {
-        case .downloading(let percent):
-            if let percent {
-                Text("\(percent)%")
-                    .font(.system(size: 12, weight: .semibold))
-                    .monospacedDigit()
-                    .foregroundStyle(Parrot.action)
-            } else {
-                // No number rather than an invented one: this fetch reports no
-                // fraction.
-                GlyphView(glyph: .downloading)
-            }
-        case .waiting:
-            SetupBadge(text: "Waiting", color: .secondary)
-        case .installed:
-            SetupBadge(text: "Installed", color: Parrot.leaf)
-        case .off(let reason):
-            SetupBadge(text: reason, color: .secondary)
-        case .failed:
-            SetupBadge(
-                text: row.blocking ? "Failed" : "Will retry",
-                color: row.blocking ? Parrot.scarlet : Parrot.amber
-            )
-        }
-    }
-
-    @ViewBuilder
-    private var bar: some View {
-        if let percent = row.percent {
-            GeometryReader { geometry in
-                Rectangle()
-                    .fill(Parrot.action)
-                    .frame(width: geometry.size.width * CGFloat(percent) / 100, height: 2)
-                    .frame(maxHeight: .infinity, alignment: .bottom)
-            }
-        }
-    }
-}
-
-/// The one row no button can fetch, so the one row with controls.
-///
-/// Amber, not scarlet: CharsiuG2P covers the base case, so an absent eSpeak NG
-/// costs some names rather than the feature.
-private struct EspeakRow: View {
-    let presence: PermissionsModel.EspeakPresence
-    let onInstall: () -> Void
-
-    @State private var copied = false
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 9) {
-            HStack(spacing: 12) {
-                VStack(alignment: .leading, spacing: 3) {
-                    HStack(spacing: 7) {
-                        Text("eSpeak NG").font(.system(size: 13, weight: .semibold))
-                        Text("GPL-3 · a separate program")
-                            .font(.system(size: 10))
-                            .foregroundStyle(.tertiary)
-                    }
-                    Text("Backs up CharsiuG2P on names it misses.")
-                        .font(.system(size: 11))
-                        .foregroundStyle(.secondary)
-                    if presence != .found {
-                        Text(how)
-                            .font(.system(size: 11))
-                            .foregroundStyle(Parrot.amber)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                }
-                Spacer(minLength: 8)
-                switch presence {
-                case .missing:
-                    Button("Run in Terminal", action: onInstall).controlSize(.small)
-                case .opening:
-                    SetupBadge(text: "Terminal open", color: .secondary)
-                case .found:
-                    SetupBadge(text: "Found", color: Parrot.leaf)
-                }
-            }
-
-            // The chained one-liner is 130 characters. Inside a sentence it is
-            // unreadable and unselectable, so it gets a field and a way to copy.
-            if presence != .found {
-                HStack(alignment: .top, spacing: 8) {
-                    Text(EspeakInstall.command)
-                        .font(.system(size: 10, design: .monospaced))
-                        .textSelection(.enabled)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    Button(copied ? "Copied" : "Copy") {
-                        EspeakInstall.copyCommand()
-                        copied = true
-                    }
-                    .controlSize(.small)
-                }
-                .padding(.leading, 10)
-                .padding(.trailing, 8)
-                .padding(.vertical, 7)
-                .background(
-                    Color.primary.opacity(0.09),
-                    in: RoundedRectangle(cornerRadius: Parrot.fieldRadius, style: .continuous)
-                )
-            }
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 9)
-        .background(
-            Color.primary.opacity(0.06),
-            in: RoundedRectangle(cornerRadius: 9, style: .continuous)
-        )
-    }
-
-    private var how: String {
-        if presence == .opening {
-            return "Terminal is running it now. This row notices on its own when it lands."
-        }
-        if EspeakInstall.brew != nil {
-            return "Not installed. This runs it in Terminal, where you can watch it."
-        }
-        return "Not installed, and neither is Homebrew. This installs Homebrew first,"
-            + " then eSpeak NG."
-    }
-}
-
-private struct SetupBadge: View {
-    let text: String
-    let color: Color
-
-    var body: some View {
-        Text(text.uppercased())
-            .font(.system(size: 10, weight: .bold))
-            .kerning(0.3)
-            .padding(.horizontal, 7)
-            .padding(.vertical, 2)
-            .background(color.opacity(0.18), in: Capsule())
-            .foregroundStyle(color)
-            .fixedSize()
+    /// The one line under the name, only on a failure. A model nothing waits
+    /// on clears its own failed fetch, so its line says what happens next
+    /// rather than asking for a decision.
+    var why: String? {
+        guard let failure = state.failure else { return nil }
+        guard !blocking else { return failure.message }
+        return failure.message + " The next dictation that needs it tries again."
     }
 }

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -537,7 +537,7 @@ enum PermissionMetrics {
     /// what is installed, what failed and whether eSpeak NG is here, so it is
     /// measured rather than declared — see `resizeToContent`. This is the size
     /// the sheet draws it at when it has no window to ask.
-    static let setupHeight: CGFloat = 740
+    static let setupHeight: CGFloat = 770
 
     static func height(for step: SetupStep) -> CGFloat? {
         switch step {
@@ -951,7 +951,7 @@ private struct SetupPane: View {
     /// waiting, and it is fixed somewhere else.
     ///
     /// An empty registry means `transcription.enabled` is false. `warmModels`
-    /// declares all five rows before this window opens and returns before
+    /// declares all six rows before this window opens and returns before
     /// declaring any only on that one setting, so there is nothing else it can
     /// mean.
     private var moment: Moment {

--- a/Sources/ParrotFlow/Phonemes.swift
+++ b/Sources/ParrotFlow/Phonemes.swift
@@ -36,11 +36,19 @@ enum Phonemes {
     /// guessed was stressed.
     static let marks: Set<Character> = ["ˈ", "ˌ", "ː", "ˑ"]
 
-    /// Where espeak-ng is, if it is anywhere. Resolved once.
+    /// Where espeak-ng is, if it is anywhere.
     ///
+    /// Resolved once when it is there. When it is not, the search runs again:
+    /// it can be installed while the app is running, and the setup screen
+    /// offers to do exactly that. Four `isExecutableFile` calls, and only on a
+    /// machine that does not have it.
+    static var binary: String? { firstLook ?? locate() }
+
+    private static let firstLook: String? = locate()
+
     /// `PARROTFLOW_ESPEAK` first, so a test can point at a stub, then the
     /// two places Homebrew puts it, then the system path.
-    static let binary: String? = {
+    static func locate() -> String? {
         var places: [String] = []
         if let named = ProcessInfo.processInfo.environment["PARROTFLOW_ESPEAK"] {
             places.append(named)
@@ -48,7 +56,7 @@ enum Phonemes {
         places += ["/opt/homebrew/bin/espeak-ng", "/usr/local/bin/espeak-ng",
                    "/usr/bin/espeak-ng"]
         return places.first { FileManager.default.isExecutableFile(atPath: $0) }
-    }()
+    }
 
     // MARK: - Asking espeak
 

--- a/Sources/ParrotFlow/SentenceReadings.swift
+++ b/Sources/ParrotFlow/SentenceReadings.swift
@@ -209,6 +209,18 @@ actor SentenceReadings {
     private var retryAfter: Date?
     private static let backoff: TimeInterval = 300
 
+    /// Forgets the backoff and starts the load, for the setup screen's repair
+    /// button.
+    ///
+    /// The two steps are one call because they are one decision. Clearing the
+    /// deadline and warming from separate tasks races: `warm` can reach the
+    /// actor first, still see the deadline, and return — leaving the row back
+    /// on "waiting" with nothing fetching.
+    func retryNow() {
+        retryAfter = nil
+        warm()
+    }
+
     /// Starts the load if nothing is doing it, and returns at once.
     func warm() {
         guard loaded == nil, loading == nil else { return }

--- a/Sources/ParrotFlow/SentenceReadings.swift
+++ b/Sources/ParrotFlow/SentenceReadings.swift
@@ -252,6 +252,13 @@ actor SentenceReadings {
         }
     }
 
+    /// Deletes the cache, so the next `prepare` fetches it again. `build`
+    /// skips the fetch whenever `isCached` is true, weights that load as the
+    /// wrong model included.
+    static func discardCache() {
+        try? FileManager.default.removeItem(at: cache.directory)
+    }
+
     private static func build(
         progress: (@Sendable (String) -> Void)?
     ) async throws -> ModelContext {

--- a/Sources/ParrotFlow/SentenceReadings.swift
+++ b/Sources/ParrotFlow/SentenceReadings.swift
@@ -42,6 +42,12 @@ actor SentenceReadings {
 
     static let shared = SentenceReadings()
 
+    /// The row the setup screen draws for it.
+    static let download = ModelDownload(
+        id: "sentence-readings", name: "Qwen3 0.6B Base", megabytes: 320, peak: 320,
+        group: .language, blocking: false
+    )
+
     /// `model.safetensors.index.json` is absent from this repository — the
     /// weights are one file — and listing it would fail the fetch.
     static let cache = MLXModelCache(
@@ -61,7 +67,8 @@ actor SentenceReadings {
             .appendingPathComponent("models/qwen3-0.6b-base-4bit", isDirectory: true),
         lockURL: AppVariant.supportDirectory
             .appendingPathComponent("models/qwen3-0.6b-base.lock"),
-        label: "sentence readings"
+        label: "sentence readings",
+        downloadID: download.id
     )
 
     static var directory: URL { cache.directory }
@@ -231,9 +238,18 @@ actor SentenceReadings {
         let task = Task<ModelContext, Error> { try await Self.build(progress: progress) }
         loading = task
         defer { loading = nil }
-        let built = try await task.value
-        loaded = built
-        return built
+        do {
+            let built = try await task.value
+            loaded = built
+            ModelDownloads.report(Self.download.id, .installed)
+            return built
+        } catch {
+            ModelDownloads.report(
+                Self.download.id,
+                .failed(ModelDownloads.failure(error, needs: Self.download.peakLabel))
+            )
+            throw error
+        }
     }
 
     private static func build(

--- a/Sources/ParrotFlow/SentenceReadings.swift
+++ b/Sources/ParrotFlow/SentenceReadings.swift
@@ -45,7 +45,8 @@ actor SentenceReadings {
     /// The row the setup screen draws for it.
     static let download = ModelDownload(
         id: "sentence-readings", name: "Qwen3 0.6B Base", megabytes: 320, peak: 320,
-        group: .language, blocking: false
+        group: .language, blocking: false,
+        costOfFailure: "a sentence a pause cut in two is left as it arrived"
     )
 
     /// `model.safetensors.index.json` is absent from this repository — the

--- a/Sources/ParrotFlow/SlotModel.swift
+++ b/Sources/ParrotFlow/SlotModel.swift
@@ -186,6 +186,14 @@ actor SlotModel {
         try await body()
     }
 
+    /// Deletes the cache, so the next `prepare` fetches it again.
+    ///
+    /// `build` already re-fetches a cache that will not load, once. This is for
+    /// the retry after that one failed too.
+    static func discardCache() {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
     /// **`.cpuAndGPU`, not the default.** On the Neural Engine this model is not
     /// approximately right, it is wrong: 0 of 238 filler lists match PyTorch and
     /// the correlation at the mask falls to 0.156. Here it is 0.99999 and up.

--- a/Sources/ParrotFlow/SlotModel.swift
+++ b/Sources/ParrotFlow/SlotModel.swift
@@ -36,7 +36,7 @@ actor SlotModel {
     /// disk: the downloaded package and the compile of it both exist until the
     /// compile finishes.
     static let download = ModelDownload(
-        id: "slot", name: "mmBERT-small", megabytes: 286, peak: 580,
+        id: "slot", name: "mmBERT-small", megabytes: 282, peak: 580,
         group: .language, blocking: false,
         costOfFailure: "the vocabulary gate asks the judge instead"
     )

--- a/Sources/ParrotFlow/SlotModel.swift
+++ b/Sources/ParrotFlow/SlotModel.swift
@@ -37,7 +37,8 @@ actor SlotModel {
     /// compile finishes.
     static let download = ModelDownload(
         id: "slot", name: "mmBERT-small", megabytes: 286, peak: 580,
-        group: .language, blocking: false
+        group: .language, blocking: false,
+        costOfFailure: "the vocabulary gate asks the judge instead"
     )
 
     private static let repository = "znaat/mmbert-small-coreml"

--- a/Sources/ParrotFlow/SlotModel.swift
+++ b/Sources/ParrotFlow/SlotModel.swift
@@ -32,6 +32,14 @@ actor SlotModel {
 
     static let shared = SlotModel()
 
+    /// The row the setup screen draws for it. The peak is not the size on
+    /// disk: the downloaded package and the compile of it both exist until the
+    /// compile finishes.
+    static let download = ModelDownload(
+        id: "slot", name: "mmBERT-small", megabytes: 286, peak: 580,
+        group: .language, blocking: false
+    )
+
     private static let repository = "znaat/mmbert-small-coreml"
     /// Pinned, not `main`. The tokenizer fixture in `tests/` is the answer for
     /// one `tokenizer.json`, and the gap cases are the answer for one set of
@@ -130,9 +138,18 @@ actor SlotModel {
         }
         loading = task
         defer { loading = nil }
-        let loaded = try await task.value
-        model = loaded
-        return loaded
+        do {
+            let loaded = try await task.value
+            model = loaded
+            ModelDownloads.report(Self.download.id, .installed)
+            return loaded
+        } catch {
+            ModelDownloads.report(
+                Self.download.id,
+                .failed(ModelDownloads.failure(error, needs: Self.download.peakLabel))
+            )
+            throw error
+        }
     }
 
     private static func build(
@@ -213,13 +230,14 @@ actor SlotModel {
         defer { try? files.removeItem(at: staging) }
 
         let reported = Reported()
+        ModelDownloads.report(download.id, .downloading(percent: nil))
         try await HubDownload.fetch(
             repo: repository, revision: revision, paths: Self.files, into: staging
         ) { fraction in
-            guard let progress else { return }
             let percent = Int((fraction * 100).rounded())
             guard reported.advanced(to: percent) else { return }
-            progress("slot model \(percent)%")
+            ModelDownloads.report(download.id, .downloading(percent: percent))
+            progress?("slot model \(percent)%")
         }
 
         let compiled = try await MLModel.compileModel(

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -34,12 +34,15 @@ actor Transcriber {
     /// `Status.downloading` cannot drift apart.
     static let speechDownload = ModelDownload(
         id: "speech", name: "Parakeet TDT 0.6B v3", megabytes: 461, peak: 461,
-        group: .sound, blocking: true
+        group: .sound, blocking: true,
+        costOfFailure: "nothing transcribes without it"
     )
 
     static let voiceDownload = ModelDownload(
         id: "voice-detector", name: "Silero VAD", megabytes: 1, peak: 1,
-        group: .sound, blocking: true
+        group: .sound, blocking: true,
+        costOfFailure: "dictation runs without it, transcribing the whole clip"
+            + " rather than only where you spoke"
     )
 
     private var vad: VadManager?

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -111,6 +111,24 @@ actor Transcriber {
         }
     }
 
+    /// Deletes the speech model, so the next `prepare` fetches it again.
+    ///
+    /// `AsrModels.downloadAndLoad` skips the download when the files are there,
+    /// so a copy that will not load is handed back to the loader for ever
+    /// unless the bytes go first. FluidAudio's cache is shared with the other
+    /// build of this app; a copy that will not load is broken for both, so
+    /// throwing it away repairs both.
+    static func discardSpeechModel() {
+        let cache = AsrModels.defaultCacheDirectory()
+        do {
+            try FileManager.default.removeItem(at: cache)
+            Log.write("speech model: deleted the damaged copy at \(cache.path)")
+        } catch {
+            Log.write("speech model: could not delete \(cache.path)"
+                + " — \(error.localizedDescription)")
+        }
+    }
+
     private func loadVad() async throws -> VadManager? {
         if let loadingVad { return try await loadingVad.value }
         let row = Self.voiceDownload

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -132,6 +132,18 @@ actor Transcriber {
         }
     }
 
+    /// The same, for the voice detector. Its own folder in the same cache.
+    static func discardVoiceDetector() {
+        let cache = MLModelConfigurationUtils.defaultModelsDirectory(for: .vad)
+        do {
+            try FileManager.default.removeItem(at: cache)
+            Log.write("voice detector: deleted the damaged copy at \(cache.path)")
+        } catch {
+            Log.write("voice detector: could not delete \(cache.path)"
+                + " — \(error.localizedDescription)")
+        }
+    }
+
     private func loadVad() async throws -> VadManager? {
         if let loadingVad { return try await loadingVad.value }
         let row = Self.voiceDownload

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -29,6 +29,19 @@ actor Transcriber {
 
     private(set) var status: Status = .idle
 
+    /// The two rows the setup screen draws for this file. `blocking` is read
+    /// back out where the status is set, so a row's severity and the flag on
+    /// `Status.downloading` cannot drift apart.
+    static let speechDownload = ModelDownload(
+        id: "speech", name: "Parakeet TDT 0.6B v3", megabytes: 461, peak: 461,
+        group: .sound, blocking: true
+    )
+
+    static let voiceDownload = ModelDownload(
+        id: "voice-detector", name: "Silero VAD", megabytes: 1, peak: 1,
+        group: .sound, blocking: true
+    )
+
     private var vad: VadManager?
     private var models: AsrModels?
 
@@ -71,7 +84,11 @@ actor Transcriber {
 
     private func loadModels() async throws -> AsrModels {
         if let loadingModels { return try await loadingModels.value }
-        setStatus(.downloading("speech model", blocking: true))
+        let row = Self.speechDownload
+        setStatus(.downloading("speech model", blocking: row.blocking))
+        // Before the first percentage, which does not arrive for a copy that
+        // is already on disk.
+        ModelDownloads.report(row.id, .downloading(percent: nil))
         let task = Task<AsrModels, Error> {
             try await AsrModels.downloadAndLoad(
                 progressHandler: { [weak self] progress in
@@ -82,16 +99,37 @@ actor Transcriber {
         }
         loadingModels = task
         defer { loadingModels = nil }
-        return try await task.value
+        do {
+            let loaded = try await task.value
+            ModelDownloads.report(row.id, .installed)
+            return loaded
+        } catch {
+            ModelDownloads.report(
+                row.id, .failed(ModelDownloads.failure(error, needs: row.peakLabel))
+            )
+            throw error
+        }
     }
 
     private func loadVad() async throws -> VadManager? {
         if let loadingVad { return try await loadingVad.value }
-        setStatus(.downloading("voice detector", blocking: true))
+        let row = Self.voiceDownload
+        setStatus(.downloading("voice detector", blocking: row.blocking))
+        ModelDownloads.report(row.id, .downloading(percent: nil))
         let task = Task<VadManager?, Error> {
-            let vad = try? await VadManager(config: .default)
-            if vad == nil { Log.write("speech gate: VAD unavailable; transcribing everything") }
-            return vad
+            do {
+                let vad = try await VadManager(config: .default)
+                ModelDownloads.report(row.id, .installed)
+                return vad
+            } catch {
+                // Swallowed, as it always was: without the gate the app
+                // transcribes everything rather than nothing. The row says so.
+                Log.write("speech gate: VAD unavailable; transcribing everything")
+                ModelDownloads.report(
+                    row.id, .failed(ModelDownloads.failure(error, needs: row.peakLabel))
+                )
+                return nil
+            }
         }
         loadingVad = task
         defer { loadingVad = nil }
@@ -137,7 +175,8 @@ actor Transcriber {
         let percent = Int((progress.fractionCompleted * 100).rounded())
         guard percent != lastReportedPercent else { return }
         lastReportedPercent = percent
-        setStatus(.downloading("\(label) \(percent)%", blocking: true))
+        setStatus(.downloading("\(label) \(percent)%", blocking: Self.speechDownload.blocking))
+        ModelDownloads.report(Self.speechDownload.id, .downloading(percent: percent))
     }
 
     /// The slot model fetch, once per process. Cleared when it fails, so the
@@ -177,12 +216,17 @@ actor Transcriber {
 
     private func reportSlotModel(_ label: String) {
         guard slotModelRunning else { return }
-        onStatusChange(.downloading(label, blocking: false))
+        // Reported, not recorded. `status` says whether the transcriber can
+        // transcribe, and during this fetch it can.
+        onStatusChange(.downloading(label, blocking: SlotModel.download.blocking))
     }
 
     private func finishSlotModel(failed: Bool) {
         slotModelRunning = false
         if failed { slotModelFetch = nil }
+        // Whatever was true before this started is true again. Usually
+        // `.ready`, which is what clears the label the fetch put up — unless
+        // the other fetch is still going, and then its label stays.
         restoreStatusIfIdle()
     }
 
@@ -218,7 +262,7 @@ actor Transcriber {
 
     private func reportSoundModel(_ label: String) {
         guard soundModelRunning else { return }
-        onStatusChange(.downloading(label, blocking: false))
+        onStatusChange(.downloading(label, blocking: NeuralPhonemes.soundDownload.blocking))
     }
 
     private func finishSoundModel(failed: Bool) {

--- a/Sources/ParrotFlow/WordVectors.swift
+++ b/Sources/ParrotFlow/WordVectors.swift
@@ -131,6 +131,13 @@ actor WordVectors {
         }
     }
 
+    /// Deletes the cache, so the next `prepare` fetches it again. `build`
+    /// skips the fetch whenever `isCached` is true, weights that load as the
+    /// wrong model included.
+    static func discardCache() {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
     private static func build(
         progress: (@Sendable (String) -> Void)?
     ) async throws -> ModelContext {

--- a/Sources/ParrotFlow/WordVectors.swift
+++ b/Sources/ParrotFlow/WordVectors.swift
@@ -30,7 +30,8 @@ actor WordVectors {
     /// The row the setup screen draws for it.
     static let download = ModelDownload(
         id: "word-vectors", name: "Qwen3 Embedding 0.6B", megabytes: 335, peak: 335,
-        group: .language, blocking: false
+        group: .language, blocking: false,
+        costOfFailure: "the sentence gate stands aside"
     )
 
     /// The cache and its download. The file list is not the whole repository:

--- a/Sources/ParrotFlow/WordVectors.swift
+++ b/Sources/ParrotFlow/WordVectors.swift
@@ -27,6 +27,12 @@ actor WordVectors {
 
     static let shared = WordVectors()
 
+    /// The row the setup screen draws for it.
+    static let download = ModelDownload(
+        id: "word-vectors", name: "Qwen3 Embedding 0.6B", megabytes: 335, peak: 335,
+        group: .language, blocking: false
+    )
+
     /// The cache and its download. The file list is not the whole repository:
     /// `model.safetensors.index.json` is absent from it, and listing a file
     /// that is not there fails the fetch on `unlisted`.
@@ -47,7 +53,8 @@ actor WordVectors {
             .appendingPathComponent("models/qwen3-embedding-0.6b-4bit", isDirectory: true),
         lockURL: AppVariant.supportDirectory
             .appendingPathComponent("models/qwen3-embedding.lock"),
-        label: "word vectors"
+        label: "word vectors",
+        downloadID: download.id
     )
 
     static var directory: URL { cache.directory }
@@ -110,9 +117,18 @@ actor WordVectors {
         let task = Task<ModelContext, Error> { try await Self.build(progress: progress) }
         loading = task
         defer { loading = nil }
-        let built = try await task.value
-        loaded = built
-        return built
+        do {
+            let built = try await task.value
+            loaded = built
+            ModelDownloads.report(Self.download.id, .installed)
+            return built
+        } catch {
+            ModelDownloads.report(
+                Self.download.id,
+                .failed(ModelDownloads.failure(error, needs: Self.download.peakLabel))
+            )
+            throw error
+        }
     }
 
     private static func build(

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -797,8 +797,10 @@ how you keep it on screen for as long as you want to look at it.
 process fetches nothing, so it runs on a sample registry whose percentage
 climbs — which is the part of that screen a still cannot show. The sheet draws
 the same screen in its four states: *Almost ready*, *Ready*, *Something was
-switched off* and *Something did not arrive*. The title is the state, so those
-four are the thing to compare.
+switched off*, *Something did not arrive* for each of the two models a
+dictation waits on, and the same screen after eSpeak NG was skipped. The title
+is the state, so those are the thing to compare. The alert *Done* raises when
+eSpeak NG is missing is a sheet on the window and cannot be drawn here.
 
 `sequence` is the one that cannot be checked from a still. The pill is a single
 panel that changes width and crossfades its contents rather than being replaced

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -763,7 +763,7 @@ $PF --panel-sheet s.png   # draw every surface into one PNG, light beside dark
 
 `--panels` takes `pill`, `notice`, `caution`, `failure`, `thinking`, `offer`,
 `confidence`, `vocabulary`, `punctuation`, `rule`, `dictation`, `preview`,
-`microphone`, `update` or `sequence`.
+`microphone`, `update`, `setup` or `sequence`.
 `--panel-sheet` draws all of
 them at once, which is where drift between them shows up.
 
@@ -792,6 +792,12 @@ seconds and thins out over the next two, the same as in the app, so it leaves
 on its own.
 Put the pointer on it and the fading stops, which is both what the app does and
 how you keep it on screen for as long as you want to look at it.
+
+`setup` is the first-run window, on the step that reports the downloads. This
+process fetches nothing, so it runs on a sample registry whose percentage
+climbs — which is the part of that screen a still cannot show. The sheet draws
+the same step twice, once with rows arriving and once with the speech model
+failed, and the last screen in four of its states.
 
 `sequence` is the one that cannot be checked from a still. The pill is a single
 panel that changes width and crossfades its contents rather than being replaced

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -793,11 +793,12 @@ on its own.
 Put the pointer on it and the fading stops, which is both what the app does and
 how you keep it on screen for as long as you want to look at it.
 
-`setup` is the first-run window, on the step that reports the downloads. This
+`setup` is the first-run window, on the one screen the walk ends on. This
 process fetches nothing, so it runs on a sample registry whose percentage
 climbs — which is the part of that screen a still cannot show. The sheet draws
-the same step twice, once with rows arriving and once with the speech model
-failed, and the last screen in four of its states.
+the same screen in its four states: *Almost ready*, *Ready*, *Something was
+switched off* and *Something did not arrive*. The title is the state, so those
+four are the thing to compare.
 
 `sequence` is the one that cannot be checked from a still. The pill is a single
 panel that changes width and crossfades its contents rather than being replaced

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,7 +75,7 @@ The menu bar item shows the current state and offers *Open Recordings
 Folder* — the wavs, if `logging.audio` is on, and `trace.jsonl` — *Settings*,
 which holds *Edit Config…* (`config.yaml`) and *Open Config Folder* —
 everything you own, so `vocabulary.yaml`, `transforms/` and `voice/` too —
-and *Permissions…*. Both open in VS Code if it is installed, and in whatever
+and *Setup…*. Both open in VS Code if it is installed, and in whatever
 the system would otherwise use if it is not. See [`logging`](#logging).
 
 ### A folder per transform

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -134,11 +134,13 @@ grep "launched —" ~/Library/Logs/ParrotFlow.log | tail -1
 Want `accessibility=Granted`. `NotGranted` means the switch is off or they
 ticked a different app.
 
-**The Downloads step.** After the two permissions the setup window shows what
-the app is fetching: five models, about 1.2 GB, started at launch. Nothing on
-that screen has to be waited for — *Continue* is always live, and only the
-speech model decides whether the last screen says "Ready". The one row with a
-button is eSpeak NG, which the app looks for rather than downloads.
+**The last screen.** After the two permissions the setup window shows one
+screen: both permissions, the five models it is fetching (about 1.2 GB, started
+at launch), and eSpeak NG. Nothing there has to be waited for — *Done* closes
+the window and the downloads carry on. The title says the state, and only the
+permissions and the speech model change it: "Almost ready" until Parakeet is
+in, then "Ready". The one line with a button is eSpeak NG, which the app looks
+for rather than downloads.
 
 ## Step 3 — Prove transcription works with no voice
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -140,7 +140,10 @@ at launch), and eSpeak NG. Nothing there has to be waited for — *Done* closes
 the window and the downloads carry on. The title says the state, and only the
 permissions and the speech model change it: "Almost ready" until Parakeet is
 in, then "Ready". The one line with a button is eSpeak NG, which the app looks
-for rather than downloads.
+for rather than downloads: it is GPL-3 and a separate program, so *Run in
+Terminal* runs the Homebrew command where it can be watched. Pressing *Done*
+without it asks once — *Install it* or *Not now* — and remembers the answer, so
+the question is asked once per install and not once per launch.
 
 ## Step 3 — Prove transcription works with no voice
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -134,6 +134,12 @@ grep "launched —" ~/Library/Logs/ParrotFlow.log | tail -1
 Want `accessibility=Granted`. `NotGranted` means the switch is off or they
 ticked a different app.
 
+**The Downloads step.** After the two permissions the setup window shows what
+the app is fetching: five models, about 1.2 GB, started at launch. Nothing on
+that screen has to be waited for — *Continue* is always live, and only the
+speech model decides whether the last screen says "Ready". The one row with a
+button is eSpeak NG, which the app looks for rather than downloads.
+
 ## Step 3 — Prove transcription works with no voice
 
 Needs no microphone.
@@ -373,8 +379,7 @@ mention but notifies nobody — tell them that.
 >
 > Settings are in `~/.config/parrotflow/config.yaml`, and the names it has
 > learnt are in `vocabulary.yaml` beside it. Both reload on save. The menu bar
-> icon has *Settings* — *Edit Config…* and *View Transforms* — and
-> *Permissions…*.
+> icon has *Settings* — *Edit Config…* and *View Transforms* — and *Setup…*.
 
 ---
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -135,7 +135,7 @@ Want `accessibility=Granted`. `NotGranted` means the switch is off or they
 ticked a different app.
 
 **The last screen.** After the two permissions the setup window shows one
-screen: both permissions, the five models it is fetching (about 1.2 GB, started
+screen: both permissions, the six models it is fetching (about 1.5 GB, started
 at launch), and eSpeak NG. Nothing there has to be waited for — *Done* closes
 the window and the downloads carry on. The title says the state, and only the
 permissions and the speech model change it: "Almost ready" until Parakeet is

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -183,7 +183,7 @@ cat <<'EOF'
 
     Next:
       1. Say yes to the microphone prompt — wait until it's granted.
-      2. Click the 🦜 icon, choose Permissions…, grant Accessibility, and
+      2. Click the 🦜 icon, choose Setup…, grant Accessibility, and
          wait until that's granted too — without it, dictation transcribes
          but can't type the result in for you.
       3. Hold Right Command, say something, let go.


### PR DESCRIPTION
Setting up ends on one screen. It lists both permissions, the six models the app fetches at launch — Parakeet TDT 0.6B v3, Silero VAD, CharsiuG2P, mmBERT-small, Qwen3 0.6B Base and Qwen3 Embedding 0.6B — with their sizes and how far each one has got, and eSpeak NG, which the app looks for rather than downloads. Each is a glyph and a line. The About panel names the same models, what each does and its licence.

The title is the state: *Almost ready* while the speech model is coming down, *Ready* once it is in, *Something was switched off* when a permission goes, *Something did not arrive* when a model a dictation waits on failed. Nothing on the screen starts a download — they start at launch in `warmModels` and carry on with the window closed — so *Done* never waits, and only a blocking failure changes the button.

Start the review at `ModelDownloads.swift`, then `SetupPane` at the bottom of `PermissionsWindow.swift`. The riskiest part is the failure mapping: five sentences, and not every model can produce all five.

<details>
<summary>One screen where there were two, and what that deleted</summary>

The first draft had a Downloads step and then a summary screen, saying the same things in two shapes. There is one now. `SetupStep` is `.permission(_)` or `.setup`, the setup screen is always the last step, and it is where the walk ends: its button closes the window rather than advancing.

`PermissionsModel.speechModel` and its four writes in `handleTranscriberStatus` are gone with it. The registry already knows whether the speech model is in, and two sources for one fact is how they drift. "Ready" means every blocking row is installed or off — with `audio.speech_gate` off the Silero VAD row is `.off`, and an off row holds nothing up.

The window takes the height its content asks for, keeping its top edge fixed when it changes. At a fixed height the *Ready* state left 190 pt of empty space under it: that state has no failures, no percentages and no command to run. `--panel-sheet` measures each pane the same way, so the sheet and the window agree.

The screen is drawn a quarter larger than the permission screens — every size on it through one factor, `SetupMetrics.scale`, the window width included: 460 becomes 575. Eleven lines is not a paragraph and it was set at a paragraph's type size. The permission screens keep their own scale, because their illustration is the recording pill at the size it will really be and scaling that would make it a picture of something else.

The *Almost ready* title stands alone. The model still coming down has its own line a few lines below with its own percentage, so a sentence naming it said twice what one glyph already said. The other states keep their sentence.

The menu bar item is now *Setup…*, and it opens this screen.

</details>

<details>
<summary>The registry: each model describes itself next to its own download</summary>

`ModelDownload` is one row — id, real name, size on disk, peak free space, group, `blocking`, state — declared as a `static let` beside the code that fetches it: `Transcriber.speechDownload`, `Transcriber.voiceDownload`, `SlotModel.download`, `SentenceReadings.download`, `WordVectors.download`, `NeuralPhonemes.soundDownload`. `ModelDownloads` collects them and holds the states. No screen keeps a list of models.

`AppDelegate.warmModels` declares the launch set — it is the code that fetches, and the one place that knows which gates are on. A model a setting turned off is registered as `.off("gate is off")` rather than left waiting for a fetch that never starts, using the same predicates `warmModels` already branches on: `audio.speech_gate` for Silero VAD, `readsSlots` for mmBERT-small, `readsBoundaries` for Qwen3 0.6B Base, `readsSentenceGate` for Qwen3 Embedding.

The fetches report as they go. The two blocking rows read `blocking` back out where `Transcriber.Status.downloading(_, blocking:)` is set, so a row's severity and the status flag cannot drift apart. The two MLX models are fetched by `MLXModelCache`, so that is where their percentage is reported from — each cache carries the id of the row it feeds.

Sizes are what lands on disk: 461, 1, 81, 282, 320 and 335 MB. mmBERT-small's peak is 580 MB because the downloaded package and its compile both exist until the compile finishes.

</details>

<details>
<summary>Failure sentences: three map to real errors, two are thinner than the design assumed</summary>

| Sentence | Reached by | Notes |
|---|---|---|
| Could not reach the server. | `HubDownload.Failure.http`, `.unlisted`, `URLError`, `AsrModelsError.downloadFailed` | The default. |
| Download stopped. | `HubDownload.Failure.truncated`, `CancellationError`, `URLError.cancelled/.timedOut/.networkConnectionLost` | Real for the three Hugging Face fetches. |
| Already downloading in another window. | `SlotModel.Failure.busy`, `MLXModelCache.Failure.busy` | mmBERT-small and the two Qwen models only. Those hold an `flock`; Parakeet and CharsiuG2P have no lock, so this is unreachable for them. |
| The installed copy is damaged. | Core ML load errors, `AsrModelsError.loadingFailed/.modelCompilationFailed`, `notQwen` from either MLX model | For mmBERT-small it only surfaces on the second failure: `build()` silently re-fetches a bad cache once. |
| Needs about N free. | `NSFileWriteOutOfSpaceError`, `POSIX ENOSPC` | Detected by error code. Never observed. |

**Parakeet cannot tell three of them apart.** `AsrModels.downloadAndLoad` wraps every reason a transfer failed into one `AsrModelsError.downloadFailed(String)` — a dropped connection, an interruption and a full disk are the same error. It is reported as "Could not reach the server". Only its load and compile failures are distinguished.

</details>

<details>
<summary>Two severities, and what the buttons do</summary>

Blocking (Parakeet, Silero VAD): a red cross, a scarlet sentence under the name, the title becomes *Something did not arrive*, and the button becomes the failure's repair — "Try again", or "Download again" for a damaged copy. `busy` gets no button, because the other build lets go on its own, so the button stays *Done*.

The title's sentence names the row that failed and what that row's absence costs, which each model carries beside its own descriptor. A failed Silero VAD says dictation runs without it and transcribes the whole clip; a failed Parakeet says nothing transcribes at all. Both are true of what the code does.

Not blocking (mmBERT-small, Qwen3 0.6B Base, Qwen3 Embedding, CharsiuG2P): an amber ring, an amber sentence that adds "The next dictation that needs it tries again", and the title does not move. A state the app gets out of by itself must not be drawn as one waiting for you.

"Download again" deletes the cache before it fetches. Every fetch here skips the download when the files are on disk, so without that the retry would hand the loader the same damaged bytes. Only rows that said "damaged" lose their cache; one that could not reach the server keeps what it had.

</details>

<details>
<summary>Leaving without eSpeak NG is a decision, asked once</summary>

eSpeak NG was one amber line among nine, and what it costs — names in your vocabulary that get missed — was not on the screen. It is a card now, the one thing on the screen drawn as one, because it is the one thing that asks for a decision: what is lost without it, what it is and why the app cannot install it, the command, and two buttons.

*Done* stops once. With eSpeak NG missing and no answer on record it raises an `NSAlert` sheet on the window — "Install eSpeak NG?", *Install it* or *Not now*. *Install it* does what *Run in Terminal* does and leaves the window open, so the line can show Terminal opening and then the binary landing. *Not now* closes the window as *Done* would and is remembered in `UserDefaults`, like the microphone notice and the update reminder: it is an answer the app already has, not a setting somebody chose, so it does not belong in `config.yaml`. Per bundle identifier, so the two builds ask separately.

Afterwards the card is gone, the line keeps its amber ring, reads "skipped", and says where to find it again. If eSpeak NG turns up later the answer is moot and the line is a green check.

It still gates nothing: *Ready* never waits for it, and *Try again* on a failed download does not ask.

</details>

<details>
<summary>Finding it: the search runs again, and the line can get out of every state</summary>

`Phonemes.binary` was a `static let`, resolved once. It now re-runs the search when the answer was nil, so a Terminal install lands without a relaunch. Four `isExecutableFile` calls, only on a machine that does not have it. The window polls it on the same 1s timer it already runs for permissions, so there is no "check again" button.

*Run in Terminal* writes the command to `install-espeak-ng.command` under the app's support directory and opens Terminal on it. Not AppleScript's `do script`: telling Terminal what to run is an Apple Event, and that puts an Automation prompt in front of someone still granting the first two permissions. With no Homebrew the installer is chained in front of `/opt/homebrew/bin/brew install espeak-ng` — by path, because installing Homebrew does not put it on the PATH of the shell that just ran the installer.

Two ways back out: a refused launch puts the line straight back to its button, and a Terminal that opened but never installed anything gives the button back after five minutes.

</details>

<details>
<summary>Known gaps, and things the code could not honour</summary>

- **The permission sentence is not the mockup's.** It reads "Accessibility is switched off. Turn it back on in System Settings, and this window updates itself." rather than "was granted and then taken away", because a revisit that skipped a permission reaches the same screen and the mockup's sentence would be false there.
- **The sentence breaks where the key starts.** The hotkey is a bordered field, not a word, so the sentence around it cannot be one wrapping `Text`. It breaks before "hold" instead: the lead wraps, the key line does not.
- **Repairing a damaged speech model deletes a cache the other build shares.** `~/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3` belongs to both builds. A copy that will not load is broken for both, so deleting it repairs both, but it is a shared directory being removed on a button press.
- **A Silero VAD failure is swallowed** — `loadVad` returns nil and the app transcribes everything, as it always did — and the line paints it scarlet, because `Status.downloading` says the fetch is blocking. The sentence says what it really costs rather than claiming nothing transcribes.
- **`transcription.enabled: false` gets its own sentence.** Nothing is fetched on that launch, so there is nothing to be ready for. The screen says dictation is switched off and where the switch is, rather than "Ready".
- **CharsiuG2P shows a spinner with no number.** `ModelHub.download` reports no fraction, and no progress is invented.
- **The Homebrew installer is still fetched over `HEAD` and run.** It is Homebrew's own documented line, shown in full in a selectable field before anything runs, and the app never runs it — Terminal does. Discussed in the review thread.

</details>

<details>
<summary>Rebased onto main, and what main changed under it</summary>

The branch was cut before `main` renamed the sentence model, moved the MLX downloads and added a sixth. Four commits sit on top of the rebase and say so.

- ModernBERT has left the app. The slot row is `SlotModel` — mmBERT-small, 282 MB.
- Qwen3 0.6B Base is a row of its own: the boundary readings, 320 MB, fetched at launch when `readsBoundaries`.
- The two MLX fetches live in `MLXModelCache` now, so the percentage is reported from there. Each cache carries the id of the row it feeds.
- The About panel names the six models and their licences.
- The sheet's fallback height fits the sixth row; the real window still measures its content.
- `SentenceReadings.warm` holds a failed load for five minutes, so *Download again* left its row waiting with nothing fetching. `retryNow` clears the deadline and warms in one actor call.

</details>

<details>
<summary>What was checked</summary>

`make test` passed before the rebase: every check, and swiftlint reported nothing in the changed files. The rebase itself was resolved on Linux with no Swift toolchain, so the build after it is verified by the `checks` job on this branch rather than locally. That job is green on the rebased head.

`--panel-sheet` draws the setup screen in six states — *Almost ready*, *Ready*, *Something was switched off*, and *Something did not arrive* twice, once for each of the two models a dictation waits on, because they cost different things, and the same screen after eSpeak NG was skipped. The title is the state, so those side by side are the thing to read. The alert *Done* raises is a sheet on the window and cannot be drawn on the sheet.

`--panels setup` puts the window on screen with a sample registry whose percentage climbs, which is the part a still cannot show. It is listed in `docs/cli.md`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYT3MEMCSpQVXm56YfxQn7
