### PR TITLE
fix: typing after a dictation is not a correction of the last word

### DIFF
--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -391,8 +391,16 @@ final class EditWatch {
     /// The test is a whole word, not a prefix. `Ghost` to `Ghostty` extends the
     /// word itself and is a real correction; `Praisy` to `Praisy's` likewise.
     /// What is refused is one reading standing whole at the start or end of the
-    /// other with a separate word beside it, so the rest has to hold a space
-    /// for this to fire at all.
+    /// other with something separate beside it.
+    ///
+    /// Separate means a space, or a stop the reading already ended on. Typing
+    /// runs straight on from the mark: `removed.` became `removed.x` and was
+    /// offered as a rule, 2026-09-05. A stop only counts when a letter or a
+    /// number follows it, so `options.` to `options.)` stays a change and is
+    /// refused later as punctuation.
+    ///
+    /// The price is that `Node.` typed out to `Node.js` reads the same way and
+    /// is dropped too. Nothing in the two strings tells them apart.
     ///
     /// Takes the two runs as they stood, not what `trimmed` returns. Only the
     /// punctuation both end on comes off here. `prone.maybe` became
@@ -406,13 +414,20 @@ final class EditWatch {
             b = b.dropLast()
         }
         let (short, long) = a.count < b.count ? (a, b) : (b, a)
-        guard short != long, long.contains(where: \.isWhitespace) else { return false }
+        guard short != long else { return false }
         guard long.hasPrefix(short) || long.hasSuffix(short) else { return false }
         // A whole word has to have appeared, or `Ghost` growing into `Ghostty`
         // would read as `Ghost` with something added.
-        let rest = long.hasPrefix(short)
-            ? long.dropFirst(short.count) : long.dropLast(short.count)
-        return rest.contains(where: \.isWhitespace)
+        let opens = long.hasPrefix(short)
+        let rest = opens ? long.dropFirst(short.count) : long.dropLast(short.count)
+        if rest.contains(where: \.isWhitespace) { return true }
+        // Either side of the join. The strip above takes a stop off both
+        // readings when they end on one, so `removed.` to `removed.Hello.`
+        // arrives here with the mark at the head of `rest` instead.
+        let join = opens ? [short.last, rest.first] : [rest.last, short.first]
+        guard join.contains(where: { $0.map { ".!?".contains($0) } == true })
+        else { return false }
+        return rest.contains { $0.isLetter || $0.isNumber }
     }
 
     /// The two readings with the punctuation they share taken off both.

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -402,17 +402,21 @@ final class EditWatch {
     /// The price is that `Node.` typed out to `Node.js` reads the same way and
     /// is dropped too. Nothing in the two strings tells them apart.
     ///
-    /// Takes the two runs as they stood, not what `trimmed` returns. Only the
-    /// punctuation both end on comes off here. `prone.maybe` became
-    /// `prone point.maybe`, and the word went *inside* the run: cutting the
-    /// shared `.maybe` first would leave `prone -> prone point`, which reads
-    /// like a word appended and is a correction the panel has to keep.
+    /// Each end is stripped on its own, not down to what the two share. The
+    /// mark can be changed by the same edit that adds the text: `rebase.`
+    /// became `rebase: https://claude.ai/…`, 2026-09-06. Sharing kept the `.`
+    /// and the `:`, so the word was not a prefix of the longer run and the
+    /// space beside it was never looked at.
+    ///
+    /// Trailing only, and the runs as they stood rather than what `trimmed`
+    /// returns. `prone.maybe` became `prone point.maybe`, and the word went
+    /// *inside* the run: cutting the shared `.maybe` first would leave
+    /// `prone -> prone point`, which reads like a word appended and is a
+    /// correction the panel has to keep.
     static func added(was: String, now: String) -> Bool {
         var a = Substring(was), b = Substring(now)
-        while let last = a.last, last == b.last, !(last.isLetter || last.isNumber) {
-            a = a.dropLast()
-            b = b.dropLast()
-        }
+        while let last = a.last, !(last.isLetter || last.isNumber) { a = a.dropLast() }
+        while let last = b.last, !(last.isLetter || last.isNumber) { b = b.dropLast() }
         let (short, long) = a.count < b.count ? (a, b) : (b, a)
         guard short != long else { return false }
         guard long.hasPrefix(short) || long.hasSuffix(short) else { return false }

--- a/tests/edit-diff-cases.yaml
+++ b/tests/edit-diff-cases.yaml
@@ -217,6 +217,31 @@ cases:
     now:     "a word in the dictation.[Image #17]"
     expect:  none
 
+  # Typing that runs straight on from a stop, with no space to mark it. From
+  # the log, 2026-09-05: one keystroke landed after the dictation and the whole
+  # word was offered as a rule.
+  - written: "❯ I mean the term that is Potentially to be removed."
+    now:     "❯ I mean the term that is Potentially to be removed.x"
+    expect:  none
+
+  # The typed text ends on a stop too, so both readings do and the mark comes
+  # off both before the test. It is then at the head of what was added.
+  - written: "to be removed."
+    now:     "to be removed.Hello."
+    expect:  none
+
+  # The same at the other end: a sentence typed in front of the word.
+  - written: "we run Ghostty"
+    now:     "we run Fine.Ghostty"
+    expect:  none
+
+  # Punctuation added after a stop is still a change, and still refused for
+  # being punctuation. The letters are what make an addition an addition.
+  - written: "keep it small."
+    now:     "keep it small.)"
+    expect:  "small. -> small.)"
+    offer:   "no, punctuation, not a name"
+
   # But a word that grows is still a correction, and so is one that splits.
   - written: "it is Ghost here"
     now:     "it is Ghostty here"

--- a/tests/edit-diff-cases.yaml
+++ b/tests/edit-diff-cases.yaml
@@ -230,6 +230,24 @@ cases:
     now:     "to be removed.Hello."
     expect:  none
 
+  # The mark changed in the same edit that added the text. From the log,
+  # 2026-09-06: the stop became a colon and a URL was pasted after it. The two
+  # runs no longer end on the same mark, so each end is stripped on its own.
+  - written: "❯ take a look at the rebase."
+    now:     "❯ take a look at the rebase: https://claude.ai/code/session_01WdUvRN"
+    expect:  none
+
+  # The mark alone, with nothing added, is still a change and still refused.
+  - written: "take a look at the rebase."
+    now:     "take a look at the rebase:"
+    expect:  "rebase. -> rebase:"
+    offer:   "no, punctuation, not a name"
+
+  # A word typed after a name that ends on a stop.
+  - written: "we deploy on Vercel."
+    now:     "we deploy on Vercel Cloud."
+    expect:  none
+
   # The same at the other end: a sentence typed in front of the word.
   - written: "we run Ghostty"
     now:     "we run Fine.Ghostty"


### PR DESCRIPTION
Type after a dictation and the vocabulary panel offered the word you typed onto
as a rule. Two shapes from the log:

| dictated | after typing | offered as a rule |
|---|---|---|
| `…to be removed.` | `…to be removed.x` | `removed.` -> `removed.x` |
| `…the rebase.` | `…the rebase: https://claude.ai/…` | `rebase.` -> `rebase: https://…` |

The panel already refuses text added beside a word. It missed both: it only
looked for a space to mark the addition, and it only took off the punctuation
the two readings share. Neither holds when typing runs straight on from a stop,
or when the same edit replaces the mark.

Start the review at `EditWatch.added`. The rest is doc comment and seven cases.

<details>
<summary>What each of the two commits changes</summary>

**A stop marks an addition, not only a space.** `added` refuses a reading that
stands whole at the start or end of a longer one with something separate beside
it. `morning` -> `morning Tasmeen` and `dictation.` -> `dictation.[Image #17]`
were both offered before it existed. It asked for whitespace, and
`removed.` -> `removed.x` has none.

Now `.!?` at the join also marks it, when a letter or a number follows. The
letters are load-bearing: without them `options.` -> `options.)` would be
dropped here, and it has to stay a change so it is refused for the right
reason, "punctuation, not a name".

The join is read from both sides, because the strip below can move the mark
from the tail of the word to the head of what was added. `removed.` ->
`removed.Hello.` arrives as `removed` and `removed.Hello`.

**Each end is stripped on its own.** It used to come off only where the two
runs agreed. `rebase.` -> `rebase: https://claude.ai/…` changed the mark in the
same edit that pasted the URL, so nothing came off, `rebase.` was not a prefix
of the longer run, and the space was never looked at. Stripping each end
separately also drops `we deploy on Vercel.` -> `we deploy on Vercel Cloud.`,
which is the same shape.

</details>

<details>
<summary>What this drops that it should not: `Node.` typed out to `Node.js`</summary>

Finishing a word yourself after the app wrote a stop is text-identical to
typing something new. `Node.` -> `Node.js` has the same shape as
`removed.` -> `removed.x`, and it is now dropped too.

Capitalisation, length, sentence position and both word lists answer the same
for the two. The lists are asked with the punctuation stripped, so they see
`nodejs` and `removedx`, and neither is a word.

One thing does separate them, measured after this PR was opened: the tail. In
`Node.js`, `main.swift`, `cli.md` and `example.com` the added text is a file
extension or a TLD. In `removed.x`, `removed.Hello`, `prone.maybe`, `it.Ghost`
and `Vercel.and` it is not. A short list of extensions checked against what was
added would keep the first group and drop the second, at no cost, and it falls
back to this PR's behaviour whenever the list misses.

It is not in this PR. It is one list against five made-up cases, and it needs a
labelled set before it decides anything. Filed as a follow-up.

</details>

<details>
<summary>Checks — `scripts/check-edit-diff.sh` passes at 46 cases, 7 new</summary>

| written | now | expect |
|---|---|---|
| `…to be removed.` | `…to be removed.x` | none |
| `to be removed.` | `to be removed.Hello.` | none |
| `…the rebase.` | `…the rebase: https://claude.ai/…` | none |
| `we deploy on Vercel.` | `we deploy on Vercel Cloud.` | none |
| `we run Ghostty` | `we run Fine.Ghostty` | none |
| `…the rebase.` | `…the rebase:` | `rebase. -> rebase:`, refused as punctuation |
| `keep it small.` | `keep it small.)` | `small. -> small.)`, refused as punctuation |

The first four are the shapes from the log and their near neighbours. The fifth
is a sentence typed in front of the word. The last two are what the letter test
protects: a mark alone is still a change, and is refused for being punctuation.

No earlier case moves.

</details>
