### PR TITLE
feat: a name the app cannot settle is asked before it is typed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,8 @@ CHECKS := numbers replacements pipeline pipeline-config wake split dotted dates 
           transform-folders eval audio-recovery possessive word-gate suggest input join \
           profiles span-rule clipboard default-config vocabulary-config learn \
           signing-identity no-voice sound slot-tokenizer sentence-case term-uses \
-          edit-diff sentence-open invented-tail sentence-window lowercase-refused
+          edit-diff sentence-open invented-tail sentence-window lowercase-refused \
+          selector
 
 test:
 	@swift build -c release

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -3990,6 +3990,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         offerHeld = false
         Log.write("correction: asking about \(worth.count) rule(s) — "
             + worth.map { "\"\($0.was)\" -> \"\($0.now)\"" }.joined(separator: ", "))
+        aimAtTheCorrection()
         pill.model.onPick = { [weak self] index in
             guard let self, commands.indices.contains(index) else { return }
             self.runOfferedCommand(commands[index].title)
@@ -4120,6 +4121,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         correctionPanel.show(
             rules: worth.map { (heard: $0.was, corrected: $0.now) }, over: sentence
         )
+    }
+
+    /// Put the learn question under the caret in the field the correction was
+    /// made in.
+    ///
+    /// This offer never aimed at all, so it drew wherever the pill was last
+    /// put — which is where the *previous dictation* landed. The edit that
+    /// raises it can come minutes later, after scrolling, in another window,
+    /// and the question would then be asked somewhere else entirely.
+    ///
+    /// The caret and nothing else. `EditWatch` fires off key events, so this
+    /// runs while the caret is still sitting at the word that was changed —
+    /// which is the same place the post-dictation pill hangs off. A field that
+    /// answers no caret leaves the pill exactly where it is: it is already
+    /// under the words of the dictation this correction is about, and the
+    /// bottom of the screen would be further from them, not nearer.
+    private func aimAtTheCorrection() {
+        guard let element = edits.field else { return }
+        guard case .found(let anchor) = CaretAnchor.read(at: element) else {
+            Log.write("correction: the field gives no caret; the pill stays where it was")
+            return
+        }
+        pill.aim(at: anchor)
     }
 
     /// A correction that runs the other way, and what to do with it.

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -1287,13 +1287,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // so it is visible precisely when the panel is open, and the promise
         // and the behaviour cannot come apart again.
         if !recorder.isRecording {
-            // The selector is the one open panel that does not draw that row.
-            // `PillMetrics.showsHold` refuses it, so a panel asking which word
-            // you meant promises nothing about holding and must not take the
-            // next hold as an instruction. The rule is still "whatever the
-            // pill is drawing"; there is now a second thing to ask it.
-            let promisesHold = pill.isOpen
-                && PillMetrics.showsHold(offerHeadline, hotkey: pill.model.hotkey)
+            // The selector is the one open panel that does not draw that row
+            // — `PillMetrics.showsHold` refuses it — so a panel asking which
+            // word you meant promises nothing about holding and must not take
+            // the next hold as an instruction. Named here rather than asked of
+            // `showsHold`, which also refuses a pill with no key registered:
+            // that is a different case and not this PR's to change.
+            var promisesHold = pill.isOpen
+            if case .choose = offerHeadline { promisesHold = false }
             keyedAtPress = afterTap || (offerIsUp && promisesHold)
             // Only when it is on, and it says which of the two put it there.
             // This is the one decision at the press you cannot see from
@@ -5706,6 +5707,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     ) -> Bool {
         let open = OpenPlaces.take(for: press.run)
         guard !open.isEmpty, config.vocabulary.asks else { return false }
+        // Not while another dictation is running. Push-to-talk does not wait,
+        // so a second press can be recording or decoding while this one asks —
+        // and then two sentences are in the air with a question between them.
+        // The newer one would land first, its offer would take the pill out
+        // from under the question, and this one's words would paste after it
+        // into whatever was in front by then.
+        //
+        // The same guard `watchTheOfferKeys` makes, for the same reason: with
+        // a dictation still running the keys are refused anyway, so the pill
+        // could only be clicked. A press that starts *after* the question is
+        // up is the safe direction — `handleHotKeyPress` ends the offer, and
+        // that writes these words before the new recording starts.
+        guard !recorder.isRecording, runsInFlight <= 0 else {
+            Log.write("selector: a dictation is still running; \(open.count) place(s)"
+                + " keep what the pipeline settled on")
+            return false
+        }
         // One question at a time, and one pill. A panel already up is somebody
         // else's — the learn offer, an update — and replacing it would throw
         // away what it was asking without showing it. Same refusal
@@ -5877,13 +5895,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// These are also the hardest places there are to label. Every free gate
     /// looked at this one and none of them could say.
     private func teach(
-        _ place: OpenPlaces.Placed, wrote word: String, in text: String,
+        _ place: OpenPlaces.Placed, wrote word: OpenPlaces.Written, in text: String,
         of pending: PendingChoice
     ) {
         let open = place.open
         Trace.chose(
-            term: open.term, kept: open.standing, chose: word, text: text,
-            range: 0 ..< text.utf16.count,
+            term: open.term, kept: open.standing, chose: word.word, text: text,
+            range: word.range,
             lang: DictationLanguage.forCorrection(
                 transcript: text, allowed: config.transcription.languages
             ),
@@ -5895,20 +5913,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // written its term into the text, so keeping what stands there keeps
         // the term. The comparison is with the reading, not the canonical term
         // — `Praisy's` keeps its possessive.
-        let kept = word == open.now
+        let kept = word.word == open.now
         do {
             try TermUses.record(
-                term: open.term, said: text, span: word, from: .chosen, counter: !kept
+                term: open.term, said: text, span: word.word, from: .chosen, counter: !kept
             )
             rebuildPortrait(for: open.term)
             // One term chosen over another says two things, and both are worth
             // keeping: the first does not live here and the second does.
-            if !kept, let other = existingTerm(named: word), other != open.term {
-                try TermUses.record(term: other, said: text, span: word, from: .chosen)
+            if !kept, let other = existingTerm(named: word.word), other != open.term {
+                try TermUses.record(term: other, said: text, span: word.word, from: .chosen)
                 rebuildPortrait(for: other)
             }
             Log.write("selector: \(open.term) \(kept ? "belongs" : "does not belong")"
-                + " in \"\(TermUses.narrowed(text, to: word))\"")
+                + " in \"\(TermUses.narrowed(text, to: word.word))\"")
         } catch {
             Log.write("selector: could not record the answer: \(error.localizedDescription)")
         }

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -4131,19 +4131,37 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// raises it can come minutes later, after scrolling, in another window,
     /// and the question would then be asked somewhere else entirely.
     ///
-    /// The caret and nothing else. `EditWatch` fires off key events, so this
-    /// runs while the caret is still sitting at the word that was changed —
-    /// which is the same place the post-dictation pill hangs off. A field that
-    /// answers no caret leaves the pill exactly where it is: it is already
-    /// under the words of the dictation this correction is about, and the
-    /// bottom of the screen would be further from them, not nearer.
+    /// `EditWatch` fires off key events, so this runs while the caret is still
+    /// sitting at the word that was changed — the same place the
+    /// post-dictation pill hangs off.
+    ///
+    /// The caret, then the input line. That second rung is `readTheAnchor`'s
+    /// 2.5 and it is not optional: a terminal answers `0+0` for a caret
+    /// always, so the caret rung alone left the question drawn wherever the
+    /// pill had last been. Which is the thing this exists to stop, and what it
+    /// still did in Ghostty — measured on a real correction, not reasoned
+    /// about.
+    ///
+    /// A field that answers neither leaves the pill exactly where it is. It is
+    /// already under the words this correction is about, and the bottom of the
+    /// screen would be further from them, not nearer.
     private func aimAtTheCorrection() {
         guard let element = edits.field else { return }
-        guard case .found(let anchor) = CaretAnchor.read(at: element) else {
-            Log.write("correction: the field gives no caret; the pill stays where it was")
+        if case .found(let anchor) = CaretAnchor.read(at: element) {
+            pill.aim(at: anchor)
             return
         }
-        pill.aim(at: anchor)
+        // The app the dictation went to, not the one in front: the correction
+        // is made in the field those words landed in, and something else may
+        // have been clicked into since.
+        if AppProfile.of(lastDictated?.owner).readsPane,
+           case .found(let box) = CaretAnchor.inputBox(at: element) {
+            Log.write("correction: no caret, so the input line it is")
+            pill.aim(at: box)
+            return
+        }
+        Log.write("correction: the field gives no caret and no input line;"
+            + " the pill stays where it was")
     }
 
     /// A correction that runs the other way, and what to do with it.

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -452,6 +452,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// The correction the pill is asking about. Its chips are answers, so
     /// `runOfferedCommand` must not look up a transform called "Yes".
     private var pendingLearn: (changes: [EditWatch.Change], sentence: String)?
+    /// The dictation being held while the pill asks which word you meant.
+    ///
+    /// The words are decoded and not yet written. Every way the question can
+    /// end writes them — see `writeTheChoice` — so this is never a sentence
+    /// that can be lost, only one that lands later than usual.
+    private var pendingChoice: PendingChoice?
     private var offerReading = Confidence.Reading()
     /// Until when this offer's Return is held. Set when the offer goes up, so
     /// an offer whose keys arrive late — a second dictation was still running —
@@ -1281,7 +1287,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // so it is visible precisely when the panel is open, and the promise
         // and the behaviour cannot come apart again.
         if !recorder.isRecording {
-            keyedAtPress = afterTap || (offerIsUp && pill.isOpen)
+            // The selector is the one open panel that does not draw that row.
+            // `PillMetrics.showsHold` refuses it, so a panel asking which word
+            // you meant promises nothing about holding and must not take the
+            // next hold as an instruction. The rule is still "whatever the
+            // pill is drawing"; there is now a second thing to ask it.
+            let promisesHold = pill.isOpen
+                && PillMetrics.showsHold(offerHeadline, hotkey: pill.model.hotkey)
+            keyedAtPress = afterTap || (offerIsUp && promisesHold)
             // Only when it is on, and it says which of the two put it there.
             // This is the one decision at the press you cannot see from
             // outside: the same key, the same meter, and the words routed
@@ -4435,9 +4448,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // ends the offer, which is the "you have moved on" signal it was
         // already sending. The letters arm when the panel opens, which is the
         // only time they are drawn on screen to be pressed.
-        let letters = pill.isOpen
-            ? Set(commands.map(\.key).filter { !$0.isEmpty })
-            : Set<String>()
+        // A selector claims its two digits instead. It has no chips — each
+        // option carries its own key — and it is never a tab, so there is no
+        // closed state for it to hold a key through.
+        let choosing = pendingChoice != nil
+        let letters = choosing
+            ? Set(["1", "2"])
+            : (pill.isOpen ? Set(commands.map(\.key).filter { !$0.isEmpty }) : Set<String>())
         // The hold is armed only for a dictation that raised the warning, and
         // only until it has been spent. Re-armed from here on every call, so an
         // offer that got its keys late — a dictation was still running — is
@@ -4453,7 +4470,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
             switch key {
             case .letter(let typed):
-                guard let index = commands.firstIndex(where: { $0.key == typed }) else { return }
+                // The digit is the option, and the pill draws it on the option
+                // itself: 1 keeps what stands there, 2 takes the other word.
+                let index = choosing
+                    ? Int(typed).map { $0 - 1 }
+                    : commands.firstIndex(where: { $0.key == typed })
+                guard let index else { return }
                 // The highlight moves first, so what runs is what the pill was
                 // showing when it ran.
                 self.pill.model.selected = index
@@ -4549,6 +4571,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// faded itself out by then, on its own clock, and this would fade it a
     /// second time. `offerDeadlinePassed` calls `endTheOffer` directly.
     private func dismissOffer(reason: String) {
+        // A selector dismissed is a question declined, and the words it was
+        // holding are still owed. `writeTheChoice` takes the surface down
+        // itself, so this returns rather than doing it twice.
+        guard pendingChoice == nil else {
+            writeTheChoice(reason: "dismissed by \(reason)")
+            return
+        }
         Log.write("offer: dismissed by \(reason)")
         endTheOffer()
         pill.hide()
@@ -4581,6 +4610,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// and a pointer that has gone without saying so is treated as one that
     /// said so: the offer gets its `offerSeconds` back and runs out normally.
     private func offerDeadlinePassed() {
+        // Nobody answered, and the words have been waiting for it. They go in
+        // as the pipeline settled them — which is what an unanswered place has
+        // always shipped, only now somebody was asked first.
+        if pendingChoice != nil, !offerHeld, !pill.pointerIsOver {
+            writeTheChoice(reason: "nobody answered")
+            return
+        }
         guard offerHeld else {
             // Open, this is the panel's deadline and not the offer's: it folds
             // and the tab stays. `pill.open(false)` calls back through `onFold`
@@ -4633,6 +4669,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// offer, which is most of the time. A caller that still needs the words
     /// the offer was about reads `offeredCorrection` before calling this.
     private func endTheOffer() {
+        // The catch-all for every ending that is not the selector's own — a
+        // new press above all. A question that is over has to write the words
+        // it was holding, whatever ended it. `writeTheChoice` clears
+        // `pendingChoice` before it calls back in here, so this runs once.
+        if pendingChoice != nil { writeTheChoice(reason: "the surface ended") }
         offerUntil = nil
         offerHeld = false
         // Including one on its way back after a message. Escape, a click
@@ -4852,6 +4893,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         wroteAtPress.removeValue(forKey: run)
         heardAtPress.removeValue(forKey: run)
         InputBox.forget(run)
+        OpenPlaces.forget(run)
         pressesInFlight.remove(run)
         cancelledPresses.remove(run)
     }
@@ -5607,7 +5649,269 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         Log.write("transcribed: \(trimmed)")
         lastTranscript = trimmed
+        // The last thing before the words go in, and the only thing that can
+        // delay them. A place the vocabulary pass could not settle is a
+        // question, and this is where it gets asked — after the command
+        // branches above, because a spoken command is not a sentence and has
+        // no place in it to ask about.
+        if askWhichWord(delivered, destination: destination, focus: focus, for: press) {
+            return
+        }
         insertDictation(delivered, to: destination, for: press)
+    }
+
+    // MARK: - Which word did you mean
+
+    /// A dictation held on the way to the field while the pill asks about it.
+    ///
+    /// Everything `insertDictation` needs is frozen in here. The answer comes
+    /// seconds later and none of it can be read again by then: focus has
+    /// moved, and `destinationAtPress` may already belong to a newer press.
+    private struct PendingChoice {
+        /// The text the pipeline settled on. This is what ships when nobody
+        /// answers, and every option 0 leaves it exactly as it is.
+        let text: String
+        let destination: Destination
+        let focus: SelectionReader.Selection?
+        let press: Press
+        /// The open places, left to right, as they stand in `text`.
+        let places: [OpenPlaces.Placed]
+        /// The same questions in the shape the pill draws them.
+        ///
+        /// Drawing only. The write is done over `text` by range, because
+        /// `ChooseRun` splits on spaces and joins with one — which would eat a
+        /// newline, a double space, and any other whitespace the dictation
+        /// actually has in it.
+        var run: ChooseRun
+        /// What was picked, in order, one per question answered. Shorter than
+        /// `places` while there are questions left.
+        var answers: [Int] = []
+        /// When the question went up, so the trace can say how long it took to
+        /// answer. One clock for the run: the questions come one after another
+        /// and it is the whole interruption that is worth knowing.
+        let asked = Date()
+    }
+
+    /// Ask about the places this dictation left open, and hold the words until
+    /// they are answered. True when it asked, and then nobody else writes.
+    ///
+    /// Refuses quietly in every case it cannot ask well: nothing left open,
+    /// the key switched off, no pill to ask on, or a place that cannot be
+    /// found in the text that actually landed. The stages after `vocabulary`
+    /// may rewrite, so a span is searched for again rather than trusted, and a
+    /// span that is gone is a question nobody can answer.
+    private func askWhichWord(
+        _ text: String, destination: Destination,
+        focus: SelectionReader.Selection?, for press: Press
+    ) -> Bool {
+        let open = OpenPlaces.take(for: press.run)
+        guard !open.isEmpty, config.vocabulary.asks else { return false }
+        // One question at a time, and one pill. A panel already up is somebody
+        // else's — the learn offer, an update — and replacing it would throw
+        // away what it was asking without showing it. Same refusal
+        // `offerToLearn` makes, for the same reason.
+        guard pendingChoice == nil, !offerIsUp else {
+            Log.write("selector: a surface is already up; \(open.count) place(s)"
+                + " keep what the pipeline settled on")
+            return false
+        }
+        let placed = OpenPlaces.located(open, in: text)
+        guard !placed.isEmpty else { return false }
+
+        // The words, as `ChooseRun` counts them. A place's word index is
+        // derived from the range that was just found, so the two views of the
+        // sentence cannot disagree about where the question is.
+        let words = text.split(separator: " ").map(String.init)
+        let questions = placed.map { place in
+            ChooseRun.Place(
+                at: text[..<place.range.lowerBound].split(separator: " ").count,
+                span: place.open.standing.split(separator: " ").count,
+                other: place.open.other
+            )
+        }
+        pendingChoice = PendingChoice(
+            text: text, destination: destination, focus: focus, press: press,
+            places: placed, run: ChooseRun(sentence: words.joined(separator: " "),
+                                           places: questions)
+        )
+        Log.write("selector: holding the words for \(placed.count) question(s) — "
+            + placed.map { "\"\($0.open.standing)\" or \"\($0.open.other)\"" }
+                .joined(separator: ", "))
+        askTheNextWord()
+        return true
+    }
+
+    /// Put the next question on the pill, or write the words if there is none.
+    ///
+    /// The pill is raised again for each question rather than edited, which is
+    /// what restarts the clock and the fade: a second question inheriting the
+    /// two seconds left on the first would be gone before it was read.
+    private func askTheNextWord() {
+        guard let pending = pendingChoice else { return }
+        guard let question = pending.run.next else {
+            writeTheChoice(reason: "every place was answered")
+            return
+        }
+        offerUntil = Date().addingTimeInterval(Self.offerSeconds)
+        offerHeld = false
+        offerPressRun = pending.press.run
+        offerHeadline = .choose(question)
+        offerReading = Confidence.Reading()
+        offerHoldsReturnUntil = nil
+        // No chips. Each option carries its own key, which is what
+        // `PillMetrics` measures the selector for.
+        offerOnScreen = []
+        Log.write("selector: \(question.line)")
+        pill.offer(
+            [], headline: offerHeadline, reading: offerReading, open: true,
+            for: Self.offerSeconds
+        )
+        pill.model.onPick = { [weak self] option in self?.answer(option) }
+        pill.model.onFold = { [weak self] in
+            // Folded to the tab, which for a selector is not a state it can be
+            // in: there is nothing to come back to, and the words are waiting.
+            self?.writeTheChoice(reason: "the pill folded")
+        }
+        pill.model.onHover = { [weak self] inside in
+            guard let self else { return }
+            if !inside { self.pill.model.selected = nil }
+            self.holdTheOffer(inside)
+        }
+        watchTheOfferKeys()
+        watchForOfferOutsideClick()
+    }
+
+    /// Take one answer: 0 keeps what stands there, 1 takes the other word.
+    private func answer(_ option: Int) {
+        guard var pending = pendingChoice else { return }
+        guard pending.answers.count < pending.places.count, (0...1).contains(option) else {
+            return
+        }
+        let place = pending.places[pending.answers.count]
+        Log.write("selector: \"\(option == 0 ? place.open.standing : place.open.other)\"")
+        pending.answers.append(option)
+        pending.run.answer(option)
+        pendingChoice = pending
+        askTheNextWord()
+    }
+
+    /// Write the words, however the question ended.
+    ///
+    /// Every ending arrives here — the last answer, Escape, a click outside,
+    /// the deadline, a new press — and every one of them writes. A place that
+    /// was never answered keeps what stands there, which is the text the
+    /// pipeline returned and the stage's own contract. So a pill that is
+    /// missed costs the question, never the sentence.
+    private func writeTheChoice(reason: String) {
+        guard let pending = pendingChoice else { return }
+        pendingChoice = nil
+        endTheOffer()
+        pill.hide()
+        let answered = pending.answers.count
+        if answered < pending.places.count {
+            Log.write("selector: \(reason) — \(pending.places.count - answered) of"
+                + " \(pending.places.count) place(s) keep what was already there")
+        }
+
+        let (text, written) = OpenPlaces.written(
+            pending.places, answers: pending.answers, in: pending.text,
+            refusing: { self.refusedSpelling($0, in: pending.text) }
+        )
+        if text != pending.text {
+            Log.write("selector: the answers rewrote the transcript")
+            Log.write("    before: \(pending.text)")
+            Log.write("    after:  \(text)")
+        }
+        // The words go in first. Recording an answer is a file write and a
+        // portrait rebuild, and neither is something the person is waiting on
+        // — what they are waiting on is the sentence.
+        //
+        // Only the places that were answered. A place the deadline defaulted
+        // is not an answer, and a term taught from one would be an opinion
+        // nobody gave.
+        let learned = (0..<answered).map { (pending.places[$0], written[$0]) }
+        lastTranscript = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        insertDictation(text, to: pending.destination, for: pending.press)
+        for (place, word) in learned {
+            teach(place, wrote: word, in: text, of: pending)
+        }
+    }
+
+    /// What to write when the term is refused: the words as they were heard,
+    /// and their capitals dropped if that is all they were.
+    ///
+    /// A span that glues to the term — `Better Stack` for `BetterStack` — and
+    /// that you have just refused is the ordinary phrase, and the decoder's
+    /// capitals are there because it thought it was writing a name. Same rule
+    /// the stage applies to a refusal of its own, and applied here for the same
+    /// reason: without it the phrase ships looking like the name it is not.
+    ///
+    /// Only where the answer changes the string. Keeping what stands there has
+    /// to mean exactly the text the pipeline returned, or answering 0 and
+    /// letting the pill run out would write two different sentences.
+    private func refusedSpelling(
+        _ place: OpenPlaces.Placed, in text: String
+    ) -> String {
+        let open = place.open
+        guard open.other == open.was, Vocabulary.glues(heard: open.was, term: open.now)
+        else { return open.other }
+        // The span as heard, because the rule has written its term over it and
+        // the term is a different length.
+        let heard = text.replacingCharacters(in: place.range, with: open.was)
+        let at = text.distance(from: text.startIndex, to: place.range.lowerBound)
+        guard let lower = VocabularyPass.lowercased(
+            open.was, in: heard, at: at, terms: Array(config.vocabulary.terms.keys)
+        ) else { return open.other }
+        Log.write("selector: \"\(open.was)\" refused as \(open.now) — written in lowercase")
+        return lower
+    }
+
+    /// What one answer teaches the term it was about.
+    ///
+    /// Both ways, and that is the whole point of asking. A term confirmed is a
+    /// sentence it lives in; a term refused is a sentence it does not — and
+    /// nothing else in the app collects the second kind except a correction
+    /// somebody makes by hand. Three of them and `TermPortrait` stops reading
+    /// the term against a floor and reads it against its own counter-examples.
+    ///
+    /// These are also the hardest places there are to label. Every free gate
+    /// looked at this one and none of them could say.
+    private func teach(
+        _ place: OpenPlaces.Placed, wrote word: String, in text: String,
+        of pending: PendingChoice
+    ) {
+        let open = place.open
+        Trace.chose(
+            term: open.term, kept: open.standing, chose: word, text: text,
+            range: 0 ..< text.utf16.count,
+            lang: DictationLanguage.forCorrection(
+                transcript: text, allowed: config.transcription.languages
+            ),
+            app: pending.press.owner?.localizedName,
+            after: Date().timeIntervalSince(pending.asked),
+            beside: clipDirectories[pending.press.run]
+        )
+        // Which side the term is on flips with the source: a rule has already
+        // written its term into the text, so keeping what stands there keeps
+        // the term. The comparison is with the reading, not the canonical term
+        // — `Praisy's` keeps its possessive.
+        let kept = word == open.now
+        do {
+            try TermUses.record(
+                term: open.term, said: text, span: word, from: .chosen, counter: !kept
+            )
+            rebuildPortrait(for: open.term)
+            // One term chosen over another says two things, and both are worth
+            // keeping: the first does not live here and the second does.
+            if !kept, let other = existingTerm(named: word), other != open.term {
+                try TermUses.record(term: other, said: text, span: word, from: .chosen)
+                rebuildPortrait(for: other)
+            }
+            Log.write("selector: \(open.term) \(kept ? "belongs" : "does not belong")"
+                + " in \"\(TermUses.narrowed(text, to: word))\"")
+        } catch {
+            Log.write("selector: could not record the answer: \(error.localizedDescription)")
+        }
     }
 
     /// An instruction found inside a dictation: route it, run it over the words

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -5770,7 +5770,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             writeTheChoice(reason: "every place was answered")
             return
         }
-        offerUntil = Date().addingTimeInterval(Self.offerSeconds)
+        // The learn question's clock, not the offer's. `offerSeconds` is six —
+        // four at full strength and two fading — which is right for a tab you
+        // may ignore and wrong for a question holding your sentence. This is
+        // the same shape the learn offer gets thirty seconds for: a sentence to
+        // read and a word to decide.
+        offerUntil = Date().addingTimeInterval(Self.learnSeconds)
         offerHeld = false
         offerPressRun = pending.press.run
         offerHeadline = .choose(question)
@@ -5782,7 +5787,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Log.write("selector: \(question.line)")
         pill.offer(
             [], headline: offerHeadline, reading: offerReading, open: true,
-            for: Self.offerSeconds
+            for: Self.learnSeconds
         )
         pill.model.onPick = { [weak self] option in self?.answer(option) }
         pill.model.onFold = { [weak self] in

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -236,7 +236,7 @@ struct Config: Decodable, Equatable {
         /// Whether a place none of the gates settles is put to you on the pill.
         ///
         /// The words wait for the answer, and that is the whole of what this
-        /// costs: a pill you do not notice holds the dictation for nine
+        /// costs: a pill you do not notice holds the dictation for thirty
         /// seconds and then types what it would have typed anyway. Off, the
         /// stage keeps what arrived and says nothing, the way it did before
         /// there was a surface to ask on.

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -233,6 +233,21 @@ struct Config: Decodable, Equatable {
         /// it shipped `Versailles` as `Vercel` inside that window.
         var gateSentence: Bool = true
 
+        /// Whether a place none of the gates settles is put to you on the pill.
+        ///
+        /// The words wait for the answer, and that is the whole of what this
+        /// costs: a pill you do not notice holds the dictation for nine
+        /// seconds and then types what it would have typed anyway. Off, the
+        /// stage keeps what arrived and says nothing, the way it did before
+        /// there was a surface to ask on.
+        ///
+        /// On. An open place is the one case in the whole pass where the app
+        /// knows that it does not know. It is also the only place a term's
+        /// counter-examples come from without waiting for somebody to correct
+        /// the text by hand, and a portrait needs three of those before it
+        /// stops reading the term against a fixed floor.
+        var asks: Bool = true
+
         /// One way this speaker's mouth turns a term into something else, and
         /// what is known about that.
         ///
@@ -511,7 +526,7 @@ struct Config: Decodable, Equatable {
         var refused: [String] = []
 
         enum CodingKeys: String, CodingKey {
-            case acoustic, terms
+            case acoustic, terms, asks
             case minSimilarity = "min_similarity"
             case offerBelow = "offer_below"
             case decideAbove = "decide_above"
@@ -576,6 +591,9 @@ struct Config: Decodable, Equatable {
             }
             if let on = try c.decodeIfPresent(Bool.self, forKey: .gateSentence) {
                 gateSentence = on
+            }
+            if let on = try c.decodeIfPresent(Bool.self, forKey: .asks) {
+                asks = on
             }
             // `gate_rank` switched a rule that wrote a name when its span read
             // worst in the sentence. The rule is gone — see `SlotGate` — so the

--- a/Sources/ParrotFlow/EditWatch.swift
+++ b/Sources/ParrotFlow/EditWatch.swift
@@ -71,7 +71,9 @@ final class EditWatch {
     /// What was dictated, so the line it went on can be found again while the
     /// field is still catching up.
     private var dictated: String?
-    private var field: AXUIElement?
+    /// Read by `AppDelegate.offerToLearn`, which puts its pill under the
+    /// caret in the field the correction was made in.
+    private(set) var field: AXUIElement?
     private var monitors: [Any] = []
     private var reported: Set<String> = []
     /// What each replaced word has become so far. Only the last state of each

--- a/Sources/ParrotFlow/OpenPlaces.swift
+++ b/Sources/ParrotFlow/OpenPlaces.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+/// The places one dictation's vocabulary pass could not settle, kept until the
+/// pill can ask about them.
+///
+/// The stage decides and the pill asks, and there is a decoder, a pipeline and
+/// two thread hops between them. `Transcriber.transcribe` returns a string, so
+/// the places cannot come back the way the text does — the same problem
+/// `InputBox` has with the field it read at the press, and the same answer: a
+/// dictionary keyed by press run, written by whoever is on the pipeline's
+/// thread and read on the main one.
+///
+/// Keyed by press run and not by "the last dictation", because push-to-talk
+/// does not wait: a second press can be recording while this one's places are
+/// still on their way.
+enum OpenPlaces {
+
+    /// One place the free gates left open, and the two readings of it.
+    ///
+    /// Both readings, and which of them is in the string. That last part is
+    /// not a detail: a `replacements` rule has already written its term into
+    /// the transcript, so what stands there is `now`, and a sound proposal
+    /// writes nothing, so what stands there is `was`. The pill's first option
+    /// is always what is already written — answering it changes nothing — and
+    /// which side the term is on flips with the source.
+    struct Open: Equatable {
+        /// What the decoder wrote over this span.
+        let was: String
+        /// The term as it would be written there, inflected as the span needs.
+        let now: String
+        /// Whether the stage left `now` in the string. False means `was`.
+        let wrote: Bool
+        /// The vocabulary term this place is about, for the uses it teaches.
+        let term: String
+        /// Where the span sits in the stage's text, counted in words.
+        ///
+        /// The stages after `vocabulary` may rewrite, so the span is searched
+        /// for again in the text that actually landed. A sentence naming the
+        /// same word twice gives two hits, and this is how the right one is
+        /// picked.
+        let word: Int
+
+        /// What is written there now, which is the pill's option 0.
+        var standing: String { wrote ? now : was }
+        /// The reading nobody has taken, which is the pill's option 1.
+        var other: String { wrote ? was : now }
+    }
+
+    /// One place, and where it turned out to be in the text that landed.
+    struct Placed: Equatable {
+        let range: Range<String.Index>
+        let open: Open
+    }
+
+    /// Where each place sits in the words that actually landed.
+    ///
+    /// The stages after `vocabulary` may rewrite, so a span is searched for
+    /// again rather than trusted — and a span that is gone is a question
+    /// nobody can answer, so it is dropped. A word, not a substring: the same
+    /// test the uses file makes, so `Vercel` does not find itself in
+    /// `Vercelli`.
+    ///
+    /// A sentence naming the word twice gives two hits, and the place's own
+    /// word index is the only thing that tells them apart. Two places never
+    /// take the same hit.
+    ///
+    /// Returned left to right, which is the order the questions are asked in
+    /// and the order the write walks.
+    static func located(_ places: [Open], in text: String) -> [Placed] {
+        var found: [Placed] = []
+        var taken: [Range<String.Index>] = []
+        func words(before at: String.Index) -> Int {
+            text[..<at].split(separator: " ").count
+        }
+        for place in places {
+            let hits = TermUses.occurrences(of: place.standing, in: text)
+                .filter { hit in !taken.contains { $0.overlaps(hit) } }
+            guard let at = hits.min(by: {
+                abs(words(before: $0.lowerBound) - place.word)
+                    < abs(words(before: $1.lowerBound) - place.word)
+            }) else {
+                Log.write("selector: \"\(place.standing)\" is not in the text that"
+                    + " landed; not asked")
+                continue
+            }
+            taken.append(at)
+            found.append(Placed(range: at, open: place))
+        }
+        return found.sorted { $0.range.lowerBound < $1.range.lowerBound }
+    }
+
+    /// The text with each answered place written the way it was answered.
+    ///
+    /// The same walk `VocabularyPass.settling` does, and for the same reason:
+    /// everything outside a place survives exactly as it arrived, newlines and
+    /// double spaces included. A word split and rejoined on single spaces
+    /// would lose both.
+    ///
+    /// `answers` may be shorter than `places` — that is a run that ended
+    /// before every question was answered. Those places keep what stands
+    /// there, which is the text the pipeline returned.
+    ///
+    /// - Parameter refusing: what to write when the answer is option 1. It is
+    ///   a closure because refusing a term can change the spelling of the
+    ///   phrase that goes back — see `AppDelegate.refusedSpelling` — and that
+    ///   needs the vocabulary and a tagger this type has no business holding.
+    static func written(
+        _ places: [Placed], answers: [Int], in text: String,
+        refusing: (Placed) -> String
+    ) -> (text: String, words: [String]) {
+        var out = "", cursor = text.startIndex
+        var written: [String] = []
+        for (index, place) in places.enumerated() {
+            out += text[cursor..<place.range.lowerBound]
+            let word = index < answers.count && answers[index] == 1
+                ? refusing(place)
+                : place.open.standing
+            written.append(word)
+            out += word
+            cursor = place.range.upperBound
+        }
+        return (out + text[cursor...], written)
+    }
+
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var byRun: [Int: [Open]] = [:]
+
+    /// Keep this run's open places. Called off the main thread, from the stage.
+    static func record(run: Int, _ places: [Open]) {
+        guard !places.isEmpty else { return }
+        lock.lock()
+        byRun[run] = places
+        lock.unlock()
+    }
+
+    /// The places, and they are gone. One dictation asks once.
+    static func take(for run: Int) -> [Open] {
+        lock.lock()
+        defer { lock.unlock() }
+        return byRun.removeValue(forKey: run) ?? []
+    }
+
+    /// This dictation is over, however it ended. Called from `dictationEnded`,
+    /// which is what keeps this from growing on the runs nobody asks about —
+    /// a cancelled dictation, or a spoken command that never reaches the pill.
+    static func forget(_ run: Int) {
+        lock.lock()
+        byRun.removeValue(forKey: run)
+        lock.unlock()
+    }
+}

--- a/Sources/ParrotFlow/OpenPlaces.swift
+++ b/Sources/ParrotFlow/OpenPlaces.swift
@@ -118,9 +118,9 @@ enum OpenPlaces {
             // Where it ended up, not where it was asked about. A place after
             // one that got longer or shorter has moved, and the trace's whole
             // job is to say which occurrence this was.
-            let from = out.utf16.count
+            let from = out.count
             out += word
-            written.append(Written(word: word, range: from ..< out.utf16.count))
+            written.append(Written(word: word, range: from ..< out.count))
             cursor = place.range.upperBound
         }
         return (out + text[cursor...], written)
@@ -129,7 +129,9 @@ enum OpenPlaces {
     /// A word as it was written, and where it sits in the text that shipped.
     struct Written: Equatable {
         let word: String
-        /// UTF-16 offsets, which is what the trace's other records use.
+        /// Character offsets, the unit `Trace.edit` already writes — see
+        /// `EditWatch.asHeard`. Two `range` fields in one trace file measuring
+        /// in different units is a trap for whatever reads them together.
         let range: Range<Int>
     }
 
@@ -137,10 +139,14 @@ enum OpenPlaces {
     nonisolated(unsafe) private static var byRun: [Int: [Open]] = [:]
 
     /// Keep this run's open places. Called off the main thread, from the stage.
+    ///
+    /// An empty list clears the run rather than leaving what was there. A
+    /// config may list `vocabulary` twice, and then the last stage to run is
+    /// the one that says what is still open — a stage that settles everything
+    /// has to be able to take the question away.
     static func record(run: Int, _ places: [Open]) {
-        guard !places.isEmpty else { return }
         lock.lock()
-        byRun[run] = places
+        if places.isEmpty { byRun.removeValue(forKey: run) } else { byRun[run] = places }
         lock.unlock()
     }
 

--- a/Sources/ParrotFlow/OpenPlaces.swift
+++ b/Sources/ParrotFlow/OpenPlaces.swift
@@ -107,19 +107,30 @@ enum OpenPlaces {
     static func written(
         _ places: [Placed], answers: [Int], in text: String,
         refusing: (Placed) -> String
-    ) -> (text: String, words: [String]) {
+    ) -> (text: String, words: [Written]) {
         var out = "", cursor = text.startIndex
-        var written: [String] = []
+        var written: [Written] = []
         for (index, place) in places.enumerated() {
             out += text[cursor..<place.range.lowerBound]
             let word = index < answers.count && answers[index] == 1
                 ? refusing(place)
                 : place.open.standing
-            written.append(word)
+            // Where it ended up, not where it was asked about. A place after
+            // one that got longer or shorter has moved, and the trace's whole
+            // job is to say which occurrence this was.
+            let from = out.utf16.count
             out += word
+            written.append(Written(word: word, range: from ..< out.utf16.count))
             cursor = place.range.upperBound
         }
         return (out + text[cursor...], written)
+    }
+
+    /// A word as it was written, and where it sits in the text that shipped.
+    struct Written: Equatable {
+        let word: String
+        /// UTF-16 offsets, which is what the trace's other records use.
+        let range: Range<Int>
     }
 
     private static let lock = NSLock()

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -1232,10 +1232,19 @@ struct Pipeline: Equatable, Codable {
         // "Keeps what is already there" is still this stage's contract.
         // Nothing below changes, and a dictation whose pill is never answered
         // writes exactly the text this returns.
+        // Written on every run, empty included: a config may list `vocabulary`
+        // twice, and the last stage is the one whose places are still open.
+        // Recording only a non-empty list would leave an earlier stage's
+        // question standing after a later one had settled it.
         if case .int(let run)? = scope["press.run"] {
             OpenPlaces.record(run: run, changes.indices.compactMap { index in
+                // The term that offered the reading, not the first of the
+                // set: several terms can overlap one span and only one of them
+                // wins the place, and an answer recorded against the other
+                // would teach the wrong name.
                 guard decided[index] == nil, !(index < taught.count && taught[index]),
-                      let term = changes[index].terms.first else { return nil }
+                      let term = changes[index].owner ?? changes[index].terms.first
+                else { return nil }
                 let change = changes[index]
                 return OpenPlaces.Open(
                     was: change.was, now: change.now,
@@ -1278,7 +1287,7 @@ struct Pipeline: Equatable, Codable {
                 ) else { continue }
                 writing[index] = VocabularyPass.Change(
                     range: change.range, was: lower, now: change.now,
-                    terms: change.terms, standing: change.standing
+                    terms: change.terms, owner: change.owner, standing: change.standing
                 )
                 Log.write("vocabulary: \"\(change.was)\" refused as \(change.now)"
                     + " — written in lowercase")

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -1225,6 +1225,29 @@ struct Pipeline: Equatable, Codable {
             Log.write("vocabulary: \(open) of \(changes.count) place(s) left open —"
                 + " each keeps what is already there")
         }
+        // Handed to whoever can ask about them. Only off the hotkey: a run
+        // with no press has nobody to put a question to, and `--pipeline`
+        // filling a dictionary that nothing empties is a leak with a name.
+        //
+        // "Keeps what is already there" is still this stage's contract.
+        // Nothing below changes, and a dictation whose pill is never answered
+        // writes exactly the text this returns.
+        if case .int(let run)? = scope["press.run"] {
+            OpenPlaces.record(run: run, changes.indices.compactMap { index in
+                guard decided[index] == nil, !(index < taught.count && taught[index]),
+                      let term = changes[index].terms.first else { return nil }
+                let change = changes[index]
+                return OpenPlaces.Open(
+                    was: change.was, now: change.now,
+                    // What `settling` is about to copy: a rule has already
+                    // written its term over the span, a sound proposal has not.
+                    wrote: String(text[change.range]) == change.now,
+                    term: term,
+                    word: text[..<change.range.lowerBound]
+                        .split(separator: " ").count
+                )
+            })
+        }
 
         // A spelling lesson is reverted by the rule and nothing else looks at
         // it. Both models measured answered all four of the archive's cases

--- a/Sources/ParrotFlow/SelectorCommand.swift
+++ b/Sources/ParrotFlow/SelectorCommand.swift
@@ -77,7 +77,11 @@ enum SelectorCommand {
         // place after one the answer made longer or shorter has moved, and
         // nothing else prints that.
         guard !ranges else {
-            print(done.words.map { "\($0.word)@\($0.range.lowerBound)-\($0.range.upperBound)" }
+            // The answered ones only. `written` returns a row per located
+            // place, and the rows past the last answer are what stands there
+            // rather than anything anybody picked.
+            print(done.words.prefix(taken.count)
+                .map { "\($0.word)@\($0.range.lowerBound)-\($0.range.upperBound)" }
                 .joined(separator: " "))
             return 0
         }

--- a/Sources/ParrotFlow/SelectorCommand.swift
+++ b/Sources/ParrotFlow/SelectorCommand.swift
@@ -19,12 +19,16 @@ import Foundation
 /// between them. `scripts/check-selector.sh` scores this entry point, so the
 /// set runs against the shipped functions rather than a copy of them.
 ///
+/// `--ranges` prints where each answered word ended up instead of the text,
+/// which is what `Trace.chose` records: a place after one the answer made
+/// longer or shorter has moved, and nothing else shows that.
+///
 /// The refusal is written plainly here — `other` as given. The app also asks
 /// `VocabularyPass.lowercased` about a glued span, which needs a tagger and
 /// the vocabulary; `--lowercase-refused` is where that half is scored.
 enum SelectorCommand {
 
-    static func run(text: String, places: [String]) -> Int32 {
+    static func run(text: String, places: [String], ranges: Bool = false) -> Int32 {
         var open: [OpenPlaces.Open] = []
         var answers: [Int?] = []
         for argument in places {
@@ -66,9 +70,18 @@ enum SelectorCommand {
         // asked one at a time, so nothing after an unanswered one was asked
         // either.
         let taken = ordered.prefix { $0 != nil }.compactMap { $0 }
-        print(OpenPlaces.written(
+        let done = OpenPlaces.written(
             located, answers: taken, in: text, refusing: { $0.open.other }
-        ).text)
+        )
+        // The word and where it ended up, which is what the trace records. A
+        // place after one the answer made longer or shorter has moved, and
+        // nothing else prints that.
+        guard !ranges else {
+            print(done.words.map { "\($0.word)@\($0.range.lowerBound)-\($0.range.upperBound)" }
+                .joined(separator: " "))
+            return 0
+        }
+        print(done.text)
         return 0
     }
 }

--- a/Sources/ParrotFlow/SelectorCommand.swift
+++ b/Sources/ParrotFlow/SelectorCommand.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Where an open place lands in the text that shipped, and what an answer
+/// writes there.
+///
+///     ParrotFlow --selector "can you ask Mick to review it." \
+///       "Mick|mixed bend|3|1"
+///     can you ask mixed bend to review it.
+///
+/// A place is `standing|other|word|answer`: what stands in the text, the
+/// reading nobody took, where the stage saw it counted in words, and the
+/// answer — `0` keeps what stands there, `1` takes the other reading, and `-`
+/// is a question nobody answered. Several places are several arguments, and
+/// they may be given in any order.
+///
+/// This is the half of the pill that is not drawing: `OpenPlaces.located`
+/// finds the span again in a text later stages may have rewritten, and
+/// `OpenPlaces.written` puts the answers back without touching anything
+/// between them. `scripts/check-selector.sh` scores this entry point, so the
+/// set runs against the shipped functions rather than a copy of them.
+///
+/// The refusal is written plainly here — `other` as given. The app also asks
+/// `VocabularyPass.lowercased` about a glued span, which needs a tagger and
+/// the vocabulary; `--lowercase-refused` is where that half is scored.
+enum SelectorCommand {
+
+    static func run(text: String, places: [String]) -> Int32 {
+        var open: [OpenPlaces.Open] = []
+        var answers: [Int?] = []
+        for argument in places {
+            let parts = argument.split(separator: "|", omittingEmptySubsequences: false)
+                .map(String.init)
+            guard parts.count == 4, let word = Int(parts[2]) else {
+                print("a place is standing|other|word|answer, not \"\(argument)\"")
+                return 2
+            }
+            let answer: Int?
+            switch parts[3] {
+            case "0": answer = 0
+            case "1": answer = 1
+            case "-": answer = nil
+            default:
+                print("an answer is 0, 1 or -, not \"\(parts[3])\"")
+                return 2
+            }
+            // `wrote` says which side the term is on, and nothing here needs
+            // to know: the two readings are given by name, and the term is
+            // only read when a use is being recorded.
+            open.append(OpenPlaces.Open(
+                was: parts[0], now: parts[1], wrote: false, term: parts[1], word: word
+            ))
+            answers.append(answer)
+        }
+        let located = OpenPlaces.located(open, in: text)
+        guard !located.isEmpty else {
+            print("NOTHING FOUND")
+            return 0
+        }
+        // Back in the order the places were located in, which is left to
+        // right and not the order they were typed.
+        let ordered = located.map { place -> Int? in
+            guard let at = open.firstIndex(where: { $0 == place.open }) else { return nil }
+            return answers[at]
+        }
+        // A run stops at the first place nobody answered: the questions are
+        // asked one at a time, so nothing after an unanswered one was asked
+        // either.
+        let taken = ordered.prefix { $0 != nil }.compactMap { $0 }
+        print(OpenPlaces.written(
+            located, answers: taken, in: text, refusing: { $0.open.other }
+        ).text)
+        return 0
+    }
+}

--- a/Sources/ParrotFlow/TeachingCommand.swift
+++ b/Sources/ParrotFlow/TeachingCommand.swift
@@ -19,7 +19,7 @@ enum TeachingCommand {
             return 2
         }
         let change = VocabularyPass.Change(
-            range: range, was: word, now: word, terms: [], standing: .rule
+            range: range, was: word, now: word, terms: [], owner: nil, standing: .rule
         )
         let taught = VocabularyPass.teaching(in: text, changes: [change])
         print(taught[0] ? "REVERT" : "ASK")

--- a/Sources/ParrotFlow/TermUses.swift
+++ b/Sources/ParrotFlow/TermUses.swift
@@ -55,6 +55,14 @@ enum TermUses {
             case correction
             /// Written by hand with `--learn --in`, to fill a portrait early.
             case seeded
+            /// Answered on the pill, before anything was typed.
+            ///
+            /// Its own source and not `correction`, because it is the one kind
+            /// that is not a correction: nothing was written and then fixed.
+            /// The app said it could not tell, and this is the answer — which
+            /// makes it the only use recorded about a place that was hard,
+            /// rather than about a place the app got wrong.
+            case chosen
         }
 
         static func == (a: Use, b: Use) -> Bool { a.said == b.said && a.span == b.span }
@@ -257,19 +265,31 @@ enum TermUses {
     /// genuine uses, and nothing that records one carries the position of the
     /// occurrence that was corrected.
     static func occurrence(of span: String, in text: String) -> Range<String.Index>? {
+        // Nil is nowhere. `Vercel` in `I visited Vercelli last year.` is not a
+        // use of the term, and a caller that only asked `contains` stored it
+        // as one.
+        occurrences(of: span, in: text).first
+    }
+
+    /// Every place `span` stands as a word.
+    ///
+    /// The pill's selector needs all of them. It holds a position taken before
+    /// the stages after `vocabulary` rewrote the transcript, so it cannot
+    /// simply take the first: picking the hit nearest that position is how the
+    /// right one of two mentions is found.
+    static func occurrences(of span: String, in text: String) -> [Range<String.Index>] {
         func word(_ c: Character) -> Bool { c.isLetter || c.isNumber }
+        var found: [Range<String.Index>] = []
         var from = text.startIndex
-        while let found = text.range(of: span, range: from ..< text.endIndex) {
-            let before = found.lowerBound == text.startIndex
-                || !word(text[text.index(before: found.lowerBound)])
-            let after = found.upperBound == text.endIndex || !word(text[found.upperBound])
-            if before && after { return found }
-            guard found.lowerBound < text.endIndex else { break }
-            from = text.index(after: found.lowerBound)
+        while let at = text.range(of: span, range: from ..< text.endIndex) {
+            let before = at.lowerBound == text.startIndex
+                || !word(text[text.index(before: at.lowerBound)])
+            let after = at.upperBound == text.endIndex || !word(text[at.upperBound])
+            if before && after { found.append(at) }
+            guard at.lowerBound < text.endIndex else { break }
+            from = text.index(after: at.lowerBound)
         }
-        // Nowhere. `Vercel` in `I visited Vercelli last year.` is not a use of
-        // the term, and a caller that only asked `contains` stored it as one.
-        return nil
+        return found
     }
 
     /// What terminals and shells draw in front of the line being typed.

--- a/Sources/ParrotFlow/Trace.swift
+++ b/Sources/ParrotFlow/Trace.swift
@@ -517,6 +517,9 @@ enum Trace {
         let chose: String
         /// The sentence as it stood when the question was asked.
         let text: String
+        /// Where `chose` stands in `text`, in character offsets — the same
+        /// unit `Edit.range` uses, so a script reading both kinds of line does
+        /// not have to know which record it is holding.
         let range: [Int]
         let lang: String
         let app: String?

--- a/Sources/ParrotFlow/Trace.swift
+++ b/Sources/ParrotFlow/Trace.swift
@@ -51,6 +51,7 @@ enum Trace {
         case dictation
         case correction
         case edit
+        case chose
     }
 
     /// The app a dictation was spoken into.
@@ -268,6 +269,33 @@ enum Trace {
         )
     }
 
+    /// Writes down a place the app could not settle, and what you said it was.
+    ///
+    /// Its own kind, not an `edit`. An edit is a thing the app got wrong and
+    /// you fixed. This is a place the app said out loud it could not tell, so
+    /// the answer is a label on a case that is known to be hard, whichever way
+    /// it went. Mixed into the edits they would read as mistakes that were
+    /// never made, and the edit corpus is what the misheard-word work reads.
+    ///
+    /// - Parameter kept: what stood there, which is what ships unanswered.
+    /// - Parameter chose: what was picked. The same string as `kept` when the
+    ///   answer was to keep it, and that is the label that costs nothing
+    ///   anywhere else to collect.
+    static func chose(
+        term: String, kept: String, chose: String, text: String, range: Range<Int>,
+        lang: String, app: String?, after: TimeInterval, beside: URL? = nil
+    ) {
+        append(
+            Chose(
+                v: version, kind: Kind.chose.rawValue, at: stamp(),
+                term: term, kept: kept, chose: chose, text: text,
+                range: [range.lowerBound, range.upperBound], lang: lang, app: app,
+                after: (after * 10).rounded() / 10
+            ),
+            to: beside ?? directory
+        )
+    }
+
     private static let queue = DispatchQueue(label: "com.parrotflow.trace")
 
     /// Waits for queued writes to reach the file. Same reason as `Log.flush` —
@@ -474,6 +502,25 @@ enum Trace {
         let lang: String
         let app: String?
         /// Seconds between the dictation landing and the change.
+        let after: Double
+    }
+
+    /// A place the vocabulary pass could not settle, and the answer. See
+    /// `chose`.
+    fileprivate struct Chose: Encodable {
+        let v: Int
+        let kind: String
+        let at: String
+        /// The vocabulary term the place was about.
+        let term: String
+        let kept: String
+        let chose: String
+        /// The sentence as it stood when the question was asked.
+        let text: String
+        let range: [Int]
+        let lang: String
+        let app: String?
+        /// Seconds between the question going up and the answer.
         let after: Double
     }
 

--- a/Sources/ParrotFlow/VocabularyPass.swift
+++ b/Sources/ParrotFlow/VocabularyPass.swift
@@ -187,6 +187,13 @@ enum VocabularyPass {
         /// reading. `terms.first` is then a different term, and anything that
         /// records what a person answered about this place would record it
         /// against the wrong name. Nil when the reading is the untouched span.
+        ///
+        /// Two parts that write the *same* reading share one entry, and the
+        /// first by position takes it — which is no better an answer than
+        /// alphabetical was. That needs two terms whose renderings over one
+        /// span come out identical, and nothing in this speaker's vocabulary
+        /// does it. What this fixes is the ordinary case: two different
+        /// readings, one of them offered.
         let owner: String?
         /// The best-evidenced of the readings in it, for `Caps.perTerm`.
         let standing: Standing

--- a/Sources/ParrotFlow/VocabularyPass.swift
+++ b/Sources/ParrotFlow/VocabularyPass.swift
@@ -176,7 +176,18 @@ enum VocabularyPass {
         /// which reads as confidence and is worth eight points of damage.
         var options: [String]
         /// The vocabulary terms this slot is about, carried into `Change`.
+        ///
+        /// Every term of every part that overlaps this span, as a sorted set.
+        /// So the first of them is alphabetical and says nothing about which
+        /// reading is on offer — see `owner`.
         let terms: [String]
+        /// The term that produced `options[1]`, when one did.
+        ///
+        /// Several parts can overlap one span, and only one of them wins the
+        /// reading. `terms.first` is then a different term, and anything that
+        /// records what a person answered about this place would record it
+        /// against the wrong name. Nil when the reading is the untouched span.
+        let owner: String?
         /// The best-evidenced of the readings in it, for `Caps.perTerm`.
         let standing: Standing
     }
@@ -457,12 +468,16 @@ enum VocabularyPass {
             }
 
             var widths: [String: Int] = [:]
+            // And whose reading each one is. First part wins, the same as
+            // `widths`, so the two tables always describe the same part.
+            var owners: [String: String] = [:]
             for part in group.parts {
                 let reading = written(part, part.other)
                 guard widths[reading] == nil else { continue }
                 widths[reading] = text.distance(
                     from: part.range.lowerBound, to: part.range.upperBound
                 )
+                owners[reading] = part.term
             }
             var rest: [String] = []
             for part in group.parts.sorted(by: { left, right in
@@ -499,6 +514,7 @@ enum VocabularyPass {
             built.append(Slot(
                 range: span, options: kept,
                 terms: Array(Set(group.parts.map(\.term))).sorted(),
+                owner: kept.count > 1 ? owners[kept[1]] : nil,
                 standing: group.parts.map(\.standing).min() ?? .wide
             ))
         }
@@ -845,8 +861,16 @@ enum VocabularyPass {
         /// needs it.
         let now: String
         /// The vocabulary terms this place is about, for anything reporting
-        /// what the stage decided.
+        /// what the stage decided. A sorted set, so its first entry is
+        /// alphabetical — `owner` is the one that offered `now`.
         let terms: [String]
+        /// The term that offered `now`, when one did. See `Slot.owner`.
+        ///
+        /// `SentenceGate` still reads `terms.first` for the portrait it asks,
+        /// which has the same fault. Left alone here: which portrait that gate
+        /// reads is a measured decision, and moving it belongs in a change
+        /// that re-runs the bench.
+        let owner: String?
         /// Where the reading came from, carried through from the slot. Read by
         /// `settle`, which gates one source and not the others.
         let standing: Standing
@@ -880,7 +904,7 @@ enum VocabularyPass {
             }
             built.append(Change(range: slot.range, was: slot.options[0],
                                 now: slot.options[1], terms: slot.terms,
-                                standing: slot.standing))
+                                owner: slot.owner, standing: slot.standing))
         }
         return built
     }

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -289,14 +289,21 @@ if let index = arguments.firstIndex(of: "--lowercase-refused") {
 }
 
 if let index = arguments.firstIndex(of: "--selector") {
-    guard arguments.indices.contains(index + 2) else {
+    // The places are counted after the flags are dropped, or
+    // `--selector "text" --ranges` reads as a call with a place in it and
+    // answers "NOTHING FOUND" — which is the answer for a span that is gone,
+    // not for a question nobody asked.
+    let places = arguments.indices.contains(index + 2)
+        ? Array(arguments[(index + 2)...].prefix { !$0.hasPrefix("--") })
+        : []
+    guard !places.isEmpty else {
         print("usage: ParrotFlow --selector \"<text>\""
-            + " \"<standing>|<other>|<word>|<answer>\"...")
+            + " \"<standing>|<other>|<word>|<answer>\"... [--ranges]")
         exit(2)
     }
     exit(SelectorCommand.run(
         text: arguments[index + 1],
-        places: Array(arguments[(index + 2)...].prefix { !$0.hasPrefix("--") }),
+        places: places,
         ranges: arguments.contains("--ranges")
     ))
 }

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -288,6 +288,18 @@ if let index = arguments.firstIndex(of: "--lowercase-refused") {
     ))
 }
 
+if let index = arguments.firstIndex(of: "--selector") {
+    guard arguments.indices.contains(index + 2) else {
+        print("usage: ParrotFlow --selector \"<text>\""
+            + " \"<standing>|<other>|<word>|<answer>\"...")
+        exit(2)
+    }
+    exit(SelectorCommand.run(
+        text: arguments[index + 1],
+        places: Array(arguments[(index + 2)...].prefix { !$0.hasPrefix("--") })
+    ))
+}
+
 if let index = arguments.firstIndex(of: "--suggest") {
     guard arguments.indices.contains(index + 1) else {
         print("usage: ParrotFlow --suggest \"<sentence>\" [--lang fr]")

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -296,7 +296,8 @@ if let index = arguments.firstIndex(of: "--selector") {
     }
     exit(SelectorCommand.run(
         text: arguments[index + 1],
-        places: Array(arguments[(index + 2)...].prefix { !$0.hasPrefix("--") })
+        places: Array(arguments[(index + 2)...].prefix { !$0.hasPrefix("--") }),
+        ranges: arguments.contains("--ranges")
     ))
 }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -435,6 +435,33 @@ say -o /tmp/t.wav --data-format=LEI16@16000 --channels=1 "testing one two three"
 $PF --transcribe /tmp/t.wav
 ```
 
+## What an answer on the pill writes
+
+```sh
+$PF --selector "<text>" "<standing>|<other>|<word>|<answer>"...
+```
+
+A place none of the gates settle is put to you on the pill, and the words wait
+for the answer. This is that write without the surface: where the span is found
+again in the text that shipped, and what goes back there.
+
+```
+$PF --selector "can you ask Mick to review it." "Mick|mixed bend|3|1"
+  can you ask mixed bend to review it.
+```
+
+A place is `standing|other|word|answer` — what stands in the text, the reading
+nobody took, where the stage saw it counted in words, and then `0` to keep what
+stands there, `1` to take the other reading, `-` for a question nobody
+answered. Several places are several arguments. `NOTHING FOUND` means no span
+was still there: the stages after `vocabulary` may rewrite, and a span that is
+gone is a question nobody can answer.
+
+The word index is what separates two mentions of the same word, and the write
+touches nothing between the places — a newline, a double space and a comma
+glued to the next word all survive it. `scripts/check-selector.sh` scores both
+halves. The lowercasing of a refused glued span is `--lowercase-refused`.
+
 ## What word does this slot want
 
 ```sh
@@ -796,8 +823,11 @@ the window has to cut at both ends.
 `selector-two` is a sentence with two open places, which is two questions. The
 pill asks about the first; the answer is written into the words, and the pill
 comes back with the second, counted "2 of 2" beside the question. The last
-answer prints the sentence it would type. Nothing triggers any of this in the
-app yet — these three and the sheet are the only ways to see it.
+answer prints the sentence it would type.
+
+A real dictation raises the same pill whenever the vocabulary gates leave a
+place open — see [transcription.md](transcription.md). What the answer does to
+the words is `--selector`, below.
 
 All three wait six seconds before the pill comes up, then read the caret and
 hang the panel off it, the way the app aims at the press. Click into a document
@@ -875,6 +905,7 @@ scripts/check-slot-gap.sh          # what the slot says about a rewrite (needs b
 scripts/check-sentence-case.sh     # the capital after a mark the join removes
 scripts/check-invented-tail.sh     # the endings the decoder wrote over silence
 scripts/check-sentence-join.sh     # which sentence marks the join removes (needs the model)
+scripts/check-selector.sh          # where an open place lands, and what an answer writes
 
 PF_VIEWPORT=Ghostty scripts/check-inplace.sh   # the same set, in another terminal
 $PF --peek 3 --via-copy                        # what Select All + Copy hands back

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -464,7 +464,7 @@ glued to the next word all survive it.
 `--ranges` prints where each answered word ended up instead of the text, which
 is what the trace records: a place after one the answer made longer has moved.
 
-`scripts/check-selector.sh` scores both halves, 20 cases. The lowercasing of a
+`scripts/check-selector.sh` scores both halves, 21 cases. The lowercasing of a
 refused glued span is `--lowercase-refused`.
 
 ## What word does this slot want

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -459,8 +459,13 @@ gone is a question nobody can answer.
 
 The word index is what separates two mentions of the same word, and the write
 touches nothing between the places — a newline, a double space and a comma
-glued to the next word all survive it. `scripts/check-selector.sh` scores both
-halves. The lowercasing of a refused glued span is `--lowercase-refused`.
+glued to the next word all survive it.
+
+`--ranges` prints where each answered word ended up instead of the text, which
+is what the trace records: a place after one the answer made longer has moved.
+
+`scripts/check-selector.sh` scores both halves, 20 cases. The lowercasing of a
+refused glued span is `--lowercase-refused`.
 
 ## What word does this slot want
 

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -459,6 +459,32 @@ counter says nothing until it gets either a counter or a third use.
 `--portrait <term> "<sentence>" <word>` prints both scores and the verdict;
 `scripts/check-counter-portrait.sh` is the run.
 
+**What nothing settles is asked.** The pill draws the sentence with the two
+readings stacked where the open place is, and 1 or 2 answers it. The words wait
+for the answer: nothing is typed until the last question is answered, so the
+sentence is only ever written once.
+
+Every way of not answering writes what the gates settled on, which is what an
+open place has always shipped. Escape, a click outside the pill, any other key,
+nine seconds, or starting the next dictation — all of them type the same text
+the stage returned. A pill you do not notice costs you the question, never the
+sentence.
+
+Several open places in one sentence are several questions, asked one at a time,
+and the count on the pill says how many are left.
+
+The answers are the reason to ask. Confirming a term keeps that sentence as a
+use; refusing one keeps it as a counter-example — the half a portrait cannot
+get any other way, because accepting an offer only ever teaches where a term
+*does* live. Three counter-examples and the term stops being read against a
+floor. Each answer also goes to `trace.jsonl` as `kind: chose`, kept apart from
+the hand edits: a place the app said out loud it could not decide is a harder
+label than a mistake somebody fixed.
+
+`asks: false` in `vocabulary.yaml` turns the question off. An open place then
+keeps what arrived in silence, the way it did before there was a surface to ask
+on.
+
 What the stage decided is written to `trace.jsonl` under its variables, so a
 decision can be replayed rather than guessed at.
 

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -466,7 +466,7 @@ sentence is only ever written once.
 
 Every way of not answering writes what the gates settled on, which is what an
 open place has always shipped. Escape, a click outside the pill, any other key,
-nine seconds, or starting the next dictation — all of them type the same text
+thirty seconds, or starting the next dictation — all of them type the same text
 the stage returned. A pill you do not notice costs you the question, never the
 sentence.
 

--- a/scripts/check-selector.sh
+++ b/scripts/check-selector.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Scores where an open place lands and what an answer writes there, against
+# tests/selector-cases.json.
+#
+#   scripts/check-selector.sh
+#
+# The pill asks about a place the vocabulary gates could not settle, and the
+# words wait for the answer. Two things have to be right for that to be safe.
+# The span has to be found again in the text that actually landed — the stages
+# after `vocabulary` may rewrite, and a span that is gone must be dropped
+# rather than guessed at. And the answers have to go back into the text
+# without touching anything between them: a newline, a double space and a
+# comma glued to the next word all belong to the person who dictated them.
+#
+# `OpenPlaces.located` and `OpenPlaces.written` are the two halves, and
+# `--selector` is the entry point, so the set runs against the shipped
+# functions rather than a copy of them.
+#
+# No model and no audio. This runs in CI and on a machine that has never
+# dictated.
+#
+# **This scores the write, not the surface.** What the pill draws is
+# `--panels selector`, `selector-long` and `selector-two`; the lowercasing of a
+# refused glued span is scripts/check-lowercase-refused.sh. Raising the pill
+# from a real dictation needs a term the gates leave open, and that is a
+# by-hand run — docs/transcription.md says which sentence does it.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/release/ParrotFlow"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+
+WORK="$(mktemp -d -t parrotflow-selector)"
+trap 'rm -rf "$WORK"' EXIT
+export PARROTFLOW_CONFIG_DIR="$WORK"
+
+# Base64, one line per field. A case holds newlines and double spaces on
+# purpose — those are what it is checking survive — and neither goes through a
+# line-per-field file as itself.
+if ! python3 -c '
+import base64, json, sys
+def b(s): return base64.b64encode(s.encode()).decode()
+for case in json.load(open(sys.argv[1])):
+    print(b(case["text"]))
+    print(b("\n".join(case["places"])))
+    print(b(case["want"]))
+    print(b(case["why"]))
+' "$ROOT/tests/selector-cases.json" > "$WORK/cases"; then
+  echo "  ✗ tests/selector-cases.json could not be read"
+  exit 1
+fi
+
+pass=0; total=0
+while IFS= read -r text64 && IFS= read -r places64 && IFS= read -r want64 \
+   && IFS= read -r why64; do
+  total=$((total + 1))
+  text="$(printf '%s' "$text64" | base64 -d)"
+  want="$(printf '%s' "$want64" | base64 -d)"
+  why="$(printf '%s' "$why64" | base64 -d)"
+  # The last line of a decoded field has no newline after it, and `read`
+  # returns non-zero there — so the trailing newline is added back rather than
+  # the loop losing its last place.
+  places=()
+  while IFS= read -r place; do places+=("$place"); done \
+    < <(printf '%s' "$places64" | base64 -d; printf '\n')
+  got="$("$BIN" --selector "$text" "${places[@]}" 2>/dev/null)"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1))
+    printf '  ✓  %s\n' "$why"
+  else
+    printf '  ✗  %s\n     got  %s\n     want %s\n' "$why" "${got:-<nothing>}" "$want"
+  fi
+done < "$WORK/cases"
+
+printf '\n%d/%d\n' "$pass" "$total"
+[ "$pass" -eq "$total" ]

--- a/scripts/check-selector.sh
+++ b/scripts/check-selector.sh
@@ -34,7 +34,14 @@ trap 'rm -rf "$WORK"' EXIT
 export PARROTFLOW_CONFIG_DIR="$WORK"
 
 # Base64, one line per field, and an empty last field for a case that wants the
-# text rather than the ranges. A case holds newlines and double spaces on
+# text rather than the ranges.
+#
+# A case cannot check a trailing newline, and does not need to: the comparison
+# below goes through `$(...)`, which strips them, and `print` adds one of its
+# own that could not be told apart from the text's. Nothing reaches the selector
+# with a newline at either end anyway — `finishTranscription` trims those off
+# before it asks. Newlines *inside* the text are what matter here, and those a
+# case does check. A case holds newlines and double spaces on
 # purpose — those are what it is checking survive — and neither goes through a
 # line-per-field file as itself.
 if ! python3 -c '

--- a/scripts/check-selector.sh
+++ b/scripts/check-selector.sh
@@ -33,7 +33,8 @@ WORK="$(mktemp -d -t parrotflow-selector)"
 trap 'rm -rf "$WORK"' EXIT
 export PARROTFLOW_CONFIG_DIR="$WORK"
 
-# Base64, one line per field. A case holds newlines and double spaces on
+# Base64, one line per field, and an empty last field for a case that wants the
+# text rather than the ranges. A case holds newlines and double spaces on
 # purpose — those are what it is checking survive — and neither goes through a
 # line-per-field file as itself.
 if ! python3 -c '
@@ -44,6 +45,7 @@ for case in json.load(open(sys.argv[1])):
     print(b("\n".join(case["places"])))
     print(b(case["want"]))
     print(b(case["why"]))
+    print(b("--ranges" if case.get("ranges") else ""))
 ' "$ROOT/tests/selector-cases.json" > "$WORK/cases"; then
   echo "  ✗ tests/selector-cases.json could not be read"
   exit 1
@@ -51,7 +53,7 @@ fi
 
 pass=0; total=0
 while IFS= read -r text64 && IFS= read -r places64 && IFS= read -r want64 \
-   && IFS= read -r why64; do
+   && IFS= read -r why64 && IFS= read -r mode64; do
   total=$((total + 1))
   text="$(printf '%s' "$text64" | base64 -d)"
   want="$(printf '%s' "$want64" | base64 -d)"
@@ -62,7 +64,12 @@ while IFS= read -r text64 && IFS= read -r places64 && IFS= read -r want64 \
   places=()
   while IFS= read -r place; do places+=("$place"); done \
     < <(printf '%s' "$places64" | base64 -d; printf '\n')
-  got="$("$BIN" --selector "$text" "${places[@]}" 2>/dev/null)"
+  mode="$(printf '%s' "$mode64" | base64 -d)"
+  if [ -n "$mode" ]; then
+    got="$("$BIN" --selector "$text" "${places[@]}" "$mode" 2>/dev/null)"
+  else
+    got="$("$BIN" --selector "$text" "${places[@]}" 2>/dev/null)"
+  fi
   if [ "$got" = "$want" ]; then
     pass=$((pass + 1))
     printf '  ✓  %s\n' "$why"

--- a/tests/selector-cases.json
+++ b/tests/selector-cases.json
@@ -1,0 +1,110 @@
+[
+  {
+    "text": "can you ask Mick to review it.",
+    "places": ["Mick|mixed bend|3|1"],
+    "want": "can you ask mixed bend to review it.",
+    "why": "one place, the other reading taken"
+  },
+  {
+    "text": "can you ask Mick to review it.",
+    "places": ["Mick|mixed bend|3|0"],
+    "want": "can you ask Mick to review it.",
+    "why": "one place kept: exactly the text the pipeline returned"
+  },
+  {
+    "text": "can you ask Mick to review it.",
+    "places": ["Mick|mixed bend|3|-"],
+    "want": "can you ask Mick to review it.",
+    "why": "unanswered is what an open place has always shipped"
+  },
+  {
+    "text": "Mick asked Mick to review it.",
+    "places": ["Mick|mixed bend|2|1"],
+    "want": "Mick asked mixed bend to review it.",
+    "why": "the word twice: the word index picks the second one"
+  },
+  {
+    "text": "Mick asked Mick to review it.",
+    "places": ["Mick|mixed bend|0|1"],
+    "want": "mixed bend asked Mick to review it.",
+    "why": "and the same place asks for the first one"
+  },
+  {
+    "text": "Mick asked Mick to review it.",
+    "places": ["Mick|mixed bend|0|1", "Mick|Mickey|2|1"],
+    "want": "mixed bend asked Mickey to review it.",
+    "why": "two places about the same word never take the same hit"
+  },
+  {
+    "text": "we moved off BetterStack in June, before the export ran.",
+    "places": ["BetterStack|better stack|3|1"],
+    "want": "we moved off better stack in June, before the export ran.",
+    "why": "a comma glued to a later word is not part of any span"
+  },
+  {
+    "text": "ask Mick, then tell BetterStack about it.",
+    "places": ["Mick|mixed bend|1|1", "BetterStack|better stack|4|0"],
+    "want": "ask mixed bend, then tell BetterStack about it.",
+    "why": "two places, one answered each way"
+  },
+  {
+    "text": "ask Mick, then tell BetterStack about it.",
+    "places": ["BetterStack|better stack|4|1", "Mick|mixed bend|1|1"],
+    "want": "ask mixed bend, then tell better stack about it.",
+    "why": "the places are answered left to right whatever order they arrive in"
+  },
+  {
+    "text": "ask Mick, then tell BetterStack about it.",
+    "places": ["Mick|mixed bend|1|-", "BetterStack|better stack|4|1"],
+    "want": "ask Mick, then tell BetterStack about it.",
+    "why": "a run stops at the first unanswered place; nothing after it was asked"
+  },
+  {
+    "text": "first line\nask Mick about it\n\nlast line",
+    "places": ["Mick|mixed bend|3|1"],
+    "want": "first line\nask mixed bend about it\n\nlast line",
+    "why": "newlines and the blank line between paragraphs survive the write"
+  },
+  {
+    "text": "ask  Mick   about it",
+    "places": ["Mick|mixed bend|1|1"],
+    "want": "ask  mixed bend   about it",
+    "why": "double spaces either side survive too"
+  },
+  {
+    "text": "ask Mick to review the Vercelli report.",
+    "places": ["Vercel|Versailles|4|1"],
+    "want": "NOTHING FOUND",
+    "why": "a word, not a substring: Vercel does not stand in Vercelli"
+  },
+  {
+    "text": "a prompt stage rewrote the sentence and the name went with it.",
+    "places": ["Mick|mixed bend|3|1"],
+    "want": "NOTHING FOUND",
+    "why": "a span a later stage removed is a question nobody can answer"
+  },
+  {
+    "text": "tell mixed bend that we are done.",
+    "places": ["mixed bend|Mick|1|1"],
+    "want": "tell Mick that we are done.",
+    "why": "a two-word span, replaced by one word"
+  },
+  {
+    "text": "tell Mick that we are done.",
+    "places": ["Mick|mixed bend|1|1"],
+    "want": "tell mixed bend that we are done.",
+    "why": "and one word replaced by two"
+  },
+  {
+    "text": "Mick",
+    "places": ["Mick|mixed bend|0|1"],
+    "want": "mixed bend",
+    "why": "the place is the whole text"
+  },
+  {
+    "text": "ask Mick's team about it.",
+    "places": ["Mick|mixed bend|1|1"],
+    "want": "ask mixed bend's team about it.",
+    "why": "a possessive is not part of the span, and survives the write"
+  }
+]

--- a/tests/selector-cases.json
+++ b/tests/selector-cases.json
@@ -1,110 +1,170 @@
 [
   {
     "text": "can you ask Mick to review it.",
-    "places": ["Mick|mixed bend|3|1"],
+    "places": [
+      "Mick|mixed bend|3|1"
+    ],
     "want": "can you ask mixed bend to review it.",
     "why": "one place, the other reading taken"
   },
   {
     "text": "can you ask Mick to review it.",
-    "places": ["Mick|mixed bend|3|0"],
+    "places": [
+      "Mick|mixed bend|3|0"
+    ],
     "want": "can you ask Mick to review it.",
     "why": "one place kept: exactly the text the pipeline returned"
   },
   {
     "text": "can you ask Mick to review it.",
-    "places": ["Mick|mixed bend|3|-"],
+    "places": [
+      "Mick|mixed bend|3|-"
+    ],
     "want": "can you ask Mick to review it.",
     "why": "unanswered is what an open place has always shipped"
   },
   {
     "text": "Mick asked Mick to review it.",
-    "places": ["Mick|mixed bend|2|1"],
+    "places": [
+      "Mick|mixed bend|2|1"
+    ],
     "want": "Mick asked mixed bend to review it.",
     "why": "the word twice: the word index picks the second one"
   },
   {
     "text": "Mick asked Mick to review it.",
-    "places": ["Mick|mixed bend|0|1"],
+    "places": [
+      "Mick|mixed bend|0|1"
+    ],
     "want": "mixed bend asked Mick to review it.",
     "why": "and the same place asks for the first one"
   },
   {
     "text": "Mick asked Mick to review it.",
-    "places": ["Mick|mixed bend|0|1", "Mick|Mickey|2|1"],
+    "places": [
+      "Mick|mixed bend|0|1",
+      "Mick|Mickey|2|1"
+    ],
     "want": "mixed bend asked Mickey to review it.",
     "why": "two places about the same word never take the same hit"
   },
   {
     "text": "we moved off BetterStack in June, before the export ran.",
-    "places": ["BetterStack|better stack|3|1"],
+    "places": [
+      "BetterStack|better stack|3|1"
+    ],
     "want": "we moved off better stack in June, before the export ran.",
     "why": "a comma glued to a later word is not part of any span"
   },
   {
     "text": "ask Mick, then tell BetterStack about it.",
-    "places": ["Mick|mixed bend|1|1", "BetterStack|better stack|4|0"],
+    "places": [
+      "Mick|mixed bend|1|1",
+      "BetterStack|better stack|4|0"
+    ],
     "want": "ask mixed bend, then tell BetterStack about it.",
     "why": "two places, one answered each way"
   },
   {
     "text": "ask Mick, then tell BetterStack about it.",
-    "places": ["BetterStack|better stack|4|1", "Mick|mixed bend|1|1"],
+    "places": [
+      "BetterStack|better stack|4|1",
+      "Mick|mixed bend|1|1"
+    ],
     "want": "ask mixed bend, then tell better stack about it.",
     "why": "the places are answered left to right whatever order they arrive in"
   },
   {
     "text": "ask Mick, then tell BetterStack about it.",
-    "places": ["Mick|mixed bend|1|-", "BetterStack|better stack|4|1"],
+    "places": [
+      "Mick|mixed bend|1|-",
+      "BetterStack|better stack|4|1"
+    ],
     "want": "ask Mick, then tell BetterStack about it.",
     "why": "a run stops at the first unanswered place; nothing after it was asked"
   },
   {
     "text": "first line\nask Mick about it\n\nlast line",
-    "places": ["Mick|mixed bend|3|1"],
+    "places": [
+      "Mick|mixed bend|3|1"
+    ],
     "want": "first line\nask mixed bend about it\n\nlast line",
     "why": "newlines and the blank line between paragraphs survive the write"
   },
   {
     "text": "ask  Mick   about it",
-    "places": ["Mick|mixed bend|1|1"],
+    "places": [
+      "Mick|mixed bend|1|1"
+    ],
     "want": "ask  mixed bend   about it",
     "why": "double spaces either side survive too"
   },
   {
     "text": "ask Mick to review the Vercelli report.",
-    "places": ["Vercel|Versailles|4|1"],
+    "places": [
+      "Vercel|Versailles|4|1"
+    ],
     "want": "NOTHING FOUND",
     "why": "a word, not a substring: Vercel does not stand in Vercelli"
   },
   {
     "text": "a prompt stage rewrote the sentence and the name went with it.",
-    "places": ["Mick|mixed bend|3|1"],
+    "places": [
+      "Mick|mixed bend|3|1"
+    ],
     "want": "NOTHING FOUND",
     "why": "a span a later stage removed is a question nobody can answer"
   },
   {
     "text": "tell mixed bend that we are done.",
-    "places": ["mixed bend|Mick|1|1"],
+    "places": [
+      "mixed bend|Mick|1|1"
+    ],
     "want": "tell Mick that we are done.",
     "why": "a two-word span, replaced by one word"
   },
   {
     "text": "tell Mick that we are done.",
-    "places": ["Mick|mixed bend|1|1"],
+    "places": [
+      "Mick|mixed bend|1|1"
+    ],
     "want": "tell mixed bend that we are done.",
     "why": "and one word replaced by two"
   },
   {
     "text": "Mick",
-    "places": ["Mick|mixed bend|0|1"],
+    "places": [
+      "Mick|mixed bend|0|1"
+    ],
     "want": "mixed bend",
     "why": "the place is the whole text"
   },
   {
     "text": "ask Mick's team about it.",
-    "places": ["Mick|mixed bend|1|1"],
+    "places": [
+      "Mick|mixed bend|1|1"
+    ],
     "want": "ask mixed bend's team about it.",
     "why": "a possessive is not part of the span, and survives the write"
+  },
+  {
+    "text": "ask Mick, then tell BetterStack about it.",
+    "places": [
+      "Mick|mixed bend|1|1",
+      "BetterStack|better stack|4|1"
+    ],
+    "want": "mixed bend@4-14 better stack@26-38",
+    "ranges": true,
+    "why": "a place moves when the answer before it wrote a longer word"
+  },
+  {
+    "text": "ask Mick, then tell BetterStack about it.",
+    "places": [
+      "Mick|mixed bend|1|0",
+      "BetterStack|better stack|4|1"
+    ],
+    "want": "Mick@4-8 better stack@20-32",
+    "ranges": true,
+    "why": "a place kept moves nothing, and the range is still the span"
   }
 ]

--- a/tests/selector-cases.json
+++ b/tests/selector-cases.json
@@ -166,5 +166,15 @@
     "want": "Mick@4-8 better stack@20-32",
     "ranges": true,
     "why": "a place kept moves nothing, and the range is still the span"
+  },
+  {
+    "text": "ask Mick, then tell BetterStack about it.",
+    "places": [
+      "Mick|mixed bend|1|1",
+      "BetterStack|better stack|4|-"
+    ],
+    "want": "mixed bend@4-14",
+    "ranges": true,
+    "why": "only the answered places have ranges; the unanswered one was never asked"
   }
 ]


### PR DESCRIPTION
PR #299 built the surface and nothing raised it. This is the trigger, and the
second half of why it is worth raising: the answer teaches the term.

A place none of the free gates settle has always shipped in silence. `settle`
returns nil, `settling` copies what it was handed, and nobody is asked. Now the
words wait. The pill draws the sentence with the two readings stacked where the
open place is, 1 or 2 answers it, and the sentence is typed once, after the last
answer. `asks: false` in `vocabulary.yaml` turns it off; the default is on.

**Not answering costs the question, never the sentence.** Escape, a click
outside, any other key, thirty seconds, or starting the next dictation all type
the text the stage returned, which is what an open place has always shipped.
Thirty is the learn question's clock: `offerSeconds` is six, which is right for
a tab you may ignore and wrong for one holding your sentence.

**No live dictation has raised this pill.** The write is scored by
`scripts/check-selector.sh`, 20 cases; the surface is `--panels selector`. The
lifecycle — the pill, the keys, the recording — has been reasoned about and not
run. The recipe below is what to run first.

<details>
<summary>The answers are the reason to ask: a counter-example has no other source</summary>

Confirming a term keeps the sentence as a use. Refusing one keeps it as a
counter-example, and `TermPortrait` needs three of those before it stops reading
a term against a fixed floor and starts reading it against its own two centres.

Nothing else in the app collects the second kind except a correction somebody
makes by hand. That was measured before: accepting offers only ever yields
positives, and six of them left a case unsettled. These are also the hardest
labels there are — every free gate looked at the place and none could say.

Each answer also goes to `trace.jsonl` as `kind: chose`, with the term, what
stood there, what was picked and the range of the span. Kept apart from
`kind: edit` on purpose: an edit is a mistake somebody fixed, and a place the
app said out loud it could not decide is a different and better label. Mixed
together they would read as mistakes that were never made, and the edit corpus
is what the misheard-word work reads.

</details>

<details>
<summary>How the places reach the pill, and why a span is searched for again</summary>

`Transcriber.transcribe` returns a string, so the stage cannot hand the places
back the way it hands back the text. `OpenPlaces` is a dictionary keyed by press
run — the same answer `InputBox` uses for the field it read at the press —
written by the pipeline thread, read on the main one, and cleared by
`dictationEnded` with the rest.

A place carries both readings and which of them is in the string. That is not a
detail: a `replacements` rule has already written its term into the transcript,
so option 0 is the term there, while a sound proposal has written nothing, so
option 0 is the word that was heard. Which side the term is on flips with the
source, and only the term name settles what an answer teaches.

The stages after `vocabulary` may rewrite, so a span is searched for again in
the text that landed, as a word rather than a substring. The nearest hit to
where the stage saw it wins, two places never take the same hit, and a span that
is gone is dropped — a question nobody can answer.

The write is by range and not by rejoining words, so a newline, a double space
and a comma glued to the next word all survive it. `ChooseRun` is used for the
drawing only; it splits on spaces and joining that back would lose all three.

</details>

<details>
<summary>What to run first — six checks, and what each one proves</summary>

The pill needs a place the gates leave open. A near miss is the easiest: a
`.fuzzy` place has no `settle` policy, so the word lists cannot reach it, and a
term with fewer than three uses and no counter-example has no portrait yet.
`PARROTFLOW_JUDGE_DUMP=1` names the slots in the log when nothing fires.

1. Dictate that sentence. The pill asks, and the words do not land.
2. Key 1 — the text lands unchanged. `vocabulary-uses.yaml` gains one row with
   `from: chosen`, and the log says `portrait: <term> is current in …`.
3. Key 2 — the span is rewritten. One row with `from: chosen, counter: true`.
4. Escape, then a second dictation left for thirty seconds — both type the
   pipeline's text, and neither writes a row.
5. Press the hotkey while the pill is up — the held words land, then the new
   recording starts.
6. `grep '"kind":"chose"' ~/Recordings/ParrotFlow/trace.jsonl`

`make test` passes, swiftlint included. `scripts/check-selector.sh` is new and
in `make test`: 21 cases over the two halves that have no surface in them —
where a span lands, and what an answer writes. `--selector "<text>"
"<standing>|<other>|<word>|<answer>"` is the entry point, and `--ranges` prints
where each answered word ended up, which is what the trace records.

</details>

<details>
<summary>What this costs, and what it does not fix</summary>

- A key that is not 1, 2 or Escape is typed into the field **before** the held
  sentence lands. `OfferKeys` returns the event before the handler runs, so the
  order is fixed. A reflex Return in a chat app sends an empty message and the
  dictation goes into the next one.
- `Trace.deliver` now times the raise, not the paste.
- The first dictations after launch ask about places the portrait would have
  settled once the word vectors are warm.
- The question is refused while another dictation is running. Push-to-talk does
  not wait, and two sentences in the air with a question between them land in
  the wrong order.
- The rate is small: 30 of 1009 vocabulary-stage runs in this speaker's archive
  had a place at all, so 3% is the ceiling. The 45% in `ParrotFlow.log` is a CLI
  batch, where the word vectors never load and the sentence gate stands aside.

</details>

<details>
<summary>The place carries the term that offered it, which review caught and this data depends on</summary>

Several parts can overlap one span, and `Slot.terms` is the sorted set of every
term among them. Only one of those terms offered the reading drawn on the pill.
`terms.first` is alphabetical, so a place offering Zulu's reading recorded a use
against Alpha and rebuilt Alpha's portrait — the exact data this PR exists to
collect, written under the wrong name. `Slot` and `Change` now carry `owner`.

`SentenceGate.swift:69` reads `change.terms.first` for the portrait it asks and
has the same fault. Not touched here: which portrait that gate reads is a
measured decision, and moving it belongs in a change that re-runs the bench.

Two more from the same round. `OpenPlaces.record` skipped an empty list, so an
earlier `vocabulary` stage's question outlived a later stage that had settled
it — nothing refuses a config listing the stage twice. And `Trace.chose` wrote
UTF-16 offsets where `Trace.edit` writes character offsets; it writes characters
now, because two `range` fields in one file measuring differently is a trap.

</details>

<details>
<summary>The learn question is now asked where the correction was made</summary>

The offer asking whether to keep a rule never aimed at all, so it drew wherever
the pill was last put — where the dictation *before* it landed. The edit that
raises it can come minutes later, after scrolling, in another window.

It aims at the caret in the field the correction was made in, the same place the
post-dictation pill hangs off. `EditWatch` fires off key events, so this runs
while the caret is still at the changed word, and the watch already holds the
field. A field that answers no caret leaves the pill where it is: it is already
under the words this correction is about.

</details>

<details>
<summary>One fix that is not new work: an open selector must not claim the hold</summary>

An open panel makes the next hold an edit instruction, because the panel draws
the row that promises it. The selector draws no such row —
`PillMetrics.showsHold` refuses `.choose` — so holding after one would have
routed the next dictation as an instruction over the selection.

Named rather than asked of `showsHold`, which also refuses a pill with no hotkey
registered. That is a different case and not this branch's to change.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
