### PR TITLE
fix: a name is not written over the spelling it was corrected from

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -4064,7 +4064,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // two things at once, and both are worth keeping: the first does
             // not live here and the second does.
             if let right = existingTerm(named: back) {
-                try TermUses.record(term: right, said: sentence, span: back)
+                // `written` is the spelling this replaced, which is what lets
+                // the portrait cut a sentence holding both of them.
+                try TermUses.record(
+                    term: right, said: sentence, span: back, heard: written
+                )
                 rebuildPortrait(for: right)
             }
             Log.write(
@@ -5178,7 +5182,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     // The span stays as typed. It has to be the word standing
                     // in the sentence, and the sentence holds what was written.
                     let term = existingTerm(named: rule.corrected) ?? rule.corrected
-                    try TermUses.record(term: term, said: corrected, span: rule.corrected)
+                    try TermUses.record(
+                        term: term, said: corrected, span: rule.corrected,
+                        heard: rule.heard
+                    )
                     rebuildPortrait(for: term)
                 } catch {
                     // A portrait that missed one sentence is worth less than a

--- a/Sources/ParrotFlow/LearnCommand.swift
+++ b/Sources/ParrotFlow/LearnCommand.swift
@@ -30,7 +30,8 @@ enum LearnCommand {
                 // built out of sentences somebody invented behaves differently
                 // from one built out of real dictation.
                 try TermUses.record(
-                    term: corrected, said: sentence, span: corrected, from: .seeded
+                    term: corrected, said: sentence, span: corrected, from: .seeded,
+                    heard: heard
                 )
             } catch {
                 print("! the sentence was not recorded in"

--- a/Sources/ParrotFlow/LearnCommand.swift
+++ b/Sources/ParrotFlow/LearnCommand.swift
@@ -71,7 +71,8 @@ enum LearnCommand {
                 }
                 if said != use.said { cut += 1 }
                 let now = TermUses.Use(
-                    said: said, span: use.span, from: use.from, counter: use.counter
+                    said: said, span: use.span, from: use.from, counter: use.counter,
+                    heard: use.heard
                 )
                 // The custom `==` is on the sentence and the span, so two rows
                 // that narrow to the same sentence collapse into one. The last

--- a/Sources/ParrotFlow/TermPortrait.swift
+++ b/Sources/ParrotFlow/TermPortrait.swift
@@ -317,9 +317,18 @@ actor TermPortrait {
     /// spellings the user actually corrected, not words that look close.
     static func rivals(of term: String, in rows: [TermUses.Use]) -> [String] {
         var out = [term]
-        for row in rows
-        where !out.contains(where: { $0.caseInsensitiveCompare(row.span) == .orderedSame }) {
-            out.append(row.span)
+        func add(_ word: String?) {
+            guard let word, !word.isEmpty,
+                  !out.contains(where: { $0.caseInsensitiveCompare(word) == .orderedSame })
+            else { return }
+            out.append(word)
+        }
+        for row in rows {
+            // The word at the site — a counter's is the ordinary word — and,
+            // on a use, the spelling the correction replaced. The second is
+            // what a term's first correction has, before any counter exists.
+            add(row.span)
+            add(row.heard)
         }
         return out
     }
@@ -543,7 +552,7 @@ actor TermPortrait {
         // sentences it was built from do not move.
         let rule = "\(minimum)/\(counterMinimum)/\(floorMinimum)/cut1"
         let joined = uses
-            .map { "\($0.counter ? "-" : "+")\($0.span)\u{1}\($0.said)" }
+            .map { "\($0.counter ? "-" : "+")\($0.span)\u{1}\($0.said)\u{1}\($0.heard ?? "")" }
             .joined(separator: "\u{2}")
         let mark = rule + "\u{3}" + joined
         let digest = SHA256.hash(data: Data(mark.utf8))

--- a/Sources/ParrotFlow/TermPortrait.swift
+++ b/Sources/ParrotFlow/TermPortrait.swift
@@ -234,7 +234,13 @@ actor TermPortrait {
     /// How this sentence reads, or nil if the term has no portrait yet.
     func read(_ span: String, in sentence: String, as term: String) async throws -> Reading? {
         guard let summary = try await summary(for: term) else { return nil }
-        let vector = try await WordVectors.shared.vector(.around, of: span, in: sentence)
+        // The same cut the portrait was built with. Without it a sentence
+        // holding both spellings scores its own term as context — the shape
+        // that made the portrait grade its own write.
+        let near = Self.context(
+            of: span, in: sentence, cutting: Self.rivals(of: term, in: TermUses.load()[term] ?? [])
+        ) ?? sentence
+        let vector = try await WordVectors.shared.vector(.around, of: span, in: near)
         let own = WordVectors.cosine(vector, summary.centre) / summary.tightness
 
         guard let centre = summary.counterCentre, let tightness = summary.counterTightness,
@@ -291,6 +297,94 @@ actor TermPortrait {
         }
     }
 
+
+    /// A term whose rows all but vanish under the cut. Thrown rather than
+    /// built from what is left: `reads` turns it into "no opinion", which is
+    /// what a term with no readable sentences should say.
+    struct Thin: Error, LocalizedError {
+        let term: String
+        let left: Int
+        var errorDescription: String? {
+            "\(term) has \(left) sentence(s) left once the other spelling is cut"
+        }
+    }
+
+    // MARK: - the other spelling
+
+    /// Every spelling of this term that could stand in one of its sentences:
+    /// the term itself, and the word at the site of each row it has. A
+    /// counter's `span` is the ordinary word, so this set is exact — it is the
+    /// spellings the user actually corrected, not words that look close.
+    static func rivals(of term: String, in rows: [TermUses.Use]) -> [String] {
+        var out = [term]
+        for row in rows
+        where !out.contains(where: { $0.caseInsensitiveCompare(row.span) == .orderedSame }) {
+            out.append(row.span)
+        }
+        return out
+    }
+
+    /// Every whole-word occurrence of `needle`, matched without case.
+    ///
+    /// Without case because a rival opening a sentence is capitalised there and
+    /// not in the row that recorded it. Over-cutting costs a few words of
+    /// context; under-cutting puts the other spelling back in the portrait.
+    private static func places(of needle: String, in text: String) -> [Range<String.Index>] {
+        guard !needle.isEmpty else { return [] }
+        func letter(_ c: Character) -> Bool { c.isLetter || c.isNumber }
+        var out: [Range<String.Index>] = []
+        var from = text.startIndex
+        while let found = text.range(
+            of: needle, options: [.caseInsensitive], range: from ..< text.endIndex
+        ) {
+            let before = found.lowerBound == text.startIndex
+                || !letter(text[text.index(before: found.lowerBound)])
+            let after = found.upperBound == text.endIndex || !letter(text[found.upperBound])
+            if before && after { out.append(found) }
+            guard found.lowerBound < text.endIndex else { break }
+            from = text.index(after: found.lowerBound)
+        }
+        return out
+    }
+
+    /// `said` cut back so no other spelling of the term reaches the span.
+    ///
+    /// "I work with Jimmy and my friend is Jimmie." stores a use of `Jimmie`
+    /// whose context holds a correct `Jimmy`, so the term's own portrait learns
+    /// that `Jimmy` nearby is evidence for writing `Jimmie`. Measured on a
+    /// seeded portrait against a clean row: the contaminated row moved two of
+    /// four sentences, both toward writing the term, and cutting here put all
+    /// four back where the clean row has them.
+    ///
+    /// `nil` when nothing but the span survives the cut. `WordVectors` averages
+    /// every token except the span, so it would have nothing to average and
+    /// would throw — inside the build loop, which costs the whole term its
+    /// portrait rather than the one row.
+    static func clipped(
+        _ said: String, at span: Range<String.Index>, cutting rivals: [String]
+    ) -> String? {
+        var lower = said.startIndex, upper = said.endIndex
+        for rival in rivals {
+            for found in places(of: rival, in: said) where !found.overlaps(span) {
+                if found.upperBound <= span.lowerBound { lower = max(lower, found.upperBound) }
+                if found.lowerBound >= span.upperBound { upper = min(upper, found.lowerBound) }
+            }
+        }
+        guard lower <= span.lowerBound, upper >= span.upperBound else { return nil }
+        let before = said[lower ..< span.lowerBound], after = said[span.upperBound ..< upper]
+        guard before.contains(where: \.isLetter) || after.contains(where: \.isLetter)
+        else { return nil }
+        return String(said[lower ..< upper])
+    }
+
+    /// The text a span should be read from: located in its sentence, then
+    /// everything past another spelling of the term cut away. `nil` only when
+    /// the cut leaves no sentence at all.
+    static func context(of span: String, in said: String, cutting rivals: [String]) -> String? {
+        guard let at = TermUses.occurrence(of: span, in: said) else { return said }
+        return clipped(said, at: at, cutting: rivals)
+    }
+
     // MARK: - building it
 
     func summary(for term: String) async throws -> Summary? {
@@ -330,7 +424,7 @@ actor TermPortrait {
             return try await running.task.value
         }
 
-        let task = Task { try await Self.build(uses, against: counters, fingerprint: mark) }
+        let task = Task { try await Self.build(term: term, uses, against: counters, fingerprint: mark) }
         building[term] = (mark: mark, task: task)
         // Only if it is still ours. A correction arriving mid-build starts its
         // own task under this key, and clearing that one would let a third
@@ -344,14 +438,22 @@ actor TermPortrait {
     }
 
     private static func build(
-        _ uses: [TermUses.Use], against counters: [TermUses.Use], fingerprint mark: String
+        term: String, _ uses: [TermUses.Use], against counters: [TermUses.Use],
+        fingerprint mark: String
     ) async throws -> Summary {
+        let rivals = rivals(of: term, in: uses + counters)
         var vectors: [[Float]] = []
         for use in uses {
+            guard let near = context(of: use.span, in: use.said, cutting: rivals) else {
+                Log.write("portrait: \(term) — \"\(use.said)\" is nothing but the term once"
+                    + " the other spelling is cut, so it is not counted")
+                continue
+            }
             vectors.append(
-                try await WordVectors.shared.vector(.around, of: use.span, in: use.said)
+                try await WordVectors.shared.vector(.around, of: use.span, in: near)
             )
         }
+        guard vectors.count >= minimum else { throw Thin(term: term, left: vectors.count) }
         let (centre, tightness) = middle(of: vectors)
 
         // Built exactly as the positives are, from the ordinary word that
@@ -361,8 +463,13 @@ actor TermPortrait {
         if counters.count >= Self.counterMinimum {
             var against: [[Float]] = []
             for use in counters {
+                guard let near = context(of: use.span, in: use.said, cutting: rivals) else {
+                    Log.write("portrait: \(term) — a counter is nothing but the word once"
+                        + " the other spelling is cut, so it is not counted")
+                    continue
+                }
                 against.append(
-                    try await WordVectors.shared.vector(.around, of: use.span, in: use.said)
+                    try await WordVectors.shared.vector(.around, of: use.span, in: near)
                 )
             }
             let (middleOf, spread) = middle(of: against)
@@ -391,10 +498,10 @@ actor TermPortrait {
             tightness: tightness,
             floor: floor,
             fingerprint: mark,
-            uses: uses.count,
+            uses: vectors.count,
             counterCentre: counterCentre,
             counterTightness: counterTightness,
-            counters: counters.count
+            counters: counterCentre == nil ? 0 : counters.count
         )
     }
 
@@ -434,7 +541,7 @@ actor TermPortrait {
         // its portrait even though it never enters one. The three minimums are
         // in it too: changing one changes what a stored summary means, and the
         // sentences it was built from do not move.
-        let rule = "\(minimum)/\(counterMinimum)/\(floorMinimum)"
+        let rule = "\(minimum)/\(counterMinimum)/\(floorMinimum)/cut1"
         let joined = uses
             .map { "\($0.counter ? "-" : "+")\($0.span)\u{1}\($0.said)" }
             .joined(separator: "\u{2}")

--- a/Sources/ParrotFlow/TermPortrait.swift
+++ b/Sources/ParrotFlow/TermPortrait.swift
@@ -176,7 +176,8 @@ actor TermPortrait {
         /// it has fewer than `counterMinimum` of them.
         var counterCentre: [Float]?
         var counterTightness: Double?
-        /// Counted whether or not there were enough to build a centre.
+        /// How many counters reached that centre. Zero when none was built,
+        /// and short of the stored rows when the cut emptied one.
         var counters: Int
     }
 
@@ -469,6 +470,9 @@ actor TermPortrait {
         // stands at the site rather than from the term.
         var counterCentre: [Float]?
         var counterTightness: Double?
+        // What actually reached the centre. A counter the cut empties is
+        // skipped below, so the stored count would overstate the portrait.
+        var counterRows = 0
         if counters.count >= Self.counterMinimum {
             var against: [[Float]] = []
             for use in counters {
@@ -485,6 +489,7 @@ actor TermPortrait {
             if spread > 0 {
                 counterCentre = middleOf
                 counterTightness = spread
+                counterRows = against.count
             }
         }
 
@@ -510,7 +515,7 @@ actor TermPortrait {
             uses: vectors.count,
             counterCentre: counterCentre,
             counterTightness: counterTightness,
-            counters: counterCentre == nil ? 0 : counters.count
+            counters: counterRows
         )
     }
 

--- a/Sources/ParrotFlow/TermUses.swift
+++ b/Sources/ParrotFlow/TermUses.swift
@@ -40,6 +40,15 @@ enum TermUses {
         /// Three of them under one term and `TermPortrait` builds a second
         /// centre from them, and reads a new sentence against both.
         var counter: Bool = false
+        /// The spelling this correction replaced, when it is known.
+        ///
+        /// A counter's `span` is already the other word, so this is only ever
+        /// set on a use. Without it a term's first correction has no record of
+        /// what was heard anywhere `TermPortrait` can reach — the rendering is
+        /// written to `vocabulary.yaml`, and the portrait has no Config — so a
+        /// sentence holding both spellings could not be cut and taught the term
+        /// backwards. Measured: 0.959 and authorising where the cut gives 0.898.
+        var heard: String?
 
         enum Source: String, Codable {
             /// The correction panel, the spoken command, or `--learn`.
@@ -109,7 +118,8 @@ enum TermUses {
                 let from = (row["from"] as? String).flatMap(Use.Source.init(rawValue:))
                 return Use(
                     said: said, span: span, from: from ?? .correction,
-                    counter: row["counter"] as? Bool ?? false
+                    counter: row["counter"] as? Bool ?? false,
+                    heard: row["heard"] as? String
                 )
             }
             if !uses.isEmpty { out[term] = uses }
@@ -127,7 +137,7 @@ enum TermUses {
     /// the later correction is the one that stands.
     static func record(
         term: String, said: String, span: String, from: Use.Source = .correction,
-        counter: Bool = false
+        counter: Bool = false, heard: String? = nil
     ) throws {
         let sentence = narrowed(said, to: span)
         // A word, not a substring. `contains` alone let `Vercelli` in.
@@ -136,7 +146,14 @@ enum TermUses {
 
         var all = try read()
         var uses = all[term] ?? []
-        let use = Use(said: sentence, span: span, from: from, counter: counter)
+        // Only when it is a different word. `vercel` corrected to `Vercel` is a
+        // capital being fixed and would cut the sentence at the term itself.
+        let other = heard.flatMap {
+            $0.caseInsensitiveCompare(span) == .orderedSame ? nil : $0
+        }
+        let use = Use(
+            said: sentence, span: span, from: from, counter: counter, heard: other
+        )
         if let already = uses.firstIndex(of: use) {
             guard uses[already].counter != counter else { return }
             uses.remove(at: already)
@@ -271,6 +288,9 @@ enum TermUses {
                 lines.append("      span: \(quoted(use.span))")
                 lines.append("      from: \(use.from.rawValue)")
                 if use.counter { lines.append("      counter: true") }
+                if let heard = use.heard, !heard.isEmpty {
+                    lines.append("      heard: \(quoted(heard))")
+                }
             }
         }
         lines.append("")

--- a/Sources/ParrotFlow/TermUses.swift
+++ b/Sources/ParrotFlow/TermUses.swift
@@ -155,7 +155,17 @@ enum TermUses {
             said: sentence, span: span, from: from, counter: counter, heard: other
         )
         if let already = uses.firstIndex(of: use) {
-            guard uses[already].counter != counter else { return }
+            guard uses[already].counter != counter else {
+                // The same row again. Nothing to write unless this correction
+                // carries the replaced spelling and the stored row predates it
+                // — a row written before `heard` existed never gains one
+                // otherwise, and the cut cannot see what it does not hold.
+                guard uses[already].heard == nil, let other else { return }
+                uses[already].heard = other
+                all[term] = uses
+                try write(all)
+                return
+            }
             uses.remove(at: already)
         }
         uses.append(use)


### PR DESCRIPTION
Correcting one spelling of a name, in a sentence that also holds another, taught the name from the wrong half. "I work with Jimmy and my friend is Jimmie." was stored whole as a use of `Jimmie`, so its portrait learned that a correct `Jimmy` nearby is evidence for writing `Jimmie`. On a seeded portrait that single row moved two of four decisions, both toward writing the name over a word that was right.

A stored sentence is now cut at the nearest other spelling on each side, on both the side that builds a portrait and the side that scores a new sentence. There is no setting and no threshold: the spellings to cut at are the ones the user actually corrected.

Start review at `TermPortrait.rivals(of:in:)` — if that set is wrong, everything downstream is. `scripts/check-counter-portrait.sh` is unchanged at 23/24 overall and 20/20 with no error on the held-out set.

<details>
<summary>Why the old behaviour was wrong — the stored side was never windowed</summary>

`SentenceGate.swift:106` windows the sentence being scored to five words either side of the span. `TermPortrait.build` did no such thing: it passed the whole stored `use.said` to `WordVectors`. So the two sides were measured differently, and a stored sentence carrying the other spelling put it straight into the term's centre.

This PR does not add the radius window to the stored side. It cuts at rivals only, so a row with no other spelling in it produces the same vector as before. That keeps the bench result below meaningful — nothing that worked changed.

</details>

<details>
<summary>The cut list is exact, so there is no distance and no threshold</summary>

Three sources, all recorded by the user:

- the term itself
- the `span` of every row the term has — a counter's span **is** the ordinary word, so counters carry their rivals already
- `heard` on a use, the spelling that correction replaced

The third is new, and it is what makes the cut work on a term's **first** correction. Before it, the rival was written to `vocabulary.yaml` as a pronunciation and `TermPortrait` has no Config access, so the spelling was recorded exactly and reachable nowhere the cut could see.

Two details worth checking:

- Matching ignores case. A spelling that opens a sentence is capitalised there and not in the row that recorded it. Over-cutting costs a few words of context; under-cutting puts the other spelling back in the portrait.
- A rival that overlaps the span is skipped. Otherwise `That was Praisy's suggestion` cuts itself, because `\bPraisy\b` matches inside `Praisy's`.
- `heard` is stored only when it differs from the span. `vercel` corrected to `Vercel` is a capital being fixed, and taking it as a rival would cut the sentence at the term.

</details>

<details>
<summary>Measurements — two of four decisions recovered, bench unchanged</summary>

Seeded `Jimmie` portrait, three uses and two counters, only the first row differing:

| sentence | contaminated row | after the cut | clean row |
|---|---|---|---|
| I work with Jimmy on the parser. | authorises | no opinion | no opinion |
| Jimmy brought the cake to the office party. | no opinion | refuses | refuses |
| My colleague Jimmy reviewed the PR. | authorises | authorises | authorises |

The cut row lands within 0.007 of a genuinely clean one, so keeping the row costs nothing against discarding it.

`scripts/check-counter-portrait.sh`, before and after:

```
the comparison — the counters kept
  the 20 held-out cases   20 right   0 wrong   0 quiet
  all 24                  23 right   1 wrong   0 quiet
```

</details>

<details>
<summary>What this does not fix — the cut leaves the rival's own predicate</summary>

The cut removes the other spelling, not the clause it belongs to. On "Je joue avec Eric au basket et avec Erik au tennis." stored as a use of `Erik`, cutting at `Eric` leaves `au basket` attached:

```
                                before   after the cut   ideal clause cut
Je joue avec Eric au basket.    0.959    0.917           0.898
```

All three authorise. The score falls and the wrong write stands. Even a clause-perfect cut removes only one of the two wrong writes on that row — the rest needs a counter, which is what the floor rule has always needed.

Also unfixed: `TermUses.occurrence` returns the **first** whole-word match, so a correction made on the second `Praisy` of `Praisy asked Praisy's team` still builds its window around the first. `Use.span`'s own docstring says the field exists to prevent this, and a string cannot. Storing the occurrence ordinal would fix it.

</details>

<details>
<summary>Review notes — two traps the change had to carry</summary>

**The cache would have hidden all of this.** A portrait is cached under `fingerprint(of:)`, which hashes the rows and not the code. A pure code change serves stale portraits forever. `rule` now carries `/cut1`, and `heard` joins the hashed row.

**`Summary.uses` and `counters` described what was on disk**, not what was built. Wrong the moment a row is skipped.

A row the cut empties is logged and skipped rather than left to throw. That `try` sits inside the build loop, so a throw there costs the term its whole portrait instead of the one row — the same silent-disappearance shape as the `said.contains(span)` filter in `TermUses.read`.

The three `AppDelegate`/`LearnCommand` call sites that now pass `heard` are the ones that already held the replaced spelling and dropped it. The counter call beside them needs nothing: a counter's span is already the other word.

</details>
