### PR TITLE
refactor: the judge is gone, so nothing says it is still there

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -841,7 +841,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// means "not this time" and nothing is remembered.
     ///
     /// Only for what somebody asked for out loud. A `prompt:` stage and the
-    /// vocabulary judge reach the same models on every dictation with nobody
+    /// vocabulary pass reach the same models on every dictation with nobody
     /// asking — see `Pipeline.runPrompt` — and they keep declining in silence.
     private func askForKeyThenRetry(_ error: Error, retry: () -> Void) -> Bool {
         let spec: ModelSpec

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -181,7 +181,7 @@ struct Config: Decodable, Equatable {
         var acoustic: Bool = false
 
         /// How far a decoded word's spelling may sit from a term and still be
-        /// worth a line on the judge's menu. FluidAudio's similarity, where
+        /// worth a line among the readings. FluidAudio's similarity, where
         /// 1.0 is the term written out exactly.
         ///
         /// One of the two numbers that replaced the single floor (F1). That
@@ -208,11 +208,11 @@ struct Config: Decodable, Equatable {
         var decideAbove: Float = 3.0
 
         /// How close a run of words must *sound* to a term before it is worth
-        /// a line on the judge's menu.
+        /// a line among the readings.
         ///
         /// The sound twin of `offerBelow`, on the same metric, and a much
         /// tighter number because it buys much more. Measured over 20891 real
-        /// dictations — see `VocabularyJudge.phonemeParts` for the table.
+        /// dictations — see `VocabularyPass.phonemeParts` for the table.
         /// 0.85 fires 147 times in that whole archive, 33 of them a name this
         /// speaker lost; 0.80 fires 826 times and most of the extra is
         /// `and me` reaching `Andrey`.
@@ -271,7 +271,7 @@ struct Config: Decodable, Equatable {
             /// `Silverstein`; as /sɪlvɚstaɪn/ it also reaches `Silberstein`,
             /// which the decoder writes and nobody wrote down. That is the
             /// only reason this field exists — see
-            /// `VocabularyJudge.phonemeParts`.
+            /// `VocabularyPass.phonemeParts`.
             ///
             /// Write it when the spelling misleads: espeak reads `Preci` as
             /// /pɹɛsaɪ/, "pre-sigh", and no floor rescues that.
@@ -1902,7 +1902,7 @@ struct Config: Decodable, Equatable {
             let name: String
             var transform: String?
             var prompt: String?
-            var caps: VocabularyJudge.Caps?
+            var caps: VocabularyPass.Caps?
             var nearMisses: Bool?
             var bySound: Bool?
             var gate: Bool?
@@ -1971,7 +1971,7 @@ struct Config: Decodable, Equatable {
                 // `- stage: vocabulary` is how it is spelled now that there is
                 // no file to name.
                 if name.caseInsensitiveCompare("vocabulary") == .orderedSame {
-                    var caps = VocabularyJudge.Caps.standard
+                    var caps = VocabularyPass.Caps.standard
                     // Each optional and each on its own: a person raising one
                     // ceiling should not have to restate the rest.
                     if let perSlot = try c.decodeIfPresent(Int.self, forKey: .maxPerSlot) {

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -637,7 +637,7 @@ final class EditWatch {
 
     /// How alike two words sound, on the better of the two ears.
     ///
-    /// Never mixed, the same rule as `VocabularyJudge`: espeak's inventory is
+    /// Never mixed, the same rule as `VocabularyPass`: espeak's inventory is
     /// not the model's, so a score compares two readings from one ear. Zero
     /// when neither answers, and near zero for a term neither can say —
     /// `when` -> `Qwen` scores 0.30. The word lists catch that one, which is

--- a/Sources/ParrotFlow/LearnCommand.swift
+++ b/Sources/ParrotFlow/LearnCommand.swift
@@ -103,7 +103,7 @@ enum LearnCommand {
     ///
     /// `--learn` also seeds a use, but only alongside a `heard:` rendering, so
     /// there was no way to record a genuine use on its own. Passing the term as
-    /// its own rendering is not a workaround: `VocabularyJudge.ruleParts` finds
+    /// its own rendering is not a workaround: `VocabularyPass.ruleParts` finds
     /// a rule substitution by searching for the term, so a self-mapping makes
     /// every correctly spelled occurrence look like something a rule wrote.
     ///

--- a/Sources/ParrotFlow/LowercaseRefusedCommand.swift
+++ b/Sources/ParrotFlow/LowercaseRefusedCommand.swift
@@ -8,7 +8,7 @@ import Foundation
 ///     ParrotFlow --lowercase-refused "Mont Blanc" "We climbed Mont Blanc."
 ///     AS HEARD
 ///
-/// `VocabularyJudge.lowercased` decides this with no model and no audio behind
+/// `VocabularyPass.lowercased` decides this with no model and no audio behind
 /// it. This is the entry point `scripts/check-lowercase-refused.sh` scores, so
 /// the set runs against the shipped function rather than against a copy of it.
 ///
@@ -21,7 +21,7 @@ enum LowercaseRefusedCommand {
             return 2
         }
         let offset = text.distance(from: text.startIndex, to: range.lowerBound)
-        guard let written = VocabularyJudge.lowercased(
+        guard let written = VocabularyPass.lowercased(
             span, in: text, at: offset, terms: terms
         ) else {
             print("AS HEARD")

--- a/Sources/ParrotFlow/Phonemes.swift
+++ b/Sources/ParrotFlow/Phonemes.swift
@@ -20,7 +20,7 @@ import Foundation
 ///
 /// Sound wins at every floor. It is still only a proposer: `praise` and
 /// `Praisy` score 0.76, so the homophone stays for the sentence to settle.
-/// See `VocabularyJudge.phonemeParts` for the floor and what it costs.
+/// See `VocabularyPass.phonemeParts` for the floor and what it costs.
 ///
 /// **espeak-ng runs as a separate process, and that is deliberate.** It is
 /// GPL-3. A separate program invoked over stdin and stdout is not part of this
@@ -198,8 +198,8 @@ enum Phonemes {
     /// Normalised Levenshtein over IPA symbols, times the square root of the
     /// length ratio — `Vocabulary.gluedSimilarity`, with sounds in place of
     /// letters. The same metric on purpose: the floors either side of the
-    /// judge are read against each other, and two numbers that mean different
-    /// things cannot be.
+    /// decision are read against each other, and two numbers that mean
+    /// different things cannot be.
     ///
     /// Checked against the Python that measured the tables above:
     /// `Olama`/`Ollama` 1.00, `praise`/`Praisy` 0.76.

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -47,7 +47,7 @@ struct Pipeline: Equatable, Codable {
         ///
         /// One stage because it was always one algorithm. It was written as
         /// three — `replacements` wrote the exact matches, `fuzzy` caught the
-        /// near ones, `vocabulary` judged them — and the order they had to run
+        /// near ones, `vocabulary` settled them — and the order they had to run
         /// in was enforced by hand, because the three were never independent.
         /// Spoken numbers as digits, in the language its own pass resolves.
         case numbers
@@ -59,7 +59,7 @@ struct Pipeline: Equatable, Codable {
         /// surface, which is why it is not part of `context` — see `InputBox`.
         case input
         /// Every substitution the vocabulary pass made, settled against the
-        /// sentence it stands in — see `VocabularyJudge` and `SentenceGate`.
+        /// sentence it stands in — see `VocabularyPass` and `SentenceGate`.
         /// The pipeline entry is `- vocabulary`. It calls no model.
         case vocabulary
         /// One of the entries in `transforms:`, run over the whole
@@ -134,9 +134,9 @@ struct Pipeline: Equatable, Codable {
         /// Read only so `validate` can refuse it by name. There is no prompt
         /// and no model in that stage, and nothing else looks at this.
         var prompt: String?
-        /// How many places one sentence may offer — see `VocabularyJudge.Caps`.
+        /// How many places one sentence may offer — see `VocabularyPass.Caps`.
         /// Absent on every other stage.
-        var caps: VocabularyJudge.Caps?
+        var caps: VocabularyPass.Caps?
         /// Whether a `heard:` rendering also matches one edit away. Absent
         /// means true.
         ///
@@ -156,7 +156,7 @@ struct Pipeline: Equatable, Codable {
         var nearMisses: Bool?
         /// Written `by_sound:`. Whether words that *sound* like a term are
         /// offered as well as words spelled like one — see
-        /// `VocabularyJudge.phonemeParts`.
+        /// `VocabularyPass.phonemeParts`.
         ///
         /// Its own switch rather than part of `near_misses:`. The two reach
         /// different words (`pressed` by sound, `Praise's` by spelling), they
@@ -168,7 +168,7 @@ struct Pipeline: Equatable, Codable {
         /// false" have to stay tellable apart.
         var bySound: Bool?
         /// Written `gate:`. Whether the two word lists and the slot's part of
-        /// speech may settle a proposal — see `VocabularyJudge.settle`.
+        /// speech may settle a proposal — see `VocabularyPass.settle`.
         ///
         /// `gate: false` leaves every proposal to the sentence gate and to
         /// whatever arrived, which is what the gate was measured against and
@@ -408,7 +408,7 @@ struct Pipeline: Equatable, Codable {
             // The prompt is compiled in. A config still naming a file is
             // refused rather than warned about: a warning leaves a filename in
             // a config doing nothing, and the person who edits that file and
-            // sees the judge behave exactly as before has no way to find out
+            // sees the pass behave exactly as before has no way to find out
             // why. Refusing says it once, at load, where they typed it.
             if let named = step.prompt, !named.isEmpty {
                 problems.append("pipeline: `- vocabulary: \(named)` names a prompt file."
@@ -473,7 +473,7 @@ struct Pipeline: Equatable, Codable {
 
     /// Stages that move the words `vocabulary` is about to talk about.
     ///
-    /// The judge is handed spans the acoustic pass measured on the transcript
+    /// The pass is handed spans the acoustic pass measured on the transcript
     /// as the decoder produced it. A stage that rewrites text moves them, and
     /// the stage then has to re-anchor by searching for the words — which is
     /// the mechanism that put the menu on the wrong `Versailles` (F3, F10).
@@ -484,14 +484,14 @@ struct Pipeline: Equatable, Codable {
     /// The stage reads spans the acoustic pass measured before the pipeline
     /// started, and any edit above it moves them (F10). The exact pass used to
     /// be an exception too, because it ran as a separate `replacements` stage
-    /// and the judge needs the rules to have fired; it is inside this stage
+    /// and the pass needs the rules to have fired; it is inside this stage
     /// now.
     private func vocabularyOrderProblems() -> [String] {
-        guard let judge = stages.firstIndex(of: .vocabulary) else { return [] }
+        guard let pass = stages.firstIndex(of: .vocabulary) else { return [] }
         // `interpret` is the exception. It ran above the whole pipeline until
         // it became a step, so it has always been above this one, and it takes
         // a mark out rather than rewriting a word.
-        let above = steps[..<judge]
+        let above = steps[..<pass]
             .filter { $0.stage.editsText && $0.stage != .interpret }
             .map { Pipeline.namespace(of: $0) }
         guard !above.isEmpty else { return [] }
@@ -1046,10 +1046,10 @@ struct Pipeline: Equatable, Codable {
     /// **Nothing here calls a model.** Every substitution used to be put to a
     /// local model, one KEEP or REVERT each, at about 900 ms a dictation. What
     /// decides now is the two word lists, the slot's part of speech, and the
-    /// two tests that read the sentence — see `VocabularyJudge.settle` and
+    /// two tests that read the sentence — see `VocabularyPass.settle` and
     /// `SentenceGate`. Every place they leave open keeps what arrived.
     ///
-    /// The mechanics are in `VocabularyJudge`. This is the wiring: which
+    /// The mechanics are in `VocabularyPass`. This is the wiring: which
     /// substitutions are gathered, which gates run, and which variables come
     /// back.
     private func settleVocabulary(
@@ -1095,7 +1095,7 @@ struct Pipeline: Equatable, Codable {
             return StageResult(text: text, vars: wrote.merging(vars) { _, new in new })
         }
 
-        let caps = step.caps ?? VocabularyJudge.Caps.standard
+        let caps = step.caps ?? VocabularyPass.Caps.standard
         // Both sources. The acoustic pass proposes with positions; a
         // `replacements` rule publishes none, so its substitutions are found by
         // searching for the term and told apart from the terms the decoder
@@ -1106,7 +1106,7 @@ struct Pipeline: Equatable, Codable {
         // text this stage was handed.
         let rules = exact.changes
         let beforeRules: String? = handed
-        var parts = VocabularyJudge.ruleParts(rules, in: text, before: beforeRules)
+        var parts = VocabularyPass.ruleParts(rules, in: text, before: beforeRules)
 
         // The near misses an exact rule cannot reach. On by default: an exact
         // rule is the narrowest route to a term, and `Praisy`'s list holding
@@ -1116,10 +1116,10 @@ struct Pipeline: Equatable, Codable {
         //
         // Nothing is written here. A near miss becomes one more place for the
         // gates to settle, and a place none of them settles keeps the word
-        // that was heard — see `VocabularyJudge.fuzzyEdits` for what it fires
+        // that was heard — see `VocabularyPass.fuzzyEdits` for what it fires
         // on and what that cost over this speaker's archive.
         if step.nearMisses ?? true {
-            let reached = VocabularyJudge.fuzzyParts(
+            let reached = VocabularyPass.fuzzyParts(
                 in: text, rules: config.vocabularyRules, claimed: parts
             )
             nearMisses = reached.count
@@ -1137,7 +1137,7 @@ struct Pipeline: Equatable, Codable {
         // and what it costs.
         if step.bySound ?? true, Pipeline.language(of: text, config: config) == "en" {
             let askedAt = Date()
-            let heard = await VocabularyJudge.phonemeParts(
+            let heard = await VocabularyPass.phonemeParts(
                 in: text, sounds: config.vocabularySounds, voice: "en-us",
                 language: "en", floor: config.vocabulary.soundBelow, claimed: parts
             )
@@ -1146,7 +1146,7 @@ struct Pipeline: Equatable, Codable {
             parts += heard
         }
 
-        let slots = VocabularyJudge.slots(in: text, from: parts, caps: caps)
+        let slots = VocabularyPass.slots(in: text, from: parts, caps: caps)
         // Two numbers on every run. How many places one sentence offers is the
         // measure of how much this stage is being asked to decide, so it has
         // to be readable before a change that widens what fires, not inferred
@@ -1176,11 +1176,11 @@ struct Pipeline: Equatable, Codable {
         guard !slots.isEmpty else {
             return result(text, ["slots": .int(0)])
         }
-        let changes = VocabularyJudge.changes(in: text, from: slots)
+        let changes = VocabularyPass.changes(in: text, from: slots)
         guard !changes.isEmpty else {
             return result(text, ["slots": .int(slots.count)])
         }
-        let taught = VocabularyJudge.teaching(in: text, changes: changes)
+        let taught = VocabularyPass.teaching(in: text, changes: changes)
 
         // The free gates. A sound proposal gets both rules; a rule
         // substitution gets the two word lists only, and only in the direction
@@ -1196,7 +1196,7 @@ struct Pipeline: Equatable, Codable {
             // settle what they settle and the slot is never asked. Read inside
             // the branch so `gate: false` does not load it either.
             let slot = (step.slotGate ?? true) ? await Vocabulary.shared.slotGate() : nil
-            settled = VocabularyJudge.settle(
+            settled = VocabularyPass.settle(
                 changes, in: text, by: [.sound: .full, .rule: .lists], gate: slot)
         } else {
             settled = [Bool?](repeating: nil, count: changes.count)
@@ -1237,7 +1237,7 @@ struct Pipeline: Equatable, Codable {
         }
 
         // A refused span that glues to the term is the ordinary phrase, so its
-        // capitals go with it — see `VocabularyJudge.lowercased`. A spelling
+        // capitals go with it — see `VocabularyPass.lowercased`. A spelling
         // lesson is exempt: it writes back exactly what was typed.
         var writing = changes
         if step.lowercaseRefused ?? true {
@@ -1250,10 +1250,10 @@ struct Pipeline: Equatable, Codable {
                 // it and the term is a different length.
                 let heard = text.replacingCharacters(in: change.range, with: change.was)
                 let at = text.distance(from: text.startIndex, to: change.range.lowerBound)
-                guard let lower = VocabularyJudge.lowercased(
+                guard let lower = VocabularyPass.lowercased(
                     change.was, in: heard, at: at, terms: terms
                 ) else { continue }
-                writing[index] = VocabularyJudge.Change(
+                writing[index] = VocabularyPass.Change(
                     range: change.range, was: lower, now: change.now,
                     terms: change.terms, standing: change.standing
                 )
@@ -1265,7 +1265,7 @@ struct Pipeline: Equatable, Codable {
         // Each place written the way it was settled, and a place nothing
         // settled left exactly as it already stands: a rule substitution keeps
         // the term it wrote, a sound proposal keeps the word that was heard.
-        let chosen = VocabularyJudge.settling(decided, in: text, changes: writing)
+        let chosen = VocabularyPass.settling(decided, in: text, changes: writing)
         // What the stage undid, in the words it put back. Named `reverted`
         // rather than `kept_as_decoded`: every place on this list is a
         // substitution somebody has to answer for.

--- a/Sources/ParrotFlow/PipelineCommand.swift
+++ b/Sources/ParrotFlow/PipelineCommand.swift
@@ -45,7 +45,7 @@ enum PipelineCommand {
         /// Its own `models:`. Without one `config.llmEnabled` is false and
         /// every stage that asks a model declines — which is right for a
         /// fixture asserting on what a stage *found*, and is why the verdicts
-        /// of the vocabulary judge were untestable from here at all.
+        /// of the vocabulary pass were untestable from here at all.
         var models: [String: ModelSpec] = [:]
 
         enum CodingKeys: String, CodingKey {

--- a/Sources/ParrotFlow/Replacements.swift
+++ b/Sources/ParrotFlow/Replacements.swift
@@ -72,8 +72,8 @@ enum Replacements {
     /// four times did one thing, not four.
     /// - Returns: the rewritten text, how many rules fired, what each one wrote
     ///   — `heard -> written`, joined by `; ` — and the substitutions
-    ///   themselves. The third is for a stage that has to judge the
-    ///   substitutions rather than make them: a judge handed only the finished
+    ///   themselves. The third is for a stage that has to weigh the
+    ///   substitutions rather than make them: a stage handed only the finished
     ///   sentence cannot see what changed in it.
     ///
     ///   The fourth is `protected`: the text this pass actually put in, with
@@ -181,7 +181,7 @@ enum Replacements {
 
     /// Every word in the text, apostrophes included so `Praise's` is one word.
     ///
-    /// Not private: `VocabularyJudge.fuzzyParts` walks the same words, and two
+    /// Not private: `VocabularyPass.fuzzyParts` walks the same words, and two
     /// definitions of "a word" in one transcript is how a span ends up in one
     /// pass and not the other.
     static func wordRanges(in text: String) -> [Range<String.Index>] {

--- a/Sources/ParrotFlow/SentenceGate.swift
+++ b/Sources/ParrotFlow/SentenceGate.swift
@@ -43,7 +43,7 @@ enum SentenceGate {
     /// nothing, the portrait says nothing. The four outcomes above are read the
     /// same way either way, so one half off leaves the other deciding alone.
     static func settle(
-        _ changes: [VocabularyJudge.Change], in text: String, given settled: [Bool?],
+        _ changes: [VocabularyPass.Change], in text: String, given settled: [Bool?],
         floor: Double, slot: Bool = true, portrait: Bool = true
     ) async -> [Bool?] {
         guard slot || portrait else { return settled }

--- a/Sources/ParrotFlow/SlotGate.swift
+++ b/Sources/ParrotFlow/SlotGate.swift
@@ -4,8 +4,9 @@ import NaturalLanguage
 /// Can a name stand where this word stands? Asked of the sentence, not of the
 /// word.
 ///
-/// The judge is a model call of about 900 ms and every proposal the lexical
-/// gate does not settle goes to it. This settles some of them with the masked
+/// A proposal the lexical gate does not settle is left open, and an open
+/// place keeps whatever is already in the text. This settles some of them
+/// with the masked
 /// language model `SlotProbe` reads: one forward pass to see what the slot
 /// wants, and one tag per word only when that pass says a name could go there.
 /// A pass is about 15 ms at sequence length 64, read out and ranked.
@@ -13,7 +14,7 @@ import NaturalLanguage
 /// One rule:
 ///
 ///     the slot refuses a name    decline
-///     anything else              judge
+///     anything else              open
 ///
 /// **Slot POS.** Mask the heard word, take the ten most likely fillers, put
 /// each back in the sentence and tag it. The modal tag is what the slot wants.
@@ -42,13 +43,13 @@ import NaturalLanguage
 ///
 /// Measured over the 50 English cases of `tests/judge-cases.yaml` by
 /// `scripts/check-slot-gate.sh`: 12 applied by the lexical gate, 15 declined
-/// here, 23 left for the judge, and no error of either kind. ModernBERT
+/// here, 23 left open, and no error of either kind. ModernBERT
 /// declined 14 and left 24 on the same set, also with no error.
 @available(macOS 14, *)
 struct SlotGate {
 
     enum Route: String {
-        case decline, judge
+        case decline, open
     }
 
     /// Tags a name cannot stand in.
@@ -69,10 +70,10 @@ struct SlotGate {
     func read(in text: String, at range: Range<String.Index>) throws -> Reading {
         let (words, span) = Self.sentence(around: range, in: text)
         guard !span.isEmpty, span.upperBound <= words.count else {
-            return Reading(tag: "", route: .judge)
+            return Reading(tag: "", route: .open)
         }
         let tag = try wants(words, at: span)
-        return Reading(tag: tag, route: Self.blocks.contains(tag) ? .decline : .judge)
+        return Reading(tag: tag, route: Self.blocks.contains(tag) ? .decline : .open)
     }
 
     // MARK: - Rule 4 and rule 6, the slot's part of speech

--- a/Sources/ParrotFlow/SlotModel.swift
+++ b/Sources/ParrotFlow/SlotModel.swift
@@ -38,7 +38,7 @@ actor SlotModel {
     static let download = ModelDownload(
         id: "slot", name: "mmBERT-small", megabytes: 282, peak: 580,
         group: .language, blocking: false,
-        costOfFailure: "a name the word lists cannot settle is left as heard"
+        costOfFailure: "a name the word lists cannot settle is left as it stands"
     )
 
     private static let repository = "znaat/mmbert-small-coreml"

--- a/Sources/ParrotFlow/SlotModel.swift
+++ b/Sources/ParrotFlow/SlotModel.swift
@@ -38,7 +38,7 @@ actor SlotModel {
     static let download = ModelDownload(
         id: "slot", name: "mmBERT-small", megabytes: 282, peak: 580,
         group: .language, blocking: false,
-        costOfFailure: "the vocabulary gate asks the judge instead"
+        costOfFailure: "a name the word lists cannot settle is left as heard"
     )
 
     private static let repository = "znaat/mmbert-small-coreml"

--- a/Sources/ParrotFlow/SoundCommand.swift
+++ b/Sources/ParrotFlow/SoundCommand.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// `--sound` — scores the vocabulary's sound path: `Phonemes` and
-/// `VocabularyJudge.phonemeParts`.
+/// `VocabularyPass.phonemeParts`.
 ///
 /// Two things are checked and they fail differently.
 ///
@@ -11,7 +11,7 @@ import Foundation
 /// the floor was chosen for a different function.
 ///
 /// The **proposal** cases are the stage: a sentence goes in, the spans it puts
-/// on the judge's menu come out. They cover what the floor is for — `geler`
+/// among the readings come out. They cover what the floor is for — `geler`
 /// reaches `Gelar`, `praise` does not reach `Praisy` — and the two traps that
 /// cost a measurement each: espeak splitting its output on punctuation, and a
 /// narrow window claiming a span a wider one should have.
@@ -118,7 +118,7 @@ enum SoundCommand {
         }
 
         for one in cases {
-            let parts = await VocabularyJudge.phonemeParts(
+            let parts = await VocabularyPass.phonemeParts(
                 in: one.text, sounds: sounds, voice: "en-us", language: "en",
                 floor: 0.85, claimed: []
             )

--- a/Sources/ParrotFlow/TeachingCommand.swift
+++ b/Sources/ParrotFlow/TeachingCommand.swift
@@ -7,7 +7,7 @@ import Foundation
 ///     ParrotFlow --teaching "upload and Versal. Sending the file" Versal
 ///     ASK
 ///
-/// `VocabularyJudge.teaching` decides this with no model, no audio and no
+/// `VocabularyPass.teaching` decides this with no model, no audio and no
 /// config behind it, and what it decides is whether a name is written over the
 /// word a correction is teaching. This is the entry point
 /// `scripts/check-spells-rule.sh` scores, so the set runs against the shipped
@@ -18,10 +18,10 @@ enum TeachingCommand {
             print("not found: \(word)")
             return 2
         }
-        let change = VocabularyJudge.Change(
+        let change = VocabularyPass.Change(
             range: range, was: word, now: word, terms: [], standing: .rule
         )
-        let taught = VocabularyJudge.teaching(in: text, changes: [change])
+        let taught = VocabularyPass.teaching(in: text, changes: [change])
         print(taught[0] ? "REVERT" : "ASK")
         return 0
     }

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -227,7 +227,7 @@ actor Transcriber {
     /// mmBERT-small, 269 MB, read by the vocabulary gate. The gate stands
     /// aside until it is on disk — `SlotModel.isCached` — so no dictation waits
     /// here. It reports progress but never `.failed`: a gate that is not there
-    /// yet is a gate that asks the judge, not a model error.
+    /// yet is a gate that leaves the place open, not a model error.
     func warmSlotModel() {
         guard slotModelFetch == nil else { return }
         slotModelRunning = true
@@ -240,7 +240,7 @@ actor Transcriber {
                 }
             } catch {
                 Log.write("slot model: \(error.localizedDescription);"
-                    + " the vocabulary gate asks the judge until it arrives")
+                    + " the vocabulary pass leaves what it cannot settle as heard")
                 failed = true
             }
             await self.finishSlotModel(failed: failed)

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -240,7 +240,7 @@ actor Transcriber {
                 }
             } catch {
                 Log.write("slot model: \(error.localizedDescription);"
-                    + " the vocabulary pass leaves what it cannot settle as heard")
+                    + " the vocabulary pass leaves what it cannot settle as it stands")
                 failed = true
             }
             await self.finishSlotModel(failed: failed)

--- a/Sources/ParrotFlow/Vocabulary.swift
+++ b/Sources/ParrotFlow/Vocabulary.swift
@@ -175,7 +175,7 @@ actor Vocabulary {
     /// not what it does and not where it is used. It gates `acousticSpans`
     /// only, so it never saw the rescorer's own proposals, the wider spans, or
     /// a `replacements` rule — and a term reaches a menu from all four. The
-    /// menu-level cap is `VocabularyJudge.Caps.perTerm`, which is applied where
+    /// menu-level cap is `VocabularyPass.Caps.perTerm`, which is applied where
     /// the four meet.
     ///
     /// Kept where it is because it is cheaper here: a detection refused now
@@ -224,8 +224,9 @@ actor Vocabulary {
     /// That needs a two-letter term, and there is none.
     ///
     /// The auto-apply path reaches this far less often since `dropsPossessive`
-    /// sends that pair to the judge. It is still what writes the reading the
-    /// judge is offered, which is where the possessive now has to survive.
+    /// leaves that pair open. It is still what writes the reading the
+    /// sentence tests are offered, which is where the possessive has to
+    /// survive.
     static func inflected(_ term: String, like heard: String) -> String {
         guard let (stem, suffix) = possessive(in: heard), !stem.isEmpty,
               gluedSimilarity(stem, term) >= gluedSimilarity(stem + suffix, term)
@@ -267,7 +268,7 @@ actor Vocabulary {
     ///
     /// A rule, not a threshold, and the same rule `dropsPossessive` is. Writing
     /// a name over `wouldn't` changes what the sentence says, in every
-    /// sentence. It routes rather than refuses: the judge reads the sentence.
+    /// sentence. It routes rather than refuses: the sentence tests read it.
     static func dropsApostrophe(heard: String, term: String) -> Bool {
         inner(in: heard) && !inner(in: term)
     }
@@ -306,16 +307,16 @@ actor Vocabulary {
     ///
     /// The rest is the spell-check gate, measured at 38/38 on declines
     /// and 0.00s: never overwrite a real word. Used here as a router rather
-    /// than a filter — a real word is not refused, it is passed to the judge,
-    /// which is the only thing that can read the sentence.
+    /// than a filter — a real word is not refused, it is left open for the
+    /// tests that read the sentence, which no word list can.
     ///
     /// Two word lists have to agree, not one. `Replacements.isRealWord` is a
     /// dictionary and has no first names in it, so `Frederick` looked like a
     /// word nobody uses and "Um not Peter, uh Frederick." was rewritten to
     /// `Redrock` with nothing reading the sentence. `WordPieces` covers that
     /// blind spot and has the opposite one, and it answers `nil` when its list
-    /// is missing — so a broken resource sends the proposal to the judge
-    /// rather than writing it in.
+    /// is missing — so a broken resource leaves the proposal open rather
+    /// than writing it in.
     ///
     /// Two cases the checker gets wrong on its own, both from
     /// `scripts/validate-judge.py`. A run of capitals is accepted as an acronym,
@@ -400,7 +401,7 @@ actor Vocabulary {
     /// True whenever the glued form is the term, which is also true when the
     /// glued form is an ordinary English phrase: `better stack` is `BetterStack`
     /// by this test and a stack that is better in every sentence anybody says.
-    /// `VocabularyJudge.settle` is where that costs nothing and where it does.
+    /// `VocabularyPass.settle` is where that costs nothing and where it does.
     static func glues(heard: String, term: String) -> Bool {
         var heard = heard, term = term
         if let left = possessive(in: heard), let right = possessive(in: term),
@@ -421,7 +422,7 @@ actor Vocabulary {
     /// is letters only, so `Mirza's` is looked up as `Mirzas` — a form neither
     /// list has ever seen, where `Mirza` itself is known to one of them. The
     /// apostrophe walks the proposal straight past both lists: measured on the
-    /// shipped binary, `--word-gate Frederick` says `judge` and
+    /// shipped binary, `--word-gate Frederick` says `open` and
     /// `--word-gate "Frederick's"` said `auto-apply`.
     ///
     /// A rule and not a threshold. "Mirza's thoughts" is not "Mirza thoughts";
@@ -434,7 +435,7 @@ actor Vocabulary {
     /// other way round — the term carries the possessive and the decoded span
     /// does not — and that correction is right. Nothing here fires on it.
     ///
-    /// A contraction reaches the judge too, since `it's` also ends in `'s`.
+    /// A contraction is left open too, since `it's` also ends in `'s`.
     /// That is the safe direction and it is nearly free: a contraction is a
     /// real word, so `unseenWord` was already sending it there.
     static func dropsPossessive(heard: String, term: String) -> Bool {

--- a/Sources/ParrotFlow/VocabularyPass.swift
+++ b/Sources/ParrotFlow/VocabularyPass.swift
@@ -43,7 +43,7 @@ import Foundation
 /// characters out of the ones that need it, and a config that installed the
 /// script without rebuilding the app left the stage silently off. Nothing
 /// crosses a process boundary now, so nothing can be re-derived wrongly.
-enum VocabularyJudge {
+enum VocabularyPass {
 
     /// How many places one sentence may offer, and how many readings each.
     /// Optional stage params, because they are the numbers a person tuning
@@ -278,7 +278,7 @@ enum VocabularyJudge {
                 // with a `vocabulary:` stage and no `replacements` above it —
                 // where a rule pair can still arrive from a scope seeded
                 // elsewhere. It used to be every path with no audio, and that
-                // cost the judge a reading under `vocabulary.acoustic: false`.
+                // cost the pass a reading under `vocabulary.acoustic: false`.
                 // One occurrence is still decidable without it: the rule is in
                 // `changes`, so it fired at least once, and a pre-existing term
                 // would be a second occurrence. More than one and nothing here
@@ -294,7 +294,7 @@ enum VocabularyJudge {
                     }
                 } else if stands.count > 1 {
                     for source in heard {
-                        Log.write("vocabulary judge: \"\(term)\" stands \(stands.count) time(s)"
+                        Log.write("vocabulary pass: \"\(term)\" stands \(stands.count) time(s)"
                             + " and no acoustic pass ran, so which one \"\(source)\" became"
                             + " cannot be told; that reading is not offered")
                     }
@@ -302,7 +302,7 @@ enum VocabularyJudge {
                 continue
             }
             guard let mine = rewritten(heard, term, in: before, became: stands.count) else {
-                Log.write("vocabulary judge: \"\(term)\" stands \(stands.count) time(s) and"
+                Log.write("vocabulary pass: \"\(term)\" stands \(stands.count) time(s) and"
                     + " the transcript before the rules cannot account for that many;"
                     + " not offering \(heard.map { "\"\($0)\"" }.joined(separator: ", ")) back")
                 continue
@@ -397,7 +397,7 @@ enum VocabularyJudge {
         for index in ranked {
             let slot = slots[index]
             guard slot.terms.contains(where: { used[$0, default: 0] < limit }) else {
-                Log.write("vocabulary judge: \"\(text[slot.range])\" is a"
+                Log.write("vocabulary pass: \"\(text[slot.range])\" is a"
                     + " \(slot.terms.joined(separator: "/")) reading past max_per_term"
                     + " \(limit); not offered")
                 continue
@@ -874,7 +874,7 @@ enum VocabularyJudge {
         for slot in slots.sorted(by: { $0.range.lowerBound < $1.range.lowerBound }) {
             guard slot.options.count > 1, slot.options[0] != slot.options[1] else { continue }
             if let last = built.last, slot.range.lowerBound < last.range.upperBound {
-                Log.write("vocabulary judge: \"\(text[slot.range])\" overlaps the place"
+                Log.write("vocabulary pass: \"\(text[slot.range])\" overlaps the place"
                     + " before it; not offered")
                 continue
             }
@@ -1105,7 +1105,7 @@ enum VocabularyJudge {
                 Log.write("vocabulary gate: \"\(change.was)\" -> \"\(change.now)\""
                     + " — the spot wants \(reading.tag), which cannot hold a name; refused")
                 return false
-            case .judge:
+            case .open:
                 return nil
             }
         }

--- a/Sources/ParrotFlow/WordGateCommand.swift
+++ b/Sources/ParrotFlow/WordGateCommand.swift
@@ -5,11 +5,11 @@ import Foundation
 ///     ParrotFlow --word-gate Frederick
 ///     spell      unknown
 ///     wordpiece  known
-///     gate       judge
+///     gate       open
 ///
 /// The two word lists behind `Vocabulary.autoApplies`, and the decision they
 /// reach together. Both verdicts are printed and not just the decision: a word
-/// can reach `judge` from either side, and a set that only read the last line
+/// can reach `open` from either side, and a set that only read the last line
 /// would pass while testing the wrong half. This is the entry point
 /// `scripts/check-word-gate.sh` scores, so the set runs against the shipped
 /// lists rather than a copy of them.
@@ -18,7 +18,7 @@ import Foundation
 ///
 ///     ParrotFlow --word-gate "Mirza's" Mirza
 ///     possessive dropped
-///     gate       judge
+///     gate       open
 ///
 /// One condition of the gate is not about a word at all. A possessive the
 /// heard text carries and the term does not is a question about the sentence,
@@ -28,13 +28,13 @@ import Foundation
 ///
 ///     ParrotFlow --word-gate merge Vercel --in "Go back to main and merge."
 ///     possessive kept
-///     gate       judge
+///     gate       open
 ///     slot       Verb
 ///     route      decline
 ///
 /// `slot` is what the masked slot wants and `route` is where the proposal goes
 /// — see `SlotGate`. Nothing is downloaded: with no cached model the slot reads
-/// `unavailable` and the route is `judge`.
+/// `unavailable` and the route is `open`.
 ///
 /// A span that glues to the term is the one case where the two lines disagree:
 ///
@@ -42,12 +42,12 @@ import Foundation
 ///       "I think Node.js and MongoDB is a much better stack than PHP and MySQL."
 ///     gate       auto-apply (a rule's write is left to the sentence)
 ///     slot       Adverb
-///     route      judge
+///     route      open
 ///
 /// The lists are never asked about a glued span, so the gate really does say
 /// auto-apply. What happens next depends on where the proposal came from, and
 /// that is not something a word and a term can say: a `replacements` rule is
-/// left open by `VocabularyJudge.settle`, and the sound path still writes it.
+/// left open by `VocabularyPass.settle`, and the sound path still writes it.
 /// The route printed is the rule's, since these two arguments carry no audio.
 ///
 /// The slot is still printed and it still decides nothing. `settle` gates a
@@ -64,7 +64,7 @@ enum WordGateCommand {
             guard let sentence, !sentence.isEmpty else { return 0 }
             guard #available(macOS 14, *) else {
                 print("slot       unavailable")
-                print("route      judge")
+                print("route      open")
                 return 0
             }
             printSlot(
@@ -94,7 +94,7 @@ enum WordGateCommand {
         case .some(false): print("wordpiece  unknown")
         case .none:        print("wordpiece  unavailable")
         }
-        print("gate       \(Vocabulary.unseenWord(letters) ? "auto-apply" : "judge")")
+        print("gate       \(Vocabulary.unseenWord(letters) ? "auto-apply" : "open")")
         return 0
     }
 
@@ -112,7 +112,7 @@ enum WordGateCommand {
         let glues = applies && Vocabulary.glues(heard: heard, term: term)
         let verdict = applies
             ? (glues ? "auto-apply (a rule's write is left to the sentence)" : "auto-apply")
-            : "judge"
+            : "open"
         print("gate       \(verdict)")
         // What a rule would do. These arguments carry no audio, so a rule is
         // the proposal this can answer about.
@@ -122,7 +122,7 @@ enum WordGateCommand {
     /// The model tiers, on the proposal the lexical gate did not settle.
     ///
     /// Nothing is downloaded. With no cached model the slot is `unavailable`
-    /// and the route is `judge`, which is what the app does — see
+    /// and the route is `open`, which is what the app does — see
     /// `Vocabulary.slotRoute`.
     @available(macOS 14, *)
     private static func printSlot(
@@ -133,22 +133,22 @@ enum WordGateCommand {
         print("language   \(language)")
         guard language == "en" else {
             print("slot       not english")
-            print("route      judge")
+            print("route      open")
             return
         }
         guard let range = Vocabulary.spans(of: heard, in: sentence).first else {
             print("slot       not found in the sentence")
-            print("route      judge")
+            print("route      open")
             return
         }
         guard let gate = load() else {
             print("slot       unavailable")
-            print("route      judge")
+            print("route      open")
             return
         }
         guard let reading = try? gate.read(in: sentence, at: range) else {
             print("slot       unreadable")
-            print("route      judge")
+            print("route      open")
             return
         }
         print("slot       \(reading.tag.isEmpty ? "untagged" : reading.tag)")
@@ -160,11 +160,11 @@ enum WordGateCommand {
         // above says.
         let route: String
         if glues {
-            route = "judge"
+            route = "open"
         } else if applies {
             route = "apply"
         } else if Vocabulary.dropsPossessive(heard: heard, term: term) {
-            route = "judge"
+            route = "open"
         } else {
             route = reading.route.rawValue
         }

--- a/Sources/ParrotFlow/WordPieces.swift
+++ b/Sources/ParrotFlow/WordPieces.swift
@@ -34,7 +34,7 @@ enum WordPieces {
     /// Three answers, not two, and the third is the point. A missing file that
     /// answered "unknown" would put the gate back exactly where it was — both
     /// lists silent, the proposal written in without asking. `nil` is what
-    /// `Vocabulary.autoApplies` turns into "ask the judge".
+    /// `Vocabulary.autoApplies` turns into "leave it open".
     static func knows(_ word: String) -> Bool? {
         guard let words else { return nil }
         return words.contains(fold(word))

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -113,17 +113,17 @@ question it answers is whether a possessive survives a substitution, and
 `scripts/check-possessive.sh` scores it against `tests/possessive-cases.yaml`.
 
 `--word-gate` asks whether a vocabulary term may be written over this word with
-nothing reading the sentence — `--word-gate Frederick` prints `judge`,
+nothing reading the sentence — `--word-gate Frederick` prints `open`,
 `--word-gate Versal` prints `auto-apply`. Two word lists decide and both have
 to say they have never seen the word: `NSSpellChecker`, which has no first
 names in it, and the whole-word half of a tokenizer vocabulary
 (`data/wordpiece.txt`), which has no rare compounds in it. Both verdicts are
-printed, because a word reaches `judge` from either side. `judge` is the route
+printed, because a word reaches `open` from either side. `open` is the route
 label for "this gate does not settle it"; nothing is asked, and a place nothing
 settles keeps what arrived. No model runs — it is a set lookup.
 
 Name the term as well and the whole gate answers about that pair —
-`--word-gate "Mirza's" Mirza` prints `possessive dropped` and `judge`. One
+`--word-gate "Mirza's" Mirza` prints `possessive dropped` and `open`. One
 condition is not about a word at all: a `'s` the heard text carries and the
 term does not would be taken out of the sentence, so this gate leaves it open.
 `scripts/check-word-gate.sh` scores both forms against
@@ -135,8 +135,8 @@ Name the sentence too — with the term, which the model tiers are about —
 ten fillers put back and tagged; `route` is where the proposal goes. The slot
 only ever declines: a name goes in a `Noun`, `Adjective` or `Pronoun` slot and
 never in a `Verb`, `Adverb` or `Preposition` one, and every other proposal
-reads `judge` — see `SlotGate`. Nothing is downloaded: with no cached slot
-model the slot reads `unavailable` and the route is `judge`.
+reads `open` — see `SlotGate`. Nothing is downloaded: with no cached slot
+model the slot reads `unavailable` and the route is `open`.
 `scripts/check-slot-gate.sh` scores the whole route against
 `tests/judge-cases.yaml`. It needs the 269 MB model, so it is not in
 `make test`.

--- a/scripts/check-lowercase-refused.sh
+++ b/scripts/check-lowercase-refused.sh
@@ -7,7 +7,7 @@
 # `Better Stack` glues to the term `BetterStack`, so the rule writes the term
 # everywhere. When the sentence refuses that place, putting back what the
 # decoder wrote puts back its capitals too — and the decoder wrote them because
-# it thought it was writing a name. `VocabularyJudge.lowercased` is the half
+# it thought it was writing a name. `VocabularyPass.lowercased` is the half
 # that decides, and `AS HEARD` is the half that keeps a real name safe.
 #
 # No model. `NLTagger` and the vocabulary answer this, so it runs in CI and on

--- a/scripts/check-slot-gate.sh
+++ b/scripts/check-slot-gate.sh
@@ -20,7 +20,7 @@
 # code rather than by a list here:
 #
 #   five are French. `Pipeline.language` says so, and the model is English.
-#   four are spelling lessons. `VocabularyJudge.teaching` reverts them with no
+#   four are spelling lessons. `VocabularyPass.teaching` reverts them with no
 #   model, so they are not a routing decision — scripts/check-spells-rule.sh
 #   is where that rule is scored.
 #

--- a/scripts/check-slot-gate.sh
+++ b/scripts/check-slot-gate.sh
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
-# Scores the whole route in front of the judge, against tests/judge-cases.yaml.
+# Scores the route the vocabulary pass takes, against tests/judge-cases.yaml.
 #
 #   scripts/check-slot-gate.sh
 #
 # Four numbers, and the last two are the ones that decide: how many proposals
 # were written without asking, how many were refused without asking, how many
-# still cost a judge call, and how many of the first two were wrong.
+# were left open, and how many of the first two were wrong.
 #
-# The judge is a model call of about 900 ms. Every proposal the free lexical
-# gate does not settle goes to it today. `SlotGate` settles some of them with a
+# A place nobody settles keeps whatever is already in the text, so an open
+# route is a decision by default and not a question asked of anything. `SlotGate` settles some of them with a
 # masked language model — see that file for the rules and their order.
 #
 # Not in `make test` and not in CI: it needs the 269 MB slot model, which
 # CI has no business downloading. Run it by hand after touching `SlotGate`,
 # `Vocabulary.autoApplies` or the tag sets. Nothing is downloaded here either —
-# with no cached model every case routes to `judge` and the run says so.
+# with no cached model every case is left open and the run says so.
 #
 # Nine of the 59 cases are not scored, and both exclusions are made by shipped
 # code rather than by a list here:
@@ -77,11 +77,11 @@ while IFS=$'\x1f' read -r number said heard term expect; do
   case "$route" in
     apply)   applied=$((applied + 1)) ;;
     decline) declined=$((declined + 1)) ;;
-    judge)   asked=$((asked + 1)) ;;
+    open)    asked=$((asked + 1)) ;;
     *)       echo "  ✗ case $number: the binary printed no route"; exit 1 ;;
   esac
 
-  # A route that decided is checked against the label. `judge` is not an
+  # A route that decided is checked against the label. `open` is not an
   # answer, so it can be neither right nor wrong here.
   mark=" "
   if [ "$route" = apply ] && [ "$expect" = decline ]; then
@@ -100,10 +100,10 @@ if [ "$total" -eq 0 ]; then
 fi
 
 printf '  %d scored, %d not (tests/judge-cases.yaml)\n' "$total" "$skipped"
-printf '  applied %d   declined %d   judge %d\n' "$applied" "$declined" "$asked"
+printf '  applied %d   declined %d   open %d\n' "$applied" "$declined" "$asked"
 printf '  wrong applies %d   wrong declines %d\n' "$wrong_apply" "$wrong_decline"
 
 # A wrong apply writes a word nobody said with no menu behind it. A wrong
 # decline loses a name the speaker did say. Neither may be traded for fewer
-# judge calls, so either one fails the run.
+# open places, so either one fails the run.
 [ "$wrong_apply" -eq 0 ] && [ "$wrong_decline" -eq 0 ]

--- a/scripts/check-spells-rule.sh
+++ b/scripts/check-spells-rule.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Scores `VocabularyJudge.teaching` against tests/spells-cases.yaml.
+# Scores `VocabularyPass.teaching` against tests/spells-cases.yaml.
 #
 #   scripts/check-spells-rule.sh
 #

--- a/scripts/check-word-gate.sh
+++ b/scripts/check-word-gate.sh
@@ -9,13 +9,13 @@
 # half of a tokenizer vocabulary, which has no rare compounds in it. Either one
 # alone overwrites a whole class of ordinary word.
 #
-# Both verdicts are checked, not only the decision. A word reaches `judge` from
+# Both verdicts are checked, not only the decision. A word reaches `open` from
 # either side, so a set that read the decision alone would pass with one half
 # broken — `Chloé` in particular, where the accent is the thing under test.
 #
 # A case with a `term` asks the whole gate about that pair instead, and checks
 # the `possessive` verdict beside the decision. Same reason: `Matthew at`
-# reaches `judge` from the glued-compound branch whatever the possessive rule
+# reaches `open` from the glued-compound branch whatever the possessive rule
 # says, so the decision alone would not show the rule firing on the wrong side.
 #
 # The last block is the fail-open case, and it is the reason the lookup answers
@@ -147,9 +147,9 @@ while IFS=$'\x1f' read -r word term spell wordpiece possessive gate; do
     continue
   fi
 
-  # An expected `judge` that came back `auto-apply` is the expensive direction:
+  # An expected `open` that came back `auto-apply` is the expensive direction:
   # a word nobody said, written into the transcript, with no menu behind it.
-  if [ "$gate" = "judge" ] && [ "$got_gate" = "auto-apply" ]; then
+  if [ "$gate" = "open" ] && [ "$got_gate" = "auto-apply" ]; then
     overwrote=$((overwrote + 1))
   fi
   printf '  ✗ %-12s got   %s\n' "$word" "$got_line"
@@ -172,13 +172,13 @@ open_ok=1
 out="$(PARROTFLOW_WORDPIECE=/nonexistent/wordpiece.txt verdicts Versal)"
 got_piece="$(field "$out" wordpiece)"
 got_gate="$(field "$out" gate)"
-if [ "$got_piece" = "unavailable" ] && [ "$got_gate" = "judge" ]; then
+if [ "$got_piece" = "unavailable" ] && [ "$got_gate" = "open" ]; then
   printf '  ✓ %-12s wordpiece %-11s %s\n' "Versal" "$got_piece" "$got_gate"
 else
   open_ok=0
-  printf '  ✗ %-12s got wordpiece %s, gate %s; want unavailable, judge\n' \
+  printf '  ✗ %-12s got wordpiece %s, gate %s; want unavailable, open\n' \
     "Versal" "$got_piece" "$got_gate"
-  echo '    a missing list must send the word to the judge, never auto-apply it'
+  echo '    a missing list must leave the word open, never auto-apply it'
 fi
 
 [ "$pass" = "$total" ] && [ "$open_ok" = 1 ]

--- a/tests/spells-cases.yaml
+++ b/tests/spells-cases.yaml
@@ -1,4 +1,4 @@
-# Spelling-lesson cases for `VocabularyJudge.teaching`.
+# Spelling-lesson cases for `VocabularyPass.teaching`.
 #
 # The rule reverts a substitution whose word sits immediately before "spells".
 # "urza spells mirza" teaches a mapping, and writing the term over the source

--- a/tests/word-gate-cases.yaml
+++ b/tests/word-gate-cases.yaml
@@ -5,7 +5,7 @@
 # `wordpiece` is `WordPieces.knows`: the whole-word half of
 # distilbert-base-uncased's tokenizer vocabulary, in data/wordpiece.txt.
 #
-#   gate: judge       something reads the sentence before the word is replaced
+#   gate: open       something reads the sentence before the word is replaced
 #   gate: auto-apply  the word is replaced, and nothing reads the sentence
 #
 # One `auto-apply` carries a note: a span the term glues to. The lists are
@@ -25,7 +25,7 @@
 # compounds in it. Measured 2026-08-29 against the shipped binary.
 #
 # Scored by `scripts/check-word-gate.sh`. Both verdicts are checked and not
-# only the decision: a word reaches `judge` from either side, and a set that
+# only the decision: a word reaches `open` from either side, and a set that
 # read the decision alone would pass while the half it meant to test was
 # broken.
 
@@ -38,38 +38,38 @@ cases:
   - word: Frederick
     spell: unknown
     wordpiece: known
-    gate: judge
+    gate: open
     why: the name the defect was found on
 
   - word: Sarah
     spell: unknown
     wordpiece: known
-    gate: judge
+    gate: open
 
   - word: Nathan
     spell: unknown
     wordpiece: known
-    gate: judge
+    gate: open
 
   - word: Ahmed
     spell: unknown
     wordpiece: known
-    gate: judge
+    gate: open
 
   - word: Bjorn
     spell: unknown
     wordpiece: known
-    gate: judge
+    gate: open
 
   - word: Xiao
     spell: unknown
     wordpiece: known
-    gate: judge
+    gate: open
 
   - word: Chloé
     spell: unknown
     wordpiece: known
-    gate: judge
+    gate: open
     why: >
       the accent. The tokenizer lowercases and then drops combining marks, and
       folding the query does the same thing, so this is looked up as `chloe`.
@@ -81,32 +81,32 @@ cases:
   - word: subtask
     spell: known
     wordpiece: unknown
-    gate: judge
+    gate: open
 
   - word: repo
     spell: known
     wordpiece: unknown
-    gate: judge
+    gate: open
 
   - word: async
     spell: known
     wordpiece: unknown
-    gate: judge
+    gate: open
 
   - word: rebase
     spell: known
     wordpiece: unknown
-    gate: judge
+    gate: open
 
   - word: tokenizer
     spell: known
     wordpiece: unknown
-    gate: judge
+    gate: open
 
   - word: Mathieu
     spell: known
     wordpiece: unknown
-    gate: judge
+    gate: open
     why: known to the French dictionary, split by an English tokenizer
 
   # --- known to both --------------------------------------------------------
@@ -114,7 +114,7 @@ cases:
   - word: Peter
     spell: known
     wordpiece: known
-    gate: judge
+    gate: open
 
   # --- known to neither, which is what the gate is for ----------------------
   # A word no dictionary and no tokenizer has seen is a mishearing, and the
@@ -162,7 +162,7 @@ cases:
   - word: "Mirza's"
     term: Mirza
     possessive: dropped
-    gate: judge
+    gate: open
     why: >
       "I'm just waiting for Mirza's thoughts about whether it's worth fixing
       the extension" — the case is in tests/judge-cases.yaml as a decline.
@@ -171,13 +171,13 @@ cases:
   - word: "Mirza’s"
     term: Mirza
     possessive: dropped
-    gate: judge
+    gate: open
     why: the typographic apostrophe, which is the one the recogniser writes
 
   - word: "Frederick's"
     term: Redrock
     possessive: dropped
-    gate: judge
+    gate: open
     why: >
       the first block of this file, defeated by one apostrophe. `Frederick`
       goes to the judge because the tokenizer knows it; `Fredericks` is known
@@ -217,10 +217,10 @@ cases:
   - word: "Matthew at"
     term: "Matthieu's"
     possessive: kept
-    gate: judge
+    gate: open
     why: >
       observed live, 2026-08-08. The judge kept "Matthew at" where the speaker
-      said "Matthieu's". `judge` here is the glued-compound branch, which
+      said "Matthieu's". `open` here is the glued-compound branch, which
       decides before the possessive is looked at — so `possessive` is the
       field under test and the decision is not.
 
@@ -251,7 +251,7 @@ cases:
   - word: "wouldn't"
     term: Redcrawl
     possessive: kept
-    gate: judge
+    gate: open
     why: >
       "I wouldn't do that today" — the letters-only form walks past both lists
       the way a possessive does. Writing a name here deletes the negation.
@@ -259,19 +259,19 @@ cases:
   - word: "they're"
     term: Praisy
     possessive: kept
-    gate: judge
+    gate: open
     why: not a possessive, and the apostrophe is doing the same damage
 
   - word: "I've"
     term: Arexvy
     possessive: kept
-    gate: judge
+    gate: open
     why: two letters and an apostrophe, unknown to both lists as `Ive`
 
   - word: "don't"
     term: Redrock
     possessive: kept
-    gate: judge
+    gate: open
     why: >
       one of the five that already reached the judge, because `dont` is a
       word — kept so the fix is not the only thing holding this case
@@ -291,7 +291,7 @@ cases:
   - word: "Sarah's"
     term: "Praisy's"
     possessive: kept
-    gate: judge
+    gate: open
     why: >
       the tokenizer knows `sarah` and nothing knows `sarahs` — an ordinary
       name was being overwritten by the glued form walking past both lists
@@ -299,7 +299,7 @@ cases:
   - word: "Mirza's"
     term: "Praisy's"
     possessive: kept
-    gate: judge
+    gate: open
     why: both lists know `mirza`, neither knows `mirzas`
 
   - word: "Precy's"
@@ -314,7 +314,7 @@ cases:
   - word: "Mirza's"
     term: Mirza
     possessive: dropped
-    gate: judge
+    gate: open
     why: >
       only one side carries it, so nothing is stripped and the possessive rule
       still refuses — "Mirza's thoughts" is not "Mirza thoughts"

--- a/tests/word-gate-cases.yaml
+++ b/tests/word-gate-cases.yaml
@@ -190,7 +190,7 @@ cases:
   #
   # The test cannot tell that from an English phrase whose glued form happens
   # to be a term, and `better stack` is one. So a `replacements` rule that has
-  # already written the term is left open by `VocabularyJudge.settle` and the
+  # already written the term is left open by `VocabularyPass.settle` and the
   # two sentence tests decide it. The sound path, which has written nothing
   # yet, still applies the glue. The note on the `gate` line says which.
 


### PR DESCRIPTION
No model has been asked about a vocabulary proposal for some time. There is no call in the stage, `SentenceGate` says so in its own comment — *"there is no model, and handing a place back with nobody to hand it to is a keep"* — and a day of the dev log carries no line from it. The code went on describing one anyway, in two places a person actually reads.

This renames what was misnamed and corrects what was untrue. No behaviour changes: `check-word-gate` is 35/35 and `check-slot-gate` is applied 12, declined 15, open 23 with no error of either kind, which is the documented baseline.

Start review at the two user-visible strings below — they are the only part that was wrong rather than merely stale. Everything else is a rename.

<details open>
<summary>The app told you a judge existed — twice, where you could see it</summary>

The setup screen's row for the slot model said the cost of it failing to arrive was:

```
costOfFailure: "the vocabulary gate asks the judge instead"
```

and the log said the same until the download landed. Neither was true. With no slot model nothing reads the slot, so a proposal the word lists cannot settle simply keeps what was heard. Both now say that.

</details>

<details>
<summary>Two renames, and why these names and not others</summary>

**`VocabularyJudge` → `VocabularyPass`** (39 uses, 12 files). It never judged anything. It holds `Caps`, `Standing`, `Slot`, `Change`, the three part-finders, `settle` and `settling` — the matching engine. The docs already called it *the vocabulary pass*, 22 times against 3 for *the vocabulary judge*.

**`SlotGate.Route.judge` → `.open`.** It means "nothing settled this, leave it open", which is what `Pipeline` already logs. This was the worst name left: `route: judge`, printed by `--word-gate`, sends a reader hunting for a stage that is not there.

That rawValue escapes into test data, so `scripts/check-slot-gate.sh`, `scripts/check-word-gate.sh` and 35 lines of `tests/word-gate-cases.yaml` move with it. Five `Log.write` lines that opened `"vocabulary judge:"` now open `"vocabulary pass:"`.

</details>

<details>
<summary>What was deliberately kept, so nobody re-files it</summary>

**`tests/judge-cases.yaml` keeps its name.** Three checks that still run read it — `check-slot-gate.sh`, `check-suggest.sh`, `check-spells-rule.sh`. The labels record what a person wanted, not what read them.

**The judge-tuning scripts and `tests/judge-menus.json` stay.** `scripts/gap-signal.py` reads that cache and is explicitly not judge tuning — *"no model call anywhere in this file"* — so deleting the cache would take a working script with it. They are also the record of how those decisions were made, which is not the same thing as a judge.

**Three notices in `Config.swift` keep the word**, because they tell someone with an old config what their old key was called.

</details>

<details>
<summary>How it was checked</summary>

```
swift build -c release        clean
make test                     green
check-word-gate               35/35
check-slot-gate               applied 12  declined 15  open 23  0 wrong either way
```

The audit that drove the sweep: every present-tense claim that a judge runs, in `Sources/` and the check scripts, is gone. What remains matches `judgement`, `judged`, the fixture filename, and the three migration notices above.

</details>
