### PR TITLE
feat: the sentence readings are the interpret step, switchable per app

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2318,9 +2318,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // The boundary readings. 320 MB and a 1.3s load, and a dictation
             // never waits for either: without this the first few dictations of
             // a launch keep the periods a pause put in. Not fetched at all when
-            // the pipeline has no `interpret` step — nothing else reads them.
-            if #available(macOS 14, *),
-               Pipeline.resolved(config: config).stages.contains(.interpret) {
+            // nothing will read them — nothing else does.
+            if #available(macOS 14, *), config.readsBoundaries {
                 Task.detached(priority: .background) {
                     await SentenceReadings.shared.warm()
                 }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2318,8 +2318,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // The boundary readings. 320 MB and a 1.3s load, and a dictation
             // never waits for either: without this the first few dictations of
             // a launch keep the periods a pause put in. Not fetched at all when
-            // the stage is off — nothing else reads them.
-            if #available(macOS 14, *), config.transcription.sentences.enabled {
+            // the pipeline has no `interpret` step — nothing else reads them.
+            if #available(macOS 14, *),
+               Pipeline.resolved(config: config).stages.contains(.interpret) {
                 Task.detached(priority: .background) {
                     await SentenceReadings.shared.warm()
                 }

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -98,18 +98,25 @@ enum CheckConfigCommand {
                 .map { "\"\($0)\"" }.joined(separator: ", ")
             emit("  · wake phrase       \(listed.isEmpty ? "none — spoken commands are off" : listed)")
             emit("  · rewrite line      \(transcription.rewriteLine ? "on" : "off (terminals can't be edited without it)")")
-            // Neither setting is the same in two languages, so both are printed
-            // per language rather than once.
+            // The floor is not the same in two languages, so it is printed per
+            // language rather than once. The marks are not: they belong to the
+            // `interpret` step, which is English only, and they are printed
+            // with it below.
             emit("  · languages         \(transcription.languages.joined(separator: ", "))")
             for language in transcription.languages {
-                emit("      \(language)  marks"
-                    + " \(transcription.marks(for: language).joined(separator: " "))"
-                    + "  slot floor"
+                emit("      \(language)  slot floor"
                     + " \(String(format: "%.2f", transcription.slotFloor(for: language)))")
             }
             // The pipeline, because "why was this not converted" is a question
             // about the order and not about a setting any more.
             let pipeline = Pipeline.resolved(config: config)
+            // The set the step actually runs with, whichever of its three homes
+            // it came from. Silent when nothing reads it.
+            if let step = pipeline.steps.first(where: { $0.stage == .interpret }) {
+                let marks = step.marks ?? transcription.marks(for: "en")
+                emit("  · sentence marks    \(marks.joined(separator: " "))"
+                    + (step.capitals == false ? "  (bare capitals off)" : ""))
+            }
             // An empty pipeline is a choice, not a blank: printing nothing
             // there reads as a display fault rather than as the answer to "why
             // did none of this run".

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -111,11 +111,17 @@ enum CheckConfigCommand {
             // about the order and not about a setting any more.
             let pipeline = Pipeline.resolved(config: config)
             // The set the step actually runs with, whichever of its three homes
-            // it came from. Silent when nothing reads it.
+            // it came from. Silent when the pipeline holds no step at all.
+            //
+            // `readsBoundaries` is the same predicate that decides whether the
+            // 320 MB model is fetched, so a line saying the step is off is
+            // also saying nothing will be downloaded for it.
             if let step = pipeline.steps.first(where: { $0.stage == .interpret }) {
                 let marks = step.marks ?? transcription.marks(for: "en")
                 emit("  · sentence marks    \(marks.joined(separator: " "))"
-                    + (step.capitals == false ? "  (bare capitals off)" : ""))
+                    + (step.capitals == false ? "  (bare capitals off)" : "")
+                    + (config.readsBoundaries
+                        ? "" : "  (off — `transcription.sentences: false`)"))
             }
             // An empty pipeline is a choice, not a blank: printing nothing
             // there reads as a display fault rather than as the answer to "why

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -2924,8 +2924,8 @@ struct Config: Decodable, Equatable {
         if !transcription.sentences.enabled {
             said.append("sentences: `transcription.sentences: false` is legacy; remove the"
                 + " `interpret` step from the pipeline instead."
-                + (interpret == nil ? "" : " Yours lists the step and this key is what"
-                    + " still turns it off"))
+                + (interpret == nil ? "" : " The step is in your pipeline and this key"
+                    + " is what still turns it off"))
         }
         // The marks moved twice — out of `sentences:` into `per_language`, and
         // now onto the step. Both older homes still answer for English.
@@ -2950,6 +2950,17 @@ struct Config: Decodable, Equatable {
                 + " `- interpret` to the front of `transcription.pipeline`")
         }
         return said
+    }
+
+    /// Whether the `interpret` step will actually read a boundary: it is in
+    /// the pipeline, and the legacy switch has not turned it off.
+    ///
+    /// One predicate, because two places warm the 320 MB sentence model and a
+    /// warm that disagrees with `Pipeline.skipReason` fetches weights nothing
+    /// will read.
+    var readsBoundaries: Bool {
+        transcription.sentences.enabled
+            && Pipeline.resolved(config: self).stages.contains(.interpret)
     }
 
     var resolvedOutputDir: URL {

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1652,15 +1652,17 @@ struct Config: Decodable, Equatable {
         /// at all.
         var languages: [String] = ["en"]
 
-        /// When a mark the transcriber wrote is taken out again — see
-        /// `SentenceJoin`.
+        /// Legacy. The switch the boundary readings had before they were the
+        /// `interpret` pipeline step — see `SentenceJoin`.
         ///
         ///     sentences: false               never look at a boundary
         ///     sentences:
         ///       marks: [".", ",", "?"]       what a boundary can be written
         ///
-        /// Two spellings, like `review:` on a pipeline step: a bare `false`
-        /// turns the stage off, anything else says what it runs with.
+        /// Both spellings are still read, and neither is refused. A rename
+        /// that turns a stage on or off without a word is the one outcome this
+        /// move must not have: `false` still turns the step off, and `marks:`
+        /// still feeds it where the step names none. `notices()` says both.
         ///
         /// One list, two jobs. The sentence enders in it — `.` and `?` — are
         /// where a boundary is looked for. Everything else in it — the comma —
@@ -1671,9 +1673,6 @@ struct Config: Decodable, Equatable {
         /// There is no threshold; the reading the model scores highest is the
         /// one that is written. `;` and `:` were measured and never changed a
         /// decision in English, so they are not in the default.
-        ///
-        /// The marks live in `per_language` now. `marks:` here is still read
-        /// and still answers for English — see `marks(for:)`.
         var sentences: Sentences = Sentences()
 
         struct Sentences: Decodable, Equatable {
@@ -1735,11 +1734,13 @@ struct Config: Decodable, Equatable {
         /// English's.
         var perLanguage: [String: Language] = [:]
 
-        /// The marks the sentence stage tries beside removing the period.
+        /// The marks the `interpret` step tries beside removing the period,
+        /// where the step names none of its own.
         ///
-        /// `transcription.sentences.marks` is the old home of the same set. It
-        /// is still read, and it answers for English only: that stage has never
-        /// run in another language.
+        /// Two old homes of the same set, in order: `per_language.<lang>.marks`
+        /// then `transcription.sentences.marks`. Both are still read, and both
+        /// answer for English only — that stage has never run in another
+        /// language.
         func marks(for language: String) -> [String] {
             if let written = perLanguage[language]?.marks { return written }
             if language == "en", sentences.marksWritten { return sentences.marks }
@@ -1828,15 +1829,15 @@ struct Config: Decodable, Equatable {
                     )
                 }
                 // The enders in the list are where a boundary is looked for.
-                // With none the stage finds nothing and does nothing, which is
-                // what `sentences: false` is for.
+                // With none the stage finds nothing and does nothing, and the
+                // way to say that is to take the step out.
                 guard kept.contains(where: { SentenceReadings.enders.contains($0) }) else {
                     throw ConfigError.invalidValue(
                         key: key,
                         value: kept.map { "`\($0)`" }.joined(separator: ", "),
                         expected: "at least one of `.`, `?` or `!` — those are where a"
                             + " boundary is looked for, so with none the stage never runs."
-                            + " Use `sentences: false` to turn it off"
+                            + " Delete the `interpret` step to turn it off"
                     )
                 }
                 let wrong = kept.filter { $0.count != 1 || !($0.first?.isPunctuation ?? false) }
@@ -1970,6 +1971,14 @@ struct Config: Decodable, Equatable {
         ///       by_sound: false
         ///       review: gpt
         ///       max_slots: 4
+        ///
+        /// `interpret` takes its options the same way:
+        ///
+        ///     - interpret
+        ///     - stage: interpret
+        ///       marks: [".", ",", "?"]
+        ///       capitals: false
+        ///       pause: 0
         struct PipelineEntry: Decodable {
             let name: String
             var transform: String?
@@ -1981,6 +1990,9 @@ struct Config: Decodable, Equatable {
             /// What `review:` said, for `Transcription.retiredReview`. Read so
             /// it can be reported, never used.
             var review: String?
+            var marks: [String]?
+            var capitals: Bool?
+            var pause: Double?
             var when: String?
             var unless: String?
             var app: String?
@@ -1997,6 +2009,7 @@ struct Config: Decodable, Equatable {
                 case maxReadings = "max_readings"
                 case maxPerSlot = "max_per_slot"
                 case maxPerTerm = "max_per_term"
+                case marks, capitals, pause
             }
 
             init(from decoder: Decoder) throws {
@@ -2052,6 +2065,17 @@ struct Config: Decodable, Equatable {
                     } else {
                         review = try c.decodeIfPresent(String.self, forKey: .review)
                     }
+                }
+                // Each optional and each on its own, as the vocabulary caps
+                // are: turning the capitals off must not restate the marks.
+                if name.caseInsensitiveCompare("interpret") == .orderedSame {
+                    if let written = try c.decodeIfPresent([String].self, forKey: .marks) {
+                        marks = try Language.checked(
+                            marks: written, key: "pipeline.interpret.marks"
+                        )
+                    }
+                    capitals = try c.decodeIfPresent(Bool.self, forKey: .capitals)
+                    pause = try c.decodeIfPresent(Double.self, forKey: .pause)
                 }
                 when = try c.decodeIfPresent(String.self, forKey: .when)
                 unless = try c.decodeIfPresent(String.self, forKey: .unless)
@@ -2235,12 +2259,18 @@ struct Config: Decodable, Equatable {
                             stage: stage, transform: entry.transform,
                             prompt: entry.prompt, caps: entry.caps,
                             nearMisses: entry.nearMisses, bySound: entry.bySound,
-                            gate: entry.gate,
+                            gate: entry.gate, marks: entry.marks,
+                            capitals: entry.capitals, pause: entry.pause,
                             when: entry.when, unless: entry.unless, app: entry.app
                         )
                     }
                     pipeline = Pipeline(steps: steps)
                 }
+            } catch let bad as ConfigError {
+                // A step's own key — `pipeline.interpret.marks` — already says
+                // what is wrong and where. Rewriting it as "not a list of
+                // steps" would send the reader to the wrong line.
+                throw bad
             } catch {
                 throw ConfigError.invalidValue(
                     key: "transcription.pipeline",
@@ -2887,12 +2917,37 @@ struct Config: Decodable, Equatable {
         // file-level key and nothing else.
         said += vocabulary.legacy.map { "vocabulary: \($0)" }
         said += transcription.sentences.legacy.map { "sentences: \($0)" }
-        // Still read, and still English's set. It moved because the slot floor
-        // keys off the language too, and two settings keyed the same way belong
-        // in one block.
-        if transcription.sentences.marksWritten, transcription.perLanguage["en"]?.marks == nil {
-            said.append("sentences: `marks:` now lives at"
-                + " `transcription.per_language.en.marks`. Yours is still read")
+        // The boundary readings are the `interpret` step now, so both of their
+        // older switches are legacy. Each is still read: a rename that turns a
+        // stage on or off without a word is the one outcome it must not have.
+        let interpret = Pipeline.resolved(config: self).steps.first { $0.stage == .interpret }
+        if !transcription.sentences.enabled {
+            said.append("sentences: `transcription.sentences: false` is legacy; remove the"
+                + " `interpret` step from the pipeline instead."
+                + (interpret == nil ? "" : " Yours lists the step and this key is what"
+                    + " still turns it off"))
+        }
+        // The marks moved twice — out of `sentences:` into `per_language`, and
+        // now onto the step. Both older homes still answer for English.
+        let legacyMarks = transcription.sentences.marksWritten
+            || transcription.perLanguage["en"]?.marks != nil
+        if legacyMarks, interpret?.marks != nil {
+            said.append("sentences: `marks:` is set on the `interpret` step and in"
+                + " `transcription."
+                + (transcription.perLanguage["en"]?.marks != nil
+                    ? "per_language.en" : "sentences")
+                + ".marks`. The step is what runs")
+        } else if legacyMarks {
+            said.append("sentences: `marks:` belongs on the `interpret` step now —"
+                + " `- {stage: interpret, marks: [\".\", \",\", \"?\"]}`."
+                + " Yours is still read")
+        }
+        // Said, not done. A pipeline written before the step existed loses the
+        // readings, and nobody runs `--check-config` after an update — so this
+        // is also what the log says at launch, through `notices()`.
+        if transcription.pipeline != nil, interpret == nil, transcription.sentences.enabled {
+            said.append("sentences: the sentence readings no longer run; add"
+                + " `- interpret` to the front of `transcription.pipeline`")
         }
         return said
     }

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -30,6 +30,17 @@ struct Pipeline: Equatable, Codable {
     /// drift apart — a stage that cannot be spelled is a stage nobody can ask
     /// for.
     enum Stage: String, Equatable, Codable, CaseIterable {
+        /// What the speaker meant, where the decoder wrote what it heard.
+        ///
+        /// Today that is the marks a pause put in: a period or a question mark
+        /// mid-sentence, and the capital after it — see `SentenceJoin`.
+        /// `marks:`, `capitals:` and `pause:` on the step say how far it
+        /// reaches. English only, and it refuses every other language itself.
+        ///
+        /// First in the list, because it reads the decoder's own words: the
+        /// pause gate lines the text up against the token timings, and a stage
+        /// above it that rewrites a word breaks that alignment.
+        case interpret
         /// Names: matched from `vocabulary.yaml`, then each match settled
         /// against the sentence it stands in. `near_misses:`, `by_sound:` and
         /// `gate:` on the step say how far it reaches — see `Step`.
@@ -62,9 +73,8 @@ struct Pipeline: Equatable, Codable {
         ///
         /// Only used to say where `vocabulary` belongs: it reads spans the
         /// acoustic pass measured before the pipeline started, and every stage
-        /// that edits text moves them (F10). `replacements` is the exception it
-        /// has to live with — the judge offers a rule's substitution back, so
-        /// the rules must already have fired.
+        /// that edits text moves them (F10). `interpret` is the exception, and
+        /// `vocabularyOrderProblems` is where that is written down.
         var editsText: Bool { self != .context && self != .input && self != .vocabulary }
 
         /// Whether it can be in a default nobody wrote.
@@ -164,6 +174,18 @@ struct Pipeline: Equatable, Codable {
         /// whatever arrived, which is what the gate was measured against and
         /// the only way to measure it again.
         var gate: Bool?
+        /// `marks:` on an `interpret` step. What a boundary can be written
+        /// with: the sentence enders in the list are where one is looked for,
+        /// the rest are readings tried at one. Absent falls back to
+        /// `transcription.per_language.<lang>.marks`.
+        var marks: [String]?
+        /// `capitals:` on an `interpret` step. Whether a capital with no mark
+        /// in front of it is read as a boundary too. Absent means true.
+        var capitals: Bool?
+        /// `pause:` on an `interpret` step. Seconds of silence a bare capital
+        /// needs in front of it before it is read. Zero or less reads every
+        /// one. Absent means `SentenceJoin.paused`.
+        var pause: Double?
         /// Run only when this matches the text as it stands *at this point* —
         /// after the stages before it, not on the original. That ordering is
         /// what lets a cheap deterministic stage make an expensive one
@@ -413,8 +435,11 @@ struct Pipeline: Equatable, Codable {
     /// now, so there is no exception left to state.
     private func vocabularyOrderProblems() -> [String] {
         guard let judge = stages.firstIndex(of: .vocabulary) else { return [] }
+        // `interpret` is the exception. It ran above the whole pipeline until
+        // it became a step, so it has always been above this one, and it takes
+        // a mark out rather than rewriting a word.
         let above = steps[..<judge]
-            .filter { $0.stage.editsText }
+            .filter { $0.stage.editsText && $0.stage != .interpret }
             .map { Pipeline.namespace(of: $0) }
         guard !above.isEmpty else { return [] }
         return ["vocabulary runs after \(above.joined(separator: ", ")), which rewrite the"
@@ -514,6 +539,15 @@ struct Pipeline: Equatable, Codable {
         for step: Step, text: String, config: Config, allowPrompts: Bool, app: App? = nil,
         scope: Scope = Scope()
     ) -> Skip? {
+        // The legacy off switch. `transcription.sentences: false` predates the
+        // step and still turns it off: reading it as "on, because the step is
+        // listed" would start a stage somebody switched off, without a word.
+        if step.stage == .interpret, !config.transcription.sentences.enabled {
+            return Skip(
+                code: "legacy_off",
+                described: "`transcription.sentences: false` turns this step off"
+            )
+        }
         if step.stage == .vocabulary {
             // It costs a model call, so it answers to the same two guards a
             // prompt does: `--replace` must stay off the network, and a spoken
@@ -645,12 +679,12 @@ struct Pipeline: Equatable, Codable {
     ///   the way to a transcript would say less than one that never moved.
     func run(
         _ text: String, config: Config, allowPrompts: Bool = true, app: App? = nil,
-        seed: Scope = Scope(),
+        seed: Scope = Scope(), words: [Trace.Word] = [],
         progress: (@Sendable (String) -> Void)? = nil
     ) async -> String {
         await runCollectingScope(
             text, config: config, allowPrompts: allowPrompts, app: app,
-            seed: seed, progress: progress
+            seed: seed, words: words, progress: progress
         ).text
     }
 
@@ -661,9 +695,12 @@ struct Pipeline: Equatable, Codable {
     /// have to say `.text` to get it. `--pipeline` and the case sets want both,
     /// and they are the reason the scope is reachable at all: a variable nothing
     /// can print is a variable nobody can debug.
+    /// `words` are the decoder's own, for the `interpret` step's pause gate.
+    /// Every other way in has no audio and hands over none, and the gate then
+    /// stands down rather than guessing.
     func runCollectingScope(
         _ text: String, config: Config, allowPrompts: Bool = true, app: App? = nil,
-        seed: Scope = Scope(),
+        seed: Scope = Scope(), words: [Trace.Word] = [],
         progress: (@Sendable (String) -> Void)? = nil
     ) async -> (text: String, scope: Scope) {
         var output = text
@@ -735,7 +772,7 @@ struct Pipeline: Equatable, Codable {
             let before = output
             let started = CFAbsoluteTimeGetCurrent()
             let result = await apply(
-                step, to: output, config: config, app: app, scope: scope
+                step, to: output, config: config, app: app, scope: scope, words: words
             )
             let seconds = CFAbsoluteTimeGetCurrent() - started
             output = result.text
@@ -782,9 +819,11 @@ struct Pipeline: Equatable, Codable {
 
     private func apply(
         _ step: Step, to text: String, config: Config, app: App?, scope: Scope,
-
+        words: [Trace.Word]
     ) async -> StageResult {
         switch step.stage {
+        case .interpret:
+            return await interpret(step, on: text, config: config, words: words)
         case .numbers:
             let done = Numbers.read(text, languages: config.transcription.languages)
             return StageResult(text: done.text, vars: ["language": .string(done.language)])
@@ -928,6 +967,29 @@ struct Pipeline: Equatable, Codable {
             if let appending = capture.appending { vars["appending"] = .bool(appending) }
             return StageResult(text: text, vars: vars)
         }
+    }
+
+    /// The marks a pause put in, taken out again — see `SentenceJoin`.
+    ///
+    /// Fails open. No model on disk, a model not in memory yet, a language
+    /// that is not English: the transcript arrives as it was, and the step
+    /// still publishes `ran: true` with `count: 0`. A boundary left as decoded
+    /// is a worse transcript; an error here would cost the sentence.
+    private func interpret(
+        _ step: Step, on text: String, config: Config, words: [Trace.Word]
+    ) async -> StageResult {
+        guard #available(macOS 14, *) else {
+            return StageResult(text: text, vars: ["count": .int(0)])
+        }
+        let language = Pipeline.language(of: text, config: config)
+        let outcome = await SentenceJoin.shared.apply(
+            to: text, config: config,
+            marks: step.marks ?? config.transcription.marks(for: language),
+            capitals: step.capitals ?? true,
+            pause: step.pause ?? SentenceJoin.paused,
+            words: words
+        )
+        return StageResult(text: outcome.text, vars: ["count": .int(outcome.count(.join))])
     }
 
     /// Every substitution the vocabulary pass made, settled where it stands.

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -426,13 +426,14 @@ struct Pipeline: Equatable, Codable {
     /// the stage then has to re-anchor by searching for the words — which is
     /// the mechanism that put the menu on the wrong `Versailles` (F3, F10).
     ///
-    /// Nothing that rewrites the transcript may run above it.
+    /// Nothing that rewrites the transcript may run above it, except
+    /// `interpret` — see below.
     ///
     /// The stage reads spans the acoustic pass measured before the pipeline
     /// started, and any edit above it moves them (F10). The exact pass used to
-    /// be the one exception, because it ran as a separate `replacements` stage
+    /// be an exception too, because it ran as a separate `replacements` stage
     /// and the judge needs the rules to have fired; it is inside this stage
-    /// now, so there is no exception left to state.
+    /// now.
     private func vocabularyOrderProblems() -> [String] {
         guard let judge = stages.firstIndex(of: .vocabulary) else { return [] }
         // `interpret` is the exception. It ran above the whole pipeline until

--- a/Sources/ParrotFlow/PipelineCommand.swift
+++ b/Sources/ParrotFlow/PipelineCommand.swift
@@ -133,7 +133,8 @@ enum PipelineCommand {
             return Pipeline.Step(
                 stage: stage, transform: entry.transform, prompt: entry.prompt,
                 caps: entry.caps, nearMisses: entry.nearMisses,
-                bySound: entry.bySound, gate: entry.gate, when: entry.when,
+                bySound: entry.bySound, gate: entry.gate, marks: entry.marks,
+                capitals: entry.capitals, pause: entry.pause, when: entry.when,
                 unless: entry.unless, app: entry.app
             )
         }
@@ -204,6 +205,13 @@ enum PipelineCommand {
                 }
                 do { _ = try await SlotModel.shared.prepare() } catch {
                     found.append("slot model — \(error.localizedDescription)")
+                }
+                // Only for a pipeline that holds the step. It is 320 MB, and a
+                // fixture without the step has nothing to read them.
+                if pipeline.stages.contains(.interpret) {
+                    do { try await SentenceReadings.shared.prepare() } catch {
+                        found.append("sentence readings — \(error.localizedDescription)")
+                    }
                 }
                 return found
             }

--- a/Sources/ParrotFlow/Replacements.swift
+++ b/Sources/ParrotFlow/Replacements.swift
@@ -28,9 +28,11 @@ enum Replacements {
     ///
     /// Kept as the entry point everything already calls, so moving the order
     /// out of this function did not move the call sites too.
+    /// `words` are the decoder's own, for the `interpret` step's pause gate.
+    /// Only the transcriber has them.
     static func apply(
         to text: String, config: Config, allowPrompts: Bool = true, app: Pipeline.App? = nil,
-        seed: Scope = Scope(),
+        seed: Scope = Scope(), words: [Trace.Word] = [],
         progress: (@Sendable (String) -> Void)? = nil
     ) async -> String {
         let language = Pipeline.language(of: text, config: config)
@@ -41,7 +43,7 @@ enum Replacements {
         seed.set("language", .string(language))
         return await Pipeline.resolved(config: config).run(
             text, config: config, allowPrompts: allowPrompts, app: app,
-            seed: seed, progress: progress
+            seed: seed, words: words, progress: progress
         )
     }
 

--- a/Sources/ParrotFlow/SentenceJoin.swift
+++ b/Sources/ParrotFlow/SentenceJoin.swift
@@ -338,12 +338,13 @@ actor SentenceJoin {
     /// the text as it is being rebuilt. A join only removes a mark, so the
     /// window a later boundary reads is the same words either way.
     ///
-    /// Nothing here waits for the model. A dictation that arrives before the
-    /// weights are in memory keeps its boundaries and starts the load, so the
-    /// first dictation after a launch pays nothing and the second is repaired.
-    /// The load is only ever started for weights already on disk: this runs
-    /// from `--pipeline` and from the check scripts now, and none of those has
-    /// any business fetching 320 MB.
+    /// Nothing here waits for the model, and nothing here loads it. A
+    /// dictation that arrives before the weights are in memory keeps its
+    /// boundaries; the transcriber started the load before the pipeline ran,
+    /// so the first dictation after a launch pays nothing and the second is
+    /// repaired. Loading from here would mean every `--pipeline` run and every
+    /// check script paying 1.3s, or fetching 320 MB it has no business
+    /// fetching.
     ///
     /// `marks`, `capitals` and `pause` are the `interpret` step's options.
     /// `words` are the decoder's own, for the pause gate. Without them every
@@ -369,7 +370,6 @@ actor SentenceJoin {
         ).sorted { $0.next.lowerBound < $1.next.lowerBound }
         guard !found.isEmpty else { return .unchanged(text) }
         guard await SentenceReadings.shared.isLoaded else {
-            if SentenceReadings.isCached { await SentenceReadings.shared.warm() }
             Log.write("sentences: \(found.count) boundary(s) left as decoded;"
                 + " the model is not in memory yet")
             return .unchanged(text)

--- a/Sources/ParrotFlow/SentenceJoin.swift
+++ b/Sources/ParrotFlow/SentenceJoin.swift
@@ -313,12 +313,12 @@ actor SentenceJoin {
     /// starts in the text.
     ///
     /// The decoder's words joined by single spaces are the text, so a word's
-    /// offset is a running length. `Transcriber.swift` runs this stage before
-    /// the pipeline for exactly that reason — every text stage after it
-    /// rewrites words the timings index. Words that do not rebuild the text
-    /// give no gate rather than a wrong one.
-    static func pauses(in text: String, words: [Trace.Word]) -> [Int: Double] {
-        guard words.map(\.word).joined(separator: " ") == text else { return [:] }
+    /// offset is a running length. The `interpret` step is first in the
+    /// pipeline for exactly that reason — every text stage above it rewrites
+    /// words the timings index. Nil when they no longer rebuild the text: no
+    /// gate rather than a wrong one, and `apply` says so in the log.
+    static func pauses(in text: String, words: [Trace.Word]) -> [Int: Double]? {
+        guard words.map(\.word).joined(separator: " ") == text else { return nil }
         var out: [Int: Double] = [:]
         var offset = 0
         var previous: Trace.Word?
@@ -341,28 +341,49 @@ actor SentenceJoin {
     /// Nothing here waits for the model. A dictation that arrives before the
     /// weights are in memory keeps its boundaries and starts the load, so the
     /// first dictation after a launch pays nothing and the second is repaired.
+    /// The load is only ever started for weights already on disk: this runs
+    /// from `--pipeline` and from the check scripts now, and none of those has
+    /// any business fetching 320 MB.
+    ///
+    /// `marks`, `capitals` and `pause` are the `interpret` step's options.
     /// `words` are the decoder's own, for the pause gate. Without them every
     /// candidate is read, which is what `--sentence-join` and the tests do.
+    ///
+    /// English only, and it refuses the rest here rather than at the call
+    /// site: the readings are scored by an English base model and the mark set
+    /// is English, so `when: language == "en"` on the step would be a line
+    /// that only restates what the stage already does.
     func apply(
-        to text: String, config: Config, words: [Trace.Word] = []
+        to text: String, config: Config, marks written: [String]? = nil,
+        capitals: Bool = true, pause: Double = SentenceJoin.paused,
+        words: [Trace.Word] = []
     ) async -> Outcome {
         let settings = config.transcription.sentences
         guard settings.enabled else { return .unchanged(text) }
         let language = Pipeline.language(of: text, config: config)
-        let marks = config.transcription.marks(for: language)
+        guard language == "en" else { return .unchanged(text) }
+        let marks = written ?? config.transcription.marks(for: language)
         let found = (
             Self.boundaries(in: text, scanning: Self.scanned(marks))
-            + Self.bareBoundaries(in: text)
+            + (capitals ? Self.bareBoundaries(in: text) : [])
         ).sorted { $0.next.lowerBound < $1.next.lowerBound }
         guard !found.isEmpty else { return .unchanged(text) }
         guard await SentenceReadings.shared.isLoaded else {
-            await SentenceReadings.shared.warm()
+            if SentenceReadings.isCached { await SentenceReadings.shared.warm() }
             Log.write("sentences: \(found.count) boundary(s) left as decoded;"
                 + " the model is not in memory yet")
             return .unchanged(text)
         }
         let terms = Array(config.vocabulary.terms.keys)
-        let pauses = words.isEmpty ? [:] : Self.pauses(in: text, words: words)
+        var pauses: [Int: Double] = [:]
+        if !words.isEmpty {
+            if let measured = Self.pauses(in: text, words: words) {
+                pauses = measured
+            } else {
+                Log.write("sentences: the words no longer rebuild the transcript, so the"
+                    + " pause gate stands down; every capital is read")
+            }
+        }
 
         var readings: [Reading] = []
         var rebuilt = ""
@@ -378,7 +399,7 @@ actor SentenceJoin {
                now == word || !Self.readable(word, in: whole, at: offset) {
                 continue
             }
-            if boundary.mark == nil, let gap = pauses[offset], gap < Self.paused {
+            if boundary.mark == nil, pause > 0, let gap = pauses[offset], gap < pause {
                 continue
             }
             let started = DispatchTime.now().uptimeNanoseconds

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -473,10 +473,11 @@ actor Transcriber {
         }
         Trace.current?.recordASR(result, model: Repo.parakeetV3.rawValue)
 
-        // Before the pipeline, because this is the last point where the words
-        // still line up with the audio they came from. Every text stage after
-        // it — numbers especially — rewrites words the token timings index.
-        var text = result.text
+        // Nothing rewrites the transcript here any more. The last pass that
+        // did — the boundary readings — is the `interpret` step, and it is
+        // handed the token timings so it can still line the words up against
+        // the audio they came from.
+        let text = result.text
         var vocabularyCount = 0
         var vocabularyChanges = ""
         // What the pass proposed and did not write, with the text it measured
@@ -509,8 +510,7 @@ actor Transcriber {
             // 320 MB and a 1.3s load, and a dictation never waits for either.
             // Fetched for a pipeline that holds the step and for no other, so
             // deleting the line stops the download.
-            if #available(macOS 14, *),
-               Pipeline.resolved(config: config).stages.contains(.interpret) {
+            if Pipeline.resolved(config: config).stages.contains(.interpret) {
                 Task { await SentenceReadings.shared.warm() }
             }
             // The set the sound pass actually reads, not the shorter one the

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -501,13 +501,16 @@ actor Transcriber {
             Task { await WordVectors.shared.warm() }
         }
 
-        // The sentence pass is English only: the readings are scored by an
-        // English base model and the mark set is English. So is the sound pass
-        // — espeak's letter-to-sound answers for French words and the answer is
-        // noise.
-        var joinedSentences = 0
+        // The sound pass is English only — espeak's letter-to-sound answers for
+        // French words and the answer is noise. So is the boundary reading,
+        // which runs in the pipeline now as the `interpret` step and refuses
+        // every other language itself.
         if Pipeline.language(of: text, config: config) == "en" {
-            if #available(macOS 14, *), config.transcription.sentences.enabled {
+            // 320 MB and a 1.3s load, and a dictation never waits for either.
+            // Fetched for a pipeline that holds the step and for no other, so
+            // deleting the line stops the download.
+            if #available(macOS 14, *),
+               Pipeline.resolved(config: config).stages.contains(.interpret) {
                 Task { await SentenceReadings.shared.warm() }
             }
             // The set the sound pass actually reads, not the shorter one the
@@ -516,14 +519,6 @@ actor Transcriber {
             // and `crawl file` alone would never fetch the model that is the
             // only thing able to match them.
             if !config.vocabularySounds.isEmpty { warmSoundModel() }
-            if #available(macOS 14, *) {
-                let joins = await SentenceJoin.shared.apply(
-                    to: text, config: config,
-                    words: Trace.words(from: result.tokenTimings ?? [])
-                )
-                text = joins.text
-                joinedSentences = joins.count(.join)
-            }
         }
 
         // After the vocabulary pass rather than before it, though the words
@@ -559,14 +554,16 @@ actor Transcriber {
                 // pipeline can read rather than an error about a missing path.
                 "vocabulary.count": .int(vocabularyCount),
                 "vocabulary.changes": .string(vocabularyChanges),
-                // The periods a pause put in and this run took out.
-                "sentences.joined": .int(joinedSentences),
         ])
         // Only when there is one. Absent says "no press", which is the honest
         // answer off the hotkey path and the one `input` declines on.
         if let press { seed.set("press.run", .int(press)) }
+        // The decoder's own words, for the `interpret` step's pause gate. This
+        // is the only caller that has them; every other way into the pipeline
+        // has no audio, and the gate stands down there.
         return await Self.applyReplacements(
             to: text, config: config, app: app, seed: seed,
+            words: Trace.words(from: result.tokenTimings ?? []),
             progress: progress
         )
     }
@@ -1060,11 +1057,12 @@ actor Transcriber {
     /// How names get fixed — see `Replacements`.
     nonisolated static func applyReplacements(
         to text: String, config: Config, app: Pipeline.App? = nil,
-        seed: Scope = Scope(),
+        seed: Scope = Scope(), words: [Trace.Word] = [],
         progress: (@Sendable (String) -> Void)? = nil
     ) async -> String {
         await Replacements.apply(
-            to: text, config: config, app: app, seed: seed, progress: progress
+            to: text, config: config, app: app, seed: seed, words: words,
+            progress: progress
         )
     }
 }

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -508,9 +508,9 @@ actor Transcriber {
         // every other language itself.
         if Pipeline.language(of: text, config: config) == "en" {
             // 320 MB and a 1.3s load, and a dictation never waits for either.
-            // Fetched for a pipeline that holds the step and for no other, so
-            // deleting the line stops the download.
-            if Pipeline.resolved(config: config).stages.contains(.interpret) {
+            // Fetched only where the step will read a boundary, so deleting
+            // the line stops the download — and so does the legacy switch.
+            if config.readsBoundaries {
                 Task { await SentenceReadings.shared.warm() }
             }
             // The set the sound pass actually reads, not the shorter one the

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -80,32 +80,27 @@ transcription:
   # entry turns off language detection.
   languages: [en, fr]
 
-  # A pause mid-sentence makes the transcriber write a period and capitalise
-  # the next word, or writes a question mark. English dictations are checked
-  # for that and the mark is taken out again. Each boundary is read three ways
-  # — the mark it carries, the comma, and no mark at all — and the reading the
-  # model scores highest is written. On by default, and only where the model is
-  # already on disk. `sentences: false` turns it off.
-  #
-  # sentences: false
-
-  # The settings that differ from one language to the next. `marks` is the
-  # list above: `.` and `?` are scanned, `,` is read beside them. `slot_floor`
-  # is how far the heard word must win by before the vocabulary gate refuses a
+  # The settings that differ from one language to the next. `slot_floor` is
+  # how far the heard word must win by before the vocabulary gate refuses a
   # rewrite: 0.20 in English, 0.30 in French, where the gaps are a third
   # narrower.
   #
   # per_language:
-  #   en: {marks: [".", ",", "?"], slot_floor: 0.20}
-  #   fr: {marks: [".", ",", "?"], slot_floor: 0.30}
+  #   en: {slot_floor: 0.20}
+  #   fr: {slot_floor: 0.30}
 
   # What a transcript runs through, in order. Remove a line to skip that
   # stage. One list for every language: a step that should only run in one
   # takes `when: language == "fr"`. See docs/pipelines.md.
   pipeline:
+    # What you meant, where the decoder wrote what it heard. A pause makes it
+    # write a period or a question mark mid-sentence and capitalise the next
+    # word; this reads each boundary and takes the mark out again. English
+    # only, and only where the model is already on disk. See docs/pipelines.md
+    # for `marks:`, `capitals:` and `pause:`.
+    - interpret
     # Matches vocabulary.yaml renderings and settles each match against the
-    # sentence it stands in. No model. Runs first, before anything else edits
-    # the text.
+    # sentence it stands in. No model. Above everything that edits the text.
     #   near_misses: false   match exactly, never one edit away
     #   by_sound: false      match spelling only, never how a word sounds
     - vocabulary

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -544,9 +544,10 @@ $PF --sentence-join "…the first usage of the LLM with. The vocabulary is slowe
 ```
 
 The mark is removed where `join` wins, and left alone otherwise. Which marks are
-scanned, and which are read beside them, is
-`transcription.per_language.<code>.marks` in `config.yaml` — the sentence enders
-in that list are scanned, the rest are readings.
+scanned, and which are read beside them, is `marks:` on the `interpret` step in
+`config.yaml` — the sentence enders in that list are scanned, the rest are
+readings. This command reads the built-in set unless a legacy `marks:` is set;
+`--pipeline` is what runs the step as the config spells it.
 `scripts/check-sentence-join.sh` scores the decisions against
 tests/sentence-boundary-cases.json, in both shapes; it needs the model, so it is
 run by hand.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,7 +27,6 @@ transcription:
   activation_phrases: [hey parrot, by the way parrot]
   languages: [en]       # en and fr are the supported values
   rewrite_line: true
-  sentences: …          # or false — joining a sentence a pause cut in two
   per_language: …       # the settings that differ from one language to the next
   pipeline: …           # see pipelines.md
   transforms: …         # see pipelines.md
@@ -455,17 +454,17 @@ language code.
 ```yaml
 transcription:
   per_language:
-    en: {marks: [".", ","], slot_floor: 0.20}
-    fr: {marks: [".", ","], slot_floor: 0.30}
+    en: {slot_floor: 0.20}
+    fr: {slot_floor: 0.30}
 ```
 
 Those are the defaults, so an empty block changes nothing. An entry overrides
 only the keys it names. A language with no entry gets English's values.
 
-`marks` are the punctuation the sentence stage tries beside removing the period
-— see [`transcription.sentences`](#transcriptionsentences). Each entry is one
-punctuation character; anything else is refused, because a mark is written into
-the sentence as punctuation.
+`marks` under a language is legacy. The set lives on the `interpret` step now —
+see [pipelines.md](pipelines.md#the-interpret-stage). One written here is still
+read, still answers for English, and is beaten by a `marks:` on the step;
+`--check-config` says which one is running.
 
 `slot_floor` is how far the word you were heard to say must beat a vocabulary
 term by before the gate refuses to write the term. The number is a difference of
@@ -477,7 +476,7 @@ free in both and costs the English gate 35 of the 55 wrong rewrites it catches.
 The gate only ever refuses, so a floor set too tight costs a name you have to
 type, never a wrong word in your text.
 
-`--check-config` prints both values for every language you listed.
+`--check-config` prints the floor for every language you listed.
 
 ## `transcription.activation_phrases`
 
@@ -502,52 +501,23 @@ correction ended up appended to the end of a line instead of replacing a word in
 it: ⌃K clears nothing in a composer, and the paste that followed landed on the
 end of what was still there.
 
-## `transcription.sentences`
+## `transcription.sentences` (legacy)
 
-A pause mid-sentence makes the transcriber write a period or a question mark,
-and capitalise the next word, so one sentence becomes two. Every such boundary
-in an English transcript is read several ways and the reading the model likes
-best wins.
+The switch for the boundary readings before they became a pipeline step. The
+step is `interpret`, and everything this key used to say now lives on that
+line — see [pipelines.md](pipelines.md#the-interpret-stage).
 
-`sentences: false` turns the whole stage off. The marks it works with are
-[`transcription.per_language`](#transcriptionper_language), default
-`[".", ",", "?"]`.
+Both spellings are still read, so an update cannot silently change what runs:
 
-One list, two jobs. The sentence enders in it — `.` and `?` — are **where a
-boundary is looked for**. Everything else in it — the comma — is a **reading
-tried at a boundary**. So each boundary is read three ways: the mark it
-carries, the comma, and no mark at all. Take `?` out of the list and question
-marks stop being scanned; take `.` out and periods do.
+- `sentences: false` still turns the step off, even when the pipeline lists it.
+  `--check-config` says to delete the `- interpret` line instead.
+- `sentences: {marks: [...]}` still feeds the step, as does
+  `per_language.<code>.marks`. A `marks:` on the step beats both, and
+  `--check-config` prints the set that is running.
 
-There is no threshold. The stage builds those three readings — `". The
-vocabulary is slower"`, `", the vocabulary is slower"`, `" the vocabulary is
-slower"` — scores each with a small causal language model, and writes the
-winner. A score is the log-probability of the continuation divided by its token
-count. Where the reading with no mark wins, the mark is removed and the next
-word is lowercased.
-
-Measured over one speaker's dictation: 81% of 140 period cuts repaired with no
-real period joined, and 82% of 325 question cuts repaired at one wrong join in
-111 real questions. The two thresholds this used to take, `join_below:` and
-`offer_below:`, repaired 26%. They are still read, and `--check-config` says
-they no longer do anything.
-
-`;` and `:` were measured and never changed a decision in English, so they are
-not in the default. Each entry is one punctuation character, and at least one
-must end a sentence; anything else is refused, because a mark is written into
-the sentence as punctuation. The set is a setting because it is
-language-dependent, which is why it lives in the language block. `marks:` under
-`sentences:` is still read and still answers for English; `--check-config` says
-where it moved.
-
-A word after a question mark does not have to be capitalised. Of 19 lines where
-the transcriber wrote `word? lowercase`, 7 hold a mark that should go and 12 a
-real question, so the reading decides and no rule could. A word after a *period*
-does have to be: that shape has never been measured, so it is left alone.
-
-English only, and only where the model is already on disk. Nothing is
-downloaded for this and nothing waits: with no model the transcript arrives as
-it was. See [transcription.md](transcription.md).
+A pipeline written before the step existed has no `- interpret` line in it, so
+the readings do not run. Nothing is inserted for you: `--check-config` and the
+log at launch both say to add the line to the front of the list.
 
 ## `transcription.replacements` is retired
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -5,6 +5,7 @@ Everything a finished transcript goes through, in order:
 ```yaml
 transcription:
   pipeline:
+    - interpret
     - vocabulary
     - numbers
     - transform: dotted
@@ -42,6 +43,7 @@ can get wrong.
 
 | Stage | What it does |
 |---|---|
+| `interpret` | What you meant, where the decoder wrote what it heard. Today that is the marks a pause put in mid-sentence, taken out again — see [The interpret stage](#the-interpret-stage). English only. |
 | `vocabulary` | Names. Matches every `heard:` rendering in `vocabulary.yaml`, reaches the near misses you have not taught, then settles each match against the sentence it stands in — see [The name stage](#the-name-stage). |
 | `numbers` | Spoken numbers as digits: "two hundred forty-three" → 243, plus ordinals, decimals, years and spoken digits. English and French, septante/huitante/nonante included, chosen per transcript. A number word on its own stays a word below ten, so "chapter three" and "on est deux" are left alone. |
 | `context` | What is on screen around the field, published as `context.*`. Never touches the transcript. Terminals only, and off unless you ask for it — see [Context](#context-what-is-on-screen-around-the-field). |
@@ -50,6 +52,76 @@ can get wrong.
 
 `numbers` rewrites transcripts that were already correct, so run `--numbers` on
 a line to see exactly what it would do before leaving it in.
+
+## The interpret stage
+
+`interpret` reads what the transcript says against what the speaker meant. It
+is not called `repunctuate` because punctuation is only the first thing it
+does: the misheard-word and disfluency passes belong here too, and they will be
+further switches on this same line.
+
+```yaml
+- interpret
+```
+
+A pause mid-sentence makes the transcriber write a period or a question mark
+and capitalise the next word, so one sentence becomes two. This stage reads
+every such boundary three ways — the mark that is there, a comma, and no mark
+at all — and writes the reading a small language model scores highest. There is
+no threshold. Where the joined reading wins, the mark is removed and the next
+word is lowercased. See
+[transcription.md](transcription.md#sentences-a-pause-cut-in-two) for what that
+repairs and what it costs.
+
+With anything to say about it, spell the stage out:
+
+```yaml
+- stage: interpret
+  marks: [".", ",", "?"]   # optional; default. What a boundary can be written with
+  capitals: true           # optional; default. false reads marks only
+  pause: 1.0               # optional; default. Seconds of silence before a bare capital
+```
+
+`marks:` is one list doing two jobs. The sentence enders in it — `.` and `?` —
+are **where a boundary is looked for**. Everything else — the comma — is a
+**reading tried at a boundary**. Take `?` out and question marks stop being
+scanned. Each entry is one punctuation character and at least one must end a
+sentence; anything else is refused by name.
+
+`capitals:` covers the fourth shape: a capitalised word with no mark in front
+of it at all, which is about a third as common as `word. Capital`. Half of
+those capitals are correct, so the stage refuses a run of capitals, a capital
+inside the word and every part of speech but the ones that open a clause.
+`capitals: false` scans the marks and nothing else.
+
+`pause:` is the silence a bare capital needs in front of it before it is read.
+A latency cut, not a safety one: the readings answer those boundaries the same
+way with or without it, and a capital with no pause in front of it is rarely
+the shape this repairs. `pause: 0` reads every one.
+
+**English only, and it says so itself.** The readings are scored by an English
+base model and the mark set is English, so the stage refuses every other
+language. `when: language == "en"` on the step would only restate that.
+
+**Put it first.** The pause gate lines the transcript up against the decoder's
+token timings, so a stage above it that rewrites a word breaks the alignment.
+When that happens the gate stands down for that dictation, the log says so, and
+the readings still run. It is the one stage allowed above `vocabulary`: it
+removes a mark rather than rewriting a word, and it ran above the whole
+pipeline before it was a step.
+
+**Nothing waits for the model, and nothing is downloaded for it here.** 320 MB,
+fetched in the background when the pipeline holds this step and never
+otherwise. A dictation that arrives before the weights are in memory keeps its
+boundaries, and the step still publishes `ran: true` with `changed: false` —
+the failure direction every stage here shares.
+
+It publishes `interpret.count`: how many boundaries were joined.
+
+`transcription.sentences` is the switch this replaces. `sentences: false` still
+turns the step off and `--check-config` says to delete the step instead;
+`marks:` under `sentences:` or under `per_language.<lang>` still feeds the
+step, and `marks:` on the step wins over both.
 
 ## The name stage
 
@@ -150,9 +222,11 @@ text. `--check-config` refuses a pipeline that puts `numbers` or a transform
 above it, because a span that has moved cannot be told from a span that was
 always wrong.
 
-There used to be one exception, `replacements`, because the stage offers a
-rule's substitution back and the rules had to have fired first. That pass is
-inside this stage now, so there is no exception left to state.
+`interpret` is the one exception, and it is where the default puts it. It
+removes a mark rather than rewriting a word, and it ran above the whole
+pipeline before it was a step. `replacements` used to be the exception, because
+the stage offers a rule's substitution back and the rules had to have fired
+first; that pass is inside this stage now.
 
 It publishes `vocabulary.slots` (how many places the sentence offered),
 `vocabulary.reverted` (the substitutions it undid, as `term -> word`) and
@@ -999,7 +1073,8 @@ any of this exists:
 They are **derived, never claimed**. A stage cannot forget to report `changed`,
 and cannot report it about the wrong string.
 
-Stages add their own on top. The built-in ones publish `vocabulary.count`,
+Stages add their own on top. `interpret.count` is how many boundaries it
+joined. The built-in ones publish `vocabulary.count`,
 `vocabulary.changes` and `vocabulary.before` — how many rules fired, which
 ones, and the sentence the stage was handed — `numbers.language`, which grammar
 actually read the numbers and is not the same answer as the pipeline's

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -485,8 +485,8 @@ said     "you should see a parrot at the top right of your screen"
 written  "You should see a parrot. At the top right of your screen."
 ```
 
-After the vocabulary pass, every such boundary in an English transcript is read
-three ways and scored by a small causal language model
+The `interpret` step reads every such boundary in an English transcript three
+ways and scores each with a small causal language model
 (`mlx-community/Qwen3-0.6B-Base-4bit`, 320 MB):
 
 ```
@@ -497,9 +497,16 @@ three ways and scored by a small causal language model
 
 Each reading is the log-probability of its continuation divided by its token
 count, and the highest wins. Nothing is compared to a threshold, so there is
-nothing to calibrate. The marks are `transcription.per_language.<code>.marks`,
-default `[".", ",", "?"]`; `;` and `:` were measured and never changed a
-decision in English.
+nothing to calibrate. The marks are `marks:` on the step, default
+`[".", ",", "?"]`; `;` and `:` were measured and never changed a decision in
+English.
+
+This is a pipeline step, and it runs at the position the list gives it — see
+[The interpret stage](pipelines.md#the-interpret-stage) for the three options
+and why it belongs first. It used to run before the pipeline, switched by
+`transcription.sentences`. That key is legacy now: a pipeline with no
+`- interpret` line in it does not read boundaries at all, and `--check-config`
+and the log at launch both say so.
 
 The list does two jobs. `.` and `?` are where a boundary is looked for; the
 comma is a reading tried at one. The first reading is always the mark the
@@ -598,8 +605,10 @@ never seen it, which is what a name it has not been told about looks like. A
 term in your `vocabulary.yaml` is asked first, because a name that is also an
 English word is the one case the lemma rule cannot see.
 
-English only. The readings are scored by an English base model, and the mark
-set is English: French uses `:` where English does not. Nothing is waited for:
+English only, and the stage refuses the rest itself, so `when: language == "en"`
+on the step is not needed. The readings are scored by an English base model, and
+the mark set is English: French uses `:` where English does not. Nothing is
+waited for:
 with no cached model, a load that threw or a boundary it cannot read, the text
 arrives as it was. A dictation that arrives before the weights are in memory
 keeps its boundaries and starts the load.

--- a/scripts/check-default-config.sh
+++ b/scripts/check-default-config.sh
@@ -48,7 +48,7 @@ defined = names(example)
 
 # The stage kinds this app understands without a name — everything else in a
 # pipeline step must be one of these, or a `transform:` naming a defined one.
-BUILTIN_STAGES = {"replacements", "fuzzy", "numbers", "vocabulary"}
+BUILTIN_STAGES = {"replacements", "fuzzy", "numbers", "vocabulary", "interpret"}
 
 def steps(doc):
     found = []

--- a/scripts/check-pipeline-config.sh
+++ b/scripts/check-pipeline-config.sh
@@ -70,7 +70,145 @@ run_config absent 'transcription:
 
 check "a config naming no pipeline loads" "$code" "0"
 check "and gets the built-in default, said out loud" \
-  "$(stages)" "numbers  (nothing configured, so every stage)"
+  "$(stages)" "interpret → numbers  (nothing configured, so every stage)"
+
+# --- the interpret step -------------------------------------------------------
+#
+# The boundary readings were a pass that ran before the pipeline and answered
+# to `transcription.sentences`. They are a step now, so the list is the switch
+# and the options live on the line.
+
+# What `--check-config` prints for the marks the step resolves to.
+marks() {
+  printf '%s\n' "$out" | sed -n 's/^  · sentence marks  *//p'
+}
+
+run_config interpret_bare 'transcription:
+  languages: [en]
+  pipeline:
+    - interpret
+    - vocabulary
+    - numbers'
+
+check "a bare - interpret line loads" "$code" "0"
+check "and runs above vocabulary without being refused for it" \
+  "$(stages)" "interpret → vocabulary → numbers"
+check "and takes the built-in marks" "$(marks)" ". , ?"
+
+run_config interpret_options 'transcription:
+  languages: [en]
+  pipeline:
+    - stage: interpret
+      marks: [".", "?"]
+      capitals: false
+      pause: 0
+      app: /term/'
+
+check "a map with every option loads" "$code" "0"
+check "and the condition is printed with the step" \
+  "$(stages)" "interpret in /term/"
+check "and the step marks are what runs" "$(marks)" ". ?  (bare capitals off)"
+
+run_config interpret_capitals 'transcription:
+  languages: [en]
+  pipeline:
+    - {stage: interpret, capitals: false}'
+
+check "capitals: false alone loads" "$code" "0"
+check "and says so beside the marks" "$(marks)" ". , ?  (bare capitals off)"
+
+run_config interpret_pause 'transcription:
+  languages: [en]
+  pipeline:
+    - {stage: interpret, pause: 0}'
+
+check "pause: 0 loads" "$code" "0"
+check "and the step still resolves" "$(stages)" "interpret"
+
+run_config interpret_bad_marks 'transcription:
+  languages: [en]
+  pipeline:
+    - {stage: interpret, marks: ["hello"]}'
+
+check "a mark that is a word is refused" "$code" "1"
+check "and the message names the key that was written" \
+  "$(printf '%s\n' "$out" | grep -c 'pipeline.interpret.marks')" "1"
+
+run_config interpret_comma_only 'transcription:
+  languages: [en]
+  pipeline:
+    - {stage: interpret, marks: [","]}'
+
+check "marks with no sentence ender is refused" "$code" "1"
+check "and says where a boundary is looked for" \
+  "$(printf '%s\n' "$out" | grep -c 'at least one of')" "1"
+
+# --- the legacy keys ----------------------------------------------------------
+
+run_config legacy_off 'transcription:
+  languages: [en]
+  sentences: false
+  pipeline:
+    - numbers'
+
+check "sentences: false with no step loads" "$code" "0"
+check "and the notice says to remove the step instead" \
+  "$(printf '%s\n' "$out" | grep -c 'is legacy; remove the `interpret` step')" "1"
+check "and no migration line is printed as well" \
+  "$(printf '%s\n' "$out" | grep -c 'the sentence readings no longer run')" "0"
+
+run_config legacy_off_listed 'transcription:
+  languages: [en]
+  sentences: false
+  pipeline:
+    - interpret'
+
+check "sentences: false beside the step loads" "$code" "0"
+check "and says the key is what still turns it off" \
+  "$(printf '%s\n' "$out" | grep -c 'this key is what still turns it off')" "1"
+
+run_config legacy_marks 'transcription:
+  languages: [en]
+  sentences:
+    marks: [".", "?"]
+  pipeline:
+    - interpret'
+
+check "the old marks: key loads" "$code" "0"
+check "and feeds the step" "$(marks)" ". ?"
+check "and the notice points at the step" \
+  "$(printf '%s\n' "$out" | grep -c '`marks:` belongs on the `interpret` step now')" "1"
+
+run_config legacy_marks_both 'transcription:
+  languages: [en]
+  per_language:
+    en: {marks: [".", "?"]}
+  pipeline:
+    - {stage: interpret, marks: [".", ",", "?"]}'
+
+check "both homes for marks: loads" "$code" "0"
+check "and the step wins" "$(marks)" ". , ?"
+check "and the notice says the step is what runs" \
+  "$(printf '%s\n' "$out" | grep -c 'The step is what runs')" "1"
+
+# --- a pipeline written before the step existed -------------------------------
+#
+# Nothing is inserted. The readings stop, and the line that says so is printed
+# by `--check-config` and written to the log at launch, because nobody runs
+# `--check-config` after an update.
+
+run_config no_interpret 'transcription:
+  languages: [en]
+  pipeline:
+    - vocabulary
+    - numbers'
+
+check "a pipeline with no interpret step loads" "$code" "0"
+check "and nothing is inserted into it" "$(stages)" "vocabulary → numbers"
+check "and the migration line says what to add" \
+  "$(printf '%s\n' "$out" | grep -c 'add `- interpret` to the front')" "1"
+check "and no marks line is printed for a step that is not there" \
+  "$(marks)" ""
 
 # --- the retired key ----------------------------------------------------------
 #
@@ -92,7 +230,7 @@ check "and says what to write instead" \
 check "and says the built-in default is what runs" \
   "$(printf '%s\n' "$out" | grep -c 'no pipeline of yours is running')" "1"
 check "and that is what resolves" \
-  "$(stages)" "numbers  (nothing configured, so every stage)"
+  "$(stages)" "interpret → numbers  (nothing configured, so every stage)"
 
 # --- any shape under the retired key ------------------------------------------
 #
@@ -109,7 +247,7 @@ check "a bare list under pipelines: is refused the same way" "$code" "1"
 check "with the same one message" \
   "$(printf '%s\n' "$out" | grep -c 'transcription.pipelines: is retired')" "1"
 check "and the built-in default resolves" \
-  "$(stages)" "numbers  (nothing configured, so every stage)"
+  "$(stages)" "interpret → numbers  (nothing configured, so every stage)"
 
 # --- the rest of the config still loads ---------------------------------------
 #
@@ -129,7 +267,7 @@ check "a refused pipelines: does not cost the rest of the config" \
 check "including a setting read after it" \
   "$(printf '%s\n' "$out" | grep -c 'copy to clipboard')" "1"
 check "and the built-in default is still what resolves" \
-  "$(stages)" "numbers  (nothing configured, so every stage)"
+  "$(stages)" "interpret → numbers  (nothing configured, so every stage)"
 
 # --- both keys ----------------------------------------------------------------
 

--- a/scripts/check-pipeline-config.sh
+++ b/scripts/check-pipeline-config.sh
@@ -166,6 +166,10 @@ run_config legacy_off_listed 'transcription:
 check "sentences: false beside the step loads" "$code" "0"
 check "and says the key is what still turns it off" \
   "$(printf '%s\n' "$out" | grep -c 'this key is what still turns it off')" "1"
+# The same predicate decides whether the 320 MB model is fetched, so a step
+# reported as off is also a step nothing is downloaded for.
+check "and the step is reported off, not merely configured" \
+  "$(marks)" ". , ?  (off — \`transcription.sentences: false\`)"
 
 run_config legacy_marks 'transcription:
   languages: [en]


### PR DESCRIPTION
The pass that takes out a period a pause put in mid-sentence used to run between the decoder and the pipeline, switched by `transcription.sentences`. It is a pipeline step now, `interpret`, so it runs where the list puts it and takes `app:`, `when:` and three options of its own. The readings and the rules are untouched — only where the stage is called from and how it is configured.

It is called `interpret` and not `repunctuate` because punctuation is only the first thing it does: the misheard-word and disfluency passes belong on this same line, as further switches beside `marks:`, `capitals:` and `pause:`.

**This changes what an existing config runs.** A `transcription.pipeline` written before this has no `- interpret` line in it, so the sentence readings stop. Nothing is inserted for you. `--check-config` and the log at launch both say to add the line. `config.example.yaml` carries it, so a new install and anyone copying the example gets the stage.

Reviewers: start at `Pipeline.interpret` and `SentenceJoin.apply`, then the notices at the end of `Config.notices()`.

Part of #277.

<details>
<summary>The line to add to your own config</summary>

Only if you wrote a `transcription.pipeline` list. A config with no `pipeline:` at all gets the step in the built-in default.

```yaml
transcription:
  pipeline:
    - interpret          # <- add this, first
    - vocabulary
    - numbers
    # …
```

`--check-config` prints `· sentence marks    . , ?` once the step is there, and stops printing `the sentence readings no longer run`.

</details>

<details>
<summary>The step, and its three options — all optional, all on by default</summary>

```yaml
- interpret
```

```yaml
- stage: interpret
  marks: [".", ",", "?"]   # what a boundary can be written with
  capitals: true           # false reads marks only
  pause: 1.0               # seconds of silence before a bare capital is read
  app: /term|slack/        # as on every step
```

- `marks:` is validated exactly as `transcription.sentences.marks` is today. The message names the key you wrote: `pipeline.interpret.marks`.
- `capitals: false` skips `bareBoundaries`, the shape #276 added.
- `pause: 0` or less reads every bare capital.
- English only, and the stage refuses every other language itself. `when: language == "en"` is not needed and is not in the example.

It publishes `interpret.ran`, `.ok`, `.changed`, `.ms` like every step, plus `interpret.count` — how many boundaries were joined. The `sentences:` log lines are unchanged.

</details>

<details>
<summary>The check scripts give the same numbers, before and after</summary>

The readings and the rules were not touched, so these had to be identical.

| Script | Before | After |
|---|---|---|
| `check-sentence-join.sh` period | 95% of cuts repaired, 0.0 false joins per 100 real endings | same |
| `check-sentence-join.sh` question | 80% of cuts repaired, 0.0 false joins per 100 real endings | same |
| `check-sentence-join.sh` bare capitals | 2 joined, 3 left as decoded, of 5 | same |
| `check-sentence-case.sh` | 39/39 | 39/39 |
| `check-sentence-probe.sh` | 65/65 within 0.05, worst gap 0.0000 | same |

`make test` exits 0. `scripts/check-pipeline-config.sh` goes from 20 cases to 50 — 30 new:

- a bare `- interpret` line loads, runs above `vocabulary`, and takes the built-in marks
- a map with `marks:`, `capitals:`, `pause:` and `app:` loads, and the condition prints with the step
- `capitals: false` alone, and `pause: 0` alone
- a mark that is a word is refused, and the message names `pipeline.interpret.marks`
- `marks:` with no sentence ender in it is refused
- `sentences: false` with no step, and `sentences: false` beside the step
- the old `sentences.marks` feeding the step, and `per_language.en.marks` beaten by a `marks:` on the step
- a pipeline with no `interpret` step: nothing inserted, the migration line printed, no marks line
- `sentences: false` beside the step reports the step off — the same predicate that decides whether the model is fetched

</details>

<details>
<summary>The legacy keys are still read, so nothing turns on or off in silence</summary>

`transcription.sentences: false` **still turns the step off, even when the pipeline lists it.** Reading it as "on, because the step is in the list" would start a stage somebody switched off, without a word. The notice says the key is legacy and that the way to turn the step off is to delete its line. It shows up as a skip in the log, with the reason, rather than as a stage that ran and found nothing.

`sentences.marks` and `per_language.<lang>.marks` still feed the step where the step names no `marks:` of its own. A `marks:` on the step beats both, and the notice says which one is running.

Neither key is refused. A config carrying one is not broken.

</details>

<details>
<summary>Why the step is allowed above `vocabulary`, which nothing else is</summary>

`--check-config` refuses a pipeline that puts a text-editing stage above `vocabulary`, because the spans that stage was given no longer point at the same words. `interpret` is exempt, and the default puts it first.

Two reasons. It ran above the whole pipeline until this change, so it has always been above `vocabulary`. And it removes a mark and lowercases one letter rather than rewriting a word.

It has to be first for its own sake as well: the pause gate lines the transcript up against the decoder's token timings. A stage above it that changes the words breaks that alignment. When that happens the gate stands down for that dictation, the log says so, and every candidate is read — the same behaviour `--sentence-join` and the case sets have always had.

</details>

<details>
<summary>What I decided that the brief did not settle</summary>

- **`sentences: false` beside a listed step turns the step off.** The brief only specified the case with no step. Honouring the key is the direction that cannot silently start a stage.
- **The bad-marks message tail changed.** It used to end "Use `sentences: false` to turn it off", which now recommends a legacy key that `--check-config` nags about. It ends "Delete the `interpret` step to turn it off". The key name and the other two messages are unchanged.
- **`--check-config` prints the marks once, with the step**, and the per-language line keeps `slot_floor` alone. The set belongs to the step and the step is English only, so printing it per language said something false as soon as the step named its own.
- **The step loads no model of its own.** `SentenceJoin.apply` is reachable from `--pipeline` and the check scripts now, so the load it used to start there would cost every CLI process 1.3s for weights it exits without using. The transcriber starts the load before the pipeline runs, and the launch warm-up starts it too — both gated on `Config.readsBoundaries`: the step is in the pipeline and the legacy switch has not turned it off.
- **`pipeline: []` gets the migration notice too.** It has no `interpret` step, and the brief's rule is written on that.
- **Nothing read `sentences.joined`.** The seed is gone and `interpret.count` replaces it; there was no reader in the tree to move.

</details>
