### PR TITLE
feat: a priority list of microphones, set from the menu bar

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -234,6 +234,12 @@ jobs:
       - name: --learn writes a pronunciation
         run: scripts/check-learn.sh
 
+      # The menu bar writes the microphone priority list into config.yaml, a
+      # file that is mostly comments — so the write is a text splice, and every
+      # shape the file can be in has to come out valid and keep its comments.
+      - name: The microphone list survives a round trip
+        run: scripts/check-microphones.sh
+
       # Two ways in, one signing identity. A check that is only right in the
       # script or only right in the app is a door that checks less than the
       # other one.

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -5871,10 +5871,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 // it below one that is already plugged in would change nothing
                 // and look broken.
                 let item = NSMenuItem(
-                    title: "\(device.name)", action: #selector(useMicrophone), keyEquivalent: ""
+                    title: device.name, action: #selector(useMicrophone), keyEquivalent: ""
                 )
                 item.target = self
-                item.representedObject = device.name
+                item.representedObject = Self.entry(for: device, among: attached)
                 item.state = device.uid == live ? .on : .off
                 menu.addItem(item)
             }
@@ -5929,15 +5929,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // and `sorted` given a predicate that is not one is allowed to return
         // anything at all.
         let ordered = attached.filter { $0.uid == first } + attached.filter { $0.uid != first }
-        // The name, unless two microphones answer to it — then the UID, which
-        // is the thing that tells them apart. Written once, and read by
-        // everyone afterwards.
-        let names = attached.map(\.name)
-        let seeded = ordered.map { device in
-            names.filter { $0 == device.name }.count > 1 ? device.uid : device.name
-        }
+        let seeded = ordered.map { Self.entry(for: $0, among: attached) }
         writeMicrophones(seeded)
         return seeded
+    }
+
+    /// What to write in the config for one microphone.
+    ///
+    /// The name, unless a second attached device answers to it — then the UID.
+    /// Two microphones can share a name, and a name is then not enough to pick
+    /// the one somebody clicked: `Recorder.device(named:)` would resolve it to
+    /// whichever CoreAudio lists first.
+    private static func entry(
+        for device: Recorder.InputDevice, among attached: [Recorder.InputDevice]
+    ) -> String {
+        attached.filter { $0.name == device.name }.count > 1 ? device.uid : device.name
     }
 
     /// What one entry in the list can be moved to.

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -894,6 +894,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // on any save of config.yaml.
         Trace.directory = config.resolvedOutputDir
 
+        // Re-read on every save, and acted on: a microphone added to the list
+        // is one the next press should already be listening through, not one
+        // that waits for a relaunch. `reevaluateInput` rebinds only when the
+        // list now names a different device.
+        recorder.preferredMicrophones = config.audio.microphones
+        recorder.reevaluateInput()
+
         configProblems = config.problems()
         for problem in configProblems { Log.write("config: \(problem)") }
         // Logged and not flashed. A `command:` transform is announced on every
@@ -5808,6 +5815,183 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    // MARK: - The microphone list
+
+    /// The priority list, and what else is plugged in.
+    ///
+    /// Built when the menu opens, never kept. Both halves move without this app
+    /// hearing about it: the list is a file somebody can edit, and the devices
+    /// are whatever is attached to the Mac this second.
+    private func microphoneMenu() -> NSMenu {
+        let menu = NSMenu()
+        // Every row here is enabled or not for a reason this file knows —
+        // whether the device is attached, whether it is already first. AppKit's
+        // own rule is "does it have a target", which would answer yes to all of
+        // them and turn the greying-out off.
+        menu.autoenablesItems = false
+        let entries = config.audio.microphones
+        let attached = Recorder.inputDevices()
+        let live = recorder.boundDevice?.uid
+
+        for (index, entry) in entries.enumerated() {
+            let match = Recorder.device(named: entry, among: attached)
+            let item = NSMenuItem(
+                title: "\(index + 1).  \(match?.name ?? entry)"
+                    + (match == nil ? "  ·  not connected" : ""),
+                action: nil,
+                keyEquivalent: ""
+            )
+            // The number is the priority; the tick is which one is actually
+            // being recorded through. They are different facts whenever
+            // something higher up the list is unplugged.
+            item.state = match != nil && match?.uid == live ? .on : .off
+            item.submenu = microphoneActions(
+                at: index, of: entries.count, live: match != nil && match?.uid == live
+            )
+            menu.addItem(item)
+        }
+
+        // Matched the same way the recorder matches, so a device does not
+        // appear twice — once as entry 2 written as "airpods", once here under
+        // its full name.
+        let unlisted = attached.filter { device in
+            !entries.contains { Recorder.device(named: $0, among: [device]) != nil }
+        }
+        if !unlisted.isEmpty {
+            if !entries.isEmpty { menu.addItem(.separator()) }
+            let header = NSMenuItem(
+                title: entries.isEmpty ? "Record through" : "Also attached", action: nil, keyEquivalent: ""
+            )
+            header.isEnabled = false
+            menu.addItem(header)
+            for device in unlisted {
+                // Straight to the top of the list, not the bottom. Picking a
+                // microphone out of this menu is asking to use it now; adding
+                // it below one that is already plugged in would change nothing
+                // and look broken.
+                let item = NSMenuItem(
+                    title: "\(device.name)", action: #selector(useMicrophone), keyEquivalent: ""
+                )
+                item.target = self
+                item.representedObject = device.name
+                item.state = device.uid == live ? .on : .off
+                menu.addItem(item)
+            }
+        }
+
+        if !entries.isEmpty {
+            menu.addItem(.separator())
+            let clear = NSMenuItem(
+                title: "Follow the System Setting",
+                action: #selector(clearMicrophones),
+                keyEquivalent: ""
+            )
+            clear.target = self
+            menu.addItem(clear)
+        }
+
+        for item in menu.items {
+            Self.hideAutomaticImage(item)
+            for child in item.submenu?.items ?? [] { Self.hideAutomaticImage(child) }
+        }
+        return menu
+    }
+
+    /// What one entry in the list can be moved to.
+    ///
+    /// A submenu rather than drag: an NSMenu row cannot be dragged onto another
+    /// row, and the two moves plus a delete say the same thing exactly.
+    private func microphoneActions(at index: Int, of count: Int, live: Bool) -> NSMenu {
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+
+        let use = NSMenuItem(title: "Record Through This", action: #selector(promoteMicrophone), keyEquivalent: "")
+        use.target = self
+        use.tag = index
+        use.isEnabled = !live
+        menu.addItem(use)
+
+        menu.addItem(.separator())
+
+        let up = NSMenuItem(title: "Move Up", action: #selector(moveMicrophoneUp), keyEquivalent: "")
+        up.target = self
+        up.tag = index
+        up.isEnabled = index > 0
+        menu.addItem(up)
+
+        let down = NSMenuItem(title: "Move Down", action: #selector(moveMicrophoneDown), keyEquivalent: "")
+        down.target = self
+        down.tag = index
+        down.isEnabled = index < count - 1
+        menu.addItem(down)
+
+        menu.addItem(.separator())
+
+        let remove = NSMenuItem(title: "Remove", action: #selector(removeMicrophone), keyEquivalent: "")
+        remove.target = self
+        remove.tag = index
+        menu.addItem(remove)
+
+        return menu
+    }
+
+    @objc private func promoteMicrophone(_ sender: NSMenuItem) {
+        var entries = config.audio.microphones
+        guard entries.indices.contains(sender.tag) else { return }
+        entries.insert(entries.remove(at: sender.tag), at: 0)
+        writeMicrophones(entries)
+    }
+
+    @objc private func moveMicrophoneUp(_ sender: NSMenuItem) {
+        var entries = config.audio.microphones
+        guard entries.indices.contains(sender.tag), sender.tag > 0 else { return }
+        entries.swapAt(sender.tag, sender.tag - 1)
+        writeMicrophones(entries)
+    }
+
+    @objc private func moveMicrophoneDown(_ sender: NSMenuItem) {
+        var entries = config.audio.microphones
+        guard entries.indices.contains(sender.tag), sender.tag < entries.count - 1 else { return }
+        entries.swapAt(sender.tag, sender.tag + 1)
+        writeMicrophones(entries)
+    }
+
+    @objc private func removeMicrophone(_ sender: NSMenuItem) {
+        var entries = config.audio.microphones
+        guard entries.indices.contains(sender.tag) else { return }
+        entries.remove(at: sender.tag)
+        writeMicrophones(entries)
+    }
+
+    @objc private func useMicrophone(_ sender: NSMenuItem) {
+        guard let name = sender.representedObject as? String else { return }
+        writeMicrophones([name] + config.audio.microphones)
+    }
+
+    @objc private func clearMicrophones(_ sender: NSMenuItem) {
+        writeMicrophones([])
+    }
+
+    /// Saves the order and starts using it.
+    ///
+    /// The write lands in `config.yaml`, the watcher reloads it, and
+    /// `applyConfig` sets the same list again — but a reload is a file event
+    /// with a debounce on it, and the microphone is expected to have changed by
+    /// the time the menu closes. So the recorder is told here as well.
+    private func writeMicrophones(_ names: [String]) {
+        do {
+            try ConfigWriter.setMicrophones(names)
+        } catch {
+            Log.write("could not write the microphone list: \(error.localizedDescription)")
+            flash("Could not write config.yaml.", tone: .caution)
+            return
+        }
+        config.audio.microphones = names
+        recorder.preferredMicrophones = names
+        recorder.reevaluateInput()
+        Log.write("microphones: \(names.isEmpty ? "following the system" : names.joined(separator: ", "))")
+    }
+
     // MARK: - Menu bar
 
     private func buildStatusItem() {
@@ -5823,8 +6007,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Under the state it qualifies: which microphone the next press will
         // listen through. Worth a row because the answer is chosen elsewhere —
         // a headset connects and silently becomes the input for everything.
+        // It unfolds into the priority list, which is how that gets decided
+        // here instead. Filled in by `menuNeedsUpdate`.
         inputDeviceItem = NSMenuItem(title: "", action: nil, keyEquivalent: "")
-        inputDeviceItem.isEnabled = false
         menu.addItem(inputDeviceItem)
 
         // Above the separator, so it reads as part of the app's state rather
@@ -6256,9 +6441,10 @@ extension AppDelegate: NSMenuDelegate {
         // recording: the device is picked in System Settings, so the moment the
         // menu opens is both the first time the answer can have changed and the
         // only time anyone can read it.
-        let device = Recorder.inputDeviceName
+        let device = recorder.boundDevice?.name ?? Recorder.inputDeviceName
         inputDeviceItem.isHidden = device == nil
         inputDeviceItem.title = device.map { "Microphone  ·  \($0)" } ?? ""
+        inputDeviceItem.submenu = microphoneMenu()
     }
 
     private var hasPermissionProblem: Bool {

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -5829,9 +5829,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // own rule is "does it have a target", which would answer yes to all of
         // them and turn the greying-out off.
         menu.autoenablesItems = false
-        let entries = config.audio.microphones
         let attached = Recorder.inputDevices()
         let live = recorder.boundDevice?.uid
+        let entries = seededMicrophones(attached: attached, live: live)
 
         for (index, entry) in entries.enumerated() {
             let match = Recorder.device(named: entry, among: attached)
@@ -5853,7 +5853,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Matched the same way the recorder matches, so a device does not
         // appear twice — once as entry 2 written as "airpods", once here under
-        // its full name.
+        // its full name. Empty right after a seed, and not empty for long: a
+        // microphone plugged in later lands here.
         let unlisted = attached.filter { device in
             !entries.contains { Recorder.device(named: $0, among: [device]) != nil }
         }
@@ -5895,6 +5896,48 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             for child in item.submenu?.items ?? [] { Self.hideAutomaticImage(child) }
         }
         return menu
+    }
+
+    /// The list to draw, writing one down first if the config has never carried
+    /// one.
+    ///
+    /// A list nobody has made is a menu with nothing in it to move, which is
+    /// how a first look at this feature finds it missing. So the first open
+    /// writes down what is attached — the microphone being recorded through at
+    /// the top, the rest in the order CoreAudio gives them — and from then on
+    /// there is something to reorder.
+    ///
+    /// Nothing about which microphone is used changes: the one at the top is
+    /// the one that was already being used. What changes is that it is now
+    /// written down, so System Settings moving the default no longer moves
+    /// this app.
+    ///
+    /// Once only. `Follow the System Setting` writes `microphones: []`, which
+    /// is a decision and is left alone — otherwise clearing the list would
+    /// refill it the next time the menu opened.
+    private func seededMicrophones(
+        attached: [Recorder.InputDevice], live: String?
+    ) -> [String] {
+        let entries = config.audio.microphones
+        guard entries.isEmpty, !attached.isEmpty, !ConfigWriter.hasMicrophonesKey() else {
+            return entries
+        }
+        let first = live ?? Recorder.defaultInputDeviceID.flatMap { device in
+            attached.first { $0.id == device }?.uid
+        }
+        // Two halves rather than a sort: "is this the one" is not an ordering,
+        // and `sorted` given a predicate that is not one is allowed to return
+        // anything at all.
+        let ordered = attached.filter { $0.uid == first } + attached.filter { $0.uid != first }
+        // The name, unless two microphones answer to it — then the UID, which
+        // is the thing that tells them apart. Written once, and read by
+        // everyone afterwards.
+        let names = attached.map(\.name)
+        let seeded = ordered.map { device in
+            names.filter { $0 == device.name }.count > 1 ? device.uid : device.name
+        }
+        writeMicrophones(seeded)
+        return seeded
     }
 
     /// What one entry in the list can be moved to.

--- a/Sources/ParrotFlow/CheckConfigCommand.swift
+++ b/Sources/ParrotFlow/CheckConfigCommand.swift
@@ -74,6 +74,7 @@ enum CheckConfigCommand {
         } else {
             emit("  · second opinion    \(config.audio.secondOpinion ? "on" : "off")")
         }
+        emitMicrophones(config, emit)
         emit("  · feedback          sound=\(config.feedback.sound)"
               + " volume=\(config.feedback.soundVolume) overlay=\(config.feedback.overlay)"
               + " correct_offer=\(config.feedback.correctOffer)"
@@ -391,6 +392,44 @@ enum CheckConfigCommand {
     }
 
     /// Which of the three bodies this is, in one column.
+    /// The priority list, and which microphone it lands on right now.
+    ///
+    /// The list on its own does not answer the question anyone has — an entry
+    /// that matches nothing attached is invisible in the file and decides
+    /// nothing — so every entry says whether it is here, and the winner is
+    /// named.
+    private static func emitMicrophones(_ config: Config, _ emit: (String) -> Void) {
+        let entries = config.audio.microphones
+        guard !entries.isEmpty else {
+            let system = Recorder.inputDeviceName ?? "none attached"
+            emit("  · microphones       none listed — the system's input device (\(system))")
+            return
+        }
+        let attached = Recorder.inputDevices()
+        let winner = Recorder.preferredDevice(from: entries)
+        emit("  · microphones       \(entries.count) listed, best first")
+        for (index, entry) in entries.enumerated() {
+            let match = Recorder.device(named: entry, among: attached)
+            // The name only when the entry is not already it: half these
+            // entries are the device's full name, and "Teams → Teams" is a
+            // line that says nothing twice.
+            let named = match.map { $0.name == entry ? "" : "→ \($0.name), " } ?? ""
+            let state: String
+            if let match, match.id == winner?.id {
+                state = "\(named)recording through this one"
+            } else if match != nil {
+                state = "\(named)attached"
+            } else {
+                state = "not attached"
+            }
+            emit("    \(index + 1). \(entry)  \(state)")
+        }
+        if winner == nil {
+            let system = Recorder.inputDeviceName ?? "none attached"
+            emit("  ! microphones       none of them is attached — falling back to \(system)")
+        }
+    }
+
     private static func kind(of transform: Config.Transform) -> String {
         switch transform.body {
         case .prompt: return "prompt "

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -2366,12 +2366,26 @@ struct Config: Decodable, Equatable {
         /// Needs `speech_gate`, which is what reads the clip as samples.
         var secondOpinion: Bool = true
 
+        /// Which microphone to record through, best first.
+        ///
+        /// An entry is what System Settings calls the device, or CoreAudio's
+        /// UID for it, or a fragment of the name — "AirPods" reaches "Nathan's
+        /// AirPods Pro". The first entry that is attached wins, and the app
+        /// opens that device whatever System Settings has the default set to.
+        ///
+        /// Empty by default, and empty means the system's choice: the input
+        /// device every other app on this Mac is using. That is what this app
+        /// did before the list existed, so an untouched config records through
+        /// the same microphone it always did.
+        var microphones: [String] = []
+
         enum CodingKeys: String, CodingKey {
             case sampleRate = "sample_rate"
             case outputDir = "output_dir"
             case minDurationSeconds = "min_duration_seconds"
             case speechGate = "speech_gate"
             case secondOpinion = "second_opinion"
+            case microphones
         }
 
         init() {}
@@ -2395,6 +2409,14 @@ struct Config: Decodable, Equatable {
             }
             if let gate = try c.decodeIfPresent(Bool.self, forKey: .speechGate) {
                 self.speechGate = gate
+            }
+            if let mics = try c.decodeIfPresent([String].self, forKey: .microphones) {
+                // Trimmed but not lowercased: these are shown back in the menu
+                // bar, and the device is called "MacBook Pro Microphone".
+                // Matching is what ignores case — see `Recorder.device(named:)`.
+                self.microphones = mics
+                    .map { $0.trimmingCharacters(in: .whitespaces) }
+                    .filter { !$0.isEmpty }
             }
             if let second = try c.decodeIfPresent(Bool.self, forKey: .secondOpinion) {
                 self.secondOpinion = second

--- a/Sources/ParrotFlow/ConfigWriter.swift
+++ b/Sources/ParrotFlow/ConfigWriter.swift
@@ -64,15 +64,8 @@ enum ConfigWriter {
         let end = endOfBlock(from: audio, in: lines)
 
         if let key = microphonesKey(in: lines, within: audio..<end) {
-            // Everything the old list occupied: the key line, and the item
-            // lines under it. A flow list — `microphones: [a, b]` — is one
-            // line and is covered by the key line alone.
-            var last = key + 1
-            while last < end,
-                  lines[last].trimmingCharacters(in: .whitespaces).hasPrefix("- ") {
-                last += 1
-            }
-            lines.replaceSubrange(key..<last, with: [keyLine] + block)
+            lines.replaceSubrange(key..<endOfList(from: key, in: lines, within: end),
+                                  with: [keyLine] + block)
             return lines.joined(separator: "\n")
         }
 
@@ -95,6 +88,29 @@ enum ConfigWriter {
             end += 1
         }
         return end
+    }
+
+    /// Everything the old list occupies: the key line and the item lines under
+    /// it, including a comment or a blank line between two items. A flow list —
+    /// `microphones: [a, b]` — is one line and is covered by the key line alone.
+    ///
+    /// A comment after the last item is left where it is. It belongs to
+    /// whatever comes next, not to the list that ended above it.
+    private static func endOfList(from key: Int, in lines: [String], within end: Int) -> Int {
+        var last = key + 1
+        var cursor = key + 1
+        while cursor < end {
+            let line = lines[cursor].trimmingCharacters(in: .whitespaces)
+            if line.hasPrefix("- ") {
+                cursor += 1
+                last = cursor
+            } else if line.isEmpty || line.hasPrefix("#") {
+                cursor += 1
+            } else {
+                break
+            }
+        }
+        return last
     }
 
     /// The `microphones:` line inside the `audio:` block, or nil if the file

--- a/Sources/ParrotFlow/ConfigWriter.swift
+++ b/Sources/ParrotFlow/ConfigWriter.swift
@@ -17,10 +17,13 @@ enum ConfigWriter {
     /// comments, and a round trip through Yams would return the settings
     /// without a word of what they mean.
     ///
-    /// An empty list takes the key out again, rather than leaving
-    /// `microphones: []` behind. The key absent and the key empty mean the same
-    /// thing — follow the system — and only one of them reads like a decision.
+    /// An empty list is written as `microphones: []`, not taken out. The two
+    /// mean the same thing to the recorder — follow the system — and different
+    /// things to the menu: the key absent is a config nobody has decided about,
+    /// which is what `hasMicrophonesKey` answers and what the menu seeds on
+    /// first open. `[]` is somebody deciding, and it is left alone.
     static func setMicrophones(_ names: [String]) throws {
+        try ConfigStore.createIfMissing()
         let url = ConfigStore.fileURL
         let original = try String(contentsOf: url, encoding: .utf8)
         let updated = setting(microphones: names, in: original)
@@ -28,35 +31,39 @@ enum ConfigWriter {
         try updated.write(to: url, atomically: true, encoding: .utf8)
     }
 
+    /// Whether `config.yaml` says anything about microphones at all.
+    ///
+    /// A config with no such key has never been asked the question. That is the
+    /// one time the menu writes a list without being told to — see
+    /// `AppDelegate.microphoneMenu`.
+    static func hasMicrophonesKey() -> Bool {
+        guard let yaml = try? String(contentsOf: ConfigStore.fileURL, encoding: .utf8) else {
+            return false
+        }
+        return microphonesKey(in: yaml.components(separatedBy: "\n")) != nil
+    }
+
     /// The file with the list replaced. Split out so it can be tested without
     /// a config on disk.
     static func setting(microphones names: [String], in yaml: String) -> String {
         var lines = yaml.components(separatedBy: "\n")
+        // An empty list is the key and nothing under it. The recorder reads the
+        // same nothing either way; what this preserves is that somebody said so.
+        let keyLine = names.isEmpty ? "  microphones: []" : "  microphones:"
         let block = names.map { "    - \(quoted($0))" }
 
         guard let audio = lines.firstIndex(where: { $0 == "audio:" }) else {
-            guard !names.isEmpty else { return yaml }
             // No `audio:` at all — a hand-trimmed config. Appended whole, after
             // a blank line, so it does not run into whatever ends the file.
             var appended = lines
             if appended.last?.isEmpty == false { appended.append("") }
-            appended.append(contentsOf: ["audio:", "  microphones:"] + block + [""])
+            appended.append(contentsOf: ["audio:", keyLine] + block + [""])
             return appended.joined(separator: "\n")
         }
 
-        // The block runs to the next line at column zero that is not blank and
-        // not a comment. A comment between two settings belongs to the setting
-        // under it, and stopping on one would splice this list above it.
-        var end = audio + 1
-        while end < lines.count {
-            let line = lines[end]
-            if !line.isEmpty, !line.hasPrefix(" "), !line.hasPrefix("#") { break }
-            end += 1
-        }
+        let end = endOfBlock(from: audio, in: lines)
 
-        if let key = lines[audio..<end].firstIndex(where: {
-            $0.trimmingCharacters(in: .whitespaces).hasPrefix("microphones:")
-        }) {
+        if let key = microphonesKey(in: lines, within: audio..<end) {
             // Everything the old list occupied: the key line, and the item
             // lines under it. A flow list — `microphones: [a, b]` — is one
             // line and is covered by the key line alone.
@@ -65,17 +72,44 @@ enum ConfigWriter {
                   lines[last].trimmingCharacters(in: .whitespaces).hasPrefix("- ") {
                 last += 1
             }
-            lines.replaceSubrange(key..<last, with: names.isEmpty ? [] : ["  microphones:"] + block)
+            lines.replaceSubrange(key..<last, with: [keyLine] + block)
             return lines.joined(separator: "\n")
         }
 
-        guard !names.isEmpty else { return yaml }
         // Under the last setting in the block rather than under `audio:`, so
         // the comment above the first setting keeps the setting it describes.
         var insertAt = end
         while insertAt > audio + 1, lines[insertAt - 1].isEmpty { insertAt -= 1 }
-        lines.insert(contentsOf: ["  microphones:"] + block, at: insertAt)
+        lines.insert(contentsOf: [keyLine] + block, at: insertAt)
         return lines.joined(separator: "\n")
+    }
+
+    /// Where the `audio:` block stops: the next line at column zero that is
+    /// neither blank nor a comment. A comment between two settings belongs to
+    /// the setting under it, and stopping on one would splice this list above it.
+    private static func endOfBlock(from start: Int, in lines: [String]) -> Int {
+        var end = start + 1
+        while end < lines.count {
+            let line = lines[end]
+            if !line.isEmpty, !line.hasPrefix(" "), !line.hasPrefix("#") { break }
+            end += 1
+        }
+        return end
+    }
+
+    /// The `microphones:` line inside the `audio:` block, or nil if the file
+    /// does not carry one. A commented-out example is not one — it is what
+    /// `config.example.yaml` ships to explain the setting.
+    private static func microphonesKey(
+        in lines: [String], within range: Range<Int>? = nil
+    ) -> Int? {
+        let range = range ?? {
+            guard let audio = lines.firstIndex(where: { $0 == "audio:" }) else { return 0..<0 }
+            return audio..<endOfBlock(from: audio, in: lines)
+        }()
+        return lines[range].firstIndex {
+            $0.trimmingCharacters(in: .whitespaces).hasPrefix("microphones:")
+        }
     }
 
     // MARK: - Learning a pronunciation

--- a/Sources/ParrotFlow/ConfigWriter.swift
+++ b/Sources/ParrotFlow/ConfigWriter.swift
@@ -9,6 +9,75 @@ import Foundation
 /// splice a pronunciation into it.
 enum ConfigWriter {
 
+    // MARK: - The microphone order
+
+    /// Writes `audio.microphones` into `config.yaml`, in the order given.
+    ///
+    /// Text-level, for the reason this whole file is: `config.yaml` is mostly
+    /// comments, and a round trip through Yams would return the settings
+    /// without a word of what they mean.
+    ///
+    /// An empty list takes the key out again, rather than leaving
+    /// `microphones: []` behind. The key absent and the key empty mean the same
+    /// thing — follow the system — and only one of them reads like a decision.
+    static func setMicrophones(_ names: [String]) throws {
+        let url = ConfigStore.fileURL
+        let original = try String(contentsOf: url, encoding: .utf8)
+        let updated = setting(microphones: names, in: original)
+        guard updated != original else { return }
+        try updated.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    /// The file with the list replaced. Split out so it can be tested without
+    /// a config on disk.
+    static func setting(microphones names: [String], in yaml: String) -> String {
+        var lines = yaml.components(separatedBy: "\n")
+        let block = names.map { "    - \(quoted($0))" }
+
+        guard let audio = lines.firstIndex(where: { $0 == "audio:" }) else {
+            guard !names.isEmpty else { return yaml }
+            // No `audio:` at all — a hand-trimmed config. Appended whole, after
+            // a blank line, so it does not run into whatever ends the file.
+            var appended = lines
+            if appended.last?.isEmpty == false { appended.append("") }
+            appended.append(contentsOf: ["audio:", "  microphones:"] + block + [""])
+            return appended.joined(separator: "\n")
+        }
+
+        // The block runs to the next line at column zero that is not blank and
+        // not a comment. A comment between two settings belongs to the setting
+        // under it, and stopping on one would splice this list above it.
+        var end = audio + 1
+        while end < lines.count {
+            let line = lines[end]
+            if !line.isEmpty, !line.hasPrefix(" "), !line.hasPrefix("#") { break }
+            end += 1
+        }
+
+        if let key = lines[audio..<end].firstIndex(where: {
+            $0.trimmingCharacters(in: .whitespaces).hasPrefix("microphones:")
+        }) {
+            // Everything the old list occupied: the key line, and the item
+            // lines under it. A flow list — `microphones: [a, b]` — is one
+            // line and is covered by the key line alone.
+            var last = key + 1
+            while last < end,
+                  lines[last].trimmingCharacters(in: .whitespaces).hasPrefix("- ") {
+                last += 1
+            }
+            lines.replaceSubrange(key..<last, with: names.isEmpty ? [] : ["  microphones:"] + block)
+            return lines.joined(separator: "\n")
+        }
+
+        guard !names.isEmpty else { return yaml }
+        // Under the last setting in the block rather than under `audio:`, so
+        // the comment above the first setting keeps the setting it describes.
+        var insertAt = end
+        while insertAt > audio + 1, lines[insertAt - 1].isEmpty { insertAt -= 1 }
+        lines.insert(contentsOf: ["  microphones:"] + block, at: insertAt)
+        return lines.joined(separator: "\n")
+    }
+
     // MARK: - Learning a pronunciation
 
     /// Records that `term` is sometimes heard as `heard`.

--- a/Sources/ParrotFlow/MicrophonesCommand.swift
+++ b/Sources/ParrotFlow/MicrophonesCommand.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// `--microphones` — every microphone attached to this Mac, with the exact
+/// names `audio.microphones` matches on.
+///
+/// The list in the config is written by hand as often as it is written by the
+/// menu, and a name typed from memory is a name that matches nothing. This is
+/// where the strings come from.
+enum MicrophonesCommand {
+
+    /// `--microphones --set "a, b"` — writes the priority list, best first.
+    /// `--microphones --set ""` clears it, which is what the menu's "Follow the
+    /// System Setting" does.
+    ///
+    /// The menu bar is where this is normally done. This is the door a script
+    /// can use, and the one `scripts/check-microphones.sh` writes through.
+    static func set(_ list: String) -> Int32 {
+        let names = list
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        do {
+            try ConfigWriter.setMicrophones(names)
+        } catch {
+            print("✗ could not write config.yaml: \(error.localizedDescription)")
+            return 1
+        }
+        print(names.isEmpty
+              ? "✓ audio.microphones cleared — following the system's input device"
+              : "✓ audio.microphones: \(names.joined(separator: ", "))")
+        return 0
+    }
+
+    static func run() -> Int32 {
+        let devices = Recorder.inputDevices()
+        guard !devices.isEmpty else {
+            print("no microphone is attached")
+            return 1
+        }
+
+        let entries = (try? ConfigStore.load())?.audio.microphones ?? []
+        let winner = Recorder.preferredDevice(from: entries)
+        let system = Recorder.defaultInputDeviceID
+
+        let width = devices.map(\.name.count).max() ?? 0
+        for device in devices {
+            var notes: [String] = []
+            if let rank = entries.firstIndex(where: {
+                Recorder.device(named: $0, among: [device]) != nil
+            }) {
+                notes.append("listed #\(rank + 1)")
+            }
+            if device.id == winner?.id { notes.append("recording through this one") }
+            if device.id == system { notes.append("the system's input device") }
+            if device.isBluetooth { notes.append("bluetooth") }
+            let name = device.name.padding(toLength: width, withPad: " ", startingAt: 0)
+            print("  \(name)  \(device.uid)"
+                  + (notes.isEmpty ? "" : "  — \(notes.joined(separator: ", "))"))
+        }
+
+        if winner == nil, !entries.isEmpty {
+            print("")
+            print("none of the \(entries.count) microphones in audio.microphones is attached")
+        }
+        return 0
+    }
+}

--- a/Sources/ParrotFlow/RecordTestCommand.swift
+++ b/Sources/ParrotFlow/RecordTestCommand.swift
@@ -22,6 +22,9 @@ enum RecordTestCommand {
         }
 
         let recorder = Recorder()
+        // Before `warmUp`, which is what opens the device. The whole point of
+        // this command is to record through what the app would record through.
+        recorder.preferredMicrophones = config.audio.microphones
         recorder.warmUp()
         var peak: Float = 0
         recorder.onLevel = { peak = max(peak, $0) }
@@ -33,6 +36,9 @@ enum RecordTestCommand {
         do {
             let url = try recorder.start(config: config)
             print("● recording \(seconds)s → \(url.lastPathComponent)")
+            // Which microphone this went through, which is the question when
+            // the clip comes back silent and the list has an entry in it.
+            print("  through    \(recorder.boundDevice?.name ?? "unknown device")")
         } catch {
             print("✗ \(error.localizedDescription)")
             return 1

--- a/Sources/ParrotFlow/Recorder.swift
+++ b/Sources/ParrotFlow/Recorder.swift
@@ -287,6 +287,10 @@ final class Recorder {
     /// Kept so `deinit` can take it off again — `AudioObjectRemovePropertyListenerBlock`
     /// matches on the block, not on a token.
     private var deviceListListener: AudioObjectPropertyListenerBlock?
+    /// Devices that were there and would not open. Skipped by the resolution
+    /// until the device list changes, so the priority list falls past one the
+    /// same way it falls past one that is unplugged. Guarded by `stateLock`.
+    private var unopenable: Set<AudioDeviceID> = []
     private let stateLock = NSLock()
 
     /// A format disagreement a rebuild has already been spent on. Main thread
@@ -366,11 +370,12 @@ final class Recorder {
     func warmUp() {
         let engine = currentEngine()
         let desired = desiredInput()
-        if let device = desired.pin { Self.pin(engine, to: device) }
+        var binding = desired.binding
+        if let device = desired.pin, !pin(engine, to: device) { binding = currentInput() }
         _ = engine.inputNode.outputFormat(forBus: 0)
         engine.prepare()
         stateLock.lock()
-        bound = desired.binding
+        bound = binding
         stateLock.unlock()
     }
 
@@ -859,7 +864,14 @@ final class Recorder {
     private func watchDeviceList() {
         var address = Self.deviceListAddress
         let listener: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
-            self?.reevaluateInput()
+            guard let self else { return }
+            // A device that refused to open gets another chance whenever the
+            // hardware moves. The IDs move with it, so keeping the old set
+            // would skip a device that never refused anything.
+            self.stateLock.lock()
+            self.unopenable.removeAll()
+            self.stateLock.unlock()
+            self.reevaluateInput()
         }
         let status = AudioObjectAddPropertyListenerBlock(
             AudioObjectID(kAudioObjectSystemObject), &address, .main, listener
@@ -901,7 +913,12 @@ final class Recorder {
     /// microphone connecting, and then `bound` names a device the engine was
     /// never opened against.
     func desiredInput() -> (binding: InputBinding?, pin: AudioDeviceID?) {
-        guard let device = Self.preferredDevice(from: preferredMicrophones) else {
+        stateLock.lock()
+        let refused = unopenable
+        stateLock.unlock()
+        guard let device = Self.preferredDevice(
+            from: preferredMicrophones, excluding: refused
+        ) else {
             return (currentInput(), nil)
         }
         return (InputBinding.of(device.id), device.id)
@@ -1065,12 +1082,15 @@ final class Recorder {
             // Before the format is read, not after. The node answers for the
             // device it is on at the moment it is asked, and that answer is what
             // the tap is installed against.
-            if let device = desired.pin { Recorder.pin(fresh, to: device) }
+            var binding = desired.binding
+            if let device = desired.pin, self?.pin(fresh, to: device) == false {
+                binding = self?.currentInput()
+            }
             // The expensive line: instantiating the input node opens the
             // device. Everything after it is cheap.
             _ = fresh.inputNode.outputFormat(forBus: 0)
             fresh.prepare()
-            self?.adopt(fresh, bound: desired.binding, took: Date().timeIntervalSince(started))
+            self?.adopt(fresh, bound: binding, took: Date().timeIntervalSince(started))
         }
     }
 
@@ -1262,9 +1282,11 @@ final class Recorder {
     /// Nil is not a failure. It is the answer that leaves the engine following
     /// the system's default input, which is what an empty list means and what
     /// this app did before the list existed.
-    static func preferredDevice(from entries: [String]) -> InputDevice? {
+    static func preferredDevice(
+        from entries: [String], excluding refused: Set<AudioDeviceID> = []
+    ) -> InputDevice? {
         guard !entries.isEmpty else { return nil }
-        let attached = inputDevices()
+        let attached = inputDevices().filter { !refused.contains($0.id) }
         for entry in entries {
             if let device = device(named: entry, among: attached) { return device }
         }
@@ -1284,13 +1306,25 @@ final class Recorder {
     /// arrives is the pinned device's. So the whole of `formatProblem` keeps
     /// working — as long as it compares against the device we pinned to, which
     /// is what `desiredInput` is for.
-    private static func pin(_ engine: AVAudioEngine, to device: AudioDeviceID) {
+    ///
+    /// False when the device would not open. The caller then has to record what
+    /// the engine is really on — the system default — rather than the device it
+    /// asked for. A binding that names a microphone the engine never opened is
+    /// a mismatch nothing can see afterwards: the comparison in
+    /// `reacquireIfInputMoved` is between the same two answers, so it agrees
+    /// with itself forever while the words come from somewhere else.
+    private func pin(_ engine: AVAudioEngine, to device: AudioDeviceID) -> Bool {
         do {
             try engine.inputNode.auAudioUnit.setDeviceID(device)
+            return true
         } catch {
             // Fail open: the engine keeps the default input, and the dictation
             // happens on the wrong microphone rather than not at all.
             Log.write("could not open microphone \(device): \(error.localizedDescription)")
+            stateLock.lock()
+            unopenable.insert(device)
+            stateLock.unlock()
+            return false
         }
     }
 

--- a/Sources/ParrotFlow/Recorder.swift
+++ b/Sources/ParrotFlow/Recorder.swift
@@ -287,10 +287,10 @@ final class Recorder {
     /// Kept so `deinit` can take it off again — `AudioObjectRemovePropertyListenerBlock`
     /// matches on the block, not on a token.
     private var deviceListListener: AudioObjectPropertyListenerBlock?
-    /// Devices that were there and would not open. Skipped by the resolution
-    /// until the device list changes, so the priority list falls past one the
-    /// same way it falls past one that is unplugged. Guarded by `stateLock`.
-    private var unopenable: Set<AudioDeviceID> = []
+    /// Devices that were there and would not open, and when they refused.
+    /// Skipped by the resolution, so the priority list falls past one the same
+    /// way it falls past one that is unplugged. Guarded by `stateLock`.
+    private var unopenable: [AudioDeviceID: Date] = [:]
     private let stateLock = NSLock()
 
     /// A format disagreement a rebuild has already been spent on. Main thread
@@ -865,7 +865,7 @@ final class Recorder {
         var address = Self.deviceListAddress
         let listener: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
             guard let self else { return }
-            // A device that refused to open gets another chance whenever the
+            // A device that refused to open gets its chance back early when the
             // hardware moves. The IDs move with it, so keeping the old set
             // would skip a device that never refused anything.
             self.stateLock.lock()
@@ -914,7 +914,12 @@ final class Recorder {
     /// never opened against.
     func desiredInput() -> (binding: InputBinding?, pin: AudioDeviceID?) {
         stateLock.lock()
-        let refused = unopenable
+        // A refusal expires here rather than on a timer. Nothing fires on its
+        // own then: the retry happens on the next press or reload after the
+        // minute is up, which is the moment it is worth anything.
+        let cutoff = Date().addingTimeInterval(-Self.refusalSeconds)
+        unopenable = unopenable.filter { $0.value > cutoff }
+        let refused = Set(unopenable.keys)
         stateLock.unlock()
         guard let device = Self.preferredDevice(
             from: preferredMicrophones, excluding: refused
@@ -1307,6 +1312,15 @@ final class Recorder {
     /// working — as long as it compares against the device we pinned to, which
     /// is what `desiredInput` is for.
     ///
+    /// How long a device that refused to open is skipped for.
+    ///
+    /// A device can refuse for a reason that passes — another app holding it,
+    /// a link still settling — and no device-list change announces it coming
+    /// back. A minute is long enough that a broken microphone is not retried on
+    /// every press, and short enough that one which recovered is picked up
+    /// again without anybody going looking for a setting.
+    private static let refusalSeconds: TimeInterval = 60
+
     /// False when the device would not open. The caller then has to record what
     /// the engine is really on — the system default — rather than the device it
     /// asked for. A binding that names a microphone the engine never opened is
@@ -1322,7 +1336,7 @@ final class Recorder {
             // happens on the wrong microphone rather than not at all.
             Log.write("could not open microphone \(device): \(error.localizedDescription)")
             stateLock.lock()
-            unopenable.insert(device)
+            unopenable[device] = Date()
             stateLock.unlock()
             return false
         }

--- a/Sources/ParrotFlow/Recorder.swift
+++ b/Sources/ParrotFlow/Recorder.swift
@@ -50,6 +50,12 @@ final class Recorder {
         /// a difference stale rather than a unit mismatch.
         static func system() -> InputBinding? {
             guard let device = Recorder.defaultInputDeviceID else { return nil }
+            return of(device)
+        }
+
+        /// The same reading, of a named device rather than of the default one.
+        /// What a `microphones:` entry resolves to.
+        static func of(_ device: AudioDeviceID) -> InputBinding {
             guard let format = inputStreamFormat(of: device) else {
                 // A device with no input stream to ask. Zeroes still compare,
                 // which is all the change detection needs, and `formatProblem`
@@ -63,7 +69,7 @@ final class Recorder {
             )
         }
 
-        private static func inputStreamFormat(
+        static func inputStreamFormat(
             of device: AudioDeviceID
         ) -> AudioStreamBasicDescription? {
             var streamsAddress = AudioObjectPropertyAddress(
@@ -242,7 +248,19 @@ final class Recorder {
     /// A property rather than a direct call so `--audio-recovery` can move the
     /// input under the recorder without moving the machine's audio settings.
     /// Nothing in the app replaces it.
+    ///
+    /// Only consulted when no `microphones:` entry matched. A configured
+    /// microphone is not what the system would hand us — it is what we go and
+    /// take — and `desiredInput` reads it from the device itself.
     var currentInput: () -> InputBinding? = InputBinding.system
+
+    /// The microphones this recorder prefers, best first — `audio.microphones`
+    /// from the config, by name or by UID.
+    ///
+    /// Empty by default, which is the system's own choice and the behaviour
+    /// this app had before: whatever System Settings calls the input device.
+    /// Set from `applyConfig`, so it moves on every save of `config.yaml`.
+    var preferredMicrophones: [String] = []
 
     /// What the engine says about its own input node, both halves of it.
     ///
@@ -266,6 +284,9 @@ final class Recorder {
     /// True while an engine is being built on `engineQueue`. Guarded by
     /// `stateLock`.
     private var rebuilding = false
+    /// Kept so `deinit` can take it off again — `AudioObjectRemovePropertyListenerBlock`
+    /// matches on the block, not on a token.
+    private var deviceListListener: AudioObjectPropertyListenerBlock?
     private let stateLock = NSLock()
 
     /// A format disagreement a rebuild has already been spent on. Main thread
@@ -316,6 +337,16 @@ final class Recorder {
 
     init() {
         observeConfigurationChanges(on: engine)
+        watchDeviceList()
+    }
+
+    deinit {
+        if let listener = deviceListListener {
+            var address = Self.deviceListAddress
+            AudioObjectRemovePropertyListenerBlock(
+                AudioObjectID(kAudioObjectSystemObject), &address, .main, listener
+            )
+        }
     }
 
     private func observeConfigurationChanges(on engine: AVAudioEngine) {
@@ -334,10 +365,12 @@ final class Recorder {
     /// until `start()` actually runs the engine.
     func warmUp() {
         let engine = currentEngine()
+        let desired = desiredInput()
+        if let device = desired.pin { Self.pin(engine, to: device) }
         _ = engine.inputNode.outputFormat(forBus: 0)
         engine.prepare()
         stateLock.lock()
-        bound = currentInput()
+        bound = desired.binding
         stateLock.unlock()
     }
 
@@ -359,7 +392,7 @@ final class Recorder {
         var engine = currentEngine()
         var formats = engineFormats(engine)
 
-        if let problem = Self.formatProblem(formats, against: currentInput()),
+        if let problem = Self.formatProblem(formats, against: desiredInput().binding),
            problem != acceptedFormatMismatch {
             // A second chance rather than an error, for both shapes of the
             // problem. An empty format means the engine is pointing at nothing;
@@ -373,7 +406,7 @@ final class Recorder {
             engine = currentEngine()
             formats = engineFormats(engine)
 
-            let remaining = Self.formatProblem(formats, against: currentInput())
+            let remaining = Self.formatProblem(formats, against: desiredInput().binding)
             if let remaining, Self.graphProblem(formats) == nil {
                 // Fail open. The engine agrees with itself and disagrees with
                 // the device: the tap will install, and whether it hears
@@ -807,6 +840,73 @@ final class Recorder {
 
     // MARK: - Device changes
 
+    private static let deviceListAddress = AudioObjectPropertyAddress(
+        mSelector: kAudioHardwarePropertyDevices,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+
+    /// Watches for microphones arriving and leaving.
+    ///
+    /// `AVAudioEngineConfigurationChange` is the engine talking about its own
+    /// device, and an engine pinned to one microphone has nothing to say when a
+    /// better one is plugged in. Without this, a priority list would only ever
+    /// be read at launch and at a save of `config.yaml`.
+    ///
+    /// Ignored while recording. A device appearing is not a reason to take the
+    /// microphone away from a sentence somebody is halfway through; the next
+    /// press picks it up.
+    private func watchDeviceList() {
+        var address = Self.deviceListAddress
+        let listener: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+            self?.reevaluateInput()
+        }
+        let status = AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject), &address, .main, listener
+        )
+        guard status == noErr else {
+            Log.write("could not watch the microphone list: CoreAudio returned \(status)")
+            return
+        }
+        deviceListListener = listener
+    }
+
+    /// Re-reads the priority list and rebinds if it now names a different
+    /// microphone.
+    ///
+    /// Called after every config load and whenever a device is attached or
+    /// removed. Both of those happen before anything has opened the microphone,
+    /// which is why nothing here builds the first engine: instantiating an
+    /// input node is what makes AVFoundation put up the native microphone
+    /// dialog, and at that moment the permissions window has not yet said why.
+    /// So it returns until something that checked the permission — `warmUp`, or
+    /// a press — has bound one.
+    func reevaluateInput() {
+        stateLock.lock()
+        let started = bound != nil
+        stateLock.unlock()
+        guard started else { return }
+        DispatchQueue.main.async { [weak self] in self?.reacquireIfInputMoved() }
+    }
+
+    /// What the next engine should be bound to, and which device to open for
+    /// it.
+    ///
+    /// `pin` is nil when nothing in `microphones:` matched — the unpinned path,
+    /// where the engine follows the system's default input and this recorder
+    /// behaves exactly as it did before the list existed.
+    ///
+    /// One resolution, two answers, on purpose. Asking twice — once for the
+    /// binding to remember and once for the device to open — can straddle a
+    /// microphone connecting, and then `bound` names a device the engine was
+    /// never opened against.
+    func desiredInput() -> (binding: InputBinding?, pin: AudioDeviceID?) {
+        guard let device = Self.preferredDevice(from: preferredMicrophones) else {
+            return (currentInput(), nil)
+        }
+        return (InputBinding.of(device.id), device.id)
+    }
+
     @objc private func configurationChanged(_ note: Notification) {
         guard isRecording else {
             DispatchQueue.main.async { [weak self] in self?.reacquireIfInputMoved() }
@@ -851,7 +951,7 @@ final class Recorder {
         let rebuilding = self.rebuilding
         stateLock.unlock()
 
-        let current = currentInput()
+        let current = desiredInput().binding
         guard current == bound else {
             rebuildEngine(because: "input moved: \(Self.describe(bound)) → \(Self.describe(current))")
             return
@@ -945,6 +1045,12 @@ final class Recorder {
         rebuildGroup.enter()
         let started = Date()
 
+        // Resolved here, once, and carried through to `adopt`. A microphone can
+        // connect during the build — 4s on Bluetooth, measured — and resolving
+        // again on the other side would record a binding the fresh engine was
+        // never opened against.
+        let desired = desiredInput()
+
         // Held strongly and left in a `defer`, so the group empties however this
         // block ends — including with the recorder already gone. A rebuild that
         // finishes without leaving it makes every later press wait 1.5s and
@@ -956,11 +1062,15 @@ final class Recorder {
                 group.leave()
             }
             let fresh = AVAudioEngine()
+            // Before the format is read, not after. The node answers for the
+            // device it is on at the moment it is asked, and that answer is what
+            // the tap is installed against.
+            if let device = desired.pin { Recorder.pin(fresh, to: device) }
             // The expensive line: instantiating the input node opens the
             // device. Everything after it is cheap.
             _ = fresh.inputNode.outputFormat(forBus: 0)
             fresh.prepare()
-            self?.adopt(fresh, took: Date().timeIntervalSince(started))
+            self?.adopt(fresh, bound: desired.binding, took: Date().timeIntervalSince(started))
         }
     }
 
@@ -981,9 +1091,7 @@ final class Recorder {
     }
 
     /// Swaps a freshly built engine in. Runs on `engineQueue`.
-    private func adopt(_ fresh: AVAudioEngine, took: TimeInterval) {
-        let binding = currentInput()
-
+    private func adopt(_ fresh: AVAudioEngine, bound binding: InputBinding?, took: TimeInterval) {
         stateLock.lock()
         // A recording started while this was being built. It is running through
         // the old engine, so the old engine stays and `bound` is left alone —
@@ -1008,7 +1116,7 @@ final class Recorder {
 
         Log.write(String(
             format: "capture engine rebuilt in %.1fs — mic=%@, %@",
-            took, Self.inputDeviceName ?? "none", Self.describe(binding)
+            took, binding.flatMap { Self.name(of: $0.device) } ?? "none", Self.describe(binding)
         ))
     }
 
@@ -1074,10 +1182,11 @@ final class Recorder {
     /// "MacBook Pro Microphone", "Nathan's AirPods Pro". Nil when the machine
     /// has no input at all.
     ///
-    /// The engine's input node follows the system's default input device; there
-    /// is no per-app choice to make here, so the default is the answer. Asked
-    /// of CoreAudio each time rather than remembered: it changes in System
-    /// Settings and by plugging something in, neither of which this app sees.
+    /// The system's own answer, which is this app's only when `microphones:`
+    /// is empty or names nothing attached. What the next press will actually
+    /// listen through is `boundDevice`. Asked of CoreAudio each time rather
+    /// than remembered: it changes in System Settings and by plugging something
+    /// in, neither of which this app sees.
     static var inputDeviceName: String? {
         guard let deviceID = defaultInputDeviceID else { return nil }
         return name(of: deviceID)
@@ -1085,6 +1194,11 @@ final class Recorder {
 
     /// A microphone: what to call it, and what to decide about it with.
     struct InputDevice {
+        /// What CoreAudio calls it today. Not written down anywhere: it is
+        /// handed back out to the next device after a reconnection, and it
+        /// moves when a device's sample rate changes — measured here, the
+        /// built-in microphone went from 109 to 108 on a rate change.
+        let id: AudioDeviceID
         /// CoreAudio's UID for the device. What tells two microphones apart,
         /// including two that answer to the same name — a headset and a webcam
         /// both called "Headset Microphone" are one string and two devices.
@@ -1094,6 +1208,109 @@ final class Recorder {
         /// What System Settings calls it, and what the notice says out loud.
         let name: String
         let isBluetooth: Bool
+    }
+
+    /// Every microphone attached right now, in CoreAudio's own order.
+    ///
+    /// Filtered to devices with an input stream, so speakers and the loopback
+    /// halves of virtual devices are not offered as things to record through.
+    static func inputDevices() -> [InputDevice] {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(
+            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size
+        ) == noErr, size > 0 else { return [] }
+
+        var ids = [AudioDeviceID](
+            repeating: 0, count: Int(size) / MemoryLayout<AudioDeviceID>.size
+        )
+        guard AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &ids
+        ) == noErr else { return [] }
+
+        return ids.compactMap { id in
+            guard InputBinding.inputStreamFormat(of: id) != nil else { return nil }
+            return inputDevice(id)
+        }
+    }
+
+    /// The device one `microphones:` entry names, or nil if nothing attached
+    /// answers to it.
+    ///
+    /// An entry is a UID or a name, matched without case. Exact first, over
+    /// every device, and only then as a fragment: "AirPods" should reach
+    /// "Nathan's AirPods Pro", and a device actually called "Display Audio"
+    /// should not lose to one called "Display Audio (2)".
+    static func device(named entry: String, among devices: [InputDevice]) -> InputDevice? {
+        let wanted = entry.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !wanted.isEmpty else { return nil }
+        if let exact = devices.first(where: {
+            $0.uid.lowercased() == wanted || $0.name.lowercased() == wanted
+        }) {
+            return exact
+        }
+        return devices.first { $0.name.lowercased().contains(wanted) }
+    }
+
+    /// The highest-priority microphone in the list that is attached right now,
+    /// or nil when none of them is.
+    ///
+    /// Nil is not a failure. It is the answer that leaves the engine following
+    /// the system's default input, which is what an empty list means and what
+    /// this app did before the list existed.
+    static func preferredDevice(from entries: [String]) -> InputDevice? {
+        guard !entries.isEmpty else { return nil }
+        let attached = inputDevices()
+        for entry in entries {
+            if let device = device(named: entry, among: attached) { return device }
+        }
+        return nil
+    }
+
+    /// Points a fresh engine's input at one device rather than at whatever the
+    /// system calls default.
+    ///
+    /// Must run before any format is read off the input node. The node's
+    /// hardware format follows the pin immediately; its tap format is the one
+    /// `installTap` asserts against, and reading it first is what leaves the
+    /// two disagreeing.
+    ///
+    /// Measured: with the default input at 44100 Hz and the pinned device at
+    /// 48000 Hz, both halves of the node report 48000 Hz, and the audio that
+    /// arrives is the pinned device's. So the whole of `formatProblem` keeps
+    /// working — as long as it compares against the device we pinned to, which
+    /// is what `desiredInput` is for.
+    private static func pin(_ engine: AVAudioEngine, to device: AudioDeviceID) {
+        do {
+            try engine.inputNode.auAudioUnit.setDeviceID(device)
+        } catch {
+            // Fail open: the engine keeps the default input, and the dictation
+            // happens on the wrong microphone rather than not at all.
+            Log.write("could not open microphone \(device): \(error.localizedDescription)")
+        }
+    }
+
+    /// One device ID, read out into the three things anything here asks of a
+    /// microphone. Nil when the ID names nothing — it can go stale between
+    /// being listed and being read.
+    private static func inputDevice(_ deviceID: AudioDeviceID) -> InputDevice? {
+        guard let name = name(of: deviceID) else { return nil }
+        // The device ID stands in where a device will not give a UID — never
+        // the name, which is what a UID is here to be better than. Two devices
+        // attached at once always have different IDs, so the fallback still
+        // tells them apart; what it cannot do is survive a reconnection, since
+        // macOS hands the ID back out. That costs a notice said a second time
+        // for the same headset, which is the safe direction to be wrong in.
+        return InputDevice(
+            id: deviceID,
+            uid: uid(of: deviceID) ?? "device-id:\(deviceID)",
+            name: name,
+            isBluetooth: isBluetooth(deviceID)
+        )
     }
 
     /// The device this recorder is bound to.
@@ -1113,18 +1330,8 @@ final class Recorder {
         stateLock.lock()
         let deviceID = bound?.device
         stateLock.unlock()
-        guard let deviceID, let name = Self.name(of: deviceID) else { return nil }
-        // The device ID stands in where a device will not give a UID — never
-        // the name, which is what a UID is here to be better than. Two devices
-        // attached at once always have different IDs, so the fallback still
-        // tells them apart; what it cannot do is survive a reconnection, since
-        // macOS hands the ID back out. That costs a notice said a second time
-        // for the same headset, which is the safe direction to be wrong in.
-        return InputDevice(
-            uid: Self.uid(of: deviceID) ?? "device-id:\(deviceID)",
-            name: name,
-            isBluetooth: Self.isBluetooth(deviceID)
-        )
+        guard let deviceID else { return nil }
+        return Self.inputDevice(deviceID)
     }
 
     /// The device's own identifier, the one that outlives a reconnection.

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -64,7 +64,14 @@ if arguments.contains("--check-config") {
 
 if arguments.contains("--microphones") {
     if let at = arguments.firstIndex(of: "--set") {
-        exit(MicrophonesCommand.set(arguments.indices.contains(at + 1) ? arguments[at + 1] : ""))
+        // `--set ""` clears the list, and a missing value must not do the same
+        // by accident: a script whose variable came out empty would silently
+        // throw away somebody's microphone order and exit 0.
+        guard arguments.indices.contains(at + 1), !arguments[at + 1].hasPrefix("--") else {
+            print("✗ --set needs a value: a comma-separated list, or \"\" to follow the system")
+            exit(1)
+        }
+        exit(MicrophonesCommand.set(arguments[at + 1]))
     }
     exit(MicrophonesCommand.run())
 }

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -62,6 +62,13 @@ if arguments.contains("--check-config") {
     exit(CheckConfigCommand.run())
 }
 
+if arguments.contains("--microphones") {
+    if let at = arguments.firstIndex(of: "--set") {
+        exit(MicrophonesCommand.set(arguments.indices.contains(at + 1) ? arguments[at + 1] : ""))
+    }
+    exit(MicrophonesCommand.run())
+}
+
 // Everything the bug form asks for, in one paste. `--url` prints the prefilled
 // issue URL instead, which is what the menu item opens.
 //

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -28,6 +28,14 @@ audio:
   # Where recordings and trace.jsonl go.
   output_dir: ~/Recordings/ParrotFlow
 
+  # Which microphone to record through, best first. The first one that is
+  # plugged in wins, whatever System Settings has the default set to, and
+  # nothing else on the Mac is moved. Names come from `--microphones`; the
+  # menu bar writes this list for you.
+  # microphones:
+  #   - Studio Display Microphone
+  #   - MacBook Pro Microphone
+
   # Skip clips with no speech, so a stray keypress does not decode room tone.
   speech_gate: true
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -366,6 +366,7 @@ $ ParrotFlow --forget Praisy
 ## Proving the microphone and the model work
 
 ```sh
+$PF --microphones        # every microphone attached, and which one wins
 $PF --record 3           # record 3s and verify the file it produced
 $PF --transcribe a.wav   # transcribe a clip
 $PF --watch-modifiers    # print which modifier keys are physically down, live
@@ -373,7 +374,16 @@ $PF --watch-taps         # tap, hold or shortcut — which edge each press comes
 $PF --audio-recovery     # what the recorder does when the microphone changes
 ```
 
-`--record` checks the result, not just that it ran: sample rate, channel count,
+`--microphones` prints what is attached, with the exact name and UID that
+`audio.microphones` matches on, and marks the one the list lands on right now.
+It is where the strings in that setting come from — a name typed from memory is
+a name that matches nothing. `--microphones --set "Studio Display Microphone,
+MacBook Pro Microphone"` writes the list, best first, and `--microphones --set ""`
+clears it; the menu bar does the same thing without the typing. See
+[configuration.md](configuration.md#audiomicrophones).
+
+`--record` records through that same list, and says which microphone it used.
+It checks the result, not just that it ran: sample rate, channel count,
 bit depth, peak level, and whether the file is the right size for its duration.
 A silent clip or a short file gets a non-zero exit.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -794,9 +794,17 @@ audio:
     - MacBook Pro Microphone
 ```
 
-Empty by default, and empty means the system's own choice — the input device
-System Settings picked, which is what every other app on the Mac uses. That is
-what ParrotFlow did before this list existed.
+**The menu writes the first one.** A config that has never carried this setting
+gets a list the first time the microphone menu is opened: everything attached,
+with the one already being recorded through at the top. Nothing about which
+microphone is used changes — what changes is that it is written down, so moving
+the default in System Settings no longer moves ParrotFlow. Prune it from the
+menu; a virtual device like `ZoomAudioDevice` is a microphone as far as CoreAudio
+is concerned, and it is not one you want to fall back to.
+
+`microphones: []` means the opposite, and is what `Follow the System Setting`
+writes: follow the system, deliberately. It is left alone. The key missing
+altogether is the only thing that seeds.
 
 An entry is what System Settings calls the device, or CoreAudio's UID for it,
 or a fragment of the name: `AirPods` reaches `Nathan's AirPods Pro`. Case is

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,7 @@ hotkey:
 
 audio:
   output_dir: ~/Recordings/ParrotFlow
+  microphones: []       # which microphone to record through, best first
   speech_gate: true     # skip clips with no speech in them
   second_opinion: true  # decode each clip twice and keep the longer decode
 
@@ -779,6 +780,46 @@ It was `free_form: true` at the top level. It is here because it is one of the
 router's answers rather than a setting of its own, and because it is the case
 that most deserves its own model — the free-form prompt is where a small local
 one is measured at its ceiling.
+
+## `audio.microphones`
+
+Which microphone to record through, best first. The first entry that is plugged
+in wins.
+
+```yaml
+audio:
+  microphones:
+    - Studio Display Microphone
+    - Nathan's AirPods Pro
+    - MacBook Pro Microphone
+```
+
+Empty by default, and empty means the system's own choice — the input device
+System Settings picked, which is what every other app on the Mac uses. That is
+what ParrotFlow did before this list existed.
+
+An entry is what System Settings calls the device, or CoreAudio's UID for it,
+or a fragment of the name: `AirPods` reaches `Nathan's AirPods Pro`. Case is
+ignored. An exact match wins over a fragment, so a device actually called
+`Display Audio` does not lose to one called `Display Audio (2)`. Two microphones
+answering to the same name is what the UID is for — `--microphones` prints both.
+
+**Only this app moves.** ParrotFlow opens the device it wants for itself and
+leaves System Settings alone. Zoom keeps using whatever it was using, and the
+default input device is still whatever you set it to.
+
+**It follows the hardware.** Plug the first microphone in and the next dictation
+is on it; unplug it and the next one is on the second entry. Nothing waits for a
+relaunch, and nothing changes during a dictation — a device arriving mid-sentence
+does not take the microphone away from the sentence.
+
+**From the menu bar.** The `Microphone · …` row unfolds into the list. Each entry
+can be moved up, moved down, removed, or made the one recording right now;
+anything else plugged in is listed underneath and joins the top of the list when
+you pick it. `Follow the System Setting` empties it again. Every one of those
+writes this setting, so the file and the menu never disagree.
+
+Run `--microphones` to see what is attached and the exact names to type.
 
 ## `audio.speech_gate`
 

--- a/scripts/check-microphones.sh
+++ b/scripts/check-microphones.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Checks that the microphone priority list survives a round trip through
+# config.yaml.
+#
+#   scripts/check-microphones.sh
+#
+# The menu bar writes this list, and it writes it into a file that is mostly
+# comments — so the write is a text splice, not a YAML round trip, and every
+# shape the file can be in has to come out valid and keep its comments. The
+# shapes: an `audio:` block with no list yet, a list already there, a list
+# written by hand as a flow sequence, and no `audio:` block at all.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/release/ParrotFlow"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+
+WORK="$(mktemp -d -t parrotflow-mics)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0; total=0; failed=""
+
+wants() {
+  total=$((total + 1))
+  if printf '%s' "$2" | grep -qF -- "$3"; then
+    pass=$((pass + 1))
+    printf '  ✓ %s\n' "$1"
+  else
+    failed="$failed
+      $1"
+    printf '  ✗ %s\n      want  %s\n      got   %s\n' "$1" "$3" "$2"
+  fi
+}
+
+counts() {
+  total=$((total + 1))
+  got="$(printf '%s' "$2" | grep -cF -- "$3")"
+  if [ "$got" = "$4" ]; then
+    pass=$((pass + 1))
+    printf '  ✓ %s\n' "$1"
+  else
+    failed="$failed
+      $1"
+    printf '  ✗ %s\n      want  %s × %s\n      got   × %s\n' "$1" "$3" "$4" "$got"
+  fi
+}
+
+rejects() {
+  total=$((total + 1))
+  if printf '%s' "$2" | grep -qF -- "$3"; then
+    failed="$failed
+      $1"
+    printf '  ✗ %s\n      unwanted  %s\n      got       %s\n' "$1" "$3" "$2"
+  else
+    pass=$((pass + 1))
+    printf '  ✓ %s\n' "$1"
+  fi
+}
+
+set_mics() { PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --microphones --set "$1" >/dev/null 2>&1; }
+config() { cat "$WORK/config.yaml"; }
+check() { PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --check-config 2>&1; }
+
+fresh() {
+  cat > "$WORK/config.yaml" <<'YAML'
+hotkey:
+  key: right_option
+
+audio:
+  # Where recordings go.
+  output_dir: ~/Recordings/ParrotFlow
+  speech_gate: true
+
+transcription:
+  languages: [en]
+YAML
+}
+
+# --- an audio block with no list yet ----------------------------------------
+fresh
+set_mics "Studio Display Microphone, MacBook Pro Microphone"
+wants "the key lands in the audio block" "$(config)" "  microphones:"
+wants "first entry, in order"           "$(config)" "    - Studio Display Microphone"
+wants "second entry, in order"          "$(config)" "    - MacBook Pro Microphone"
+wants "the comment above output_dir survives" "$(config)" "# Where recordings go."
+wants "the block below is untouched"    "$(config)" "transcription:"
+wants "it parses, best first"           "$(check)"  "2 listed, best first"
+
+# --- replacing a list that is already there ---------------------------------
+set_mics "MacBook Pro Microphone"
+wants "the new list is written"    "$(config)" "    - MacBook Pro Microphone"
+rejects "the old entry is gone"    "$(config)" "Studio Display Microphone"
+counts "the key is written once"   "$(config)" "microphones:" 1
+counts "and holds one entry"       "$(config)" "    - " 1
+
+# --- clearing it ------------------------------------------------------------
+set_mics ""
+rejects "the key is removed, not emptied" "$(config)" "microphones"
+wants "the rest of the audio block stays" "$(config)" "  speech_gate: true"
+wants "an empty list follows the system"  "$(check)"  "none listed"
+
+# --- a list a person wrote as a flow sequence -------------------------------
+cat > "$WORK/config.yaml" <<'YAML'
+audio:
+  output_dir: ~/Recordings/ParrotFlow
+  microphones: [Old One, Other One]
+  speech_gate: true
+
+transcription:
+  languages: [en]
+YAML
+set_mics "MacBook Pro Microphone"
+rejects "the flow list is replaced whole" "$(config)" "Old One"
+wants "by a block list"                   "$(config)" "    - MacBook Pro Microphone"
+wants "in the place the old one had"      "$(config)" "  speech_gate: true"
+counts "and written once"                 "$(config)" "microphones:" 1
+
+# --- no audio block at all --------------------------------------------------
+printf 'transcription:\n  languages: [en]\n' > "$WORK/config.yaml"
+set_mics "MacBook Pro Microphone"
+wants "an audio block is added" "$(config)" "audio:"
+wants "with the list under it"  "$(config)" "    - MacBook Pro Microphone"
+wants "and it still parses"     "$(check)"  "1 listed, best first"
+
+# --- a name that is not a plain word ----------------------------------------
+fresh
+set_mics "Nathan's AirPods: Pro"
+wants "punctuation is quoted" "$(config)" '- "Nathan'"'"'s AirPods: Pro"'
+wants "and it still parses"   "$(check)"  "1 listed, best first"
+
+printf '\n%d/%d\n' "$pass" "$total"
+[ -n "$failed" ] && printf 'failed:%s\n' "$failed"
+[ "$pass" -eq "$total" ]

--- a/scripts/check-microphones.sh
+++ b/scripts/check-microphones.sh
@@ -57,6 +57,7 @@ rejects() {
 }
 
 set_mics() { PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --microphones --set "$1" >/dev/null 2>&1; }
+bare_set() { PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --microphones --set 2>&1; }
 config() { cat "$WORK/config.yaml"; }
 check() { PARROTFLOW_CONFIG_DIR="$WORK" "$BIN" --check-config 2>&1; }
 
@@ -127,6 +128,30 @@ set_mics "MacBook Pro Microphone"
 wants "an audio block is added" "$(config)" "audio:"
 wants "with the list under it"  "$(config)" "    - MacBook Pro Microphone"
 wants "and it still parses"     "$(check)"  "1 listed, best first"
+
+# --- a comment between two entries ------------------------------------------
+cat > "$WORK/config.yaml" <<'YAML'
+audio:
+  microphones:
+    - Old One
+    # the one in the meeting room
+    - Other One
+  speech_gate: true
+
+transcription:
+  languages: [en]
+YAML
+set_mics "MacBook Pro Microphone"
+rejects "an entry above the comment goes" "$(config)" "Old One"
+rejects "and the one below it too"        "$(config)" "Other One"
+wants "the setting under the list stays"  "$(config)" "  speech_gate: true"
+
+# --- a missing value is not an empty one ------------------------------------
+fresh
+set_mics "MacBook Pro Microphone"
+bare_set >/dev/null 2>&1
+wants "--set with no value is refused"    "$(bare_set)" "needs a value"
+wants "and the list is left alone"        "$(config)"   "    - MacBook Pro Microphone"
 
 # --- a name that is not a plain word ----------------------------------------
 fresh

--- a/scripts/check-microphones.sh
+++ b/scripts/check-microphones.sh
@@ -94,9 +94,16 @@ counts "and holds one entry"       "$(config)" "    - " 1
 
 # --- clearing it ------------------------------------------------------------
 set_mics ""
-rejects "the key is removed, not emptied" "$(config)" "microphones"
+wants "the key stays, emptied"            "$(config)" "  microphones: []"
+counts "with nothing under it"            "$(config)" "    - " 0
 wants "the rest of the audio block stays" "$(config)" "  speech_gate: true"
 wants "an empty list follows the system"  "$(check)"  "none listed"
+
+# An emptied list is a decision — the menu seeds a list only into a config that
+# has never carried the key, and `[]` is how "follow the system" says so.
+set_mics "MacBook Pro Microphone"
+wants "and it can be filled again" "$(config)" "    - MacBook Pro Microphone"
+counts "still written once"        "$(config)" "microphones:" 1
 
 # --- a list a person wrote as a flow sequence -------------------------------
 cat > "$WORK/config.yaml" <<'YAML'


### PR DESCRIPTION
`audio.microphones` is a priority list. The first microphone in it that is plugged in is the one ParrotFlow records through, whatever System Settings has the default input set to. Only this app moves — it opens the device for itself, so Zoom keeps using what it was using. The list is set from the menu bar: the `Microphone · …` row now unfolds, and each entry can be moved up, moved down, removed, or made the one recording now.

Empty is the old behaviour, byte for byte: no list, no pin, follow the system. But a config that has never carried the setting gets a list written the first time the menu is opened — everything attached, with the mic already in use at the top. That changes no microphone; it writes down the one you were already on, so System Settings moving the default stops moving this app.

Reviewers: start at `Recorder.desiredInput()`. It is the one place that decides both what the engine is bound to and which device to open, and everything else in `Recorder.swift` is the existing change-detection now asking it instead of asking the system default.

<details>
<summary>The pin was measured, not assumed — the tap format follows the pinned device, not the default</summary>

The load-bearing question was whether an `AVAudioEngine` can be pinned to a non-default input without breaking the format checks `Recorder` already does. It can, with `inputNode.auAudioUnit.setDeviceID`, and it has to happen before any format is read off the node.

Measured on this machine, with the built-in mic at 44100 Hz as the system default and a second device at 48000 Hz pinned:

| | sample rate |
|---|---|
| system default input | 44100 Hz |
| pinned device | 48000 Hz |
| node tap format | 48000 Hz |
| node hardware format | 48000 Hz |

Both halves of the node follow the pin. So `graphProblem` and `formatProblem` keep working unchanged — as long as `formatProblem` compares against the device we pinned to rather than the default, which is what `desiredInput()` is for.

The discriminating end-to-end test used the Teams loopback driver, which is silent:

```
microphones: teams   → through Microsoft Teams Audio, peak 0.000  (silent)
microphones: (empty) → through MacBook Pro Microphone, peak 0.33
```

The system default was the built-in mic in both runs.

</details>

<details>
<summary>Why the device list is watched as well as the engine</summary>

`AVAudioEngineConfigurationChange` is the engine talking about its own device. An engine pinned to one microphone has nothing to say when a better one is plugged in, so a priority list would only ever be read at launch and on a save of `config.yaml`.

`Recorder.watchDeviceList()` adds a listener on `kAudioHardwarePropertyDevices`. It is ignored while recording: a device arriving is not a reason to take the microphone away from a sentence somebody is halfway through, and the next press picks it up.

It is also ignored until something has bound an engine. Instantiating an input node is what makes AVFoundation put up the native microphone dialog, and at launch that would come before the permissions window has explained why — the same reason `warmUp` is already gated on the permission. `reevaluateInput()` returns while `bound` is nil.

</details>

<details>
<summary>Two things a config file can say, and only one of them seeds</summary>

The seed has to happen once. Without a way to tell "never decided" from "decided to follow the system", `Follow the System Setting` would clear the list and the next menu open would refill it.

- key absent — nobody has been asked. The menu seeds.
- `microphones: []` — somebody said follow the system. Left alone.

Both decode to an empty array, so the difference is asked of the file text, in `ConfigWriter.hasMicrophonesKey()`.

</details>

<details>
<summary>Matching an entry to a device, and what it does when two answer to the same name</summary>

An entry is a name, CoreAudio's UID, or a fragment of a name — `AirPods` reaches `Nathan's AirPods Pro`. Case is ignored. An exact match over every attached device wins before any fragment is tried, so a device called `Display Audio` does not lose to one called `Display Audio (2)`.

Two microphones can answer to the same name, and that is what the UID is for. `--microphones` prints both. The seed writes the UID instead of the name when the name is ambiguous.

</details>

<details>
<summary>Three CLI doors, because the list is typed by hand as often as it is clicked</summary>

```sh
$PF --microphones                          # what is attached, with names and UIDs
$PF --microphones --set "Studio Mic, Mac"  # write the order, best first
$PF --microphones --set ""                 # follow the system
$PF --check-config                         # which entries are attached, which wins
$PF --record 2                             # says which microphone it recorded through
```

`--microphones` is where the strings in the setting come from. A name typed from memory is a name that matches nothing.

</details>

<details>
<summary>What is not verified here — hot-plug, on a Mac with nothing to unplug</summary>

This machine has one real microphone and two virtual driver devices. Nobody has watched the list fail over to entry 2 when entry 1 is unplugged, and back again. The listener is wired and the rate-change test showed device IDs do move under CoreAudio, but the failover itself wants a headset and a pair of hands.

Also worth knowing: CoreAudio calls a virtual driver an input device, so `ZoomAudioDevice` and the Teams loopback are seeded into the list like anything else. They are exactly the wrong thing to fall back to — the clip comes back silent. They are removed from the menu in one click, and the docs say so.

</details>

<details>
<summary>Tests — scripts/check-microphones.sh, 25 cases over the four shapes config.yaml can be in</summary>

The menu writes into a file that is mostly comments, so the write is a text splice rather than a YAML round trip. Every shape the file can be in has to come out valid with its comments intact:

- an `audio:` block with no list yet
- a list already there, replaced
- a list a person wrote as a flow sequence, `microphones: [a, b]`
- no `audio:` block at all
- emptied to `[]`, then filled again
- a name that is not a plain word, `Nathan's AirPods: Pro`

25/25. Wired into `.github/workflows/checks.yml`. `check-audio-recovery.sh` 14/14, `check-learn.sh` 45/45 and `check-default-config.sh` still pass.

</details>
