### PR TITLE
feat: a launch panel says which models are arriving and when you can talk

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -20,6 +20,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let recorder = Recorder()
     private let pill = PillHUD()
     private let permissions = PermissionsWindowController()
+    /// The panel that says what this launch is fetching. See `LaunchPanel`.
+    private let launch = LaunchPanel()
     private let bugReport = BugReportWindow()
 
     private var statusItem: NSStatusItem!
@@ -620,6 +622,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // arrive. The window reports the fetches; it does not own them.
         permissions.onRetryDownloads = { [weak self] in self?.retryDownloads() }
         warmModels()
+
+        // After a grace, not with the fetches. `warmModels` declares every row
+        // as `waiting` and the ones already on disk report `installed` a moment
+        // later, so asking immediately would put a panel up on every launch and
+        // take it down again before it could be read. Long enough for a cached
+        // model to say so, short enough that a real download is still announced
+        // before anybody wonders.
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.launchPanelGraceSeconds) {
+            [weak self] in
+            guard let self else { return }
+            self.launch.showIfNeeded(hotkey: self.hotKeys.binding?.displayName)
+        }
 
 
         warmUpLLM()
@@ -2310,6 +2324,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     ///
     /// The dictation path still calls both. A fetch that fails clears itself,
     /// and the next English dictation is the next chance.
+    /// How long a launch is given to turn out to have nothing to say.
+    private static let launchPanelGraceSeconds: TimeInterval = 0.8
+
     private func warmModels() {
         guard config.transcription.enabled else { return }
         let transcriber = transcriber

--- a/Sources/ParrotFlow/LaunchPanel.swift
+++ b/Sources/ParrotFlow/LaunchPanel.swift
@@ -23,6 +23,9 @@ import SwiftUI
 final class LaunchPanel {
 
     private var panel: NSPanel?
+    private var watch: AnyCancellable?
+    /// Which of the two heights the window is currently built at.
+    private var listing = false
 
     private let downloads: ModelDownloads
 
@@ -51,6 +54,32 @@ final class LaunchPanel {
         // Never key, and never `NSApp.activate`. This opens on its own at
         // login, while somebody is typing into something else.
         panel?.riseIntoView(makeKey: false)
+
+        // The rows come and go, so the panel is two heights and has to be
+        // resized between them. Debounced: a fetch reports every percent, and
+        // a layout pass per percent to find the height has not changed is the
+        // trap `PermissionsWindowController.resizeToContent` fell into first.
+        watch = downloads.objectWillChange
+            .debounce(for: .milliseconds(100), scheduler: DispatchQueue.main)
+            .sink { [weak self] _ in self?.resize() }
+    }
+
+    /// Takes the height this state needs, keeping the panel where it is.
+    ///
+    /// `setContentSize` holds the bottom-left corner, so a panel that grew
+    /// would climb up the screen and one that shrank would sink. Re-centring on
+    /// the old centre keeps it still.
+    private func resize() {
+        guard let panel, panel.isVisible else { return }
+        let wanted = LaunchModel.moment(of: downloads.rows) == .downloading
+        guard wanted != listing else { return }
+        listing = wanted
+        let centre = NSPoint(x: panel.frame.midX, y: panel.frame.midY)
+        let size = LaunchMetrics.windowSize(listing: wanted)
+        panel.setContentSize(size)
+        panel.setFrameOrigin(NSPoint(
+            x: centre.x - size.width / 2, y: centre.y - size.height / 2
+        ))
     }
 
     /// It waits to be dismissed. Nothing takes it down on a timer.
@@ -62,6 +91,7 @@ final class LaunchPanel {
     /// this panel is a person pressing a button, and the button is the receipt
     /// that they read the line above it.
     func dismiss() {
+        watch = nil
         guard let panel, panel.isVisible else { return }
         NSAnimationContext.runAnimationGroup { context in
             context.duration = 0.22
@@ -77,11 +107,8 @@ final class LaunchPanel {
         let hosting = NSHostingView(rootView: LaunchView(onHide: { [weak self] in
             self?.dismiss()
         }).environmentObject(model))
-        hosting.frame = NSRect(
-            x: 0, y: 0,
-            width: LaunchMetrics.width + LaunchMetrics.bleed * 2,
-            height: LaunchMetrics.height + LaunchMetrics.bleed * 2
-        )
+        listing = LaunchModel.moment(of: downloads.rows) == .downloading
+        hosting.frame = NSRect(origin: .zero, size: LaunchMetrics.windowSize(listing: listing))
         hosting.autoresizingMask = [.width, .height]
 
         let panel = NSPanel(
@@ -131,10 +158,25 @@ enum LaunchMetrics {
     /// outside its own window, which drew the edge around the margin rather
     /// than around the glass.
     static let width: CGFloat = 440
-    /// The tallest it gets, which is the downloading state. The content is
-    /// centred in it, so the shorter states do not move the panel.
-    static let height: CGFloat = 400
     static let padding: CGFloat = 30
+
+    /// A list, and a line. The panel is two heights, and the window is resized
+    /// between them.
+    ///
+    /// One fixed height does not work. It was fixed, at what three rows need,
+    /// and a first install declares six: the sentence and the button were
+    /// pushed out of the panel. The list is capped now — see `LaunchModel.shown`
+    /// — and the short states would sit in a mostly empty panel if they were
+    /// held at the tall one.
+    static let listed: CGFloat = 440
+    static let plain: CGFloat = 280
+
+    static func height(listing: Bool) -> CGFloat { listing ? listed : plain }
+
+    /// The window: the surface, plus the margin the material's shadow lands in.
+    static func windowSize(listing: Bool) -> NSSize {
+        NSSize(width: width + bleed * 2, height: height(listing: listing) + bleed * 2)
+    }
     /// Transparent room around the panel. It held the bloom, which has gone;
     /// it is kept because the material casts its own shadow and a window with
     /// no margin clips it square at the edge.
@@ -199,6 +241,17 @@ final class LaunchModel: ObservableObject {
         downloads.rows.filter(\.state.isPending)
     }
 
+    /// At most three rows, in the order the launch declared them.
+    ///
+    /// A first install has six models to fetch and this is a splash, not the
+    /// setup screen's inventory. Three is what the panel is tall enough to
+    /// hold, and the heading above them already carries the total. Declaration
+    /// order rather than most-advanced-first, so a row never overtakes another
+    /// and the list only ever shortens.
+    static let listLimit = 3
+
+    var shown: [ModelDownload] { Array(coming.prefix(Self.listLimit)) }
+
     /// "937 MB", counting only what has not landed.
     var remaining: String? {
         let left = coming.reduce(0.0) { total, row in
@@ -261,7 +314,8 @@ private struct LaunchView: View {
         }
         .frame(
             width: LaunchMetrics.width - LaunchMetrics.padding * 2,
-            height: LaunchMetrics.height - LaunchMetrics.padding * 2
+            height: LaunchMetrics.height(listing: model.moment == .downloading)
+                - LaunchMetrics.padding * 2
         )
         .padding(LaunchMetrics.padding)
         // Nothing is painted over the material: `parrotSurface` skips its own
@@ -345,7 +399,7 @@ private struct LaunchView: View {
                 .frame(maxWidth: .infinity)
                 .padding(.bottom, 16)
 
-            ForEach(model.coming) { row in
+            ForEach(model.shown) { row in
                 LaunchRow(row: row)
             }
 

--- a/Sources/ParrotFlow/LaunchPanel.swift
+++ b/Sources/ParrotFlow/LaunchPanel.swift
@@ -1,0 +1,513 @@
+import AppKit
+import Combine
+import SwiftUI
+
+/// The surface the app puts up while it is getting its models.
+///
+/// It exists because a launch that has work to do says nothing. `warmModels`
+/// starts up to a gigabyte of fetches in the background and reports them into
+/// `ModelDownloads`, and the only place those rows are drawn is the setup
+/// window — which does not open on a launch where both permissions are already
+/// granted. So an upgrade that adds a model downloads it in silence, and the
+/// stages that read it stand aside meanwhile with nothing on screen to say so.
+///
+/// It is deliberately not the setup window. That screen is a list of everything
+/// the app needs and a place to fix what is missing; this one asks nothing and
+/// offers nothing but the door. It says what the app is doing, in the app's own
+/// face, and goes.
+///
+/// Glass rather than the near-black ground the other panels take. Every Mac
+/// that runs ParrotFlow is Apple silicon and every Apple silicon Mac runs
+/// macOS 26, so `ParrotGlass` is the platform material here rather than a
+/// fallback anybody sees. See `ParrotGlass.isPlatform`.
+final class LaunchPanel {
+
+    private var panel: NSPanel?
+
+    private let downloads: ModelDownloads
+
+    /// What the ready line tells you to hold. Nil when nothing bound, and then
+    /// the line is left out rather than naming a key that does nothing.
+    var hotkey: String?
+
+    init(downloads: ModelDownloads = .shared) {
+        self.downloads = downloads
+    }
+
+    /// Shows it only if this launch has something to wait for.
+    ///
+    /// Asked after `warmModels` has declared its rows. A launch with everything
+    /// on disk and in memory has nothing to say and says nothing: no flash, no
+    /// panel that appears and leaves before it can be read.
+    func showIfNeeded(hotkey: String?) {
+        self.hotkey = hotkey
+        guard LaunchModel.moment(of: downloads.rows) != .ready else { return }
+        show()
+    }
+
+    func show() {
+        if panel == nil { build() }
+        position()
+        // Never key, and never `NSApp.activate`. This opens on its own at
+        // login, while somebody is typing into something else.
+        panel?.riseIntoView(makeKey: false)
+    }
+
+    /// It waits to be dismissed. Nothing takes it down on a timer.
+    ///
+    /// The last thing it says is which key to hold, and that is the one
+    /// sentence a first launch exists to deliver. A panel that reached it and
+    /// then faded on its own would deliver it to an empty chair — the moment
+    /// the models land is not the moment somebody is looking. So the end of
+    /// this panel is a person pressing a button, and the button is the receipt
+    /// that they read the line above it.
+    func dismiss() {
+        guard let panel, panel.isVisible else { return }
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.22
+            panel.animator().alphaValue = 0
+        } completionHandler: {
+            panel.orderOut(nil)
+            panel.alphaValue = 1
+        }
+    }
+
+    private func build() {
+        let model = LaunchModel(downloads: downloads, hotkey: hotkey)
+        let hosting = NSHostingView(rootView: LaunchView(onHide: { [weak self] in
+            self?.dismiss()
+        }).environmentObject(model))
+        hosting.frame = NSRect(
+            x: 0, y: 0,
+            width: LaunchMetrics.width + LaunchMetrics.bleed * 2,
+            height: LaunchMetrics.height + LaunchMetrics.bleed * 2
+        )
+        hosting.autoresizingMask = [.width, .height]
+
+        let panel = NSPanel(
+            contentRect: hosting.frame,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.contentView = ParrotGlass.container(
+            hosting, radius: Parrot.panelRadius, inset: LaunchMetrics.bleed,
+            // Lighter than the preview panel's. Nothing here is selected or
+            // read word by word — it is a name, a sentence and three numbers,
+            // and the material's own legibility pass carries them.
+            tint: NSColor.black.withAlphaComponent(0.12)
+        )
+        panel.isFloatingPanel = true
+        panel.level = .floating
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        // The bloom bleeds into the margin, so a window shadow would trace the
+        // blur rather than the panel. Same reason as every other surface here.
+        panel.hasShadow = false
+        panel.hidesOnDeactivate = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.adoptParrotAppearance()
+        self.panel = panel
+    }
+
+    /// Centred, and a little above the middle.
+    ///
+    /// Dead centre puts it over whatever somebody is reading. The optical
+    /// centre is higher than the geometric one anyway, which is where a thing
+    /// that introduces itself belongs.
+    private func position() {
+        guard let panel, let frame = NSScreen.main?.visibleFrame else { return }
+        let size = panel.frame.size
+        panel.setFrameOrigin(NSPoint(
+            x: frame.midX - size.width / 2,
+            y: frame.midY - size.height / 2 + frame.height * 0.08
+        ))
+    }
+}
+
+enum LaunchMetrics {
+    /// The surface, margin included — the same number the window is built at.
+    /// Taking these as the content's size instead put the view 60 points
+    /// outside its own window, which drew the edge around the margin rather
+    /// than around the glass.
+    static let width: CGFloat = 440
+    /// The tallest it gets, which is the downloading state. The content is
+    /// centred in it, so the shorter states do not move the panel.
+    static let height: CGFloat = 400
+    static let padding: CGFloat = 30
+    /// Transparent room around the panel. It held the bloom, which has gone;
+    /// it is kept because the material casts its own shadow and a window with
+    /// no margin clips it square at the edge.
+    static let bleed: CGFloat = 34
+    static let bird: CGFloat = 76
+}
+
+/// What the panel is saying, worked out from the rows the fetches report into.
+///
+/// A class rather than a computed property on the view because the view has to
+/// be handed something that publishes, and `ModelDownloads` publishes rows for
+/// a screen that lists all of them. This is the same rows read as one sentence.
+final class LaunchModel: ObservableObject {
+
+    enum Moment: Equatable {
+        /// Bytes are still arriving. The only state that names anything.
+        case downloading
+        /// They are all here and going into memory.
+        case loading
+        /// Nothing a dictation needs is still coming.
+        case ready
+        /// A model a dictation waits on did not arrive. Named, because the app
+        /// cannot transcribe and a panel that kept saying "getting ready" would
+        /// be lying.
+        case stuck(String)
+    }
+
+    let downloads: ModelDownloads
+    let hotkey: String?
+    private var watch: AnyCancellable?
+
+    init(downloads: ModelDownloads, hotkey: String? = nil) {
+        self.downloads = downloads
+        self.hotkey = hotkey
+        watch = downloads.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+    }
+
+    var moment: Moment { Self.moment(of: downloads.rows) }
+
+    static func moment(of rows: [ModelDownload]) -> Moment {
+        if let stuck = rows.first(where: { $0.blocking && $0.state.hasFailed }) {
+            return .stuck(stuck.name)
+        }
+        if rows.contains(where: { if case .downloading = $0.state { return true }
+                                  if case .waiting = $0.state { return true }
+                                  return false }) {
+            return .downloading
+        }
+        if rows.contains(where: { $0.state == .loading }) { return .loading }
+        return .ready
+    }
+
+    /// The rows worth naming: the ones that are not here yet.
+    ///
+    /// Installed rows are left out rather than ticked. This is not the setup
+    /// screen's inventory — a row that has arrived is not news, and a list that
+    /// only ever grows shorter is easier to read than one that never changes
+    /// length.
+    var coming: [ModelDownload] {
+        downloads.rows.filter(\.state.isPending)
+    }
+
+    /// "937 MB", counting only what has not landed.
+    var remaining: String? {
+        let left = coming.reduce(0.0) { total, row in
+            switch row.state {
+            case .downloading(let percent):
+                return total + Double(row.megabytes) * (1 - Double(percent ?? 0) / 100)
+            // The bytes are already here; what is left is a load, not a
+            // download. Counted whole, a row that had finished downloading kept
+            // its full size in the figure.
+            case .loading, .installed:
+                return total
+            case .waiting, .off, .failed:
+                return total + Double(row.megabytes)
+            }
+        }
+        guard left >= 1 else { return nil }
+        return ModelDownloads.size(megabytes: Int(left.rounded()))
+    }
+}
+
+// MARK: - The panel
+
+private struct LaunchView: View {
+    @EnvironmentObject private var model: LaunchModel
+    let onHide: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            PlumageBird(size: LaunchMetrics.bird)
+
+            // New York. The three the design pass left open were serif,
+            // rounded and wide caps; this is the one surface in the app that is
+            // only the app saying its own name, and nothing else here is set in
+            // a serif.
+            Text(AppVariant.displayName)
+                .font(.system(size: 31, weight: .medium, design: .serif))
+                .foregroundStyle(.white.opacity(0.96))
+                .padding(.top, 16)
+
+            switch model.moment {
+            case .loading:
+                Breath(text: "Loading models")
+            case .ready:
+                ready
+            case .stuck(let name):
+                VStack(spacing: 18) {
+                    Text("\(name) did not arrive. Open Setup… from the menu bar.")
+                        .font(.system(size: 13))
+                        .foregroundStyle(Parrot.scarlet)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.horizontal, 12)
+                    Button("Got it", action: onHide)
+                        .buttonStyle(GlassPill(tinted: true))
+                }
+                .padding(.top, 14)
+            case .downloading:
+                downloading
+            }
+        }
+        .frame(
+            width: LaunchMetrics.width - LaunchMetrics.padding * 2,
+            height: LaunchMetrics.height - LaunchMetrics.padding * 2
+        )
+        .padding(LaunchMetrics.padding)
+        // Nothing is painted over the material: `parrotSurface` skips its own
+        // scrim and sheen where the platform has Liquid Glass.
+        //
+        // `rim: false`, which is the one place this surface parts company with
+        // the pill and the dialogs. The plumage rim is how a hand-drawn dark
+        // panel says where it ends and that it is the app's; Liquid Glass draws
+        // its own edge and lights it, so a turning rim on top is a second
+        // border arguing with the first. What is left is the plain hairline the
+        // rim carried on its inside anyway.
+        // `edge: .clear` as well, so nothing of ours is drawn on the boundary
+        // at all. The material has its own lit edge; a hairline of ours beside
+        // it is a second line a fraction away from the first, which is what a
+        // rendering glitch looks like.
+        //
+        // No bloom either. It is the rim's colours blurred and thrown past the
+        // edge, so with no rim it was a coloured fringe with nothing making it
+        // — warm on one corner, cool on the other, and reading as a halo the
+        // compositor had got wrong.
+        .parrotSurface(
+            RoundedRectangle(cornerRadius: Parrot.panelRadius, style: .continuous),
+            glass: true,
+            rim: false,
+            edge: .clear
+        )
+        .padding(LaunchMetrics.bleed)
+    }
+
+    /// Without a bound key there is nothing to hold, so the line goes rather
+    /// than naming one that does nothing. See `SetupPane.unregisteredHotkey`.
+    @ViewBuilder
+    private var ready: some View {
+        if let hotkey = model.hotkey {
+            VStack(spacing: 18) {
+                HStack(spacing: 7) {
+                    Text("Hold")
+                Text(hotkey)
+                    .font(.system(size: 14, weight: .medium, design: .rounded))
+                    .foregroundStyle(.white.opacity(0.96))
+                    .padding(.horizontal, 9)
+                    .padding(.vertical, 2)
+                    .background(.white.opacity(0.14), in: RoundedRectangle(
+                        cornerRadius: Parrot.fieldRadius, style: .continuous
+                    ))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: Parrot.fieldRadius, style: .continuous)
+                            .strokeBorder(Parrot.action.opacity(0.6), lineWidth: 1.5)
+                    }
+                    Text("to dictate")
+                }
+                .font(.system(size: 14))
+                .foregroundStyle(.white.opacity(0.72))
+
+                Button("Got it", action: onHide)
+                    .buttonStyle(GlassPill(tinted: true))
+            }
+            .padding(.top, 15)
+        } else {
+            VStack(spacing: 18) {
+                Text("Ready")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.white.opacity(0.72))
+                Button("Got it", action: onHide)
+                    .buttonStyle(GlassPill(tinted: true))
+            }
+            .padding(.top, 15)
+        }
+    }
+
+    /// The one state that names the models.
+    ///
+    /// It names them because it is the one that takes minutes, and a wait you
+    /// are given no reason for is longer than the same wait explained. Loading
+    /// takes seconds and says nothing but its own name.
+    private var downloading: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(heading)
+                .font(.system(size: 13))
+                .foregroundStyle(.white.opacity(0.62))
+                .frame(maxWidth: .infinity)
+                .padding(.bottom, 16)
+
+            ForEach(model.coming) { row in
+                LaunchRow(row: row)
+            }
+
+            Text("These models improve your dictation by understanding what you meant.")
+                .font(.system(size: 12.5))
+                .foregroundStyle(.white.opacity(0.6))
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.top, 8)
+
+            HStack {
+                Spacer()
+                Button("Hide", action: onHide)
+                    .buttonStyle(GlassPill())
+            }
+            .padding(.top, 15)
+        }
+        .padding(.top, 22)
+    }
+
+    private var heading: String {
+        let count = model.coming.count
+        let models = count == 1 ? "one model" : "\(count) models"
+        guard let remaining = model.remaining else { return "Downloading \(models)" }
+        return "Downloading \(models) · \(remaining) left"
+    }
+}
+
+/// One model on its way, and how far it has got.
+private struct LaunchRow: View {
+    let row: ModelDownload
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Text(row.name)
+                    .font(.system(size: 14))
+                    .foregroundStyle(.white.opacity(0.9))
+                Spacer(minLength: 8)
+                if let note {
+                    Text(note)
+                        .font(.system(size: 12.5))
+                        .monospacedDigit()
+                        .foregroundStyle(.white.opacity(row.state == .loading ? 0.6 : 0.85))
+                }
+            }
+            GeometryReader { geometry in
+                ZStack(alignment: .leading) {
+                    Capsule().fill(.white.opacity(0.18))
+                    Capsule()
+                        .fill(Parrot.mix(Parrot.sky, .white, 0.35))
+                        .frame(width: geometry.size.width * fraction)
+                }
+            }
+            .frame(height: 2)
+        }
+        .padding(.bottom, 11)
+    }
+
+    private var note: String? {
+        switch row.state {
+        case .downloading(let percent): return percent.map { "\($0)%" }
+        case .loading: return "loading"
+        case .waiting, .installed, .off, .failed: return nil
+        }
+    }
+
+    /// A bar that is full but not ticked is what loading looks like: the bytes
+    /// are all here and the model is not.
+    private var fraction: CGFloat {
+        switch row.state {
+        case .downloading(let percent): return CGFloat(percent ?? 0) / 100
+        case .loading, .installed: return 1
+        case .waiting, .off, .failed: return 0
+        }
+    }
+}
+
+/// A line that breathes, for a wait with no number on it.
+private struct Breath: View {
+    let text: String
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var lit = false
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 14))
+            .foregroundStyle(.white.opacity(lit ? 1 : 0.6))
+            .padding(.top, 14)
+            .onAppear {
+                guard !reduceMotion else { return }
+                withAnimation(.easeInOut(duration: 1.1).repeatForever(autoreverses: true)) {
+                    lit = true
+                }
+            }
+    }
+}
+
+/// The bird at a size no menu bar drawing has.
+///
+/// `Resources/parrot.svg` is the drawing the icons are cut from, and AppKit
+/// renders SVG natively, so it is the one asset that is sharp at 76 points. The
+/// PNGs stop at 72 pixels — 24 points — and are the fallback for a build that
+/// did not copy the drawing in.
+struct PlumageBird: View {
+    var size: CGFloat = 76
+
+    var body: some View {
+        Group {
+            if let drawing {
+                Image(nsImage: drawing)
+                    .resizable()
+                    .interpolation(.high)
+                    .aspectRatio(contentMode: .fit)
+            } else if let solid = NSImage(named: "ParrotSolid") {
+                LinearGradient(
+                    colors: [Parrot.scarlet, Parrot.amber, Parrot.leaf, Parrot.sky],
+                    startPoint: .topLeading, endPoint: .bottomTrailing
+                )
+                .mask {
+                    Image(nsImage: solid)
+                        .resizable()
+                        .interpolation(.high)
+                        .aspectRatio(contentMode: .fit)
+                }
+            }
+        }
+        .frame(width: size * 46 / 68, height: size)
+    }
+
+    private var drawing: NSImage? {
+        guard let url = Bundle.main.url(forResource: "parrot", withExtension: "svg")
+        else { return nil }
+        return NSImage(contentsOf: url)
+    }
+}
+
+/// What `.buttonStyle(.glass)` gives on macOS 26, spelled out here because the
+/// deployment target is 14 and the style is not available below it.
+private struct GlassPill: ButtonStyle {
+    /// The one button on the panel that is being asked for, rather than
+    /// offered. `Glass.regular.tint(_)` is the same idea on macOS 26.
+    var tinted = false
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: tinted ? 13 : 12, weight: tinted ? .medium : .regular))
+            .foregroundStyle(.white.opacity(configuration.isPressed ? 0.6 : 0.92))
+            .padding(.horizontal, tinted ? 20 : 13)
+            .padding(.vertical, tinted ? 7 : 5)
+            .background(fill(pressed: configuration.isPressed), in: Capsule())
+            .overlay {
+                Capsule().strokeBorder(
+                    tinted ? Parrot.action.opacity(0.5) : .white.opacity(0.14),
+                    lineWidth: tinted ? 1 : 0.5
+                )
+            }
+    }
+
+    private func fill(pressed: Bool) -> AnyShapeStyle {
+        guard tinted else {
+            return AnyShapeStyle(Color.white.opacity(pressed ? 0.06 : 0.12))
+        }
+        return AnyShapeStyle(Parrot.action.opacity(pressed ? 0.22 : 0.38))
+    }
+}

--- a/Sources/ParrotFlow/ModelDownloads.swift
+++ b/Sources/ParrotFlow/ModelDownloads.swift
@@ -52,6 +52,14 @@ struct ModelDownload: Identifiable, Equatable {
         case waiting
         /// Nil percent for a fetch that reports no fraction.
         case downloading(percent: Int?)
+        /// The bytes are on disk and the model is going into memory.
+        ///
+        /// Its own state rather than the tail of `downloading`, because the two
+        /// fail differently and take different times: a fetch is minutes and a
+        /// network, a load is seconds and a chip. The stage that reads the model
+        /// stands aside through both, and until this one ends the model is not
+        /// there — which is what made 100% followed by a tick a lie.
+        case loading
         case installed
         case failed(Failure)
         /// A setting turned it off. The string is what the row says instead of
@@ -72,7 +80,7 @@ struct ModelDownload: Identifiable, Equatable {
         /// and the screen says so in its own sentence.
         var isPending: Bool {
             switch self {
-            case .waiting, .downloading: return true
+            case .waiting, .downloading, .loading: return true
             case .installed, .off, .failed: return false
             }
         }
@@ -197,7 +205,7 @@ final class ModelDownloads: ObservableObject {
         return blocking.allSatisfy {
             switch $0.state {
             case .installed, .off: return true
-            case .waiting, .downloading, .failed: return false
+            case .waiting, .downloading, .loading, .failed: return false
             }
         }
     }

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -648,6 +648,7 @@ enum PanelsCommand {
         let updatePanel = UpdatePanel()
         var ticker: Timer?
         var setupWindow: NSWindow?
+        var launchPanel: LaunchPanel?
 
         switch surface {
         case "notice":
@@ -800,6 +801,45 @@ enum PanelsCommand {
                     Transcriber.speechDownload.id, to: .downloading(percent: percent)
                 )
             }
+        // The launch panel, walked through the three things it says: a
+        // download with a number on it, the load after it, and the end. It has
+        // no still worth looking at — the whole point of it is that it moves —
+        // so the preview runs the sequence on a loop rather than parking on one
+        // state. Same reasoning as `sequence` below.
+        case "launch":
+            let downloads = ModelDownloads()
+            downloads.expect(SlotModel.download)
+            downloads.expect(SentenceReadings.download)
+            downloads.expect(WordVectors.download)
+            let coming = [
+                SlotModel.download.id, SentenceReadings.download.id, WordVectors.download.id
+            ]
+            let panel = LaunchPanel(downloads: downloads)
+            launchPanel = panel
+            panel.showIfNeeded(hotkey: "Right ⌥")
+            var percent = 0
+            ticker = Timer.scheduledTimer(withTimeInterval: 0.06, repeats: true) { _ in
+                percent += 1
+                if percent > 190 {
+                    percent = 0
+                    for id in coming { downloads.update(id, to: .waiting) }
+                    panel.showIfNeeded(hotkey: "Right ⌥")
+                    return
+                }
+                // Staggered, the way they really arrive: they start together
+                // and the smallest lands first.
+                for (index, id) in coming.enumerated() {
+                    let share = Double(percent) * (1.0 - Double(index) * 0.22)
+                    if share >= 100 {
+                        // Downloaded is not loaded. Every one of them spends a
+                        // moment here, which is the state this panel was built
+                        // to have a word for.
+                        downloads.update(id, to: share >= 118 ? .installed : .loading)
+                    } else {
+                        downloads.update(id, to: .downloading(percent: Int(share)))
+                    }
+                }
+            }
         case "pill":
             pill.recording(icon: sampleIcon())
             // A meter frozen at zero says nothing about how the meter looks.
@@ -841,13 +881,14 @@ enum PanelsCommand {
         default:
             print("usage: ParrotFlow --panels <notice|caution|failure|thinking|offer"
                 + "|vocabulary|punctuation|rule|dictation|preview|microphone|keyboard|pill|learn|learn-long"
-                + "|update|setup|sequence> [seconds]")
+                + "|update|setup|launch|sequence> [seconds]")
             return 2
         }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + seconds) {
             ticker?.invalidate()
             setupWindow?.close()
+            launchPanel?.dismiss()
             exit(0)
         }
         app.run()

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -807,13 +807,19 @@ enum PanelsCommand {
         // so the preview runs the sequence on a loop rather than parking on one
         // state. Same reasoning as `sequence` below.
         case "launch":
+            // All six, which is what a first install declares. Three of them
+            // are drawn — see `LaunchModel.shown` — and the panel has to be
+            // right at the number it will really be handed, not at the number
+            // that fits.
             let downloads = ModelDownloads()
-            downloads.expect(SlotModel.download)
-            downloads.expect(SentenceReadings.download)
-            downloads.expect(WordVectors.download)
-            let coming = [
-                SlotModel.download.id, SentenceReadings.download.id, WordVectors.download.id
-            ]
+            for row in [
+                Transcriber.speechDownload, Transcriber.voiceDownload,
+                NeuralPhonemes.soundDownload, SlotModel.download,
+                SentenceReadings.download, WordVectors.download
+            ] {
+                downloads.expect(row)
+            }
+            let coming = downloads.rows.map(\.id)
             let panel = LaunchPanel(downloads: downloads)
             launchPanel = panel
             panel.showIfNeeded(hotkey: "Right ⌥")
@@ -829,7 +835,7 @@ enum PanelsCommand {
                 // Staggered, the way they really arrive: they start together
                 // and the smallest lands first.
                 for (index, id) in coming.enumerated() {
-                    let share = Double(percent) * (1.0 - Double(index) * 0.22)
+                    let share = Double(percent) * (1.0 - Double(index) * 0.11)
                     if share >= 100 {
                         // Downloaded is not loaded. Every one of them spends a
                         // moment here, which is the state this panel was built

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -1419,7 +1419,7 @@ private extension ModelDownload {
     var glyph: SetupGlyph {
         switch state {
         case .installed: return .granted
-        case .downloading: return .downloading
+        case .downloading, .loading: return .downloading
         case .waiting: return .queued
         case .off: return .turnedOff
         // Amber for a fetch the app retries by itself, a cross for one that
@@ -1437,6 +1437,7 @@ private extension ModelDownload {
     var note: String? {
         switch state {
         case .downloading(let percent): return percent.map { "\($0)%" }
+        case .loading: return "loading"
         case .off(let reason): return reason
         case .installed, .waiting, .failed: return nil
         }

--- a/Sources/ParrotFlow/SentenceReadings.swift
+++ b/Sources/ParrotFlow/SentenceReadings.swift
@@ -276,6 +276,9 @@ actor SentenceReadings {
         progress: (@Sendable (String) -> Void)?
     ) async throws -> ModelContext {
         try await cache.ensure(progress: progress)
+        // 1.3s of load after the download, with the boundary stage standing
+        // aside throughout. Reported, so the wait has a name.
+        ModelDownloads.report(download.id, .loading)
         let context = try await loadModel(from: cache.directory, using: FolderTokenizer())
         guard context.model is Qwen3Model else {
             throw Failure.notQwen(String(describing: type(of: context.model)))

--- a/Sources/ParrotFlow/SlotModel.swift
+++ b/Sources/ParrotFlow/SlotModel.swift
@@ -157,6 +157,8 @@ actor SlotModel {
         progress: (@Sendable (String) -> Void)?
     ) async throws -> MLModel {
         if isCached {
+            // Compiled and on disk, so this launch only has to open it.
+            ModelDownloads.report(download.id, .loading)
             do { return try load() } catch {
                 Log.write(
                     "slot model: the cached copy will not load"
@@ -165,6 +167,9 @@ actor SlotModel {
             }
         }
         try await underLock { try await fetch(progress: progress) }
+        // The compile is the long half of this one — the .mlpackage is built
+        // and then deleted — and it happens inside `load`.
+        ModelDownloads.report(download.id, .loading)
         return try load()
     }
 

--- a/Sources/ParrotFlow/WordVectors.swift
+++ b/Sources/ParrotFlow/WordVectors.swift
@@ -143,6 +143,10 @@ actor WordVectors {
         progress: (@Sendable (String) -> Void)?
     ) async throws -> ModelContext {
         try await cache.ensure(progress: progress)
+        // The bytes are here and the model is not. A 4-bit 0.6B takes a couple
+        // of seconds to come up and the sentence gate stands aside for all of
+        // it — see `SentenceGate.settle`.
+        ModelDownloads.report(download.id, .loading)
         let context = try await loadModel(from: cache.directory, using: FolderTokenizer())
         guard context.model is Qwen3Model else {
             throw Failure.notQwen(String(describing: type(of: context.model)))

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -48,6 +48,9 @@ cp "$ROOT/Resources/AppIcon.icns" "$APP/Contents/Resources/"
 # an accident.
 cp "$ROOT"/Resources/MenuBarParrot*.png "$APP/Contents/Resources/"
 cp "$ROOT"/Resources/ParrotSolid*.png "$APP/Contents/Resources/"
+# The drawing itself, not a cut of it. AppKit renders SVG, and the launch panel
+# draws the bird at 76 points — three times the largest PNG here.
+cp "$ROOT/Resources/parrot.svg" "$APP/Contents/Resources/"
 
 # The shipped transforms and the default config.yaml are seeded from here —
 # copied, not baked into the binary as strings, so there is one copy of each


### PR DESCRIPTION
A launch with work to do said nothing. `warmModels` starts up to 1.47 GB of fetches and reports them into `ModelDownloads`, and the only screen that draws those rows is the setup window — which does not open when both permissions are already granted. So an upgrade that adds models downloads them in silence, and the stages that read them stand aside meanwhile with nothing on screen to say so.

This adds `LaunchPanel`: it opens 0.8s after the fetches are declared, and only if something is still coming. It names the models while bytes are arriving, says "Loading models" while they go into memory, and ends on the key to hold. It waits to be dismissed rather than fading on a timer.

`ModelDownload.State` gains a `loading` case, reported by the three models that fetch and load in two steps. A row no longer goes from 100% straight to a tick while the model is not yet in memory — the setup screen gets that too.

Start the review at `LaunchPanel.swift`. Everything else is small. Run `--panels launch` to see it: it loops the whole sequence.

<details>
<summary>The panel is Liquid Glass, and it is the first surface here with no rim and no bloom</summary>

`ParrotGlass` has wrapped `NSGlassEffectView` since the pill adopted it, with an `NSVisualEffectView` fallback below macOS 26. That fallback serves no hardware: every Mac that runs ParrotFlow is Apple silicon (`README.md:32`, and `docs/setup.md:60` checks `uname -m`), and every Apple silicon Mac runs macOS 26. It is reachable only by someone on an M-series Mac who has not updated.

So this panel takes the platform material, and `parrotSurface(glass:)` is on a call site again for the first time — section 6 of `docs/proposals/hud-placement-and-offer.md` kept that path alive for exactly this surface.

It passes `rim: false, edge: .clear`, which no other surface does:

- The plumage rim is how a hand-drawn dark panel says where it ends and that it belongs to the app. Liquid Glass draws and lights its own edge, so a turning rim on top is a second border a fraction away from the first. It read as a rendering glitch.
- `PlumageBloom` is the rim's colours blurred and thrown past the edge. With no rim it was a coloured fringe with nothing making it — warm on one corner, cool on the other.

The 34pt transparent margin stays. The material casts its own shadow and a window with no margin clips it square.

</details>

<details>
<summary>Why the panel waits for a button instead of fading when the models land</summary>

The last thing it says is which key to hold, and on a first launch that is the only sentence the app has to deliver. The moment the models land is not the moment somebody is looking, so a panel that reached that state and faded would deliver it to an empty chair.

"Got it" is the receipt that the line above it was read. The same word the microphone and keyboard notices use.

While work is outstanding the button says "Hide" instead. Nothing here starts a fetch and nothing here stops one — closing the panel does not touch the downloads.

</details>

<details>
<summary>`loading` is its own state because a fetch and a load fail differently</summary>

A fetch is minutes and a network; a load is seconds and a chip. The stage that reads the model stands aside through both, and until the load ends the model is not there.

Reported in three places, each between the download and the load:

| File | Where |
|---|---|
| `WordVectors.swift` | after `cache.ensure`, before `loadModel` |
| `SentenceReadings.swift` | after `cache.ensure`, before `loadModel` |
| `SlotModel.swift` | before `load()`, on both the cached and the fetched path |

Parakeet is not one of them: `AsrModels.downloadAndLoad` is a single call with nothing between the halves.

`isPending` counts `loading` as still coming, and `speechIsIn` counts it as not yet in. The setup screen shows it as the spinner glyph with "loading" at the right edge.

</details>

<details>
<summary>What is not decided here</summary>

- **It shows on every launch that has anything pending**, which includes a fully cached launch while the models load. That is a few seconds and one click. If it should only appear the first time, or only when something is actually downloading, that is a one-line change to `showIfNeeded`.
- **A non-blocking failure does not hold the panel.** Only a model a dictation waits on reaches the `stuck` state. A failed Qwen row closes the panel and lives in Setup… — which today has no per-row retry button, because the retry in the foot is driven by `blockingFailure`.
- **The 300 MB `RetiredModels` prune is not mentioned.** An upgrade deletes it silently. It may deserve a line.
- **Not seen below macOS 26.** The `NSVisualEffectView` path still compiles and still runs; nobody has looked at the panel on it.

</details>

<details>
<summary>Checks</summary>

`swift build` and `swift build -c release` are clean. `swiftlint` reports nothing in the new or changed code — the 37 warnings it prints are all pre-existing. The `make test` check scripts were not run: none of them touch this surface, and several need models and Ollama.

The bird is `Resources/parrot.svg`, now copied into the bundle. AppKit renders SVG natively, so it is sharp at 76 points; the committed PNGs stop at 72 pixels, which is 24 points. `PlumageBird` falls back to `ParrotSolid` under a plumage gradient when the drawing is not in the bundle.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Ew8sx7tZVgdejXXaBqbFR
