### PR TITLE
feat: the vocabulary gates can be switched off one by one, per app

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2314,7 +2314,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // The rest together, once speech is in. None of them blocks a
             // dictation: the stages that read them stand aside until they are
             // in memory.
-            await transcriber.warmSlotModel()
+            if config.readsSlots { await transcriber.warmSlotModel() }
             // The boundary readings. 320 MB and a 1.3s load, and a dictation
             // never waits for either: without this the first few dictations of
             // a launch keep the periods a pause put in. Not fetched at all when
@@ -2340,9 +2340,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 // on the one launch that installed them.
                 NeuralPhonemes.warmCache()
             }
-            // 335 MB, and only the sentence gate reads them. Someone who turns
-            // the gate off should not pay for it.
-            if #available(macOS 14, *), config.vocabulary.gateSentence {
+            // 335 MB, and only the two tests that read the sentence read
+            // them. Someone who switches both off should not pay for it.
+            if #available(macOS 14, *), config.readsSentenceGate {
                 Task.detached(priority: .background) { await WordVectors.shared.warm() }
             }
         }
@@ -3872,11 +3872,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// like a session of corrections, which is the reason to think this
     /// matters, and `gate_ms` on a running app is what would settle it.
     ///
-    /// Only with the sentence gate on. `SentenceGate` is the only thing that
-    /// reads a portrait, and with it off this would fetch 335 MB of word
-    /// vectors to answer a question nobody asks.
+    /// Only where a portrait will be read. `SentenceGate` is the only thing
+    /// that reads one, so with `portrait: false` on the step — or the legacy
+    /// `gate_sentence: false` — this would fetch 335 MB of word vectors to
+    /// answer a question nobody asks.
     private func rebuildPortrait(for term: String) {
-        guard config.vocabulary.gateSentence else { return }
+        guard config.readsPortraits else { return }
         guard #available(macOS 14, *) else { return }
         Task.detached(priority: .background) {
             let started = Date()

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -107,42 +107,27 @@ enum CheckConfigCommand {
             // `interpret` step, which is English only, and they are printed
             // with it below.
             emit("  · languages         \(transcription.languages.joined(separator: ", "))")
-            // A pipeline may hold more than one `vocabulary` step — one per app
-            // is the reason the options are on the step at all — and each names
-            // its own floor and its own gates. Printing the first step's numbers
-            // for all of them describes a pipeline nobody wrote, so with more
-            // than one they are printed a step at a time, named as the pipeline
-            // line names them.
-            if vocabularySteps.count > 1 {
-                let width = vocabularySteps.map { described($0).count }.max() ?? 0
-                for step in vocabularySteps {
-                    let floors = transcription.languages.map { language in
-                        let floor = transcription.slotFloor(for: language, on: step)
-                        return "\(language) \(String(format: "%.2f", floor))"
-                    }.joined(separator: "  ")
-                    let name = described(step)
-                        .padding(toLength: width, withPad: " ", startingAt: 0)
-                    emit("      \(name)  slot floor \(floors)"
-                        + "  \(gates(of: step, config: config))")
-                }
-            } else {
-                for language in transcription.languages {
-                    let floor = transcription.slotFloor(
-                        for: language, on: vocabularySteps.first
-                    )
-                    emit("      \(language)  slot floor \(String(format: "%.2f", floor))")
-                }
+            // One line per `vocabulary` step, whether there is one or five. A
+            // pipeline may hold several — one per app is the reason these
+            // options live on the step — and each names its own floor and its
+            // own gates, so there is no step whose numbers can stand for the
+            // rest. Silent when the pipeline holds none, which is also what
+            // says nothing is downloaded for them: the switches on these lines
+            // are the ones that decide whether each model is fetched.
+            let width = vocabularySteps.map { described($0).count }.max() ?? 0
+            for step in vocabularySteps {
+                let floors = transcription.languages.map { language in
+                    let floor = transcription.slotFloor(for: language, on: step)
+                    return "\(language) \(String(format: "%.2f", floor))"
+                }.joined(separator: "  ")
+                let name = described(step)
+                    .padding(toLength: width, withPad: " ", startingAt: 0)
+                emit("      \(name)  slot floor \(floors)"
+                    + "  \(gates(of: step, config: config))")
             }
-            // Which of the two tests that read the sentence will run. The same
-            // switches decide whether each model is fetched, so a line saying a
-            // half is off is also saying nothing is downloaded for it. Silent
-            // when the pipeline holds no `vocabulary` step, and printed with
-            // each step above when it holds several.
-            if vocabularySteps.count == 1, let step = vocabularySteps.first {
-                emit("  · vocabulary gates  \(gates(of: step, config: config))"
-                    + (config.vocabulary.gateSentence
-                        ? "" : "  (the sentence tests are off —"
-                            + " `vocabulary.gate_sentence: false`)"))
+            if !vocabularySteps.isEmpty, !config.vocabulary.gateSentence {
+                emit("      the sentence tests are off —"
+                    + " `vocabulary.gate_sentence: false`")
             }
             // The set the step runs with. Silent when the pipeline holds no
             // step at all, which is also what says nothing is downloaded for it.

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -101,23 +101,45 @@ enum CheckConfigCommand {
             // The pipeline, because "why was this not converted" is a question
             // about the order and not about a setting any more.
             let pipeline = Pipeline.resolved(config: config)
-            let vocabulary = pipeline.steps.first { $0.stage == .vocabulary }
+            let vocabularySteps = pipeline.steps.filter { $0.stage == .vocabulary }
             // The floor is not the same in two languages, so it is printed per
             // language rather than once. The marks are not: they belong to the
             // `interpret` step, which is English only, and they are printed
             // with it below.
             emit("  · languages         \(transcription.languages.joined(separator: ", "))")
-            for language in transcription.languages {
-                let floor = transcription.slotFloor(for: language, on: vocabulary)
-                emit("      \(language)  slot floor \(String(format: "%.2f", floor))")
+            // A pipeline may hold more than one `vocabulary` step — one per app
+            // is the reason the options are on the step at all — and each names
+            // its own floor and its own gates. Printing the first step's numbers
+            // for all of them describes a pipeline nobody wrote, so with more
+            // than one they are printed a step at a time, named as the pipeline
+            // line names them.
+            if vocabularySteps.count > 1 {
+                let width = vocabularySteps.map { described($0).count }.max() ?? 0
+                for step in vocabularySteps {
+                    let floors = transcription.languages.map { language in
+                        let floor = transcription.slotFloor(for: language, on: step)
+                        return "\(language) \(String(format: "%.2f", floor))"
+                    }.joined(separator: "  ")
+                    let name = described(step)
+                        .padding(toLength: width, withPad: " ", startingAt: 0)
+                    emit("      \(name)  slot floor \(floors)"
+                        + "  \(gates(of: step, config: config))")
+                }
+            } else {
+                for language in transcription.languages {
+                    let floor = transcription.slotFloor(
+                        for: language, on: vocabularySteps.first
+                    )
+                    emit("      \(language)  slot floor \(String(format: "%.2f", floor))")
+                }
             }
-            // Which of the two tests that read the sentence will run, and the
-            // same predicates that decide whether their models are fetched — so
-            // a line saying a half is off is also saying nothing is downloaded
-            // for it. Silent when the pipeline holds no `vocabulary` step.
-            if vocabulary != nil {
-                emit("  · vocabulary gates  slot \(config.readsSlots ? "on" : "off"),"
-                    + " portrait \(config.readsPortraits ? "on" : "off")"
+            // Which of the two tests that read the sentence will run. The same
+            // switches decide whether each model is fetched, so a line saying a
+            // half is off is also saying nothing is downloaded for it. Silent
+            // when the pipeline holds no `vocabulary` step, and printed with
+            // each step above when it holds several.
+            if vocabularySteps.count == 1, let step = vocabularySteps.first {
+                emit("  · vocabulary gates  \(gates(of: step, config: config))"
                     + (config.vocabulary.gateSentence
                         ? "" : "  (the sentence tests are off —"
                             + " `vocabulary.gate_sentence: false`)"))
@@ -137,14 +159,7 @@ enum CheckConfigCommand {
             // pipeline that explains nothing.
             let stages = pipeline.steps.isEmpty
                 ? "nothing — the list is empty"
-                : pipeline.steps.map { step -> String in
-                    var described = step.stage.name
-                    if let transform = step.transform { described += " \(transform)" }
-                    if let when = step.when { described += " when \(when)" }
-                    if let unless = step.unless { described += " unless \(unless)" }
-                    if let app = step.app { described += " in \(app)" }
-                    return described
-                }.joined(separator: " → ")
+                : pipeline.steps.map(described).joined(separator: " → ")
             let source = transcription.pipeline == nil
                 ? "  (nothing configured, so every stage)" : ""
             emit("  · pipeline          \(stages)\(source)")
@@ -424,6 +439,27 @@ enum CheckConfigCommand {
     /// failures and our validation errors as `DecodingError.dataCorrupted`, and
     /// the default `localizedDescription` for either is useless ("Yams.YamlError
     /// error 2"). `YamlError`'s own description carries the line and column.
+    /// A step as the pipeline line names it: the stage, what it runs, and the
+    /// conditions on it. Shared so a step described twice is described once.
+    private static func described(_ step: Pipeline.Step) -> String {
+        var out = step.stage.name
+        if let transform = step.transform { out += " \(transform)" }
+        if let when = step.when { out += " when \(when)" }
+        if let unless = step.unless { out += " unless \(unless)" }
+        if let app = step.app { out += " in \(app)" }
+        return out
+    }
+
+    /// Which of the two tests that read the sentence this step will run.
+    ///
+    /// The slot half is not gated by `gate_sentence:`, because the slot is also
+    /// read by the lexical gate, which that key has never touched.
+    private static func gates(of step: Pipeline.Step, config: Config) -> String {
+        let slot = step.slotGate ?? true
+        let portrait = (step.portrait ?? true) && config.vocabulary.gateSentence
+        return "slot \(slot ? "on" : "off"), portrait \(portrait ? "on" : "off")"
+    }
+
     static func describe(_ error: Error) -> String {
         switch error {
         case let configError as ConfigError:

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -122,18 +122,12 @@ enum CheckConfigCommand {
                         ? "" : "  (the sentence tests are off —"
                             + " `vocabulary.gate_sentence: false`)"))
             }
-            // The set the step actually runs with, whichever of its three homes
-            // it came from. Silent when the pipeline holds no step at all.
-            //
-            // `readsBoundaries` is the same predicate that decides whether the
-            // 320 MB model is fetched, so a line saying the step is off is
-            // also saying nothing will be downloaded for it.
+            // The set the step runs with. Silent when the pipeline holds no
+            // step at all, which is also what says nothing is downloaded for it.
             if let step = pipeline.steps.first(where: { $0.stage == .interpret }) {
                 let marks = step.marks ?? transcription.marks(for: "en")
                 emit("  · sentence marks    \(marks.joined(separator: " "))"
-                    + (step.capitals == false ? "  (bare capitals off)" : "")
-                    + (config.readsBoundaries
-                        ? "" : "  (off — `transcription.sentences: false`)"))
+                    + (step.capitals == false ? "  (bare capitals off)" : ""))
             }
             // An empty pipeline is a choice, not a blank: printing nothing
             // there reads as a display fault rather than as the answer to "why

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -98,18 +98,30 @@ enum CheckConfigCommand {
                 .map { "\"\($0)\"" }.joined(separator: ", ")
             emit("  · wake phrase       \(listed.isEmpty ? "none — spoken commands are off" : listed)")
             emit("  · rewrite line      \(transcription.rewriteLine ? "on" : "off (terminals can't be edited without it)")")
+            // The pipeline, because "why was this not converted" is a question
+            // about the order and not about a setting any more.
+            let pipeline = Pipeline.resolved(config: config)
+            let vocabulary = pipeline.steps.first { $0.stage == .vocabulary }
             // The floor is not the same in two languages, so it is printed per
             // language rather than once. The marks are not: they belong to the
             // `interpret` step, which is English only, and they are printed
             // with it below.
             emit("  · languages         \(transcription.languages.joined(separator: ", "))")
             for language in transcription.languages {
-                emit("      \(language)  slot floor"
-                    + " \(String(format: "%.2f", transcription.slotFloor(for: language)))")
+                let floor = transcription.slotFloor(for: language, on: vocabulary)
+                emit("      \(language)  slot floor \(String(format: "%.2f", floor))")
             }
-            // The pipeline, because "why was this not converted" is a question
-            // about the order and not about a setting any more.
-            let pipeline = Pipeline.resolved(config: config)
+            // Which of the two tests that read the sentence will run, and the
+            // same predicates that decide whether their models are fetched — so
+            // a line saying a half is off is also saying nothing is downloaded
+            // for it. Silent when the pipeline holds no `vocabulary` step.
+            if vocabulary != nil {
+                emit("  · vocabulary gates  slot \(config.readsSlots ? "on" : "off"),"
+                    + " portrait \(config.readsPortraits ? "on" : "off")"
+                    + (config.vocabulary.gateSentence
+                        ? "" : "  (the sentence tests are off —"
+                            + " `vocabulary.gate_sentence: false`)"))
+            }
             // The set the step actually runs with, whichever of its three homes
             // it came from. Silent when the pipeline holds no step at all.
             //

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1721,13 +1721,19 @@ struct Config: Decodable, Equatable {
             }
         }
 
-        /// The settings that key off which language you dictated in.
+        /// Legacy. The settings that key off which language you dictated in.
         ///
         ///     transcription:
         ///       per_language:
         ///         fr:
         ///           slot_floor: 0.30
         ///           marks: [".", ",", "?"]
+        ///
+        /// Both of its keys live on a pipeline step now — `marks:` on
+        /// `interpret`, `slot_floor:` on `vocabulary` — so the whole block is
+        /// legacy. It is still read, and neither key is refused: a move that
+        /// changes what a gate does without a word is the one outcome this must
+        /// not have. `notices()` says so.
         ///
         /// An entry overrides only the keys it names. Everything else keeps the
         /// built-in value for that language, and a language with no entry keeps
@@ -1749,8 +1755,21 @@ struct Config: Decodable, Equatable {
 
         /// How far the heard word must win by before the vocabulary gate
         /// refuses a rewrite — see `SlotReference`.
-        func slotFloor(for language: String) -> Double {
-            perLanguage[language]?.slotFloor
+        ///
+        /// `step` is the `vocabulary` step that is running. A `slot_floor:` on
+        /// it answers alone: a language its map does not name keeps the
+        /// built-in value rather than falling back to `per_language`, so one
+        /// map is one complete statement of the floors.
+        ///
+        /// `transcription.per_language.<lang>.slot_floor` is the old home and
+        /// still feeds a step that names none.
+        func slotFloor(for language: String, on step: Pipeline.Step? = nil) -> Double {
+            if let written = step?.slotFloor {
+                return written.value(for: language)
+                    ?? Language.builtIn[language]?.slotFloor
+                    ?? Language.defaultSlotFloor
+            }
+            return perLanguage[language]?.slotFloor
                 ?? Language.builtIn[language]?.slotFloor
                 ?? Language.defaultSlotFloor
         }
@@ -1797,19 +1816,26 @@ struct Config: Decodable, Equatable {
                     marks = try Self.checked(marks: written, key: "\(path).marks")
                 }
                 if let written = try c.decodeIfPresent(Double.self, forKey: .slotFloor) {
-                    // The gap is one cosine minus another, so it never goes
-                    // below -2 and a floor of 2 refuses nothing. At 0 or less
-                    // the faintest lean against the term refuses it.
-                    guard written > 0, written <= 2 else {
-                        throw ConfigError.invalidValue(
-                            key: "\(path).slot_floor",
-                            value: "\(written)",
-                            expected: "a number above 0 and at most 2 — 0.20 in English,"
-                                + " 0.30 in French"
-                        )
-                    }
-                    slotFloor = written
+                    slotFloor = try Self.checked(slotFloor: written, key: "\(path).slot_floor")
                 }
+            }
+
+            /// The gap is one cosine minus another, so it never goes below -2
+            /// and a floor of 2 refuses nothing. At 0 or less the faintest lean
+            /// against the term refuses it.
+            ///
+            /// `key` names where it was written, because there are two homes —
+            /// the step's `slot_floor:` and the legacy `per_language` one.
+            static func checked(slotFloor written: Double, key: String) throws -> Double {
+                guard written > 0, written <= 2 else {
+                    throw ConfigError.invalidValue(
+                        key: key,
+                        value: "\(written)",
+                        expected: "a number above 0 and at most 2 — 0.20 in English,"
+                            + " 0.30 in French"
+                    )
+                }
+                return written
             }
 
             /// A mark is one punctuation character. Any word here would be
@@ -1969,6 +1995,9 @@ struct Config: Decodable, Equatable {
         ///       when: vocabulary.count > 0
         ///       near_misses: false
         ///       by_sound: false
+        ///       slot_gate: false
+        ///       portrait: false
+        ///       slot_floor: {en: 0.20, fr: 0.30}
         ///       review: gpt
         ///       max_slots: 4
         ///
@@ -1987,6 +2016,9 @@ struct Config: Decodable, Equatable {
             var nearMisses: Bool?
             var bySound: Bool?
             var gate: Bool?
+            var slotGate: Bool?
+            var portrait: Bool?
+            var slotFloor: Pipeline.Step.SlotFloor?
             /// What `review:` said, for `Transcription.retiredReview`. Read so
             /// it can be reported, never used.
             var review: String?
@@ -2010,6 +2042,9 @@ struct Config: Decodable, Equatable {
                 case maxPerSlot = "max_per_slot"
                 case maxPerTerm = "max_per_term"
                 case marks, capitals, pause
+                case slotGate = "slot_gate"
+                case portrait
+                case slotFloor = "slot_floor"
             }
 
             init(from decoder: Decoder) throws {
@@ -2057,6 +2092,9 @@ struct Config: Decodable, Equatable {
                     nearMisses = try c.decodeIfPresent(Bool.self, forKey: .nearMisses)
                     bySound = try c.decodeIfPresent(Bool.self, forKey: .bySound)
                     gate = try c.decodeIfPresent(Bool.self, forKey: .gate)
+                    slotGate = try c.decodeIfPresent(Bool.self, forKey: .slotGate)
+                    portrait = try c.decodeIfPresent(Bool.self, forKey: .portrait)
+                    slotFloor = try Self.slotFloor(from: c)
                     // Two spellings, `review: false` and `review: <model>`,
                     // and neither reaches anything now. Read in both shapes so
                     // the message names what was written.
@@ -2080,6 +2118,42 @@ struct Config: Decodable, Equatable {
                 when = try c.decodeIfPresent(String.self, forKey: .when)
                 unless = try c.decodeIfPresent(String.self, forKey: .unless)
                 app = try c.decodeIfPresent(String.self, forKey: .app)
+            }
+
+            /// `slot_floor:` in either spelling — a number for every language,
+            /// or a map naming them one by one.
+            ///
+            /// Two spellings because a single-language machine should not have
+            /// to write its own language code to move one number, and a
+            /// bilingual one cannot say what it means with a single number:
+            /// the two floors were measured apart.
+            private static func slotFloor(
+                from c: KeyedDecodingContainer<CodingKeys>
+            ) throws -> Pipeline.Step.SlotFloor? {
+                let key = "pipeline.vocabulary.slot_floor"
+                if let every = (try? c.decodeIfPresent(Double.self, forKey: .slotFloor)) ?? nil {
+                    return Pipeline.Step.SlotFloor(
+                        everyLanguage: try Language.checked(slotFloor: every, key: key)
+                    )
+                }
+                guard let written = (try? c.decodeIfPresent(
+                    [String: Double].self, forKey: .slotFloor
+                )) ?? nil else {
+                    guard c.contains(.slotFloor) else { return nil }
+                    throw ConfigError.invalidValue(
+                        key: key,
+                        value: "neither a number nor a map",
+                        expected: "a number for every language — `slot_floor: 0.20` — or a"
+                            + " map — `slot_floor: {en: 0.20, fr: 0.30}`"
+                    )
+                }
+                var floors: [String: Double] = [:]
+                for (language, floor) in written {
+                    floors[language] = try Language.checked(
+                        slotFloor: floor, key: "\(key).\(language)"
+                    )
+                }
+                return Pipeline.Step.SlotFloor(byLanguage: floors)
             }
         }
 
@@ -2259,7 +2333,9 @@ struct Config: Decodable, Equatable {
                             stage: stage, transform: entry.transform,
                             prompt: entry.prompt, caps: entry.caps,
                             nearMisses: entry.nearMisses, bySound: entry.bySound,
-                            gate: entry.gate, marks: entry.marks,
+                            gate: entry.gate, slotGate: entry.slotGate,
+                            portrait: entry.portrait, slotFloor: entry.slotFloor,
+                            marks: entry.marks,
                             capitals: entry.capitals, pause: entry.pause,
                             when: entry.when, unless: entry.unless, app: entry.app
                         )
@@ -2949,6 +3025,17 @@ struct Config: Decodable, Equatable {
             said.append("sentences: the sentence readings no longer run; add"
                 + " `- interpret` to the front of `transcription.pipeline`")
         }
+        // Both keys of `per_language` live on a step now, so the block itself
+        // is legacy. Still read, and the step wins where both are written.
+        if transcription.perLanguage.values.contains(where: { $0.slotFloor != nil }) {
+            let step = Pipeline.resolved(config: self).steps.first { $0.stage == .vocabulary }
+            said.append("per_language: `transcription.per_language` is legacy —"
+                + " `slot_floor:` belongs on the `vocabulary` step now,"
+                + " `- {stage: vocabulary, slot_floor: {en: 0.20, fr: 0.30}}`."
+                + (step?.slotFloor == nil
+                    ? " Yours is still read"
+                    : " The step names one, and the step is what runs"))
+        }
         return said
     }
 
@@ -2961,6 +3048,40 @@ struct Config: Decodable, Equatable {
     var readsBoundaries: Bool {
         transcription.sentences.enabled
             && Pipeline.resolved(config: self).stages.contains(.interpret)
+    }
+
+    /// The `vocabulary` steps in the pipeline. More than one is legal, so
+    /// every predicate below asks whether *any* of them wants the model.
+    private var vocabularySteps: [Pipeline.Step] {
+        Pipeline.resolved(config: self).steps.filter { $0.stage == .vocabulary }
+    }
+
+    /// The `vocabulary` step the commands report on. The first, because a
+    /// second one is a rerun of the same stage rather than a different
+    /// configuration to describe.
+    var vocabularyStep: Pipeline.Step? { vocabularySteps.first }
+
+    /// Whether anything will read the 269 MB slot model: a `vocabulary` step
+    /// is in the pipeline and has not switched it off.
+    ///
+    /// One predicate for the same reason `readsBoundaries` is one: three
+    /// places warm this model, and a warm that disagrees with the step
+    /// downloads weights nothing will read.
+    var readsSlots: Bool {
+        vocabularySteps.contains { $0.slotGate ?? true }
+    }
+
+    /// Whether anything will read the 400 MB word vectors. Both tests that
+    /// read the sentence need them, so either switch keeps them.
+    var readsSentenceGate: Bool {
+        vocabulary.gateSentence
+            && vocabularySteps.contains { ($0.slotGate ?? true) || ($0.portrait ?? true) }
+    }
+
+    /// Whether a term's portrait is worth building — see
+    /// `AppDelegate.rebuildPortrait`.
+    var readsPortraits: Bool {
+        vocabulary.gateSentence && vocabularySteps.contains { $0.portrait ?? true }
     }
 
     var resolvedOutputDir: URL {

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -2842,6 +2842,19 @@ struct Config: Decodable, Equatable {
         // Said whether or not there are terms: a file can carry the old
         // file-level key and nothing else.
         said += vocabulary.legacy.map { "vocabulary: \($0)" }
+        // A floor for a language `languages:` does not list never runs: the
+        // lookup keys off the language of the transcript, and that list is
+        // what the detector may answer. Said rather than refused — the floor
+        // is a real setting for a real language, and `languages:` is the
+        // narrower list, changed far more often than the floors are.
+        for step in Pipeline.resolved(config: self).steps where step.stage == .vocabulary {
+            let idle = (step.slotFloor?.byLanguage.keys.sorted() ?? [])
+                .filter { !transcription.languages.contains($0) }
+            guard !idle.isEmpty else { continue }
+            said.append("pipeline: `slot_floor:` names"
+                + " \(idle.map { "`\($0)`" }.joined(separator: ", ")), which"
+                + " `transcription.languages` does not — that floor never runs")
+        }
         return said
     }
 

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -2027,6 +2027,17 @@ struct Config: Decodable, Equatable {
                             + " map — `slot_floor: {en: 0.20, fr: 0.30}`"
                     )
                 }
+                // A language nothing dictates in is a floor that never runs.
+                // Refused rather than kept, because a key that loads and does
+                // nothing is the failure `problems()` exists to prevent.
+                let unknown = written.keys.filter { !DictationLanguage.supported.contains($0) }
+                guard unknown.isEmpty else {
+                    throw ConfigError.invalidValue(
+                        key: key,
+                        value: unknown.sorted().map { "`\($0)`" }.joined(separator: ", "),
+                        expected: "one of \(DictationLanguage.supported.joined(separator: ", "))"
+                    )
+                }
                 var floors: [String: Double] = [:]
                 for (language, floor) in written {
                     floors[language] = try Language.checked(

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1824,6 +1824,15 @@ struct Config: Decodable, Equatable {
         /// "grammar is not a stage" is not what went wrong.
         var contradictoryEntries: [String] = []
 
+        /// An option written on a stage that does not read it — `slot_gate:`
+        /// on `numbers`, `marks:` on `vocabulary`. Each entry is already a
+        /// sentence, because the key and the stage it belongs to are both known
+        /// where it is found and neither is known here.
+        ///
+        /// Refused rather than ignored: a switch that loads and does nothing is
+        /// somebody believing a gate is off while it runs.
+        var misplacedOptions: [String] = []
+
         /// `review:` on a `vocabulary` step, which named the model that read
         /// each substitution. There is no model in that stage now, so the key
         /// is read and does nothing — announced through `notices()` the way
@@ -1910,6 +1919,9 @@ struct Config: Decodable, Equatable {
             var app: String?
             /// `stage:` and `transform:`/`prompt:`/`vocabulary:` on one entry.
             var namesBoth = false
+            /// Options this stage does not read — see
+            /// `Transcription.misplacedOptions`.
+            var misplaced: [String] = []
 
             private enum CodingKeys: String, CodingKey {
                 case stage, transform, prompt, vocabulary, when, unless, app
@@ -1995,10 +2007,27 @@ struct Config: Decodable, Equatable {
                     capitals = try c.decodeIfPresent(Bool.self, forKey: .capitals)
                     pause = try c.decodeIfPresent(Double.self, forKey: .pause)
                 }
+                for (owner, keys) in Self.stageKeys
+                where owner.caseInsensitiveCompare(name) != .orderedSame {
+                    misplaced += keys.filter { c.contains($0) }.map {
+                        "`\($0.stringValue):` is an option on the `\(owner)` stage."
+                            + " It does nothing here"
+                    }
+                }
                 when = try c.decodeIfPresent(String.self, forKey: .when)
                 unless = try c.decodeIfPresent(String.self, forKey: .unless)
                 app = try c.decodeIfPresent(String.self, forKey: .app)
             }
+
+            /// Which stage reads which option. Only these two stages have any:
+            /// `stage:`, `when:`, `unless:` and `app:` are read on every line.
+            private static let stageKeys: [(String, [CodingKeys])] = [
+                ("vocabulary", [
+                    .nearMisses, .bySound, .gate, .slotGate, .portrait, .slotFloor,
+                    .review, .maxSlots, .maxReadings, .maxPerSlot, .maxPerTerm,
+                ]),
+                ("interpret", [.marks, .capitals, .pause]),
+            ]
 
             /// `slot_floor:` in either spelling — a number for every language,
             /// or a map naming them one by one.
@@ -2179,6 +2208,7 @@ struct Config: Decodable, Equatable {
                             .trimmingCharacters(in: .whitespacesAndNewlines), !named.isEmpty {
                             retiredReview.append(named)
                         }
+                        misplacedOptions += entry.misplaced.map { "`\(entry.name)`: \($0)" }
                         return Pipeline.Step(
                             stage: stage, transform: entry.transform,
                             prompt: entry.prompt, caps: entry.caps,
@@ -2683,6 +2713,9 @@ struct Config: Decodable, Equatable {
         for name in Set(transcription.unknownStages).sorted() {
             found.append("pipeline: \"\(name)\" is not a stage — have: "
                 + Pipeline.stageNames.joined(separator: ", "))
+        }
+        for said in Set(transcription.misplacedOptions).sorted() {
+            found.append("pipeline: \(said)")
         }
         for name in Set(transcription.contradictoryEntries).sorted() {
             found.append("pipeline: an entry names both `stage:` and `prompt: \(name)`"

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1652,131 +1652,30 @@ struct Config: Decodable, Equatable {
         /// at all.
         var languages: [String] = ["en"]
 
-        /// Legacy. The switch the boundary readings had before they were the
-        /// `interpret` pipeline step — see `SentenceJoin`.
-        ///
-        ///     sentences: false               never look at a boundary
-        ///     sentences:
-        ///       marks: [".", ",", "?"]       what a boundary can be written
-        ///
-        /// Both spellings are still read, and neither is refused. A rename
-        /// that turns a stage on or off without a word is the one outcome this
-        /// move must not have: `false` still turns the step off, and `marks:`
-        /// still feeds it where the step names none. `notices()` says both.
-        ///
-        /// One list, two jobs. The sentence enders in it — `.` and `?` — are
-        /// where a boundary is looked for. Everything else in it — the comma —
-        /// is a reading tried at every boundary. So a boundary is read three
-        /// ways: the mark it carries, the comma, and no mark at all. Drop `?`
-        /// from the list and question marks stop being scanned.
-        ///
-        /// There is no threshold; the reading the model scores highest is the
-        /// one that is written. `;` and `:` were measured and never changed a
-        /// decision in English, so they are not in the default.
-        var sentences: Sentences = Sentences()
-
-        struct Sentences: Decodable, Equatable {
-            var enabled = true
-            /// The old home of the mark set. Read through
-            /// `Transcription.marks(for:)`, which prefers `per_language`;
-            /// `marksWritten` says the file set this one.
-            var marks: [String] = Language.defaultMarks
-            var marksWritten = false
-
-            /// Keys still read and no longer acted on, for `notices()`.
-            var legacy: [String] = []
-
-            enum CodingKeys: String, CodingKey {
-                case marks
-            }
-
-            /// The two thresholds the argmax replaced. Read only so that a
-            /// config still setting them can be told they do nothing.
-            private enum LegacyKeys: String, CodingKey {
-                case joinBelow = "join_below"
-                case offerBelow = "offer_below"
-            }
-
-            init() {}
-
-            init(from decoder: Decoder) throws {
-                if let on = try? decoder.singleValueContainer().decode(Bool.self) {
-                    enabled = on
-                    return
-                }
-                let c = try decoder.container(keyedBy: CodingKeys.self)
-                if let written = try c.decodeIfPresent([String].self, forKey: .marks) {
-                    marks = try Language.checked(
-                        marks: written, key: "transcription.sentences.marks"
-                    )
-                    marksWritten = true
-                }
-                let old = try decoder.container(keyedBy: LegacyKeys.self)
-                for key in [LegacyKeys.joinBelow, .offerBelow]
-                where ((try? old.decodeIfPresent(Double.self, forKey: key)) ?? nil) != nil {
-                    legacy.append("`\(key.stringValue):` was a threshold on a score."
-                        + " The boundary is settled by which reading the model scores"
-                        + " highest now, so there is nothing left to set")
-                }
-            }
-        }
-
-        /// Legacy. The settings that key off which language you dictated in.
-        ///
-        ///     transcription:
-        ///       per_language:
-        ///         fr:
-        ///           slot_floor: 0.30
-        ///           marks: [".", ",", "?"]
-        ///
-        /// Both of its keys live on a pipeline step now — `marks:` on
-        /// `interpret`, `slot_floor:` on `vocabulary` — so the whole block is
-        /// legacy. It is still read, and neither key is refused: a move that
-        /// changes what a gate does without a word is the one outcome this must
-        /// not have. `notices()` says so.
-        ///
-        /// An entry overrides only the keys it names. Everything else keeps the
-        /// built-in value for that language, and a language with no entry keeps
-        /// English's.
-        var perLanguage: [String: Language] = [:]
-
         /// The marks the `interpret` step tries beside removing the period,
-        /// where the step names none of its own.
-        ///
-        /// Two old homes of the same set, in order: `per_language.<lang>.marks`
-        /// then `transcription.sentences.marks`. Both are still read, and both
-        /// answer for English only — that stage has never run in another
-        /// language.
+        /// where the step names none of its own. English only — that stage has
+        /// never run in another language.
         func marks(for language: String) -> [String] {
-            if let written = perLanguage[language]?.marks { return written }
-            if language == "en", sentences.marksWritten { return sentences.marks }
-            return Language.builtIn[language]?.marks ?? Language.defaultMarks
+            Language.builtIn[language]?.marks ?? Language.defaultMarks
         }
 
         /// How far the heard word must win by before the vocabulary gate
         /// refuses a rewrite — see `SlotReference`.
         ///
-        /// `step` is the `vocabulary` step that is running. A `slot_floor:` on
-        /// it answers alone: a language its map does not name keeps the
-        /// built-in value rather than falling back to `per_language`, so one
-        /// map is one complete statement of the floors.
-        ///
-        /// `transcription.per_language.<lang>.slot_floor` is the old home and
-        /// still feeds a step that names none.
+        /// `step` is the `vocabulary` step that is running. Its `slot_floor:`
+        /// answers where it names the language, and a language it does not
+        /// name keeps the built-in value.
         func slotFloor(for language: String, on step: Pipeline.Step? = nil) -> Double {
-            if let written = step?.slotFloor {
-                return written.value(for: language)
-                    ?? Language.builtIn[language]?.slotFloor
-                    ?? Language.defaultSlotFloor
-            }
-            return perLanguage[language]?.slotFloor
+            step?.slotFloor?.value(for: language)
                 ?? Language.builtIn[language]?.slotFloor
                 ?? Language.defaultSlotFloor
         }
 
-        /// What one language sets. Every key is optional: naming a language to
-        /// change one of them must not silently reset the others.
-        struct Language: Decodable, Equatable {
+        /// What one language gets before a step says otherwise. Both values
+        /// live on a pipeline step now — `marks:` on `interpret`, `slot_floor:`
+        /// on `vocabulary` — so this is the built-in table and the two checks
+        /// those keys are read through, and nothing in the file decodes into it.
+        struct Language: Equatable {
             var marks: [String]?
             var slotFloor: Double?
 
@@ -1802,30 +1701,12 @@ struct Config: Decodable, Equatable {
                 self.slotFloor = slotFloor
             }
 
-            enum CodingKeys: String, CodingKey {
-                case marks
-                case slotFloor = "slot_floor"
-            }
-
-            init(from decoder: Decoder) throws {
-                let named = decoder.codingPath.last?.stringValue ?? ""
-                let path = "transcription.per_language"
-                    + (named.isEmpty ? "" : ".\(named)")
-                let c = try decoder.container(keyedBy: CodingKeys.self)
-                if let written = try c.decodeIfPresent([String].self, forKey: .marks) {
-                    marks = try Self.checked(marks: written, key: "\(path).marks")
-                }
-                if let written = try c.decodeIfPresent(Double.self, forKey: .slotFloor) {
-                    slotFloor = try Self.checked(slotFloor: written, key: "\(path).slot_floor")
-                }
-            }
-
             /// The gap is one cosine minus another, so it never goes below -2
             /// and a floor of 2 refuses nothing. At 0 or less the faintest lean
             /// against the term refuses it.
             ///
-            /// `key` names where it was written, because there are two homes —
-            /// the step's `slot_floor:` and the legacy `per_language` one.
+            /// `key` names the language the map entry was written under, so a
+            /// bad number in a map says which one.
             static func checked(slotFloor written: Double, key: String) throws -> Double {
                 guard written > 0, written <= 2 else {
                     throw ConfigError.invalidValue(
@@ -1884,8 +1765,7 @@ struct Config: Decodable, Equatable {
         }
 
         enum CodingKeys: String, CodingKey {
-            case enabled, replacements, pipeline, languages, sentences
-            case perLanguage = "per_language"
+            case enabled, replacements, pipeline, languages
             case insertMode = "insert_mode"
             case activationPhrases = "activation_phrases"
             case activationPhrase = "activation_phrase"
@@ -2260,47 +2140,6 @@ struct Config: Decodable, Equatable {
                 // than no language at all, so a typo degrades instead of
                 // leaving the correction prompt undefined.
                 languages = known.isEmpty ? ["en"] : known
-            }
-            // Not `try?`. Swallowing the error leaves joining on with stock
-            // thresholds, and a stage that rewrites the transcript must not be
-            // reached by a line the file got wrong.
-            do {
-                if let v = try c.decodeIfPresent(Sentences.self, forKey: .sentences) {
-                    sentences = v
-                }
-            } catch let bad as ConfigError {
-                throw bad
-            } catch {
-                throw ConfigError.invalidValue(
-                    key: "transcription.sentences",
-                    value: "not a sentence setting",
-                    expected: "`false`, or `marks:` as a list of punctuation marks"
-                )
-            }
-            // Not `try?` either, and for the same reason: a floor the file got
-            // wrong must not leave the gate running on a stock one.
-            do {
-                if let written = try c.decodeIfPresent(
-                    [String: Language].self, forKey: .perLanguage
-                ) {
-                    let unknown = written.keys.filter { !DictationLanguage.supported.contains($0) }
-                    guard unknown.isEmpty else {
-                        throw ConfigError.invalidValue(
-                            key: "transcription.per_language",
-                            value: unknown.sorted().map { "`\($0)`" }.joined(separator: ", "),
-                            expected: "one of \(DictationLanguage.supported.joined(separator: ", "))"
-                        )
-                    }
-                    perLanguage = written
-                }
-            } catch let bad as ConfigError {
-                throw bad
-            } catch {
-                throw ConfigError.invalidValue(
-                    key: "transcription.per_language",
-                    value: "not a language block",
-                    expected: "a language code, then `marks:` or `slot_floor:` under it"
-                )
             }
             // Wrapped, as `replacements:` is below and for the same reason.
             // Anything thrown here leaves `ConfigStore.load()` entirely, and at
@@ -2992,62 +2831,16 @@ struct Config: Decodable, Equatable {
         // Said whether or not there are terms: a file can carry the old
         // file-level key and nothing else.
         said += vocabulary.legacy.map { "vocabulary: \($0)" }
-        said += transcription.sentences.legacy.map { "sentences: \($0)" }
-        // The boundary readings are the `interpret` step now, so both of their
-        // older switches are legacy. Each is still read: a rename that turns a
-        // stage on or off without a word is the one outcome it must not have.
-        let interpret = Pipeline.resolved(config: self).steps.first { $0.stage == .interpret }
-        if !transcription.sentences.enabled {
-            said.append("sentences: `transcription.sentences: false` is legacy; remove the"
-                + " `interpret` step from the pipeline instead."
-                + (interpret == nil ? "" : " The step is in your pipeline and this key"
-                    + " is what still turns it off"))
-        }
-        // The marks moved twice — out of `sentences:` into `per_language`, and
-        // now onto the step. Both older homes still answer for English.
-        let legacyMarks = transcription.sentences.marksWritten
-            || transcription.perLanguage["en"]?.marks != nil
-        if legacyMarks, interpret?.marks != nil {
-            said.append("sentences: `marks:` is set on the `interpret` step and in"
-                + " `transcription."
-                + (transcription.perLanguage["en"]?.marks != nil
-                    ? "per_language.en" : "sentences")
-                + ".marks`. The step is what runs")
-        } else if legacyMarks {
-            said.append("sentences: `marks:` belongs on the `interpret` step now —"
-                + " `- {stage: interpret, marks: [\".\", \",\", \"?\"]}`."
-                + " Yours is still read")
-        }
-        // Said, not done. A pipeline written before the step existed loses the
-        // readings, and nobody runs `--check-config` after an update — so this
-        // is also what the log says at launch, through `notices()`.
-        if transcription.pipeline != nil, interpret == nil, transcription.sentences.enabled {
-            said.append("sentences: the sentence readings no longer run; add"
-                + " `- interpret` to the front of `transcription.pipeline`")
-        }
-        // Both keys of `per_language` live on a step now, so the block itself
-        // is legacy. Still read, and the step wins where both are written.
-        if transcription.perLanguage.values.contains(where: { $0.slotFloor != nil }) {
-            let step = Pipeline.resolved(config: self).steps.first { $0.stage == .vocabulary }
-            said.append("per_language: `transcription.per_language` is legacy —"
-                + " `slot_floor:` belongs on the `vocabulary` step now,"
-                + " `- {stage: vocabulary, slot_floor: {en: 0.20, fr: 0.30}}`."
-                + (step?.slotFloor == nil
-                    ? " Yours is still read"
-                    : " The step names one, and the step is what runs"))
-        }
         return said
     }
 
-    /// Whether the `interpret` step will actually read a boundary: it is in
-    /// the pipeline, and the legacy switch has not turned it off.
+    /// Whether the `interpret` step will read a boundary: it is in the
+    /// pipeline.
     ///
     /// One predicate, because two places warm the 320 MB sentence model and a
-    /// warm that disagrees with `Pipeline.skipReason` fetches weights nothing
-    /// will read.
+    /// warm that disagrees with the pipeline fetches weights nothing will read.
     var readsBoundaries: Bool {
-        transcription.sentences.enabled
-            && Pipeline.resolved(config: self).stages.contains(.interpret)
+        Pipeline.resolved(config: self).stages.contains(.interpret)
     }
 
     /// The `vocabulary` steps in the pipeline. More than one is legal, so

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -174,6 +174,28 @@ struct Pipeline: Equatable, Codable {
         /// whatever arrived, which is what the gate was measured against and
         /// the only way to measure it again.
         var gate: Bool?
+        /// Written `slot_gate:`. Whether anything reads the mmBERT slot — the
+        /// part of speech the spot wants, in `SlotGate`, and the ten words it
+        /// expects there, in `SlotReference`. Absent means true.
+        ///
+        /// One switch for both because they are one model, and the promise the
+        /// switch makes is that `false` downloads nothing. Each half takes the
+        /// path it already has on a machine the 269 MB is not on: the lexical
+        /// gate settles what the word lists settle and asks nothing more, and
+        /// the sentence gate is left to the portrait alone.
+        var slotGate: Bool?
+        /// Written `portrait:`. Whether a term's own sentences and its
+        /// counter-examples may settle a proposal — see `TermPortrait`. Absent
+        /// means true.
+        ///
+        /// `false` takes the path a term with too few uses already has: the
+        /// portrait says nothing, and the slot's refusal is all that can speak.
+        var portrait: Bool?
+        /// Written `slot_floor:`. How far the heard word must win by before
+        /// `SlotReference` refuses the rewrite. Absent falls back to the legacy
+        /// `transcription.per_language.<lang>.slot_floor`, then to the built-in
+        /// value for the language — see `Transcription.slotFloor(for:on:)`.
+        var slotFloor: SlotFloor?
         /// `marks:` on an `interpret` step. What a boundary can be written
         /// with: the sentence enders in the list are where one is looked for,
         /// the rest are readings tried at one. Absent falls back to
@@ -202,6 +224,23 @@ struct Pipeline: Equatable, Codable {
         /// the cost of an anchor people forget — which `validate` refuses
         /// rather than leaving to run everywhere in silence.
         var app: String?
+
+        /// What `slot_floor:` said, in either spelling.
+        ///
+        ///     slot_floor: 0.20                 every language
+        ///     slot_floor: {en: 0.20, fr: 0.30} one at a time
+        ///
+        /// A language the map does not name keeps its built-in floor. The map
+        /// is read as the whole statement of the floors, so it does not fall
+        /// back to `per_language` for the languages it leaves out.
+        struct SlotFloor: Equatable, Codable {
+            var everyLanguage: Double?
+            var byLanguage: [String: Double] = [:]
+
+            func value(for language: String) -> Double? {
+                byLanguage[language] ?? everyLanguage
+            }
+        }
 
         /// Whether a condition is a pattern rather than an expression.
         ///
@@ -1116,7 +1155,14 @@ struct Pipeline: Equatable, Codable {
         // spells names into it on runs where nothing was even offered.
         var census = "vocabulary: \(slots.count) slot(s) from \(parts.count) proposal(s)"
         if bySound > 0 { census += " (\(bySound) by sound)" }
-        if config.vocabulary.gateSentence { census += ", sentence gate on" }
+        // Which of the two halves is on, not just that the gate is: a place
+        // decided by the portrait alone reads nothing like one both tests saw.
+        let reading = [
+            (step.slotGate ?? true) ? "slot" : nil, (step.portrait ?? true) ? "portrait" : nil,
+        ].compactMap { $0 }
+        if config.vocabulary.gateSentence, !reading.isEmpty {
+            census += ", sentence gate on (\(reading.joined(separator: " + ")))"
+        }
         if !slots.isEmpty, ProcessInfo.processInfo.environment["PARROTFLOW_JUDGE_DUMP"] != nil {
             census += " — " + slots.map {
                 "\"\(text[$0.range])\" (\($0.terms.joined(separator: "/")))"
@@ -1139,10 +1185,13 @@ struct Pipeline: Equatable, Codable {
         // `taught` wins over the gate, because a spelling lesson is settled by
         // a rule that is 4/4 where the models measured were 0/4.
         let gatedAt = Date()
+        // `slot_gate: false` passes no gate at all, which is the path a machine
+        // without the 269 MB model already takes: the word lists settle what
+        // they settle and the slot's part of speech is never asked.
+        let slotGate = (step.slotGate ?? true) ? await Vocabulary.shared.slotGate() : nil
         let settled = (step.gate ?? true)
             ? VocabularyJudge.settle(
-                changes, in: text, by: [.sound: .full, .rule: .lists],
-                gate: await Vocabulary.shared.slotGate())
+                changes, in: text, by: [.sound: .full, .rule: .lists], gate: slotGate)
             : [Bool?](repeating: nil, count: changes.count)
         var decided: [Bool?] = changes.indices.map { index in
             index < taught.count && taught[index] ? false : settled[index]
@@ -1152,8 +1201,9 @@ struct Pipeline: Equatable, Codable {
             decided = await SentenceGate.settle(
                 changes, in: text, given: decided,
                 floor: config.transcription.slotFloor(
-                    for: Pipeline.language(of: text, config: config)
-                )
+                    for: Pipeline.language(of: text, config: config), on: step
+                ),
+                slot: step.slotGate ?? true, portrait: step.portrait ?? true
             )
         }
         gateSeconds = Date().timeIntervalSince(gatedAt)

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -1182,14 +1182,18 @@ struct Pipeline: Equatable, Codable {
         // `taught` wins over the gate, because a spelling lesson is settled by
         // a rule that is 4/4 where the models measured were 0/4.
         let gatedAt = Date()
-        // `slot_gate: false` passes no gate at all, which is the path a machine
-        // without the 269 MB model already takes: the word lists settle what
-        // they settle and the slot's part of speech is never asked.
-        let slotGate = (step.slotGate ?? true) ? await Vocabulary.shared.slotGate() : nil
-        let settled = (step.gate ?? true)
-            ? VocabularyJudge.settle(
-                changes, in: text, by: [.sound: .full, .rule: .lists], gate: slotGate)
-            : [Bool?](repeating: nil, count: changes.count)
+        let settled: [Bool?]
+        if step.gate ?? true {
+            // `slot_gate: false` passes no gate at all, which is the path a
+            // machine without the 269 MB model already takes: the word lists
+            // settle what they settle and the slot is never asked. Read inside
+            // the branch so `gate: false` does not load it either.
+            let slot = (step.slotGate ?? true) ? await Vocabulary.shared.slotGate() : nil
+            settled = VocabularyJudge.settle(
+                changes, in: text, by: [.sound: .full, .rule: .lists], gate: slot)
+        } else {
+            settled = [Bool?](repeating: nil, count: changes.count)
+        }
         var decided: [Bool?] = changes.indices.map { index in
             index < taught.count && taught[index] ? false : settled[index]
         }

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -192,14 +192,22 @@ struct Pipeline: Equatable, Codable {
         /// portrait says nothing, and the slot's refusal is all that can speak.
         var portrait: Bool?
         /// Written `slot_floor:`. How far the heard word must win by before
-        /// `SlotReference` refuses the rewrite. Absent falls back to the legacy
-        /// `transcription.per_language.<lang>.slot_floor`, then to the built-in
-        /// value for the language — see `Transcription.slotFloor(for:on:)`.
+        /// `SlotReference` refuses the rewrite. A language it does not name
+        /// keeps the built-in value for that language — see
+        /// `Transcription.slotFloor(for:on:)`.
         var slotFloor: SlotFloor?
         /// `marks:` on an `interpret` step. What a boundary can be written
-        /// with: the sentence enders in the list are where one is looked for,
-        /// the rest are readings tried at one. Absent falls back to
-        /// `transcription.per_language.<lang>.marks`.
+        /// with. Absent takes the built-in set for the language.
+        ///
+        /// One list, two jobs. The sentence enders in it — `.` and `?` — are
+        /// where a boundary is looked for. Everything else in it — the comma —
+        /// is a reading tried at every boundary. So a boundary is read three
+        /// ways: the mark it carries, the comma, and no mark at all. Drop `?`
+        /// from the list and question marks stop being scanned.
+        ///
+        /// There is no threshold; the reading the model scores highest is the
+        /// one that is written. `;` and `:` were measured and never changed a
+        /// decision in English, so they are not in the default.
         var marks: [String]?
         /// `capitals:` on an `interpret` step. Whether a capital with no mark
         /// in front of it is read as a boundary too. Absent means true.
@@ -230,9 +238,7 @@ struct Pipeline: Equatable, Codable {
         ///     slot_floor: 0.20                 every language
         ///     slot_floor: {en: 0.20, fr: 0.30} one at a time
         ///
-        /// A language the map does not name keeps its built-in floor. The map
-        /// is read as the whole statement of the floors, so it does not fall
-        /// back to `per_language` for the languages it leaves out.
+        /// A language the map does not name keeps its built-in floor.
         struct SlotFloor: Equatable, Codable {
             var everyLanguage: Double?
             var byLanguage: [String: Double] = [:]
@@ -579,15 +585,6 @@ struct Pipeline: Equatable, Codable {
         for step: Step, text: String, config: Config, allowPrompts: Bool, app: App? = nil,
         scope: Scope = Scope()
     ) -> Skip? {
-        // The legacy off switch. `transcription.sentences: false` predates the
-        // step and still turns it off: reading it as "on, because the step is
-        // listed" would start a stage somebody switched off, without a word.
-        if step.stage == .interpret, !config.transcription.sentences.enabled {
-            return Skip(
-                code: "legacy_off",
-                described: "`transcription.sentences: false` turns this step off"
-            )
-        }
         if step.stage == .vocabulary {
             // It costs a model call, so it answers to the same two guards a
             // prompt does: `--replace` must stay off the network, and a spoken

--- a/Sources/ParrotFlow/PipelineCommand.swift
+++ b/Sources/ParrotFlow/PipelineCommand.swift
@@ -133,7 +133,9 @@ enum PipelineCommand {
             return Pipeline.Step(
                 stage: stage, transform: entry.transform, prompt: entry.prompt,
                 caps: entry.caps, nearMisses: entry.nearMisses,
-                bySound: entry.bySound, gate: entry.gate, marks: entry.marks,
+                bySound: entry.bySound, gate: entry.gate, slotGate: entry.slotGate,
+                portrait: entry.portrait, slotFloor: entry.slotFloor,
+                marks: entry.marks,
                 capitals: entry.capitals, pause: entry.pause, when: entry.when,
                 unless: entry.unless, app: entry.app
             )
@@ -200,11 +202,18 @@ enum PipelineCommand {
         if warm, #available(macOS 14, *) {
             let failures = Blocking.run { () async -> [String] in
                 var found: [String] = []
-                do { try await WordVectors.shared.prepare() } catch {
-                    found.append("word vectors — \(error.localizedDescription)")
+                // Only what the pipeline's own steps will read. A fixture that
+                // switches a gate off has nothing to do with these weights, and
+                // `--warm` is a download.
+                if config.readsSentenceGate {
+                    do { try await WordVectors.shared.prepare() } catch {
+                        found.append("word vectors — \(error.localizedDescription)")
+                    }
                 }
-                do { _ = try await SlotModel.shared.prepare() } catch {
-                    found.append("slot model — \(error.localizedDescription)")
+                if config.readsSlots {
+                    do { _ = try await SlotModel.shared.prepare() } catch {
+                        found.append("slot model — \(error.localizedDescription)")
+                    }
                 }
                 // Only for a pipeline that holds the step. It is 320 MB, and a
                 // fixture without the step has nothing to read them.

--- a/Sources/ParrotFlow/PipelineCommand.swift
+++ b/Sources/ParrotFlow/PipelineCommand.swift
@@ -29,10 +29,6 @@ enum PipelineCommand {
     /// A fixture is a config with everything irrelevant left out.
     private struct Fixture: Decodable {
         var languages: [String] = ["en"]
-        /// The floor the vocabulary gate reads and the marks the sentence
-        /// stage tries. A fixture that cannot state its floor cannot say what
-        /// the gate was scored at.
-        var perLanguage: [String: Config.Transcription.Language] = [:]
         var replacements: [String: [String]] = [:]
         var pipeline: [Config.Transcription.PipelineEntry] = []
         /// Its own `transforms:`, decoded by `Config` rather than re-read here,
@@ -54,15 +50,11 @@ enum PipelineCommand {
 
         enum CodingKeys: String, CodingKey {
             case languages, replacements, pipeline, transforms, vocabulary, lists, models
-            case perLanguage = "per_language"
         }
 
         init(from decoder: Decoder) throws {
             let c = try decoder.container(keyedBy: CodingKeys.self)
             if let v = try c.decodeIfPresent([String].self, forKey: .languages) { languages = v }
-            if let v = try c.decodeIfPresent(
-                [String: Config.Transcription.Language].self, forKey: .perLanguage
-            ) { perLanguage = v }
             if let v = try c.decodeIfPresent([String: [String]].self, forKey: .replacements) {
                 replacements = v
             }
@@ -148,7 +140,6 @@ enum PipelineCommand {
         let pipeline = Pipeline(steps: steps)
         var config = Config()
         config.transcription.languages = fixture.languages
-        config.transcription.perLanguage = fixture.perLanguage
         config.transcription.replacements = fixture.replacements
         config.transcription.pipeline = pipeline
         config.transforms = fixture.transforms

--- a/Sources/ParrotFlow/SentenceGate.swift
+++ b/Sources/ParrotFlow/SentenceGate.swift
@@ -36,11 +36,17 @@ enum SentenceGate {
     ///
     /// `floor` is how far the heard word must win by before `SlotReference`
     /// refuses. It keys off the language of the transcript — see
-    /// `Config.Transcription.slotFloor(for:)`.
+    /// `Config.Transcription.slotFloor(for:on:)`.
+    ///
+    /// `slot` and `portrait` are the step's own switches. Each off is the path
+    /// that half already has when it cannot answer: `SlotReference` refuses
+    /// nothing, the portrait says nothing. The four outcomes above are read the
+    /// same way either way, so one half off leaves the other deciding alone.
     static func settle(
         _ changes: [VocabularyJudge.Change], in text: String, given settled: [Bool?],
-        floor: Double
+        floor: Double, slot: Bool = true, portrait: Bool = true
     ) async -> [Bool?] {
+        guard slot || portrait else { return settled }
         // Never on the dictation's time. The word vectors are 400 MB and the
         // first MLX call warms Metal; waiting for that with the pill on screen
         // reads as the app having hung, which is what it did.
@@ -49,7 +55,9 @@ enum SentenceGate {
             Log.write("sentence gate: the word vectors are not loaded yet; skipped")
             return settled
         }
-        guard SlotModel.isCached else {
+        // Only the slot half reads it. With that half off the portrait runs on
+        // a machine the 269 MB was never fetched to.
+        if slot, !SlotModel.isCached {
             Log.write("sentence gate: the slot model is not cached yet; skipped")
             return settled
         }
@@ -98,11 +106,15 @@ enum SentenceGate {
             let near = TermPortrait.window(around: from ..< upto, in: heard)
 
             if out[index] == true {
-                let portrait = await TermPortrait.shared.reads(
+                // Only the portrait may take a rule's write back out. With it
+                // off the write stands, which is what it did before the
+                // portrait existed.
+                guard portrait else { continue }
+                let read = await TermPortrait.shared.reads(
                     change.was, in: near, as: term
                 )
                 looked += 1
-                if portrait == .refuses {
+                if read == .refuses {
                     out[index] = false
                     Log.write(
                         "sentence gate: \"\(change.was)\" -> \(term) taken back out"
@@ -115,23 +127,25 @@ enum SentenceGate {
                 continue
             }
 
-            let refuses: Bool
-            do {
-                let gap = try await SlotReference.gap(
-                    term: change.now, heard: change.was, at: change.range, in: text
-                )
-                refuses = gap < -floor
-            } catch {
-                // A place the slot cannot read is a place this stage has no
-                // opinion about, not one to guess at.
-                Log.write("sentence gate: \(change.was) — \(error.localizedDescription)")
-                continue
+            var refuses = false
+            if slot {
+                do {
+                    let gap = try await SlotReference.gap(
+                        term: change.now, heard: change.was, at: change.range, in: text
+                    )
+                    refuses = gap < -floor
+                } catch {
+                    // A place the slot cannot read is a place this stage has no
+                    // opinion about, not one to guess at.
+                    Log.write("sentence gate: \(change.was) — \(error.localizedDescription)")
+                    continue
+                }
             }
-            let portrait = await TermPortrait.shared.reads(
-                change.was, in: near, as: term
-            )
+            let read = portrait
+                ? await TermPortrait.shared.reads(change.was, in: near, as: term)
+                : TermPortrait.Verdict.nothing
 
-            switch (refuses, portrait) {
+            switch (refuses, read) {
             case (true, .authorises):
                 Log.write("sentence gate: \"\(change.was)\" -> \(term) — the two disagree")
             case (true, _), (false, .refuses):

--- a/Sources/ParrotFlow/SentenceJoin.swift
+++ b/Sources/ParrotFlow/SentenceJoin.swift
@@ -359,8 +359,6 @@ actor SentenceJoin {
         capitals: Bool = true, pause: Double = SentenceJoin.paused,
         words: [Trace.Word] = []
     ) async -> Outcome {
-        let settings = config.transcription.sentences
-        guard settings.enabled else { return .unchanged(text) }
         let language = Pipeline.language(of: text, config: config)
         guard language == "en" else { return .unchanged(text) }
         let marks = written ?? config.transcription.marks(for: language)

--- a/Sources/ParrotFlow/SentenceJoinCommand.swift
+++ b/Sources/ParrotFlow/SentenceJoinCommand.swift
@@ -29,7 +29,7 @@ enum SentenceJoinCommand {
         let config = (try? ConfigStore.load()) ?? Config()
         if caseOnly {
             let terms = Array(config.vocabulary.terms.keys)
-            let scan = SentenceJoin.scanned(config.transcription.sentences.marks)
+            let scan = SentenceJoin.scanned(config.transcription.marks(for: "en"))
             let found = (
                 SentenceJoin.boundaries(in: text, scanning: scan)
                 + SentenceJoin.bareBoundaries(in: text)

--- a/Sources/ParrotFlow/SlotGapCommand.swift
+++ b/Sources/ParrotFlow/SlotGapCommand.swift
@@ -42,8 +42,10 @@ enum SlotGapCommand {
             return 1
         case .success(let (gap, words)):
             print("expected  \(words.joined(separator: " "))")
-            let floor = ((try? ConfigStore.load()) ?? Config())
-                .transcription.slotFloor(for: language)
+            let config = (try? ConfigStore.load()) ?? Config()
+            let floor = config.transcription.slotFloor(
+                for: language, on: config.vocabularyStep
+            )
             let verdict = gap < -floor ? "refuse" : "no opinion"
             print("gap       \(String(format: "%+.3f", gap))   \(verdict)")
             return 0

--- a/Sources/ParrotFlow/SlotReference.swift
+++ b/Sources/ParrotFlow/SlotReference.swift
@@ -30,9 +30,9 @@ import Foundation
 /// at the English floor: no correct rewrite refused, no ordinary word
 /// overwritten.
 ///
-/// **The floor is per language and it lives in the config**, at
-/// `transcription.per_language.<code>.slot_floor` — 0.20 in English, 0.30 in
-/// French. It is the raw difference of two cosines, not divided by anything.
+/// **The floor is per language and it lives in the config**, as `slot_floor:`
+/// on the `vocabulary` step — 0.20 in English, 0.30 in French. It is the raw
+/// difference of two cosines, not divided by anything.
 /// Dividing by the spread of the ten words looks like it should help and does
 /// the opposite: a sentence holding a rare name makes the ten words collapse
 /// together, the spread goes to 0.002, and the ratio explodes on exactly the

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -497,8 +497,8 @@ actor Transcriber {
         //
         // Fetched at launch too. This is the retry: a fetch that failed clears
         // itself, and the next dictation tries again.
-        warmSlotModel()
-        if config.vocabulary.gateSentence, #available(macOS 14, *) {
+        if config.readsSlots { warmSlotModel() }
+        if config.readsSentenceGate, #available(macOS 14, *) {
             Task { await WordVectors.shared.warm() }
         }
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -80,15 +80,6 @@ transcription:
   # entry turns off language detection.
   languages: [en, fr]
 
-  # The settings that differ from one language to the next. `slot_floor` is
-  # how far the heard word must win by before the vocabulary gate refuses a
-  # rewrite: 0.20 in English, 0.30 in French, where the gaps are a third
-  # narrower.
-  #
-  # per_language:
-  #   en: {slot_floor: 0.20}
-  #   fr: {slot_floor: 0.30}
-
   # What a transcript runs through, in order. Remove a line to skip that
   # stage. One list for every language: a step that should only run in one
   # takes `when: language == "fr"`. See docs/pipelines.md.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -184,7 +184,10 @@ so a case file states the setup it assumes instead of inheriting this machine's.
   sentence gate never makes a dictation wait, so in a one-shot run nothing has
   loaded them and the two tests that read the sentence are skipped every time —
   this is the only way to see them from the command line. Off by default: it is
-  about 600 MB of downloads, and `make test` must not need one.
+  about 600 MB of downloads, and `make test` must not need one. Only what the
+  fixture's own pipeline reads: a fixture with `slot_gate: false` on its
+  `vocabulary` step fetches no slot model, and one with no `vocabulary` step
+  fetches neither.
 - `--lang en,fr` stands in for the configured `languages:`, so a case file does
   not depend on how this Mac is set up.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -440,8 +440,8 @@ $PF --slot-gap "The old house looked ghostly in the fog." ghostly Ghostty
 
 `gap` is `cos(term, centre) − cos(heard, centre)`. Below the floor for the
 language the rewrite is refused; above it the slot has no opinion. The floor is
-`transcription.per_language.<code>.slot_floor`, 0.20 in English and 0.30 in
-French, and `--lang` picks which one the verdict is read at. The gap itself is
+`slot_floor:` on the `vocabulary` step, 0.20 in English and 0.30 in French, and
+`--lang` picks which one the verdict is read at. The gap itself is
 the same number either way. It only ever refuses — a term is
 unknown to the tokenizer by construction, so it can never win this comparison.
 The ten words are printed because they explain the number: a slot whose ten

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,7 +27,6 @@ transcription:
   activation_phrases: [hey parrot, by the way parrot]
   languages: [en]       # en and fr are the supported values
   rewrite_line: true
-  per_language: …       # legacy; both of its keys live on a pipeline step now
   pipeline: …           # see pipelines.md
   transforms: …         # see pipelines.md
 
@@ -446,44 +445,6 @@ language. One entry means no detection runs at all.
 Most spoken first: the first entry is the fallback for transcripts too short to
 judge, under four words. Supported values are `en` and `fr`.
 
-## `transcription.per_language` (legacy)
-
-The settings that differed from one language to the next, in one block keyed by
-language code. Both of its keys live on a pipeline step now, so the whole block
-is legacy — `marks` on `interpret`, `slot_floor` on `vocabulary`. See
-[pipelines.md](pipelines.md).
-
-```yaml
-transcription:
-  per_language:
-    en: {slot_floor: 0.20}
-    fr: {slot_floor: 0.30}
-```
-
-Neither key is refused, so an update cannot silently change what runs. An entry
-overrides only the keys it names, and a language with no entry gets English's
-values.
-
-- `marks` is still read and still answers for English. A `marks:` on the
-  `interpret` step beats it.
-- `slot_floor` is still read and still feeds a `vocabulary` step that names no
-  floor of its own. A `slot_floor:` on the step beats it, and the step's map is
-  the whole statement: a language the map leaves out takes its built-in floor
-  rather than the one written here.
-
-`--check-config` says which home is running, and prints the resolved floor for
-every language you listed.
-
-`slot_floor` is how far the word you were heard to say must beat a vocabulary
-term by before the gate refuses to write the term. The number is a difference of
-two cosines, so it must be above 0 and at most 2. It does not carry between
-languages: French gaps are about a third narrower. On a 201-case French bench,
-0.20 wrongly refuses 7 correct rewrites of 84 and 0.30 refuses 2, at a cost of
-19 of the 117 wrong rewrites caught. No single value works for both — 0.40 is
-free in both and costs the English gate 35 of the 55 wrong rewrites it catches.
-The gate only ever refuses, so a floor set too tight costs a name you have to
-type, never a wrong word in your text.
-
 ## `transcription.activation_phrases`
 
 Say one of these instead of dictating and what follows is an instruction:
@@ -506,24 +467,6 @@ never touches this. It used to be the fallback for those too, which is how a
 correction ended up appended to the end of a line instead of replacing a word in
 it: ⌃K clears nothing in a composer, and the paste that followed landed on the
 end of what was still there.
-
-## `transcription.sentences` (legacy)
-
-The switch for the boundary readings before they became a pipeline step. The
-step is `interpret`, and everything this key used to say now lives on that
-line — see [pipelines.md](pipelines.md#the-interpret-stage).
-
-Both spellings are still read, so an update cannot silently change what runs:
-
-- `sentences: false` still turns the step off, even when the pipeline lists it.
-  `--check-config` says to delete the `- interpret` line instead.
-- `sentences: {marks: [...]}` still feeds the step, as does
-  `per_language.<code>.marks`. A `marks:` on the step beats both, and
-  `--check-config` prints the set that is running.
-
-A pipeline written before the step existed has no `- interpret` line in it, so
-the readings do not run. Nothing is inserted for you: `--check-config` and the
-log at launch both say to add the line to the front of the list.
 
 ## `transcription.replacements` is retired
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,7 +27,7 @@ transcription:
   activation_phrases: [hey parrot, by the way parrot]
   languages: [en]       # en and fr are the supported values
   rewrite_line: true
-  per_language: …       # the settings that differ from one language to the next
+  per_language: …       # legacy; both of its keys live on a pipeline step now
   pipeline: …           # see pipelines.md
   transforms: …         # see pipelines.md
 
@@ -446,10 +446,12 @@ language. One entry means no detection runs at all.
 Most spoken first: the first entry is the fallback for transcripts too short to
 judge, under four words. Supported values are `en` and `fr`.
 
-## `transcription.per_language`
+## `transcription.per_language` (legacy)
 
-The settings that differ from one language to the next, in one block keyed by
-language code.
+The settings that differed from one language to the next, in one block keyed by
+language code. Both of its keys live on a pipeline step now, so the whole block
+is legacy — `marks` on `interpret`, `slot_floor` on `vocabulary`. See
+[pipelines.md](pipelines.md).
 
 ```yaml
 transcription:
@@ -458,13 +460,19 @@ transcription:
     fr: {slot_floor: 0.30}
 ```
 
-Those are the defaults, so an empty block changes nothing. An entry overrides
-only the keys it names. A language with no entry gets English's values.
+Neither key is refused, so an update cannot silently change what runs. An entry
+overrides only the keys it names, and a language with no entry gets English's
+values.
 
-`marks` under a language is legacy. The set lives on the `interpret` step now —
-see [pipelines.md](pipelines.md#the-interpret-stage). One written here is still
-read, still answers for English, and is beaten by a `marks:` on the step;
-`--check-config` says which one is running.
+- `marks` is still read and still answers for English. A `marks:` on the
+  `interpret` step beats it.
+- `slot_floor` is still read and still feeds a `vocabulary` step that names no
+  floor of its own. A `slot_floor:` on the step beats it, and the step's map is
+  the whole statement: a language the map leaves out takes its built-in floor
+  rather than the one written here.
+
+`--check-config` says which home is running, and prints the resolved floor for
+every language you listed.
 
 `slot_floor` is how far the word you were heard to say must beat a vocabulary
 term by before the gate refuses to write the term. The number is a difference of
@@ -475,8 +483,6 @@ languages: French gaps are about a third narrower. On a 201-case French bench,
 free in both and costs the English gate 35 of the 55 wrong rewrites it catches.
 The gate only ever refuses, so a floor set too tight costs a name you have to
 type, never a wrong word in your text.
-
-`--check-config` prints the floor for every language you listed.
 
 ## `transcription.activation_phrases`
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -223,7 +223,7 @@ Both on by default, and each off is a path the stage already has.
   three confirmed uses.
 
 Both off and neither model is fetched. `--check-config` prints the pair on one
-line, from the same predicate that decides whether each model is downloaded:
+line, from the same predicates that decide whether each model is downloaded:
 
 ```
   · vocabulary gates  slot on, portrait off

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -241,7 +241,8 @@ at a time and a language it leaves out keeps its built-in floor.
 0.20 in English and 0.30 in French are the built-in values. French gaps are
 about a third narrower, and no single number serves both: on a 201-case French
 bench the English floor wrongly refuses 7 correct rewrites of 84 and 0.30
-refuses 2. It must be above 0 and at most 2.
+refuses 2. It must be above 0 and at most 2, and a map key has to be a language
+the app supports — one that is not is refused rather than silently ignored.
 
 `--check-config` prints the resolved floor for every language you listed.
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -118,10 +118,8 @@ the failure direction every stage here shares.
 
 It publishes `interpret.count`: how many boundaries were joined.
 
-`transcription.sentences` is the switch this replaces. `sentences: false` still
-turns the step off and `--check-config` says to delete the step instead;
-`marks:` under `sentences:` or under `per_language.<lang>` still feeds the
-step, and `marks:` on the step wins over both.
+Delete the line to turn the step off. A pipeline without it does not read
+boundaries at all, and nothing is downloaded for it.
 
 ## The name stage
 
@@ -245,9 +243,7 @@ about a third narrower, and no single number serves both: on a 201-case French
 bench the English floor wrongly refuses 7 correct rewrites of 84 and 0.30
 refuses 2. It must be above 0 and at most 2.
 
-`transcription.per_language.<lang>.slot_floor` is the old home. It is still
-read and still feeds a step that names no floor of its own; a `slot_floor:` on
-the step beats it, and `--check-config` says which is running.
+`--check-config` prints the resolved floor for every language you listed.
 
 **`max_per_term` is the one to move if a name is being missed.** One name
 reaches the list from five directions — a rule that already rewrote the text,

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -153,6 +153,11 @@ what the decoder wrote and the term — so a third reading would be built and
 never shown. Refused rather than rounded down, because a number that says one
 thing and does another teaches nobody anything.
 
+**An option on the wrong stage is refused.** `slot_gate:` on `numbers`, or
+`marks:` on `vocabulary`, used to load and do nothing. `--check-config` names
+the key, the stage it was written on and the stage that reads it. A switch that
+loads and does nothing is somebody believing a gate is off while it runs.
+
 **It calls no model.** It used to: every substitution went to a local model,
 one KEEP or REVERT each, at about 900 ms a dictation and an Ollama on the
 machine. What decides now is free and local to the app:

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -222,12 +222,19 @@ Both on by default, and each off is a path the stage already has.
   taken back out. It is what the stage does today for a term with fewer than
   three confirmed uses.
 
-Both off and neither model is fetched. `--check-config` prints the pair on one
-line, from the same predicates that decide whether each model is downloaded:
+Both off and neither model is fetched. `--check-config` prints one line per
+`vocabulary` step, carrying the step's floors and its two switches — the same
+switches that decide whether each model is downloaded:
 
 ```
-  · vocabulary gates  slot on, portrait off
+  · languages         en, fr
+      vocabulary            slot floor en 0.20  fr 0.30  slot on, portrait on
+      vocabulary in /term/  slot floor en 0.45  fr 0.45  slot on, portrait off
 ```
+
+One line per step and not one for the pipeline, because a pipeline may hold
+more than one `vocabulary` step — one per app is the reason these options are
+on the step — and each names its own.
 
 **`slot_floor:` is how far the heard word must win by** before the slot test
 refuses the rewrite. A number applies to every language; a map names them one
@@ -246,7 +253,8 @@ the app supports — one that is not is refused rather than silently ignored. A
 key that names a supported language your `languages:` list leaves out loads and
 never runs, and `--check-config` says so.
 
-`--check-config` prints the resolved floor for every language you listed.
+`--check-config` prints the resolved floor for every language you listed, on
+the step's own line.
 
 **`max_per_term` is the one to move if a name is being missed.** One name
 reaches the list from five directions — a rule that already rewrote the text,

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -242,7 +242,9 @@ at a time and a language it leaves out keeps its built-in floor.
 about a third narrower, and no single number serves both: on a 201-case French
 bench the English floor wrongly refuses 7 correct rewrites of 84 and 0.30
 refuses 2. It must be above 0 and at most 2, and a map key has to be a language
-the app supports — one that is not is refused rather than silently ignored.
+the app supports — one that is not is refused rather than silently ignored. A
+key that names a supported language your `languages:` list leaves out loads and
+never runs, and `--check-config` says so.
 
 `--check-config` prints the resolved floor for every language you listed.
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -143,6 +143,9 @@ name or a mapping, and it cannot be both:
   near_misses: true   # optional; default. false matches renderings exactly
   by_sound: true      # optional; default. false matches spelling only
   gate: true          # optional; default. false leaves every place open
+  slot_gate: true     # optional; default. false reads no slot model
+  portrait: true      # optional; default. false reads no term portrait
+  slot_floor: 0.20    # optional; or {en: 0.20, fr: 0.30}
   max_per_slot: 2     # optional; readings per place, the decoder's included
   max_per_term: 2     # optional; places in one sentence about the same name
 ```
@@ -163,8 +166,7 @@ machine. What decides now is free and local to the app:
    preposition cannot hold a name. Refuse it.
 3. **The two tests that read the sentence** — whether the term belongs where
    the word was heard, and whether this sentence looks like the ones the term
-   was confirmed in. See `gate_sentence:` in
-   [docs/configuration.md](configuration.md).
+   was confirmed in. `slot_gate:` and `portrait:` below switch them.
 
 **Everything they leave open keeps what arrived.** A `replacements` rule has
 already written its term, so an open place ships the term. A near miss or a
@@ -208,6 +210,44 @@ Neither writes anything. Each opens one more place for the gates to settle, and
 a place none of them settles keeps the word that was heard — so the looser
 match costs a gate call, not a sentence. `near_misses: false` puts matching
 back to exact and whole-word.
+
+**`slot_gate:` and `portrait:` switch the two tests that read the sentence.**
+Both on by default, and each off is a path the stage already has.
+
+- `slot_gate: false` reads no slot model. That is mmBERT-small, 269 MB, and
+  nothing downloads it: rule 2 above is skipped, and the test that asks whether
+  the term belongs where the word was heard is skipped too. Every place is left
+  to the portrait, or to whatever arrived. It is what the stage does today on a
+  machine the weights are not on.
+- `portrait: false` reads no portrait. A term's own sentences say nothing, so
+  nothing is authorised on that evidence and a rule's substitution is never
+  taken back out. It is what the stage does today for a term with fewer than
+  three confirmed uses.
+
+Both off and neither model is fetched. `--check-config` prints the pair on one
+line, from the same predicate that decides whether each model is downloaded:
+
+```
+  · vocabulary gates  slot on, portrait off
+```
+
+**`slot_floor:` is how far the heard word must win by** before the slot test
+refuses the rewrite. A number applies to every language; a map names them one
+at a time and a language it leaves out keeps its built-in floor.
+
+```yaml
+- {stage: vocabulary, slot_floor: 0.20}
+- {stage: vocabulary, slot_floor: {en: 0.20, fr: 0.30}}
+```
+
+0.20 in English and 0.30 in French are the built-in values. French gaps are
+about a third narrower, and no single number serves both: on a 201-case French
+bench the English floor wrongly refuses 7 correct rewrites of 84 and 0.30
+refuses 2. It must be above 0 and at most 2.
+
+`transcription.per_language.<lang>.slot_floor` is the old home. It is still
+read and still feeds a step that names no floor of its own; a `slot_floor:` on
+the step beats it, and `--check-config` says which is running.
 
 **`max_per_term` is the one to move if a name is being missed.** One name
 reaches the list from five directions — a rule that already rewrote the text,

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -503,10 +503,8 @@ English.
 
 This is a pipeline step, and it runs at the position the list gives it — see
 [The interpret stage](pipelines.md#the-interpret-stage) for the three options
-and why it belongs first. It used to run before the pipeline, switched by
-`transcription.sentences`. That key is legacy now: a pipeline with no
-`- interpret` line in it does not read boundaries at all, and `--check-config`
-and the log at launch both say so.
+and why it belongs first. A pipeline with no `- interpret` line in it does not
+read boundaries at all, and nothing is downloaded for them.
 
 The list does two jobs. `.` and `?` are where a boundary is looked for; the
 comma is a reading tried at one. The first reading is always the mark the

--- a/scripts/check-pipeline-config.sh
+++ b/scripts/check-pipeline-config.sh
@@ -212,12 +212,12 @@ run_config gates_both_off 'transcription:
 check "both switches off loads" "$code" "0"
 check "and neither model is read" "$(gates)" "slot off, portrait off"
 
-run_config gates_legacy_switch 'transcription:
+run_config gates_file_switch 'transcription:
   languages: [en]
   pipeline:
     - vocabulary' 'gate_sentence: false'
 
-check "the legacy gate_sentence: false loads" "$code" "0"
+check "gate_sentence: false loads" "$code" "0"
 check "and turns both sentence tests off, naming the key" \
   "$(gates)" "slot on, portrait off  (the sentence tests are off — \`vocabulary.gate_sentence: false\`)"
 
@@ -267,6 +267,15 @@ run_config floor_bad_map 'transcription:
 check "an out-of-range language in a map is refused" "$code" "1"
 check "and the message names that language" \
   "$(printf '%s\n' "$out" | grep -c 'pipeline.vocabulary.slot_floor.fr')" "1"
+
+run_config floor_bad_language 'transcription:
+  languages: [en]
+  pipeline:
+    - {stage: vocabulary, slot_floor: {fe: 0.30}}'
+
+check "a language nothing dictates in is refused" "$code" "1"
+check "and the message says which languages there are" \
+  "$(printf '%s\n' "$out" | grep -c 'one of en, fr')" "1"
 
 run_config floor_bad_shape 'transcription:
   languages: [en]

--- a/scripts/check-pipeline-config.sh
+++ b/scripts/check-pipeline-config.sh
@@ -33,6 +33,8 @@ run_config() {
   local dir="$WORK/$1"
   mkdir -p "$dir"
   printf '%s\n' "$2" > "$dir/config.yaml"
+  # `gate_sentence:` is the only key here that lives in vocabulary.yaml.
+  if [ "$#" -ge 3 ]; then printf '%s\n' "$3" > "$dir/vocabulary.yaml"; fi
   out="$(PARROTFLOW_CONFIG_DIR="$dir" "$BIN" --check-config 2>/dev/null)"
   code=$?
 }
@@ -213,6 +215,159 @@ check "and the migration line says what to add" \
   "$(printf '%s\n' "$out" | grep -c 'add `- interpret` to the front')" "1"
 check "and no marks line is printed for a step that is not there" \
   "$(marks)" ""
+
+# --- the vocabulary step's gates ----------------------------------------------
+#
+# Two tests read the sentence and each has its own switch, both on by default.
+# The line `--check-config` prints is the same predicate that decides whether
+# the model behind each one is fetched, so a gate reported off is a gate
+# nothing is downloaded for.
+
+gates() {
+  printf '%s\n' "$out" | sed -n 's/^  · vocabulary gates  *//p'
+}
+# One language's resolved slot floor, whichever of the two homes it came from.
+floor() {
+  printf '%s\n' "$out" | sed -n "s/^      $1  slot floor //p"
+}
+
+run_config gates_default 'transcription:
+  languages: [en, fr]
+  pipeline:
+    - vocabulary'
+
+check "a bare - vocabulary line has both gates on" "$(gates)" "slot on, portrait on"
+check "and the built-in floors" "$(floor en)/$(floor fr)" "0.20/0.30"
+
+run_config gates_slot_off 'transcription:
+  languages: [en]
+  pipeline:
+    - {stage: vocabulary, slot_gate: false}'
+
+check "slot_gate: false loads" "$code" "0"
+check "and reports the slot gate off, the portrait still on" \
+  "$(gates)" "slot off, portrait on"
+
+run_config gates_portrait_off 'transcription:
+  languages: [en]
+  pipeline:
+    - {stage: vocabulary, portrait: false}'
+
+check "portrait: false loads" "$code" "0"
+check "and reports the portrait off, the slot gate still on" \
+  "$(gates)" "slot on, portrait off"
+
+run_config gates_both_off 'transcription:
+  languages: [en]
+  pipeline:
+    - {stage: vocabulary, slot_gate: false, portrait: false}'
+
+check "both switches off loads" "$code" "0"
+check "and neither model is read" "$(gates)" "slot off, portrait off"
+
+run_config gates_legacy_switch 'transcription:
+  languages: [en]
+  pipeline:
+    - vocabulary' 'gate_sentence: false'
+
+check "the legacy gate_sentence: false loads" "$code" "0"
+check "and turns both sentence tests off, naming the key" \
+  "$(gates)" "slot on, portrait off  (the sentence tests are off — \`vocabulary.gate_sentence: false\`)"
+
+# --- the slot floor, on the step ----------------------------------------------
+
+run_config floor_scalar 'transcription:
+  languages: [en, fr]
+  pipeline:
+    - {stage: vocabulary, slot_floor: 0.35}'
+
+check "a bare number loads" "$code" "0"
+check "and applies to every language" "$(floor en)/$(floor fr)" "0.35/0.35"
+
+run_config floor_map 'transcription:
+  languages: [en, fr]
+  pipeline:
+    - {stage: vocabulary, slot_floor: {en: 0.25, fr: 0.45}}'
+
+check "a map loads" "$code" "0"
+check "and each language gets its own" "$(floor en)/$(floor fr)" "0.25/0.45"
+
+run_config floor_map_partial 'transcription:
+  languages: [en, fr]
+  pipeline:
+    - {stage: vocabulary, slot_floor: {fr: 0.45}}'
+
+check "a map naming one language loads" "$code" "0"
+check "and the language it misses keeps its built-in floor" \
+  "$(floor en)/$(floor fr)" "0.20/0.45"
+
+run_config floor_bad 'transcription:
+  languages: [en]
+  pipeline:
+    - {stage: vocabulary, slot_floor: 0}'
+
+check "a floor of 0 on the step is refused" "$code" "1"
+check "and the message names the key that was written" \
+  "$(printf '%s\n' "$out" | grep -c 'pipeline.vocabulary.slot_floor')" "1"
+check "and says what a floor may be, as it always has" \
+  "$(printf '%s\n' "$out" | grep -c 'a number above 0 and at most 2')" "1"
+
+run_config floor_bad_map 'transcription:
+  languages: [en, fr]
+  pipeline:
+    - {stage: vocabulary, slot_floor: {en: 0.20, fr: 3}}'
+
+check "an out-of-range language in a map is refused" "$code" "1"
+check "and the message names that language" \
+  "$(printf '%s\n' "$out" | grep -c 'pipeline.vocabulary.slot_floor.fr')" "1"
+
+run_config floor_bad_shape 'transcription:
+  languages: [en]
+  pipeline:
+    - {stage: vocabulary, slot_floor: "0.20"}'
+
+check "a floor that is neither a number nor a map is refused" "$code" "1"
+check "and the message shows both spellings" \
+  "$(printf '%s\n' "$out" | grep -c 'slot_floor: {en: 0.20, fr: 0.30}')" "1"
+
+# --- the legacy floor ---------------------------------------------------------
+#
+# `transcription.per_language` is legacy now that both of its keys live on a
+# step. It is still read, and it still feeds a step that names no floor.
+
+run_config floor_legacy 'transcription:
+  languages: [en, fr]
+  per_language:
+    fr: {slot_floor: 0.45}
+  pipeline:
+    - vocabulary'
+
+check "the old per_language floor loads" "$code" "0"
+check "and feeds the step" "$(floor en)/$(floor fr)" "0.20/0.45"
+check "and the notice says the block is legacy" \
+  "$(printf '%s\n' "$out" | grep -c '`transcription.per_language` is legacy')" "1"
+
+run_config floor_both 'transcription:
+  languages: [en, fr]
+  per_language:
+    fr: {slot_floor: 0.45}
+  pipeline:
+    - {stage: vocabulary, slot_floor: {fr: 0.35}}'
+
+check "both homes for the floor loads" "$code" "0"
+check "and the step wins, the language it misses taking its built-in" \
+  "$(floor en)/$(floor fr)" "0.20/0.35"
+check "and the notice says the step is what runs" \
+  "$(printf '%s\n' "$out" | grep -c 'the step is what runs')" "1"
+
+run_config floor_legacy_bad 'transcription:
+  languages: [en]
+  per_language:
+    en: {slot_floor: 0}'
+
+check "an out-of-range legacy floor is refused as it always was" "$code" "1"
+check "and still names its own key" \
+  "$(printf '%s\n' "$out" | grep -c 'transcription.per_language.en.slot_floor')" "1"
 
 # --- the retired key ----------------------------------------------------------
 #

--- a/scripts/check-pipeline-config.sh
+++ b/scripts/check-pipeline-config.sh
@@ -221,6 +221,21 @@ check "gate_sentence: false loads" "$code" "0"
 check "and turns both sentence tests off, naming the key" \
   "$(gates)" "slot on, portrait off  (the sentence tests are off — \`vocabulary.gate_sentence: false\`)"
 
+run_config gates_two_steps 'transcription:
+  languages: [en, fr]
+  pipeline:
+    - {stage: vocabulary, slot_floor: 0.25}
+    - {stage: vocabulary, slot_floor: 0.45, portrait: false, app: /term/}'
+
+check "two vocabulary steps load" "$code" "0"
+# One line each. The first step's numbers printed for both would describe a
+# pipeline nobody wrote.
+check "and each names its own floor and its own gates" \
+  "$(printf '%s\n' "$out" | sed -n 's/^      vocabulary *//p' | tr '\n' '|')" \
+  "slot floor en 0.25  fr 0.25  slot on, portrait on|in /term/  slot floor en 0.45  fr 0.45  slot on, portrait off|"
+check "and no single gates line is printed as well" \
+  "$(gates)" ""
+
 # --- the slot floor, on the step ----------------------------------------------
 
 run_config floor_scalar 'transcription:

--- a/scripts/check-pipeline-config.sh
+++ b/scripts/check-pipeline-config.sh
@@ -268,6 +268,16 @@ check "an out-of-range language in a map is refused" "$code" "1"
 check "and the message names that language" \
   "$(printf '%s\n' "$out" | grep -c 'pipeline.vocabulary.slot_floor.fr')" "1"
 
+run_config floor_idle_language 'transcription:
+  languages: [en]
+  pipeline:
+    - {stage: vocabulary, slot_floor: {en: 0.25, fr: 0.45}}'
+
+check "a floor for a language languages: omits loads" "$code" "0"
+check "and the floor that does run is the step's" "$(floor en)" "0.25"
+check "and the notice says the other one never runs" \
+  "$(printf '%s\n' "$out" | grep -c 'that floor never runs')" "1"
+
 run_config floor_bad_language 'transcription:
   languages: [en]
   pipeline:

--- a/scripts/check-pipeline-config.sh
+++ b/scripts/check-pipeline-config.sh
@@ -78,7 +78,7 @@ check "and gets the built-in default, said out loud" \
 #
 # The boundary readings were a pass that ran before the pipeline and answered
 # to `transcription.sentences`. They are a step now, so the list is the switch
-# and the options live on the line.
+# and the options live on the line. Neither old key is read any more.
 
 # What `--check-config` prints for the marks the step resolves to.
 marks() {
@@ -145,65 +145,12 @@ check "marks with no sentence ender is refused" "$code" "1"
 check "and says where a boundary is looked for" \
   "$(printf '%s\n' "$out" | grep -c 'at least one of')" "1"
 
-# --- the legacy keys ----------------------------------------------------------
-
-run_config legacy_off 'transcription:
-  languages: [en]
-  sentences: false
-  pipeline:
-    - numbers'
-
-check "sentences: false with no step loads" "$code" "0"
-check "and the notice says to remove the step instead" \
-  "$(printf '%s\n' "$out" | grep -c 'is legacy; remove the `interpret` step')" "1"
-check "and no migration line is printed as well" \
-  "$(printf '%s\n' "$out" | grep -c 'the sentence readings no longer run')" "0"
-
-run_config legacy_off_listed 'transcription:
-  languages: [en]
-  sentences: false
-  pipeline:
-    - interpret'
-
-check "sentences: false beside the step loads" "$code" "0"
-check "and says the key is what still turns it off" \
-  "$(printf '%s\n' "$out" | grep -c 'this key is what still turns it off')" "1"
-# The same predicate decides whether the 320 MB model is fetched, so a step
-# reported as off is also a step nothing is downloaded for.
-check "and the step is reported off, not merely configured" \
-  "$(marks)" ". , ?  (off — \`transcription.sentences: false\`)"
-
-run_config legacy_marks 'transcription:
-  languages: [en]
-  sentences:
-    marks: [".", "?"]
-  pipeline:
-    - interpret'
-
-check "the old marks: key loads" "$code" "0"
-check "and feeds the step" "$(marks)" ". ?"
-check "and the notice points at the step" \
-  "$(printf '%s\n' "$out" | grep -c '`marks:` belongs on the `interpret` step now')" "1"
-
-run_config legacy_marks_both 'transcription:
-  languages: [en]
-  per_language:
-    en: {marks: [".", "?"]}
-  pipeline:
-    - {stage: interpret, marks: [".", ",", "?"]}'
-
-check "both homes for marks: loads" "$code" "0"
-check "and the step wins" "$(marks)" ". , ?"
-check "and the notice says the step is what runs" \
-  "$(printf '%s\n' "$out" | grep -c 'The step is what runs')" "1"
-
-# --- a pipeline written before the step existed -------------------------------
+# --- a pipeline with no interpret step ----------------------------------------
 #
-# Nothing is inserted. The readings stop, and the line that says so is printed
-# by `--check-config` and written to the log at launch, because nobody runs
-# `--check-config` after an update.
+# Absent from the list means off, in silence, like every other step. Nothing is
+# inserted and nothing is said about it.
 
-run_config no_interpret 'transcription:
+run_config without_step 'transcription:
   languages: [en]
   pipeline:
     - vocabulary
@@ -211,10 +158,10 @@ run_config no_interpret 'transcription:
 
 check "a pipeline with no interpret step loads" "$code" "0"
 check "and nothing is inserted into it" "$(stages)" "vocabulary → numbers"
-check "and the migration line says what to add" \
-  "$(printf '%s\n' "$out" | grep -c 'add `- interpret` to the front')" "1"
 check "and no marks line is printed for a step that is not there" \
   "$(marks)" ""
+check "and nothing is said about the step being absent" \
+  "$(printf '%s\n' "$out" | grep -ci 'interpret')" "0"
 
 # --- the vocabulary step's gates ----------------------------------------------
 #
@@ -329,45 +276,6 @@ run_config floor_bad_shape 'transcription:
 check "a floor that is neither a number nor a map is refused" "$code" "1"
 check "and the message shows both spellings" \
   "$(printf '%s\n' "$out" | grep -c 'slot_floor: {en: 0.20, fr: 0.30}')" "1"
-
-# --- the legacy floor ---------------------------------------------------------
-#
-# `transcription.per_language` is legacy now that both of its keys live on a
-# step. It is still read, and it still feeds a step that names no floor.
-
-run_config floor_legacy 'transcription:
-  languages: [en, fr]
-  per_language:
-    fr: {slot_floor: 0.45}
-  pipeline:
-    - vocabulary'
-
-check "the old per_language floor loads" "$code" "0"
-check "and feeds the step" "$(floor en)/$(floor fr)" "0.20/0.45"
-check "and the notice says the block is legacy" \
-  "$(printf '%s\n' "$out" | grep -c '`transcription.per_language` is legacy')" "1"
-
-run_config floor_both 'transcription:
-  languages: [en, fr]
-  per_language:
-    fr: {slot_floor: 0.45}
-  pipeline:
-    - {stage: vocabulary, slot_floor: {fr: 0.35}}'
-
-check "both homes for the floor loads" "$code" "0"
-check "and the step wins, the language it misses taking its built-in" \
-  "$(floor en)/$(floor fr)" "0.20/0.35"
-check "and the notice says the step is what runs" \
-  "$(printf '%s\n' "$out" | grep -c 'the step is what runs')" "1"
-
-run_config floor_legacy_bad 'transcription:
-  languages: [en]
-  per_language:
-    en: {slot_floor: 0}'
-
-check "an out-of-range legacy floor is refused as it always was" "$code" "1"
-check "and still names its own key" \
-  "$(printf '%s\n' "$out" | grep -c 'transcription.per_language.en.slot_floor')" "1"
 
 # --- the retired key ----------------------------------------------------------
 #

--- a/scripts/check-pipeline-config.sh
+++ b/scripts/check-pipeline-config.sh
@@ -235,6 +235,33 @@ check "and each names its own floor and its own gates" \
   "$(steps)" \
   "slot floor en 0.25  fr 0.25  slot on, portrait on|in /term/  slot floor en 0.45  fr 0.45  slot on, portrait off|"
 
+# --- an option on the wrong stage ---------------------------------------------
+#
+# Refused, not dropped. A switch that loads and does nothing is somebody
+# believing a gate is off while it runs.
+
+run_config option_wrong_stage 'transcription:
+  languages: [en]
+  pipeline:
+    - {stage: numbers, slot_gate: false}
+    - {stage: vocabulary, marks: [".", "?"]}'
+
+check "an option on a stage that does not read it is refused" \
+  "$(printf '%s\n' "$out" | grep -c 'is an option on the')" "2"
+check "and each message names the stage that does read it" \
+  "$(printf '%s\n' "$out" | grep -c 'option on the `vocabulary` stage')" "1"
+check "and the stage it was written on" \
+  "$(printf '%s\n' "$out" | grep -c '`numbers`: `slot_gate:`')" "1"
+
+run_config option_right_stage 'transcription:
+  languages: [en]
+  pipeline:
+    - {stage: interpret, marks: [".", "?"]}
+    - {stage: vocabulary, slot_gate: false, near_misses: false}'
+
+check "an option on the stage that reads it is not refused" \
+  "$(printf '%s\n' "$out" | grep -c 'is an option on the')" "0"
+
 # --- the slot floor, on the step ----------------------------------------------
 
 run_config floor_scalar 'transcription:

--- a/scripts/check-pipeline-config.sh
+++ b/scripts/check-pipeline-config.sh
@@ -170,12 +170,10 @@ check "and nothing is said about the step being absent" \
 # the model behind each one is fetched, so a gate reported off is a gate
 # nothing is downloaded for.
 
-gates() {
-  printf '%s\n' "$out" | sed -n 's/^  · vocabulary gates  *//p'
-}
-# One language's resolved slot floor, whichever of the two homes it came from.
-floor() {
-  printf '%s\n' "$out" | sed -n "s/^      $1  slot floor //p"
+# The `vocabulary` step lines, one per step, joined with |. Each carries the
+# step's resolved floors and its two switches.
+steps() {
+  printf '%s\n' "$out" | sed -n 's/^      vocabulary *//p' | tr '\n' '|'
 }
 
 run_config gates_default 'transcription:
@@ -183,8 +181,8 @@ run_config gates_default 'transcription:
   pipeline:
     - vocabulary'
 
-check "a bare - vocabulary line has both gates on" "$(gates)" "slot on, portrait on"
-check "and the built-in floors" "$(floor en)/$(floor fr)" "0.20/0.30"
+check "a bare - vocabulary line has both gates on and the built-in floors" \
+  "$(steps)" "slot floor en 0.20  fr 0.30  slot on, portrait on|"
 
 run_config gates_slot_off 'transcription:
   languages: [en]
@@ -193,7 +191,7 @@ run_config gates_slot_off 'transcription:
 
 check "slot_gate: false loads" "$code" "0"
 check "and reports the slot gate off, the portrait still on" \
-  "$(gates)" "slot off, portrait on"
+  "$(steps)" "slot floor en 0.20  slot off, portrait on|"
 
 run_config gates_portrait_off 'transcription:
   languages: [en]
@@ -202,7 +200,7 @@ run_config gates_portrait_off 'transcription:
 
 check "portrait: false loads" "$code" "0"
 check "and reports the portrait off, the slot gate still on" \
-  "$(gates)" "slot on, portrait off"
+  "$(steps)" "slot floor en 0.20  slot on, portrait off|"
 
 run_config gates_both_off 'transcription:
   languages: [en]
@@ -210,7 +208,8 @@ run_config gates_both_off 'transcription:
     - {stage: vocabulary, slot_gate: false, portrait: false}'
 
 check "both switches off loads" "$code" "0"
-check "and neither model is read" "$(gates)" "slot off, portrait off"
+check "and neither model is read" \
+  "$(steps)" "slot floor en 0.20  slot off, portrait off|"
 
 run_config gates_file_switch 'transcription:
   languages: [en]
@@ -219,7 +218,9 @@ run_config gates_file_switch 'transcription:
 
 check "gate_sentence: false loads" "$code" "0"
 check "and turns both sentence tests off, naming the key" \
-  "$(gates)" "slot on, portrait off  (the sentence tests are off — \`vocabulary.gate_sentence: false\`)"
+  "$(steps)" "slot floor en 0.20  slot on, portrait off|"
+check "and the key is named under the step" \
+  "$(printf '%s\n' "$out" | grep -c 'the sentence tests are off')" "1"
 
 run_config gates_two_steps 'transcription:
   languages: [en, fr]
@@ -231,10 +232,8 @@ check "two vocabulary steps load" "$code" "0"
 # One line each. The first step's numbers printed for both would describe a
 # pipeline nobody wrote.
 check "and each names its own floor and its own gates" \
-  "$(printf '%s\n' "$out" | sed -n 's/^      vocabulary *//p' | tr '\n' '|')" \
+  "$(steps)" \
   "slot floor en 0.25  fr 0.25  slot on, portrait on|in /term/  slot floor en 0.45  fr 0.45  slot on, portrait off|"
-check "and no single gates line is printed as well" \
-  "$(gates)" ""
 
 # --- the slot floor, on the step ----------------------------------------------
 
@@ -244,7 +243,8 @@ run_config floor_scalar 'transcription:
     - {stage: vocabulary, slot_floor: 0.35}'
 
 check "a bare number loads" "$code" "0"
-check "and applies to every language" "$(floor en)/$(floor fr)" "0.35/0.35"
+check "and applies to every language" \
+  "$(steps)" "slot floor en 0.35  fr 0.35  slot on, portrait on|"
 
 run_config floor_map 'transcription:
   languages: [en, fr]
@@ -252,7 +252,8 @@ run_config floor_map 'transcription:
     - {stage: vocabulary, slot_floor: {en: 0.25, fr: 0.45}}'
 
 check "a map loads" "$code" "0"
-check "and each language gets its own" "$(floor en)/$(floor fr)" "0.25/0.45"
+check "and each language gets its own" \
+  "$(steps)" "slot floor en 0.25  fr 0.45  slot on, portrait on|"
 
 run_config floor_map_partial 'transcription:
   languages: [en, fr]
@@ -261,7 +262,7 @@ run_config floor_map_partial 'transcription:
 
 check "a map naming one language loads" "$code" "0"
 check "and the language it misses keeps its built-in floor" \
-  "$(floor en)/$(floor fr)" "0.20/0.45"
+  "$(steps)" "slot floor en 0.20  fr 0.45  slot on, portrait on|"
 
 run_config floor_bad 'transcription:
   languages: [en]
@@ -289,7 +290,8 @@ run_config floor_idle_language 'transcription:
     - {stage: vocabulary, slot_floor: {en: 0.25, fr: 0.45}}'
 
 check "a floor for a language languages: omits loads" "$code" "0"
-check "and the floor that does run is the step's" "$(floor en)" "0.25"
+check "and the floor that does run is the step's" \
+  "$(steps)" "slot floor en 0.25  slot on, portrait on|"
 check "and the notice says the other one never runs" \
   "$(printf '%s\n' "$out" | grep -c 'that floor never runs')" "1"
 

--- a/scripts/check-slot-gap.sh
+++ b/scripts/check-slot-gap.sh
@@ -29,7 +29,7 @@ done
 [ -n "$BIN" ] || { echo "build first: swift build"; exit 1; }
 
 CASES="$ROOT/tests/slot-gap-cases.yaml"
-# A scratch config, so a `per_language:` floor on this machine cannot change the
+# A scratch config, so a `slot_floor:` on this machine cannot change the
 # verdicts. The floors the cases were picked against are the built-in ones.
 WORK="$(mktemp -d -t parrotflow-slot-gap)"
 trap 'rm -rf "$WORK"' EXIT


### PR DESCRIPTION
The two tests that read the sentence — the mmBERT slot and the term portrait — had no switch of their own, and the floor one of them reads lived in `transcription.per_language`. They are options on the `vocabulary` step now: `slot_gate:`, `portrait:` and `slot_floor:`, all optional, both switches on by default. So either gate can be turned off per app or per language like any other step option.

Each `false` takes the path that half already has when it cannot answer, so nothing new had to be measured. `slot_gate: false` also downloads nothing: the warm-up at launch, the retry per dictation and `--warm` read the same predicates as the step.

`transcription.per_language` is deleted, and so is `transcription.sentences` from #279. Neither has been released, so no config in the world carries one, and a legacy read nobody needs is a second way to say the same thing. A step absent from the pipeline is off, silently, like every other step.

Reviewers: start at `SentenceGate.settle` and the four predicates at the end of `Config.swift` — `readsBoundaries`, `readsSlots`, `readsSentenceGate`, `readsPortraits`.

Built with `swift build -c release`; `make test` exits 0 locally. Greptile cannot build Swift, so the build claims here are mine.

Closes #277.

<details>
<summary>The step, and its three new options — all optional, both switches on by default</summary>

```yaml
- stage: vocabulary
  slot_gate: true                   # the mmBERT slot, 269 MB
  portrait: true                    # the term portrait, on the word vectors
  slot_floor: {en: 0.20, fr: 0.30}  # or a bare number, for every language
  app: /term|slack/                 # as on every step
```

Nothing is added to `config.example.yaml`. The options exist and are documented in `docs/pipelines.md`.

`slot_gate: false` reads no slot model, in either place it is used: rule 2 of the stage — the part of speech the spot wants, in `SlotGate` — is skipped, and so is `SlotReference`, the test that asks whether the term belongs where the word was heard. One switch for both because they are one model, and the promise the switch makes is that `false` downloads nothing.

`portrait: false` reads no portrait. Nothing is authorised on a term's own sentences, and a rule's substitution is never taken back out.

`slot_floor:` takes a number for every language, or a map. A language the map does not name keeps its built-in floor — the map is the whole statement of the floors. Range check unchanged: above 0 and at most 2. The message names the key that was written, `pipeline.vocabulary.slot_floor` or `pipeline.vocabulary.slot_floor.fr`. A map key that is not a language the app supports is refused, as `per_language` refused one. A key naming a supported language your `languages:` list leaves out loads and never runs, and `--check-config` says so.

`--check-config` prints one line per `vocabulary` step, carrying that step's floors and its two switches — the same switches that decide whether each model is fetched:

```
  · languages         en, fr
      vocabulary            slot floor en 0.20  fr 0.30  slot on, portrait on
      vocabulary in /term/  slot floor en 0.45  fr 0.45  slot on, portrait off
```

One line per step and not one for the pipeline: a pipeline may hold several `vocabulary` steps — one per app is the reason these options are on the step — and each names its own. Nothing is printed when the pipeline holds no `vocabulary` step, which is also what says nothing is downloaded for it.

</details>

<details>
<summary>Each switch off is a path the stage already had, so no arm is new</summary>

The brief asked that `false` take the "not available" path each half already has. It does.

| Switch | What `false` does | What already does that |
|---|---|---|
| `slot_gate: false` | no `SlotGate` is passed to `VocabularyJudge.settle`; `SlotReference` is not asked and refuses nothing | a machine the 269 MB model is not on — `Vocabulary.slotGate()` returns nil, and `SlotModel.isCached` is false |
| `portrait: false` | `TermPortrait` returns nothing for every place | a term with fewer than three confirmed uses — `TermPortrait.summary` returns nil |

The four outcomes in `SentenceGate` are read the same way either way, so one half off leaves the other deciding alone rather than shutting the stage down. A place neither settles keeps what arrived, as it always has.

`SentenceGate.settle` returns early when both are off, and its `SlotModel.isCached` guard is now asked only when the slot half is on — otherwise the portrait would stand down on a machine the slot model was never fetched to.

Run end to end through `--pipeline … --warm`, one term (`Ghostty`, heard as `ghostly`) and one sentence the term does not belong in:

| Fixture | Output | `gate_ms` |
|---|---|---|
| `slot_gate: false` | `The old house looked Ghostty in the fog.` | 9 |
| `portrait: false` | `The old house looked ghostly in the fog.` | 3536 |
| both `false` | `The old house looked Ghostty in the fog.` | 9 |

The slot alone gets this sentence right. The portrait alone has no uses for the term, so it says nothing and the rule's write ships — which is what a term with no portrait has always done. `gate_ms` at 9 against 3536 is the slot model not being loaded.

</details>

<details>
<summary>The check scripts give the same numbers, before and after</summary>

The gates and the readings were not touched, so these had to be identical. Run at `origin/issue-264` and again at the head of this branch.

| Script | Before | After |
|---|---|---|
| `check-slot-gate.sh` | 50 scored, applied 12, declined 15, judge 23, 0 wrong either way | same |
| `check-slot-gap.sh` | 16/16 | same |
| `check-portrait.sh` | 11/11 | same |
| `check-counter-portrait.sh` | held-out 20 right / 0 wrong / 0 quiet; all 24 → 23/1/0 | same |
| `check-word-vector.sh` | 12/12 | same |
| `check-vocabulary-config.sh` | 63/63 | same |
| `check-span-rule.sh` | 6/6 | same |
| `check-sound.sh` | 3/3 | same |
| `check-term-uses.sh` | 47/47 | same |
| `check-default-config.sh` | pass, 7 pipeline steps | same |
| `check-sentence-join.sh` | period 95%, question 80%, 0.0 false joins; bare capitals 2 joined of 5 | same |
| `check-sentence-case.sh` | 39/39 | same |
| `check-sentence-probe.sh` | 65/65 within 0.05 | same |

Every one of those outputs is byte-identical apart from `check-word-gate.sh`, which is flaky on this machine: `Frederick` reads as spell-known or spell-unknown depending on `NSSpellChecker` state. It gave 34/35 on the baseline run and 35/35 after, and the difference is that one case. `make test` exits 0.

`scripts/check-pipeline-config.sh` goes from 50 cases to 72 — 35 new, 13 deleted with the two keys:

- a bare `- vocabulary` line has both gates on and the built-in floors
- `slot_gate: false`, `portrait: false`, and both off, each reported on the gates line
- `vocabulary.gate_sentence: false` turns both sentence tests off and the line names the key
- a scalar floor applies to every language; a map gives each its own
- a map naming one language leaves the other on its built-in floor
- a floor of 0 is refused, and the message names `pipeline.vocabulary.slot_floor`
- an out-of-range language in a map is refused, and the message names that language
- a map keyed on a language the app does not support is refused, naming the ones there are
- a map keyed on a supported language `languages:` leaves out loads, and the notice says that floor never runs
- two `vocabulary` steps each report their own floor and their own gates, and neither stands in for the other
- an option on a stage that does not read it is refused, naming the key, the stage it was written on and the stage that reads it
- the same option on the stage that does read it is not
- a `slot_floor:` that is neither a number nor a map is refused, and the message shows both spellings
- a pipeline with no `interpret` step says nothing about it

</details>

<details>
<summary>Two config keys are deleted rather than read, and why that is safe here</summary>

`transcription.sentences` and `transcription.per_language` were both kept as legacy reads — the first by #279, the second by the first commit of this PR. Neither has been released. There is no installed base, so there is no config carrying either key, and keeping them means two ways to say the same thing forever.

Gone, in the second commit:

- `transcription.sentences` in full, including `Sentences.enabled`, `sentences.marks` and the `legacy_off` skip in `Pipeline.skipReason`. `Config.readsBoundaries` is now only "an `interpret` step is in the pipeline".
- The migration notice from #279 and the line it wrote to the log at launch. A step absent from the list is off, in silence, like every other step. `pipeline: []` is no longer nagged either.
- `transcription.per_language` in full, both `marks` and `slot_floor`. `Config.Transcription.Language` stays as the built-in table and the two range checks, and nothing in the file decodes into it.

Neither key gets a special message. `--check-config` has no generic unknown-key report, so a config still carrying one is ignored in silence — which is the state of every key nobody has written.

`docs/configuration.md` loses both sections. `config.example.yaml` loses the `per_language` paragraph.

</details>

<details>
<summary>An option on the wrong stage used to load and do nothing — now it is refused</summary>

Each stage's options are decoded inside a branch keyed on the stage name, so `slot_gate:` on `numbers`, or `marks:` on `vocabulary`, was dropped by `Decodable` without a word. That predates this PR — #279 added `marks:`, `capitals:` and `pause:` the same way — but this PR adds three more keys to the same shape, so it is fixed here.

`--check-config` now names the key, the stage it was written on and the stage that reads it:

```
  ✗ pipeline: `numbers`: `slot_gate:` is an option on the `vocabulary` stage. It does nothing here
  ✗ pipeline: `vocabulary`: `marks:` is an option on the `interpret` stage. It does nothing here
```

It goes in the same list as an unknown stage name, and for the same reason: a switch that loads and does nothing is somebody believing a gate is off while it runs.

</details>

<details>
<summary>What I decided that the brief did not settle</summary>

- **`slot_gate:` covers both readers of mmBERT**, not only `SentenceGate`'s half. The brief named `SlotGate` and also asked that `slot_gate: false` download no mmBERT. Both are satisfied only if the one switch covers `SlotGate` and `SlotReference`, since those are the two things that read the model. `gate:` is untouched and still switches the word lists.
- **A map is the whole statement of the floors.** A language the map does not name takes its built-in value, per the brief. With the legacy key deleted there is nothing else it could fall back to.
- **`vocabulary.gate_sentence` is honoured and not reported as legacy.** It is an undocumented key in `vocabulary.yaml` that turns both sentence tests off, and `--check-config`'s gates line already names it when it is set. A notice on top of that is a nag.
- **`--warm` only fetches what the fixture's own pipeline reads.** It used to fetch both models unconditionally, which now contradicts a fixture that switches a gate off.
- **`--slot-gap` reads the step's floor.** It read `transcription.slotFloor(for:)` before. Leaving it would make the command disagree with the app about where the line is.
- **Multiple `vocabulary` steps**: a model is warmed if any step wants it; the commands report on the first.
- **The census line names the halves** — `sentence gate on (slot + portrait)` — because a place decided by the portrait alone reads nothing like one both tests saw.

</details>

<details>
<summary>The line your own config needs — one, and it is from #279</summary>

Nothing for the new options: they are all optional and default to what the app does today. Neither `~/.config/parrotflow/config.yaml` nor `~/.config/parrotflow-dev/config.yaml` writes `transcription.sentences` or `transcription.per_language`, so nothing breaks there.

But both write an explicit `pipeline:` list with no `- interpret` line, so the sentence readings do not run — and with the migration notice deleted, nothing says so any more. Add the line to both if you want them:

```yaml
transcription:
  pipeline:
    - interpret          # <- add this, first
    - context
    - input
    - stage: vocabulary
    # …
```

`--check-config` prints `· sentence marks    . , ?` once it is there.

</details>
