### PR TITLE
feat: the listening pill wears the ring and its light

### DIFF
--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -256,6 +256,11 @@ enum PanelsCommand {
             icon: sampleIcon(), level: 0.4, docked: .below
         )
         let thinkingDocked = pill(.working("Thinking…"), docked: .below)
+        // Free: no anchor, so no line under it to say where the words are
+        // going. The icon says it instead, which is the one difference between
+        // this and the tab above it.
+        let listeningFree = pill(.recording(nil), icon: sampleIcon(), level: 0.55, docked: .free)
+        let thinkingFree = pill(.working("Thinking…"), icon: sampleIcon(), docked: .free)
 
         let overlay = pill(.recording(nil), icon: sampleIcon(), level: 0.75)
 
@@ -427,6 +432,10 @@ enum PanelsCommand {
              pillSize(editing), .dark, true),
             (AnyView(PillView().environmentObject(thinkingDocked)),
              pillSize(thinkingDocked), .dark, true),
+            (AnyView(PillView().environmentObject(listeningFree)),
+             pillSize(listeningFree), .dark, true),
+            (AnyView(PillView().environmentObject(thinkingFree)),
+             pillSize(thinkingFree), .dark, true),
             (AnyView(PillView().environmentObject(tab)),
              pillSize(tab), .dark, true),
             (AnyView(PillView().environmentObject(tabWarned)),
@@ -581,7 +590,7 @@ enum PanelsCommand {
     private static func pillSize(_ model: PillModel) -> NSSize {
         PillMetrics.panelSize(
             for: model.state, hasIcon: model.appIcon != nil, hotkey: model.hotkey,
-            docked: model.docked != nil
+            dock: model.docked
         )
     }
 

--- a/Sources/ParrotFlow/ParrotStyle.swift
+++ b/Sources/ParrotFlow/ParrotStyle.swift
@@ -249,19 +249,24 @@ struct PlumageRim<S: InsettableShape>: View {
     @State private var angle: Double = -90
     @State private var breath = false
 
+    private var pulses: Bool { pulsing && !reduceMotion }
+
     var body: some View {
         shape
             .strokeBorder(
                 AngularGradient(colors: wheel, center: .center, angle: .degrees(angle)),
                 lineWidth: alive ? 2 : 1.4
             )
-            .opacity(alive ? 1 : (breath ? 1 : 0.9))
+            // The swing is downward: 0.35 at the trough against 0.9 standing
+            // still. A light that only brightens reads as a sheen; one that
+            // nearly goes out reads as a breath.
+            .opacity(alive ? 1 : (pulses ? (breath ? 1 : 0.35) : 0.9))
             // The way down is a plain ease. A repeating animation attached to
             // the change that stops the pulse goes on repeating, so the rim
             // would still be breathing at the offer.
             .animation(Parrot.pulse(breath), value: breath)
-            .onChange(of: pulsing, initial: true) { _, _ in breath = pulsing && !reduceMotion }
-            .onChange(of: reduceMotion) { _, _ in breath = pulsing && !reduceMotion }
+            .onChange(of: pulsing, initial: true) { _, _ in breath = pulses }
+            .onChange(of: reduceMotion) { _, _ in breath = pulses }
             // A white hairline just inside keeps the edge glassy in light mode,
             // where saturated colour alone reads as a sticker.
             //
@@ -554,9 +559,9 @@ enum ParrotGlass {
 struct PlumageBloom<S: InsettableShape>: View {
     let shape: S
     var alive: Bool = false
-    /// Breathe between the resting glow and the bright one, standing still.
-    /// The colours do not move: the light gets stronger and weaker, which is
-    /// what a microphone that is open and hearing nothing yet looks like.
+    /// Breathe, standing still. The colours do not move: the light goes almost
+    /// out and comes back, which is what a microphone that is open and hearing
+    /// nothing yet looks like. See `trough`.
     var pulsing: Bool = false
     /// The colours the glow is made of. See `PlumageRim.wheel`.
     var wheel: [Color] = Parrot.wheel
@@ -598,19 +603,30 @@ struct PlumageBloom<S: InsettableShape>: View {
             // what keeps the glow from reading as a decal.
             bloom(width: 22, blur: 22, opacity: strength(0.10, 0.19), angle: inner)
         }
+        // The whole halo, dimmed as one. The layers hold the bright values
+        // while it pulses and this is what swings, so the beat is a light
+        // going out rather than four opacities drifting apart.
+        .opacity(pulses ? (breath ? 1 : Self.trough) : 1)
         .animation(.easeInOut(duration: 0.4), value: alive)
         .animation(Parrot.pulse(breath), value: breath)
         .onChange(of: alive) { _, _ in spin() }
         .onAppear { spin() }
-        .onChange(of: pulsing, initial: true) { _, _ in breath = pulsing && !reduceMotion }
-        .onChange(of: reduceMotion) { _, _ in breath = pulsing && !reduceMotion }
+        .onChange(of: pulsing, initial: true) { _, _ in breath = pulses }
+        .onChange(of: reduceMotion) { _, _ in breath = pulses }
     }
+
+    private var pulses: Bool { pulsing && !reduceMotion }
+
+    /// How little is left at the bottom of a breath. Near dark on purpose: the
+    /// pulse has to be readable in the corner of an eye, and the top of the
+    /// swing is already the brightest this surface ever gets.
+    private static var trough: Double { 0.15 }
 
     /// The busy strength while the app is busy, and at the top of every breath.
     /// Nothing is brighter than `alive` was: the pulse borrows its values, so
     /// the surface has one bright and one resting look, not three.
     private func strength(_ rest: Double, _ bright: Double) -> Double {
-        (alive || breath ? bright : rest) * intensity
+        (alive || pulses ? bright : rest) * intensity
     }
 
     private func bloom(width: CGFloat, blur: CGFloat, opacity: Double, angle: Double) -> some View {

--- a/Sources/ParrotFlow/ParrotStyle.swift
+++ b/Sources/ParrotFlow/ParrotStyle.swift
@@ -68,6 +68,12 @@ enum Parrot {
     static let panelRadius: CGFloat = 18
     static let panelPadding: CGFloat = 16
     static let fieldRadius: CGFloat = 7
+
+    /// One trip round for a rim that is turning. Here rather than on
+    /// `PlumageRim`, which is generic over its shape and cannot be named
+    /// without one. See `PlumageRim.spin`.
+    static let busyTurn: TimeInterval = 1.8
+    static let slowTurn: TimeInterval = 6
 }
 
 // MARK: - Surface
@@ -86,11 +92,12 @@ extension View {
     /// and the glow drifts with it. That combination means the app is busy, and
     /// nothing else may borrow it.
     ///
-    /// `turning` is the rim alone, at a third of the speed and at its resting
-    /// weight. The offer uses it: a surface asking to be answered before it
-    /// goes should be the one thing on screen that moves. It is not the busy
-    /// signal, because the weight, the brightness and the drifting glow are
-    /// what make that one — see `PlumageRim.spin`.
+    /// `turning` is the rim alone, at its resting weight, and `turnSeconds` is
+    /// how long one trip round takes. It is not the busy signal: the weight,
+    /// the brightness and the drifting glow are what make that one. The
+    /// listening pill turns at the busy speed and keeps the resting weight —
+    /// the microphone being open is worth saying, and is not the app being
+    /// busy. See `PlumageRim.spin`.
     ///
     /// `glass` gives the surface a thickness: a lighter scrim, a sheen down the
     /// face, and the rim's inner hairline weighted to the top so the edge reads
@@ -122,10 +129,11 @@ extension View {
     /// the translucent ones already take their colour from what is behind
     /// them, and a wash on top of that is paint on a window.
     func parrotSurface<S: InsettableShape>(
-        _ shape: S, alive: Bool = false, turning: Bool = false, glass: Bool = false,
+        _ shape: S, alive: Bool = false, turning: Bool = false,
+        turnSeconds: TimeInterval? = nil, glass: Bool = false,
         solid: Bool = false, scrim: Double? = nil, wash: Color? = nil,
         wheel: [Color] = Parrot.wheel, rim: Bool = true,
-        edge: Color = Color.white.opacity(0.09), edgeShimmer: Bool = false
+        edge: Color = Color.white.opacity(0.09)
     ) -> some View {
         background {
             if solid {
@@ -183,70 +191,19 @@ extension View {
         // The lit edge is the rim's own inner hairline, weighted to the top —
         // not a line of its own. See `PlumageRim`.
         //
-        // `rim: false` is for a surface that is not floating. The plumage says
-        // "this is a thing of the app's, over your document"; a surface hanging
-        // off a line of your text is already placed by what it is attached to,
-        // and a turning rim on it reads as a sticker on the page. It takes a
-        // plain hairline instead — the same one the rim carries on its inside.
+        // `rim: false` is for a surface the system already draws an edge on.
+        // Liquid Glass lights its own boundary, and a turning rim on top of
+        // that is a second border arguing with the first. It takes `edge`
+        // instead — the plain hairline the rim carries on its inside.
         .overlay {
             if rim {
-                PlumageRim(shape: shape, alive: alive, turning: turning, glass: glass, wheel: wheel)
-            } else {
-                DockedEdge(shape: shape, colour: edge, shimmering: edgeShimmer)
-            }
-        }
-    }
-}
-
-/// The line round a docked surface, and the light that runs along it while it
-/// is working.
-///
-/// The busy signal on a floating pill is the plumage rim turning fast. A docked
-/// surface has no rim to turn, and the bird inside it is already carrying the
-/// plumage — so the edge shimmers instead: one bright arc travelling over the
-/// line that is there anyway. Everything else about the surface stays still,
-/// which is what keeps the movement readable rather than busy-looking.
-private struct DockedEdge<S: InsettableShape>: View {
-    let shape: S
-    let colour: Color
-    var shimmering: Bool = false
-
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var angle: Double = -90
-
-    /// One trip round. Close to the sweep through the bird without dividing
-    /// into it, so the two never fall into step and read as one mechanism.
-    private static var turnSeconds: TimeInterval { 1.7 }
-
-    var body: some View {
-        Group {
-            if shimmering, !reduceMotion {
-                shape.strokeBorder(
-                    AngularGradient(
-                        stops: [
-                            .init(color: colour, location: 0),
-                            .init(color: .white.opacity(0.85), location: 0.07),
-                            .init(color: colour, location: 0.22),
-                            .init(color: colour, location: 1),
-                        ],
-                        center: .center, angle: .degrees(angle)
-                    ),
-                    lineWidth: 1
+                PlumageRim(
+                    shape: shape, alive: alive, turning: turning, turnSeconds: turnSeconds,
+                    glass: glass, wheel: wheel
                 )
             } else {
-                shape.strokeBorder(colour, lineWidth: 1)
+                shape.strokeBorder(edge, lineWidth: 1)
             }
-        }
-        .onChange(of: shimmering, initial: true) { _, _ in spin() }
-    }
-
-    private func spin() {
-        guard shimmering, !reduceMotion else {
-            withAnimation(.default) { angle = -90 }
-            return
-        }
-        withAnimation(.linear(duration: Self.turnSeconds).repeatForever(autoreverses: false)) {
-            angle = 270
         }
     }
 }
@@ -257,6 +214,8 @@ struct PlumageRim<S: InsettableShape>: View {
     var alive: Bool = false
     /// Turn without saying the app is busy. See `spin`.
     var turning: Bool = false
+    /// One trip round while `turning`, in seconds. Nil is `Parrot.slowTurn`.
+    var turnSeconds: TimeInterval?
     /// Weight the inner hairline toward the top, so it reads as light on the
     /// edge. See the hairline below.
     var glass: Bool = false
@@ -307,12 +266,15 @@ struct PlumageRim<S: InsettableShape>: View {
 
     /// One turn of the feathers, at the speed the surface asked for.
     ///
-    /// Busy is 1.8s. `turning` is `slowTurn`, which is slow enough that you
-    /// see the colours move rather than a rim spinning — and the bloom behind
-    /// it stays still either way, which is the other half of why the two do
-    /// not read alike. That stillness is also what keeps this affordable: a
-    /// drifting bloom is four Gaussian blurs re-rendered every frame, measured
-    /// at 40% of a core. See `PlumageBloom.spin`.
+    /// Busy is `Parrot.busyTurn`, and it is the weight and the drifting glow
+    /// that say so rather than the speed — the listening pill borrows this
+    /// clock at the resting weight. `turning` on its own is `Parrot.slowTurn`,
+    /// slow enough that you see the colours move rather than a rim spinning.
+    ///
+    /// The bloom behind it stays still whatever the rim does, which is what
+    /// keeps this affordable: a drifting bloom is four Gaussian blurs
+    /// re-rendered every frame, measured at 40% of a core. See
+    /// `PlumageBloom.spin`.
     ///
     /// The rim alone measured at about 11% of a core on the offer pill, for
     /// the five seconds the offer is up. The pill standing still is 0-3%.
@@ -321,16 +283,11 @@ struct PlumageRim<S: InsettableShape>: View {
             withAnimation(.default) { angle = -90 }
             return
         }
-        withAnimation(
-            .linear(duration: alive ? 1.8 : Self.slowTurn).repeatForever(autoreverses: false)
-        ) {
+        let seconds = alive ? Parrot.busyTurn : (turnSeconds ?? Parrot.slowTurn)
+        withAnimation(.linear(duration: seconds).repeatForever(autoreverses: false)) {
             angle = 270
         }
     }
-
-    /// One trip round a rim that is not saying anything is happening.
-    /// Computed rather than stored: this type is generic over its shape.
-    static var slowTurn: TimeInterval { 6 }
 }
 
 // MARK: - Fields
@@ -631,7 +588,7 @@ struct PlumageBloom<S: InsettableShape>: View {
     /// Still, the reason to stop it is the rule that was already written on
     /// `PlumageRim`: a glow that drifts while nothing is happening says
     /// something is happening. At rest the bloom is simply there — lit,
-    /// uneven, and still. The offer turns its rim slowly and the bloom stays
+    /// uneven, and still. The listening pill turns its rim and the bloom stays
     /// out of it, which is what keeps "busy" a signal of its own.
     private func spin() {
         guard alive, !reduceMotion else {

--- a/Sources/ParrotFlow/ParrotStyle.swift
+++ b/Sources/ParrotFlow/ParrotStyle.swift
@@ -74,6 +74,21 @@ enum Parrot {
     /// without one. See `PlumageRim.spin`.
     static let busyTurn: TimeInterval = 1.8
     static let slowTurn: TimeInterval = 6
+    /// The rim while the app is working on what it heard. It does not divide
+    /// into the bird's 1.5s sweep, so the two never fall into step.
+    static let workingTurn: TimeInterval = 1.7
+
+    /// One way of the breath, for anything that pulses. The clock the recording
+    /// dot has always used.
+    static let breath: TimeInterval = 0.7
+
+    /// The breath, going or stopping. `repeatForever` only on the way up: the
+    /// same animation on the change that ends the pulse repeats that change
+    /// instead, and the light never settles.
+    static func pulse(_ going: Bool) -> Animation {
+        let ease = Animation.easeInOut(duration: breath)
+        return going ? ease.repeatForever(autoreverses: true) : ease
+    }
 }
 
 // MARK: - Surface
@@ -94,10 +109,14 @@ extension View {
     ///
     /// `turning` is the rim alone, at its resting weight, and `turnSeconds` is
     /// how long one trip round takes. It is not the busy signal: the weight,
-    /// the brightness and the drifting glow are what make that one. The
-    /// listening pill turns at the busy speed and keeps the resting weight —
-    /// the microphone being open is worth saying, and is not the app being
-    /// busy. See `PlumageRim.spin`.
+    /// the brightness and the drifting glow are what make that one. See
+    /// `PlumageRim.spin`.
+    ///
+    /// `pulsing` is the rim standing still and breathing instead, with the
+    /// bloom behind it. A ring going round says the app is doing something; a
+    /// light that breathes says it is waiting for you. The pill takes the first
+    /// while it works on a dictation and the second while the microphone is
+    /// open.
     ///
     /// `glass` gives the surface a thickness: a lighter scrim, a sheen down the
     /// face, and the rim's inner hairline weighted to the top so the edge reads
@@ -130,7 +149,7 @@ extension View {
     /// them, and a wash on top of that is paint on a window.
     func parrotSurface<S: InsettableShape>(
         _ shape: S, alive: Bool = false, turning: Bool = false,
-        turnSeconds: TimeInterval? = nil, glass: Bool = false,
+        turnSeconds: TimeInterval? = nil, pulsing: Bool = false, glass: Bool = false,
         solid: Bool = false, scrim: Double? = nil, wash: Color? = nil,
         wheel: [Color] = Parrot.wheel, rim: Bool = true,
         edge: Color = Color.white.opacity(0.09)
@@ -199,7 +218,7 @@ extension View {
             if rim {
                 PlumageRim(
                     shape: shape, alive: alive, turning: turning, turnSeconds: turnSeconds,
-                    glass: glass, wheel: wheel
+                    pulsing: pulsing, glass: glass, wheel: wheel
                 )
             } else {
                 shape.strokeBorder(edge, lineWidth: 1)
@@ -216,6 +235,9 @@ struct PlumageRim<S: InsettableShape>: View {
     var turning: Bool = false
     /// One trip round while `turning`, in seconds. Nil is `Parrot.slowTurn`.
     var turnSeconds: TimeInterval?
+    /// Breathe rather than turn. The rim brightens and dims with the bloom
+    /// behind it, so the edge and the halo read as one light. See `PlumageBloom`.
+    var pulsing: Bool = false
     /// Weight the inner hairline toward the top, so it reads as light on the
     /// edge. See the hairline below.
     var glass: Bool = false
@@ -225,6 +247,7 @@ struct PlumageRim<S: InsettableShape>: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var angle: Double = -90
+    @State private var breath = false
 
     var body: some View {
         shape
@@ -232,7 +255,13 @@ struct PlumageRim<S: InsettableShape>: View {
                 AngularGradient(colors: wheel, center: .center, angle: .degrees(angle)),
                 lineWidth: alive ? 2 : 1.4
             )
-            .opacity(alive ? 1 : 0.9)
+            .opacity(alive ? 1 : (breath ? 1 : 0.9))
+            // The way down is a plain ease. A repeating animation attached to
+            // the change that stops the pulse goes on repeating, so the rim
+            // would still be breathing at the offer.
+            .animation(Parrot.pulse(breath), value: breath)
+            .onChange(of: pulsing, initial: true) { _, _ in breath = pulsing && !reduceMotion }
+            .onChange(of: reduceMotion) { _, _ in breath = pulsing && !reduceMotion }
             // A white hairline just inside keeps the edge glassy in light mode,
             // where saturated colour alone reads as a sticker.
             //
@@ -267,9 +296,10 @@ struct PlumageRim<S: InsettableShape>: View {
     /// One turn of the feathers, at the speed the surface asked for.
     ///
     /// Busy is `Parrot.busyTurn`, and it is the weight and the drifting glow
-    /// that say so rather than the speed — the listening pill borrows this
-    /// clock at the resting weight. `turning` on its own is `Parrot.slowTurn`,
-    /// slow enough that you see the colours move rather than a rim spinning.
+    /// that say so rather than the speed. `turning` on its own takes
+    /// `turnSeconds`, and nil is `Parrot.slowTurn` — slow enough that you see
+    /// the colours move rather than a rim spinning. The pill asks for
+    /// `Parrot.workingTurn` while it works on a dictation.
     ///
     /// The bloom behind it stays still whatever the rim does, which is what
     /// keeps this affordable: a drifting bloom is four Gaussian blurs
@@ -524,6 +554,10 @@ enum ParrotGlass {
 struct PlumageBloom<S: InsettableShape>: View {
     let shape: S
     var alive: Bool = false
+    /// Breathe between the resting glow and the bright one, standing still.
+    /// The colours do not move: the light gets stronger and weaker, which is
+    /// what a microphone that is open and hearing nothing yet looks like.
+    var pulsing: Bool = false
     /// The colours the glow is made of. See `PlumageRim.wheel`.
     var wheel: [Color] = Parrot.wheel
     /// How much of it there is. The same absolute spill reads as far less
@@ -534,6 +568,7 @@ struct PlumageBloom<S: InsettableShape>: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var outer: Double = -90
     @State private var inner: Double = 90
+    @State private var breath = false
 
     var body: some View {
         ZStack {
@@ -553,19 +588,29 @@ struct PlumageBloom<S: InsettableShape>: View {
             // coloured borders drawn on top of each other, which is exactly
             // what it looked like. A blur spreads one source; a shadow repeats
             // it.
-            bloom(width: 9, blur: 24, opacity: (alive ? 0.22 : 0.13) * intensity, angle: outer)
-            bloom(width: 9, blur: 13, opacity: (alive ? 0.28 : 0.18) * intensity, angle: outer)
-            bloom(width: 9, blur: 5, opacity: (alive ? 0.42 : 0.28) * intensity, angle: outer)
+            bloom(width: 9, blur: 24, opacity: strength(0.13, 0.22), angle: outer)
+            bloom(width: 9, blur: 13, opacity: strength(0.18, 0.28), angle: outer)
+            bloom(width: 9, blur: 5, opacity: strength(0.28, 0.42), angle: outer)
 
             // The unevenness, and the only layer that disagrees about where the
             // colours are. Wide and heavily blurred so it has no edge of its
             // own: it brightens one side of the halo and then another, which is
             // what keeps the glow from reading as a decal.
-            bloom(width: 22, blur: 22, opacity: (alive ? 0.19 : 0.10) * intensity, angle: inner)
+            bloom(width: 22, blur: 22, opacity: strength(0.10, 0.19), angle: inner)
         }
         .animation(.easeInOut(duration: 0.4), value: alive)
+        .animation(Parrot.pulse(breath), value: breath)
         .onChange(of: alive) { _, _ in spin() }
         .onAppear { spin() }
+        .onChange(of: pulsing, initial: true) { _, _ in breath = pulsing && !reduceMotion }
+        .onChange(of: reduceMotion) { _, _ in breath = pulsing && !reduceMotion }
+    }
+
+    /// The busy strength while the app is busy, and at the top of every breath.
+    /// Nothing is brighter than `alive` was: the pulse borrows its values, so
+    /// the surface has one bright and one resting look, not three.
+    private func strength(_ rest: Double, _ bright: Double) -> Double {
+        (alive || breath ? bright : rest) * intensity
     }
 
     private func bloom(width: CGFloat, blur: CGFloat, opacity: Double, angle: Double) -> some View {
@@ -588,8 +633,8 @@ struct PlumageBloom<S: InsettableShape>: View {
     /// Still, the reason to stop it is the rule that was already written on
     /// `PlumageRim`: a glow that drifts while nothing is happening says
     /// something is happening. At rest the bloom is simply there — lit,
-    /// uneven, and still. The listening pill turns its rim and the bloom stays
-    /// out of it, which is what keeps "busy" a signal of its own.
+    /// uneven, and still. `pulsing` brightens and dims it without moving the
+    /// colours, which is a much cheaper thing to ask for than the drift.
     private func spin() {
         guard alive, !reduceMotion else {
             withAnimation(.easeInOut(duration: 0.4)) { outer = -90; inner = 90 }

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -78,9 +78,8 @@ enum PillState: Equatable {
     case offer([OfferedCommand], Headline?, Confidence.Reading, open: Bool)
 
     /// Whether the microphone is open, or the words it heard are still being
-    /// worked on. One question, asked in three places: the rim turns while this
-    /// is true, the bloom is drawn behind it, and the window carries the wide
-    /// margin the bloom needs.
+    /// worked on. One question, asked twice: the bloom is drawn while this is
+    /// true, and the window carries the wide margin the bloom needs.
     var isListening: Bool {
         switch self {
         case .recording, .working: return true
@@ -2048,11 +2047,15 @@ struct PillView: View {
         //
         // The rim is on every state, docked or free. It is what makes the pill
         // findable over a dark composer, where a near-black tab with a leaf
-        // hairline is black on nearly black. It turns while the microphone is
-        // open and stands still once the offer arrives, so the movement means
-        // "still listening" and nothing else.
+        // hairline is black on nearly black.
+        //
+        // It pulses while the microphone is open and turns while the app is
+        // working on what it heard. Two different things are happening and they
+        // read as two: a light that breathes is a thing waiting for you, and a
+        // ring going round is a thing doing something.
         .parrotSurface(
-            shape, turning: isListening, turnSeconds: Parrot.busyTurn, solid: true,
+            shape, turning: isWorking, turnSeconds: Parrot.workingTurn,
+            pulsing: isRecording, solid: true,
             wash: wash, wheel: warning?.wheel ?? Parrot.wheel
         )
         // Under the capsule, so it is the capsule's shape and not the glow's.
@@ -2065,7 +2068,10 @@ struct PillView: View {
             // dark desktop, and the offer is answered rather than found: it has
             // your attention already, and it takes the mouse.
             if isListening {
-                PlumageBloom(shape: shape, wheel: warning?.wheel ?? Parrot.wheel)
+                PlumageBloom(
+                    shape: shape, pulsing: isRecording,
+                    wheel: warning?.wheel ?? Parrot.wheel
+                )
             }
         }
         // The margin the bloom spills into while listening, and the much
@@ -2085,6 +2091,16 @@ struct PillView: View {
     }
 
     private var isListening: Bool { model.state.isListening }
+
+    private var isRecording: Bool {
+        if case .recording = model.state { return true }
+        return false
+    }
+
+    private var isWorking: Bool {
+        if case .working = model.state { return true }
+        return false
+    }
 
     private var isDocked: Bool { model.docked != nil }
 
@@ -2257,7 +2273,7 @@ private struct RecordingContent: View {
                 .frame(width: PillMetrics.dot, height: PillMetrics.dot)
                 .shadow(color: Parrot.scarlet.opacity(0.7), radius: 4)
                 .opacity(pulse ? 0.35 : 1)
-                .animation(.easeInOut(duration: 0.7).repeatForever(autoreverses: true), value: pulse)
+                .animation(Parrot.pulse(pulse), value: pulse)
 
             Meter(level: level)
                 .frame(width: PillMetrics.meter, height: 14)

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -76,6 +76,19 @@ enum PillState: Equatable {
     /// have to carry the same three values to be able to open into this one,
     /// and every switch in the file would have to handle both.
     case offer([OfferedCommand], Headline?, Confidence.Reading, open: Bool)
+
+    /// Whether the microphone is open, or the words it heard are still being
+    /// worked on. One question, asked in three places: the rim turns while this
+    /// is true, the bloom is drawn behind it, and the window carries the wide
+    /// margin the bloom needs. Three switches over the same cases is how one of
+    /// them ends up disagreeing, and a margin that disagrees with the window is
+    /// a surface drawn at the wrong size.
+    var isListening: Bool {
+        switch self {
+        case .recording, .working: return true
+        case .notice, .offer: return false
+        }
+    }
 }
 
 /// What an offer says above its chips.
@@ -351,9 +364,9 @@ final class PillHUD {
     /// The offer's fade, waiting out the hold. See `decay(over:)`.
     private var pendingDecayFade: DispatchWorkItem?
 
-    /// The margin this surface wants, which is not the same for all of them.
-    /// See `PillMetrics.dockBleed`.
-    private var currentBleed: CGFloat { PillMetrics.bleed(docked: isDocked) }
+    /// The margin this surface wants, which is not the same in every state.
+    /// See `PillMetrics.bleed(for:)`.
+    private var currentBleed: CGFloat { PillMetrics.bleed(for: model.state) }
 
     /// The glass under the capsule, taken out of the window while it is docked.
     ///
@@ -1249,18 +1262,17 @@ final class PillHUD {
 
     /// Whether this is the docked surface rather than the floating capsule.
     ///
-    /// Always, now. The two forms are not two sizes of the same thing, they are
-    /// two objects: the docked one is part of the line it hangs off, and the
-    /// floating one is a black lozenge with the plumage rim turning on it, in
-    /// the middle of the screen. Anything that picks between them makes one
-    /// message come out as two surfaces, and it did — twice.
+    /// Always, now. The two forms were two objects rather than two sizes of one
+    /// thing, and anything that picked between them made one message come out
+    /// as two surfaces. It did — twice.
     ///
     /// First it asked for an anchor. An app that will not say where its caret
     /// is — Slack gives none at the press and its composer repaints on insert,
     /// so the diff finds nothing either — got the floating lozenge, and a
-    /// 165x131 window around a 61x27 tab. Fifty-two points of invisible window
-    /// on every side, taking the mouse, sitting exactly where you are typing.
-    /// That is where "I cannot click on buttons" came from.
+    /// 165x131 window around a 61x27 tab, taking the mouse where you are
+    /// typing. That is where "I cannot click on buttons" came from. The margin
+    /// follows the state now rather than the form, and only the offer takes the
+    /// mouse — see `PillMetrics.bleed(for:)`.
     ///
     /// Then it asked whether a dictation was on screen. That left every notice
     /// raised before a recording starts wearing the old lozenge — including the
@@ -1292,7 +1304,7 @@ enum PillMetrics {
     /// square edge is the one saying which line this is about.
     static let dockRadius: CGFloat = 12
 
-    /// What a docked surface stands on, and the line round it.
+    /// What a docked surface stands on.
     ///
     /// Near-black was right for a surface that floated: it appears over
     /// documents, terminals and dark editors without knowing which, and a dark
@@ -1312,7 +1324,6 @@ enum PillMetrics {
     /// lit chip has to stand out from. `OfferContent.chip` carries the fill at
     /// 28% and the edge at 62% against this 12%, which is what keeps it.
     static let dockedWash = Parrot.leaf.opacity(0.12)
-    static let dockedEdge = Parrot.leaf.opacity(0.34)
 
     // MARK: The tab
 
@@ -1414,8 +1425,9 @@ enum PillMetrics {
     /// spilling outward was cut off square at the window edge — which is the
     /// one artefact that gives a floating surface away as a window.
     ///
-    /// It costs nothing: the margin is fully transparent and the panel ignores
-    /// the mouse, so a wider window is not a bigger target for anything.
+    /// It costs nothing while the microphone is open: the margin is fully
+    /// transparent and the panel ignores the mouse in every state but the
+    /// offer, which is the state that does not take this margin.
     /// `width(for:)` and `height` stay the size of the capsule you can see;
     /// `panelSize` is what the window is set to.
     /// Wide enough for the widest blur's tail to reach zero before the window
@@ -1431,23 +1443,27 @@ enum PillMetrics {
     /// less there is to see.
     static let bleed: CGFloat = 52
 
-    /// The margin a docked surface gets, which is only what its shadow needs.
+    /// The margin once the bloom is gone, which is only what the shadow needs.
     ///
-    /// The 52 above is for a blur to fade out in, and a docked surface has no
-    /// blur. Keeping it would cost something real now that the pointer opens
-    /// the tab: the panel stops ignoring the mouse while an offer is up, so
-    /// every point of transparent window is a point of your document that
-    /// swallows a click — 150x124 of it around a 46x20 tab, sitting exactly
-    /// where you are about to click. Twelve covers the shadow and nothing else.
+    /// The 52 above is for a blur to fade out in, and the offer draws no blur.
+    /// Keeping it would cost something real: the panel stops ignoring the mouse
+    /// while an offer is up, so every point of transparent window is a point of
+    /// your document that swallows a click — 150x124 of it around a 46x20 tab,
+    /// sitting exactly where you are about to click. Twelve covers the shadow
+    /// and nothing else.
     static let dockBleed: CGFloat = 12
 
-    static func bleed(docked: Bool) -> CGFloat { docked ? dockBleed : bleed }
+    /// The margin this state wants. Wide while the bloom is drawn, and small
+    /// once it is not. See `PillState.isListening`.
+    static func bleed(for state: PillState) -> CGFloat {
+        state.isListening ? bleed : dockBleed
+    }
 
     static func panelSize(
         for state: PillState, hasIcon: Bool, hotkey: String = "", docked: Bool = false
     ) -> NSSize {
         let width = width(for: state, hasIcon: hasIcon, hotkey: hotkey, docked: docked)
-        let margin = bleed(docked: docked)
+        let margin = bleed(for: state)
         return NSSize(
             width: width + margin * 2,
             height: height(for: state, width: width, hotkey: hotkey, docked: docked) + margin * 2
@@ -2033,13 +2049,15 @@ struct PillView: View {
         // said. The line says it, but the line is on a pill you have already
         // learned to ignore: the surface changing colour is what gets looked
         // at, and it is the same signal the caution notices use.
-        // The offer turns its rim slowly, on its own: it is the one state with
-        // a deadline, and the only one you are meant to answer. Slow, and with
-        // the glow behind it left still, so it does not read as the busy rim.
+        //
+        // The rim is on every state, docked or free. It is what makes the pill
+        // findable over a dark composer, where a near-black tab with a leaf
+        // hairline is black on nearly black. It turns while the microphone is
+        // open and stands still once the offer arrives, so the movement means
+        // "still listening" and nothing else.
         .parrotSurface(
-            shape, alive: isWorking, turning: isOffer && !isDocked, solid: true,
-            wash: wash, wheel: warning?.wheel ?? Parrot.wheel,
-            rim: !isDocked, edge: edge, edgeShimmer: isWorking && isDocked
+            shape, turning: isListening, turnSeconds: Parrot.busyTurn, solid: true,
+            wash: wash, wheel: warning?.wheel ?? Parrot.wheel
         )
         // Under the capsule, so it is the capsule's shape and not the glow's.
         .shadow(color: .black.opacity(0.22), radius: 7, y: 2)
@@ -2047,24 +2065,21 @@ struct PillView: View {
         // back, which is where the bloom has to be — over the fill it would be
         // a coloured film on the surface rather than light coming off the edge.
         .background {
-            // No bloom on a docked surface, for the reason it has no rim: light
-            // coming off the edge is what a thing floating over your document
-            // does, and this one is sitting on the line.
-            if !isDocked {
-                PlumageBloom(
-                    shape: shape, alive: isWorking,
-                    wheel: warning?.wheel ?? Parrot.wheel
-                )
+            // Only while listening. It is the light that finds the pill on a
+            // dark desktop, and the offer is answered rather than found: it has
+            // your attention already, and it takes the mouse.
+            if isListening {
+                PlumageBloom(shape: shape, wheel: warning?.wheel ?? Parrot.wheel)
             }
         }
-        // The transparent margin the bloom spills into, and the much smaller one
-        // a docked surface needs for its shadow. See `PillMetrics.dockBleed`.
+        // The margin the bloom spills into while listening, and the much
+        // smaller one the shadow needs after. See `PillMetrics.dockBleed`.
         //
         // The same number `PillMetrics.panelSize` added to the window, and it
         // has to be: the window is sized from there and the surface is inset
         // from here, so a disagreement is a surface drawn at the wrong size
         // inside a window of the right one.
-        .padding(PillMetrics.bleed(docked: isDocked))
+        .padding(PillMetrics.bleed(for: model.state))
         // Bound to the state alone. The meter is fed about ten times a second
         // and must not drag a crossfade along behind it.
         .animation(.easeInOut(duration: PillHUD.motion), value: model.state)
@@ -2073,15 +2088,7 @@ struct PillView: View {
         .animation(.easeInOut(duration: PillHUD.motion), value: model.docked)
     }
 
-    private var isWorking: Bool {
-        if case .working = model.state { return true }
-        return false
-    }
-
-    private var isOffer: Bool {
-        if case .offer = model.state { return true }
-        return false
-    }
+    private var isListening: Bool { model.state.isListening }
 
     private var isDocked: Bool { model.docked != nil }
 
@@ -2104,28 +2111,20 @@ struct PillView: View {
     /// Amber for a dictation the app is unsure of, scarlet once it has taken a
     /// Return over it — the same surface one step along, because the second
     /// state is the first one being ignored.
-    private var warning: (wash: Color, wheel: [Color], edge: Color)? {
+    private var warning: (wash: Color, wheel: [Color])? {
         guard case .offer(_, _, let reading, _) = model.state, reading.warning != nil else {
             return nil
         }
         return reading.stopped
-            ? (Parrot.scarlet.opacity(0.26), Parrot.stopped, Parrot.scarlet.opacity(0.45))
-            : (Parrot.amber.opacity(0.24), Parrot.warned, Parrot.amber.opacity(0.40))
+            ? (Parrot.scarlet.opacity(0.26), Parrot.stopped)
+            : (Parrot.amber.opacity(0.24), Parrot.warned)
     }
 
     /// The colour laid over the ground. A warning first, and otherwise the
-    /// docked surface's own lift — see `PillMetrics.dockedWash`. Nothing at all
-    /// while it floats: a floating pill is read against its rim, and the rim is
-    /// still there.
+    /// docked surface's own lift — see `PillMetrics.dockedWash`.
     private var wash: Color? {
         if let warning { return warning.wash }
         return isDocked ? PillMetrics.dockedWash : nil
-    }
-
-    /// The line round it, which only a docked surface draws — everything else
-    /// has the rim. Read by `parrotSurface` under `rim: false`.
-    private var edge: Color {
-        warning?.edge ?? PillMetrics.dockedEdge
     }
 
     /// A fixed radius, not a `Capsule`. At the pill's resting height the
@@ -2690,9 +2689,8 @@ private struct OfferKeyCap: View {
     @State private var angle: Double = -90
 
     /// One trip round the border. Long enough that the light never reads as a
-    /// spinner, short enough to be seen inside the offer's hold. It does not
-    /// divide into the rim's `PlumageRim.slowTurn`, so the two never fall into
-    /// step.
+    /// spinner, short enough to be seen inside the offer's hold. It is the only
+    /// thing moving on an offer: the rim stops turning when the offer arrives.
     private static let turnSeconds: TimeInterval = 3.4
     private static let radius: CGFloat = 4
 

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -399,9 +399,18 @@ final class PillHUD {
     private var wantedSize: NSSize {
         PillMetrics.panelSize(
             for: model.state, hasIcon: model.appIcon != nil, hotkey: model.shownHotkey,
-            docked: isDocked
+            dock: wantedDock
         )
     }
+
+    /// Which way the surface will hang, known before it is placed.
+    ///
+    /// The size is worked out first and `anchor` decides the dock after, so
+    /// this has to answer the same question early. It can: the anchor is read
+    /// at the press, and a dictation with none is the one that lands free.
+    /// Below and above are the same width, so the two attached cases are one
+    /// answer here.
+    private var wantedDock: Dock? { near == nil ? .free : .below }
 
     /// One number for the whole surface: the rise, the morph and the fade.
     ///
@@ -1389,12 +1398,17 @@ enum PillMetrics {
         return "\(initial) \(parts[1])"
     }
 
-    /// The tab while the microphone is open: the bird, and whatever the hold is
-    /// for when it is not dictation.
-    static func tabWidth(label: String?) -> CGFloat {
-        let mark = tabPadding * 2 + tabMark
-        guard let label else { return mark }
-        return mark + tabGap + min(title(label), editWidth) + selectionFit
+    /// The app icon on a tab that hangs off nothing. See `tabWidth`.
+    static let tabIcon: CGFloat = 20
+
+    /// The tab while the microphone is open: the bird, the icon when there is
+    /// no line to say where the words are going, and whatever the hold is for
+    /// when it is not dictation.
+    static func tabWidth(label: String?, icon: Bool = false) -> CGFloat {
+        var width = tabPadding * 2 + tabMark
+        if icon { width += tabGap + tabIcon }
+        guard let label else { return width }
+        return width + tabGap + min(title(label), editWidth) + selectionFit
     }
 
     /// Past this the words being edited are truncated rather than the tab
@@ -1455,13 +1469,13 @@ enum PillMetrics {
     }
 
     static func panelSize(
-        for state: PillState, hasIcon: Bool, hotkey: String = "", docked: Bool = false
+        for state: PillState, hasIcon: Bool, hotkey: String = "", dock: Dock? = nil
     ) -> NSSize {
-        let width = width(for: state, hasIcon: hasIcon, hotkey: hotkey, docked: docked)
+        let width = width(for: state, hasIcon: hasIcon, hotkey: hotkey, dock: dock)
         let margin = bleed(for: state)
         return NSSize(
             width: width + margin * 2,
-            height: height(for: state, width: width, hotkey: hotkey, docked: docked) + margin * 2
+            height: height(for: state, width: width, hotkey: hotkey, dock: dock) + margin * 2
         )
     }
 
@@ -1599,7 +1613,7 @@ enum PillMetrics {
     /// An offer with nothing to say about the decode is the height the pill has
     /// always been, so a dictation that went fine changes nothing.
     static func height(
-        for state: PillState, width: CGFloat, hotkey: String = "", docked: Bool = false
+        for state: PillState, width: CGFloat, hotkey: String = "", dock: Dock? = nil
     ) -> CGFloat {
         guard case .offer(let commands, let headline, let reading, let open) = state else {
             // Docked, the recording and the transcribing are the bird's own tab
@@ -1607,7 +1621,7 @@ enum PillMetrics {
             // sentence needs the height it has always had whether it is hanging
             // off a line or floating at the bottom of the screen.
             if case .notice = state { return height }
-            return docked ? tabHeight : height
+            return dock == nil ? height : tabHeight
         }
         guard open else { return tabHeight }
         // A selection offer is three rows: the words, the chips, and the line
@@ -1701,20 +1715,23 @@ enum PillMetrics {
     static let meter: CGFloat = 66
 
     static func width(
-        for state: PillState, hasIcon: Bool, hotkey: String = "", docked: Bool = false
+        for state: PillState, hasIcon: Bool, hotkey: String = "", dock: Dock? = nil
     ) -> CGFloat {
+        // The icon says where the words are going, and a tab hanging off a line
+        // has already said it by hanging there. Free, nothing else says it.
+        let icon = hasIcon && dock == .free
         switch state {
         case .recording(let label):
-            // Docked, the whole recording state is the bird — no dot, no bars,
-            // no icon. A label still widens it, because tap-then-hold has to
-            // say what the hold is for before you speak.
-            guard docked else { return recording(hasIcon: hasIcon, label: label) }
-            return tabWidth(label: label)
+            // Docked, the whole recording state is the bird — no dot, no bars.
+            // A label still widens it, because tap-then-hold has to say what
+            // the hold is for before you speak.
+            guard dock != nil else { return recording(hasIcon: hasIcon, label: label) }
+            return tabWidth(label: label, icon: icon)
         case .working(let message):
             // Docked, the plumage travels through the bird while it thinks. The
             // message is what the undocked one is for — a download has no line
             // to hang from.
-            return docked ? tabWidth(label: nil) : text(message)
+            return dock == nil ? text(message) : tabWidth(label: nil, icon: icon)
         case .notice(let message, _): return text(message)
         case .offer(let commands, let headline, let reading, let open):
             guard open else { return tabWidth(hotkey: hotkey) }
@@ -2014,12 +2031,16 @@ struct PillView: View {
                 switch model.state {
                 case .recording(let label):
                     RecordingContent(
-                        level: model.level, icon: model.appIcon, label: label, docked: isDocked
+                        level: model.level, icon: model.appIcon, label: label,
+                        dock: model.docked
                     )
                     .transition(.opacity)
                 case .working(let message):
-                    MessageContent(message: message, tone: .thinking, docked: isDocked)
-                        .transition(.opacity)
+                    MessageContent(
+                        message: message, tone: .thinking, dock: model.docked,
+                        icon: model.appIcon
+                    )
+                    .transition(.opacity)
                 case .notice(let message, let tone):
                     MessageContent(message: message, tone: tone)
                         .transition(.opacity)
@@ -2217,9 +2238,9 @@ private struct RecordingContent: View {
     let icon: NSImage?
     /// What this recording is for, when it is not dictation.
     var label: String?
-    /// Hanging off the line the words are going into, which is the ordinary
-    /// case. See `body`.
-    var docked = false
+    /// Which way the surface hangs. Nil is the floating capsule; `.free` is
+    /// the tab with no line under it. See `body`.
+    var dock: Dock?
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var pulse = false
@@ -2229,7 +2250,7 @@ private struct RecordingContent: View {
     private static let editedText = Color(red: 0.875, green: 0.941, blue: 0.906)
 
     var body: some View {
-        if docked { tab } else { capsule }
+        if dock == nil { capsule } else { tab }
     }
 
     /// The whole recording state, in the shape it ends in.
@@ -2244,6 +2265,12 @@ private struct RecordingContent: View {
             PlumageMeter(
                 level: Double(level), size: PillMetrics.tabMark, blind: icon == nil
             )
+            // Attached to a line, the line says where the words are going. Free
+            // it says nothing, so the icon comes back — the same job it did on
+            // the old floating capsule.
+            if dock == .free, let icon {
+                AppIconMark(icon: icon)
+            }
             if let label {
                 // In the highlight the offer uses for the same job, because it
                 // is the same claim: these words, the ones sitting in that
@@ -2303,21 +2330,44 @@ private struct RecordingContent: View {
     }
 }
 
+/// Where the words are going, on a tab with no line under it.
+///
+/// Smaller than the 22 the floating capsule drew it at: this sits in a 27pt tab
+/// beside an 18pt bird, and 22 filled it edge to edge.
+private struct AppIconMark: View {
+    let icon: NSImage
+
+    var body: some View {
+        Image(nsImage: icon)
+            .resizable()
+            .interpolation(.high)
+            .frame(width: PillMetrics.tabIcon, height: PillMetrics.tabIcon)
+    }
+}
+
 private struct MessageContent: View {
     let message: String
     let tone: NoticeTone
     /// Hanging off the line, where there is no room for a sentence and none
     /// needed: the bird standing full says the words are in and something is
     /// being done with them, which is the whole of what "Thinking…" said.
-    var docked = false
+    var dock: Dock?
+    /// Where the words are going, shown only on a tab that hangs off nothing.
+    /// See `RecordingContent.tab`.
+    var icon: NSImage?
 
     var body: some View {
-        if docked {
-            PlumageMeter(level: 1, size: PillMetrics.tabMark, working: true)
-                .padding(.horizontal, PillMetrics.tabPadding)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
-        } else {
+        if dock == nil {
             capsule
+        } else {
+            HStack(spacing: PillMetrics.tabGap) {
+                PlumageMeter(level: 1, size: PillMetrics.tabMark, working: true)
+                if dock == .free, let icon {
+                    AppIconMark(icon: icon)
+                }
+            }
+            .padding(.horizontal, PillMetrics.tabPadding)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         }
     }
 

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -80,9 +80,7 @@ enum PillState: Equatable {
     /// Whether the microphone is open, or the words it heard are still being
     /// worked on. One question, asked in three places: the rim turns while this
     /// is true, the bloom is drawn behind it, and the window carries the wide
-    /// margin the bloom needs. Three switches over the same cases is how one of
-    /// them ends up disagreeing, and a margin that disagrees with the window is
-    /// a surface drawn at the wrong size.
+    /// margin the bloom needs.
     var isListening: Bool {
         switch self {
         case .recording, .working: return true
@@ -1209,20 +1207,31 @@ final class PillHUD {
     /// the whole claim this surface makes. The wobble the pane edge was hiding
     /// is still there and is now the price of saying something exact.
     ///
-    /// `bleed` is taken off because it is transparent: what has to line up with
-    /// the words is the surface, not the window the glow spills into.
+    /// Everything here is worked out for the capsule you can see, and the
+    /// margin is taken off once at the end. The margin is transparent and it
+    /// changes with the state — 52 while listening, 12 after — so a position
+    /// clamped as a window would move the capsule 40pt sideways at the offer
+    /// for no reason the user can see.
     private func beside(
         _ target: NSRect, column: CGFloat, size: NSSize, on visible: NSRect
     ) -> (origin: NSPoint, dock: Dock?) {
         let gap = isDocked ? PillMetrics.dockGap : PillMetrics.floatGap
+        let margin = currentBleed
+        let capsule = NSSize(
+            width: size.width - margin * 2, height: size.height - margin * 2
+        )
+        // The room the capsule keeps to, which is the screen less the smallest
+        // margin any state takes. The wider one is allowed off the screen: it
+        // is transparent, a borderless panel keeps an origin outside the
+        // display, and pulling it back in would move the capsule.
+        let room = visible.insetBy(dx: PillMetrics.dockBleed, dy: PillMetrics.dockBleed)
 
         var dock = Dock.below
-        var y = target.minY - gap - size.height + currentBleed
-        if y < visible.minY {
-            y = target.maxY + gap - currentBleed
+        var y = target.minY - gap - capsule.height
+        if y < room.minY {
+            y = target.maxY + gap
             dock = .above
         }
-        let x = column - currentBleed
 
         // Clamped into the screen, which is also what folds the panel back from
         // the right edge: a surface wider than the room left beside the words
@@ -1230,8 +1239,8 @@ final class PillHUD {
         // off the display. The row is untouched by that, so it still names the
         // line it belongs to.
         return (NSPoint(
-            x: min(max(x, visible.minX), visible.maxX - size.width),
-            y: min(max(y, visible.minY), visible.maxY - size.height)
+            x: min(max(column, room.minX), room.maxX - capsule.width) - margin,
+            y: min(max(y, room.minY), room.maxY - capsule.height) - margin
         ), isDocked ? dock : nil)
     }
 
@@ -1262,22 +1271,9 @@ final class PillHUD {
 
     /// Whether this is the docked surface rather than the floating capsule.
     ///
-    /// Always, now. The two forms were two objects rather than two sizes of one
-    /// thing, and anything that picked between them made one message come out
-    /// as two surfaces. It did — twice.
-    ///
-    /// First it asked for an anchor. An app that will not say where its caret
-    /// is — Slack gives none at the press and its composer repaints on insert,
-    /// so the diff finds nothing either — got the floating lozenge, and a
-    /// 165x131 window around a 61x27 tab, taking the mouse where you are
-    /// typing. That is where "I cannot click on buttons" came from. The margin
-    /// follows the state now rather than the form, and only the offer takes the
-    /// mouse — see `PillMetrics.bleed(for:)`.
-    ///
-    /// Then it asked whether a dictation was on screen. That left every notice
-    /// raised before a recording starts wearing the old lozenge — including the
-    /// one that says the press failed, which is the message most likely to be
-    /// looked at closely.
+    /// Always, now. Twice it was asked to pick — first on whether there was an
+    /// anchor, then on whether a dictation was on screen — and both times one
+    /// message came out as two different surfaces.
     ///
     /// The anchor decides *where* the surface goes, never what it is: with one
     /// it hangs off a line and squares the edge that touches it, and without

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1069,8 +1069,8 @@ feedback:
     word: 0.50       # and it holds a word this bad
 ```
 
-When both trip, the pill comes up amber — washed ground, amber rim, amber glow
-— and carries one line above the chips: `This may not be what you said`, then
+When both trip, the pill comes up amber — washed ground, amber rim — and
+carries one line above the chips: `This may not be what you said`, then
 the word. The colour is the signal. The line says what it means.
 
 It needs `correct_offer`. It does not need `confidence`: the coloured sentence

--- a/docs/proposals/hud-placement-and-offer.md
+++ b/docs/proposals/hud-placement-and-offer.md
@@ -218,13 +218,22 @@ The docked surface was near-black with a leaf hairline, which over Slack's
 composer is black on nearly black. The pill now wears the plumage rim in every
 state, docked or free, and the leaf edge is gone. The leaf wash stays.
 
-While the microphone is open — recording and working — the rim turns once every
-1.8s and the bloom is drawn behind it, so the pill is found by the light off its
-edge. At an offer and at a notice the rim stands still and there is no bloom:
-those states are answered, not looked for. The margin follows the same line, 52
-for the blur to fade out in and 12 after, and only the offer takes the mouse, so
-the wide margin swallows no clicks. The docked working shimmer is gone; the
-turning rim says the same thing.
+The bloom is drawn while the microphone is open and while the app works on what
+it heard, so the pill is found by the light off its edge. The light says which
+of the two is happening. While recording, the rim stands still and the light
+pulses, 0.7s each way, on the clock the old scarlet dot used. While working, the
+rim turns, once every 1.7s, which is what the docked edge shimmered at. At an
+offer and at a notice the rim stands still and there is no bloom: those states
+are answered, not looked for.
+
+The margin follows the same line, 52 for the blur to fade out in and 12 after,
+and only the offer takes the mouse, so the wide margin swallows no clicks.
+
+Cost, measured with `--panels` as CPU seconds over a 12s window: 6-12% of a core
+recording, 8% working, 0% on a still notice. The pulse is not what that buys —
+the same surface with the pulse taken out measured 9.3% and 9.7%, so the cost is
+the meter being fed twenty times a second. The drifting bloom that was rejected
+earlier measured 40%.
 
 Direction C of <https://claude.ai/code/artifact/edabef77-cd1b-46ee-9c67-077e766b21f9>.
 

--- a/docs/proposals/hud-placement-and-offer.md
+++ b/docs/proposals/hud-placement-and-offer.md
@@ -221,10 +221,17 @@ state, docked or free, and the leaf edge is gone. The leaf wash stays.
 The bloom is drawn while the microphone is open and while the app works on what
 it heard, so the pill is found by the light off its edge. The light says which
 of the two is happening. While recording, the rim stands still and the light
-pulses, 0.7s each way, on the clock the old scarlet dot used. While working, the
-rim turns, once every 1.7s, which is what the docked edge shimmered at. At an
-offer and at a notice the rim stands still and there is no bloom: those states
-are answered, not looked for.
+pulses, 0.7s each way, on the clock the old scarlet dot used. The swing is
+downward: the halo falls to 0.15 of its lit strength and the rim to 0.35, so it
+reads as a light going out and coming back rather than a sheen on the edge.
+While working, the rim turns, once every 1.7s, which is what the docked edge
+shimmered at. At an offer and at a notice the rim stands still and there is no
+bloom: those states are answered, not looked for.
+
+A tab that hangs off nothing carries the target app's icon again, beside the
+bird, at 20pt. `Dock.free` is the case with no anchor, so there is no line under
+the tab to say where the words are going. Attached below or above a line, there
+is, and the tab stays the bird alone.
 
 The margin follows the same line, 52 for the blur to fade out in and 12 after,
 and only the offer takes the mouse, so the wide margin swallows no clicks.

--- a/docs/proposals/hud-placement-and-offer.md
+++ b/docs/proposals/hud-placement-and-offer.md
@@ -212,6 +212,22 @@ same way.
 - Everything else stands: pulsing dot, live meter, destination icon, and the
   narrow no-icon pill that says the words have nowhere to go.
 
+### 2026-09-08: the ring, and its light
+
+The docked surface was near-black with a leaf hairline, which over Slack's
+composer is black on nearly black. The pill now wears the plumage rim in every
+state, docked or free, and the leaf edge is gone. The leaf wash stays.
+
+While the microphone is open — recording and working — the rim turns once every
+1.8s and the bloom is drawn behind it, so the pill is found by the light off its
+edge. At an offer and at a notice the rim stands still and there is no bloom:
+those states are answered, not looked for. The margin follows the same line, 52
+for the blur to fade out in and 12 after, and only the offer takes the mouse, so
+the wide margin swallows no clicks. The docked working shimmer is gone; the
+turning rim says the same thing.
+
+Direction C of <https://claude.ai/code/artifact/edabef77-cd1b-46ee-9c67-077e766b21f9>.
+
 ---
 
 ## 3. The offer


### PR DESCRIPTION
The pill you see while the microphone is open was near-black on a leaf wash with
a leaf hairline. Over Slack's composer that is black on nearly black, and at the
bottom of the screen it is a dark mark on a dark desktop. The plumage rim is now
drawn on the pill in every state, docked or free, with the bloom lit behind it
while the app is listening or working.

The light says which of the two is happening. While you talk, the rim stands
still and the light pulses, 0.7s each way, on the clock the recording dot has
always used. The swing is downward: the halo falls to 0.15 of its lit strength
and the rim to 0.35, so it reads as a light going out and coming back. While the
app works on what it heard, the rim turns at 1.7s and the bloom stands still. At
an offer and at a notice the rim is still and there is no bloom. Reduce Motion
gets neither the pulse nor the turn.

A tab that hangs off nothing carries the target app's icon again, beside the
bird, at 20pt. That is the dictation with no anchor: there is no line under the
tab to say where the words are going, which is the job the icon did on the old
floating capsule. Attached to a line, the line says it and there is no icon.

The window's transparent margin follows the same line: 52pt while listening for
the blur to fade out in, 12pt after. The pill ignores the mouse in every state
but the offer, so the wide margin swallows no clicks.

Review the margin first. `PillMetrics.panelSize`, `PillHUD.currentBleed` and the
`.padding` in `PillView` all have to read the same number, or the surface is
drawn at the wrong size inside a window of the right one. They all read
`PillMetrics.bleed(for:)` now, which reads one `PillState.isListening`. Second
commit: `beside` used to clamp the *window* into the screen, so beside a
left-snapped pane the capsule would have jumped 40pt when the margin shrank at
the offer. It clamps the capsule now.

Direction C, "the ring and its light", of the design canvas:
<https://claude.ai/code/artifact/edabef77-cd1b-46ee-9c67-077e766b21f9>

<details>
<summary>What changed, line by line</summary>

- `PillView.pill` calls `parrotSurface` with the rim unconditional. The leaf
  edge (`PillMetrics.dockedEdge`) is deleted; the leaf wash stays as the ground.
- The rim keeps its resting weight — 1.4pt, 0.9 opacity, the inner white
  hairline at 0.5. `PlumageRim` takes a `turnSeconds` and a `pulsing`; `alive`
  is untouched, so what it means for any other surface is unchanged. The
  durations live on `Parrot` (`busyTurn` 1.8 for `alive`, `workingTurn` 1.7 for
  the pill, `slowTurn` 6, `breath` 0.7), which are namable from a call site —
  `PlumageRim` is generic over its shape.
- `PlumageBloom` is drawn while `.recording` or `.working`. It never drifts. It
  breathes between its resting values and the ones `alive` already used, so the
  surface has one bright look and one resting look rather than three.
- `PillMetrics.bleed(docked:)` became `bleed(for: PillState)`.
- The docked working shimmer is gone; the turning rim replaces it. `DockedEdge`
  then had no caller. The launch panel is the one surface still passing
  `rim: false`, and it passes `edge: .clear`, so the rimless path is now a plain
  `strokeBorder` in `parrotSurface`.
- Reduce Motion is unchanged: the rim stands still.

</details>

<details>
<summary>The panel sheet: the ring is on every state, the bloom only while listening</summary>

`.build/release/ParrotFlow --panel-sheet sheet.png`, read in both columns.

| Surface | Rim | Bloom | Icon |
|---|---|---|---|
| `notice` "Grammar applied", docked | plumage, square along the top edge | none | — |
| `notice` caution, docked | plumage | none | — |
| `working` "Thinking…", floating capsule | plumage | lit | — |
| `recording` docked, three widths | plumage, square top | lit | none |
| `working` docked | plumage, square top | lit | none |
| `recording` free | plumage, all four corners | lit | Mail, beside the bird |
| `working` free | plumage, all four corners | lit | Mail, beside the bird |
| offer tab, closed | plumage, square top | none | none |
| offer tab, warned | amber and scarlet, amber wash | none | none |
| offer open, every variant | plumage | none | none |

The rim follows `DockedShape`, so a docked tab keeps its square edge against the
line and the ring runs along it. No surface collapsed: every pill is drawn at
its capsule size inside its window, with the halo whole rather than cut off
square. A still catches one frame of the pulse and cannot be aimed: in the last
render the recording tabs came out near the bottom of the breath, with the halo
much fainter than the working tab's.

The bird draws as a fallback capsule in the sheet. That is the sheet running
outside the app bundle, not a change here.

</details>

<details>
<summary>What it costs: the pulse is free, the meter is what the pill spends</summary>

`--panels <surface>` with the surface on screen, measuring CPU seconds burned
over a 12s window (`ps -o time=`), which is steadier than sampling `%cpu`.

| Surface | What moves | Of one core |
|---|---|---|
| `pill` | the pulse, and the meter fed 20 times a second | 6.1%, 8.9%, 12.2% |
| `pill`, pulse taken out | the meter only | 9.3%, 9.7% |
| `thinking` | the rim turning at 1.7s | 7.9%, 8.4% |
| `notice` | nothing | 0.0% |

The pulse does not show above the noise: the control with it removed lands in
the same band. So all four bloom layers pulse rather than only the widest. The
drifting bloom that was rejected earlier measured 40%; a pulse changes opacities
and moves no colours, which is the cheap half of what a drift does.

</details>

<details>
<summary>What this PR cannot show, and one thing only a live run can</summary>

`make test` passes (every check). The sheet is a still image, so it does not
show the turning or the reduce-motion path.

The margin has never animated before: `isDocked` was always true, so it was
always 12. At recording → offer the `.padding` now animates 52 → 12 in SwiftUI
while the window shrinks 80pt in AppKit, both over `PillHUD.motion`. The
positions the two ends compute agree — `beside` places the capsule and takes the
margin off last — but those are two animators with matching durations, not one
clock. If they drift by a frame the capsule may wobble for 180ms at that morph.
Worth one look at a real dictation.

The wide margin can now hang up to 40pt off the screen beside a snapped window.
It is transparent, and a borderless `NSPanel` keeps an origin outside the
display: a panel placed at -40,-40 read its frame back unchanged, through both
`setFrameOrigin` and `setFrame`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
