### PR TITLE
feat: a term the sentence refuses is written back in lowercase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ CHECKS := numbers replacements pipeline pipeline-config wake split dotted dates 
           transform-folders eval audio-recovery possessive word-gate suggest input join \
           profiles span-rule clipboard default-config vocabulary-config learn \
           signing-identity no-voice sound slot-tokenizer sentence-case term-uses \
-          edit-diff sentence-open invented-tail sentence-window
+          edit-diff sentence-open invented-tail sentence-window lowercase-refused
 
 test:
 	@swift build -c release

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -442,7 +442,10 @@ enum CheckConfigCommand {
     private static func gates(of step: Pipeline.Step, config: Config) -> String {
         let slot = step.slotGate ?? true
         let portrait = (step.portrait ?? true) && config.vocabulary.gateSentence
-        return "slot \(slot ? "on" : "off"), portrait \(portrait ? "on" : "off")"
+        // Named only when it is off, as `(bare capitals off)` is on the
+        // `interpret` line. On is the default and the line is long already.
+        let lowercase = step.lowercaseRefused == false ? "  (lowercase refused off)" : ""
+        return "slot \(slot ? "on" : "off"), portrait \(portrait ? "on" : "off")\(lowercase)"
     }
 
     static func describe(_ error: Error) -> String {

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1886,6 +1886,7 @@ struct Config: Decodable, Equatable {
         ///       by_sound: false
         ///       slot_gate: false
         ///       portrait: false
+        ///       lowercase_refused: false
         ///       slot_floor: {en: 0.20, fr: 0.30}
         ///       review: gpt
         ///       max_slots: 4
@@ -1907,6 +1908,7 @@ struct Config: Decodable, Equatable {
             var gate: Bool?
             var slotGate: Bool?
             var portrait: Bool?
+            var lowercaseRefused: Bool?
             var slotFloor: Pipeline.Step.SlotFloor?
             /// What `review:` said, for `Transcription.retiredReview`. Read so
             /// it can be reported, never used.
@@ -1936,6 +1938,7 @@ struct Config: Decodable, Equatable {
                 case marks, capitals, pause
                 case slotGate = "slot_gate"
                 case portrait
+                case lowercaseRefused = "lowercase_refused"
                 case slotFloor = "slot_floor"
             }
 
@@ -1986,6 +1989,9 @@ struct Config: Decodable, Equatable {
                     gate = try c.decodeIfPresent(Bool.self, forKey: .gate)
                     slotGate = try c.decodeIfPresent(Bool.self, forKey: .slotGate)
                     portrait = try c.decodeIfPresent(Bool.self, forKey: .portrait)
+                    lowercaseRefused = try c.decodeIfPresent(
+                        Bool.self, forKey: .lowercaseRefused
+                    )
                     slotFloor = try Self.slotFloor(from: c)
                     // Two spellings, `review: false` and `review: <model>`,
                     // and neither reaches anything now. Read in both shapes so
@@ -2023,7 +2029,8 @@ struct Config: Decodable, Equatable {
             /// `stage:`, `when:`, `unless:` and `app:` are read on every line.
             private static let stageKeys: [(String, [CodingKeys])] = [
                 ("vocabulary", [
-                    .nearMisses, .bySound, .gate, .slotGate, .portrait, .slotFloor,
+                    .nearMisses, .bySound, .gate, .slotGate, .portrait,
+                    .lowercaseRefused, .slotFloor,
                     .review, .maxSlots, .maxReadings, .maxPerSlot, .maxPerTerm,
                 ]),
                 ("interpret", [.marks, .capitals, .pause]),
@@ -2214,7 +2221,9 @@ struct Config: Decodable, Equatable {
                             prompt: entry.prompt, caps: entry.caps,
                             nearMisses: entry.nearMisses, bySound: entry.bySound,
                             gate: entry.gate, slotGate: entry.slotGate,
-                            portrait: entry.portrait, slotFloor: entry.slotFloor,
+                            portrait: entry.portrait,
+                            lowercaseRefused: entry.lowercaseRefused,
+                            slotFloor: entry.slotFloor,
                             marks: entry.marks,
                             capitals: entry.capitals, pause: entry.pause,
                             when: entry.when, unless: entry.unless, app: entry.app

--- a/Sources/ParrotFlow/LowercaseRefusedCommand.swift
+++ b/Sources/ParrotFlow/LowercaseRefusedCommand.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// How a glued span the sentence refused is written back.
+///
+///     ParrotFlow --lowercase-refused "Better Stack" \
+///       "a much Better Stack than before"
+///     better stack
+///     ParrotFlow --lowercase-refused "Mont Blanc" "We climbed Mont Blanc."
+///     AS HEARD
+///
+/// `VocabularyJudge.lowercased` decides this with no model and no audio behind
+/// it. This is the entry point `scripts/check-lowercase-refused.sh` scores, so
+/// the set runs against the shipped function rather than against a copy of it.
+///
+/// The span is located by its first occurrence in the text, which is what
+/// gives the tagger the offset it needs.
+enum LowercaseRefusedCommand {
+    static func run(span: String, text: String, terms: [String]) -> Int32 {
+        guard let range = text.range(of: span) else {
+            print("not found: \(span)")
+            return 2
+        }
+        let offset = text.distance(from: text.startIndex, to: range.lowerBound)
+        guard let written = VocabularyJudge.lowercased(
+            span, in: text, at: offset, terms: terms
+        ) else {
+            print("AS HEARD")
+            return 0
+        }
+        print(written)
+        return 0
+    }
+}

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -191,6 +191,13 @@ struct Pipeline: Equatable, Codable {
         /// `false` takes the path a term with too few uses already has: the
         /// portrait says nothing, and the slot's refusal is all that can speak.
         var portrait: Bool?
+        /// Written `lowercase_refused:`. Whether a glued span the sentence
+        /// refuses is written back in lowercase instead of as heard. Absent
+        /// means true.
+        ///
+        /// `false` puts the span back exactly as the decoder wrote it, which
+        /// is what every other refusal in this stage does.
+        var lowercaseRefused: Bool?
         /// Written `slot_floor:`. How far the heard word must win by before
         /// `SlotReference` refuses the rewrite. A language it does not name
         /// keeps the built-in value for that language — see
@@ -1229,14 +1236,40 @@ struct Pipeline: Equatable, Codable {
                 + lessons.joined(separator: "; "))
         }
 
+        // A refused span that glues to the term is the ordinary phrase, so its
+        // capitals go with it — see `VocabularyJudge.lowercased`. A spelling
+        // lesson is exempt: it writes back exactly what was typed.
+        var writing = changes
+        if step.lowercaseRefused ?? true {
+            let terms = Array(config.vocabulary.terms.keys)
+            for index in changes.indices where decided[index] == false {
+                guard !(index < taught.count && taught[index]) else { continue }
+                let change = changes[index]
+                guard Vocabulary.glues(heard: change.was, term: change.now) else { continue }
+                // The span as heard, because a rule has written its term over
+                // it and the term is a different length.
+                let heard = text.replacingCharacters(in: change.range, with: change.was)
+                let at = text.distance(from: text.startIndex, to: change.range.lowerBound)
+                guard let lower = VocabularyJudge.lowercased(
+                    change.was, in: heard, at: at, terms: terms
+                ) else { continue }
+                writing[index] = VocabularyJudge.Change(
+                    range: change.range, was: lower, now: change.now,
+                    terms: change.terms, standing: change.standing
+                )
+                Log.write("vocabulary: \"\(change.was)\" refused as \(change.now)"
+                    + " — written in lowercase")
+            }
+        }
+
         // Each place written the way it was settled, and a place nothing
         // settled left exactly as it already stands: a rule substitution keeps
         // the term it wrote, a sound proposal keeps the word that was heard.
-        let chosen = VocabularyJudge.settling(decided, in: text, changes: changes)
+        let chosen = VocabularyJudge.settling(decided, in: text, changes: writing)
         // What the stage undid, in the words it put back. Named `reverted`
         // rather than `kept_as_decoded`: every place on this list is a
         // substitution somebody has to answer for.
-        let reverted = zip(changes, decided).filter { $0.1 == false }.map {
+        let reverted = zip(writing, decided).filter { $0.1 == false }.map {
             "\($0.0.now) -> \($0.0.was)"
         }
         if chosen != text {

--- a/Sources/ParrotFlow/PipelineCommand.swift
+++ b/Sources/ParrotFlow/PipelineCommand.swift
@@ -126,7 +126,9 @@ enum PipelineCommand {
                 stage: stage, transform: entry.transform, prompt: entry.prompt,
                 caps: entry.caps, nearMisses: entry.nearMisses,
                 bySound: entry.bySound, gate: entry.gate, slotGate: entry.slotGate,
-                portrait: entry.portrait, slotFloor: entry.slotFloor,
+                portrait: entry.portrait,
+                lowercaseRefused: entry.lowercaseRefused,
+                slotFloor: entry.slotFloor,
                 marks: entry.marks,
                 capitals: entry.capitals, pause: entry.pause, when: entry.when,
                 unless: entry.unless, app: entry.app

--- a/Sources/ParrotFlow/VocabularyJudge.swift
+++ b/Sources/ParrotFlow/VocabularyJudge.swift
@@ -995,11 +995,16 @@ enum VocabularyJudge {
     /// Whether the span at `offset` opens a sentence, so its first capital is
     /// there for the sentence and not for a name.
     ///
-    /// A quote or a bracket in front of the span counts, whichever way it
-    /// faces. `"` opens the sentence in `He said "Better Stack is down."` and
-    /// closes the one before it in `He said "it is down." Better Stack is
-    /// fine.`, and looking further back does not separate the two reliably.
-    /// Both keep the capital, so the ambiguity costs nothing.
+    /// A quote in front of the span counts on its own, whichever way it faces.
+    /// `"` opens the sentence in `He said "Better Stack is down."` and closes
+    /// the one before it in `He said "it is down." Better Stack is fine.`, and
+    /// looking further back does not separate the two: the opening one has an
+    /// ordinary word behind it. Both keep the capital, so the ambiguity costs
+    /// nothing.
+    ///
+    /// A bracket does not. It is skipped and the scan carries on behind it, so
+    /// `We migrated last year. (Better Stack is down.)` opens a sentence and
+    /// `We use (Better Stack) today` does not.
     private static func opensSentence(_ text: String, at offset: Int) -> Bool {
         guard let start = text.index(
             text.startIndex, offsetBy: offset, limitedBy: text.endIndex
@@ -1008,17 +1013,15 @@ enum VocabularyJudge {
         while cursor > text.startIndex {
             let before = text.index(before: cursor)
             let character = text[before]
-            guard character.isWhitespace else {
-                return Self.enders.contains(character) || Self.quotes.contains(character)
-            }
             cursor = before
+            if character.isWhitespace || Self.brackets.contains(character) { continue }
+            return Self.enders.contains(character) || Self.quotes.contains(character)
         }
         return true
     }
 
-    private static let quotes: Set<Character> = [
-        "\"", "'", "“", "”", "‘", "’", "«", "»", "(", ")", "[", "]", "{", "}",
-    ]
+    private static let quotes: Set<Character> = ["\"", "'", "“", "”", "‘", "’", "«", "»"]
+    private static let brackets: Set<Character> = ["(", ")", "[", "]", "{", "}"]
     private static let enders: Set<Character> = [".", "?", "!"]
 
     /// How far a source may be settled without a model.

--- a/Sources/ParrotFlow/VocabularyJudge.swift
+++ b/Sources/ParrotFlow/VocabularyJudge.swift
@@ -994,6 +994,12 @@ enum VocabularyJudge {
 
     /// Whether the span at `offset` opens a sentence, so its first capital is
     /// there for the sentence and not for a name.
+    ///
+    /// A quote or a bracket in front of the span counts, whichever way it
+    /// faces. `"` opens the sentence in `He said "Better Stack is down."` and
+    /// closes the one before it in `He said "it is down." Better Stack is
+    /// fine.`, and looking further back does not separate the two reliably.
+    /// Both keep the capital, so the ambiguity costs nothing.
     private static func opensSentence(_ text: String, at offset: Int) -> Bool {
         guard let start = text.index(
             text.startIndex, offsetBy: offset, limitedBy: text.endIndex
@@ -1002,17 +1008,17 @@ enum VocabularyJudge {
         while cursor > text.startIndex {
             let before = text.index(before: cursor)
             let character = text[before]
-            guard character.isWhitespace || Self.closers.contains(character) else {
-                return Self.enders.contains(character)
+            guard character.isWhitespace else {
+                return Self.enders.contains(character) || Self.quotes.contains(character)
             }
             cursor = before
         }
         return true
     }
 
-    /// What may stand between a sentence ender and the span. A quoted sentence
-    /// ends `…said."` and the next one still opens a sentence.
-    private static let closers: Set<Character> = ["\"", "'", "”", "’", ")", "]", "}", "»"]
+    private static let quotes: Set<Character> = [
+        "\"", "'", "“", "”", "‘", "’", "«", "»", "(", ")", "[", "]", "{", "}",
+    ]
     private static let enders: Set<Character> = [".", "?", "!"]
 
     /// How far a source may be settled without a model.

--- a/Sources/ParrotFlow/VocabularyJudge.swift
+++ b/Sources/ParrotFlow/VocabularyJudge.swift
@@ -944,6 +944,77 @@ enum VocabularyJudge {
         return out + text[cursor...]
     }
 
+    /// The heard span written in lowercase, or `nil` when it must stay exactly
+    /// as heard.
+    ///
+    /// A span that glues to a term — `Better Stack` for `BetterStack` — and
+    /// that the sentence then refused is the ordinary phrase, and the portrait
+    /// has just said so. Putting back what the decoder wrote puts back its
+    /// capitals too, and those are there because it thought it was writing a
+    /// name.
+    ///
+    /// Each word is asked of `SentenceJoin.written`, which keeps a capital for
+    /// `I`, for a word in capitals throughout, for a vocabulary term, for a
+    /// name `NLTagger` knows, and for a word the lexicon gives no lemma for. A
+    /// capital that survives any of those refuses the whole span: one word the
+    /// lexicon has never seen makes the span a name rather than a phrase.
+    /// Measured on `nameTypeOrLexicalClass` — `Better` and `Stack` are both
+    /// `Noun` with a lemma, `Mont` and `Blanc` are both `PersonalName` with
+    /// none, and `API` is in capitals throughout.
+    ///
+    /// `text` must already hold the span as heard, and `offset` is where the
+    /// span starts in it. A rule has written its term into the transcript, and
+    /// the term is a different length, so the caller rebuilds the text the way
+    /// `SentenceGate` does.
+    static func lowercased(
+        _ span: String, in text: String, at offset: Int, terms: [String]
+    ) -> String? {
+        let opens = opensSentence(text, at: offset)
+        var out = "", index = span.startIndex, isFirst = true
+        while index < span.endIndex {
+            guard !span[index].isWhitespace else {
+                out.append(span[index])
+                index = span.index(after: index)
+                continue
+            }
+            var end = index
+            while end < span.endIndex, !span[end].isWhitespace {
+                end = span.index(after: end)
+            }
+            let word = String(span[index..<end])
+            let at = offset + span.distance(from: span.startIndex, to: index)
+            let now = SentenceJoin.written(word, in: text, at: at, terms: terms)
+            if now == word, word.first?.isUppercase == true { return nil }
+            out += isFirst && opens ? word : now
+            isFirst = false
+            index = end
+        }
+        return out == span ? nil : out
+    }
+
+    /// Whether the span at `offset` opens a sentence, so its first capital is
+    /// there for the sentence and not for a name.
+    private static func opensSentence(_ text: String, at offset: Int) -> Bool {
+        guard let start = text.index(
+            text.startIndex, offsetBy: offset, limitedBy: text.endIndex
+        ) else { return false }
+        var cursor = start
+        while cursor > text.startIndex {
+            let before = text.index(before: cursor)
+            let character = text[before]
+            guard character.isWhitespace || Self.closers.contains(character) else {
+                return Self.enders.contains(character)
+            }
+            cursor = before
+        }
+        return true
+    }
+
+    /// What may stand between a sentence ender and the span. A quoted sentence
+    /// ends `…said."` and the next one still opens a sentence.
+    private static let closers: Set<Character> = ["\"", "'", "”", "’", ")", "]", "}", "»"]
+    private static let enders: Set<Character> = [".", "?", "!"]
+
     /// How far a source may be settled without a model.
     enum Gating {
         /// The two word lists, and nothing else. They can only say "keep what

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -260,6 +260,20 @@ if let index = arguments.firstIndex(of: "--word-gate") {
     exit(WordGateCommand.run(word: arguments[index + 1], term: term, sentence: sentence))
 }
 
+if let index = arguments.firstIndex(of: "--lowercase-refused") {
+    guard arguments.indices.contains(index + 2) else {
+        print("usage: ParrotFlow --lowercase-refused \"<span>\" \"<text>\" [--terms \"a,b\"]")
+        exit(2)
+    }
+    let terms = arguments.firstIndex(of: "--terms").flatMap {
+        arguments.indices.contains($0 + 1) ? arguments[$0 + 1] : nil
+    }
+    exit(LowercaseRefusedCommand.run(
+        span: arguments[index + 1], text: arguments[index + 2],
+        terms: terms?.split(separator: ",").map(String.init) ?? []
+    ))
+}
+
 if let index = arguments.firstIndex(of: "--suggest") {
     guard arguments.indices.contains(index + 1) else {
         print("usage: ParrotFlow --suggest \"<sentence>\" [--lang fr]")

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -94,6 +94,7 @@ transcription:
     # sentence it stands in. No model. Above everything that edits the text.
     #   near_misses: false   match exactly, never one edit away
     #   by_sound: false      match spelling only, never how a word sounds
+    #   lowercase_refused: false   revert a refused glued span as heard
     - vocabulary
     - numbers                            # "two hundred forty-three" -> 243
     - transform: punctuation             # "is that true question mark" -> is that true?

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -143,6 +143,7 @@ name or a mapping, and it cannot be both:
   gate: true          # optional; default. false leaves every place open
   slot_gate: true     # optional; default. false reads no slot model
   portrait: true      # optional; default. false reads no term portrait
+  lowercase_refused: true  # optional; default. false reverts a refused span as heard
   slot_floor: 0.20    # optional; or {en: 0.20, fr: 0.30}
   max_per_slot: 2     # optional; readings per place, the decoder's included
   max_per_term: 2     # optional; places in one sentence about the same name
@@ -240,6 +241,28 @@ switches that decide whether each model is downloaded:
 One line per step and not one for the pipeline, because a pipeline may hold
 more than one `vocabulary` step — one per app is the reason these options are
 on the step — and each names its own.
+
+**`lowercase_refused:` writes a refused glued span in lowercase.** On by
+default. A span that glues to a term — `Better Stack` for `BetterStack` — is
+matched before any word list is read, so the term is written at every place.
+When a sentence test then refuses one, putting back what the decoder wrote puts
+back its capitals: `a much Better Stack than before`. The decoder wrote those
+capitals because it thought it was writing a name, and the portrait has just
+said this is the ordinary phrase. So the span is written `better stack`.
+
+It fires only on a refused place that glues, and only when every word of the
+span passes the same lexicon test `interpret` uses — `NLTagger` must give the
+word a lemma and must not call it a name. `Mont Blanc` for a term `MontBlanc`
+is left as heard, and so is any word in capitals throughout. A capital that
+starts a sentence is kept, and a possessive survives: `Better Stack's` becomes
+`better stack's`.
+
+**A spelling lesson is exempt.** "urza spells mirza" writes back exactly what
+was typed, capitals included, and this rule never touches it.
+
+`lowercase_refused: false` reverts as heard, which is what every other refusal
+in this stage does. `--check-config` names it on the step's line only when it
+is off.
 
 **`slot_floor:` is how far the heard word must win by** before the slot test
 refuses the rewrite. A number applies to every language; a map names them one

--- a/scripts/check-lowercase-refused.sh
+++ b/scripts/check-lowercase-refused.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Scores how a refused glued span is written back, against
+# tests/lowercase-refused-cases.json.
+#
+#   scripts/check-lowercase-refused.sh
+#
+# `Better Stack` glues to the term `BetterStack`, so the rule writes the term
+# everywhere. When the sentence refuses that place, putting back what the
+# decoder wrote puts back its capitals too — and the decoder wrote them because
+# it thought it was writing a name. `VocabularyJudge.lowercased` is the half
+# that decides, and `AS HEARD` is the half that keeps a real name safe.
+#
+# No model. `NLTagger` and the vocabulary answer this, so it runs in CI and on
+# a machine that has never dictated.
+#
+# A case may name `terms`, which is the vocabulary the span is asked against.
+# A word the vocabulary already knows refuses the whole span.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/release/ParrotFlow"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+
+WORK="$(mktemp -d -t parrotflow-lowercase-refused)"
+trap 'rm -rf "$WORK"' EXIT
+export PARROTFLOW_CONFIG_DIR="$WORK"
+
+# Five lines per case, so a case holding a quote or an apostrophe arrives whole.
+if ! python3 -c '
+import json, sys
+for case in json.load(open(sys.argv[1])):
+    print(case["span"])
+    print(case["text"])
+    print(case["want"])
+    print(case.get("terms", ""))
+    print(case["why"])
+' "$ROOT/tests/lowercase-refused-cases.json" > "$WORK/cases"; then
+  echo "  ✗ tests/lowercase-refused-cases.json could not be read"
+  exit 1
+fi
+
+pass=0; total=0
+while IFS= read -r span && IFS= read -r text && IFS= read -r want \
+   && IFS= read -r terms && IFS= read -r why; do
+  total=$((total + 1))
+  if [ -n "$terms" ]; then
+    got="$("$BIN" --lowercase-refused "$span" "$text" --terms "$terms" 2>/dev/null)"
+  else
+    got="$("$BIN" --lowercase-refused "$span" "$text" 2>/dev/null)"
+  fi
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1))
+    printf '  ✓  %-16s %s\n' "$got" "$why"
+  else
+    printf '  ✗  %-16s want %s — %s\n' "${got:-<nothing>}" "$want" "$why"
+  fi
+done < "$WORK/cases"
+
+printf '\n%d/%d\n' "$pass" "$total"
+[ "$pass" -eq "$total" ]

--- a/scripts/check-lowercase-refused.sh
+++ b/scripts/check-lowercase-refused.sh
@@ -15,6 +15,22 @@
 #
 # A case may name `terms`, which is the vocabulary the span is asked against.
 # A word the vocabulary already knows refuses the whole span.
+#
+# **This scores the rewrite, not the stage.** The rule only fires where a
+# sentence test refused a place, and both of those read a model, so no
+# deterministic run can reach it — `make test` must not need a download. The
+# stage end to end is two fixtures and a by-hand run, the way
+# scripts/check-portrait.sh is:
+#
+#   W=$(mktemp -d) && cp tests/fixtures/vocabulary-uses-portrait.yaml \
+#     "$W/vocabulary-uses.yaml"
+#   PARROTFLOW_CONFIG_DIR=$W .build/release/ParrotFlow --warm --quiet \
+#     --pipeline tests/pipelines/vocabulary-lowercase.yaml \
+#     "We have now we now have a much Better Stack than before we migrated
+#      to the Better Stack platform."
+#
+# writes `a much better stack`, and vocabulary-lowercase-off.yaml, which is the
+# same fixture with `lowercase_refused: false`, writes `a much Better Stack`.
 set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BIN="$ROOT/.build/release/ParrotFlow"

--- a/scripts/check-pipeline-config.sh
+++ b/scripts/check-pipeline-config.sh
@@ -235,6 +235,23 @@ check "and each names its own floor and its own gates" \
   "$(steps)" \
   "slot floor en 0.25  fr 0.25  slot on, portrait on|in /term/  slot floor en 0.45  fr 0.45  slot on, portrait off|"
 
+run_config lowercase_default 'transcription:
+  languages: [en]
+  pipeline:
+    - vocabulary'
+
+check "a bare - vocabulary line writes a refused glued span in lowercase" \
+  "$(steps)" "slot floor en 0.20  slot on, portrait on|"
+
+run_config lowercase_off 'transcription:
+  languages: [en]
+  pipeline:
+    - {stage: vocabulary, lowercase_refused: false}'
+
+check "lowercase_refused: false loads" "$code" "0"
+check "and is named on the step's line" \
+  "$(steps)" "slot floor en 0.20  slot on, portrait on  (lowercase refused off)|"
+
 # --- an option on the wrong stage ---------------------------------------------
 #
 # Refused, not dropped. A switch that loads and does nothing is somebody
@@ -252,6 +269,15 @@ check "and each message names the stage that does read it" \
   "$(printf '%s\n' "$out" | grep -c 'option on the `vocabulary` stage')" "1"
 check "and the stage it was written on" \
   "$(printf '%s\n' "$out" | grep -c '`numbers`: `slot_gate:`')" "1"
+
+run_config lowercase_wrong_stage 'transcription:
+  languages: [en]
+  pipeline:
+    - {stage: numbers, lowercase_refused: false}
+    - vocabulary'
+
+check "lowercase_refused: on another stage is refused too" \
+  "$(printf '%s\n' "$out" | grep -c '`numbers`: `lowercase_refused:`')" "1"
 
 run_config option_right_stage 'transcription:
   languages: [en]

--- a/tests/lowercase-refused-cases.json
+++ b/tests/lowercase-refused-cases.json
@@ -30,6 +30,18 @@
     "why": "an opening quote in front of the span is a sentence start too"
   },
   {
+    "span": "Better Stack",
+    "text": "We use (Better Stack) today",
+    "want": "better stack",
+    "why": "a bracket mid-sentence is not a sentence start"
+  },
+  {
+    "span": "Better Stack",
+    "text": "We migrated last year. (Better Stack is down.)",
+    "want": "Better stack",
+    "why": "a bracket is skipped, and the period behind it is the sentence start"
+  },
+  {
     "span": "Better Stack's",
     "text": "The Better Stack's dashboard is down.",
     "want": "better stack's",

--- a/tests/lowercase-refused-cases.json
+++ b/tests/lowercase-refused-cases.json
@@ -1,0 +1,63 @@
+[
+  {
+    "span": "Better Stack",
+    "text": "We have now we now have a much Better Stack than before we migrated to the BetterStack platform.",
+    "want": "better stack",
+    "why": "the dictation this rule was built for; the portrait refused this place"
+  },
+  {
+    "span": "Better Stack",
+    "text": "Clearly we have now a much Better Stack than before starting using the BetterStack monitoring platform.",
+    "want": "better stack",
+    "why": "the second dictation, same phrase, same refusal"
+  },
+  {
+    "span": "Better Stack",
+    "text": "Better Stack is down again.",
+    "want": "Better stack",
+    "why": "the span starts the text, so its first capital is the sentence's"
+  },
+  {
+    "span": "Better Stack",
+    "text": "He said \"it is down.\" Better Stack is fine.",
+    "want": "Better stack",
+    "why": "a closing quote between the period and the span is still a sentence start"
+  },
+  {
+    "span": "Better Stack's",
+    "text": "The Better Stack's dashboard is down.",
+    "want": "better stack's",
+    "why": "the possessive suffix survives the lowercasing"
+  },
+  {
+    "span": "Better Stack's",
+    "text": "Better Stack's dashboard is down.",
+    "want": "Better stack's",
+    "why": "sentence start and a possessive at once"
+  },
+  {
+    "span": "Mont Blanc",
+    "text": "We climbed Mont Blanc last year.",
+    "want": "AS HEARD",
+    "why": "NLTagger calls both words PersonalName and gives neither a lemma"
+  },
+  {
+    "span": "API Key",
+    "text": "The API Key is wrong.",
+    "want": "AS HEARD",
+    "why": "a word in capitals throughout is never lowercased, and it refuses the span"
+  },
+  {
+    "span": "Better Stack",
+    "text": "a much Better Stack than before",
+    "want": "AS HEARD",
+    "terms": "Stack",
+    "why": "a word the vocabulary knows as a term refuses the span"
+  },
+  {
+    "span": "better stack",
+    "text": "a much better stack than before",
+    "want": "AS HEARD",
+    "why": "nothing to lowercase, so the span is left exactly as it arrived"
+  }
+]

--- a/tests/lowercase-refused-cases.json
+++ b/tests/lowercase-refused-cases.json
@@ -24,6 +24,12 @@
     "why": "a closing quote between the period and the span is still a sentence start"
   },
   {
+    "span": "Better Stack",
+    "text": "He said \"Better Stack is down.\"",
+    "want": "Better stack",
+    "why": "an opening quote in front of the span is a sentence start too"
+  },
+  {
     "span": "Better Stack's",
     "text": "The Better Stack's dashboard is down.",
     "want": "better stack's",

--- a/tests/pipelines/vocabulary-lowercase-off.yaml
+++ b/tests/pipelines/vocabulary-lowercase-off.yaml
@@ -1,0 +1,17 @@
+# The same fixture with the rule off: a refused span reverts as heard.
+#
+# `Better Stack` glues to `BetterStack`, so the rule writes the term at every
+# place and only the sentence can refuse one. That needs the portrait, so this
+# fixture is not in `make test` — see the by-hand run at the top of
+# scripts/check-lowercase-refused.sh.
+#
+languages: [en]
+vocabulary:
+  terms:
+    BetterStack:
+      kind: organization
+      pronunciations:
+        - heard: Better Stack
+          from: correction
+pipeline:
+  - {stage: vocabulary, lowercase_refused: false}

--- a/tests/pipelines/vocabulary-lowercase.yaml
+++ b/tests/pipelines/vocabulary-lowercase.yaml
@@ -1,0 +1,17 @@
+# The name stage writing a refused glued span in lowercase.
+#
+# `Better Stack` glues to `BetterStack`, so the rule writes the term at every
+# place and only the sentence can refuse one. That needs the portrait, so this
+# fixture is not in `make test` — see the by-hand run at the top of
+# scripts/check-lowercase-refused.sh.
+#
+languages: [en]
+vocabulary:
+  terms:
+    BetterStack:
+      kind: organization
+      pronunciations:
+        - heard: Better Stack
+          from: correction
+pipeline:
+  - vocabulary


### PR DESCRIPTION
A span that glues to a term — `Better Stack` for `BetterStack` — is matched before any word list is read, so the rule writes the term at every place. When a sentence test refuses one, the revert put back what the decoder wrote, capitals included: `a much Better Stack than before`. The portrait had just said this is the ordinary phrase, so the stage now writes `better stack` there.

The switch is `lowercase_refused:` on the `vocabulary` step. On by default. `false` reverts as heard, exactly as today, and `--check-config` refuses the key on any other stage.

Start with `Sources/ParrotFlow/VocabularyJudge.swift` — `lowercased` is the whole rule and is pure. The rest is wiring.

<details>
<summary>NLTagger does not call `Better Stack` a name, so `SentenceJoin.written` is reused per word</summary>

The two dictations, tagged with `nameTypeOrLexicalClass` and `.lemma`, language forced to English as `written` does:

| Sentence | Word | Tag | Lemma |
|---|---|---|---|
| `We have now we now have a much Better Stack than before we migrated to the BetterStack platform.` | `Better` | Noun | `better` |
| | `Stack` | Noun | `stack` |
| `Clearly we have now a much Better Stack than before starting using the BetterStack monitoring platform.` | `Better` | Noun | `better` |
| | `Stack` | Noun | `stack` |

The name type does not fire, so `written` is reused per word rather than the lemma test alone. That keeps the four other reasons it holds a capital: `I`, a word in capitals throughout, a vocabulary term, and a word the lexicon gives no lemma for.

The controls behave, on the same probe:

| Span | Word | Tag | Lemma |
|---|---|---|---|
| `Mont Blanc` | `Mont` | PersonalName | empty |
| | `Blanc` | PersonalName | empty |
| `API Key` | `API` | OrganizationName | empty |

One capital that survives `written` refuses the whole span. So `Mont Blanc` for a term `MontBlanc` is left as heard, and so is `API Key`.

</details>

<details>
<summary>End to end with the portrait model — both dictations reproduce, and the option off reverts as before</summary>

`--pipeline` with `--warm`, one process at a time. The portrait numbers match the log line for line.

Dictation 1, portrait 0.966 against 1.029 at the first place:

```
before: We have now we now have a much BetterStack than before we migrated to the BetterStack platform.
after:  We have now we now have a much better stack than before we migrated to the BetterStack platform.
reverted = "BetterStack -> better stack"
```

Dictation 2, portrait 0.962 against 1.030 at the first place, 1.023 against 0.931 at the second:

```
before: Clearly we have now a much BetterStack than before starting using the BetterStack monitoring platform.
after:  Clearly we have now a much better stack than before starting using the BetterStack monitoring platform.
```

The same first sentence with `lowercase_refused: false`:

```
after:  We have now we now have a much Better Stack than before we migrated to the BetterStack platform.
```

One log line when the rule fires:

```
vocabulary: "Better Stack" refused as BetterStack — written in lowercase
```

</details>

<details>
<summary>Checks — `make test` green, 13/13 on the new set, no number moved</summary>

`make test` in the worktree, `swift build -c release` first, swiftlint clean of anything new:

```
numbers 97/97   replacements 23/23   pipeline 94/94   pipeline-config 76/76
wake 24/24   split 14/14   dotted 81/81   dates 26/26   keyed 26/26
transform-folders 30/30   eval 29/29   audio-recovery 14/14   possessive 35/35
word-gate 35/35   input 14/14   join 46/46   span-rule 6/6
vocabulary-config 63/63   learn 45/45   no-voice 5/5   sound 13/13 + 3/3
slot-tokenizer 21/21   sentence-case 39/39   invented-tail 16/16
sentence-window 11/11   lowercase-refused 13/13
Every check passed.
```

`pipeline-config` is 76/76 against 72/72 before: four new checks, no expected string changed. `lowercase-refused` is new — `scripts/check-lowercase-refused.sh`, 13 cases in `tests/lowercase-refused-cases.json`, no model, added to `CHECKS`.

The cases: the two dictations, a sentence-initial span keeping its capital, a span after a closing quote and one after an opening quote, a bracket mid-sentence and a bracket after a period, a possessive both mid-sentence and sentence-initial, `Mont Blanc`, `API Key`, a span holding a vocabulary term, and a span already lowercase.

The stage end to end needs the portrait model, so it is not in `make test` — the same place `scripts/check-portrait.sh` sits. `tests/pipelines/vocabulary-lowercase.yaml` and `vocabulary-lowercase-off.yaml` are the two fixtures, and the by-hand command is at the top of the check script. It seeds the portrait from the committed `tests/fixtures/vocabulary-uses-portrait.yaml`, so it reproduces from the repository.

</details>

<details>
<summary>Decisions the brief left open</summary>

- **A kept capital refuses the whole span, not just that word.** One rule covers `Mont Blanc`, `API Key` and a span holding a vocabulary term. The brief asked for both a per-span guard and a per-word capitals rule; whole-span refusal is the stricter of the two and never writes half a phrase down.
- **`--check-config` names the option only when it is off**, as `(bare capitals off)` does on the `interpret` line. No existing expected string moved.
- **No language gate.** `written` forces English. On French text with a glued capitalised span the tagger returns an empty lemma for most words, so the span is refused and left as heard — measured on `Meilleure Pile`, `Rouge Rocher` and `Belle Vue`, all three refused. That is the direction this stage already fails in.
- **A sound proposal is included.** The condition is `decided == false` and glues, whatever the standing. A sound place the portrait took back out is lowercased the same way.
- **The terms passed to `written`** are `config.vocabulary.terms.keys`. The CLI takes them on `--terms`, so a case can name them.
- **New CLI flag `--lowercase-refused "<span>" "<text>" [--terms "a,b"]`**, beside `--word-gate`, so the check script scores the shipped function.

</details>

<details>
<summary>What this does not cover</summary>

A run of capitals that matches no term is #274 and is untouched. This rule needs a vocabulary term the span glues to, and a sentence test that refused it.

A place left open (`nil`) is untouched, and a refused place that does not glue — `Versailles -> Vercel` — still reverts as heard.

</details>
