### PR TITLE
fix: a press that did nothing now works, or says why

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1258,6 +1258,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // and the behaviour cannot come apart again.
         if !recorder.isRecording {
             keyedAtPress = afterTap || (offerIsUp && pill.isOpen)
+            // Only when it is on, and it says which of the two put it there.
+            // This is the one decision at the press you cannot see from
+            // outside: the same key, the same meter, and the words routed
+            // instead of written down. A hold taken as an edit when you meant
+            // to dictate left nothing in the log to name the reason.
+            if keyedAtPress {
+                Log.write(
+                    "hold: an edit instruction — \(afterTap ? "the tap before it" : "the open panel")"
+                )
+            }
         }
         // Read before anything this press does, so an abort later can tell the
         // transcription this press started from one that was already running.
@@ -3656,7 +3666,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // stops a recording, and a stop that came out short is a stop — the
         // press was simply never delivered. Summoning there would answer a key
         // meant for the microphone, and do it over the *previous* sentence.
-        guard !recorder.isRecording, runsInFlight <= 0 else { return }
+        // Said out loud, all three of them. Every way out of here used to be a
+        // bare `return`, so a tap that did nothing left a log with nothing in
+        // it between the last dictation and the next one — and "nothing
+        // happens" is exactly how this is reported.
+        guard !recorder.isRecording, runsInFlight <= 0 else {
+            Log.write(
+                "summon: not now — recording \(recorder.isRecording),"
+                + " \(runsInFlight) run(s) in flight"
+            )
+            return
+        }
         // A tap while the offer is already open is a tap at nothing. Raising a
         // second one over the first would take the letters again and restart a
         // clock the pointer may be deliberately holding.
@@ -3664,10 +3684,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Closed, it is the opposite gesture rather than none: the tab is on
         // screen so that a tap can open it, and the key it draws is this one.
         if offerIsUp {
-            if !pill.isOpen { openTheOffer() }
+            if !pill.isOpen {
+                openTheOffer()
+            } else {
+                Log.write("summon: the panel is already open")
+            }
             return
         }
-        guard config.feedback.correctOffer else { return }
+        guard config.feedback.correctOffer else {
+            Log.write("summon: the offer is switched off in config.yaml")
+            return
+        }
 
         // The selection wins, and it never goes stale: it is what you are
         // pointing at now. It is also the only target this can have in an app

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -99,6 +99,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let previewPanel = PreviewPanel()
     /// Says once per microphone that this one will cost you words.
     private let micNotice = MicNotice()
+    private let keyboardNotice = KeyboardNotice()
     /// The release notes, and the three answers to them.
     private let updatePanel = UpdatePanel()
     private var pendingSelection: SelectionReader.Selection?
@@ -3350,6 +3351,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // the decoder is done, and by then the default input can be another
         // device — see `micAtPress`.
         micNotice.showIfNeeded(press.mic)
+        // And the other thing that can be wrong with a dictation nobody has
+        // been told about: another app holding Secure Event Input, which takes
+        // Escape and the offer's letters away. Here for the same reason as the
+        // microphone — this is the moment before those keys matter, and being
+        // told at the moment you press one is being told too late, with the
+        // letter already in your document.
+        //
+        // Never both at once. They are the same panel in the same corner, and
+        // the second one would sit on the first.
+        if !micNotice.isShowing { keyboardNotice.showIfNeeded() }
 
         guard config.feedback.correctOffer else { return }
         guard let text = lastTranscript?.trimmingCharacters(in: .whitespacesAndNewlines),

--- a/Sources/ParrotFlow/AudioRecoveryCommand.swift
+++ b/Sources/ParrotFlow/AudioRecoveryCommand.swift
@@ -556,29 +556,29 @@ enum AudioRecoveryCommand {
     }
 
     /// Turns the run loop until the condition holds or the time is up.
-    /// Let the wall clock past `min_duration_seconds`, which is what `stop`
-    /// measures a clip by.
-    ///
-    /// The buffers below are pushed through in microseconds, so a clip made of
-    /// twenty of them is three seconds of audio and no time at all. `stop`
-    /// reads the clock, calls that shorter than the floor, and returns nil —
-    /// which every check here then reports as "nothing was written". It is the
-    /// harness that has to wait, not the recorder that has to count frames: the
-    /// floor exists to throw away a key pressed and released, and that is a
-    /// question about time.
-    private static func pause(_ seconds: TimeInterval) {
-        settle(untilTrue: { false }, seconds: seconds)
-    }
-
-    /// Comfortably over the 0.3s floor.
-    private static let overTheFloor: TimeInterval = 0.4
-
     private static func settle(untilTrue condition: () -> Bool, seconds: TimeInterval) {
         let deadline = Date().addingTimeInterval(seconds)
         while !condition(), Date() < deadline {
             RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.02))
         }
     }
+
+    /// Let the wall clock past `min_duration_seconds`, which is what `stop`
+    /// measures a clip by.
+    ///
+    /// The buffers in the checks above are pushed through in microseconds, so a
+    /// clip made of twenty of them is three seconds of audio and no time at
+    /// all. `stop` reads the clock, calls that shorter than the floor, and
+    /// returns nil — which every check here then reports as "nothing was
+    /// written". It is the harness that has to wait, not the recorder that has
+    /// to count frames: the floor exists to throw away a key pressed and
+    /// released, and that is a question about time.
+    private static func pause(_ seconds: TimeInterval) {
+        settle(untilTrue: { false }, seconds: seconds)
+    }
+
+    /// Comfortably over the 0.3s floor.
+    private static let overTheFloor: TimeInterval = 0.4
 
     // MARK: - Cases
 

--- a/Sources/ParrotFlow/AudioRecoveryCommand.swift
+++ b/Sources/ParrotFlow/AudioRecoveryCommand.swift
@@ -59,6 +59,8 @@ enum AudioRecoveryCommand {
         print("The engine and its own input")
         var graph = 0
         graph += checkAGraphThatDisagreesWithItselfIsRebuilt() ? 0 : 1
+        graph += checkAMismatchThatSurvivesItsRebuildIsLeftAlone() ? 0 : 1
+        graph += checkTheTapIsInstalledAtTheHardwareFormat() ? 0 : 1
         graph += checkAnExceptionComesBackAsAValue() ? 0 : 1
         graph += checkAReplacedEngineIsNotReleasedOnTheSpot() ? 0 : 1
         failures += graph
@@ -75,7 +77,7 @@ enum AudioRecoveryCommand {
         capture += checkOneLostBufferIsForgiven(config: config) ? 0 : 1
         failures += capture
 
-        let total = cases.count + 7
+        let total = cases.count + 9
         print("")
         print("  \(total - failures)/\(total)")
         return failures == 0 ? 0 : 1
@@ -149,6 +151,76 @@ enum AudioRecoveryCommand {
             return say(false, name, "the device had not moved, so the change was dropped")
         }
         return say(true, name, "rebuilt")
+    }
+
+    /// The same mismatch, over and over, buys one engine and not a hundred.
+    ///
+    /// A rebuild retires the engine it replaced; releasing that one ten seconds
+    /// later posts a configuration change of its own. If the mismatch is still
+    /// there — a machine whose two reads simply never agree — the change finds
+    /// it and rebuilds again, forever. Measured on 2026-09-06: 40 rebuilds in
+    /// fifteen minutes on an idle app, each one opening the microphone.
+    private static func checkAMismatchThatSurvivesItsRebuildIsLeftAlone() -> Bool {
+        let name = "a mismatch that outlives its rebuild is kept"
+        let binding = Recorder.InputBinding(device: 2, sampleRate: 24000, channels: 1)
+        guard let tap = format(24000), let hardware = format(16000) else {
+            return say(false, name, "could not build the formats")
+        }
+
+        let recorder = Recorder()
+        recorder.currentInput = { binding }
+        recorder.warmUp()
+
+        // Every engine this recorder builds comes out mismatched, which is the
+        // machine being reproduced: no rebuild can clear it.
+        recorder.engineFormats = { _ in
+            Recorder.EngineFormats(tap: tap, hardware: hardware)
+        }
+        recorder.simulateConfigurationChange()
+        settle(untilTrue: { recorder.rebuilds > 0 }, seconds: 2)
+        guard recorder.rebuilds == 1 else {
+            return say(false, name, "the first change bought \(recorder.rebuilds) engine(s)")
+        }
+
+        for _ in 0..<3 { recorder.simulateConfigurationChange() }
+        settle(untilTrue: { recorder.rebuilds > 1 }, seconds: 1)
+        guard recorder.rebuilds == 1 else {
+            return say(false, name, "\(recorder.rebuilds) engines for one mismatch")
+        }
+        return say(true, name, "one engine, then left alone")
+    }
+
+    /// The tap goes on at the format `installTap` asserts against.
+    ///
+    /// Its own words: "required condition is false: format.sampleRate ==
+    /// inputHWFormat.sampleRate". So when the node describes its input two
+    /// ways, the hardware one is the only one that can be handed over — and
+    /// handing it the other is what refused the press and asked for another.
+    private static func checkTheTapIsInstalledAtTheHardwareFormat() -> Bool {
+        let name = "the tap is installed at the hardware format"
+        guard let tap = format(24000), let hardware = format(48000) else {
+            return say(false, name, "could not build the formats")
+        }
+        // What an input node answers when it is pointing at nothing: a format
+        // object with no rate in it. `AVAudioFormat` will not build one from a
+        // rate of zero, so it is made the way the node makes one.
+        let empty = AVAudioFormat()
+        let picked = Recorder.captureFormat(
+            Recorder.EngineFormats(tap: tap, hardware: hardware)
+        )
+        guard picked.sampleRate == hardware.sampleRate else {
+            return say(false, name, "picked \(Int(picked.sampleRate)) Hz, not the hardware's 48000")
+        }
+        // A node pointing at nothing is the one case the other half stands in
+        // for: an empty hardware read is not a second description, it is no
+        // description at all.
+        let fallback = Recorder.captureFormat(
+            Recorder.EngineFormats(tap: tap, hardware: empty)
+        )
+        guard fallback.sampleRate == tap.sampleRate else {
+            return say(false, name, "an empty hardware read was taken as a format")
+        }
+        return say(true, name, "48000 Hz, and the tap format when there is none")
     }
 
     /// An NSException raised inside a Swift frame comes back as a value.
@@ -294,6 +366,7 @@ enum AudioRecoveryCommand {
             return false
         }
         for _ in 0..<20 { recorder.process(buffer: tone(format, frames: 4096)) }
+        pause(overTheFloor)
 
         guard let recording = recorder.stop(config: config) else {
             print("  ✗ a tone at the new rate is written  — nothing was written")
@@ -348,6 +421,7 @@ enum AudioRecoveryCommand {
             return false
         }
         for _ in 0..<20 { recorder.process(buffer: tone(live, frames: 4096)) }
+        pause(overTheFloor)
 
         let recording = recorder.stop(config: config)
         settle(untilTrue: { reported != nil }, seconds: 2)
@@ -450,6 +524,7 @@ enum AudioRecoveryCommand {
         }
         for _ in 0..<20 { recorder.process(buffer: tone(live, frames: 4096)) }
         for _ in 0..<buffers { recorder.process(buffer: tone(other, frames: 4096)) }
+        pause(overTheFloor)
 
         let recording = recorder.stop(config: config)
         settle(untilTrue: { reported != nil }, seconds: 1)
@@ -481,6 +556,23 @@ enum AudioRecoveryCommand {
     }
 
     /// Turns the run loop until the condition holds or the time is up.
+    /// Let the wall clock past `min_duration_seconds`, which is what `stop`
+    /// measures a clip by.
+    ///
+    /// The buffers below are pushed through in microseconds, so a clip made of
+    /// twenty of them is three seconds of audio and no time at all. `stop`
+    /// reads the clock, calls that shorter than the floor, and returns nil —
+    /// which every check here then reports as "nothing was written". It is the
+    /// harness that has to wait, not the recorder that has to count frames: the
+    /// floor exists to throw away a key pressed and released, and that is a
+    /// question about time.
+    private static func pause(_ seconds: TimeInterval) {
+        settle(untilTrue: { false }, seconds: seconds)
+    }
+
+    /// Comfortably over the 0.3s floor.
+    private static let overTheFloor: TimeInterval = 0.4
+
     private static func settle(untilTrue condition: () -> Bool, seconds: TimeInterval) {
         let deadline = Date().addingTimeInterval(seconds)
         while !condition(), Date() < deadline {

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -251,7 +251,15 @@ final class EditWatch {
 
     /// Hand over what was found, once, in the order it was found.
     private func tell() {
-        guard !seen.isEmpty else { return }
+        guard !seen.isEmpty else {
+            // Once per watch, and only after a key went by. A watch nobody
+            // typed into has nothing to say and saying so every time would
+            // bury the times it does.
+            if keysSeen > 0, reported.insert("told nothing").inserted {
+                Log.write("edit watch: \(keysSeen) key(s) and no correction to hand over")
+            }
+            return
+        }
         let changes = seen.values.sorted { $0.at < $1.at }
             .filter { told.insert("\($0.at)\u{1}\($0.now)").inserted }
         seen = [:]
@@ -269,8 +277,20 @@ final class EditWatch {
 
     private func read() {
         // Nothing to compare against until the line has been found.
-        guard let before, let field else { return }
-        guard Date().timeIntervalSince(lastLook) > 0.15 else { return }
+        guard let before, let field else {
+            if reported.insert("no line").inserted {
+                Log.write("edit watch: nothing to compare against; the line was never found")
+            }
+            return
+        }
+        // Two reads inside 150 ms are one read. Said out loud because the
+        // second one is usually Return arriving on top of the settle, and a
+        // Return that reads nothing is the moment the correction is handed
+        // over — or is not.
+        guard Date().timeIntervalSince(lastLook) > 0.15 else {
+            Log.write("edit watch: read again inside 150 ms; keeping the last one")
+            return
+        }
         lastLook = Date()
 
         guard let whole = CaretAnchor.snapshot(of: field) else {
@@ -308,7 +328,17 @@ final class EditWatch {
         // nobody meant — deleting `Prezi` back to `P` before typing `Praisy`
         // reported `Prezi -> P` as a correction — and only the last state is
         // one. Told when the watch ends, which is when you move on.
-        for change in found { seen[change.at] = change }
+        //
+        // Said out loud on the way in, because the gap between finding one and
+        // handing it over is minutes long and nothing used to mark either end.
+        // A correction found and then lost — the app quit, the field went —
+        // looked exactly like one that was never seen.
+        for change in found {
+            if seen[change.at]?.now != change.now {
+                Log.write("edit watch: holding \"\(change.was)\" -> \"\(change.now)\"")
+            }
+            seen[change.at] = change
+        }
     }
 
     // MARK: - the comparison

--- a/Sources/ParrotFlow/KeyboardNotice.swift
+++ b/Sources/ParrotFlow/KeyboardNotice.swift
@@ -66,14 +66,24 @@ final class KeyboardNotice {
     private var panel: NSPanel?
     private let model = KeyboardNoticeModel()
 
-    /// The holder already spoken about.
+    /// An episode of the keyboard being somebody else's.
+    ///
+    /// Not a bare `pid_t?`: a screen lock holds the keyboard and names nobody,
+    /// so nil would mean "said, about nobody" and "nothing said yet" at once —
+    /// and the two comparing equal ate the one notice that episode gets.
+    private enum Episode: Equatable {
+        case app(pid_t)
+        case unnamed
+    }
+
+    /// The episode already spoken about.
     ///
     /// Cleared the moment secure input goes off, so a second episode is said
     /// again. Not kept across launches, unlike `MicNotice.lastDevice`: that one
     /// remembers a decision you made about your own hardware, and this is a
     /// state some other app is in right now. Remembering it would mean staying
     /// quiet the next time the keyboard died.
-    private var told: pid_t?
+    private var told: Episode?
 
     var isShowing: Bool { panel?.isVisible == true }
 
@@ -87,8 +97,9 @@ final class KeyboardNotice {
             told = nil
             return
         }
-        guard told != holder.pid else { return }
-        told = holder.pid
+        let episode = holder.pid.map(Episode.app) ?? .unnamed
+        guard told != episode else { return }
+        told = episode
         Log.write("keyboard: \(holder.described) has secure input on; said so once")
         show(app: holder.described)
     }

--- a/Sources/ParrotFlow/KeyboardNotice.swift
+++ b/Sources/ParrotFlow/KeyboardNotice.swift
@@ -1,0 +1,276 @@
+import AppKit
+import Carbon.HIToolbox
+import Darwin
+import SwiftUI
+
+/// Who has Secure Event Input on, if anybody.
+///
+/// One app turns it on for a password field and macOS stops handing the
+/// keyboard to every other process on the machine. There is no permission that
+/// exempts an app from that, and there should not be — it is the whole point of
+/// it. So this exists to *name* the app, which is the one thing a person needs
+/// and cannot get without `ioreg`.
+///
+/// Costs nothing: two reads, no Accessibility, no Input Monitoring.
+enum SecureInput {
+
+    struct Holder {
+        /// Nil when the flag is on and the session carries no owner — a screen
+        /// lock, loginwindow. Then there is a dead keyboard and nobody to name.
+        let pid: pid_t?
+        let name: String?
+
+        /// What the notice calls it. "Another app" is not a name and is still
+        /// better than a sentence about nothing.
+        var described: String { name ?? "Another app" }
+    }
+
+    /// Nil when the keyboard is ours to watch.
+    static func holder() -> Holder? {
+        guard IsSecureEventInputEnabled() else { return nil }
+        guard let session = CGSessionCopyCurrentDictionary() as? [String: Any],
+              let pid = session["kCGSSessionSecureInputPID"] as? pid_t, pid > 0
+        else { return Holder(pid: nil, name: nil) }
+        return Holder(pid: pid, name: name(of: pid))
+    }
+
+    /// The app's name, and the process's when it is not an app.
+    ///
+    /// Electron turns secure input on from a helper process, and
+    /// `NSRunningApplication` answers nil for one — it is not a GUI app. The
+    /// executable name is then what there is, and "Notion Helper" still tells
+    /// you what to quit. Measured on 2026-09-06: pid 1002 came back "Notion"
+    /// through the first path and pid 1115 "Notion Helper" through the second.
+    private static func name(of pid: pid_t) -> String? {
+        if let app = NSRunningApplication(processIdentifier: pid) {
+            return app.localizedName ?? app.bundleIdentifier
+        }
+        var buffer = [CChar](repeating: 0, count: 4096)
+        guard proc_pidpath(pid, &buffer, UInt32(buffer.count)) > 0 else { return nil }
+        let path = String(cString: buffer)
+        return path.isEmpty ? nil : (path as NSString).lastPathComponent
+    }
+}
+
+/// Says, once per episode, that another app has taken the keyboard.
+///
+/// The same shape as `MicNotice` and for the same reason: it is not a status,
+/// it is a thing to read, act on, and not be told again. On the pill it would
+/// be in the way of the offer, which is the surface it is about.
+///
+/// The collapsed sentence carries the fix rather than the diagnosis. What you
+/// need at that moment is which app to go and quit; what secure input *is* can
+/// wait behind the disclosure.
+final class KeyboardNotice {
+
+    private var panel: NSPanel?
+    private let model = KeyboardNoticeModel()
+
+    /// The holder already spoken about.
+    ///
+    /// Cleared the moment secure input goes off, so a second episode is said
+    /// again. Not kept across launches, unlike `MicNotice.lastDevice`: that one
+    /// remembers a decision you made about your own hardware, and this is a
+    /// state some other app is in right now. Remembering it would mean staying
+    /// quiet the next time the keyboard died.
+    private var told: pid_t?
+
+    var isShowing: Bool { panel?.isVisible == true }
+
+    /// After a dictation, if the keyboard is not ours and we have not said so.
+    ///
+    /// Here rather than at the moment a key is pressed, because by then it is
+    /// too late: the letter has already gone into the document instead of
+    /// running the command. This is the moment before the offer's keys matter.
+    func showIfNeeded() {
+        guard let holder = SecureInput.holder() else {
+            told = nil
+            return
+        }
+        guard told != holder.pid else { return }
+        told = holder.pid
+        Log.write("keyboard: \(holder.described) has secure input on; said so once")
+        show(app: holder.described)
+    }
+
+    /// Put it on screen for a named app, the flag aside.
+    ///
+    /// Split out so `--panels keyboard` raises the surface the app raises,
+    /// rather than a copy of it that can drift — and so it can be looked at on
+    /// a machine where nothing is holding the keyboard.
+    func show(app: String) {
+        model.app = app
+        model.expanded = false
+        model.onClose = { [weak self] in self?.dismiss() }
+
+        if panel == nil { build() }
+        resize()
+        reposition()
+        panel?.riseIntoView(makeKey: false)
+    }
+
+    private func dismiss() {
+        panel?.orderOut(nil)
+    }
+
+    private func build() {
+        let hosting = NSHostingView(rootView: KeyboardNoticeView().environmentObject(model))
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: KeyboardNoticeMetrics.width,
+                                height: KeyboardNoticeMetrics.height(expanded: false)),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.contentView = hosting
+        panel.isFloatingPanel = true
+        panel.level = .floating
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.hasShadow = true
+        panel.hidesOnDeactivate = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.adoptParrotAppearance()
+        self.panel = panel
+
+        model.onResize = { [weak self] in self?.resize() }
+    }
+
+    private func resize() {
+        guard let panel else { return }
+        let height = KeyboardNoticeMetrics.height(expanded: model.expanded)
+        let origin = panel.frame.origin
+        panel.setFrame(
+            NSRect(x: origin.x, y: origin.y, width: KeyboardNoticeMetrics.width, height: height),
+            display: true, animate: panel.isVisible
+        )
+        panel.contentView?.frame = NSRect(
+            x: 0, y: 0, width: KeyboardNoticeMetrics.width, height: height
+        )
+    }
+
+    /// Bottom right, where `MicNotice` goes. The two never share the moment —
+    /// see the caller.
+    private func reposition() {
+        guard let panel else { return }
+        let mouse = NSEvent.mouseLocation
+        let screen = NSScreen.screens.first { NSMouseInRect(mouse, $0.frame, false) } ?? NSScreen.main
+        guard let frame = screen?.visibleFrame else { return }
+        panel.setFrameOrigin(NSPoint(
+            x: frame.maxX - panel.frame.width - 24,
+            y: frame.minY + 24
+        ))
+    }
+}
+
+enum KeyboardNoticeMetrics {
+    static let width: CGFloat = 380
+    /// Two heights, as in `MicNoticeMetrics`: the sentence is one app name long
+    /// and the reasons are fixed text, so there is nothing to measure that is
+    /// not known when it is written. Both states are on `--panels keyboard`.
+    static func height(expanded: Bool) -> CGFloat { expanded ? 300 : 118 }
+}
+
+final class KeyboardNoticeModel: ObservableObject {
+    @Published var app = "Another app"
+    @Published var expanded = false {
+        didSet { onResize?() }
+    }
+    var onClose: (() -> Void)?
+    var onResize: (() -> Void)?
+}
+
+struct KeyboardNoticeView: View {
+    @EnvironmentObject private var model: KeyboardNoticeModel
+
+    /// Written as the three questions somebody asks in this order: what is
+    /// broken, why, and what to do about it. The last one is the reason the
+    /// notice exists, so it is the one with the exact steps in it.
+    private static let reasons = [
+        (
+            "What stops working",
+            "Escape cannot cancel a dictation, and the offer's letters cannot run its commands. Clicking the pill still works."
+        ),
+        (
+            "Why",
+            "An app turns it on for a password field. macOS then hides every key from every other app, this one included."
+        ),
+        (
+            "How to clear it",
+            "Click into an ordinary field in that app, or switch away and back. Quitting it always works."
+        ),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 9) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 12))
+                    .foregroundStyle(Parrot.amber)
+                    .padding(.top, 1)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("\(model.app) has taken the keyboard")
+                        .font(.system(size: 13, weight: .semibold, design: .rounded))
+                        .fixedSize(horizontal: false, vertical: true)
+                    Text("Quit it, or click out of its password field.")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 0)
+            }
+
+            if model.expanded {
+                VStack(alignment: .leading, spacing: 7) {
+                    ForEach(Self.reasons, id: \.0) { reason in
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(reason.0)
+                                .font(.system(size: 11, weight: .semibold, design: .rounded))
+                                .foregroundStyle(Parrot.amber.opacity(0.9))
+                            Text(reason.1)
+                                .font(.system(size: 11.5))
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                }
+                .padding(.leading, 21)
+            }
+
+            HStack(spacing: 8) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.16)) { model.expanded.toggle() }
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 9, weight: .bold))
+                            .rotationEffect(.degrees(model.expanded ? 90 : 0))
+                        Text(model.expanded ? "Less" : "Why")
+                    }
+                    .font(.system(size: 12, weight: .medium, design: .rounded))
+                    .foregroundStyle(.secondary)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+
+                Spacer(minLength: 0)
+
+                Button("Got it") { model.onClose?() }
+                    .font(.system(size: 12, weight: .medium, design: .rounded))
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.primary)
+                    .padding(.horizontal, 11)
+                    .padding(.vertical, 4)
+                    .background {
+                        Capsule().fill(Color.white.opacity(0.12))
+                    }
+            }
+        }
+        .padding(Parrot.panelPadding)
+        .frame(width: KeyboardNoticeMetrics.width, alignment: .leading)
+        .parrotSurface(
+            RoundedRectangle(cornerRadius: Parrot.panelRadius, style: .continuous),
+            solid: true
+        )
+    }
+}

--- a/Sources/ParrotFlow/MicNotice.swift
+++ b/Sources/ParrotFlow/MicNotice.swift
@@ -20,6 +20,10 @@ final class MicNotice {
     private var panel: NSPanel?
     private let model = MicNoticeModel()
 
+    /// Whether it is on screen. Read by whatever would raise a second notice
+    /// into the same corner.
+    var isShowing: Bool { panel?.isVisible == true }
+
     /// The device the last dictation was recorded on, by UID, whether or not
     /// anything was said about it.
     ///

--- a/Sources/ParrotFlow/ModifierKey.swift
+++ b/Sources/ParrotFlow/ModifierKey.swift
@@ -331,9 +331,20 @@ final class ModifierKeyMonitor {
         // is somebody who meant to tap-and-hold and let go too early, and
         // summoning twice for it would be answering a gesture nobody made.
         let wasTap = !wasPressed && !isSpent && !afterTap
+        // Read before `endHold`, which clears it.
+        let isSpent = self.isSpent
         endHold()
         guard !wasPressed else { onRelease?(); return }
-        guard wasTap else { return }
+        guard wasTap else {
+            // A key that went down and up and was neither a dictation nor a
+            // tap. Both reasons are ordinary — a shortcut, or the second half
+            // of a tap-and-hold — and both look from outside like a press that
+            // did nothing, so the log has to be able to tell them apart.
+            Log.write(
+                "key: neither press nor tap — \(isSpent ? "another key joined it" : "it followed a tap")"
+            )
+            return
+        }
         tappedAt = Self.physicalEdge()
         let timer = Timer(timeInterval: Self.tapGrace, repeats: false) { [weak self] _ in
             guard let self else { return }
@@ -350,6 +361,7 @@ final class ModifierKeyMonitor {
             // rather than of `isDown`, which is the poll's view and is exactly
             // what has not caught up yet.
             guard self.key?.isPressed != true || !self.pressIsTheTapsSecondHalf() else {
+                Log.write("key: the tap is the first half of a tap-and-hold")
                 return
             }
             self.onTap?()

--- a/Sources/ParrotFlow/ModifierKey.swift
+++ b/Sources/ParrotFlow/ModifierKey.swift
@@ -439,16 +439,6 @@ final class ModifierKeyMonitor {
     /// late in exactly this way.
     ///
     /// It costs no permission: the age of an event is not the event.
-    /// What to call an event in a log line.
-    private static func name(of event: NSEvent) -> String {
-        switch event.type {
-        case .keyDown: return "a key"
-        case .scrollWheel: return "a scroll"
-        case .rightMouseDown: return "a right click"
-        default: return "a click"
-        }
-    }
-
     private static func physicalEdge() -> Date {
         let age = CGEventSource.secondsSinceLastEventType(
             .combinedSessionState, eventType: .flagsChanged
@@ -457,6 +447,16 @@ final class ModifierKeyMonitor {
         // poll's own clock is then the best available.
         guard age.isFinite, age >= 0, age < 1 else { return Date() }
         return Date().addingTimeInterval(-age)
+    }
+
+    /// What to call an event in a log line.
+    private static func name(of event: NSEvent) -> String {
+        switch event.type {
+        case .keyDown: return "a key"
+        case .scrollWheel: return "a scroll"
+        case .rightMouseDown: return "a right click"
+        default: return "a click"
+        }
     }
 
     /// Whether a key or a click landed between the modifier going down and the

--- a/Sources/ParrotFlow/ModifierKey.swift
+++ b/Sources/ParrotFlow/ModifierKey.swift
@@ -205,6 +205,14 @@ final class ModifierKeyMonitor {
     /// this window says what.
     static let tapGrace: TimeInterval = 0.4
 
+    /// How old the modifier's own down edge can be and still be this press.
+    ///
+    /// The poll runs every 25 ms, so a real edge is milliseconds old. Ten poll
+    /// intervals is room for a main thread that stalled and nothing like the
+    /// seconds a frozen reading comes back with. See
+    /// `sawInputBeforeTheMonitors`.
+    static let edgeIsThisPress: TimeInterval = 0.25
+
     private var key: ModifierKey?
     private var pressDelay: TimeInterval = 0
     /// The key is physically down.
@@ -214,6 +222,10 @@ final class ModifierKeyMonitor {
     /// This hold has been ruled out. Stays set until the key comes up, so a
     /// second key in the same shortcut cannot abort twice.
     private var isSpent = false
+    /// Why the hold above was spent, in the words the log writes it. Set by
+    /// `somethingElseHappened`, read once at the release. Nil until something
+    /// spends one.
+    private var spentBecause: String?
 
     var isMonitoring: Bool { timer != nil }
 
@@ -275,8 +287,9 @@ final class ModifierKeyMonitor {
         }
 
         // Held, and another modifier joined it: a chord, not a dictation.
-        if down, !isSpent, flags & ModifierKey.allDeviceMasks & ~key.mask != 0 {
-            somethingElseHappened()
+        let others = flags & ModifierKey.allDeviceMasks & ~key.mask
+        if down, !isSpent, others != 0 {
+            somethingElseHappened("another modifier is down — flags 0x\(String(others, radix: 16))")
         }
     }
 
@@ -303,8 +316,8 @@ final class ModifierKeyMonitor {
         // the key physically went down. A `⌘S` typed faster than that lands in
         // the gap and is never seen, so the delay would expire on silence and
         // open the mic. Ask the event source about the gap instead.
-        if sawInputBeforeTheMonitors() {
-            somethingElseHappened()
+        if let landed = sawInputBeforeTheMonitors() {
+            somethingElseHappened("\(landed) landed before the monitors were on")
             return
         }
         let timer = Timer(timeInterval: pressDelay, repeats: false) { [weak self] _ in
@@ -341,7 +354,8 @@ final class ModifierKeyMonitor {
             // of a tap-and-hold — and both look from outside like a press that
             // did nothing, so the log has to be able to tell them apart.
             Log.write(
-                "key: neither press nor tap — \(isSpent ? "another key joined it" : "it followed a tap")"
+                "key: neither press nor tap — "
+                + (isSpent ? (spentBecause ?? "something else happened") : "it followed a tap")
             )
             return
         }
@@ -373,8 +387,9 @@ final class ModifierKeyMonitor {
     /// The one path out of a hold that was meant for something else. Delivered
     /// as an abort only if a press went out for it — otherwise the press
     /// simply never happens and there is nothing to tell anyone about.
-    private func somethingElseHappened() {
+    private func somethingElseHappened(_ why: String) {
         guard !isSpent else { return }
+        spentBecause = why
         let wasPressed = pressDelivered
         isSpent = true
         pressDelivered = false
@@ -424,6 +439,16 @@ final class ModifierKeyMonitor {
     /// late in exactly this way.
     ///
     /// It costs no permission: the age of an event is not the event.
+    /// What to call an event in a log line.
+    private static func name(of event: NSEvent) -> String {
+        switch event.type {
+        case .keyDown: return "a key"
+        case .scrollWheel: return "a scroll"
+        case .rightMouseDown: return "a right click"
+        default: return "a click"
+        }
+    }
+
     private static func physicalEdge() -> Date {
         let age = CGEventSource.secondsSinceLastEventType(
             .combinedSessionState, eventType: .flagsChanged
@@ -447,13 +472,41 @@ final class ModifierKeyMonitor {
     /// through this API, and a trackpad flick keeps sending events for about a
     /// second — so asking would abort every dictation started after scrolling a
     /// page. The monitor half still catches scrolls, with the momentum filter.
-    private func sawInputBeforeTheMonitors() -> Bool {
+    ///
+    /// The whole comparison rests on the modifier's own age being this press's
+    /// age, and there is one state where it is not. Secure Event Input — a
+    /// terminal with secure keyboard entry, a password field, an app that
+    /// turned it on and never turned it back off — stops the session source
+    /// recording the keyboard, and the reading freezes. The poll has just seen
+    /// the key go down and this API says the last `flagsChanged` was four
+    /// seconds ago, so every click and keystroke in those four seconds is
+    /// "newer than the modifier" and the press is thrown away as a shortcut.
+    /// Measured on 2026-09-06 with Notion holding secure input: a modifier
+    /// reported 4621 ms old, and roughly every second press refused.
+    ///
+    /// So a stale edge abstains rather than guesses. The poll runs every 25 ms
+    /// and this is called from it, so a real edge is milliseconds old; anything
+    /// past a quarter of a second is the source not talking about this press,
+    /// and the monitors installed a line above are what is left to catch a
+    /// shortcut. `physicalEdge` guards the same reading the same way.
+    private func sawInputBeforeTheMonitors() -> String? {
         func age(_ type: CGEventType) -> CFTimeInterval {
             CGEventSource.secondsSinceLastEventType(.combinedSessionState, eventType: type)
         }
         let modifierWentDown = age(.flagsChanged)
-        let others: [CGEventType] = [.keyDown, .leftMouseDown, .rightMouseDown, .otherMouseDown]
-        return others.contains { age($0) < modifierWentDown }
+        guard modifierWentDown.isFinite, modifierWentDown >= 0,
+              modifierWentDown < Self.edgeIsThisPress else { return nil }
+        let others: [(CGEventType, String)] = [
+            (.keyDown, "a key"), (.leftMouseDown, "a click"),
+            (.rightMouseDown, "a right click"), (.otherMouseDown, "a click"),
+        ]
+        for (type, name) in others where age(type) < modifierWentDown {
+            return String(
+                format: "%@ %.0f ms old against a modifier %.0f ms old",
+                name, age(type) * 1000, modifierWentDown * 1000
+            )
+        }
+        return nil
     }
 
     private func watchForOtherInput() {
@@ -467,7 +520,7 @@ final class ModifierKeyMonitor {
             // and treating it as one would abort a dictation started right
             // after scrolling a page.
             guard event.type != .scrollWheel || event.momentumPhase.isEmpty else { return }
-            self?.somethingElseHappened()
+            self?.somethingElseHappened("\(Self.name(of: event)) arrived while it was held")
         }
         // The global monitor sees events while another app is in front, which
         // is every ordinary dictation. The local one sees them while a panel of

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -33,6 +33,9 @@ enum PanelsCommand {
     /// A Bluetooth headset with a long name, because the notice puts the name
     /// in its first sentence and a short one would not say whether it fits.
     private static let sampleMicName = "Tasmin's AirPods Pro Max"
+    /// A real app that really does this, and a long enough name to show what a
+    /// long one costs the box.
+    private static let sampleKeyboardApp = "Notion Helper (Renderer)"
 
     /// A release body longer than the panel is tall — a heading, two sections,
     /// and two links on every line. Longer on purpose: the pane only scrolls
@@ -258,6 +261,15 @@ enum PanelsCommand {
         micNoticeOpen.mic = sampleMicName
         micNoticeOpen.expanded = true
 
+        // Both states again, and the same argument: the collapsed one is what
+        // you read, the open one is the three questions under it. The app name
+        // is somebody else's and can be any length.
+        let keyboardNotice = KeyboardNoticeModel()
+        keyboardNotice.app = sampleKeyboardApp
+        let keyboardNoticeOpen = KeyboardNoticeModel()
+        keyboardNoticeOpen.app = sampleKeyboardApp
+        keyboardNoticeOpen.expanded = true
+
         let preview = PreviewModel()
         preview.load(
             prompt: "Grammar",
@@ -392,6 +404,14 @@ enum PanelsCommand {
             (AnyView(MicNoticeView().environmentObject(micNoticeOpen)),
              NSSize(width: MicNoticeMetrics.width,
                     height: MicNoticeMetrics.height(expanded: true)), .dark, true),
+            // Beside it, because it is the same object about the other half of
+            // a dictation: the keyboard rather than the microphone.
+            (AnyView(KeyboardNoticeView().environmentObject(keyboardNotice)),
+             NSSize(width: KeyboardNoticeMetrics.width,
+                    height: KeyboardNoticeMetrics.height(expanded: false)), .dark, true),
+            (AnyView(KeyboardNoticeView().environmentObject(keyboardNoticeOpen)),
+             NSSize(width: KeyboardNoticeMetrics.width,
+                    height: KeyboardNoticeMetrics.height(expanded: true)), .dark, true),
             (AnyView(CorrectionView().environmentObject(correction)),
              NSSize(width: CorrectionMetrics.width, height: CorrectionMetrics.height(forRows: correction.rows.count)), .dark, false),
             (AnyView(CorrectionView().environmentObject(rule)),
@@ -562,6 +582,7 @@ enum PanelsCommand {
         let correction = CorrectionPanel()
         let preview = PreviewPanel()
         let micNotice = MicNotice()
+        let keyboardNotice = KeyboardNotice()
         let updatePanel = UpdatePanel()
         var ticker: Timer?
         var setupWindow: NSWindow?
@@ -630,6 +651,10 @@ enum PanelsCommand {
         // machine whose microphone is wired.
         case "microphone":
             micNotice.show(mic: sampleMicName)
+        // Raised for a named app rather than for whatever is really holding
+        // the keyboard, which on a healthy machine is nothing at all.
+        case "keyboard":
+            keyboardNotice.show(app: sampleKeyboardApp)
         // The one surface that is a window rather than a floating panel over
         // the words. Sized from the notes it is given, so a long release is
         // what shows whether it scrolls.
@@ -716,7 +741,7 @@ enum PanelsCommand {
             }
         default:
             print("usage: ParrotFlow --panels <notice|caution|failure|thinking|offer"
-                + "|vocabulary|punctuation|rule|dictation|preview|microphone|pill"
+                + "|vocabulary|punctuation|rule|dictation|preview|microphone|keyboard|pill"
                 + "|update|setup|sequence> [seconds]")
             return 2
         }

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -432,11 +432,8 @@ final class PillHUD {
     /// started again here unless the pointer is on it, which is the one thing
     /// that means you are still deciding.
     func open(_ wanted: Bool, byPointer: Bool = false) {
-        guard case .offer(let commands, let headline, let reading, let was) = model.state
-        else { return }
-        // Off the screen counts as closed — see `isOpen` — so opening it again
-        // has to actually raise it, even though the state already says open.
-        guard was != wanted || (wanted && !model.onScreen) else { return }
+        guard case .offer(let commands, let headline, let reading, let was) = model.state,
+              was != wanted else { return }
         if wanted { openedByPointer = byPointer } else { openedByPointer = false }
         Log.write("pill: the offer \(wanted ? "opened" : "folded")\(byPointer ? ", by the pointer" : "")")
         set(.offer(commands, headline, reading, open: wanted))
@@ -450,16 +447,7 @@ final class PillHUD {
     }
 
     /// Whether what is on screen is an offer, and whether it is unfolded.
-    ///
-    /// On screen is half the question and it used to be left out. Nothing
-    /// clears `state` on the way out — a panel taken off by `hide` keeps saying
-    /// `.offer(open: true)` for as long as nothing replaces it — so a surface
-    /// that had been gone for minutes still answered yes. Two things read this
-    /// and both are about the panel a person can see: whether the next hold is
-    /// an edit instruction, which the open panel's last row promises, and
-    /// whether a tap has a tab to unfold. Neither is true of a panel that is
-    /// not there.
-    var isOpen: Bool { offerIsOpen && model.onScreen }
+    var isOpen: Bool { offerIsOpen }
     private var offerIsOpen: Bool {
         if case .offer(_, _, _, let open) = model.state { return open }
         return false

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -447,7 +447,16 @@ final class PillHUD {
     }
 
     /// Whether what is on screen is an offer, and whether it is unfolded.
-    var isOpen: Bool { offerIsOpen }
+    ///
+    /// On screen is half the question and it used to be left out. Nothing
+    /// clears `state` on the way out — a panel taken off by `hide` keeps saying
+    /// `.offer(open: true)` for as long as nothing replaces it — so a surface
+    /// that had been gone for minutes still answered yes. Two things read this
+    /// and both are about the panel a person can see: whether the next hold is
+    /// an edit instruction, which the open panel's last row promises, and
+    /// whether a tap has a tab to unfold. Neither is true of a panel that is
+    /// not there.
+    var isOpen: Bool { offerIsOpen && model.onScreen }
     private var offerIsOpen: Bool {
         if case .offer(_, _, _, let open) = model.state { return open }
         return false

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -432,8 +432,11 @@ final class PillHUD {
     /// started again here unless the pointer is on it, which is the one thing
     /// that means you are still deciding.
     func open(_ wanted: Bool, byPointer: Bool = false) {
-        guard case .offer(let commands, let headline, let reading, let was) = model.state,
-              was != wanted else { return }
+        guard case .offer(let commands, let headline, let reading, let was) = model.state
+        else { return }
+        // Off the screen counts as closed — see `isOpen` — so opening it again
+        // has to actually raise it, even though the state already says open.
+        guard was != wanted || (wanted && !model.onScreen) else { return }
         if wanted { openedByPointer = byPointer } else { openedByPointer = false }
         Log.write("pill: the offer \(wanted ? "opened" : "folded")\(byPointer ? ", by the pointer" : "")")
         set(.offer(commands, headline, reading, open: wanted))

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -205,7 +205,9 @@ final class PillModel: ObservableObject {
     /// Published rather than worked out in the view, because only `beside` knows
     /// it: the choice is made from how much room is left under the line, which
     /// is a question about the screen and not about the state.
-    @Published var docked: Dock?
+    /// `.free` until the first placement, never nil: the surface has one form
+    /// and the dock says which edge of it touches the line — see `isDocked`.
+    @Published var docked: Dock? = .free
 
     @Published var level: Float = 0
     @Published var elapsed: TimeInterval = 0
@@ -365,7 +367,6 @@ final class PillHUD {
     // MARK: - The states
 
     func recording(icon: NSImage?, label: String? = nil) {
-        inDictation = true
         model.elapsed = 0
         model.level = 0
         model.appIcon = icon
@@ -850,7 +851,6 @@ final class PillHUD {
     private func fadeOut() {
         pendingHide = nil
         pendingDismiss = nil
-        inDictation = false
         pointerHolds = false
         openedByPointer = false
         pendingOpen?.cancel(); pendingOpen = nil
@@ -1211,48 +1211,31 @@ final class PillHUD {
         }
     }
 
-    /// Whether this is the offer's surface rather than the pill's.
-    ///
-    /// The state alone, and it used to ask for an anchor as well. That was
-    /// wrong and it showed: an app that will not say where its caret is — Slack
-    /// gives none at the press and its composer repaints on insert, so the diff
-    /// finds nothing either — got the old floating lozenge with the plumage rim
-    /// on it, and a 165x131 window around a 61x27 tab. Fifty-two points of
-    /// invisible window on every side, taking the mouse, sitting exactly where
-    /// you are typing. That is where "I cannot click on buttons" came from.
-    ///
-    /// The anchor decides *where* the offer goes, not *what it is*. With one it
-    /// hangs off a line and squares the edge that touches it; without one it
-    /// sits at the bottom of the screen with all four corners rounded — see
-    /// `Dock.free`. Either way it is the offer, so it is tinted, it has no rim,
-    /// and its window is the size of the thing you can see.
     /// Whether this is the docked surface rather than the floating capsule.
     ///
-    /// Everything a dictation puts on screen, and nothing else.
+    /// Always, now. The two forms are not two sizes of the same thing, they are
+    /// two objects: the docked one is part of the line it hangs off, and the
+    /// floating one is a black lozenge with the plumage rim turning on it, in
+    /// the middle of the screen. Anything that picks between them makes one
+    /// message come out as two surfaces, and it did — twice.
     ///
-    /// It used to ask for an anchor as well, and that was the offer's old bug
-    /// made twice: an app that will not say where its caret is got the old
-    /// capsule while it listened and the new tab when the words landed, so one
-    /// dictation was two objects again. The anchor decides *where* the surface
-    /// goes — beside the line, or at the bottom of the screen with all four
-    /// corners rounded, see `Dock.free` — never what it is.
+    /// First it asked for an anchor. An app that will not say where its caret
+    /// is — Slack gives none at the press and its composer repaints on insert,
+    /// so the diff finds nothing either — got the floating lozenge, and a
+    /// 165x131 window around a 61x27 tab. Fifty-two points of invisible window
+    /// on every side, taking the mouse, sitting exactly where you are typing.
+    /// That is where "I cannot click on buttons" came from.
     ///
-    /// A recording is always a dictation: there is no other reason the
-    /// microphone is open. Transcribing and a notice are not, so they follow
-    /// the recording through `inDictation`, which is what keeps a download's
-    /// progress and an update notice in the capsule where a sentence fits.
-    private var isDocked: Bool {
-        switch model.state {
-        case .offer, .recording: return true
-        case .working, .notice: return inDictation
-        }
-    }
-
-    /// Whether what is on screen belongs to a dictation.
+    /// Then it asked whether a dictation was on screen. That left every notice
+    /// raised before a recording starts wearing the old lozenge — including the
+    /// one that says the press failed, which is the message most likely to be
+    /// looked at closely.
     ///
-    /// Set when the microphone opens and cleared when the surface goes, so
-    /// every state between those two is the dictation's and wears its shape.
-    private var inDictation = false
+    /// The anchor decides *where* the surface goes, never what it is: with one
+    /// it hangs off a line and squares the edge that touches it, and without
+    /// one it sits at the bottom of the screen with all four corners rounded.
+    /// See `Dock.free`.
+    private var isDocked: Bool { true }
 }
 
 // MARK: - Metrics

--- a/Sources/ParrotFlow/Recorder.swift
+++ b/Sources/ParrotFlow/Recorder.swift
@@ -284,6 +284,11 @@ final class Recorder {
     /// True while an engine is being built on `engineQueue`. Guarded by
     /// `stateLock`.
     private var rebuilding = false
+    /// A graph mismatch the last rebuild did not clear, in the words
+    /// `graphProblem` writes it. Nil when the engine agrees with itself.
+    /// Written by `adopt`, read by `reacquireIfInputMoved`, guarded by
+    /// `stateLock`.
+    private var unfixableGraph: String?
     /// Kept so `deinit` can take it off again — `AudioObjectRemovePropertyListenerBlock`
     /// matches on the block, not on a token.
     private var deviceListListener: AudioObjectPropertyListenerBlock?
@@ -394,6 +399,28 @@ final class Recorder {
         reacquireIfInputMoved()
         try waitForRebuild()
 
+        do {
+            return try openTheMicrophone(config: config)
+        } catch RecorderError.inputMovedWhileStarting {
+            // One more attempt, on the engine that failure has just asked for.
+            // The hardware format can move inside the milliseconds between
+            // being read and being installed against, and the answer to that
+            // is the rebuild that has already started — not a message asking
+            // for the press again, which is this same retry with a step in it
+            // for the person who is already talking.
+            Log.write("the tap did not install; trying once more on a fresh engine")
+            try waitForRebuild()
+            return try openTheMicrophone(config: config)
+        }
+    }
+
+    /// One attempt at opening the microphone: agree on a format, make the file,
+    /// install the tap, run the engine.
+    ///
+    /// Split out of `start` so the whole of it can be tried twice. Everything
+    /// that throws `inputMovedWhileStarting` has already asked for a fresh
+    /// engine on its way out, so the second attempt is made against that one.
+    private func openTheMicrophone(config: Config) throws -> URL {
         var engine = currentEngine()
         var formats = engineFormats(engine)
 
@@ -411,48 +438,34 @@ final class Recorder {
             engine = currentEngine()
             formats = engineFormats(engine)
 
-            let remaining = Self.formatProblem(formats, against: desiredInput().binding)
-            if let remaining, Self.graphProblem(formats) == nil {
-                // Fail open. The engine agrees with itself and disagrees with
-                // the device: the tap will install, and whether it hears
-                // anything is what the counters in `process` are for. A
-                // recording that may be wrong beats refusing to record — but
-                // said out loud, because the whole point of #95 is that this
-                // used to be the silent path.
+            if let remaining = Self.formatProblem(formats, against: desiredInput().binding) {
+                // Fail open, for both shapes of it now. A format that
+                // disagrees with the device installs and may hear nothing,
+                // which is what the counters in `process` are for. A node that
+                // describes itself two ways installs too, at the format
+                // `captureFormat` picks. A recording that may be wrong beats
+                // refusing to record — but said out loud, because the whole
+                // point of #95 is that this used to be the silent path.
                 //
-                // Remembered, because a device whose engine and stream never
-                // agree would otherwise buy a rebuild on every single press,
-                // which is a second bug wearing the first one's clothes.
+                // Remembered, because a machine whose two reads never agree
+                // would otherwise buy a rebuild on every single press, which is
+                // a second bug wearing the first one's clothes. That is exactly
+                // what a mismatch that outlives its rebuild used to do: refuse
+                // the press, ask for another one, and refuse that too.
                 acceptedFormatMismatch = remaining
                 Log.write("after the rebuild, \(remaining) — recording anyway")
                 report("The microphone is not answering as expected.")
             } else {
-                // Either it cleared, or the engine still disagrees with itself.
-                // That second one is never remembered: it is not a device to be
-                // lived with, it is a graph a rebuild has always fixed, and the
-                // press after this one has to be allowed to try again.
                 acceptedFormatMismatch = nil
             }
         }
-        guard formats.tap.sampleRate > 0, formats.tap.channelCount > 0 else {
+        let capture = Self.captureFormat(formats)
+        guard capture.sampleRate > 0, capture.channelCount > 0 else {
             throw RecorderError.noInputDevice
         }
         let inputNode = engine.inputNode
 
-        let url = try openCapture(inputFormat: formats.tap, config: config)
-
-        // The last look, at the one number `installTap` is about to assert on.
-        // The hardware format can move between the check above and this line —
-        // that is a few milliseconds, and settling a Bluetooth link lands
-        // inside them. Re-read rather than trusted, because being wrong here
-        // does not return an error.
-        if let problem = Self.graphProblem(engineFormats(engine)) {
-            Log.write("\(problem) — not installing the tap")
-            teardown()
-            try? FileManager.default.removeItem(at: url)
-            rebuildEngine(because: problem)
-            throw RecorderError.inputMovedWhileStarting
-        }
+        let url = try openCapture(inputFormat: capture, config: config)
 
         // Wrapped, because `installTap` reports this by raising an
         // NSException, which unwinds through the hotkey handler and out of the
@@ -461,7 +474,7 @@ final class Recorder {
         // changed" look like "the app died". The engine is thrown away rather
         // than reused — whatever raised it is in whatever state it was in.
         if let raised = runCatchingObjCExceptions({
-            inputNode.installTap(onBus: 0, bufferSize: 4096, format: formats.tap) { [weak self] buffer, _ in
+            inputNode.installTap(onBus: 0, bufferSize: 4096, format: capture) { [weak self] buffer, _ in
                 self?.process(buffer: buffer)
             }
         }) {
@@ -997,6 +1010,17 @@ final class Recorder {
         // costs nothing: an engine that agrees with itself has no problem to
         // find here.
         guard let problem = Self.graphProblem(engineFormats(engine)) else { return }
+
+        // Not the same mismatch a rebuild has already failed to clear. This is
+        // what ran the app in a circle: a rebuild retires an engine, releasing
+        // that engine ten seconds later posts a configuration change, the
+        // change finds the same mismatch, and it rebuilds again. 40 rebuilds
+        // between 19:02 and 19:17 on 2026-09-06, on a machine sitting idle with
+        // AirPods on it, each one opening the microphone to build a node.
+        stateLock.lock()
+        let known = unfixableGraph
+        stateLock.unlock()
+        guard problem != known else { return }
         rebuildEngine(because: problem)
     }
 
@@ -1004,12 +1028,39 @@ final class Recorder {
         binding?.described ?? "no input device"
     }
 
-    /// Why this engine cannot have a tap installed on it, or nil if it can.
+    /// The format a tap on this engine has to be installed with.
     ///
-    /// Asked of the engine alone, so it holds wherever the device is: a graph
-    /// whose two halves disagree is unusable against every device, including
-    /// the one it is pointing at. `installTap` makes the same comparison and
-    /// answers it by raising an exception, so this has to be asked first.
+    /// The hardware one — `inputNode.inputFormat(forBus:)` — because that is
+    /// the number `installTap` compares against, in so many words: "required
+    /// condition is false: format.sampleRate == inputHWFormat.sampleRate". So
+    /// handing it that format cannot raise, whatever the other half says.
+    ///
+    /// The two are the same number whenever the node agrees with itself, which
+    /// is every settled device, so this changes nothing on the ordinary path.
+    /// It is the disagreement that used to end the press: the tap format was
+    /// handed over, `installTap` asserted on the hardware one, and the answer
+    /// was a message asking for the press again.
+    ///
+    /// The tap format stands in whenever the two agree on the rate, so nothing
+    /// moves on a healthy machine — and when the hardware read is empty, which
+    /// is a node pointing at nothing rather than a node describing itself
+    /// twice. The guard in `openTheMicrophone` is what refuses that.
+    ///
+    /// Not private: `--audio-recovery` installs against it.
+    static func captureFormat(_ formats: EngineFormats) -> AVAudioFormat {
+        guard formats.hardware.sampleRate > 0, formats.hardware.channelCount > 0,
+              formats.hardware.sampleRate != formats.tap.sampleRate else {
+            return formats.tap
+        }
+        return formats.hardware
+    }
+
+    /// Why this engine describes its own input two ways, or nil if it does not.
+    ///
+    /// Asked of the engine alone, so it holds wherever the device is. A rebuild
+    /// is what has always cleared it, and it is worth one — but only one. It is
+    /// no longer a reason to refuse a press: `captureFormat` picks the half
+    /// `installTap` asserts on, so the tap installs either way.
     ///
     /// This is #123. The engine was at 24000 Hz, the device was at 24000 Hz,
     /// every check agreed — and the node's own hardware format had moved when
@@ -1130,6 +1181,12 @@ final class Recorder {
         engine = fresh
         bound = binding
         rebuildCount += 1
+        // Whether the rebuild cleared the graph, recorded on the way past. A
+        // mismatch that survives its own replacement is a machine to be lived
+        // with rather than news, and `reacquireIfInputMoved` stops buying
+        // engines for it. Set on every rebuild, so a device that moves and then
+        // settles gets its chance again.
+        unfixableGraph = Self.graphProblem(engineFormats(fresh))
         stateLock.unlock()
 
         NotificationCenter.default.removeObserver(

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,6 +1,11 @@
 # ParrotFlow configuration
 # Edit and save — changes are picked up automatically. Delete any line to
 # get its default back. `--check-config` says what the file adds up to.
+#
+# Agents: the docs are in the repository, github.com/znat/parrotflow.
+# Start at AGENTS.md — it routes to the page for the job. Every key here is
+# in docs/configuration.md. Validate with the binary, not by reading:
+#   /Applications/ParrotFlow.app/Contents/MacOS/ParrotFlow --check-config
 
 hotkey:
   # A bare modifier (right_option, right_command, right_control, fn, ...) or

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -419,9 +419,11 @@ CoreAudio against the engine: has the input moved. `The engine and its own
 input` is the engine against itself — the two formats it holds for its input
 node, which is the pair `installTap` compares. A microphone can move only that
 pair, and it is the more expensive way to be wrong: a stale binding costs a
-silent clip, while a graph that disagrees with itself makes `installTap` raise
-an exception through the hotkey handler, and the app then answers its menu and
-records nothing until it is restarted. The `This machine` block prints both
+silent clip, while a tap installed at the wrong half of that pair makes
+`installTap` raise an exception through the hotkey handler. The tap now goes on
+at the hardware format, which is the half `installTap` asserts against, so a
+node that describes its input two ways records instead of refusing — it is
+worth one rebuild, and only one. The `This machine` block prints both
 comparisons for whatever is plugged in right now.
 
 You can make a test clip without a microphone at all — `say` writes exactly the


### PR DESCRIPTION
Pressing the hotkey did nothing about half the time, and starting a dictation could refuse twice in a row with "The microphone changed as the recording started — press again". Idle, the app rebuilt its capture engine every ten seconds, forever: 40 rebuilds between 19:02 and 19:17 on 2026-09-06, each one opening the microphone. Three separate causes, each found by putting a log line where there had been a silent `return`. A fourth failure — Escape and the offer's letters going dead — turned out to be another app holding Secure Event Input, which nothing can work around, so the app now names that app and says what to do about it.

Start the review at `Recorder.captureFormat` and `ModifierKey.sawInputBeforeTheMonitors`. Those two are the whole of what a person feels. `KeyboardNotice.swift` is 276 of the 673 added lines and changes no existing behaviour.

`--audio-recovery` goes from 14 checks to 16, and the four under `Capture after a device change` pass again after failing silently for weeks.

<details>
<summary>The microphone refused presses that were going to work, and the refusal ran the app in a circle</summary>

The input node holds two formats for itself: the tap format and its own hardware format. They can disagree for as long as the machine stays as it is — 24000 Hz and 48000 Hz on an idle Mac with AirPods on it. `graphProblem` called that unusable, so a press was refused before anything was tried, and the press after it was refused the same way.

That pair is only ever compared by `installTap`, and its exception names which half it asserts on:

```
required condition is false: format.sampleRate == inputHWFormat.sampleRate
```

So the tap is now installed at the hardware format, which cannot raise, and the check in front of it is gone — it could only ever refuse a press that was going to work. `captureFormat` hands back the tap format whenever the two rates agree, so nothing moves on a healthy machine.

The loop was the same mismatch seen over and over. A rebuild retires the engine it replaced; releasing that engine ten seconds later posts another configuration change; the change found the mismatch and rebuilt again. A mismatch that outlives its own rebuild is now remembered, and every rebuild sets that fresh, so a device that moves and then settles gets its chance again.

Confirmed on a real device change at 21:36 — the RØDE was replaced by the built-in microphone and the two formats came back 44100 and 48000. One rebuild, then it recorded. Under the old code that press was a refusal.

Two new `--audio-recovery` cases cover it: one mismatch buys one engine and not a hundred, and the tap goes on at the hardware format.

</details>

<details>
<summary>The hotkey worked one press in two because a system clock stops ticking under secure input</summary>

A press is held back for `press_delay_seconds` and delivered only if nothing else happened in the window. The cheap half of that test compares two ages from `CGEventSource.secondsSinceLastEventType`: the modifier's own down edge, and the last key or click. Anything newer than the modifier arrived after it, which is what a shortcut looks like.

Secure Event Input stops the session source recording the keyboard, and the reading freezes. The poll saw the key go down 25 ms ago and the API said the last `flagsChanged` was seconds ago, which makes every click and keystroke inside those seconds newer than the modifier. Whether a press survived came down to whether you had touched anything recently.

Measured on 2026-09-06 while another app held secure input:

```
key: neither press nor tap — a click 1121 ms old against a modifier 4621 ms old
key: neither press nor tap — a key 2734 ms old against a modifier 4234 ms old
key: neither press nor tap — a key 1183 ms old against a modifier 2183 ms old
```

A stale edge abstains now. Past a quarter of a second the reading is not about this press, and the monitors installed a line above are what is left to catch a shortcut. `physicalEdge` already guarded the same API the same way.

The same swallowed press was also why tapping the hotkey stopped opening the offer panel: a spent hold is neither a press nor a tap.

</details>

<details>
<summary>Another app can take your keyboard, and until now nothing said which one</summary>

Secure Event Input is the OS promising that no other process sees the keyboard. Escape stops cancelling a dictation and the offer's letters stop running its commands — and pressing one does two wrong things at once, because the command does not run and the letter goes into the document.

No permission gets past it, and none should. What the app can do is name the app holding it, which is the one thing a person needs and cannot get without `ioreg`. On 2026-09-06 Notion held it from some time between 18:59 and 19:19 until it was quit.

So there is a notice, in the same panel and the same corner as the Bluetooth microphone notice, said once per episode:

> **Notion has taken the keyboard**
> Quit it, or click out of its password field.

`Why` opens onto what stops working, why it happens, and the three ways to clear it: click into an ordinary field in that app, switch away and back, or quit it.

The name costs two reads and no permission — `NSRunningApplication` for an app, `proc_pidpath` for a process that is not one. macOS attributes the flag to the responsible app, so a CLI tool that enables it from a terminal is reported as the terminal.

Dictation is untouched by any of this and keeps working: the hotkey reads modifier flags rather than events.

`--panels keyboard` raises the notice, and both its states are on `--panel-sheet`.

</details>

<details>
<summary>The pill had two forms and gave the failure messages the wrong one</summary>

A notice raised during a dictation hung off the line you were typing on. The same message raised by a press that failed came out as a floating black lozenge with the plumage rim turning on it, in the middle of the screen — because the surface picked its form by asking whether a dictation was on screen, and a press that fails never starts one.

There is one form now. The anchor decides where the surface goes and no longer decides what it is: hanging off the line when there is one, and `Dock.free` when there is not, which is the same tint and the same margin with all four corners rounded. Net −17 lines.

</details>

<details>
<summary>Two commits guessed at a cause, and are reverted here rather than dropped</summary>

`pill.isOpen` reads a state nothing clears on the way out, so a panel taken off the screen goes on saying it is open. That is real, and it was never shown to be what anybody reported. The tap that did not open the panel and the hold taken as an edit instruction have one cause between them, and it is the frozen event clock above.

A change nothing scored does not stay, so both are reverted. The log lines they added stayed — those are what found the real cause an hour later.

Every silent exit on those paths now says why it took it: `summon:`, `key:`, `hold: an edit instruction — …`, and four lines in `EditWatch` that say what it is holding and what it had nothing to hand over.

</details>

<details>
<summary>What this does not fix</summary>

Two reports from the same session are still open. Neither has reproduced since these fixes went in, and both now write a line naming the reason instead of nothing:

- A hold after the offer panel closes being taken as an edit instruction.
- A word corrected by hand that never reached the vocabulary panel. The evidence points at the app being restarted between the correction being held and the Return that would have handed it over, but that is not proven.

`KeyboardNoticeMetrics.height(expanded:)` is a fixed 300pt, the way `MicNoticeMetrics` is. The collapsed state has been seen; the expanded one has not.

</details>
