### PR TITLE
fix: a grammar edit is not a vocabulary rule

### DIFF
--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3989,38 +3989,54 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Words kept either side of the change on the pill.
     static let learnWindow = 5
 
-    /// A stop that ends a sentence rather than sitting inside a word.
+    /// Marks that belong to the sentence they close rather than to the next
+    /// one. A stop inside a quotation is still the end of a sentence.
+    private static let closers: Set<Character> = [
+        "\"", "'", "\u{201D}", "\u{2019}", ")", "]", "}", "\u{BB}",
+    ]
+
+    /// Where the sentence ending at `i` stops, or nil if the mark there ends
+    /// no sentence.
     ///
     /// A letter before it and a space, the end, or a capital after it.
     /// `painter.Jon` is two sentences a dictation ran together and `3.5` is
     /// one number; the character alone cannot tell them apart, and the pill
     /// showing half a number is worse than the pill showing one word too many.
-    private static func endsSentence(_ text: [Character], at i: Int) -> Bool {
-        guard ".?!".contains(text[i]), i > 0, text[i - 1].isLetter else { return false }
-        guard i + 1 < text.count else { return true }
-        let next = text[i + 1]
-        return next.isWhitespace || next.isUppercase
+    ///
+    /// The index returned is past any closing quote or bracket, so `he said
+    /// "hello." Jon` cuts after the quotation and not before it. Read as the
+    /// next character, `\u{201D}` is neither a space nor a capital and the whole
+    /// sentence was kept.
+    private static func sentenceEnd(_ text: [Character], at i: Int) -> Int? {
+        guard ".?!".contains(text[i]), i > 0, text[i - 1].isLetter else { return nil }
+        var next = i + 1
+        while next < text.count, closers.contains(text[next]) { next += 1 }
+        guard next < text.count else { return next }
+        guard text[next].isWhitespace || text[next].isUppercase else { return nil }
+        return next
     }
 
     /// Whether a sentence ends anywhere in `text`.
     static func closesSentence(_ text: String) -> Bool {
         let chars = Array(text)
-        return chars.indices.contains { endsSentence(chars, at: $0) }
+        return chars.indices.contains { sentenceEnd(chars, at: $0) != nil }
     }
 
     /// What is left of `text` after the last sentence that ends inside it.
     static func afterLastStop(_ text: String) -> String {
         let chars = Array(text)
         var cut = 0
-        for i in chars.indices where endsSentence(chars, at: i) { cut = i + 1 }
+        for i in chars.indices {
+            if let end = sentenceEnd(chars, at: i) { cut = end }
+        }
         return String(chars[cut...]).trimmingCharacters(in: .whitespaces)
     }
 
     /// `text` up to and including the first stop that ends a sentence.
     static func toFirstStop(_ text: String) -> String {
         let chars = Array(text)
-        for i in chars.indices where endsSentence(chars, at: i) {
-            return String(chars[...i])
+        for i in chars.indices {
+            if let end = sentenceEnd(chars, at: i) { return String(chars[..<end]) }
         }
         return text
     }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3989,6 +3989,42 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Words kept either side of the change on the pill.
     static let learnWindow = 5
 
+    /// A stop that ends a sentence rather than sitting inside a word.
+    ///
+    /// A letter before it and a space, the end, or a capital after it.
+    /// `painter.Jon` is two sentences a dictation ran together and `3.5` is
+    /// one number; the character alone cannot tell them apart, and the pill
+    /// showing half a number is worse than the pill showing one word too many.
+    private static func endsSentence(_ text: [Character], at i: Int) -> Bool {
+        guard ".?!".contains(text[i]), i > 0, text[i - 1].isLetter else { return false }
+        guard i + 1 < text.count else { return true }
+        let next = text[i + 1]
+        return next.isWhitespace || next.isUppercase
+    }
+
+    /// Whether a sentence ends anywhere in `text`.
+    static func closesSentence(_ text: String) -> Bool {
+        let chars = Array(text)
+        return chars.indices.contains { endsSentence(chars, at: $0) }
+    }
+
+    /// What is left of `text` after the last sentence that ends inside it.
+    static func afterLastStop(_ text: String) -> String {
+        let chars = Array(text)
+        var cut = 0
+        for i in chars.indices where endsSentence(chars, at: i) { cut = i + 1 }
+        return String(chars[cut...]).trimmingCharacters(in: .whitespaces)
+    }
+
+    /// `text` up to and including the first stop that ends a sentence.
+    static func toFirstStop(_ text: String) -> String {
+        let chars = Array(text)
+        for i in chars.indices where endsSentence(chars, at: i) {
+            return String(chars[...i])
+        }
+        return text
+    }
+
     static func learnPayload(for change: EditWatch.Change) -> Learn {
         let words = change.sentence.split(separator: " ").map(String.init)
         let span = max(1, change.now.split(separator: " ").count)
@@ -4001,15 +4037,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let trailing = covered.hasPrefix(change.now)
             ? String(covered.dropFirst(change.now.count)) : ""
         let rest = words.dropFirst(end)
+        // The sentence the word is in, before the word count is applied.
+        // Counting words assumes a stop has a space after it, and a field full
+        // of dictations has none: `sports. John is a painter.Jon is a
+        // musician.` is seven words holding three sentences, so five words
+        // either side drew four of them. Reported 2026-09-08.
+        let kept = Self.afterLastStop(head).split(separator: " ").map(String.init)
+        // The stop the pair carried is in `trailing`, not in `rest`: `trimmed`
+        // took it off both readings. Asked over `rest` alone, `Ghost.` ->
+        // `Ghostty.` ran on into the sentence after it.
+        let ahead = Self.closesSentence(change.now + trailing) ? []
+            : Self.toFirstStop(rest.joined(separator: " "))
+                .split(separator: " ").map(String.init)
         // A window, not the sentence. The pill is measured for one line, and a
         // long dictation wrapped into a box built for it. Five words either
         // side is what the portrait cut settled on for the same reason: enough
         // to place the word, short enough to read at a glance.
-        let kept = head.split(separator: " ").map(String.init)
         let lead = kept.count > Self.learnWindow
-            ? "… " + kept.suffix(Self.learnWindow).joined(separator: " ") : head
-        let tail = rest.prefix(Self.learnWindow).joined(separator: " ")
-            + (rest.count > Self.learnWindow ? " …" : "")
+            ? "… " + kept.suffix(Self.learnWindow).joined(separator: " ")
+            : kept.joined(separator: " ")
+        let tail = ahead.prefix(Self.learnWindow).joined(separator: " ")
+            + (ahead.count > Self.learnWindow ? " …" : "")
         return Learn(
             term: change.now, heard: change.was, before: lead,
             after: trailing + (tail.isEmpty ? "" : " " + tail)

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3901,14 +3901,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             guard let self else { return }
             var worth: [EditWatch.Change] = []
             for change in candidates {
-                let sound = await EditWatch.soundsAlike(
-                    change.was, change.now,
-                    language: DictationLanguage.forCorrection(
-                        transcript: change.sentence,
-                        allowed: self.config.transcription.languages
-                    )
+                // One answer, read by both tests. The ear and the tagger
+                // disagreeing about which language this is would be a way in
+                // for a rule neither would offer on its own.
+                let language = DictationLanguage.forCorrection(
+                    transcript: change.sentence,
+                    allowed: self.config.transcription.languages
                 )
-                if self.teaches(change, sound: sound) { worth.append(change) }
+                let sound = await EditWatch.soundsAlike(
+                    change.was, change.now, language: language
+                )
+                if self.teaches(change, sound: sound, language: language) {
+                    worth.append(change)
+                }
             }
             guard !worth.isEmpty else { return }
             // Same rule as `offerOverReselected`: never over a recording and
@@ -4175,8 +4180,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `sound` is the second way in: a mishearing can land on an ordinary word
     /// — `borderplay` -> `boilerplate` — which the word lists always refuse.
     /// Only `.ordinary`, since punctuation scores 1.00 by construction.
-    private func teaches(_ change: EditWatch.Change, sound: Float) -> Bool {
-        guard let refusal = EditWatch.offers(change, sound: sound) else {
+    private func teaches(
+        _ change: EditWatch.Change, sound: Float, language: String
+    ) -> Bool {
+        guard let refusal = EditWatch.offers(
+            change, sound: sound, language: language
+        ) else {
             Log.write("correction: \"\(change.was)\" -> \"\(change.now)\" is offered"
                 + " — sound \(String(format: "%.2f", sound))")
             return true

--- a/Sources/ParrotFlow/EditDiffCommand.swift
+++ b/Sources/ParrotFlow/EditDiffCommand.swift
@@ -38,7 +38,10 @@ enum EditDiffCommand {
             print("  words: \(EditWatch.refusal(for: change) == nil ? "yes" : "no")")
             // `offers` alone decides. `refusal` only picks the wording of a
             // yes, so `score-offers.py` can still tell the two ways in apart.
-            switch (EditWatch.offers(change, sound: sound), EditWatch.refusal(for: change)) {
+            switch (
+                EditWatch.offers(change, sound: sound, language: language),
+                EditWatch.refusal(for: change)
+            ) {
             case (.some(let refusal), _):
                 print("  offer: no, \(refusal)")
             case (.none, .none):

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -548,12 +548,15 @@ final class EditWatch {
         case ordinary
         /// The heard side ends a sentence, so the pair straddles a cut.
         case ended
+        /// The two readings are one word in two forms.
+        case inflected
 
         var description: String {
             switch self {
             case .punctuation: return "punctuation, not a name"
             case .ordinary: return "ordinary English"
             case .ended: return "the heard side ends a sentence"
+            case .inflected: return "the same word in another form"
             }
         }
     }
@@ -616,6 +619,54 @@ final class EditWatch {
     /// the pair, this asks sound to classify one already in hand.
     static let soundFloor: Float = 0.65
 
+    /// Whether the two readings are one word said two ways.
+    ///
+    /// Inflection is the sound rule's blind spot. Two forms of one French verb
+    /// are homophones — `passez` and `passé` both come out /pase/ — so
+    /// `soundsAlike` scores them 1.00 and the ordinary-English refusal is
+    /// overruled. `passez` -> `passé` was offered as a vocabulary rule on
+    /// 2026-09-08. Writing it would make the app spell one form as another in
+    /// every sentence afterwards.
+    ///
+    /// `NLTagger`'s lemma answers it: both forms return `passer`. It is the
+    /// dictionary form, so one test covers tense, gender and number in any
+    /// language macOS tags, rather than a list of endings per language:
+    ///
+    ///     tense    passez / passé      run / ran      walk / walked
+    ///     gender   grand / grande      le / la        heureux / heureuse
+    ///     number   cheval / chevaux    user / users   mouse / mice
+    ///
+    /// What it does not reach is a pair macOS holds as two words rather than
+    /// two forms: `chien` and `chienne` lemmatise to themselves, and so do
+    /// `acteur` and `actrice`. Both are still offered.
+    ///
+    /// Both sides must have one, which is what keeps the test from reaching a
+    /// name. A word no dictionary knows returns no lemma at all — `Prezi`,
+    /// `borderplay` and `Mik` all do — so the rule can only ever fire on two
+    /// known words, and never on the mishearings the sound rule is there for.
+    ///
+    /// The words alone, not the sentence around them. Measured on the pairs
+    /// this has to separate, a lone form lemmatises the same as one in its
+    /// sentence, and the span a change covers is not always a whole token of
+    /// the line it came from.
+    ///
+    /// Lowercased first, the same reason `Vocabulary.unseenWord` does it: a
+    /// capital changes the analysis. `Passez` and `Passé` at the head of a
+    /// sentence come back as two nouns lemmatised to themselves, where the
+    /// lowercased pair is one verb twice. The cost is a surname that is also a
+    /// conjugation — `Mange` against `mangez` — which stops being offered.
+    static func inflected(_ was: String, _ now: String, language: String) -> Bool {
+        func lemma(_ word: String) -> String? {
+            let bare = word.trimmingCharacters(in: .whitespaces).lowercased()
+            guard !bare.isEmpty else { return nil }
+            let tokens = Tagger.tokens(in: bare, language: language)
+            guard tokens.count == 1 else { return nil }
+            return tokens[0].lemma?.lowercased()
+        }
+        guard let a = lemma(was), let b = lemma(now) else { return false }
+        return a == b
+    }
+
     /// Whether a correction is worth offering as a rule, sound included.
     ///
     /// The whole decision, in one place. The sound branch used to be written
@@ -624,14 +675,31 @@ final class EditWatch {
     /// A heard side ending a sentence is a cut, not a word: `Q.` -> `cue`
     /// scores 1.00 because neither ear says the stop, so sound alone lets it
     /// through. 4 of the 122 recorded corrections, all noise, recall unchanged.
-    static func offers(_ change: Change, sound: Float) -> Refusal? {
+    ///
+    /// `inflected` is the other thing sound cannot see, and it beats the sound
+    /// rule rather than joining it: two forms of one verb score 1.00 on every
+    /// ear there is.
+    static func offers(_ change: Change, sound: Float, language: String) -> Refusal? {
         // Only ever over an accept. Asked first it shadowed `punctuation` on
         // `rebase.` -> `rebase:`, which was already refused for a better reason.
         let ended = change.was.trimmingCharacters(in: .whitespaces).last.map {
             ".?!".contains($0)
         } == true
-        guard let refusal = refusal(for: change) else { return ended ? .ended : nil }
-        if case .ordinary = refusal, sound >= soundFloor { return ended ? .ended : nil }
+        // Over an accept too. `refusal` returns nil for a capitalised word
+        // that does not open its sentence, so `Passez` -> `Passé` mid-line
+        // never reaches the word test at all.
+        let inflected = inflected(change.was, change.now, language: language)
+        guard let refusal = refusal(for: change) else {
+            if inflected { return .inflected }
+            return ended ? .ended : nil
+        }
+        guard case .ordinary = refusal else { return refusal }
+        // Ahead of the sound rule rather than inside it. Both refuse, but the
+        // word lists get there first whenever the two forms do not sound alike
+        // — `grand` -> `grande` — and "ordinary English" is the vaguer of two
+        // true answers. `punctuation` still wins: `refusal` asks it first.
+        if inflected { return .inflected }
+        if sound >= soundFloor { return ended ? .ended : nil }
         return refusal
     }
 

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -465,7 +465,13 @@ final class EditWatch {
         while let last = a.last, !(last.isLetter || last.isNumber) { a = a.dropLast() }
         while let last = b.last, !(last.isLetter || last.isNumber) { b = b.dropLast() }
         let (short, long) = a.count < b.count ? (a, b) : (b, a)
-        guard short != long else { return false }
+        // The whole addition can be punctuation, and the strip above has just
+        // taken it off both readings: `mask.` -> `mask (___).` arrives here as
+        // `mask` twice. Nothing was replaced — `(___)` was typed beside the
+        // word — and the space in front of it is what says so. `small.` ->
+        // `small.)` and `Praisy` -> `Praisy's` have no space and stay changes
+        // to the word. Reported 2026-09-08.
+        guard short != long else { return typed(was, now).contains(where: \.isWhitespace) }
         guard long.hasPrefix(short) || long.hasSuffix(short) else { return false }
         // A whole word has to have appeared, or `Ghost` growing into `Ghostty`
         // would read as `Ghost` with something added.
@@ -479,6 +485,28 @@ final class EditWatch {
         guard join.contains(where: { $0.map { ".!?".contains($0) } == true })
         else { return false }
         return rest.contains { $0.isLetter || $0.isNumber }
+    }
+
+    /// The characters one reading has and the other does not.
+    ///
+    /// What is left of the longer once the head and the tail the two share are
+    /// off it. Not `trimmed`, which cuts only at punctuation and keeps whole
+    /// words: this is the raw difference, and it is read for one thing only —
+    /// whether a space was typed with it.
+    static func typed(_ was: String, _ now: String) -> Substring {
+        let (short, long) = was.count < now.count ? (was, now) : (now, was)
+        var head = short.startIndex, from = long.startIndex
+        while head < short.endIndex, from < long.endIndex, short[head] == long[from] {
+            head = short.index(after: head)
+            from = long.index(after: from)
+        }
+        var tail = short.endIndex, to = long.endIndex
+        while tail > head, to > from,
+              short[short.index(before: tail)] == long[long.index(before: to)] {
+            tail = short.index(before: tail)
+            to = long.index(before: to)
+        }
+        return long[from ..< to]
     }
 
     /// The two readings with the punctuation they share taken off both.
@@ -658,7 +686,11 @@ final class EditWatch {
     static func inflected(_ was: String, _ now: String, language: String) -> Bool {
         func lemma(_ word: String) -> String? {
             let bare = word.trimmingCharacters(in: .whitespaces).lowercased()
-            guard !bare.isEmpty else { return nil }
+            // One word, as written. `Tagger` omits punctuation, so
+            // `mask (___)` comes back as the single token `mask` and reads as
+            // `mask` in another form. A span the decoder split — `red crawl`
+            // for `Redcrawl` — must reach the offer for the same reason.
+            guard !bare.isEmpty, !bare.contains(where: \.isWhitespace) else { return nil }
             let tokens = Tagger.tokens(in: bare, language: language)
             guard tokens.count == 1 else { return nil }
             return tokens[0].lemma?.lowercased()

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -131,9 +131,14 @@ struct Learn: Equatable {
     let before: String
     let after: String
 
+    /// The lead and the space after it, which is nothing when the change is
+    /// the first word of its sentence. Most changes are, now that the window
+    /// stops at the sentence.
+    var lead: String { before.isEmpty ? "" : before + " " }
+
     /// For the log only. The view draws the pieces; they are not one face.
     var line: String {
-        "\(PillMetrics.learnLead) “\(before) \(heard) \(term)\(after)”"
+        "\(PillMetrics.learnLead) “\(lead)\(heard) \(term)\(after)”"
     }
 }
 
@@ -2473,7 +2478,7 @@ private struct OfferContent: View {
             // Far enough back that the two words carry the row.
             let quiet = Color(white: 0.62)
             (
-                Text(it.before + " ").font(face).foregroundColor(quiet)
+                Text(it.lead).font(face).foregroundColor(quiet)
                 + Text(it.heard).font(mono.weight(.medium)).foregroundColor(Color(white: 0.52))
                     .strikethrough(true, color: Self.struck)
                 + Text(" ").font(face)

--- a/docs/corrections.md
+++ b/docs/corrections.md
@@ -58,6 +58,15 @@ them and the term stops being written wherever it is proposed: a new sentence
 has to look more like the ones you confirmed than like the ones you took it out
 of — see [Checking the result](transcription.md#checking-the-result).
 
+**One word in another form teaches nothing either.** Correcting `passez` to
+`passé` is a grammar fix, not a pronunciation: both forms sound the same, so
+the rule would spell one tense as the other in every sentence afterwards. Two
+readings that lemmatise to the same word are never offered, which covers tense,
+gender and number in any language macOS tags — `grand`/`grande`,
+`cheval`/`chevaux`, `user`/`users`, `mouse`/`mice`. A pair macOS holds as two
+words is still offered, so `chien` to `chienne` gets through. The edit is
+written to `trace.jsonl` either way.
+
 ## Saying the spelling instead
 
 You can skip the panel entirely and just say the correction:

--- a/scripts/check-edit-diff.sh
+++ b/scripts/check-edit-diff.sh
@@ -24,9 +24,9 @@ done
 
 failed=0
 seen=0
-while IFS=$'\t' read -r written now want offer heard; do
+while IFS=$'\t' read -r written now want offer heard lang; do
   seen=$((seen + 1))
-  out="$("$BIN" --edit-diff "$written" "$now" 2>/dev/null)"
+  out="$("$BIN" --edit-diff "$written" "$now" --lang "$lang" 2>/dev/null)"
   got="$(grep -vE "^  (in|opens|offer|heard|sound|learn|words|pill): " <<<"$out" | paste -sd '|' - | sed 's/|/ | /g')"
   if [ "$heard" != "-" ]; then
     gotHeard="$(grep -E "^  heard: " <<<"$out" | sed 's/^  heard: //' | paste -sd '|' - | sed 's/|/ | /g')"
@@ -53,7 +53,7 @@ while IFS=$'\t' read -r written now want offer heard; do
 done < <(python3 -c '
 import sys, yaml
 for c in yaml.safe_load(open(sys.argv[1]))["cases"]:
-    print("\t".join([c["written"], c["now"], str(c["expect"]), str(c.get("offer", "-")), str(c.get("heard", "-"))]))
+    print("\t".join([c["written"], c["now"], str(c["expect"]), str(c.get("offer", "-")), str(c.get("heard", "-")), str(c.get("lang", "en"))]))
 ' "$ROOT/tests/edit-diff-cases.yaml")
 
 if [ "$seen" -eq 0 ]; then echo "Failed: edit-diff — no case was read"; exit 1; fi

--- a/scripts/check-edit-diff.sh
+++ b/scripts/check-edit-diff.sh
@@ -12,7 +12,8 @@
 # A case with `offer:` also checks `EditWatch.refusal`, which says whether the
 # panel opens on the correction. That half asks the spell checker and the
 # word-piece list, so it is this machine's answer. A case with `heard:` checks
-# the window and range `EditWatch.asHeard` writes to the trace.
+# the window and range `EditWatch.asHeard` writes to the trace, and one with
+# `learn:` the line the pill draws.
 set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BIN=""
@@ -24,7 +25,7 @@ done
 
 failed=0
 seen=0
-while IFS=$'\t' read -r written now want offer heard lang; do
+while IFS=$'\t' read -r written now want offer heard learn lang; do
   seen=$((seen + 1))
   out="$("$BIN" --edit-diff "$written" "$now" --lang "$lang" 2>/dev/null)"
   got="$(grep -vE "^  (in|opens|offer|heard|sound|learn|words|pill): " <<<"$out" | paste -sd '|' - | sed 's/|/ | /g')"
@@ -42,6 +43,15 @@ while IFS=$'\t' read -r written now want offer heard lang; do
     printf '  ✗ %s: got "%s", expected "%s"\n' "${written:0:34}" "$got" "$want"
     failed=1
   fi
+  if [ "$learn" != "-" ]; then
+    gotLearn="$(grep -E "^  learn: " <<<"$out" | sed 's/^  learn: //' | paste -sd '|' - | sed 's/|/ | /g')"
+    if [ "$gotLearn" = "$learn" ]; then
+      printf '    learn: %s\n' "$gotLearn"
+    else
+      printf '  ✗ %s: learn "%s", expected "%s"\n' "${written:0:34}" "$gotLearn" "$learn"
+      failed=1
+    fi
+  fi
   [ "$offer" = "-" ] && continue
   gotOffer="$(grep -E "^  offer: " <<<"$out" | sed 's/^  offer: //' | paste -sd '|' - | sed 's/|/ | /g')"
   if [ "$gotOffer" = "$offer" ]; then
@@ -53,7 +63,7 @@ while IFS=$'\t' read -r written now want offer heard lang; do
 done < <(python3 -c '
 import sys, yaml
 for c in yaml.safe_load(open(sys.argv[1]))["cases"]:
-    print("\t".join([c["written"], c["now"], str(c["expect"]), str(c.get("offer", "-")), str(c.get("heard", "-")), str(c.get("lang", "en"))]))
+    print("\t".join([c["written"], c["now"], str(c["expect"]), str(c.get("offer", "-")), str(c.get("heard", "-")), str(c.get("learn", "-")), str(c.get("lang", "en"))]))
 ' "$ROOT/tests/edit-diff-cases.yaml")
 
 if [ "$seen" -eq 0 ]; then echo "Failed: edit-diff — no case was read"; exit 1; fi

--- a/tests/edit-diff-cases.yaml
+++ b/tests/edit-diff-cases.yaml
@@ -358,6 +358,20 @@ cases:
     expect:  "Ghost -> Ghostty"
     learn:   'Learn? “I use Ghost Ghostty.”'
 
+  # A stop inside a quotation still ends the sentence. Read as the plain next
+  # character, a closing quote is neither a space nor a capital, and the whole
+  # sentence in front was kept.
+  - written: "He said “hello.” John is a painter."
+    now:     "He said “hello.” Jon is a painter."
+    expect:  "John -> Jon"
+    learn:   'Learn? “John Jon is a painter.”'
+
+  # And a closing bracket.
+  - written: "We shipped it (finally.) John is a painter."
+    now:     "We shipped it (finally.) Jon is a painter."
+    expect:  "John -> Jon"
+    learn:   'Learn? “John Jon is a painter.”'
+
   # A stop inside a number is not a sentence, so the window runs past it.
   - written: "the Prezi build took 3.5 seconds to finish"
     now:     "the Praisy build took 3.5 seconds to finish"

--- a/tests/edit-diff-cases.yaml
+++ b/tests/edit-diff-cases.yaml
@@ -6,6 +6,7 @@
 #                            per span when there are several
 # heard:  <a>..<b> in "…"    the window and range written to the trace; optional
 # lang:   en | fr            what the pipeline resolved; optional, en by default
+# learn:  Learn? “…”         the line the pill draws; optional
 #
 # The strict half matters more than the generous one. A rewrite read as a
 # correction teaches a term a sentence nobody meant, and a portrait built on
@@ -314,6 +315,33 @@ cases:
     now:     "there is a lot of boilerplate in this file"
     expect:  "borderplay -> boilerplate"
     offer:   "yes, ordinary English but it sounds like it"
+
+  # The pill's window stops at the sentence. A field holding several dictations
+  # runs them together with no space after the stop, so counting words alone
+  # drew four sentences. Reported 2026-09-08.
+  - written: "Erik likes individual sports. John is a painter.Jon is a musician."
+    now:     "Erik likes individual sports. Jon is a painter.Jon is a musician."
+    expect:  "John -> Jon"
+    learn:   'Learn? “John Jon is a painter.”'
+
+  # The change is the last word of its sentence, so the stop is on the pair
+  # rather than in the words after it.
+  - written: "I use Ghost. It is good today my friend."
+    now:     "I use Ghostty. It is good today my friend."
+    expect:  "Ghost -> Ghostty"
+    learn:   'Learn? “I use Ghost Ghostty.”'
+
+  # A stop inside a number is not a sentence, so the window runs past it.
+  - written: "the Prezi build took 3.5 seconds to finish"
+    now:     "the Praisy build took 3.5 seconds to finish"
+    expect:  "Prezi -> Praisy"
+    learn:   'Learn? “the Prezi Praisy build took 3.5 seconds to …”'
+
+  # And with no stop anywhere, the word count is still what cuts.
+  - written: "one two three four five six seven Prezi eight nine ten eleven twelve"
+    now:     "one two three four five six seven Praisy eight nine ten eleven twelve"
+    expect:  "Prezi -> Praisy"
+    learn:   'Learn? “… three four five six seven Prezi Praisy eight nine ten eleven twelve”'
 
 # Not here: the input box between two rules, and a line wrapped onto a second
 # row. Both are several lines of screen, and this set carries one case per line.

--- a/tests/edit-diff-cases.yaml
+++ b/tests/edit-diff-cases.yaml
@@ -5,6 +5,7 @@
 # offer:  yes | no, <why>    whether the panel opens on it; optional, and one
 #                            per span when there are several
 # heard:  <a>..<b> in "…"    the window and range written to the trace; optional
+# lang:   en | fr            what the pipeline resolved; optional, en by default
 #
 # The strict half matters more than the generous one. A rewrite read as a
 # correction teaches a term a sentence nobody meant, and a portrait built on
@@ -268,6 +269,51 @@ cases:
   - written: "ask Praisy today"
     now:     "ask Praisy's today"
     expect:  "Praisy -> Praisy's"
+
+# One word in another form is not a pronunciation. Two forms of one French
+# verb are homophones, so the sound rule scores them 1.00 and overrules the
+# word lists. `passez` -> `passé` was offered as a rule on 2026-09-08.
+  - written: "Hello, passez un bon week-end."
+    now:     "Hello, passé un bon week-end."
+    expect:  "passez -> passé"
+    lang:    fr
+    offer:   "no, the same word in another form"
+
+  # Number, by the same lemma. The rule is not about verbs — one test covers
+  # tense, gender and number. From the trace, 2026-09-04.
+  - written: "how many user are on the plan"
+    now:     "how many users are on the plan"
+    expect:  "user -> users"
+    offer:   "no, the same word in another form"
+
+  # Gender.
+  - written: "c'est une grand maison"
+    now:     "c'est une grande maison"
+    expect:  "grand -> grande"
+    lang:    fr
+    offer:   "no, the same word in another form"
+
+  # An irregular plural, where no ending rule would reach it.
+  - written: "the mouse are in the trap"
+    now:     "the mice are in the trap"
+    expect:  "mouse -> mice"
+    offer:   "no, the same word in another form"
+
+  # A capitalised form mid-line never reaches the word test, so the refusal has
+  # to be asked over the accept as well.
+  - written: "Je disais. Passez un bon week-end."
+    now:     "Je disais. Passé un bon week-end."
+    expect:  "Passez -> Passé"
+    lang:    fr
+    offer:   "no, the same word in another form"
+
+  # The control the rule must not touch: a mishearing onto an ordinary word,
+  # which is the whole reason the sound rule exists. Neither word has a lemma,
+  # so the two readings cannot share one.
+  - written: "there is a lot of borderplay in this file"
+    now:     "there is a lot of boilerplate in this file"
+    expect:  "borderplay -> boilerplate"
+    offer:   "yes, ordinary English but it sounds like it"
 
 # Not here: the input box between two rules, and a line wrapped onto a second
 # row. Both are several lines of screen, and this set carries one case per line.

--- a/tests/edit-diff-cases.yaml
+++ b/tests/edit-diff-cases.yaml
@@ -308,6 +308,33 @@ cases:
     lang:    fr
     offer:   "no, the same word in another form"
 
+  # Nothing was replaced — a mark was typed beside the word. `mask` ->
+  # `mask (___)` was offered as a rule on 2026-09-08: the whole addition is
+  # punctuation, and `added` strips that off both readings before comparing,
+  # so it saw one word twice and no addition.
+  - written: "What if we mask with a neutral term? Like a mask."
+    now:     "What if we mask with a neutral term? Like a mask (___)."
+    expect:  none
+
+  # A space typed on the end is the same shape and equally not a correction.
+  - written: "he plays the guitar"
+    now:     "he plays the guitar "
+    expect:  none
+
+  # But a mark typed straight onto the word still changes it, and is refused
+  # for being punctuation rather than dropped. No space, nothing beside it.
+  - written: "keep it small"
+    now:     "keep it small."
+    expect:  "small -> small."
+    offer:   "no, punctuation, not a name"
+
+  # And the span the decoder split still reaches the offer. Trimming the ends
+  # must not reach the space in the middle.
+  - written: "we run the red crawl every night"
+    now:     "we run the Redcrawl every night"
+    expect:  "red crawl -> Redcrawl"
+    offer:   "yes"
+
   # The control the rule must not touch: a mishearing onto an ordinary word,
   # which is the whole reason the sound rule exists. Neither word has a lemma,
   # so the two readings cannot share one.


### PR DESCRIPTION
Three things the offer after a hand edit got wrong, all found in one session of using the app. Correcting `passez` to `passé` was offered as a vocabulary rule, which would spell one tense as the other in every French sentence afterwards. Typing `(___)` after `mask` was offered too, though nothing was replaced. And a correction in a field holding several dictations drew almost the whole field on the pill.

Recall does not move: 88% before and after, on the 145 corrections recorded in the dev trace. Precision goes from 44% to 46%.

Start the review at `EditWatch.inflected` and `EditWatch.added`. Both are pure functions with cases in `tests/edit-diff-cases.yaml`, so `scripts/check-edit-diff.sh` scores what ships rather than a copy of it.

<details>
<summary>Sound cannot see inflection, and the lemma can — tense, gender and number in one test</summary>

Two forms of one word are homophones. `passez` and `passé` both come out /pase/, so `soundsAlike` scores them 1.00 and overrules the word lists. That override is right for `borderplay` -> `boilerplate` and wrong here, and no sound test can separate the two.

`NLTagger`'s lemma can: both forms return `passer`. It is the dictionary form, so one test covers every kind of agreement rather than a list of endings per language:

|  | pair | lemma |
|---|---|---|
| tense | `passez` / `passé`, `run` / `ran`, `walk` / `walked` | passer, run, walk |
| gender | `grand` / `grande`, `le` / `la`, `heureux` / `heureuse` | grand, le, heureux |
| number | `cheval` / `chevaux`, `user` / `users`, `mouse` / `mice` | cheval, user, mouse |

Both sides must have a lemma, which is what keeps the test away from a name. `Prezi`, `borderplay`, `Mik` and `lectour` have none at all, so it can only ever fire on two known words. Ten controls were checked and all stay offered: `Erik`/`Eric`, `Mick`/`Mik`, `Prezi`/`Praisy`, `Ghost`/`Ghostty`, `borderplay`/`boilerplate`, `pass`/`pause`, `when`/`Qwen`, `John`/`Jon`, `Spacey`/`Spacy`, `lectour`/`Lectoure`.

Asked lowercased, the same reason `Vocabulary.unseenWord` does it: `Passez` and `Passé` at the head of a sentence come back as two nouns lemmatised to themselves.

Asked before the sound rule rather than inside it. Both refuse, but the word lists get there first whenever the two forms do not sound alike — `grand` -> `grande` — and "ordinary English" is the vaguer of two true answers.

</details>

<details>
<summary>Measurements — 63 offers to 61, no mishearing lost</summary>

`scripts/score-offers.py` against a binary built from `origin/main`, same trace, same 139 proposals:

| | offers | real | noise | precision | recall |
|---|---|---|---|---|---|
| before | 63 | 28 | 35 | 44% | 88% |
| after | 61 | 28 | 33 | 46% | 88% |

The two it drops are `passez` -> `passé` and `user` -> `users`. Neither is a mishearing by the hand label, so recall does not move.

On the 145 corrections in the trace as it now stands, the two rules catch:

    another form   passez -> passé   user -> users   page -> pages   show -> showed
    added beside   mask -> mask (___)   guitar -> "guitar "

</details>

<details>
<summary>What it does not reach — a pair macOS holds as two words</summary>

`chien` / `chienne` and `acteur` / `actrice` lemmatise to themselves rather than to a shared form, so they are still offered. They are separate lexemes to `NLTagger`, and nothing here overrides that.

</details>

<details>
<summary>Nothing was replaced when a mark is typed beside a word, and `added` could not see it</summary>

`added` is already the test for this — it drops `morning` -> `morning Tasmeen`. It missed `mask` -> `mask (___)` because it strips trailing marks off both readings before comparing, and here the whole addition is marks. `mask.` and `mask (___).` both collapse to `mask`, the two are equal, and it returns early. The evidence it needed was in what the strip threw away.

It now reads the raw difference when the stripped readings match, and the space in front of what was typed is what says it went beside the word:

    mask.    -> mask (___).    " (___)"   nothing was replaced
    guitar   -> "guitar "      " "        nothing was replaced
    small    -> small.         "."        the word changed
    Praisy   -> Praisy's       "'s"       the word changed
    rebase.  -> rebase:        "."        the word changed

The last three are pinned cases that had to keep working. The change is dropped rather than refused, which is what `added` already does, so there is no offer and no `kind: edit` row.

`inflected` no longer takes a lemma from a reading with whitespace in it. `Tagger` omits punctuation, so `mask (___)` came back as the single token `mask` and was being refused as `mask` in another form — the right answer for the wrong reason.

</details>

<details>
<summary>The pill drew four sentences because it counted words, and a run-together field has none</summary>

`learnPayload` keeps five words either side of the change. That assumes a stop has a space after it. A field holding several dictations has none: `sports. John is a painter.Jon is a musician.` is seven words holding three sentences, so five either side is four sentences of screen.

The window now cuts at the stop itself, before the words are counted. A stop counts when a letter comes before it and a space, the end, or a capital comes after, so `painter.Jon` is a boundary and `3.5` is not. On the reported case the pill goes from 508px to 153px:

    before  … basketball team.Erik likes individual sports. John Jon is a painter.Jon is a …
    after   John Jon is a painter.

The stop that ends the change's own sentence is on the pair rather than in the words after it — `trimmed` takes it off both readings and `learnPayload` puts it back. Asked over the following words alone, `Ghost.` -> `Ghostty.` ran on into the next sentence.

Also drops the gap in front of the struck word. `before` is empty whenever the change opens its sentence, which is most of them now, and the view drew the space anyway.

</details>

<details>
<summary>Review notes — where the risk is</summary>

Eleven new cases in `tests/edit-diff-cases.yaml`. `scripts/check-edit-diff.sh` gained a `lang:` column, so a French case is tagged in French, and a `learn:` column that checks the line the pill draws.

The riskiest line is the raw-difference test in `added`, because it decides whether a change is recorded at all. The three cases that had to survive it — `small` -> `small.`, `Praisy` -> `Praisy's`, `rebase.` -> `rebase:` — are in the set.

`EditWatch.offers` now takes a `language:`. It is resolved once at the caller and read by both the ear and the tagger; two sources for one field is how they disagree.

I first fixed the `mask` case by trimming the ends in `onlyPunctuation`, then reverted it. With the `added` rule in place that symptom does not occur anywhere in the 145 recorded corrections, and an unmeasured guard is worse than none.

</details>
