### PR TITLE
feat: names that share a sound each get their own portrait

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -281,3 +281,10 @@ jobs:
       # a run dropped from one and not the other is invisible.
       - name: Endings the decoder invented
         run: scripts/check-invented-tail.sh
+
+      # Several names with one sound: which terms are derived into one group,
+      # what the decision rule does with scores written by hand, and what a
+      # correction against a term records. No model — the portraits behind it
+      # are scored by scripts/check-counter-portrait.sh, which needs one.
+      - name: Sound groups
+        run: scripts/check-sound-group.sh

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ CHECKS := numbers replacements pipeline pipeline-config wake split dotted dates 
           profiles span-rule clipboard default-config vocabulary-config learn \
           signing-identity no-voice sound slot-tokenizer sentence-case term-uses \
           edit-diff sentence-open invented-tail sentence-window lowercase-refused \
-          selector
+          selector sound-group
 
 test:
 	@swift build -c release

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -4216,7 +4216,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let heard = config.vocabulary.terms[term]?.heard ?? []
         let ours = heard.contains { $0.caseInsensitiveCompare(back) == .orderedSame }
         do {
-            for row in try CorrectionRecording.apply(rows, said: sentence, near: word) {
+            for row in try CorrectionRecording.apply(
+                rows, said: sentence, near: word, blocking: soundGroups
+            ) {
                 rebuildPortrait(for: row.term)
                 switch row {
                 case .use(let right, _, _):
@@ -4284,6 +4286,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 term, Date().timeIntervalSince(started)
             ))
         }
+    }
+
+    /// The sound groups of the vocabulary as it stands, derived fresh.
+    ///
+    /// Cheap — a few dozen terms and the uses file — and it has to be fresh:
+    /// a correction a moment ago may have created the term that makes this a
+    /// group of two.
+    private var soundGroups: [SoundGroup.Group] {
+        SoundGroup.groups(terms: config.vocabulary.terms, uses: TermUses.load())
     }
 
     /// The vocabulary term this word is, ignoring case and any possessive.
@@ -5377,9 +5388,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     // Which occurrence: a terminal field holds every dictation
                     // since the last Return, and the word that was corrected is
                     // rarely the first copy of it.
-                    try TermUses.record(
-                        term: term, said: corrected, span: rule.corrected,
-                        heard: rule.heard, near: word
+                    try CorrectionRecording.apply(
+                        [.use(term: term, span: rule.corrected, heard: rule.heard)],
+                        said: corrected, near: word, blocking: soundGroups
                     )
                     rebuildPortrait(for: term)
                 } catch {
@@ -5977,7 +5988,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // ordinary word picked is a counter under the term that was proposed.
         // A group place offers several names, and only the one you picked
         // learns anything.
-        let picked = existingTerm(named: word.word)
+        var picked: String?
+        switch CorrectionRecording.picked(
+            word.word, proposedBy: open.term, in: config.vocabulary.terms
+        ) {
+        case .use(let term): picked = term
+        case .create(let name): picked = createPerson(named: name)
+        case .counter: picked = nil
+        }
         let replaced = word.word == open.standing ? nil : open.standing
         let rows: [CorrectionRecording.Row] = picked.map {
             [.use(term: $0, span: word.word, heard: replaced)]
@@ -5987,7 +6005,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let at = text.prefix(word.range.lowerBound).split(separator: " ").count
         do {
             for row in try CorrectionRecording.apply(
-                rows, said: text, from: .chosen, near: at
+                rows, said: text, from: .chosen, near: at, blocking: soundGroups
             ) {
                 rebuildPortrait(for: row.term)
             }
@@ -5999,6 +6017,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         } catch {
             Log.write("selector: could not record the answer: \(error.localizedDescription)")
+        }
+    }
+
+    /// Writes a bare term for a person, and returns the name it was written
+    /// under. Nil when the file could not be written.
+    ///
+    /// No pronunciation: nothing was misheard. The recogniser spells this name
+    /// correctly, and the term exists so the name has a portrait of its own and
+    /// joins the group that shares its sound.
+    private func createPerson(named word: String) -> String? {
+        let bare = word.trimmingCharacters(in: .punctuationCharacters)
+        guard !bare.isEmpty else { return nil }
+        do {
+            try ConfigWriter.addVocabularyTerm(bare, kind: .person)
+            Log.write("selector: \(bare) is a name and was not a term — written to"
+                + " vocabulary.yaml as a person, with no pronunciation")
+            flash("Saved  \(bare) is a name", tone: .done)
+            return bare
+        } catch {
+            Log.write("selector: could not write \(bare) to vocabulary.yaml:"
+                + " \(error.localizedDescription)")
+            return nil
         }
     }
 

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -5993,7 +5993,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             word.word, proposedBy: open.term, in: config.vocabulary.terms
         ) {
         case .use(let term): picked = term
-        case .create(let name): picked = createPerson(named: name)
+        case .create(let name, let kind): picked = createTerm(named: name, kind: kind)
         case .counter: picked = nil
         }
         let replaced = word.word == open.standing ? nil : open.standing
@@ -6020,19 +6020,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// Writes a bare term for a person, and returns the name it was written
+    /// Writes a bare term for a name, and returns the name it was written
     /// under. Nil when the file could not be written.
     ///
     /// No pronunciation: nothing was misheard. The recogniser spells this name
     /// correctly, and the term exists so the name has a portrait of its own and
     /// joins the group that shares its sound.
-    private func createPerson(named word: String) -> String? {
+    private func createTerm(named word: String, kind: WordKind) -> String? {
         let bare = word.trimmingCharacters(in: .punctuationCharacters)
         guard !bare.isEmpty else { return nil }
         do {
-            try ConfigWriter.addVocabularyTerm(bare, kind: .person)
+            try ConfigWriter.addVocabularyTerm(bare, kind: kind)
             Log.write("selector: \(bare) is a name and was not a term — written to"
-                + " vocabulary.yaml as a person, with no pronunciation")
+                + " vocabulary.yaml as a \(kind.rawValue), with no pronunciation")
             flash("Saved  \(bare) is a name", tone: .done)
             return bare
         } catch {

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -4305,7 +4305,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// a correction a moment ago may have created the term that makes this a
     /// group of two.
     private var soundGroups: [SoundGroup.Group] {
-        SoundGroup.groups(terms: config.vocabulary.terms, uses: TermUses.load())
+        // From the file, not from `config`. A term written a moment ago —
+        // by this very correction — reaches `config` through a file watcher,
+        // which has not fired yet, and the new member would be in no group.
+        let terms = (try? ConfigStore.load())?.vocabulary.terms ?? config.vocabulary.terms
+        return SoundGroup.groups(terms: terms, uses: TermUses.load())
     }
 
     /// The vocabulary term this word is, ignoring case and any possessive.

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -4207,11 +4207,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// Keep the sentence under the term as a place it does not belong.
     ///
-    /// True only when a row was written. `TermUses.record` writes nothing when
-    /// the word does not stand in the sentence as a word, and says so by doing
-    /// nothing at all, so the position is asked for first: a change that is
-    /// neither kept nor offered is a correction the app watched you make and
-    /// threw away.
+    /// True only when a row was written, which is what "taken" means to the
+    /// caller: a change this returns false for goes on to the correction
+    /// panel. `CorrectionRecording.apply` writes nothing when the word does
+    /// not stand in the narrowed sentence, and nothing when the sentence names
+    /// two members of one sound group, and it says so by returning no rows.
+    /// A change that is neither kept nor offered is a correction the app
+    /// watched you make and threw away.
+    ///
+    /// A blocked sentence is therefore offered. `learn` tries the recording
+    /// once more against the panel's own text, and refuses to write a
+    /// pronunciation whose heard side is already a term — between two members
+    /// of one group that rendering opens the group rather than rewriting
+    /// anything, so nothing is lost by not writing it.
     private func recordCounter(
         wrote written: String, put back: String, in sentence: String, near word: Int? = nil
     ) -> Bool {
@@ -4226,10 +4234,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         let heard = config.vocabulary.terms[term]?.heard ?? []
         let ours = heard.contains { $0.caseInsensitiveCompare(back) == .orderedSame }
+        var wrote = false
         do {
             for row in try CorrectionRecording.apply(
                 rows, said: sentence, near: word, blocking: soundGroups
             ) {
+                wrote = true
                 rebuildPortrait(for: row.term)
                 switch row {
                 case .use(let right, _, _):
@@ -4251,7 +4261,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Log.write("could not record the correction: \(error.localizedDescription)")
             return false
         }
-        return true
+        return wrote
     }
 
     /// Builds a term's portrait now, because its uses just changed.
@@ -4308,8 +4318,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // From the file, not from `config`. A term written a moment ago —
         // by this very correction — reaches `config` through a file watcher,
         // which has not fired yet, and the new member would be in no group.
-        let terms = (try? ConfigStore.load())?.vocabulary.terms ?? config.vocabulary.terms
-        return SoundGroup.groups(terms: terms, uses: TermUses.load())
+        //
+        // `vocabulary.yaml` alone. `ConfigStore.load()` also refreshes the
+        // shipped examples and decodes `config.yaml`, and this is read on
+        // interaction paths. An empty vocabulary is a valid answer, so there
+        // is nothing to fall back to.
+        return SoundGroup.groups(terms: ConfigStore.loadVocabulary().terms, uses: TermUses.load())
     }
 
     /// The vocabulary term this word is, ignoring case and any possessive.
@@ -6014,7 +6028,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             word.word, proposedBy: open.term, in: config.vocabulary.terms
         ) {
         case .use(let term): picked = term
-        case .create(let name, let kind): picked = createTerm(named: name, kind: kind)
+        case .create(let name, let kind):
+            // Nil here is a write that failed, not the counter answer. Filing
+            // it as a counter would store the opposite of what was answered:
+            // you said this is a name, and the term that was proposed would
+            // keep the sentence as a place it does not belong.
+            guard let created = createTerm(named: name, kind: kind) else {
+                Log.write("selector: \(name) could not be written to vocabulary.yaml;"
+                    + " nothing is recorded about \(open.term) either")
+                return
+            }
+            picked = created
         case .counter: picked = nil
         }
         let replaced = word.word == open.standing ? nil : open.standing

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -4191,6 +4191,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func counterTerm(wrote written: String, put back: String) -> String? {
         guard let term = existingTerm(named: written) else { return nil }
         guard existingTerm(named: back) != term else { return nil }
+        // A name the vocabulary has never seen is not an ordinary word. The
+        // rule offer handles it — the rendering is written, the term is
+        // created, the sentence is a use — so this branch stands aside and
+        // lets it. See `CorrectionRecording.learns`.
+        if let new = CorrectionRecording.learns(
+            wrote: written, put: back, in: config.vocabulary.terms
+        ) {
+            Log.write("correction: \(new.name) is a name and not a term yet —"
+                + " \(term) keeps no counter, the rule is offered instead")
+            return nil
+        }
         return term
     }
 
@@ -5367,8 +5378,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 continue
             }
             do {
+                // The kind as well, when this correction is what creates the
+                // term. `WordKind` is a label a person can read and correct,
+                // and a name written with none says less than the tagger knew.
                 try ConfigWriter.addVocabularyPronunciation(
-                    term: rule.corrected, heard: rule.heard
+                    term: rule.corrected, heard: rule.heard,
+                    kind: CorrectionRecording.learns(
+                        wrote: rule.heard, put: rule.corrected, in: config.vocabulary.terms
+                    )?.kind
                 )
                 // The sentence too, not only the mapping. It is what a term's
                 // portrait is built from, and this is the only moment the app

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -4115,7 +4115,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         correctionPanel.onSave = { [weak self] rules, _ in
             // The field is already right — the person fixed it themselves. Only
             // the rules are new, so `learn` and nothing after it.
-            _ = self?.learn(rules, in: sentence)
+            //
+            // Where the correction was, so the sentence stored is the one that
+            // was corrected and not an earlier copy of the same name.
+            _ = self?.learn(rules, in: sentence, near: worth.first?.nowAt)
         }
         correctionPanel.onCancel = { Log.write("correction: the rules were declined") }
         correctionPanel.show(
@@ -4177,7 +4180,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// holds that rule. No row is offered either way. Returns true when it
     /// took the change.
     private func recordCounter(_ change: EditWatch.Change, in sentence: String) -> Bool {
-        recordCounter(wrote: change.was, put: change.now, in: sentence)
+        recordCounter(wrote: change.was, put: change.now, in: sentence, near: change.nowAt)
     }
 
     /// The term a correction runs against, or nil if it runs the usual way.
@@ -4199,7 +4202,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// neither kept nor offered is a correction the app watched you make and
     /// threw away.
     private func recordCounter(
-        wrote written: String, put back: String, in sentence: String
+        wrote written: String, put back: String, in sentence: String, near word: Int? = nil
     ) -> Bool {
         guard let term = counterTerm(wrote: written, put: back) else { return false }
         let rows = CorrectionRecording.rows(
@@ -4213,7 +4216,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let heard = config.vocabulary.terms[term]?.heard ?? []
         let ours = heard.contains { $0.caseInsensitiveCompare(back) == .orderedSame }
         do {
-            for row in try CorrectionRecording.apply(rows, said: sentence) {
+            for row in try CorrectionRecording.apply(rows, said: sentence, near: word) {
                 rebuildPortrait(for: row.term)
                 switch row {
                 case .use(let right, _, _):
@@ -4753,7 +4756,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 Log.write("correction: keeping \(pending.changes.count) rule(s)")
                 _ = learn(
                     pending.changes.map { TaughtRule(heard: $0.was, corrected: $0.now) },
-                    in: pending.sentence
+                    in: pending.sentence, near: pending.changes.first?.nowAt
                 )
             case "Edit":
                 Log.write("correction: opening the panel to edit the rule(s)")
@@ -5333,7 +5336,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// False means one could not be written and the user has already been shown
     /// why. Nothing after it should run: a correction that half-saved and then
     /// went on to rewrite the field would leave the two disagreeing.
-    private func learn(_ rules: [TaughtRule], in corrected: String) -> Bool {
+    private func learn(
+        _ rules: [TaughtRule], in corrected: String, near word: Int? = nil
+    ) -> Bool {
         for rule in rules {
             // A rule whose heard side is already a term runs the other way:
             // the app wrote the term where it did not belong and you put the
@@ -5342,7 +5347,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // be the mirror of a rule that stands, and then each word proposes
             // the other for as long as both are there.
             if let term = counterTerm(wrote: rule.heard, put: rule.corrected) {
-                if !recordCounter(wrote: rule.heard, put: rule.corrected, in: corrected) {
+                if !recordCounter(
+                    wrote: rule.heard, put: rule.corrected, in: corrected, near: word
+                ) {
                     Log.write("correction: \(rule.heard) -> \(rule.corrected) runs against"
                         + " \(term); no counter-example was written and no rule either")
                 }
@@ -5367,9 +5374,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     // The span stays as typed. It has to be the word standing
                     // in the sentence, and the sentence holds what was written.
                     let term = existingTerm(named: rule.corrected) ?? rule.corrected
+                    // Which occurrence: a terminal field holds every dictation
+                    // since the last Return, and the word that was corrected is
+                    // rarely the first copy of it.
                     try TermUses.record(
                         term: term, said: corrected, span: rule.corrected,
-                        heard: rule.heard
+                        heard: rule.heard, near: word
                     )
                     rebuildPortrait(for: term)
                 } catch {
@@ -5972,8 +5982,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let rows: [CorrectionRecording.Row] = picked.map {
             [.use(term: $0, span: word.word, heard: replaced)]
         } ?? [.counter(term: open.term, span: word.word)]
+        // Which occurrence, in words: the pill can be asked about the second
+        // mention of a name in a field that holds several dictations.
+        let at = text.prefix(word.range.lowerBound).split(separator: " ").count
         do {
-            for row in try CorrectionRecording.apply(rows, said: text, from: .chosen) {
+            for row in try CorrectionRecording.apply(
+                rows, said: text, from: .chosen, near: at
+            ) {
                 rebuildPortrait(for: row.term)
             }
             let said = TermUses.narrowed(text, to: word.word)

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -4172,12 +4172,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// rule that already exists, and then each word proposes the other for as
     /// long as both stand.
     ///
-    /// So the tell is the left side: a heard word that is already a term. The
-    /// sentence is kept under that term as a counter-example — a place it does
-    /// not live — and no row is offered. Returns true when it took the change.
-    ///
-    /// Three of these and `TermPortrait` stops reading the term against a
-    /// floor and reads it against them.
+    /// So the tell is the left side: a heard word that is already a term. What
+    /// is written depends on what you put back — `CorrectionRecording.rows`
+    /// holds that rule. No row is offered either way. Returns true when it
+    /// took the change.
     private func recordCounter(_ change: EditWatch.Change, in sentence: String) -> Bool {
         recordCounter(wrote: change.was, put: change.now, in: sentence)
     }
@@ -4204,33 +4202,37 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         wrote written: String, put back: String, in sentence: String
     ) -> Bool {
         guard let term = counterTerm(wrote: written, put: back) else { return false }
+        let rows = CorrectionRecording.rows(
+            wrote: written, put: back, terms: Array(config.vocabulary.terms.keys)
+        )
         guard TermUses.occurrence(of: back, in: sentence) != nil else {
             Log.write("correction: \"\(back)\" does not stand in the sentence,"
-                + " so \(term) gets no counter-example")
+                + " so \(term) learns nothing from it")
             return false
         }
         let heard = config.vocabulary.terms[term]?.heard ?? []
         let ours = heard.contains { $0.caseInsensitiveCompare(back) == .orderedSame }
         do {
-            try TermUses.record(term: term, said: sentence, span: back, counter: true)
-            rebuildPortrait(for: term)
-            // One term corrected into another — `Praizy` into `Praisy` — says
-            // two things at once, and both are worth keeping: the first does
-            // not live here and the second does.
-            if let right = existingTerm(named: back) {
-                // `written` is the spelling this replaced, which is what lets
-                // the portrait cut a sentence holding both of them.
-                try TermUses.record(
-                    term: right, said: sentence, span: back, heard: written
-                )
-                rebuildPortrait(for: right)
+            for row in try CorrectionRecording.apply(rows, said: sentence) {
+                rebuildPortrait(for: row.term)
+                switch row {
+                case .use(let right, _, _):
+                    // One term put back over another — `Mik` to `Mick` — is a
+                    // use of the one you typed and nothing at all about the
+                    // one that lost. They share a sound, and this sentence is
+                    // where the winner lives.
+                    Log.write("correction: \"\(written)\" -> \"\(back)\" is a use of"
+                        + " \(right), and \(term) keeps no counter for it")
+                    flash("Saved  \(right) belongs there", tone: .done)
+                case .counter:
+                    Log.write(
+                        "correction: \"\(written)\" -> \"\(back)\" is a counter-example for"
+                            + " \(term)\(ours ? ", written by its own rule" : "")")
+                    flash("Noted  \(term) does not belong there", tone: .done)
+                }
             }
-            Log.write(
-                "correction: \"\(written)\" -> \"\(back)\" is a counter-example for"
-                    + " \(term)\(ours ? ", written by its own rule" : "")")
-            flash("Noted  \(term) does not belong there", tone: .done)
         } catch {
-            Log.write("could not record the counter-example: \(error.localizedDescription)")
+            Log.write("could not record the correction: \(error.localizedDescription)")
             return false
         }
         return true
@@ -4283,15 +4285,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// The vocabulary term this word is, ignoring case and any possessive.
     private func existingTerm(named word: String) -> String? {
-        var bare = word.trimmingCharacters(in: .whitespaces)
-        if let mine = Vocabulary.possessive(in: bare) {
-            bare = String(bare.dropLast(mine.suffix.count))
-        }
-        bare = bare.trimmingCharacters(in: .punctuationCharacters)
-        guard !bare.isEmpty else { return nil }
-        return config.vocabulary.terms.keys.first {
-            $0.caseInsensitiveCompare(bare) == .orderedSame
-        }
+        CorrectionRecording.term(named: word, in: Array(config.vocabulary.terms.keys))
     }
 
     /// Is this correction about a name, or about English? The decision is
@@ -4491,12 +4485,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // ends the offer, which is the "you have moved on" signal it was
         // already sending. The letters arm when the panel opens, which is the
         // only time they are drawn on screen to be pressed.
-        // A selector claims its two digits instead. It has no chips — each
-        // option carries its own key — and it is never a tab, so there is no
-        // closed state for it to hold a key through.
+        // A selector claims one digit per reading instead. It has no chips —
+        // each option carries its own key — and it is never a tab, so there is
+        // no closed state for it to hold a key through. Two readings almost
+        // always; a place where several terms share the sound has one row per
+        // member.
         let choosing = pendingChoice != nil
+        let rows = min(9, max(2, pendingChoice?.run.next?.options.count ?? 3))
         let letters = choosing
-            ? Set(["1", "2"])
+            ? Set((1 ... rows).map(String.init))
             : (pill.isOpen ? Set(commands.map(\.key).filter { !$0.isEmpty }) : Set<String>())
         // The hold is armed only for a dictation that raised the warning, and
         // only until it has been spent. Re-armed from here on every call, so an
@@ -4514,7 +4511,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             switch key {
             case .letter(let typed):
                 // The digit is the option, and the pill draws it on the option
-                // itself: 1 keeps what stands there, 2 takes the other word.
+                // itself: 1 keeps what stands there, the rest are the readings
+                // under it.
                 let index = choosing
                     ? Int(typed).map { $0 - 1 }
                     : commands.firstIndex(where: { $0.key == typed })
@@ -5786,7 +5784,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             ChooseRun.Place(
                 at: text[..<place.range.lowerBound].split(separator: " ").count,
                 span: place.open.standing.split(separator: " ").count,
-                other: place.open.other
+                others: Array(place.open.options.dropFirst())
             )
         }
         pendingChoice = PendingChoice(
@@ -5795,7 +5793,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                            places: questions)
         )
         Log.write("selector: holding the words for \(placed.count) question(s) — "
-            + placed.map { "\"\($0.open.standing)\" or \"\($0.open.other)\"" }
+            + placed.map { $0.open.options.map { "\"\($0)\"" }.joined(separator: " or ") }
                 .joined(separator: ", "))
         askTheNextWord()
         return true
@@ -5846,14 +5844,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         watchForOfferOutsideClick()
     }
 
-    /// Take one answer: 0 keeps what stands there, 1 takes the other word.
+    /// Take one answer: 0 keeps what stands there, the rest are the readings
+    /// under it.
     private func answer(_ option: Int) {
         guard var pending = pendingChoice else { return }
-        guard pending.answers.count < pending.places.count, (0...1).contains(option) else {
-            return
-        }
-        let place = pending.places[pending.answers.count]
-        Log.write("selector: \"\(option == 0 ? place.open.standing : place.open.other)\"")
+        let place = pending.places[min(pending.answers.count, pending.places.count - 1)]
+        guard pending.answers.count < pending.places.count,
+              option >= 0, option <= place.open.elsewhere
+        else { return }
+        Log.write("selector: " + (option == place.open.elsewhere
+            ? "something else — \"\(place.open.was)\" stands and nothing is recorded"
+            : "\"\(place.open.options[option])\""))
         pending.answers.append(option)
         pending.run.answer(option)
         pendingChoice = pending
@@ -5880,7 +5881,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let (text, written) = OpenPlaces.written(
             pending.places, answers: pending.answers, in: pending.text,
-            refusing: { self.refusedSpelling($0, in: pending.text) }
+            refusing: { self.refusedSpelling($0, chose: $1, in: pending.text) }
         )
         if text != pending.text {
             Log.write("selector: the answers rewrote the transcript")
@@ -5894,7 +5895,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Only the places that were answered. A place the deadline defaulted
         // is not an answer, and a term taught from one would be an opinion
         // nobody gave.
-        let learned = (0..<answered).map { (pending.places[$0], written[$0]) }
+        // "Something else" is an answer and teaches nothing, so it is not in
+        // here. The word it wrote is what was heard, and the correction that
+        // follows is an ordinary one.
+        let learned = (0..<answered)
+            .filter { written[$0].teaches }
+            .map { (pending.places[$0], written[$0]) }
         lastTranscript = text.trimmingCharacters(in: .whitespacesAndNewlines)
         insertDictation(text, to: pending.destination, for: pending.press)
         for (place, word) in learned {
@@ -5915,18 +5921,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// to mean exactly the text the pipeline returned, or answering 0 and
     /// letting the pill run out would write two different sentences.
     private func refusedSpelling(
-        _ place: OpenPlaces.Placed, in text: String
+        _ place: OpenPlaces.Placed, chose word: String, in text: String
     ) -> String {
         let open = place.open
-        guard open.other == open.was, Vocabulary.glues(heard: open.was, term: open.now)
-        else { return open.other }
+        guard word == open.was, Vocabulary.glues(heard: open.was, term: open.now)
+        else { return word }
         // The span as heard, because the rule has written its term over it and
         // the term is a different length.
         let heard = text.replacingCharacters(in: place.range, with: open.was)
         let at = text.distance(from: text.startIndex, to: place.range.lowerBound)
         guard let lower = VocabularyPass.lowercased(
             open.was, in: heard, at: at, terms: Array(config.vocabulary.terms.keys)
-        ) else { return open.other }
+        ) else { return word }
         Log.write("selector: \"\(open.was)\" refused as \(open.now) — written in lowercase")
         return lower
     }
@@ -5956,24 +5962,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             after: Date().timeIntervalSince(pending.asked),
             beside: clipDirectories[pending.press.run]
         )
-        // Which side the term is on flips with the source: a rule has already
-        // written its term into the text, so keeping what stands there keeps
-        // the term. The comparison is with the reading, not the canonical term
-        // — `Praisy's` keeps its possessive.
-        let kept = word.word == open.now
+        // The word that was written decides what this teaches, the same rule a
+        // correction follows: a term picked is a use of that term, and an
+        // ordinary word picked is a counter under the term that was proposed.
+        // A group place offers several names, and only the one you picked
+        // learns anything.
+        let picked = existingTerm(named: word.word)
+        let replaced = word.word == open.standing ? nil : open.standing
+        let rows: [CorrectionRecording.Row] = picked.map {
+            [.use(term: $0, span: word.word, heard: replaced)]
+        } ?? [.counter(term: open.term, span: word.word)]
         do {
-            try TermUses.record(
-                term: open.term, said: text, span: word.word, from: .chosen, counter: !kept
-            )
-            rebuildPortrait(for: open.term)
-            // One term chosen over another says two things, and both are worth
-            // keeping: the first does not live here and the second does.
-            if !kept, let other = existingTerm(named: word.word), other != open.term {
-                try TermUses.record(term: other, said: text, span: word.word, from: .chosen)
-                rebuildPortrait(for: other)
+            for row in try CorrectionRecording.apply(rows, said: text, from: .chosen) {
+                rebuildPortrait(for: row.term)
             }
-            Log.write("selector: \(open.term) \(kept ? "belongs" : "does not belong")"
-                + " in \"\(TermUses.narrowed(text, to: word.word))\"")
+            let said = TermUses.narrowed(text, to: word.word)
+            if let picked {
+                Log.write("selector: \(picked) belongs in \"\(said)\"")
+            } else {
+                Log.write("selector: \(open.term) does not belong in \"\(said)\"")
+            }
         } catch {
             Log.write("selector: could not record the answer: \(error.localizedDescription)")
         }

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -723,12 +723,30 @@ struct Config: Decodable, Equatable {
     /// spotter fires where the audio agrees — and dropping the rules would
     /// change what the pipeline sees on every clip. It is a measurement of its
     /// own, not a side effect of adding the sound.
+    ///
+    /// **A rendering that opens a sound group is not a rule.** `Mik` writing
+    /// down `heard: Mick` while `Mick` is a term of its own does not mean
+    /// every "Mick" is Mik — it means the two share a sound. A rule there
+    /// rewrites the sentence before anything can read it. The same holds for a
+    /// rendering two terms both claim: one of them would win by sort order.
+    /// Those words open the group instead, and `SoundGroup` decides. See
+    /// `docs/proposals/sound-groups.md`.
+    ///
+    /// One rule per source. Two rules with the same left side are a rewrite
+    /// that depends on which one the pass reads first.
     var vocabularyRules: [Transcription.Rule] {
-        vocabulary.terms
+        let opens = SoundGroup.openings(in: vocabulary.terms)
+        var written = Set<String>()
+        return vocabulary.terms
             .flatMap { term, entry in
-                entry.heard.map { Transcription.Rule(source: $0, replacement: term) }
+                entry.heard.map { (source: $0, term: term) }
             }
-            .sorted { $0.source < $1.source }
+            .sorted { ($0.source, $0.term) < ($1.source, $1.term) }
+            .compactMap { pair in
+                guard !opens.contains(pair.source.lowercased()) else { return nil }
+                guard written.insert(pair.source).inserted else { return nil }
+                return Transcription.Rule(source: pair.source, replacement: pair.term)
+            }
     }
 
     /// The pronunciations that will be searched for in the audio, with the

--- a/Sources/ParrotFlow/ConfigWriter.swift
+++ b/Sources/ParrotFlow/ConfigWriter.swift
@@ -147,6 +147,43 @@ enum ConfigWriter {
         try updated.write(to: url, atomically: true, encoding: .utf8)
     }
 
+    /// Writes a term with nothing under it but its kind.
+    ///
+    /// For a name the recogniser already spells right: there is no rendering
+    /// to record, and a term with no pronunciations is still a term — it has a
+    /// portrait, and it shares a sound with whatever else opens its group.
+    static func addVocabularyTerm(_ term: String, kind: WordKind) throws {
+        let url = ConfigStore.vocabularyURL
+        let original = (try? String(contentsOf: url, encoding: .utf8)) ?? "terms: {}\n"
+        var updated = insertBareTerm(term, into: original)
+        updated = setting(kind: kind, of: term, in: updated)
+        try updated.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    /// The file with `term:` under `terms:`, or unchanged when it is there.
+    ///
+    /// The same three shapes `insertVocabulary` handles: no `terms:` block at
+    /// all, `terms: {}`, and a block to append to.
+    static func insertBareTerm(_ term: String, into yaml: String) -> String {
+        var lines = yaml.components(separatedBy: "\n")
+        let entry = ["  \(quoted(term)):"]
+        guard let termsIndex = lines.firstIndex(where: { $0.hasPrefix("terms:") }) else {
+            var out = lines
+            if let last = out.last, !last.isEmpty { out.append("") }
+            out.append("terms:")
+            out.append(contentsOf: entry)
+            return out.joined(separator: "\n")
+        }
+        if lines[termsIndex].trimmingCharacters(in: .whitespaces).hasSuffix("{}") {
+            lines[termsIndex] = "terms:"
+            lines.insert(contentsOf: entry, at: termsIndex + 1)
+            return lines.joined(separator: "\n")
+        }
+        guard termLine(for: term, in: lines, under: termsIndex) == nil else { return yaml }
+        lines.insert(contentsOf: entry, at: endOfBlock(in: lines, from: termsIndex))
+        return lines.joined(separator: "\n")
+    }
+
     /// Writes `kind:` under the term, replacing whatever it said before.
     ///
     /// Run after `insertVocabulary`, so the term exists and any flow mapping

--- a/Sources/ParrotFlow/CorrectionRecording.swift
+++ b/Sources/ParrotFlow/CorrectionRecording.swift
@@ -155,6 +155,10 @@ enum CorrectionRecording {
     /// Returns the rows that were written, which is fewer than it was given
     /// when the word does not stand in the sentence as a word — `TermUses`
     /// refuses those, and says so by writing nothing.
+    ///
+    /// `groups` does two jobs. A sentence naming two members of one group is
+    /// recorded nowhere, and a place a member takes is given up by the rest of
+    /// the group — see `release`.
     @discardableResult
     static func apply(
         _ rows: [Row], said sentence: String, from source: TermUses.Use.Source = .correction,
@@ -181,9 +185,32 @@ enum CorrectionRecording {
                     near: word
                 )
             }
+            try release(sentence, of: row, near: word, in: groups)
             written.append(row)
         }
         return written
+    }
+
+    /// The rest of the group gives up the place this row just took.
+    ///
+    /// One sentence, one owner per place. Without this a sentence recorded
+    /// under Eric and then corrected to Erik is held by both, and the two
+    /// centres are pulled toward each other by the sentence that was meant to
+    /// separate them. Polarity does not matter: a counter under a member is a
+    /// claim on the place as well.
+    ///
+    /// A group of one has nothing to give up.
+    private static func release(
+        _ sentence: String, of row: Row, near word: Int?, in groups: [SoundGroup.Group]
+    ) throws {
+        guard let group = groups.first(where: {
+            $0.members.contains { $0.caseInsensitiveCompare(row.term) == .orderedSame }
+        }), group.isGroup else { return }
+        let span = span(of: row)
+        try TermUses.release(
+            TermUses.narrowed(sentence, to: span, near: word), at: span,
+            from: group.members, to: row.term, opening: group.openings
+        )
     }
 
     static func span(of row: Row) -> String {

--- a/Sources/ParrotFlow/CorrectionRecording.swift
+++ b/Sources/ParrotFlow/CorrectionRecording.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// What a correction that runs against a term teaches, and to which term.
+///
+/// The app wrote one word and you put another back. What that says depends on
+/// what you put:
+///
+/// - an ordinary word — `Vercel` back to `Versailles` — says nothing about a
+///   term called Versailles and everything about where Vercel lives. It is a
+///   **counter** under Vercel.
+/// - another term — `Mik` back to `Mick` — says where Mick lives. It is a
+///   **use** of Mick, with `heard:` set to the spelling it replaced. Nothing
+///   is written under Mik: the two share a sound, and the sentence is Mick's
+///   evidence, not evidence against Mik.
+///
+/// The second used to write both rows, and those are the rows that poisoned
+/// the portraits: every sentence one member lived in was stored as a place the
+/// other does not, so the loser's counter centre filled up with sentences
+/// about its own group. See `docs/proposals/sound-groups.md`.
+enum CorrectionRecording {
+
+    /// One row to write in `vocabulary-uses.yaml`.
+    enum Row: Equatable {
+        /// A sentence the term lives in, and the spelling it replaced.
+        case use(term: String, span: String, heard: String?)
+        /// A sentence the term does not live in. `span` is the word that does.
+        case counter(term: String, span: String)
+
+        var term: String {
+            switch self {
+            case .use(let term, _, _), .counter(let term, _): return term
+            }
+        }
+    }
+
+    /// What one correction writes.
+    ///
+    /// Empty when the word that was written is not a term at all. That is the
+    /// ordinary direction — an ordinary word corrected into a name — and the
+    /// correction panel offers a rule for it instead.
+    ///
+    /// The same term on both sides is a capital or a possessive being fixed,
+    /// and says nothing about where anything lives.
+    static func rows(
+        wrote written: String, put back: String, terms: [String]
+    ) -> [Row] {
+        guard let lost = term(named: written, in: terms) else { return [] }
+        guard let right = term(named: back, in: terms) else {
+            return [.counter(term: lost, span: back)]
+        }
+        guard right != lost else { return [] }
+        return [.use(term: right, span: back, heard: written)]
+    }
+
+    /// Writes them. One row per call to `TermUses.record`, in order.
+    ///
+    /// Returns the rows that were written, which is fewer than it was given
+    /// when the word does not stand in the sentence as a word — `TermUses`
+    /// refuses those, and says so by writing nothing.
+    @discardableResult
+    static func apply(
+        _ rows: [Row], said sentence: String, from source: TermUses.Use.Source = .correction
+    ) throws -> [Row] {
+        var written: [Row] = []
+        for row in rows {
+            guard TermUses.occurrence(of: span(of: row), in: sentence) != nil else { continue }
+            switch row {
+            case .use(let term, let span, let heard):
+                try TermUses.record(
+                    term: term, said: sentence, span: span, from: source, heard: heard
+                )
+            case .counter(let term, let span):
+                try TermUses.record(
+                    term: term, said: sentence, span: span, from: source, counter: true
+                )
+            }
+            written.append(row)
+        }
+        return written
+    }
+
+    static func span(of row: Row) -> String {
+        switch row {
+        case .use(_, let span, _), .counter(_, let span): return span
+        }
+    }
+
+    /// The vocabulary term this word is, ignoring case and any possessive.
+    static func term(named word: String, in terms: [String]) -> String? {
+        var bare = word.trimmingCharacters(in: .whitespaces)
+        if let mine = Vocabulary.possessive(in: bare) {
+            bare = String(bare.dropLast(mine.suffix.count))
+        }
+        bare = bare.trimmingCharacters(in: .punctuationCharacters)
+        guard !bare.isEmpty else { return nil }
+        return terms.first { $0.caseInsensitiveCompare(bare) == .orderedSame }
+    }
+}

--- a/Sources/ParrotFlow/CorrectionRecording.swift
+++ b/Sources/ParrotFlow/CorrectionRecording.swift
@@ -42,14 +42,53 @@ enum CorrectionRecording {
     /// The same term on both sides is a capital or a possessive being fixed,
     /// and says nothing about where anything lives.
     static func rows(
-        wrote written: String, put back: String, terms: [String]
+        wrote written: String, put back: String, terms: [String],
+        kinds: [String: Config.Vocabulary.Term] = [:]
     ) -> [Row] {
         guard let lost = term(named: written, in: terms) else { return [] }
         guard let right = term(named: back, in: terms) else {
+            // A name with no term yet is not an ordinary word, and a counter
+            // under the name it replaced is the poisoning this model exists to
+            // end: five sentences about a third person filed as places the
+            // second one does not live. It is a rendering to learn instead —
+            // see `learns`.
+            if learns(wrote: written, put: back, in: kinds) != nil { return [] }
             return [.counter(term: lost, span: back)]
         }
         guard right != lost else { return [] }
         return [.use(term: right, span: back, heard: written)]
+    }
+
+    /// The term a correction onto a new name asks to create, and its kind.
+    ///
+    /// `Anna` corrected to `Annah` where only `Anna` is a term: the word put
+    /// back is a name the vocabulary has never seen. The ordinary correction
+    /// path already knows what to do with that — write the rendering, create
+    /// the term, record the sentence as a use — and it never got the chance,
+    /// because the counter branch took every correction whose left side was a
+    /// term. Measured on decoded audio, 2026-09-10: five sentences about a
+    /// third person became five counters under the second, and the pooled
+    /// plain centre then scored 0.945 on a sentence that was hers.
+    ///
+    /// The rendering it writes — `heard: Anna` under `Annah` — is not a
+    /// substitution rule, because `Anna` is another term's spelling. It opens
+    /// the group, which is the only thing that lets the new name be proposed
+    /// at all.
+    static func learns(
+        wrote written: String, put back: String, in terms: [String: Config.Vocabulary.Term]
+    ) -> (name: String, kind: WordKind)? {
+        guard let lost = term(named: written, in: Array(terms.keys)),
+              term(named: back, in: Array(terms.keys)) == nil
+        else { return nil }
+        guard case .create(let name, let kind) = picked(back, proposedBy: lost, in: terms)
+        else { return nil }
+        // A person only. On the pill you are choosing between names offered
+        // for one sound, and a place or a company picked there is a name you
+        // chose. A correction is the other direction — a term taken back out —
+        // and `Vercel` corrected to `Versailles` is the counter-example the
+        // portrait is built from, not a new member of the group.
+        guard kind == .person else { return nil }
+        return (name, kind)
     }
 
     /// What picking a word on the pill means.

--- a/Sources/ParrotFlow/CorrectionRecording.swift
+++ b/Sources/ParrotFlow/CorrectionRecording.swift
@@ -141,12 +141,20 @@ enum CorrectionRecording {
     /// Erik on 2026-09-10, and every later "Eric the musician" was refused,
     /// 0.80 against 0.93 and 0.90 against 0.92.
     ///
+    /// Read on the sentence the row is recorded in, not on the whole field.
+    /// A terminal field holds every dictation since the last Return, so
+    /// "Erik presented first. Eric plays cello." names both members only when
+    /// it is read whole — and the row that correction writes is about the
+    /// second sentence, where only Eric stands.
+    ///
     /// Nil when fewer than two members stand there, which is every ordinary
     /// correction.
     static func blocked(
-        _ sentence: String, term: String, in groups: [SoundGroup.Group]
+        _ sentence: String, term: String, span: String, near word: Int? = nil,
+        in groups: [SoundGroup.Group]
     ) -> [String]? {
-        let standing = SoundGroup.standing(in: sentence, of: term, in: groups)
+        let said = TermUses.narrowed(sentence, to: span, near: word)
+        let standing = SoundGroup.standing(in: said, of: term, in: groups)
         return standing.count > 1 ? standing : nil
     }
 
@@ -166,7 +174,9 @@ enum CorrectionRecording {
     ) throws -> [Row] {
         var written: [Row] = []
         for row in rows {
-            if let two = blocked(sentence, term: row.term, in: groups) {
+            if let two = blocked(
+                sentence, term: row.term, span: span(of: row), near: word, in: groups
+            ) {
                 Log.write("uses: \"\(TermUses.narrowed(sentence, to: span(of: row), near: word))\""
                     + " names both \(two.joined(separator: " and ")) — it says nothing about"
                     + " either, so nothing is recorded")

--- a/Sources/ParrotFlow/CorrectionRecording.swift
+++ b/Sources/ParrotFlow/CorrectionRecording.swift
@@ -52,6 +52,59 @@ enum CorrectionRecording {
         return [.use(term: right, span: back, heard: written)]
     }
 
+    /// What picking a word on the pill means.
+    enum Picked: Equatable {
+        /// A term already: the sentence is a use of it.
+        case use(term: String)
+        /// A name with no term yet. Every person is a term, so it is written
+        /// as one — `kind: person`, no pronunciation, because nothing was
+        /// misheard — and the sentence is a use of it.
+        case create(name: String)
+        /// An ordinary word: a counter under the term that was proposed, which
+        /// is the sentence plain owns.
+        case counter(term: String)
+    }
+
+    /// Which of the three this answer is.
+    ///
+    /// A person the recogniser spells right never gets a term the ordinary
+    /// way: nothing is ever corrected, so nothing ever creates one, and every
+    /// sentence about them piles up as a counter under somebody else's name.
+    /// The pill is the one place that can tell — the word was picked over a
+    /// name, and the tagger or the proposing term says it is a name too.
+    static func picked(
+        _ word: String, proposedBy term: String, in terms: [String: Config.Vocabulary.Term]
+    ) -> Picked {
+        if let already = self.term(named: word, in: Array(terms.keys)) {
+            return .use(term: already)
+        }
+        let bare = word.trimmingCharacters(in: .punctuationCharacters)
+        guard !bare.isEmpty else { return .counter(term: term) }
+        if terms[term]?.kind == .person || NamePlace.isPersonalName(bare) {
+            return .create(name: bare)
+        }
+        return .counter(term: term)
+    }
+
+    /// The two group members standing in this sentence, when there are two.
+    ///
+    /// A sentence naming two members of one group belongs to neither, and
+    /// storing it under either one teaches the wrong thing about both. The
+    /// rival clip cuts the window at the other spelling, and what survives
+    /// between them is still the sentence: "So I tried again with Erik the
+    /// musician and Eric the software engineer." was kept as a counter under
+    /// Erik on 2026-09-10, and every later "Eric the musician" was refused,
+    /// 0.80 against 0.93 and 0.90 against 0.92.
+    ///
+    /// Nil when fewer than two members stand there, which is every ordinary
+    /// correction.
+    static func blocked(
+        _ sentence: String, term: String, in groups: [SoundGroup.Group]
+    ) -> [String]? {
+        let standing = SoundGroup.standing(in: sentence, of: term, in: groups)
+        return standing.count > 1 ? standing : nil
+    }
+
     /// Writes them. One row per call to `TermUses.record`, in order.
     ///
     /// Returns the rows that were written, which is fewer than it was given
@@ -60,10 +113,16 @@ enum CorrectionRecording {
     @discardableResult
     static func apply(
         _ rows: [Row], said sentence: String, from source: TermUses.Use.Source = .correction,
-        near word: Int? = nil
+        near word: Int? = nil, blocking groups: [SoundGroup.Group] = []
     ) throws -> [Row] {
         var written: [Row] = []
         for row in rows {
+            if let two = blocked(sentence, term: row.term, in: groups) {
+                Log.write("uses: \"\(TermUses.narrowed(sentence, to: span(of: row), near: word))\""
+                    + " names both \(two.joined(separator: " and ")) — it says nothing about"
+                    + " either, so nothing is recorded")
+                continue
+            }
             guard TermUses.occurrence(of: span(of: row), in: sentence) != nil else { continue }
             switch row {
             case .use(let term, let span, let heard):

--- a/Sources/ParrotFlow/CorrectionRecording.swift
+++ b/Sources/ParrotFlow/CorrectionRecording.swift
@@ -56,10 +56,10 @@ enum CorrectionRecording {
     enum Picked: Equatable {
         /// A term already: the sentence is a use of it.
         case use(term: String)
-        /// A name with no term yet. Every person is a term, so it is written
-        /// as one — `kind: person`, no pronunciation, because nothing was
-        /// misheard — and the sentence is a use of it.
-        case create(name: String)
+        /// A name with no term yet. Every name is a term, so it is written as
+        /// one — with the kind the tagger read and no pronunciation, because
+        /// nothing was misheard — and the sentence is a use of it.
+        case create(name: String, kind: WordKind)
         /// An ordinary word: a counter under the term that was proposed, which
         /// is the sentence plain owns.
         case counter(term: String)
@@ -80,9 +80,15 @@ enum CorrectionRecording {
         }
         let bare = word.trimmingCharacters(in: .punctuationCharacters)
         guard !bare.isEmpty else { return .counter(term: term) }
-        if terms[term]?.kind == .person || NamePlace.isPersonalName(bare) {
-            return .create(name: bare)
-        }
+        // What the tagger read, when it read a name at all. A place or an
+        // organization picked here is a term too, and labelling it `person`
+        // would put a guess in the file under the name of a fact.
+        let read = NamePlace.kind(of: bare)
+        if read != .word { return .create(name: bare, kind: read) }
+        // The company it keeps: a term that names a person was proposed over
+        // this word, so the word sounds like a person's name. The tagger has
+        // nothing to say about it, so `person` is the only kind on offer.
+        if terms[term]?.kind == .person { return .create(name: bare, kind: .person) }
         return .counter(term: term)
     }
 

--- a/Sources/ParrotFlow/CorrectionRecording.swift
+++ b/Sources/ParrotFlow/CorrectionRecording.swift
@@ -59,7 +59,8 @@ enum CorrectionRecording {
     /// refuses those, and says so by writing nothing.
     @discardableResult
     static func apply(
-        _ rows: [Row], said sentence: String, from source: TermUses.Use.Source = .correction
+        _ rows: [Row], said sentence: String, from source: TermUses.Use.Source = .correction,
+        near word: Int? = nil
     ) throws -> [Row] {
         var written: [Row] = []
         for row in rows {
@@ -67,11 +68,13 @@ enum CorrectionRecording {
             switch row {
             case .use(let term, let span, let heard):
                 try TermUses.record(
-                    term: term, said: sentence, span: span, from: source, heard: heard
+                    term: term, said: sentence, span: span, from: source, heard: heard,
+                    near: word
                 )
             case .counter(let term, let span):
                 try TermUses.record(
-                    term: term, said: sentence, span: span, from: source, counter: true
+                    term: term, said: sentence, span: span, from: source, counter: true,
+                    near: word
                 )
             }
             written.append(row)

--- a/Sources/ParrotFlow/LearnCommand.swift
+++ b/Sources/ParrotFlow/LearnCommand.swift
@@ -111,14 +111,18 @@ enum LearnCommand {
     ///
     /// `word` is what stands where the term goes, for a sentence that inflects
     /// it — `Praisy's` — and defaults to the term itself.
-    static func supporting(term: String, sentence: String, span: String? = nil) -> Int32 {
+    static func supporting(
+        term: String, sentence: String, span: String? = nil, near word: Int? = nil
+    ) -> Int32 {
         let written = span ?? term
         guard TermUses.occurrence(of: written, in: sentence) != nil else {
             print("✗ \"\(written)\" does not stand as a word in that sentence")
             return 1
         }
         do {
-            try TermUses.record(term: term, said: sentence, span: written, from: .seeded)
+            try TermUses.record(
+                term: term, said: sentence, span: written, from: .seeded, near: word
+            )
             print("✓ \(term) belongs at \"\(written)\"")
             return 0
         } catch {

--- a/Sources/ParrotFlow/NamePlace.swift
+++ b/Sources/ParrotFlow/NamePlace.swift
@@ -1,0 +1,77 @@
+import Foundation
+import NaturalLanguage
+
+/// Is this place one name against another?
+///
+/// The slot test asks whether the term can stand where the word was heard, and
+/// it answers by comparing vectors: a term is unknown to the tokenizer by
+/// construction, and an ordinary word is not, so the heard word always wins by
+/// a margin that says nothing about the sentence. That is the point when the
+/// heard word is ordinary — `versus` really does belong where `Vercel` was
+/// proposed.
+///
+/// It is not the point when the heard word is a name too. Measured on the
+/// live app, 2026-09-10: `Eric` against the term `Erik` gives a gap of −0.254
+/// in "Eric plays the piano.", −0.253 in "Eric plays the guitar." and −0.257
+/// in "Eric is a musician." — the same refusal three times, because `Eric` is
+/// in the tokenizer and `Erik` is not. The place was settled before the
+/// portrait or the pill could see it, so a new name could never start.
+///
+/// Three tells, any one of which makes it a name against a name:
+///
+/// - the term says so: `kind: person` in `vocabulary.yaml`;
+/// - `NLTagger` reads the heard word as a personal name;
+/// - the heard word is a `heard:` rendering somebody wrote down. A rendering
+///   is a spelling of a name by definition.
+enum NamePlace {
+
+    /// Whether the slot test has to stand aside at this place.
+    static func bothNames(
+        heard: String, term: String, in terms: [String: Config.Vocabulary.Term]
+    ) -> Bool {
+        let bare = word(of: term)
+        let named = terms.first { $0.key.caseInsensitiveCompare(bare) == .orderedSame }
+        if named?.value.kind == .person { return true }
+        if renderings(of: heard, in: terms) { return true }
+        return isPersonalName(word(of: heard))
+    }
+
+    /// A `heard:` rendering of any term, matched without case.
+    private static func renderings(
+        of heard: String, in terms: [String: Config.Vocabulary.Term]
+    ) -> Bool {
+        let needle = word(of: heard)
+        return terms.values.contains { entry in
+            entry.heard.contains { $0.caseInsensitiveCompare(needle) == .orderedSame }
+        }
+    }
+
+    /// What `NLTagger` calls this word, standing on its own in a plain
+    /// sentence.
+    ///
+    /// In a frame, not bare: the tagger reads a lone word as a noun whatever
+    /// it is. The frame is neutral — nothing in it names a person — so what
+    /// comes back is about the word.
+    static func isPersonalName(_ word: String) -> Bool {
+        let bare = String(word.prefix { $0.isLetter || $0 == "-" || $0 == "'" })
+        guard bare.count > 1, bare.first?.isUppercase == true else { return false }
+        let framed = "I spoke to \(bare) about it."
+        let tagger = NLTagger(tagSchemes: [.nameTypeOrLexicalClass])
+        tagger.string = framed
+        tagger.setLanguage(.english, range: framed.startIndex ..< framed.endIndex)
+        guard let at = framed.range(of: bare) else { return false }
+        let tag = tagger.tag(at: at.lowerBound, unit: .word, scheme: .nameTypeOrLexicalClass)
+            .0?.rawValue
+        return WordKind.from(tag: tag) == .person
+    }
+
+    /// The first word of a span, without its possessive or its punctuation.
+    private static func word(of span: String) -> String {
+        var bare = span.trimmingCharacters(in: .whitespaces)
+        if let mine = Vocabulary.possessive(in: bare) {
+            bare = String(bare.dropLast(mine.suffix.count))
+        }
+        bare = bare.trimmingCharacters(in: .punctuationCharacters)
+        return String(bare.prefix { !$0.isWhitespace })
+    }
+}

--- a/Sources/ParrotFlow/NamePlace.swift
+++ b/Sources/ParrotFlow/NamePlace.swift
@@ -46,23 +46,29 @@ enum NamePlace {
         }
     }
 
-    /// What `NLTagger` calls this word, standing on its own in a plain
-    /// sentence.
+    static func isPersonalName(_ word: String) -> Bool {
+        kind(of: word) == .person
+    }
+
+    /// What kind of name `NLTagger` reads this word as, or `.word` when it
+    /// reads no name at all.
     ///
     /// In a frame, not bare: the tagger reads a lone word as a noun whatever
-    /// it is. The frame is neutral — nothing in it names a person — so what
-    /// comes back is about the word.
-    static func isPersonalName(_ word: String) -> Bool {
+    /// it is. The frame names nobody and nowhere, so what comes back is about
+    /// the word — `Sarah` is a person in it, `Versailles` a place, `Microsoft`
+    /// an organization, and `Cancel`, `Merge`, `Price`, `The` and `Match` are
+    /// none of the three.
+    static func kind(of word: String) -> WordKind {
         let bare = String(word.prefix { $0.isLetter || $0 == "-" || $0 == "'" })
-        guard bare.count > 1, bare.first?.isUppercase == true else { return false }
-        let framed = "I spoke to \(bare) about it."
+        guard bare.count > 1, bare.first?.isUppercase == true else { return .word }
+        let framed = "We talked about \(bare) again yesterday."
         let tagger = NLTagger(tagSchemes: [.nameTypeOrLexicalClass])
         tagger.string = framed
         tagger.setLanguage(.english, range: framed.startIndex ..< framed.endIndex)
-        guard let at = framed.range(of: bare) else { return false }
+        guard let at = framed.range(of: bare) else { return .word }
         let tag = tagger.tag(at: at.lowerBound, unit: .word, scheme: .nameTypeOrLexicalClass)
             .0?.rawValue
-        return WordKind.from(tag: tag) == .person
+        return WordKind.from(tag: tag)
     }
 
     /// The first word of a span, without its possessive or its punctuation.

--- a/Sources/ParrotFlow/OpenPlaces.swift
+++ b/Sources/ParrotFlow/OpenPlaces.swift
@@ -40,10 +40,39 @@ enum OpenPlaces {
         /// picked.
         let word: Int
 
+        /// The members of the sound group this place is between, best first.
+        ///
+        /// Empty at every ordinary place, which is one span with one
+        /// alternative. A group place is several names sharing the word that
+        /// was heard, and each of them is a reading — see `SoundGroup`.
+        var group: [String] = []
+
         /// What is written there now, which is the pill's option 0.
         var standing: String { wrote ? now : was }
         /// The reading nobody has taken, which is the pill's option 1.
         var other: String { wrote ? was : now }
+
+        /// Every reading on offer, what stands in the text first.
+        ///
+        /// A group member spelled the way the word was heard is offered once,
+        /// as that first row. Choosing it writes the same characters either
+        /// way, and it is recorded as a use of that member because the word it
+        /// writes is a term.
+        var options: [String] {
+            guard !group.isEmpty else { return [standing, other] }
+            let heard = standing
+            return [heard] + group.filter {
+                $0.caseInsensitiveCompare(heard) != .orderedSame
+            }.prefix(SoundGroup.ceiling)
+        }
+
+        /// The answer that means none of them: "something else".
+        ///
+        /// It writes what was heard and teaches nothing. Every other answer
+        /// says something about a term — this one says the question had no
+        /// right answer, and the correction you make by hand afterwards goes
+        /// through the panel exactly as it does today.
+        var elsewhere: Int { options.count }
     }
 
     /// One place, and where it turned out to be in the text that landed.
@@ -100,27 +129,40 @@ enum OpenPlaces {
     /// before every question was answered. Those places keep what stands
     /// there, which is the text the pipeline returned.
     ///
-    /// - Parameter refusing: what to write when the answer is option 1. It is
-    ///   a closure because refusing a term can change the spelling of the
+    /// - Parameter refusing: what to write when the answer is not option 0. It
+    ///   is a closure because refusing a term can change the spelling of the
     ///   phrase that goes back — see `AppDelegate.refusedSpelling` — and that
     ///   needs the vocabulary and a tagger this type has no business holding.
+    ///   It is handed the reading that was picked.
     static func written(
         _ places: [Placed], answers: [Int], in text: String,
-        refusing: (Placed) -> String
+        refusing: (Placed, String) -> String
     ) -> (text: String, words: [Written]) {
         var out = "", cursor = text.startIndex
         var written: [Written] = []
         for (index, place) in places.enumerated() {
             out += text[cursor..<place.range.lowerBound]
-            let word = index < answers.count && answers[index] == 1
-                ? refusing(place)
-                : place.open.standing
+            let answer = index < answers.count ? answers[index] : 0
+            let options = place.open.options
+            let elsewhere = answer == place.open.elsewhere
+            let word: String
+            if elsewhere {
+                // What was heard, written as it was heard. Nothing has been
+                // decided, so nothing is tidied either.
+                word = place.open.was
+            } else if answer > 0, answer < options.count {
+                word = refusing(place, options[answer])
+            } else {
+                word = place.open.standing
+            }
             // Where it ended up, not where it was asked about. A place after
             // one that got longer or shorter has moved, and the trace's whole
             // job is to say which occurrence this was.
             let from = out.count
             out += word
-            written.append(Written(word: word, range: from ..< out.count))
+            written.append(
+                Written(word: word, range: from ..< out.count, teaches: !elsewhere)
+            )
             cursor = place.range.upperBound
         }
         return (out + text[cursor...], written)
@@ -133,6 +175,8 @@ enum OpenPlaces {
         /// `EditWatch.asHeard`. Two `range` fields in one trace file measuring
         /// in different units is a trap for whatever reads them together.
         let range: Range<Int>
+        /// False for "something else", the one answer that records nothing.
+        var teaches = true
     }
 
     private static let lock = NSLock()

--- a/Sources/ParrotFlow/OpenPlaces.swift
+++ b/Sources/ParrotFlow/OpenPlaces.swift
@@ -60,10 +60,7 @@ enum OpenPlaces {
         /// writes is a term.
         var options: [String] {
             guard !group.isEmpty else { return [standing, other] }
-            let heard = standing
-            return [heard] + group.filter {
-                $0.caseInsensitiveCompare(heard) != .orderedSame
-            }.prefix(SoundGroup.ceiling)
+            return SoundGroup.offered(standing, of: group)
         }
 
         /// The answer that means none of them: "something else".

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -74,18 +74,18 @@ enum PanelsCommand {
                     + " finished running on the new cluster can you ask mixed bend"
                     + " to review the pull request before the end of the week so we"
                     + " can ship it on Monday.",
-                [("mixed bend", "Mick")]
+                [("mixed bend", ["Mick"])]
             )
         case "two":
             return selector(
                 "so after the standup tomorrow morning can you ask mixed bend to"
                     + " review it and then tell the team that we moved everything"
                     + " off BetterStack in June before the export runs again",
-                [("mixed bend", "Mick"), ("BetterStack", "better stack")]
+                [("mixed bend", ["Mick"]), ("BetterStack", ["better stack"])]
             )
         default:
             return selector(
-                "can you ask mixed bend to review it.", [("mixed bend", "Mick")]
+                "can you ask mixed bend to review it.", [("mixed bend", ["Mick"])]
             )
         }
     }
@@ -99,15 +99,15 @@ enum PanelsCommand {
         for option in answered { run.answer(option) }
         guard let step = run.next else {
             // Unreachable: every run here has more places than answers.
-            return Choose(before: "", heard: run.sentence, other: "",
-                          after: "", step: 1, steps: 1)
+            return Choose(before: "", options: [run.sentence], after: "",
+                          step: 1, steps: 1)
         }
         return step
     }
 
     /// The places named by the words they cover, which is how they read here.
     private static func selector(
-        _ sentence: String, _ pairs: [(heard: String, other: String)]
+        _ sentence: String, _ pairs: [(heard: String, others: [String])]
     ) -> ChooseRun {
         let words = sentence.split(separator: " ").map(String.init)
         var places: [ChooseRun.Place] = []
@@ -115,7 +115,9 @@ enum PanelsCommand {
         for pair in pairs {
             let phrase = pair.heard.split(separator: " ").map(String.init)
             guard let at = firstIndex(of: phrase, in: words, from: from) else { continue }
-            places.append(ChooseRun.Place(at: at, span: phrase.count, other: pair.other))
+            places.append(
+                ChooseRun.Place(at: at, span: phrase.count, others: pair.others)
+            )
             from = at + phrase.count
         }
         return ChooseRun(sentence: sentence, places: places)

--- a/Sources/ParrotFlow/PillHUD.swift
+++ b/Sources/ParrotFlow/PillHUD.swift
@@ -167,10 +167,12 @@ struct Learn: Equatable {
 struct Choose: Equatable {
     /// The prose before the place. A leading "…" when the window cut it.
     let before: String
-    /// What the stage left in the string. Option 0.
-    let heard: String
-    /// The word it could not rule out. Option 1.
-    let other: String
+    /// Every reading of the place, what the stage left in the string first.
+    ///
+    /// Two of them almost always: what was heard and the one word that could
+    /// not be ruled out. A place where several terms share the sound carries
+    /// one row per member — see `SoundGroup`.
+    let options: [String]
     /// The prose after the place. A trailing "…" when the window cut it.
     let after: String
     /// Which question this is, and how many there are.
@@ -181,9 +183,12 @@ struct Choose: Equatable {
     /// the surface says an answer is not the end of it.
     var count: String? { steps > 1 ? "\(step) of \(steps)" : nil }
 
+    /// What stands in the string, which is the row nobody has to click.
+    var heard: String { options.first ?? "" }
+
     /// For the log only. The view draws the pieces.
     var line: String {
-        "\(PillMetrics.chooseLead) “\(before) [\(heard)|\(other)] \(after)”"
+        "\(PillMetrics.chooseLead) “\(before) [\(options.joined(separator: "|"))] \(after)”"
     }
 
     /// The sentence cut to a window around the place.
@@ -191,7 +196,7 @@ struct Choose: Equatable {
     /// `at` and `span` are word indices into `words`. An ellipsis is written
     /// only where words were dropped.
     static func windowed(
-        words: [String], at: Int, span: Int, other: String,
+        words: [String], at: Int, span: Int, others: [String],
         step: Int = 1, steps: Int = 1, window: Int = AppDelegate.learnWindow
     ) -> Choose {
         func run(_ range: Range<Int>) -> [String] {
@@ -205,8 +210,8 @@ struct Choose: Equatable {
             before: head.count > window
                 ? "… " + head.suffix(window).joined(separator: " ")
                 : head.joined(separator: " "),
-            heard: run(at ..< (at + span)).joined(separator: " "),
-            other: other,
+            options: [run(at ..< (at + span)).joined(separator: " ")] + others
+                + [PillMetrics.chooseElsewhere],
             after: tail.prefix(window).joined(separator: " ")
                 + (tail.count > window ? " …" : ""),
             step: step, steps: steps
@@ -220,15 +225,15 @@ struct Choose: Equatable {
     /// either side; past that the place itself is what is too wide, and
     /// `.lineLimit(1)` truncates.
     static func fitted(
-        words: [String], at: Int, span: Int, other: String,
+        words: [String], at: Int, span: Int, others: [String],
         step: Int = 1, steps: Int = 1, window: Int = AppDelegate.learnWindow
     ) -> Choose {
         var size = window
-        var kept = windowed(words: words, at: at, span: span, other: other,
+        var kept = windowed(words: words, at: at, span: span, others: others,
                             step: step, steps: steps, window: size)
         while size > 1, !PillMetrics.chooseFits(kept) {
             size -= 1
-            kept = windowed(words: words, at: at, span: span, other: other,
+            kept = windowed(words: words, at: at, span: span, others: others,
                             step: step, steps: steps, window: size)
         }
         return kept
@@ -249,7 +254,8 @@ struct ChooseRun {
         /// Moves when an earlier answer writes a different number of words.
         var at: Int
         let span: Int
-        let other: String
+        /// The readings beside what was heard, in the order they are offered.
+        let others: [String]
     }
 
     private(set) var words: [String]
@@ -266,7 +272,7 @@ struct ChooseRun {
         guard answered < places.count else { return nil }
         let place = places[answered]
         return .fitted(
-            words: words, at: place.at, span: place.span, other: place.other,
+            words: words, at: place.at, span: place.span, others: place.others,
             step: answered + 1, steps: places.count
         )
     }
@@ -274,14 +280,16 @@ struct ChooseRun {
     /// The sentence as it stands, which after the last answer is what to type.
     var sentence: String { words.joined(separator: " ") }
 
-    /// Take an answer: 0 keeps what was heard, 1 writes the other word.
+    /// Take an answer: 0 keeps what was heard, anything else writes that
+    /// reading.
     mutating func answer(_ option: Int) {
         guard answered < places.count else { return }
         let place = places[answered]
         answered += 1
-        guard option == 1, place.at >= 0, place.at + place.span <= words.count
+        guard option > 0, option <= place.others.count,
+              place.at >= 0, place.at + place.span <= words.count
         else { return }
-        let written = place.other.split(separator: " ").map(String.init)
+        let written = place.others[option - 1].split(separator: " ").map(String.init)
         words.replaceSubrange(place.at ..< (place.at + place.span), with: written)
         let shift = written.count - place.span
         guard shift != 0 else { return }
@@ -440,9 +448,10 @@ final class PillModel: ObservableObject {
     /// Closures rather than published state: they are messages out of the view,
     /// and nothing about them should redraw it.
     ///
-    /// On a selector the index is the option: 0 keeps what was heard, 1 takes
-    /// the other word. There is one place on the pill, so a click is the whole
-    /// answer — whoever raised it asks the next question, if there is one.
+    /// On a selector the index is the option: 0 keeps what was heard, and the
+    /// rest are the readings under it, in the order they are drawn. There is
+    /// one place on the pill, so a click is the whole answer — whoever raised
+    /// it asks the next question, if there is one.
     var onPick: ((Int) -> Void)?
     var onHover: ((Bool) -> Void)?
     /// The open panel folded back to the tab on its own.
@@ -1788,12 +1797,12 @@ enum PillMetrics {
             * (rule + blockGap)
         if case .learn(let it) = headline {
             extra += learnRows(it) + blockGap
-        } else if case .choose = headline {
+        } else if case .choose(let it) = headline {
             // The pill's own 42 is one chip row and the 16 of air that centres
             // it. The selector draws no chips — each option carries its own key
             // — so give the row back and keep the air. `OfferContent` skips the
             // chip block on the same condition, so nothing is left in its place.
-            extra += chooseRows
+            extra += chooseRows(it.options.count)
             if commands.isEmpty { extra -= chipRowHeight }
         } else if headline?.ownsARow == true {
             extra += selectionRow + blockGap
@@ -2104,6 +2113,13 @@ enum PillMetrics {
     /// The option's word: the prose's size and weight, in the monospaced face.
     static let chooseWordFont: NSFont =
         .monospacedSystemFont(ofSize: 14, weight: .medium)
+    /// The last row of every question: none of these.
+    ///
+    /// It writes what was heard and records nothing, so the correction you
+    /// make afterwards is an ordinary one — the panel offers a rule for it the
+    /// way it always has.
+    static let chooseElsewhere = "something else"
+
     /// Between the two options of one place.
     static let chooseChipGap: CGFloat = 4
     /// Between the lead and the sentence.
@@ -2112,10 +2128,12 @@ enum PillMetrics {
     /// beside it. The view lays the row out at this spacing.
     static let chooseWordGap: CGFloat = 5
 
-    /// The lead, then the sentence with the stack standing in it. Two rows
-    /// whatever the sentence is: the row is never allowed to wrap.
-    static let chooseRows: CGFloat =
-        learnRow + chooseGap + chooseChipHeight * 2 + chooseChipGap
+    /// The lead, then the sentence with the stack standing in it. One row per
+    /// reading, and the row itself is never allowed to wrap.
+    static func chooseRows(_ options: Int) -> CGFloat {
+        let rows = CGFloat(max(2, options))
+        return learnRow + chooseGap + chooseChipHeight * rows + chooseChipGap * (rows - 1)
+    }
 
     /// One option's capsule, measured in the face the word is set in.
     static func chooseChipWidth(_ word: String) -> CGFloat {
@@ -2127,7 +2145,7 @@ enum PillMetrics {
     /// options, and a space either side of the stack. The lead row when a
     /// short sentence leaves it the wider of the two.
     static func chooseWidth(_ it: Choose) -> CGFloat {
-        var width = max(chooseChipWidth(it.heard), chooseChipWidth(it.other))
+        var width = it.options.map(chooseChipWidth).max() ?? 0
         var pieces = 1
         func prose(_ run: String) {
             guard !run.isEmpty else { return }
@@ -2794,8 +2812,9 @@ private struct OfferContent: View {
                 HStack(spacing: PillMetrics.chooseWordGap) {
                     if !it.before.isEmpty { prose(it.before) }
                     VStack(alignment: .leading, spacing: PillMetrics.chooseChipGap) {
-                        option(it.heard, index: 0)
-                        option(it.other, index: 1)
+                        ForEach(Array(it.options.enumerated()), id: \.offset) { row in
+                            option(row.element, index: row.offset)
+                        }
                     }
                     if !it.after.isEmpty { prose(it.after) }
                 }

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -1225,7 +1225,8 @@ struct Pipeline: Equatable, Codable {
                 floor: config.transcription.slotFloor(
                     for: Pipeline.language(of: text, config: config), on: step
                 ),
-                slot: step.slotGate ?? true, portrait: step.portrait ?? true
+                slot: step.slotGate ?? true, portrait: step.portrait ?? true,
+                terms: config.vocabulary.terms
             )
             decided = settledBySentence.decided
             // A group place comes back proposing the member that won, or

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -1308,7 +1308,8 @@ struct Pipeline: Equatable, Codable {
                 ) else { continue }
                 writing[index] = VocabularyPass.Change(
                     range: change.range, was: lower, now: change.now,
-                    terms: change.terms, owner: change.owner, standing: change.standing
+                    terms: change.terms, owner: change.owner, standing: change.standing,
+                    group: change.group
                 )
                 Log.write("vocabulary: \"\(change.was)\" refused as \(change.now)"
                     + " — written in lowercase")

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -1146,7 +1146,21 @@ struct Pipeline: Equatable, Codable {
             parts += heard
         }
 
-        let slots = VocabularyPass.slots(in: text, from: parts, caps: caps)
+        // The places where several terms share the word that was heard. Built
+        // before the others and not from parts: a group place carries every
+        // member as a reading, where a part carries one alternative. A part
+        // that lands on the same span is dropped — the group's reading of it
+        // is the wider question, and a second slot over the same words would
+        // be a question nobody can answer twice.
+        let groups = SoundGroup.groups(terms: config.vocabulary.terms, uses: TermUses.load())
+        let opened = VocabularyPass.groupSlots(in: text, groups: groups)
+        if !opened.isEmpty {
+            parts = parts.filter { part in
+                !opened.contains { $0.range.overlaps(part.range) }
+            }
+        }
+        let slots = (opened + VocabularyPass.slots(in: text, from: parts, caps: caps))
+            .sorted { $0.range.lowerBound < $1.range.lowerBound }
         // Two numbers on every run. How many places one sentence offers is the
         // measure of how much this stage is being asked to decide, so it has
         // to be readable before a change that widens what fires, not inferred
@@ -1176,7 +1190,7 @@ struct Pipeline: Equatable, Codable {
         guard !slots.isEmpty else {
             return result(text, ["slots": .int(0)])
         }
-        let changes = VocabularyPass.changes(in: text, from: slots)
+        var changes = VocabularyPass.changes(in: text, from: slots)
         guard !changes.isEmpty else {
             return result(text, ["slots": .int(slots.count)])
         }
@@ -1206,13 +1220,17 @@ struct Pipeline: Equatable, Codable {
         }
         // The two tests that read the sentence, on whatever is still open.
         if config.vocabulary.gateSentence, #available(macOS 14, *) {
-            decided = await SentenceGate.settle(
+            let settledBySentence = await SentenceGate.settle(
                 changes, in: text, given: decided,
                 floor: config.transcription.slotFloor(
                     for: Pipeline.language(of: text, config: config), on: step
                 ),
                 slot: step.slotGate ?? true, portrait: step.portrait ?? true
             )
+            decided = settledBySentence.decided
+            // A group place comes back proposing the member that won, or
+            // carrying the ones still standing. Nothing else in a change moves.
+            changes = settledBySentence.changes
         }
         gateSeconds = Date().timeIntervalSince(gatedAt)
 
@@ -1253,7 +1271,10 @@ struct Pipeline: Equatable, Codable {
                     wrote: String(text[change.range]) == change.now,
                     term: term,
                     word: text[..<change.range.lowerBound]
-                        .split(separator: " ").count
+                        .split(separator: " ").count,
+                    // The members still standing, when several terms share the
+                    // word that was heard. The pill offers one row each.
+                    group: change.group
                 )
             })
         }

--- a/Sources/ParrotFlow/SelectorCommand.swift
+++ b/Sources/ParrotFlow/SelectorCommand.swift
@@ -58,9 +58,17 @@ enum SelectorCommand {
             // `wrote` says which side the term is on, and nothing here needs
             // to know: the two readings are given by name, and the term is
             // only read when a use is being recorded.
-            open.append(OpenPlaces.Open(
+            let place = OpenPlaces.Open(
                 was: parts[0], now: parts[1], wrote: false, term: parts[1], word: word
-            ))
+            )
+            // A row past "something else" was never offered. Taken as given,
+            // `OpenPlaces.written` kept what stands there and called it
+            // teaching.
+            if let picked = answer, picked > place.elsewhere {
+                print("this place offers rows 0 to \(place.elsewhere), not \"\(parts[3])\"")
+                return 2
+            }
+            open.append(place)
             answers.append(answer)
         }
         let located = OpenPlaces.located(open, in: text)

--- a/Sources/ParrotFlow/SelectorCommand.swift
+++ b/Sources/ParrotFlow/SelectorCommand.swift
@@ -9,9 +9,14 @@ import Foundation
 ///
 /// A place is `standing|other|word|answer`: what stands in the text, the
 /// reading nobody took, where the stage saw it counted in words, and the
-/// answer — `0` keeps what stands there, `1` takes the other reading, and `-`
-/// is a question nobody answered. Several places are several arguments, and
-/// they may be given in any order.
+/// answer — `0` keeps what stands there, `1` takes the other reading, the row
+/// past the last reading is "something else", and `-` is a question nobody
+/// answered. Several places are several arguments, and they may be given in
+/// any order.
+///
+/// `--taught` prints what each answer teaches instead of the text: the word,
+/// and whether a row is written about it. "Something else" is the one answer
+/// that writes none.
 ///
 /// This is the half of the pill that is not drawing: `OpenPlaces.located`
 /// finds the span again in a text later stages may have rewritten, and
@@ -28,7 +33,9 @@ import Foundation
 /// the vocabulary; `--lowercase-refused` is where that half is scored.
 enum SelectorCommand {
 
-    static func run(text: String, places: [String], ranges: Bool = false) -> Int32 {
+    static func run(
+        text: String, places: [String], ranges: Bool = false, taught: Bool = false
+    ) -> Int32 {
         var open: [OpenPlaces.Open] = []
         var answers: [Int?] = []
         for argument in places {
@@ -40,12 +47,13 @@ enum SelectorCommand {
             }
             let answer: Int?
             switch parts[3] {
-            case "0": answer = 0
-            case "1": answer = 1
             case "-": answer = nil
             default:
-                print("an answer is 0, 1 or -, not \"\(parts[3])\"")
-                return 2
+                guard let picked = Int(parts[3]), picked >= 0 else {
+                    print("an answer is a row number or -, not \"\(parts[3])\"")
+                    return 2
+                }
+                answer = picked
             }
             // `wrote` says which side the term is on, and nothing here needs
             // to know: the two readings are given by name, and the term is
@@ -71,11 +79,17 @@ enum SelectorCommand {
         // either.
         let taken = ordered.prefix { $0 != nil }.compactMap { $0 }
         let done = OpenPlaces.written(
-            located, answers: taken, in: text, refusing: { $0.open.other }
+            located, answers: taken, in: text, refusing: { _, word in word }
         )
         // The word and where it ended up, which is what the trace records. A
         // place after one the answer made longer or shorter has moved, and
         // nothing else prints that.
+        guard !taught else {
+            print(done.words.prefix(taken.count)
+                .map { "\($0.word) \($0.teaches ? "teaches" : "nothing")" }
+                .joined(separator: "; "))
+            return 0
+        }
         guard !ranges else {
             // The answered ones only. `written` returns a row per located
             // place, and the rows past the last answer are what stands there

--- a/Sources/ParrotFlow/SentenceGate.swift
+++ b/Sources/ParrotFlow/SentenceGate.swift
@@ -68,9 +68,15 @@ enum SentenceGate {
         }
         // Only the slot half reads it. With that half off the portrait runs on
         // a machine the 269 MB was never fetched to.
+        //
+        // A group place is not one of the places it reads: every reading there
+        // is a name, so the slot has nothing to separate and is never asked.
+        // Those still run.
+        var groupsOnly = false
         if slot, !SlotModel.isCached {
-            Log.write("sentence gate: the slot model is not cached yet; skipped")
-            return (settled, changes)
+            groupsOnly = true
+            Log.write("sentence gate: the slot model is not cached yet;"
+                + " only group places are read")
         }
 
         var out = settled
@@ -79,6 +85,7 @@ enum SentenceGate {
             guard index < out.count, out[index] != false else { continue }
             guard let term = change.terms.first else { continue }
             guard change.range.upperBound <= text.endIndex else { continue }
+            guard !groupsOnly || change.group.count > 1 else { continue }
 
             // A place an earlier rule already decided to write. The two word
             // lists write a name whenever the heard word is in neither of them,

--- a/Sources/ParrotFlow/SentenceGate.swift
+++ b/Sources/ParrotFlow/SentenceGate.swift
@@ -28,6 +28,15 @@ import Foundation
 @available(macOS 14, *)
 enum SentenceGate {
 
+    /// The places, and what each one settled to.
+    ///
+    /// The changes come back because a group place can change what it is
+    /// proposing: `now` is one member when it arrives here and the winning
+    /// member when it leaves, and `group` is cut to the members still standing
+    /// — which is the list the pill offers when nobody wins. Nothing else in a
+    /// change moves.
+    typealias Settled = (decided: [Bool?], changes: [VocabularyPass.Change])
+
     /// Fills in the places the earlier rules left open.
     ///
     /// `settled` carries one entry per change: `true` writes the term, `false`
@@ -45,21 +54,22 @@ enum SentenceGate {
     static func settle(
         _ changes: [VocabularyPass.Change], in text: String, given settled: [Bool?],
         floor: Double, slot: Bool = true, portrait: Bool = true
-    ) async -> [Bool?] {
-        guard slot || portrait else { return settled }
+    ) async -> Settled {
+        var changes = changes
+        guard slot || portrait else { return (settled, changes) }
         // Never on the dictation's time. The word vectors are 400 MB and the
         // first MLX call warms Metal; waiting for that with the pill on screen
         // reads as the app having hung, which is what it did.
         guard await WordVectors.shared.isLoaded else {
             await WordVectors.shared.warm()
             Log.write("sentence gate: the word vectors are not loaded yet; skipped")
-            return settled
+            return (settled, changes)
         }
         // Only the slot half reads it. With that half off the portrait runs on
         // a machine the 269 MB was never fetched to.
         if slot, !SlotModel.isCached {
             Log.write("sentence gate: the slot model is not cached yet; skipped")
-            return settled
+            return (settled, changes)
         }
 
         var out = settled
@@ -104,6 +114,39 @@ enum SentenceGate {
             let from = heard.index(heard.startIndex, offsetBy: start)
             let upto = heard.index(from, offsetBy: change.was.count)
             let near = TermPortrait.window(around: from ..< upto, in: heard)
+
+            // A place where several terms share the heard word. Every member
+            // is scored against its own portrait and against the group's
+            // pooled counter rows, and the best of them wins by the same band
+            // — see `SoundGroup.decide`. The slot test is not asked: it
+            // compares one term with one heard word, and here every reading is
+            // a name, so it has nothing to separate.
+            //
+            // With the portrait off there is nothing left to decide a group
+            // place with, so it keeps what was heard.
+            if change.group.count > 1 {
+                guard portrait else { continue }
+                looked += 1
+                let verdict = await TermPortrait.shared.reads(
+                    group: change.group, change.was, in: near
+                )
+                switch verdict {
+                case .write(let member):
+                    changes[index] = change.writing(member)
+                    out[index] = true
+                    Log.write("sentence gate: \"\(change.was)\" -> \(member) —"
+                        + " this is where it lives")
+                case .keep:
+                    out[index] = false
+                    Log.write("sentence gate: \"\(change.was)\" kept — no member of"
+                        + " \(change.group.joined(separator: "/")) lives here")
+                case .open(let members):
+                    changes[index] = change.offering(members)
+                    Log.write("sentence gate: \"\(change.was)\" — nothing separates"
+                        + " \(members.joined(separator: "/")); the place is left open")
+                }
+                continue
+            }
 
             if out[index] == true {
                 // Only the portrait may take a rule's write back out. With it
@@ -163,6 +206,6 @@ enum SentenceGate {
         if looked == 0 {
             Log.write("sentence gate: nothing left to read in \(changes.count) place(s)")
         }
-        return out
+        return (out, changes)
     }
 }

--- a/Sources/ParrotFlow/SentenceGate.swift
+++ b/Sources/ParrotFlow/SentenceGate.swift
@@ -53,7 +53,8 @@ enum SentenceGate {
     /// same way either way, so one half off leaves the other deciding alone.
     static func settle(
         _ changes: [VocabularyPass.Change], in text: String, given settled: [Bool?],
-        floor: Double, slot: Bool = true, portrait: Bool = true
+        floor: Double, slot: Bool = true, portrait: Bool = true,
+        terms: [String: Config.Vocabulary.Term] = [:]
     ) async -> Settled {
         var changes = changes
         guard slot || portrait else { return (settled, changes) }
@@ -170,8 +171,18 @@ enum SentenceGate {
                 continue
             }
 
+            // One name against another. The slot test cannot read such a
+            // place — the heard word is in the tokenizer and the term never is
+            // — so it refuses every one of them, and refusing settles the
+            // place before the portrait or the pill can see it. See
+            // `NamePlace`.
+            let names = NamePlace.bothNames(heard: change.was, term: change.now, in: terms)
+            if slot, names {
+                Log.write("sentence gate: \"\(change.was)\" and \(change.now) are both"
+                    + " names — the slot cannot separate them, so it is not asked")
+            }
             var refuses = false
-            if slot {
+            if slot, !names {
                 do {
                     let gap = try await SlotReference.gap(
                         term: change.now, heard: change.was, at: change.range, in: text

--- a/Sources/ParrotFlow/SoundGroup.swift
+++ b/Sources/ParrotFlow/SoundGroup.swift
@@ -26,6 +26,17 @@ enum SoundGroup {
     /// alternative — and a group place is the one thing that breaks it.
     static let ceiling = 4
 
+    /// The readings one group place offers: what was heard, then the members.
+    ///
+    /// The heard word is a member's own spelling as often as not, and then it
+    /// is one of the names the cap counts. Counting only the rest, a group of
+    /// five put five names on the pill.
+    static func offered(_ heard: String, of members: [String]) -> [String] {
+        let rest = members.filter { $0.caseInsensitiveCompare(heard) != .orderedSame }
+        let room = rest.count == members.count ? ceiling : ceiling - 1
+        return [heard] + rest.prefix(room)
+    }
+
     /// A set of terms that share a sound.
     struct Group: Equatable {
         /// The terms, sorted, so a group reads the same way twice.

--- a/Sources/ParrotFlow/SoundGroup.swift
+++ b/Sources/ParrotFlow/SoundGroup.swift
@@ -189,13 +189,20 @@ enum SoundGroup {
         /// How many confirmed uses the term has.
         var uses: Int = 1
 
-        /// A member nobody has ever confirmed. It cannot lose, because there
-        /// is nothing to lose with: scoring the others against it would settle
-        /// a place on one name's evidence while the other has none. Measured
-        /// on the live app, 2026-09-10: with `Eric` at zero uses, `Erik` won
-        /// "Eric the musician." 0.898 to 0.600 and the name was written
-        /// silently.
-        var unknown: Bool { uses == 0 }
+        /// A member with no portrait: nobody has confirmed it, or it has too
+        /// few sentences to describe itself yet. It cannot lose, because there
+        /// is nothing to lose with — scoring the others against it would
+        /// settle a place on one name's evidence while the other has none.
+        ///
+        /// Measured on the live app, 2026-09-10: with `Eric` at zero uses,
+        /// `Erik` won "Eric the musician." 0.898 to 0.600 and the name was
+        /// written silently. Measured again the same day on decoded audio,
+        /// with `Erik` at two uses and `Eric` at one and neither carrying a
+        /// counter: no member could be scored at all, and reading that as "no
+        /// member stands" kept the word that was heard on every sentence — a
+        /// decision, so the pill was never asked. A place nothing can be said
+        /// about is a question, not an answer.
+        var unknown: Bool { score == nil }
 
         /// Below its own floor is out. A candidate with fewer than
         /// `TermPortrait.floorMinimum` uses has no floor and is never out on
@@ -242,6 +249,21 @@ enum SoundGroup {
             return .open(known.map(\.name) + unknown.map(\.name))
         }
         var standing = members.filter(\.stands)
+        // Nobody standing, and no plain centre to fall back on. "Keep what was
+        // heard" is the ordinary word winning — and with no counter row
+        // anywhere in the group there is no ordinary word to win, so keeping
+        // is an assumption rather than a decision. Measured on decoded audio,
+        // 2026-09-10, three uses each and no counters: `Erik` led 0.791 to
+        // 0.649 on "Eric is a musician." and 0.647 to 0.747 the other way on
+        // "Eric is a software engineer." — the right name first both times,
+        // and both below floors read off three short sentences. Kept, that
+        // types Eric twice and asks nothing.
+        //
+        // Best first, so the pill's top row carries the ranking the floors
+        // threw away.
+        if standing.isEmpty, plain == nil {
+            return .open(members.sorted { ($0.score ?? 0) > ($1.score ?? 0) }.map(\.name))
+        }
         // Plain is a member with no name and no floor.
         if let plain { standing.append(Candidate(name: "", score: plain, floor: nil)) }
         let ranked = standing.sorted { ($0.score ?? 0) > ($1.score ?? 0) }

--- a/Sources/ParrotFlow/SoundGroup.swift
+++ b/Sources/ParrotFlow/SoundGroup.swift
@@ -125,8 +125,13 @@ enum SoundGroup {
     /// is another term's spelling, and a rendering two terms share. A rule
     /// there would write one member's name over the other's sound before
     /// anything could read the sentence.
+    ///
+    /// Counted per owning term, not per entry. `Versal` and `versal` under one
+    /// term are two renderings of it, and counting entries made that term's own
+    /// rendering look shared: it stopped being a rule and opened no group,
+    /// because the group is a singleton.
     static func openings(in terms: [String: Config.Vocabulary.Term]) -> Set<String> {
-        var seen: [String: Int] = [:]
+        var owners: [String: Set<String>] = [:]
         var spellings = Set<String>()
         for name in terms.keys { spellings.insert(name.lowercased()) }
         for (name, entry) in terms {
@@ -135,11 +140,11 @@ enum SoundGroup {
                 // Its own spelling is not a link. `vercel` -> `Vercel` is a
                 // capital being fixed, and every term may render itself.
                 guard word != name.lowercased() else { continue }
-                seen[word, default: 0] += 1
+                owners[word, default: []].insert(name.lowercased())
             }
         }
         var out = Set<String>()
-        for (word, count) in seen where count > 1 || spellings.contains(word) {
+        for (word, claimants) in owners where claimants.count > 1 || spellings.contains(word) {
             out.insert(word)
         }
         return out

--- a/Sources/ParrotFlow/SoundGroup.swift
+++ b/Sources/ParrotFlow/SoundGroup.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+/// The terms that share a sound, and how a place between them is decided.
+///
+/// `Mik` and `Mick` are two people and the decoder writes "Mick" for both.
+/// Under the old model one of them owned the sound: `heard: Mick` was a rule
+/// that rewrote every "Mick" to "Mik", and the only thing that could undo it
+/// was Mik's portrait, where Mick lived as a counter-example. Mick had no
+/// portrait at all.
+///
+/// A group is derived, never declared. No field says one exists — see
+/// `groups(terms:uses:)` for the three links. Every member keeps its own
+/// portrait, and one more member has no name: **plain**, the ordinary word
+/// that sounds like this. Plain's portrait is the counter rows of the group's
+/// members, pooled.
+///
+/// A group of one is every term that shares its sound with nothing, which is
+/// almost all of them. Those go the way they always have — the caller reads
+/// one portrait, not a group. See `docs/proposals/sound-groups.md`.
+enum SoundGroup {
+
+    /// How many named members one place may offer.
+    ///
+    /// Four, and the pill shows them plus "as heard". The old ceiling of two
+    /// readings a place was a property of the shape — one span, one
+    /// alternative — and a group place is the one thing that breaks it.
+    static let ceiling = 4
+
+    /// A set of terms that share a sound.
+    struct Group: Equatable {
+        /// The terms, sorted, so a group reads the same way twice.
+        let members: [String]
+        /// Every word that opens it: each member's spelling and each member's
+        /// `heard:` renderings, lowercased.
+        let openings: Set<String>
+
+        var isGroup: Bool { members.count > 1 }
+    }
+
+    // MARK: - Deriving
+
+    /// Every group in a vocabulary, one per term, singletons included.
+    ///
+    /// Three links, and any of them puts two terms together:
+    ///
+    /// - one term's spelling is a `heard:` rendering of the other;
+    /// - the two share a `heard:` rendering;
+    /// - a counter row under one term has a span that is the other's spelling.
+    ///
+    /// They are transitive: linking Mik to Mick and Mick to Mic puts all three
+    /// in one group. Case never decides — a rendering is written the way the
+    /// decoder wrote it, and a spelling the way its owner spells it.
+    static func groups(
+        terms: [String: Config.Vocabulary.Term], uses: [String: [TermUses.Use]] = [:]
+    ) -> [Group] {
+        let names = terms.keys.sorted()
+        guard !names.isEmpty else { return [] }
+        var at: [String: Int] = [:]
+        for (index, name) in names.enumerated() { at[name.lowercased()] = index }
+
+        var parent = Array(names.indices)
+        func find(_ index: Int) -> Int {
+            var root = index
+            while parent[root] != root { root = parent[root] }
+            var walk = index
+            while parent[walk] != walk { let next = parent[walk]; parent[walk] = root; walk = next }
+            return root
+        }
+        func union(_ a: Int, _ b: Int) {
+            let (x, y) = (find(a), find(b))
+            if x != y { parent[max(x, y)] = min(x, y) }
+        }
+
+        var sharing: [String: [Int]] = [:]
+        for (index, name) in names.enumerated() {
+            for rendering in terms[name]?.heard ?? [] {
+                let word = rendering.lowercased()
+                // A rendering that is another term's spelling.
+                if let other = at[word], other != index { union(index, other) }
+                sharing[word, default: []].append(index)
+            }
+            // A counter row's span is the ordinary word that stood there. When
+            // that word is another term, the two are the same sound.
+            for row in uses[name] ?? [] where row.counter {
+                if let other = at[row.span.lowercased()], other != index { union(index, other) }
+            }
+        }
+        // A rendering two terms both claim.
+        for (_, claimants) in sharing where claimants.count > 1 {
+            for index in claimants.dropFirst() { union(claimants[0], index) }
+        }
+
+        var bundled: [Int: [Int]] = [:]
+        for index in names.indices { bundled[find(index), default: []].append(index) }
+        return bundled.keys.sorted().map { root in
+            let members = (bundled[root] ?? []).map { names[$0] }.sorted()
+            var openings = Set<String>()
+            for member in members {
+                openings.insert(member.lowercased())
+                for rendering in terms[member]?.heard ?? [] {
+                    openings.insert(rendering.lowercased())
+                }
+            }
+            return Group(members: members, openings: openings)
+        }
+    }
+
+    /// The group a heard word opens, or nil when no group of two or more does.
+    ///
+    /// A word opens a group when it is a member's spelling or a member's
+    /// `heard:` rendering. A counter span does not open one: it links two
+    /// terms, and what it stands for is plain.
+    static func opened(by word: String, in groups: [Group]) -> Group? {
+        let needle = word.lowercased()
+        return groups.first { $0.isGroup && $0.openings.contains(needle) }
+    }
+
+    /// Every rendering that must not become a substitution rule.
+    ///
+    /// Two kinds, and both open a group instead of rewriting: a rendering that
+    /// is another term's spelling, and a rendering two terms share. A rule
+    /// there would write one member's name over the other's sound before
+    /// anything could read the sentence.
+    static func openings(in terms: [String: Config.Vocabulary.Term]) -> Set<String> {
+        var seen: [String: Int] = [:]
+        var spellings = Set<String>()
+        for name in terms.keys { spellings.insert(name.lowercased()) }
+        for (name, entry) in terms {
+            for rendering in entry.heard {
+                let word = rendering.lowercased()
+                // Its own spelling is not a link. `vercel` -> `Vercel` is a
+                // capital being fixed, and every term may render itself.
+                guard word != name.lowercased() else { continue }
+                seen[word, default: 0] += 1
+            }
+        }
+        var out = Set<String>()
+        for (word, count) in seen where count > 1 || spellings.contains(word) {
+            out.insert(word)
+        }
+        return out
+    }
+
+    // MARK: - Deciding
+
+    /// One candidate at a place: what it scored, and the floor it has to clear.
+    ///
+    /// Plain has no floor. Its portrait is pooled counter rows, and a floor is
+    /// read off a term's own uses.
+    struct Candidate: Equatable {
+        let name: String
+        let score: Double
+        let floor: Double?
+
+        /// Below its own floor is out. A candidate with fewer than
+        /// `TermPortrait.floorMinimum` uses has no floor and is never out on
+        /// that ground.
+        var stands: Bool { floor.map { score > $0 } ?? true }
+    }
+
+    /// What the group says about a place.
+    enum Verdict: Equatable {
+        /// Write this member's spelling.
+        case write(String)
+        /// Keep what was heard: plain won, or nobody stood.
+        case keep
+        /// Two or more stand and none of them leads. The pill asks, and these
+        /// are the members to offer, best first.
+        case open([String])
+    }
+
+    /// The nearest centre, with floors.
+    ///
+    /// 1. A candidate below its own floor is out.
+    /// 2. Among those standing, the best wins if it leads the second by more
+    ///    than `band`.
+    /// 3. A named member winning writes its spelling; plain winning keeps what
+    ///    was heard.
+    /// 4. Nobody standing keeps what was heard.
+    /// 5. Two standing and no lead opens the place.
+    ///
+    /// The heard spelling gets no bonus. Which homophone the recogniser
+    /// reached for is frequency, not evidence.
+    static func decide(
+        _ members: [Candidate], plain: Double?, band: Double = 0.01
+    ) -> Verdict {
+        var standing = members.filter(\.stands)
+        // Plain is a member with no name and no floor.
+        if let plain { standing.append(Candidate(name: "", score: plain, floor: nil)) }
+        let ranked = standing.sorted { $0.score > $1.score }
+        guard let best = ranked.first else { return .keep }
+        if ranked.count > 1, best.score - ranked[1].score <= band {
+            return .open(ranked.filter { !$0.name.isEmpty }.map(\.name))
+        }
+        return best.name.isEmpty ? .keep : .write(best.name)
+    }
+}

--- a/Sources/ParrotFlow/SoundGroup.swift
+++ b/Sources/ParrotFlow/SoundGroup.swift
@@ -189,20 +189,17 @@ enum SoundGroup {
         /// How many confirmed uses the term has.
         var uses: Int = 1
 
-        /// A member with no portrait: nobody has confirmed it, or it has too
-        /// few sentences to describe itself yet. It cannot lose, because there
-        /// is nothing to lose with — scoring the others against it would
-        /// settle a place on one name's evidence while the other has none.
+        /// A member nobody has ever confirmed. It cannot lose, because there
+        /// is nothing to lose with: scoring the others against it would settle
+        /// a place on one name's evidence while the other has none. Measured
+        /// on the live app, 2026-09-10: with `Eric` at zero uses, `Erik` won
+        /// "Eric the musician." 0.898 to 0.600 and the name was written
+        /// silently.
         ///
-        /// Measured on the live app, 2026-09-10: with `Eric` at zero uses,
-        /// `Erik` won "Eric the musician." 0.898 to 0.600 and the name was
-        /// written silently. Measured again the same day on decoded audio,
-        /// with `Erik` at two uses and `Eric` at one and neither carrying a
-        /// counter: no member could be scored at all, and reading that as "no
-        /// member stands" kept the word that was heard on every sentence — a
-        /// decision, so the pill was never asked. A place nothing can be said
-        /// about is a question, not an answer.
-        var unknown: Bool { score == nil }
+        /// One sentence is enough to stop being unknown. A group member is
+        /// scored against the others rather than against a fixed floor, so it
+        /// can take part from its first use — see `TermPortrait.centre(of:)`.
+        var unknown: Bool { uses == 0 }
 
         /// Below its own floor is out. A candidate with fewer than
         /// `TermPortrait.floorMinimum` uses has no floor and is never out on

--- a/Sources/ParrotFlow/SoundGroup.swift
+++ b/Sources/ParrotFlow/SoundGroup.swift
@@ -33,6 +33,8 @@ enum SoundGroup {
         /// Every word that opens it: each member's spelling and each member's
         /// `heard:` renderings, lowercased.
         let openings: Set<String>
+        /// The renderings each member wrote down, as they are spelled.
+        let renderings: [String: [String]]
 
         var isGroup: Bool { members.count > 1 }
     }
@@ -95,13 +97,15 @@ enum SoundGroup {
         return bundled.keys.sorted().map { root in
             let members = (bundled[root] ?? []).map { names[$0] }.sorted()
             var openings = Set<String>()
+            var written: [String: [String]] = [:]
             for member in members {
                 openings.insert(member.lowercased())
-                for rendering in terms[member]?.heard ?? [] {
+                written[member] = terms[member]?.heard ?? []
+                for rendering in written[member] ?? [] {
                     openings.insert(rendering.lowercased())
                 }
             }
-            return Group(members: members, openings: openings)
+            return Group(members: members, openings: openings, renderings: written)
         }
     }
 
@@ -141,6 +145,36 @@ enum SoundGroup {
         return out
     }
 
+    /// The members of `term`'s group that stand in this sentence, as words.
+    ///
+    /// Each word is charged to one member: the term that spells it that way
+    /// when there is one, and otherwise the term that wrote the rendering
+    /// down. Without that, "Mick is adjusting the piano." would name both Mick
+    /// and Mik — `Mick` is one's spelling and the other's rendering — and
+    /// every correction of it would be refused.
+    ///
+    /// Two members standing in one sentence is a sentence that belongs to
+    /// neither. See `CorrectionRecording`.
+    static func standing(in sentence: String, of term: String, in groups: [Group]) -> [String] {
+        guard let group = groups.first(where: {
+            $0.members.contains { $0.caseInsensitiveCompare(term) == .orderedSame }
+        }) else { return [] }
+        var owner: [String: String] = [:]
+        func stands(_ word: String) -> Bool {
+            !TermPortrait.places(of: word, in: sentence).isEmpty
+        }
+        for member in group.members where stands(member) {
+            owner[member.lowercased()] = member
+        }
+        for member in group.members {
+            for rendering in group.renderings[member] ?? []
+            where owner[rendering.lowercased()] == nil && stands(rendering) {
+                owner[rendering.lowercased()] = member
+            }
+        }
+        return Array(Set(owner.values)).sorted()
+    }
+
     // MARK: - Deciding
 
     /// One candidate at a place: what it scored, and the floor it has to clear.
@@ -149,13 +183,27 @@ enum SoundGroup {
     /// read off a term's own uses.
     struct Candidate: Equatable {
         let name: String
-        let score: Double
+        /// Nil when nothing could be scored: no portrait yet, or none at all.
+        let score: Double?
         let floor: Double?
+        /// How many confirmed uses the term has.
+        var uses: Int = 1
+
+        /// A member nobody has ever confirmed. It cannot lose, because there
+        /// is nothing to lose with: scoring the others against it would settle
+        /// a place on one name's evidence while the other has none. Measured
+        /// on the live app, 2026-09-10: with `Eric` at zero uses, `Erik` won
+        /// "Eric the musician." 0.898 to 0.600 and the name was written
+        /// silently.
+        var unknown: Bool { uses == 0 }
 
         /// Below its own floor is out. A candidate with fewer than
         /// `TermPortrait.floorMinimum` uses has no floor and is never out on
         /// that ground.
-        var stands: Bool { floor.map { score > $0 } ?? true }
+        var stands: Bool {
+            guard let score else { return false }
+            return floor.map { score > $0 } ?? true
+        }
     }
 
     /// What the group says about a place.
@@ -184,12 +232,21 @@ enum SoundGroup {
     static func decide(
         _ members: [Candidate], plain: Double?, band: Double = 0.01
     ) -> Verdict {
+        // A member nobody has ever confirmed decides nothing and loses
+        // nothing. The place is open and the pill lists it with the rest —
+        // which is the only way that member ever gets a first sentence.
+        let unknown = members.filter(\.unknown)
+        if !unknown.isEmpty {
+            let known = members.filter { !$0.unknown && $0.stands }
+                .sorted { ($0.score ?? 0) > ($1.score ?? 0) }
+            return .open(known.map(\.name) + unknown.map(\.name))
+        }
         var standing = members.filter(\.stands)
         // Plain is a member with no name and no floor.
         if let plain { standing.append(Candidate(name: "", score: plain, floor: nil)) }
-        let ranked = standing.sorted { $0.score > $1.score }
+        let ranked = standing.sorted { ($0.score ?? 0) > ($1.score ?? 0) }
         guard let best = ranked.first else { return .keep }
-        if ranked.count > 1, best.score - ranked[1].score <= band {
+        if ranked.count > 1, (best.score ?? 0) - (ranked[1].score ?? 0) <= band {
             return .open(ranked.filter { !$0.name.isEmpty }.map(\.name))
         }
         return best.name.isEmpty ? .keep : .write(best.name)

--- a/Sources/ParrotFlow/SoundGroupCommand.swift
+++ b/Sources/ParrotFlow/SoundGroupCommand.swift
@@ -55,29 +55,31 @@ enum SoundGroupCommand {
         return 0
     }
 
-    /// `--group-decide <term>:<score>:<floor> … [--plain <score>]`
+    /// `--group-decide <term>:<score>:<floor>[:<uses>] … [--plain <score>]`
     ///
     /// A floor of `-` is a member with too few uses to have one, which never
-    /// falls out on that ground.
+    /// falls out on that ground. A score of `-` is a member that could not be
+    /// scored, and `:0` at the end is a member nobody has ever confirmed —
+    /// unknown, which is not the same as out.
     static func decide(_ members: [String], plain: Double?) -> Int32 {
         var candidates: [SoundGroup.Candidate] = []
         for member in members {
             let parts = member.split(separator: ":", omittingEmptySubsequences: false)
                 .map(String.init)
-            guard parts.count == 3, let score = Double(parts[1]) else {
-                print("a member is <term>:<score>:<floor>, not \"\(member)\"")
+            guard parts.count == 3 || parts.count == 4 else {
+                print("a member is <term>:<score>:<floor>[:<uses>], not \"\(member)\"")
                 return 2
             }
             candidates.append(SoundGroup.Candidate(
-                name: parts[0], score: score, floor: Double(parts[2])
+                name: parts[0], score: Double(parts[1]), floor: Double(parts[2]),
+                uses: parts.count == 4 ? (Int(parts[3]) ?? 1) : 1
             ))
         }
         for candidate in candidates {
             let floor = candidate.floor.map { String(format: "%.3f", $0) } ?? "—"
-            print(String(
-                format: "%@  %.3f  floor %@  %@", pad(candidate.name, 10), candidate.score,
-                pad(floor, 5), candidate.stands ? "stands" : "out"
-            ))
+            let score = candidate.score.map { String(format: "%.3f", $0) } ?? "—"
+            let how = candidate.unknown ? "unknown" : (candidate.stands ? "stands" : "out")
+            print("\(pad(candidate.name, 10))  \(pad(score, 5))  floor \(pad(floor, 5))  \(how)")
         }
         if let plain { print(String(format: "%@  %.3f", pad("plain", 10), plain)) }
         print(said(SoundGroup.decide(candidates, plain: plain)))
@@ -109,9 +111,17 @@ enum SoundGroupCommand {
             print("nothing: \(wrote) is not a term, or the two are the same term")
             return 0
         }
+        let groups = SoundGroup.groups(terms: config.vocabulary.terms, uses: TermUses.load())
+        if let sentence, let row = rows.first,
+           let two = CorrectionRecording.blocked(sentence, term: row.term, in: groups) {
+            print("blocked \(two.joined(separator: " "))")
+            return 0
+        }
         if !dry, let sentence {
             do {
-                let written = try CorrectionRecording.apply(rows, said: sentence)
+                let written = try CorrectionRecording.apply(
+                    rows, said: sentence, blocking: groups
+                )
                 guard !written.isEmpty else {
                     print("nothing: \"\(put)\" does not stand in the sentence as a word")
                     return 0
@@ -128,6 +138,57 @@ enum SoundGroupCommand {
             case .counter(let term, let span):
                 print("counter \(term) \"\(span)\"")
             }
+        }
+        return 0
+    }
+
+    /// `--picked <word> <term> --in "<sentence>"` — what an answer on the pill
+    /// records, and it records it.
+    ///
+    /// Prints `use <term>`, `create <name>` — a person written to
+    /// `vocabulary.yaml` and then used — or `counter <term>`, and `blocked` in
+    /// front of any of them when the sentence names two members of one group.
+    static func picked(word: String, term: String, sentence: String?, dry: Bool) -> Int32 {
+        let config = (try? ConfigStore.load()) ?? Config()
+        var answer = CorrectionRecording.picked(
+            word, proposedBy: term, in: config.vocabulary.terms
+        )
+        if case .create(let name) = answer, !dry {
+            do {
+                try ConfigWriter.addVocabularyTerm(name, kind: .person)
+            } catch {
+                print("✗ \(error.localizedDescription)")
+                return 1
+            }
+            answer = .create(name: name)
+        }
+        let row: CorrectionRecording.Row
+        switch answer {
+        case .use(let already): row = .use(term: already, span: word, heard: nil)
+        case .create(let name): row = .use(term: name, span: word, heard: nil)
+        case .counter(let proposed): row = .counter(term: proposed, span: word)
+        }
+        let groups = SoundGroup.groups(
+            terms: (try? ConfigStore.load())?.vocabulary.terms ?? [:], uses: TermUses.load()
+        )
+        if let sentence, let two = CorrectionRecording.blocked(
+            sentence, term: row.term, in: groups
+        ) {
+            print("blocked \(two.joined(separator: " "))")
+            return 0
+        }
+        if let sentence, !dry {
+            do {
+                try CorrectionRecording.apply([row], said: sentence, from: .chosen)
+            } catch {
+                print("✗ \(error.localizedDescription)")
+                return 1
+            }
+        }
+        switch answer {
+        case .use(let already): print("use \(already)")
+        case .create(let name): print("create \(name)")
+        case .counter(let proposed): print("counter \(proposed)")
         }
         return 0
     }

--- a/Sources/ParrotFlow/SoundGroupCommand.swift
+++ b/Sources/ParrotFlow/SoundGroupCommand.swift
@@ -105,8 +105,35 @@ enum SoundGroupCommand {
     ) -> Int32 {
         let config = (try? ConfigStore.load()) ?? Config()
         let rows = CorrectionRecording.rows(
-            wrote: wrote, put: put, terms: Array(config.vocabulary.terms.keys)
+            wrote: wrote, put: put, terms: Array(config.vocabulary.terms.keys),
+            kinds: config.vocabulary.terms
         )
+        // A name with no term yet: the correction panel offers the rendering
+        // as a rule, and that writes the term and the use. Written here too,
+        // so the command does what the app does.
+        if let new = CorrectionRecording.learns(
+            wrote: wrote, put: put, in: config.vocabulary.terms
+        ) {
+            guard !dry else {
+                print("learn \(new.name) \(new.kind.rawValue) heard \(wrote)")
+                return 0
+            }
+            do {
+                try ConfigWriter.addVocabularyPronunciation(
+                    term: new.name, heard: wrote, kind: new.kind
+                )
+                if let sentence {
+                    try CorrectionRecording.apply(
+                        [.use(term: new.name, span: new.name, heard: wrote)], said: sentence
+                    )
+                }
+            } catch {
+                print("✗ \(error.localizedDescription)")
+                return 1
+            }
+            print("learn \(new.name) \(new.kind.rawValue) heard \(wrote)")
+            return 0
+        }
         guard !rows.isEmpty else {
             print("nothing: \(wrote) is not a term, or the two are the same term")
             return 0

--- a/Sources/ParrotFlow/SoundGroupCommand.swift
+++ b/Sources/ParrotFlow/SoundGroupCommand.swift
@@ -146,7 +146,9 @@ enum SoundGroupCommand {
         }
         let groups = SoundGroup.groups(terms: config.vocabulary.terms, uses: TermUses.load())
         if let sentence, let row = rows.first,
-           let two = CorrectionRecording.blocked(sentence, term: row.term, in: groups) {
+           let two = CorrectionRecording.blocked(
+               sentence, term: row.term, span: CorrectionRecording.span(of: row), in: groups
+           ) {
             print("blocked \(two.joined(separator: " "))")
             return 0
         }
@@ -204,7 +206,7 @@ enum SoundGroupCommand {
             terms: (try? ConfigStore.load())?.vocabulary.terms ?? [:], uses: TermUses.load()
         )
         if let sentence, let two = CorrectionRecording.blocked(
-            sentence, term: row.term, in: groups
+            sentence, term: row.term, span: CorrectionRecording.span(of: row), in: groups
         ) {
             print("blocked \(two.joined(separator: " "))")
             return 0

--- a/Sources/ParrotFlow/SoundGroupCommand.swift
+++ b/Sources/ParrotFlow/SoundGroupCommand.swift
@@ -123,8 +123,14 @@ enum SoundGroupCommand {
                     term: new.name, heard: wrote, kind: new.kind
                 )
                 if let sentence {
+                    // Reloaded, because the term was written a line ago and it
+                    // is the one that decides which group this row is in.
+                    let after = (try? ConfigStore.load()) ?? config
                     try CorrectionRecording.apply(
-                        [.use(term: new.name, span: new.name, heard: wrote)], said: sentence
+                        [.use(term: new.name, span: new.name, heard: wrote)], said: sentence,
+                        blocking: SoundGroup.groups(
+                            terms: after.vocabulary.terms, uses: TermUses.load()
+                        )
                     )
                 }
             } catch {
@@ -205,7 +211,9 @@ enum SoundGroupCommand {
         }
         if let sentence, !dry {
             do {
-                try CorrectionRecording.apply([row], said: sentence, from: .chosen)
+                try CorrectionRecording.apply(
+                    [row], said: sentence, from: .chosen, blocking: groups
+                )
             } catch {
                 print("✗ \(error.localizedDescription)")
                 return 1

--- a/Sources/ParrotFlow/SoundGroupCommand.swift
+++ b/Sources/ParrotFlow/SoundGroupCommand.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+/// The three halves of a sound group that need no model: which terms are in
+/// one, what the decision rule does with scores, and what a correction writes.
+///
+///     ParrotFlow --sound-group Mick
+///     members  Mick Mik
+///     opens    meek mick mik
+///     rule     none
+///
+///     ParrotFlow --group-decide Mik:0.90:0.80 Mick:0.86:- --plain 0.70
+///     Mik    0.900  floor 0.800  stands
+///     Mick   0.860  floor —      stands
+///     plain  0.700
+///     write Mik
+///
+///     ParrotFlow --correction Mik Mick --in "Mick is adjusting the piano."
+///     use Mick "Mick" heard Mik
+///
+/// `scripts/check-sound-group.sh` scores all three, so the set runs against
+/// the shipped functions rather than a copy of them. The whole thing with a
+/// model behind it is `--portrait <heard> "<sentence>"`.
+enum SoundGroupCommand {
+
+    /// `--sound-group <word>` — the terms that share this word's sound.
+    static func group(_ word: String) -> Int32 {
+        let config = (try? ConfigStore.load()) ?? Config()
+        let groups = SoundGroup.groups(terms: config.vocabulary.terms, uses: TermUses.load())
+        let needle = word.lowercased()
+        if let held = groups.first(where: { $0.openings.contains(needle) }) {
+            print("members  \(held.members.joined(separator: " "))")
+            print("opens    \(held.openings.sorted().joined(separator: " "))")
+        } else {
+            print("no term: \(word)")
+        }
+        // Whether this word is still a substitution rule. A word that opens a
+        // group of two or more is not one, and nothing else shows that half of
+        // the change.
+        let rule = config.vocabularyRules.first {
+            $0.source.caseInsensitiveCompare(word) == .orderedSame
+        }
+        print("rule     \(rule?.replacement ?? "none")")
+        return 0
+    }
+
+    /// `--group-decide <term>:<score>:<floor> … [--plain <score>]`
+    ///
+    /// A floor of `-` is a member with too few uses to have one, which never
+    /// falls out on that ground.
+    static func decide(_ members: [String], plain: Double?) -> Int32 {
+        var candidates: [SoundGroup.Candidate] = []
+        for member in members {
+            let parts = member.split(separator: ":", omittingEmptySubsequences: false)
+                .map(String.init)
+            guard parts.count == 3, let score = Double(parts[1]) else {
+                print("a member is <term>:<score>:<floor>, not \"\(member)\"")
+                return 2
+            }
+            candidates.append(SoundGroup.Candidate(
+                name: parts[0], score: score, floor: Double(parts[2])
+            ))
+        }
+        for candidate in candidates {
+            let floor = candidate.floor.map { String(format: "%.3f", $0) } ?? "—"
+            print(String(
+                format: "%@  %.3f  floor %@  %@", pad(candidate.name, 10), candidate.score,
+                pad(floor, 5), candidate.stands ? "stands" : "out"
+            ))
+        }
+        if let plain { print(String(format: "%@  %.3f", pad("plain", 10), plain)) }
+        print(said(SoundGroup.decide(candidates, plain: plain)))
+        return 0
+    }
+
+    /// What a verdict is called, which is the line a check script reads.
+    static func said(_ verdict: SoundGroup.Verdict) -> String {
+        switch verdict {
+        case .write(let term): return "write \(term)"
+        case .keep: return "keep"
+        case .open(let members): return "open \(members.joined(separator: " "))"
+        }
+    }
+
+    /// `--correction <wrote> <put> --in "<sentence>"` — the rows a correction
+    /// that runs against a term writes, and the file after it.
+    ///
+    /// `--dry` prints them without writing. Otherwise they land in
+    /// `vocabulary-uses.yaml`, the same call the app makes.
+    static func correction(
+        wrote: String, put: String, sentence: String?, dry: Bool
+    ) -> Int32 {
+        let config = (try? ConfigStore.load()) ?? Config()
+        let rows = CorrectionRecording.rows(
+            wrote: wrote, put: put, terms: Array(config.vocabulary.terms.keys)
+        )
+        guard !rows.isEmpty else {
+            print("nothing: \(wrote) is not a term, or the two are the same term")
+            return 0
+        }
+        if !dry, let sentence {
+            do {
+                let written = try CorrectionRecording.apply(rows, said: sentence)
+                guard !written.isEmpty else {
+                    print("nothing: \"\(put)\" does not stand in the sentence as a word")
+                    return 0
+                }
+            } catch {
+                print("✗ \(error.localizedDescription)")
+                return 1
+            }
+        }
+        for row in rows {
+            switch row {
+            case .use(let term, let span, let heard):
+                print("use \(term) \"\(span)\"" + (heard.map { " heard \($0)" } ?? ""))
+            case .counter(let term, let span):
+                print("counter \(term) \"\(span)\"")
+            }
+        }
+        return 0
+    }
+
+    private static func pad(_ text: String, _ width: Int) -> String {
+        text.count >= width ? text : text + String(repeating: " ", count: width - text.count)
+    }
+}

--- a/Sources/ParrotFlow/SoundGroupCommand.swift
+++ b/Sources/ParrotFlow/SoundGroupCommand.swift
@@ -43,6 +43,18 @@ enum SoundGroupCommand {
         return 0
     }
 
+    /// `--name-place <heard> <term>` — whether the slot test stands aside here.
+    ///
+    /// `names` means both sides are names and the slot cannot separate them;
+    /// `ordinary` means an ordinary word against a term, which is the place the
+    /// slot exists for. See `NamePlace`.
+    static func namePlace(heard: String, term: String) -> Int32 {
+        let config = (try? ConfigStore.load()) ?? Config()
+        let names = NamePlace.bothNames(heard: heard, term: term, in: config.vocabulary.terms)
+        print(names ? "names" : "ordinary")
+        return 0
+    }
+
     /// `--group-decide <term>:<score>:<floor> … [--plain <score>]`
     ///
     /// A floor of `-` is a member with too few uses to have one, which never

--- a/Sources/ParrotFlow/SoundGroupCommand.swift
+++ b/Sources/ParrotFlow/SoundGroupCommand.swift
@@ -145,7 +145,7 @@ enum SoundGroupCommand {
     /// `--picked <word> <term> --in "<sentence>"` — what an answer on the pill
     /// records, and it records it.
     ///
-    /// Prints `use <term>`, `create <name>` — a person written to
+    /// Prints `use <term>`, `create <name> <kind>` — a name written to
     /// `vocabulary.yaml` and then used — or `counter <term>`, and `blocked` in
     /// front of any of them when the sentence names two members of one group.
     static func picked(word: String, term: String, sentence: String?, dry: Bool) -> Int32 {
@@ -153,19 +153,18 @@ enum SoundGroupCommand {
         var answer = CorrectionRecording.picked(
             word, proposedBy: term, in: config.vocabulary.terms
         )
-        if case .create(let name) = answer, !dry {
+        if case .create(let name, let kind) = answer, !dry {
             do {
-                try ConfigWriter.addVocabularyTerm(name, kind: .person)
+                try ConfigWriter.addVocabularyTerm(name, kind: kind)
             } catch {
                 print("✗ \(error.localizedDescription)")
                 return 1
             }
-            answer = .create(name: name)
         }
         let row: CorrectionRecording.Row
         switch answer {
         case .use(let already): row = .use(term: already, span: word, heard: nil)
-        case .create(let name): row = .use(term: name, span: word, heard: nil)
+        case .create(let name, _): row = .use(term: name, span: word, heard: nil)
         case .counter(let proposed): row = .counter(term: proposed, span: word)
         }
         let groups = SoundGroup.groups(
@@ -187,7 +186,7 @@ enum SoundGroupCommand {
         }
         switch answer {
         case .use(let already): print("use \(already)")
-        case .create(let name): print("create \(name)")
+        case .create(let name, let kind): print("create \(name) \(kind.rawValue)")
         case .counter(let proposed): print("counter \(proposed)")
         }
         return 0

--- a/Sources/ParrotFlow/TermPortrait.swift
+++ b/Sources/ParrotFlow/TermPortrait.swift
@@ -308,6 +308,9 @@ actor TermPortrait {
         let floor: Double?
         let uses: Int
         let stands: Bool
+        /// No confirmed use at all. Not out — never seen. See
+        /// `SoundGroup.Candidate.unknown`.
+        var unknown: Bool { uses == 0 }
     }
 
     /// How a group of terms reads one place.
@@ -346,15 +349,22 @@ actor TermPortrait {
             // it has never been corrected, so nothing describes where it
             // lives.
             guard let summary = try? await summary(for: member) else {
+                let uses = stored[member]?.filter { !$0.counter }.count ?? 0
                 standing.append(Standing(
-                    term: member, score: nil, floor: nil,
-                    uses: stored[member]?.filter { !$0.counter }.count ?? 0, stands: false
+                    term: member, score: nil, floor: nil, uses: uses, stands: false
+                ))
+                // Zero uses is a member nobody has confirmed. It reaches the
+                // decision as itself rather than being left out of it: a place
+                // between a name with sentences and a name with none is not a
+                // place any score can settle.
+                candidates.append(SoundGroup.Candidate(
+                    name: member, score: nil, floor: nil, uses: uses
                 ))
                 continue
             }
             let score = WordVectors.cosine(vector, summary.centre) / summary.tightness
             let candidate = SoundGroup.Candidate(
-                name: member, score: score, floor: summary.floor
+                name: member, score: score, floor: summary.floor, uses: summary.uses
             )
             candidates.append(candidate)
             standing.append(Standing(
@@ -386,7 +396,8 @@ actor TermPortrait {
             let reading = try await read(group: members, span, in: sentence)
             let said = reading.members.map { member in
                 let score = member.score.map { String(format: "%.3f", $0) } ?? "—"
-                return "\(member.term) \(score)\(member.stands ? "" : " (out)")"
+                let how = member.unknown ? " (unknown)" : (member.stands ? "" : " (out)")
+                return "\(member.term) \(score)\(how)"
             }.joined(separator: ", ")
             let plain = reading.plain.map { String(format: "%.3f", $0) } ?? "—"
             Log.write("portrait: \"\(span)\" opens \(members.joined(separator: "/")) —"

--- a/Sources/ParrotFlow/TermPortrait.swift
+++ b/Sources/ParrotFlow/TermPortrait.swift
@@ -308,9 +308,10 @@ actor TermPortrait {
         let floor: Double?
         let uses: Int
         let stands: Bool
-        /// No confirmed use at all. Not out — never seen. See
+        /// No portrait to read: never confirmed, or too few sentences to
+        /// describe itself yet. Not out — nothing is known. See
         /// `SoundGroup.Candidate.unknown`.
-        var unknown: Bool { uses == 0 }
+        var unknown: Bool { score == nil }
     }
 
     /// How a group of terms reads one place.

--- a/Sources/ParrotFlow/TermPortrait.swift
+++ b/Sources/ParrotFlow/TermPortrait.swift
@@ -432,7 +432,7 @@ actor TermPortrait {
         let uses = (stored[member] ?? []).filter { !$0.counter }
         guard !uses.isEmpty else { return nil }
         let mark = Self.fingerprint(of: uses) + "\u{4}" + rivals.joined(separator: "\u{1}")
-        if let held = memberCache[mark] { return held }
+        if let held = memberCache[member], held.mark == mark { return held.built }
 
         var vectors: [[Float]] = []
         for use in uses {
@@ -448,14 +448,20 @@ actor TermPortrait {
             centre: middle, tightness: tightness, floor: Self.floor(of: vectors),
             uses: vectors.count
         )
-        memberCache[mark] = built
+        memberCache[member] = (mark: mark, built: built)
         return built
     }
 
     /// Held for the run only, like `plainCache`: a centre cut with one group's
     /// rivals means nothing to another group.
-    private var memberCache:
-        [String: (centre: [Float], tightness: Double, floor: Double?, uses: Int)] = [:]
+    ///
+    /// One entry per member, and the mark it was built from sits in the value.
+    /// Keyed by the mark instead, every correction left the centre it
+    /// invalidated behind — 1024 floats each, for as long as the app runs.
+    private var memberCache: [String: (
+        mark: String,
+        built: (centre: [Float], tightness: Double, floor: Double?, uses: Int)
+    )] = [:]
 
     /// The group's plain centre: every member's counter rows, pooled.
     ///
@@ -472,8 +478,9 @@ actor TermPortrait {
         var rows: [TermUses.Use] = []
         for member in members { rows += (stored[member] ?? []).filter(\.counter) }
         guard rows.count >= Self.counterMinimum else { return nil }
+        let group = members.sorted().joined(separator: "\u{1}")
         let mark = Self.fingerprint(of: rows) + "\u{4}" + rivals.joined(separator: "\u{1}")
-        if let held = plainCache[mark] { return held }
+        if let held = plainCache[group], held.mark == mark { return held.built }
 
         var vectors: [[Float]] = []
         for row in rows {
@@ -486,14 +493,20 @@ actor TermPortrait {
         let (centre, tightness) = Self.middle(of: vectors)
         guard tightness > 0 else { return nil }
         let built = (centre: centre, tightness: tightness, rows: vectors.count)
-        plainCache[mark] = built
+        plainCache[group] = (mark: mark, built: built)
         return built
     }
 
     /// Held for the run only. A pooled centre is a few embeddings and it
     /// depends on rows from several terms, so it is not worth the cache file's
     /// invalidation rules.
-    private var plainCache: [String: (centre: [Float], tightness: Double, rows: Int)] = [:]
+    ///
+    /// One entry per group, not per member: the centre is pooled over the
+    /// whole group. The mark is in the value, so a row written anywhere in the
+    /// group replaces the entry instead of adding one.
+    private var plainCache: [String: (
+        mark: String, built: (centre: [Float], tightness: Double, rows: Int)
+    )] = [:]
 
     /// Every spelling that could stand at a group's place: each member's own
     /// rivals, pooled.

--- a/Sources/ParrotFlow/TermPortrait.swift
+++ b/Sources/ParrotFlow/TermPortrait.swift
@@ -298,6 +298,158 @@ actor TermPortrait {
         }
     }
 
+    // MARK: - a group of terms
+
+    /// One member of a group at one place, and the numbers behind it.
+    struct Standing {
+        let term: String
+        /// Nil when the term has no portrait at all, and then it never stands.
+        let score: Double?
+        let floor: Double?
+        let uses: Int
+        let stands: Bool
+    }
+
+    /// How a group of terms reads one place.
+    struct GroupReading {
+        let members: [Standing]
+        /// Against the group's pooled counter rows, or nil when it has none.
+        let plain: Double?
+        /// How many counter rows reached that centre.
+        let plainRows: Int
+        let verdict: SoundGroup.Verdict
+    }
+
+    /// What every member of a group says about this sentence, and who wins.
+    ///
+    /// One vector, scored against every member's own centre and against the
+    /// pooled counter rows. One vector and not one per member: the window is
+    /// cut at every member's spelling and at every counter span *before* it is
+    /// embedded, so the same reading of the sentence is what each portrait is
+    /// asked about. Cutting per member would score them on different text.
+    ///
+    /// `span` is the word standing at the place — what was heard, not any
+    /// member's spelling.
+    func read(
+        group members: [String], _ span: String, in sentence: String
+    ) async throws -> GroupReading {
+        let stored = TermUses.load()
+        let rivals = Self.rivals(of: members, in: stored)
+        let near = Self.context(of: span, in: sentence, cutting: rivals) ?? sentence
+        let vector = try await WordVectors.shared.vector(.around, of: span, in: near)
+
+        var standing: [Standing] = []
+        var candidates: [SoundGroup.Candidate] = []
+        for member in members {
+            // A member with no portrait cannot be scored, so it cannot stand.
+            // That is the ordinary state of the second name in a new group:
+            // it has never been corrected, so nothing describes where it
+            // lives.
+            guard let summary = try? await summary(for: member) else {
+                standing.append(Standing(
+                    term: member, score: nil, floor: nil,
+                    uses: stored[member]?.filter { !$0.counter }.count ?? 0, stands: false
+                ))
+                continue
+            }
+            let score = WordVectors.cosine(vector, summary.centre) / summary.tightness
+            let candidate = SoundGroup.Candidate(
+                name: member, score: score, floor: summary.floor
+            )
+            candidates.append(candidate)
+            standing.append(Standing(
+                term: member, score: score, floor: summary.floor, uses: summary.uses,
+                stands: candidate.stands
+            ))
+        }
+
+        var plain: Double?
+        var plainRows = 0
+        if let pooled = try await self.plain(of: members, cutting: rivals, in: stored) {
+            plain = WordVectors.cosine(vector, pooled.centre) / pooled.tightness
+            plainRows = pooled.rows
+        }
+        return GroupReading(
+            members: standing, plain: plain, plainRows: plainRows,
+            verdict: SoundGroup.decide(candidates, plain: plain, band: Self.band)
+        )
+    }
+
+    /// The same, with every failure reading as "keep what was heard".
+    ///
+    /// The group path is the only thing deciding a group place, so an error
+    /// here has to leave the transcript exactly as it arrived.
+    func reads(
+        group members: [String], _ span: String, in sentence: String
+    ) async -> SoundGroup.Verdict {
+        do {
+            let reading = try await read(group: members, span, in: sentence)
+            let said = reading.members.map { member in
+                let score = member.score.map { String(format: "%.3f", $0) } ?? "—"
+                return "\(member.term) \(score)\(member.stands ? "" : " (out)")"
+            }.joined(separator: ", ")
+            let plain = reading.plain.map { String(format: "%.3f", $0) } ?? "—"
+            Log.write("portrait: \"\(span)\" opens \(members.joined(separator: "/")) —"
+                + " \(said), plain \(plain) — \(reading.verdict)")
+            return reading.verdict
+        } catch {
+            Log.write("portrait: \(members.joined(separator: "/")) could not be scored"
+                + " (\(error.localizedDescription))")
+            return .keep
+        }
+    }
+
+    /// The group's plain centre: every member's counter rows, pooled.
+    ///
+    /// Plain is "an ordinary word that sounds like this" — Mick Jagger, the
+    /// Versailles castle, a better stack than PHP. Nobody writes those down as
+    /// a term, and each member's counter rows are exactly the sentences where
+    /// one of them was put back to an ordinary word.
+    ///
+    /// Cached under the rows it was built from, the same way `summary` is: a
+    /// row added anywhere in the group rebuilds it, and nothing else does.
+    private func plain(
+        of members: [String], cutting rivals: [String], in stored: [String: [TermUses.Use]]
+    ) async throws -> (centre: [Float], tightness: Double, rows: Int)? {
+        var rows: [TermUses.Use] = []
+        for member in members { rows += (stored[member] ?? []).filter(\.counter) }
+        guard rows.count >= Self.counterMinimum else { return nil }
+        let mark = Self.fingerprint(of: rows) + "\u{4}" + rivals.joined(separator: "\u{1}")
+        if let held = plainCache[mark] { return held }
+
+        var vectors: [[Float]] = []
+        for row in rows {
+            guard let near = Self.context(of: row.span, in: row.said, cutting: rivals) else {
+                continue
+            }
+            vectors.append(try await WordVectors.shared.vector(.around, of: row.span, in: near))
+        }
+        guard !vectors.isEmpty else { return nil }
+        let (centre, tightness) = Self.middle(of: vectors)
+        guard tightness > 0 else { return nil }
+        let built = (centre: centre, tightness: tightness, rows: vectors.count)
+        plainCache[mark] = built
+        return built
+    }
+
+    /// Held for the run only. A pooled centre is a few embeddings and it
+    /// depends on rows from several terms, so it is not worth the cache file's
+    /// invalidation rules.
+    private var plainCache: [String: (centre: [Float], tightness: Double, rows: Int)] = [:]
+
+    /// Every spelling that could stand at a group's place: each member's own
+    /// rivals, pooled.
+    static func rivals(of members: [String], in stored: [String: [TermUses.Use]]) -> [String] {
+        var out: [String] = []
+        for member in members {
+            for word in rivals(of: member, in: stored[member] ?? []) {
+                guard !out.contains(where: { $0.caseInsensitiveCompare(word) == .orderedSame })
+                else { continue }
+                out.append(word)
+            }
+        }
+        return out
+    }
 
     /// A term whose rows all but vanish under the cut. Thrown rather than
     /// built from what is left: `reads` turns it into "no opinion", which is
@@ -339,7 +491,7 @@ actor TermPortrait {
     /// Without case because a rival opening a sentence is capitalised there and
     /// not in the row that recorded it. Over-cutting costs a few words of
     /// context; under-cutting puts the other spelling back in the portrait.
-    private static func places(of needle: String, in text: String) -> [Range<String.Index>] {
+    static func places(of needle: String, in text: String) -> [Range<String.Index>] {
         guard !needle.isEmpty else { return [] }
         func letter(_ c: Character) -> Bool { c.isLetter || c.isNumber }
         var out: [Range<String.Index>] = []

--- a/Sources/ParrotFlow/TermPortrait.swift
+++ b/Sources/ParrotFlow/TermPortrait.swift
@@ -308,10 +308,9 @@ actor TermPortrait {
         let floor: Double?
         let uses: Int
         let stands: Bool
-        /// No portrait to read: never confirmed, or too few sentences to
-        /// describe itself yet. Not out — nothing is known. See
+        /// No sentence at all. Not out — never seen. See
         /// `SoundGroup.Candidate.unknown`.
-        var unknown: Bool { score == nil }
+        var unknown: Bool { uses == 0 }
     }
 
     /// How a group of terms reads one place.
@@ -345,31 +344,28 @@ actor TermPortrait {
         var standing: [Standing] = []
         var candidates: [SoundGroup.Candidate] = []
         for member in members {
-            // A member with no portrait cannot be scored, so it cannot stand.
-            // That is the ordinary state of the second name in a new group:
-            // it has never been corrected, so nothing describes where it
-            // lives.
-            guard let summary = try? await summary(for: member) else {
+            // A member with no sentence at all cannot be scored. That is the
+            // ordinary state of the second name in a new group: it has never
+            // been corrected, so nothing describes where it lives, and it
+            // reaches the decision as unknown rather than being left out of
+            // it.
+            guard let held = try await centre(of: member, cutting: rivals, in: stored) else {
                 let uses = stored[member]?.filter { !$0.counter }.count ?? 0
                 standing.append(Standing(
                     term: member, score: nil, floor: nil, uses: uses, stands: false
                 ))
-                // Zero uses is a member nobody has confirmed. It reaches the
-                // decision as itself rather than being left out of it: a place
-                // between a name with sentences and a name with none is not a
-                // place any score can settle.
                 candidates.append(SoundGroup.Candidate(
                     name: member, score: nil, floor: nil, uses: uses
                 ))
                 continue
             }
-            let score = WordVectors.cosine(vector, summary.centre) / summary.tightness
+            let score = WordVectors.cosine(vector, held.centre) / held.tightness
             let candidate = SoundGroup.Candidate(
-                name: member, score: score, floor: summary.floor, uses: summary.uses
+                name: member, score: score, floor: held.floor, uses: held.uses
             )
             candidates.append(candidate)
             standing.append(Standing(
-                term: member, score: score, floor: summary.floor, uses: summary.uses,
+                term: member, score: score, floor: held.floor, uses: held.uses,
                 stands: candidate.stands
             ))
         }
@@ -410,6 +406,56 @@ actor TermPortrait {
             return .keep
         }
     }
+
+    /// One member's centre, from whatever sentences it has.
+    ///
+    /// Not `summary(for:)`. That one refuses a term with fewer than
+    /// `floorMinimum` uses and no counter-example, because the single-term
+    /// path has nothing to compare a score against and would write on a guess.
+    /// A group member has the other members to lose to, so one sentence is
+    /// enough to take part: with one use the centre is that sentence and the
+    /// tightness is 1.
+    ///
+    /// The floor is still read off the term's own uses leaving one out, so it
+    /// still needs three of them. Below that a member has no floor and cannot
+    /// be out on one — it can only lose the comparison.
+    ///
+    /// Measured on the live app, 2026-09-10: `Eric` at two uses had no centre
+    /// at all, so a two-member group asked nine times in a row and would have
+    /// gone on asking until both names reached three.
+    ///
+    /// Cut with the *group's* rivals, the same cut the sentence gets, so every
+    /// member is described by the same reading of its own sentences.
+    private func centre(
+        of member: String, cutting rivals: [String], in stored: [String: [TermUses.Use]]
+    ) async throws -> (centre: [Float], tightness: Double, floor: Double?, uses: Int)? {
+        let uses = (stored[member] ?? []).filter { !$0.counter }
+        guard !uses.isEmpty else { return nil }
+        let mark = Self.fingerprint(of: uses) + "\u{4}" + rivals.joined(separator: "\u{1}")
+        if let held = memberCache[mark] { return held }
+
+        var vectors: [[Float]] = []
+        for use in uses {
+            guard let near = Self.context(of: use.span, in: use.said, cutting: rivals) else {
+                continue
+            }
+            vectors.append(try await WordVectors.shared.vector(.around, of: use.span, in: near))
+        }
+        guard !vectors.isEmpty else { return nil }
+        let (middle, tightness) = Self.middle(of: vectors)
+        guard tightness > 0 else { return nil }
+        let built = (
+            centre: middle, tightness: tightness, floor: Self.floor(of: vectors),
+            uses: vectors.count
+        )
+        memberCache[mark] = built
+        return built
+    }
+
+    /// Held for the run only, like `plainCache`: a centre cut with one group's
+    /// rivals means nothing to another group.
+    private var memberCache:
+        [String: (centre: [Float], tightness: Double, floor: Double?, uses: Int)] = [:]
 
     /// The group's plain centre: every member's counter rows, pooled.
     ///
@@ -657,20 +703,7 @@ actor TermPortrait {
             }
         }
 
-        // What a genuine use scores, each one measured against a portrait that
-        // does not contain it. Anything else compares a sentence with itself.
-        var floor: Double?
-        if uses.count >= floorMinimum {
-            var selves: [Double] = []
-            for index in vectors.indices {
-                let rest = vectors.enumerated().filter { $0.offset != index }.map(\.element)
-                guard rest.count > 1 else { continue }
-                let (restCentre, restTightness) = middle(of: rest)
-                guard restTightness > 0 else { continue }
-                selves.append(cosine(vectors[index], restCentre) / restTightness)
-            }
-            if !selves.isEmpty { floor = quantileOf(selves, at: quantile) }
-        }
+        let floor = Self.floor(of: vectors)
         return Summary(
             centre: centre,
             tightness: tightness,
@@ -681,6 +714,24 @@ actor TermPortrait {
             counterTightness: counterTightness,
             counters: counterRows
         )
+    }
+
+    /// What a genuine use scores, each one measured against a portrait that
+    /// does not contain it. Anything else compares a sentence with itself.
+    ///
+    /// Nil below `floorMinimum` vectors: there is nothing to leave out.
+    private static func floor(of vectors: [[Float]]) -> Double? {
+        guard vectors.count >= floorMinimum else { return nil }
+        var selves: [Double] = []
+        for index in vectors.indices {
+            let rest = vectors.enumerated().filter { $0.offset != index }.map(\.element)
+            guard rest.count > 1 else { continue }
+            let (restCentre, restTightness) = middle(of: rest)
+            guard restTightness > 0 else { continue }
+            selves.append(cosine(vectors[index], restCentre) / restTightness)
+        }
+        guard !selves.isEmpty else { return nil }
+        return quantileOf(selves, at: quantile)
     }
 
     /// The unit mean, and how close the members sit to it.

--- a/Sources/ParrotFlow/TermPortraitCommand.swift
+++ b/Sources/ParrotFlow/TermPortraitCommand.swift
@@ -97,9 +97,9 @@ enum TermPortraitCommand {
             for member in reading.members {
                 let score = member.score.map { String(format: "%.3f", $0) } ?? "—"
                 let floor = member.floor.map { String(format: "%.3f", $0) } ?? "—"
+                let how = member.unknown ? "unknown" : (member.stands ? "stands" : "out")
                 print("  \(pad(member.term, 14)) uses \(pad(String(member.uses), 4))"
-                    + " score \(pad(score, 7)) floor \(pad(floor, 7))"
-                    + " \(member.stands ? "stands" : "out")")
+                    + " score \(pad(score, 7)) floor \(pad(floor, 7)) \(how)")
             }
             if let plain = reading.plain {
                 print("  \(pad("plain", 14)) rows \(pad(String(reading.plainRows), 4))"

--- a/Sources/ParrotFlow/TermPortraitCommand.swift
+++ b/Sources/ParrotFlow/TermPortraitCommand.swift
@@ -52,6 +52,62 @@ enum TermPortraitCommand {
         text.count >= width ? text : text + String(repeating: " ", count: width - text.count)
     }
 
+    /// `--portrait <heard> "<sentence>"` — the group that word opens, and what
+    /// each member says about the sentence.
+    ///
+    ///     ParrotFlow --portrait Mick "Mick is adjusting the piano."
+    ///     group  Mick Mik   opened by "Mick"
+    ///       Mick   uses 3   score 0.912   floor 0.880   stands
+    ///       Mik    uses 5   score 0.874   floor 0.901   out
+    ///       plain  rows 4   score 0.803
+    ///     write Mick
+    ///
+    /// The window is the one the gate reads — `TermPortrait.window` — so this
+    /// scores the shipped path. A word that opens no group of two or more
+    /// falls through to the term form above, which is what it has always
+    /// printed.
+    static func group(heard: String, sentence: String) -> Int32 {
+        let config = (try? ConfigStore.load()) ?? Config()
+        let groups = SoundGroup.groups(terms: config.vocabulary.terms, uses: TermUses.load())
+        guard let group = SoundGroup.opened(by: heard, in: groups) else {
+            return run(term: heard, sentence: sentence, span: nil)
+        }
+        let near = TermUses.occurrence(of: heard, in: sentence).map {
+            TermPortrait.window(around: $0, in: sentence)
+        } ?? sentence
+        let outcome = Blocking.run { () async -> Result<TermPortrait.GroupReading, Error> in
+            do {
+                return .success(
+                    try await TermPortrait.shared.read(group: group.members, heard, in: near)
+                )
+            } catch {
+                return .failure(error)
+            }
+        }
+        switch outcome {
+        case .failure(let error):
+            print("✗ \(error.localizedDescription)")
+            return 1
+        case .success(let reading):
+            print("group  \(group.members.joined(separator: " "))   opened by \"\(heard)\"")
+            for member in reading.members {
+                let score = member.score.map { String(format: "%.3f", $0) } ?? "—"
+                let floor = member.floor.map { String(format: "%.3f", $0) } ?? "—"
+                print("  \(pad(member.term, 14)) uses \(pad(String(member.uses), 4))"
+                    + " score \(pad(score, 7)) floor \(pad(floor, 7))"
+                    + " \(member.stands ? "stands" : "out")")
+            }
+            if let plain = reading.plain {
+                print("  \(pad("plain", 14)) rows \(pad(String(reading.plainRows), 4))"
+                    + " score \(pad(String(format: "%.3f", plain), 7))")
+            } else {
+                print("  \(pad("plain", 14)) no counter row in the group")
+            }
+            print(SoundGroupCommand.said(reading.verdict))
+            return 0
+        }
+    }
+
     static func run(term: String, sentence: String?, span: String?) -> Int32 {
         typealias Answer = (TermPortrait.Summary?, TermPortrait.Reading?)
         let outcome = Blocking.run { () async -> Result<Answer, Error> in

--- a/Sources/ParrotFlow/TermPortraitCommand.swift
+++ b/Sources/ParrotFlow/TermPortraitCommand.swift
@@ -69,7 +69,11 @@ enum TermPortraitCommand {
     static func group(heard: String, sentence: String) -> Int32 {
         let config = (try? ConfigStore.load()) ?? Config()
         let groups = SoundGroup.groups(terms: config.vocabulary.terms, uses: TermUses.load())
-        guard let group = SoundGroup.opened(by: heard, in: groups) else {
+        // Any group, a group of one included: the cold start of a new name is
+        // exactly what this has to show, and that is a member with one use, no
+        // floor and no counter row anywhere.
+        let needle = heard.lowercased()
+        guard let group = groups.first(where: { $0.openings.contains(needle) }) else {
             return run(term: heard, sentence: sentence, span: nil)
         }
         let near = TermUses.occurrence(of: heard, in: sentence).map {
@@ -103,8 +107,33 @@ enum TermPortraitCommand {
             } else {
                 print("  \(pad("plain", 14)) no counter row in the group")
             }
+            // A group of one is read by the term's own portrait, not by the
+            // group rule — that is the regression gate, and printing the group
+            // rule's answer here would describe a path the app does not take.
+            guard group.isGroup else {
+                print(SoundGroupCommand.said(alone(group.members[0], heard, in: near)))
+                return 0
+            }
             print(SoundGroupCommand.said(reading.verdict))
             return 0
+        }
+    }
+
+    /// What the app does at a place where one term shares the word: the term's
+    /// own portrait, read the way `SentenceGate` reads it.
+    ///
+    /// Nothing either way leaves the place open, and an open place is the one
+    /// the pill asks about.
+    private static func alone(
+        _ term: String, _ heard: String, in near: String
+    ) -> SoundGroup.Verdict {
+        let reading = Blocking.run { () async -> TermPortrait.Reading? in
+            try? await TermPortrait.shared.read(heard, in: near, as: term)
+        }
+        switch reading?.verdict {
+        case .authorises: return .write(term)
+        case .refuses: return .keep
+        case .nothing, nil: return .open([term])
         }
     }
 

--- a/Sources/ParrotFlow/TermUses.swift
+++ b/Sources/ParrotFlow/TermUses.swift
@@ -289,8 +289,18 @@ enum TermUses {
     ) -> Range<String.Index>? {
         let hits = occurrences(of: span, in: text)
         guard let word else { return hits.first }
+        // Counted the way `EditWatch.words` counts, which is where the number
+        // comes from: any whitespace splits, and a shell prompt in front of the
+        // line is not a word.
+        var from = text.startIndex
+        while from < text.endIndex, text[from].isWhitespace { from = text.index(after: from) }
+        if from < text.endIndex, prompts.contains(text[from]) {
+            from = text.index(after: from)
+        }
         func at(_ hit: Range<String.Index>) -> Int {
-            text[..<hit.lowerBound].split(separator: " ").count
+            guard hit.lowerBound > from else { return 0 }
+            return text[from ..< hit.lowerBound]
+                .split(whereSeparator: \.isWhitespace).count
         }
         return hits.min { abs(at($0) - word) < abs(at($1) - word) }
     }

--- a/Sources/ParrotFlow/TermUses.swift
+++ b/Sources/ParrotFlow/TermUses.swift
@@ -208,6 +208,75 @@ enum TermUses {
         try write(all)
     }
 
+    /// Where a row sits, whatever spelling stands at the span.
+    ///
+    /// The text on either side of the term. "Eric has a new piano." under Eric
+    /// and "Erik has a new piano." under Erik are one place, which is how a
+    /// group can see that two of its members claim the same sentence.
+    struct Place: Hashable {
+        let before: String
+        let after: String
+    }
+
+    /// Every place `span` stands in `said`.
+    static func places(of span: String, in said: String) -> Set<Place> {
+        Set(occurrences(of: span, in: said).map {
+            Place(
+                before: String(said[said.startIndex ..< $0.lowerBound]),
+                after: String(said[$0.upperBound...])
+            )
+        })
+    }
+
+    /// Takes a place away from every term but the one that just claimed it.
+    ///
+    /// A sentence has one owner per place. Two members of a sound group both
+    /// holding it pull their centres toward each other: the pill records "Eric
+    /// has a new piano." under Eric, the correction that follows records "Erik
+    /// has a new piano." under Erik, and the first row stays. Polarity does not
+    /// matter — a counter is a claim on the place too, and the group's plain
+    /// centre is built out of counters.
+    ///
+    /// Only a row whose own span is one of `openings` goes, so a row standing
+    /// at the same place with an unrelated word in it is left alone. Returns
+    /// the terms that lost a row; their portraits are keyed on a fingerprint of
+    /// their uses, so each rebuilds itself the next time it is read.
+    @discardableResult
+    static func release(
+        _ said: String, at span: String, from terms: [String], to owner: String,
+        opening openings: Set<String>
+    ) throws -> [String] {
+        let claimed = places(of: span, in: said)
+        guard !claimed.isEmpty else { return [] }
+        var all = try read()
+        var moved: [String] = []
+        for term in terms where term.caseInsensitiveCompare(owner) != .orderedSame {
+            guard let rows = all[term] else { continue }
+            let kept = rows.filter { row in
+                guard openings.contains(bare(row.span)) else { return true }
+                return places(of: row.span, in: row.said).isDisjoint(with: claimed)
+            }
+            guard kept.count < rows.count else { continue }
+            all[term] = kept
+            moved.append(term)
+            Log.write("uses: \"\(said)\" is \(owner)'s place now —"
+                + " the row under \(term) is gone")
+        }
+        guard !moved.isEmpty else { return [] }
+        try write(all)
+        return moved
+    }
+
+    /// A span as the group spells its openings: no possessive, no punctuation,
+    /// lower case.
+    private static func bare(_ word: String) -> String {
+        var text = word.trimmingCharacters(in: .whitespaces)
+        if let mine = Vocabulary.possessive(in: text) {
+            text = String(text.dropLast(mine.suffix.count))
+        }
+        return text.trimmingCharacters(in: .punctuationCharacters).lowercased()
+    }
+
     /// Drops every use of one term, and says how many went.
     ///
     /// Case-insensitive, like `--forget` itself: somebody typing `praisy` means

--- a/Sources/ParrotFlow/TermUses.swift
+++ b/Sources/ParrotFlow/TermUses.swift
@@ -248,6 +248,15 @@ enum TermUses {
     ) throws -> [String] {
         let claimed = places(of: span, in: said)
         guard !claimed.isEmpty else { return [] }
+        // The same name standing twice in one sentence is two places, and a
+        // row records no occurrence, so a release would take the row written
+        // for the other one. Nothing goes until a row says which occurrence it
+        // is; the cost is a place two members still share.
+        guard claimed.count == 1 else {
+            Log.write("uses: \"\(said)\" names \(span) more than once, and a row does not"
+                + " say which one — no row is released")
+            return []
+        }
         var all = try read()
         var moved: [String] = []
         for term in terms where term.caseInsensitiveCompare(owner) != .orderedSame {

--- a/Sources/ParrotFlow/TermUses.swift
+++ b/Sources/ParrotFlow/TermUses.swift
@@ -143,14 +143,24 @@ enum TermUses {
     /// The same sentence and span recorded the other way round replaces what
     /// was there. One sentence cannot both hold the term and refuse it, and
     /// the later correction is the one that stands.
+    /// `near` is which occurrence, counted in words of `said`. A field holds
+    /// every dictation since the last Return, so the word being corrected is
+    /// often the *second* `Erik` in it — and narrowing to the first stored the
+    /// sentence that was already there, which is the same row again, so
+    /// nothing was written and nothing was said. Measured on the live app,
+    /// 2026-09-10.
     static func record(
         term: String, said: String, span: String, from: Use.Source = .correction,
-        counter: Bool = false, heard: String? = nil
+        counter: Bool = false, heard: String? = nil, near word: Int? = nil
     ) throws {
-        let sentence = narrowed(said, to: span)
+        let sentence = narrowed(said, to: span, near: word)
         // A word, not a substring. `contains` alone let `Vercelli` in.
         guard !sentence.isEmpty, !span.isEmpty,
-              occurrence(of: span, in: sentence) != nil else { return }
+              occurrence(of: span, in: sentence) != nil else {
+            Log.write("uses: \(term) learns nothing from \"\(said.prefix(60))\""
+                + " — \"\(span)\" does not stand in it as a word")
+            return
+        }
 
         var all = try read()
         var uses = all[term] ?? []
@@ -168,7 +178,11 @@ enum TermUses {
                 // carries the replaced spelling and the stored row predates it
                 // — a row written before `heard` existed never gains one
                 // otherwise, and the cut cannot see what it does not hold.
-                guard uses[already].heard == nil, let other else { return }
+                guard uses[already].heard == nil, let other else {
+                    Log.write("uses: \(term) already holds \"\(sentence)\";"
+                        + " nothing written")
+                    return
+                }
                 uses[already].heard = other
                 all[term] = uses
                 try write(all)
@@ -220,9 +234,9 @@ enum TermUses {
     /// A full stop only ends a sentence when what follows is a space, an
     /// upper-case letter, or nothing. Dictation arrives glued — "terminal.I'm
     /// using" has to come apart — while `Node.js` and `3.5` must not.
-    static func narrowed(_ said: String, to span: String) -> String {
+    static func narrowed(_ said: String, to span: String, near word: Int? = nil) -> String {
         let text = said.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let at = occurrence(of: span, in: text) else { return text }
+        guard let at = place(of: span, in: text, near: word) else { return text }
 
         func ends(_ i: String.Index) -> Bool {
             guard ".!?".contains(text[i]) else { return false }
@@ -264,6 +278,23 @@ enum TermUses {
     /// A term that occurs twice as a word still takes the first: both are
     /// genuine uses, and nothing that records one carries the position of the
     /// occurrence that was corrected.
+    /// The occurrence nearest `word`, counted in words, or the first when
+    /// nothing says which.
+    ///
+    /// The same rule `OpenPlaces.located` uses. A field is every dictation
+    /// since the last Return, so one name can stand in it several times and
+    /// only the position tells them apart.
+    static func place(
+        of span: String, in text: String, near word: Int?
+    ) -> Range<String.Index>? {
+        let hits = occurrences(of: span, in: text)
+        guard let word else { return hits.first }
+        func at(_ hit: Range<String.Index>) -> Int {
+            text[..<hit.lowerBound].split(separator: " ").count
+        }
+        return hits.min { abs(at($0) - word) < abs(at($1) - word) }
+    }
+
     static func occurrence(of span: String, in text: String) -> Range<String.Index>? {
         // Nil is nowhere. `Vercel` in `I visited Vercelli last year.` is not a
         // use of the term, and a caller that only asked `contains` stored it

--- a/Sources/ParrotFlow/VocabularyPass.swift
+++ b/Sources/ParrotFlow/VocabularyPass.swift
@@ -558,26 +558,38 @@ enum VocabularyPass {
     /// Nothing is written here. A group place always reaches the portrait —
     /// the word lists cannot separate two names that are both names.
     static func groupSlots(in text: String, groups: [SoundGroup.Group]) -> [Slot] {
-        var built: [Slot] = []
-        var taken: [Range<String.Index>] = []
+        var found: [(at: Range<String.Index>, group: SoundGroup.Group, order: Int)] = []
         for group in groups where group.isGroup {
             for opening in group.openings.sorted() {
                 for at in TermPortrait.places(of: opening, in: text) {
-                    guard !taken.contains(where: { $0.overlaps(at) }) else { continue }
-                    let heard = String(text[at])
-                    let others = group.members
-                        .filter { $0.caseInsensitiveCompare(heard) != .orderedSame }
-                        .prefix(SoundGroup.ceiling)
-                    guard !others.isEmpty else { continue }
-                    taken.append(at)
-                    built.append(Slot(
-                        range: at, options: [heard] + others, terms: group.members,
-                        owner: others.first, standing: .sound, group: group.members
-                    ))
+                    found.append((at, group, found.count))
                 }
             }
         }
-        return built.sorted { $0.range.lowerBound < $1.range.lowerBound }
+        // Left to right, and the widest opening first where two start at the
+        // same word. Taken in the order the openings sort in, `Mik` claimed
+        // the span inside `Mik Jagger` and the wider reading was dropped.
+        found.sort { left, right in
+            if left.at.lowerBound != right.at.lowerBound {
+                return left.at.lowerBound < right.at.lowerBound
+            }
+            let a = text.distance(from: left.at.lowerBound, to: left.at.upperBound)
+            let b = text.distance(from: right.at.lowerBound, to: right.at.upperBound)
+            return a != b ? a > b : left.order < right.order
+        }
+        var built: [Slot] = []
+        var taken: [Range<String.Index>] = []
+        for (at, group, _) in found {
+            guard !taken.contains(where: { $0.overlaps(at) }) else { continue }
+            let options = SoundGroup.offered(String(text[at]), of: group.members)
+            guard options.count > 1 else { continue }
+            taken.append(at)
+            built.append(Slot(
+                range: at, options: options, terms: group.members,
+                owner: options.dropFirst().first, standing: .sound, group: group.members
+            ))
+        }
+        return built
     }
 
     // MARK: - Fuzzy renderings

--- a/Sources/ParrotFlow/VocabularyPass.swift
+++ b/Sources/ParrotFlow/VocabularyPass.swift
@@ -57,6 +57,13 @@ enum VocabularyPass {
         /// expressed. It was 3 while the answer was a letter on a menu. A
         /// place that offers `Praisy` and `Praisy's` over "praise" loses the
         /// second of them here, which is the price of the shape.
+        ///
+        /// A sound group is the one place that shape does not hold. Several
+        /// terms share the word that was heard, and each of them is a reading
+        /// of it, so a group place carries up to `SoundGroup.ceiling` members
+        /// beside what was heard. This number does not bound those: it is
+        /// about a span with an alternative, and a group place is a span with
+        /// a list.
         var perSlot = 2
         /// Places in one sentence that may be about the same term.
         ///
@@ -115,7 +122,8 @@ enum VocabularyPass {
                 found.append("vocabulary: max_per_slot is \(perSlot), and a place is one"
                     + " span with one alternative — \(Self.readingCeiling) is the most it"
                     + " can offer. Anything past the second reading would be built and"
-                    + " never shown")
+                    + " never shown. A place where several terms share the heard word is"
+                    + " the exception, and it is not this number: see SoundGroup.ceiling")
             }
             if let readings {
                 found.append("vocabulary: max_readings is \(readings) and nothing reads it."
@@ -197,6 +205,13 @@ enum VocabularyPass {
         let owner: String?
         /// The best-evidenced of the readings in it, for `Caps.perTerm`.
         let standing: Standing
+        /// The terms of the sound group this place opens, when it opens one.
+        ///
+        /// Empty everywhere else, which is every place in a vocabulary where
+        /// no two terms share a sound. A group place carries every member as a
+        /// reading rather than one alternative, and only the portrait decides
+        /// it — see `SoundGroup`.
+        var group: [String] = []
     }
 
     /// One proposal reduced to what the question needs: a span, what stands
@@ -526,6 +541,43 @@ enum VocabularyPass {
             ))
         }
         return capped(built, in: text, to: caps.perTerm)
+    }
+
+    /// Every place a heard word opens a sound group, as one slot each.
+    ///
+    /// A group place is not built from parts. A part carries one alternative,
+    /// and here the alternatives are the other members — several readings of
+    /// one span, all of them equally proposed. The heard spelling comes first,
+    /// as it does everywhere else, and the members follow in their own order,
+    /// capped at `SoundGroup.ceiling`.
+    ///
+    /// The word itself is a member's spelling as often as not: "Mick" opens
+    /// the group Mick and Mik belong to, and Mick is then what is already
+    /// written. It is offered once, as the heard reading.
+    ///
+    /// Nothing is written here. A group place always reaches the portrait —
+    /// the word lists cannot separate two names that are both names.
+    static func groupSlots(in text: String, groups: [SoundGroup.Group]) -> [Slot] {
+        var built: [Slot] = []
+        var taken: [Range<String.Index>] = []
+        for group in groups where group.isGroup {
+            for opening in group.openings.sorted() {
+                for at in TermPortrait.places(of: opening, in: text) {
+                    guard !taken.contains(where: { $0.overlaps(at) }) else { continue }
+                    let heard = String(text[at])
+                    let others = group.members
+                        .filter { $0.caseInsensitiveCompare(heard) != .orderedSame }
+                        .prefix(SoundGroup.ceiling)
+                    guard !others.isEmpty else { continue }
+                    taken.append(at)
+                    built.append(Slot(
+                        range: at, options: [heard] + others, terms: group.members,
+                        owner: others.first, standing: .sound, group: group.members
+                    ))
+                }
+            }
+        }
+        return built.sorted { $0.range.lowerBound < $1.range.lowerBound }
     }
 
     // MARK: - Fuzzy renderings
@@ -881,6 +933,24 @@ enum VocabularyPass {
         /// Where the reading came from, carried through from the slot. Read by
         /// `settle`, which gates one source and not the others.
         let standing: Standing
+        /// The members of the sound group this place is between, or empty.
+        ///
+        /// Written by `groupSlots` and rewritten by `SentenceGate`, which
+        /// leaves the members still standing here when it cannot pick one —
+        /// that list is what the pill offers.
+        var group: [String] = []
+
+        /// The same place, with this member as the reading to write.
+        func writing(_ member: String) -> Change {
+            Change(range: range, was: was, now: member, terms: terms, owner: member,
+                   standing: standing, group: group)
+        }
+
+        /// The same place, cut to the members still standing, best first.
+        func offering(_ members: [String]) -> Change {
+            Change(range: range, was: was, now: members.first ?? now, terms: terms,
+                   owner: members.first ?? owner, standing: standing, group: members)
+        }
     }
 
     /// The substitutions to settle, left to right.
@@ -911,7 +981,8 @@ enum VocabularyPass {
             }
             built.append(Change(range: slot.range, was: slot.options[0],
                                 now: slot.options[1], terms: slot.terms,
-                                owner: slot.owner, standing: slot.standing))
+                                owner: slot.owner, standing: slot.standing,
+                                group: slot.group))
         }
         return built
     }
@@ -1106,6 +1177,15 @@ enum VocabularyPass {
         gate: SlotGate?
     ) -> [Bool?] {
         changes.map { change -> Bool? in
+            // A place where several terms share the heard word is never
+            // settled here. Both readings are names, so the word lists say
+            // "not a word" about either of them, and the spot holds a name
+            // whichever one wins. Only the portraits can separate them.
+            guard change.group.count < 2 else {
+                Log.write("vocabulary gate: \"\(change.was)\" opens"
+                    + " \(change.group.joined(separator: "/")) — left to the portraits")
+                return nil
+            }
             guard let allowed = policy[change.standing] else { return nil }
             // The reading that is actually going in, not the canonical term.
             // `Precy's -> Praisy's` keeps its possessive; asking about

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -298,13 +298,14 @@ if let index = arguments.firstIndex(of: "--selector") {
         : []
     guard !places.isEmpty else {
         print("usage: ParrotFlow --selector \"<text>\""
-            + " \"<standing>|<other>|<word>|<answer>\"... [--ranges]")
+            + " \"<standing>|<other>|<word>|<answer>\"... [--ranges|--taught]")
         exit(2)
     }
     exit(SelectorCommand.run(
         text: arguments[index + 1],
         places: places,
-        ranges: arguments.contains("--ranges")
+        ranges: arguments.contains("--ranges"),
+        taught: arguments.contains("--taught")
     ))
 }
 
@@ -537,7 +538,51 @@ if let index = arguments.firstIndex(of: "--portrait") {
     }
     let sentence = arguments.indices.contains(index + 2) ? arguments[index + 2] : nil
     let span = arguments.indices.contains(index + 3) ? arguments[index + 3] : nil
+    // A word and a sentence with no span is the group form: the word is what
+    // was heard, and every term that shares its sound reads the sentence. It
+    // falls back to the term form when the word opens no group.
+    if let sentence, span == nil {
+        exit(TermPortraitCommand.group(heard: arguments[index + 1], sentence: sentence))
+    }
     exit(TermPortraitCommand.run(term: arguments[index + 1], sentence: sentence, span: span))
+}
+
+if let index = arguments.firstIndex(of: "--sound-group") {
+    guard arguments.indices.contains(index + 1) else {
+        print("usage: ParrotFlow --sound-group <word>")
+        exit(2)
+    }
+    exit(SoundGroupCommand.group(arguments[index + 1]))
+}
+
+if let index = arguments.firstIndex(of: "--group-decide") {
+    var members: [String] = []
+    for argument in arguments[(index + 1)...] {
+        if argument.hasPrefix("--") { break }
+        members.append(argument)
+    }
+    guard !members.isEmpty else {
+        print("usage: ParrotFlow --group-decide <term>:<score>:<floor> … [--plain <score>]")
+        exit(2)
+    }
+    let plain = arguments.firstIndex(of: "--plain").flatMap { at in
+        arguments.indices.contains(at + 1) ? Double(arguments[at + 1]) : nil
+    }
+    exit(SoundGroupCommand.decide(members, plain: plain))
+}
+
+if let index = arguments.firstIndex(of: "--correction") {
+    guard arguments.indices.contains(index + 2) else {
+        print("usage: ParrotFlow --correction <wrote> <put> --in \"<sentence>\" [--dry]")
+        exit(2)
+    }
+    let sentence = arguments.firstIndex(of: "--in").flatMap { at in
+        arguments.indices.contains(at + 1) ? arguments[at + 1] : nil
+    }
+    exit(SoundGroupCommand.correction(
+        wrote: arguments[index + 1], put: arguments[index + 2], sentence: sentence,
+        dry: arguments.contains("--dry")
+    ))
 }
 
 if let index = arguments.firstIndex(of: "--slot-gap") {

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -552,6 +552,20 @@ if let index = arguments.firstIndex(of: "--portrait") {
     exit(TermPortraitCommand.run(term: arguments[index + 1], sentence: sentence, span: span))
 }
 
+if let index = arguments.firstIndex(of: "--picked") {
+    guard arguments.indices.contains(index + 2) else {
+        print("usage: ParrotFlow --picked <word> <term> --in \"<sentence>\" [--dry]")
+        exit(2)
+    }
+    let sentence = arguments.firstIndex(of: "--in").flatMap { at in
+        arguments.indices.contains(at + 1) ? arguments[at + 1] : nil
+    }
+    exit(SoundGroupCommand.picked(
+        word: arguments[index + 1], term: arguments[index + 2], sentence: sentence,
+        dry: arguments.contains("--dry")
+    ))
+}
+
 if let index = arguments.firstIndex(of: "--name-place") {
     guard arguments.indices.contains(index + 2) else {
         print("usage: ParrotFlow --name-place <heard> <term>")

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -450,8 +450,13 @@ if let index = arguments.firstIndex(of: "--for") {
     }
     let span = arguments.indices.contains(index + 3)
         && !arguments[index + 3].hasPrefix("--") ? arguments[index + 3] : nil
+    // Which occurrence, counted in words. A field holds every dictation since
+    // the last Return, so the same name can stand in it more than once.
+    let near = arguments.firstIndex(of: "--near").flatMap { at in
+        arguments.indices.contains(at + 1) ? Int(arguments[at + 1]) : nil
+    }
     exit(LearnCommand.supporting(
-        term: arguments[index + 1], sentence: arguments[index + 2], span: span
+        term: arguments[index + 1], sentence: arguments[index + 2], span: span, near: near
     ))
 }
 
@@ -545,6 +550,14 @@ if let index = arguments.firstIndex(of: "--portrait") {
         exit(TermPortraitCommand.group(heard: arguments[index + 1], sentence: sentence))
     }
     exit(TermPortraitCommand.run(term: arguments[index + 1], sentence: sentence, span: span))
+}
+
+if let index = arguments.firstIndex(of: "--name-place") {
+    guard arguments.indices.contains(index + 2) else {
+        print("usage: ParrotFlow --name-place <heard> <term>")
+        exit(2)
+    }
+    exit(SoundGroupCommand.namePlace(heard: arguments[index + 1], term: arguments[index + 2]))
 }
 
 if let index = arguments.firstIndex(of: "--sound-group") {

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -452,8 +452,15 @@ if let index = arguments.firstIndex(of: "--for") {
         && !arguments[index + 3].hasPrefix("--") ? arguments[index + 3] : nil
     // Which occurrence, counted in words. A field holds every dictation since
     // the last Return, so the same name can stand in it more than once.
-    let near = arguments.firstIndex(of: "--near").flatMap { at in
-        arguments.indices.contains(at + 1) ? Int(arguments[at + 1]) : nil
+    var near: Int?
+    if let at = arguments.firstIndex(of: "--near") {
+        // Ignored, `--near abc` recorded the first occurrence instead, which
+        // can attach the use to the wrong sentence.
+        guard arguments.indices.contains(at + 1), let which = Int(arguments[at + 1]) else {
+            print("usage: --near <word>, counted in words")
+            exit(2)
+        }
+        near = which
     }
     exit(LearnCommand.supporting(
         term: arguments[index + 1], sentence: arguments[index + 2], span: span, near: near

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -281,6 +281,9 @@ $PF --command "hey parrot, Tasmin spells T A S M E E N" "<last transcript>" \
 $PF --learn <heard> <corrected>
 $PF --for <term> "<sentence>" [word]
 $PF --against <term> "<sentence>" <word>
+$PF --correction <wrote> <put> --in "<sentence>" [--dry]
+$PF --sound-group <word>
+$PF --group-decide <term>:<score>:<floor>... [--plain <score>]
 ```
 
 `--route` shows which transform an instruction reaches and why — the router
@@ -314,6 +317,36 @@ closer to the sentences the term belongs in than to these.
 $ ParrotFlow --against Vercel "I love visiting the Versailles Castle." Versailles
 ✓ Vercel does not belong at "Versailles"
 ```
+
+`--correction` is what a correction the app watched you make writes, and it
+writes it. A term put back over another term is a use of the one you typed,
+carrying the spelling it replaced; an ordinary word put back is a counter under
+the term that was proposed. Never both. `--dry` prints the rows without
+touching the file.
+
+```
+$ ParrotFlow --correction Mik Mick --in "Mick is adjusting the piano."
+use Mick "Mick" heard Mik
+```
+
+`--sound-group` prints the terms that share a word's sound, every word that
+opens that group, and whether the word is still a substitution rule — one that
+opens a group of two or more is not. `--group-decide` runs the decision rule on
+scores you write down: a member is `<term>:<score>:<floor>`, a floor of `-` is
+a member with too few uses to have one, and `--plain` is the score against the
+group's pooled counter rows. The last line is the verdict.
+
+```
+$ ParrotFlow --group-decide Mik:0.90:0.80 Mick:0.86:- --plain 0.70
+Mik         0.900  floor 0.800  stands
+Mick        0.860  floor —      stands
+plain       0.700
+write Mik
+```
+
+The same decision with the real portraits behind it is
+`--portrait <heard> "<sentence>"`, which prints the group the word opens, each
+member's score and floor, plain's score and the verdict.
 
 ## Giving a model its API key
 
@@ -452,10 +485,14 @@ $PF --selector "can you ask Mick to review it." "Mick|mixed bend|3|1"
 
 A place is `standing|other|word|answer` — what stands in the text, the reading
 nobody took, where the stage saw it counted in words, and then `0` to keep what
-stands there, `1` to take the other reading, `-` for a question nobody
-answered. Several places are several arguments. `NOTHING FOUND` means no span
-was still there: the stages after `vocabulary` may rewrite, and a span that is
-gone is a question nobody can answer.
+stands there, `1` to take the other reading, `2` for "something else", `-` for
+a question nobody answered. Several places are several arguments.
+`NOTHING FOUND` means no span was still there: the stages after `vocabulary`
+may rewrite, and a span that is gone is a question nobody can answer.
+
+A place where several names share the heard word has one row per member, so the
+answer can go past `1`. The row after the last reading is always "something
+else": it writes what was heard and records nothing.
 
 The word index is what separates two mentions of the same word, and the write
 touches nothing between the places — a newline, a double space and a comma
@@ -463,6 +500,8 @@ glued to the next word all survive it.
 
 `--ranges` prints where each answered word ended up instead of the text, which
 is what the trace records: a place after one the answer made longer has moved.
+`--taught` prints what each answer records instead: the word, and `teaches` or
+`nothing`.
 
 `scripts/check-selector.sh` scores both halves, 21 cases. The lowercasing of a
 refused glued span is `--lowercase-refused`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -284,6 +284,7 @@ $PF --against <term> "<sentence>" <word>
 $PF --correction <wrote> <put> --in "<sentence>" [--dry]
 $PF --sound-group <word>
 $PF --group-decide <term>:<score>:<floor>... [--plain <score>]
+$PF --name-place <heard> <term>
 ```
 
 `--route` shows which transform an instruction reaches and why — the router
@@ -346,7 +347,17 @@ write Mik
 
 The same decision with the real portraits behind it is
 `--portrait <heard> "<sentence>"`, which prints the group the word opens, each
-member's score and floor, plain's score and the verdict.
+member's score and floor, plain's score and the verdict. A group of one prints
+the same way, so the cold start of a new name is readable: one use, no floor,
+no counter row, nothing decided.
+
+`--name-place` says whether the slot test stands aside at a place: `names` when
+both sides are names and the slot cannot separate them, `ordinary` when it is
+an ordinary word against a term.
+
+`--for` takes `--near <n>`, the word the correction was at. A terminal joins
+dictations with no space after the stop, so one field holds the same name
+several times and the position is what says which sentence to store.
 
 ## Giving a model its API key
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -285,6 +285,7 @@ $PF --correction <wrote> <put> --in "<sentence>" [--dry]
 $PF --sound-group <word>
 $PF --group-decide <term>:<score>:<floor>... [--plain <score>]
 $PF --name-place <heard> <term>
+$PF --picked <word> <term> --in "<sentence>" [--dry]
 ```
 
 `--route` shows which transform an instruction reaches and why — the router
@@ -333,9 +334,11 @@ use Mick "Mick" heard Mik
 `--sound-group` prints the terms that share a word's sound, every word that
 opens that group, and whether the word is still a substitution rule — one that
 opens a group of two or more is not. `--group-decide` runs the decision rule on
-scores you write down: a member is `<term>:<score>:<floor>`, a floor of `-` is
-a member with too few uses to have one, and `--plain` is the score against the
-group's pooled counter rows. The last line is the verdict.
+scores you write down: a member is `<term>:<score>:<floor>[:<uses>]`, a floor
+of `-` is a member with too few uses to have one, a score of `-` is one that
+could not be scored, `:0` is a member nobody has ever confirmed — unknown,
+which opens the place rather than losing it — and `--plain` is the score
+against the group's pooled counter rows. The last line is the verdict.
 
 ```
 $ ParrotFlow --group-decide Mik:0.90:0.80 Mick:0.86:- --plain 0.70
@@ -354,6 +357,13 @@ no counter row, nothing decided.
 `--name-place` says whether the slot test stands aside at a place: `names` when
 both sides are names and the slot cannot separate them, `ordinary` when it is
 an ordinary word against a term.
+
+`--picked` is what an answer on the pill records, and it records it: `use
+<term>` for a word that is already a term, `create <name>` for a name that is
+not one yet — written to `vocabulary.yaml` as a person with no pronunciation —
+and `counter <term>` for an ordinary word. `blocked <a> <b>` instead of any of
+them means the sentence names two members of one group, so nothing is written.
+`--correction` answers the same way.
 
 `--for` takes `--near <n>`, the word the correction was at. A terminal joins
 dictations with no space after the stop, so one field holds the same name

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -359,9 +359,9 @@ both sides are names and the slot cannot separate them, `ordinary` when it is
 an ordinary word against a term.
 
 `--picked` is what an answer on the pill records, and it records it: `use
-<term>` for a word that is already a term, `create <name>` for a name that is
-not one yet — written to `vocabulary.yaml` as a person with no pronunciation —
-and `counter <term>` for an ordinary word. `blocked <a> <b>` instead of any of
+<term>` for a word that is already a term, `create <name> <kind>` for a name
+that is not one yet — written to `vocabulary.yaml` with no pronunciation, under
+the kind the tagger read — and `counter <term>` for an ordinary word. `blocked <a> <b>` instead of any of
 them means the sentence names two members of one group, so nothing is written.
 `--correction` answers the same way.
 

--- a/docs/proposals/sound-groups.md
+++ b/docs/proposals/sound-groups.md
@@ -143,10 +143,11 @@ They are part of the model, not fixes around it.
 - **A member with no use at all is unknown, not out.** It has never been seen,
   so it cannot lose a comparison it was never in. One unknown member opens the
   place and the pill lists it. That is how a member gets its first sentence.
-- **A name picked on the pill becomes a term**, with `kind: person` and no
-  pronunciation, and the sentence is a use of it. A person the recogniser
-  spells right is never corrected, so nothing else ever creates their term.
-  Plain stays what it always was: an ordinary word.
+- **A name picked on the pill becomes a term**, with no pronunciation and the
+  kind the tagger read — person, place or organization — and the sentence is a
+  use of it. A person the recogniser spells right is never corrected, so
+  nothing else ever creates their term. Plain stays what it always was: an
+  ordinary word.
 - **A sentence naming two members of one group is recorded nowhere.** The
   rival clip cuts the window at the other name and the words between the two
   survive, which are the sentence. Corrections and pill answers both refuse it.

--- a/docs/proposals/sound-groups.md
+++ b/docs/proposals/sound-groups.md
@@ -158,6 +158,11 @@ They are part of the model, not fixes around it.
 - **A sentence naming two members of one group is recorded nowhere.** The
   rival clip cuts the window at the other name and the words between the two
   survive, which are the sentence. Corrections and pill answers both refuse it.
+- **A place has one owner.** Recording a sentence under one member takes it
+  off every other member, whatever its polarity. Otherwise the pill's "Eric has
+  a new piano." stays under Eric after you correct it to Erik, and both centres
+  move toward each other. A place is the text on either side of the term, so
+  the two spellings are one place. Only a row whose span opens the group goes.
 
 ## What must not move
 

--- a/docs/proposals/sound-groups.md
+++ b/docs/proposals/sound-groups.md
@@ -140,9 +140,11 @@ hand. The existing `--portrait <term> "<sentence>" <span>` form keeps working.
 Three rules were added after the prototype met real dictation on 2026-09-10.
 They are part of the model, not fixes around it.
 
-- **A member with no portrait is unknown, not out.** Nothing is known about it,
-  so it cannot lose a comparison it was never in. One unknown member opens the
+- **A member with no use is unknown, not out.** Nothing is known about it, so
+  it cannot lose a comparison it was never in. One unknown member opens the
   place and the pill lists it. That is how a member gets its first sentence.
+  One sentence is enough to stop being unknown: a group member has a centre
+  from its first use.
 - **Nobody standing keeps what was heard only when plain has a centre.** With
   no counter row anywhere in the group there is no ordinary word to win, so
   the place is opened, best first.

--- a/docs/proposals/sound-groups.md
+++ b/docs/proposals/sound-groups.md
@@ -140,9 +140,12 @@ hand. The existing `--portrait <term> "<sentence>" <span>` form keeps working.
 Three rules were added after the prototype met real dictation on 2026-09-10.
 They are part of the model, not fixes around it.
 
-- **A member with no use at all is unknown, not out.** It has never been seen,
+- **A member with no portrait is unknown, not out.** Nothing is known about it,
   so it cannot lose a comparison it was never in. One unknown member opens the
   place and the pill lists it. That is how a member gets its first sentence.
+- **Nobody standing keeps what was heard only when plain has a centre.** With
+  no counter row anywhere in the group there is no ordinary word to win, so
+  the place is opened, best first.
 - **A name picked on the pill becomes a term**, with no pronunciation and the
   kind the tagger read — person, place or organization — and the sentence is a
   use of it. A person the recogniser spells right is never corrected, so

--- a/docs/proposals/sound-groups.md
+++ b/docs/proposals/sound-groups.md
@@ -151,6 +151,10 @@ They are part of the model, not fixes around it.
   use of it. A person the recogniser spells right is never corrected, so
   nothing else ever creates their term. Plain stays what it always was: an
   ordinary word.
+- **A correction onto a name with no term creates it**, with the rendering it
+  replaced, so the new name joins the group. Only a person: a place or an
+  organization put back is still a counter, which is what a portrait is built
+  from.
 - **A sentence naming two members of one group is recorded nowhere.** The
   rival clip cuts the window at the other name and the words between the two
   survive, which are the sentence. Corrections and pill answers both refuse it.

--- a/docs/proposals/sound-groups.md
+++ b/docs/proposals/sound-groups.md
@@ -1,0 +1,145 @@
+# Sound groups: several names, one sound
+
+Decided 2026-09-09 after a real failure. Mik and Mick are two people. The
+recogniser hears "Mick" for both. Today Mik owns the sound: `heard: Mick` is
+a rule that rewrites every "Mick" to "Mik", and the only thing that can undo
+it is Mik's portrait, where Mick lives as a counter-example. Mick has no
+portrait of his own. On "Mick is adjusting the piano" the portrait scored
+0.886 own against 0.874 counter, band 0.01, and wrote Mik.
+
+The fix is not a better threshold. It is a model where every name is a term
+with its own portrait, and the sound is shared.
+
+## The model
+
+**A group is a set of terms that share a sound.** It is derived, never
+declared. Two terms are in one group when any of these holds:
+
+- one term's spelling is a `heard:` rendering of the other (Mik has
+  `heard: Mick`, and Mick is a term);
+- the two share a `heard:` rendering (both have `heard: meek`);
+- a counter row under one term has a span that is the other term's spelling.
+
+Groups are transitive. A term with no such link is a group of one, and a
+group of one must behave exactly as the app does today. That is the
+regression gate.
+
+**A group has one more member with no name: plain.** Plain is "an ordinary
+word that sounds like this": Mick Jagger, the Versailles castle, "a better
+stack than PHP". Its portrait is the counter rows of the group's members,
+pooled. Today's counter centre is plain's centre for a group of one.
+
+**A heard word opens the whole group.** When a heard word is any member's
+spelling or any member's `heard:` rendering, the place carries every member
+as a candidate, the heard spelling included. A `heard:` that equals another
+term's spelling is no longer a substitution rule; it opens the group. A group
+place never auto-applies through the word-list tier; it always reaches the
+portrait.
+
+**The decision is nearest centre, with floors.** Score the window around the
+place against each member's own centre, divided by that member's own
+tightness, as `TermPortrait` does now. Plain is scored the same way against
+the pooled counter centre.
+
+1. A member below its own floor is out. A member with fewer than
+   `floorMinimum` uses has no floor and is never out on that ground.
+2. Among the members standing, the best wins if it leads the second best by
+   more than `band`.
+3. A win by a named member writes that spelling. A win by plain keeps what
+   was heard.
+4. No member standing: keep what was heard, record nothing.
+5. Two or more standing and no lead: the place is open and the pill asks.
+
+The heard spelling gets no bonus. The recogniser's choice between homophones
+is frequency, not evidence.
+
+**Recording.** What a correction or a pill answer writes depends on what was
+put in:
+
+- put back, or chosen, a word that is a term: a **use** of that term, with
+  `heard:` set to the spelling it replaced. No counter row under the term
+  that lost. "Mick is playing guitar" is a use of Mick, and by that fact a
+  place Mik does not live.
+- put back an ordinary word, or "as heard" chosen on the pill: a **counter**
+  under the term that was proposed, exactly as today.
+
+The "one term corrected into another" branch that writes two rows for one
+sentence goes away. That branch is what produced the poisoned rows.
+
+**The rival clip.** The window is cut at any other member's spelling and at
+any counter span, before it enters a portrait. Today it is cut at counter
+spans only.
+
+**The pill.** An open group place lists the standing members, the heard
+spelling first, and "as heard" last. Reuse the stacked surface from #299 and
+the mechanism from #300. Cap the list; four members plus as-heard is enough.
+Do not design a new surface.
+
+One more option after "as heard": **something else**. It writes the heard
+spelling and records nothing — no use, no counter. The user then corrects the
+word by hand, and the edit watch and the correction panel handle that edit as
+they do today: a rule offer, a use for the term typed, or a counter. So the
+list is the standing members with the heard spelling first, then "as heard",
+then "something else", with the members still capped at four. The last two
+differ in what they teach: "as heard" says the heard word is right and records
+a counter under the group, which is plain; "something else" says none of the
+options are right and leaves the file untouched.
+
+## The files
+
+No new field in either file. Every row that exists today keeps its meaning.
+
+```yaml
+# vocabulary.yaml
+terms:
+  Mik:
+    pronunciations:
+      - heard: Mick        # another term: Mik and Mick are one group
+      - heard: meek
+  Mick:
+    pronunciations:
+      - heard: meek        # shared: same group, no conflict
+  Vercel:
+    pronunciations:
+      - heard: Versal      # no other term sounds like it: a group of one
+```
+
+```yaml
+# vocabulary-uses.yaml
+terms:
+  "Mik":
+    - said: "Mik is reviewing my PR."
+      span: "Mik"
+      from: correction
+      heard: "Mick"
+    - said: "But he's not Mick Jagger."
+      span: "Mick"
+      from: chosen
+      counter: true               # "as heard" on the pill: plain
+  "Mick":
+    - said: "Mick is adjusting the piano."
+      span: "Mick"
+      from: correction
+      heard: "Mik"                # a use of Mick, not a counter of Mik
+  "Vercel":
+    - said: "We visited the Versailles castle."
+      span: "Versailles"
+      from: correction
+      counter: true               # an ordinary word: the only counter still written
+```
+
+## What the experiment needs
+
+`--portrait <heard> "<sentence>"` with a heard word instead of a term must
+print the group it opens and, per member and for plain, the score, the floor,
+whether it stands, then the verdict. This is how the change will be judged by
+hand. The existing `--portrait <term> "<sentence>" <span>` form keeps working.
+
+## What must not move
+
+`scripts/check-counter-portrait.sh` on `tests/portrait-cases.tsv`, and
+`scripts/check-slot-gate.sh` on `tests/judge-cases.yaml`. Run both before the
+first change and after the last. A group of one has to give the same numbers.
+Name against name has no bench and none should be invented from dictation;
+the derivation, the decision rule on synthetic centres, and the recording
+rules get unit tests.

--- a/docs/proposals/sound-groups.md
+++ b/docs/proposals/sound-groups.md
@@ -135,6 +135,22 @@ print the group it opens and, per member and for plain, the score, the floor,
 whether it stands, then the verdict. This is how the change will be judged by
 hand. The existing `--portrait <term> "<sentence>" <span>` form keeps working.
 
+## What the first live tests changed
+
+Three rules were added after the prototype met real dictation on 2026-09-10.
+They are part of the model, not fixes around it.
+
+- **A member with no use at all is unknown, not out.** It has never been seen,
+  so it cannot lose a comparison it was never in. One unknown member opens the
+  place and the pill lists it. That is how a member gets its first sentence.
+- **A name picked on the pill becomes a term**, with `kind: person` and no
+  pronunciation, and the sentence is a use of it. A person the recogniser
+  spells right is never corrected, so nothing else ever creates their term.
+  Plain stays what it always was: an ordinary word.
+- **A sentence naming two members of one group is recorded nowhere.** The
+  rival clip cuts the window at the other name and the words between the two
+  survive, which are the sentence. Corrections and pill answers both refuse it.
+
 ## What must not move
 
 `scripts/check-counter-portrait.sh` on `tests/portrait-cases.tsv`, and

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -556,6 +556,16 @@ decoded audio, 2026-09-10: five sentences about a third person had become five
 counters under the second, and the pooled plain centre then scored 0.945 on a
 sentence that was hers.
 
+**A place has one owner.** A sentence recorded under one member is taken off
+every other member of the group, whatever its polarity. The pill records "Eric
+has a new piano." under Eric, you correct it to Erik, and without this both
+names hold the same sentence at the same place and their centres are pulled
+together by the words meant to separate them. A place is the text on either
+side of the term, so the two spellings are the same place. Only a row whose own
+span opens the group goes. The log names the row that moved. The portrait of
+the member that lost it is keyed on a fingerprint of its uses, so it rebuilds
+itself the next time it is read.
+
 **A sentence naming two members of one group is recorded nowhere.** It belongs
 to neither, and the rival clip cannot save it: cutting the window at the other
 name leaves the words between them, which are the sentence. "So I tried again

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -192,11 +192,12 @@ right whenever the spelling is a word.
 #### Per term
 
 **`kind`** is what the term names: `person`, `place`, `organization` or `word`.
-The correction panel writes it, proposing a value from the macOS word tagger.
-Nothing reads it yet. It is here so the stages that will need it have something
-to read, the way `seen` and `from` were added to a pronunciation before anything
-counted them. A term written before the key existed has no `kind`, and that is
-not the same as `word`.
+The correction panel writes it, proposing a value from the macOS word tagger,
+and so does a term created from an answer on the pill. Two things read it.
+`NamePlace` asks whether the heard word and the term are both names, and the
+slot test stands aside when they are. A word picked on the pill under a term
+that says `kind: person` is written as a person. A term written before the key
+existed has no `kind`, and that is not the same as `word`.
 
 **`pronunciations`** is the ways this term actually comes out of the
 recogniser. Each entry does two jobs. It is an exact rule, which is what

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -486,6 +486,12 @@ it leads the second by more than 0.01. A named member winning writes its
 spelling, plain winning keeps what was heard, and nobody standing keeps it too.
 Two standing and no lead is an open place, and the pill asks.
 
+A member with no confirmed use at all is **unknown**, which is not the same as
+out: it has never been seen, so it cannot lose a comparison it was never in.
+One unknown member opens the place and the pill lists it, which is the only way
+that member gets a first sentence. Once every member has a use the rule above
+runs as written.
+
 `--portrait <heard> "<sentence>"` prints the group a word opens, every member's
 score and floor, plain's score and the verdict.
 `scripts/check-sound-group.sh` scores the derivation, the decision rule and
@@ -517,7 +523,23 @@ is a **counter** under the term that was proposed — the half a portrait cannot
 get any other way, because accepting an offer only ever teaches where a term
 *does* live. One correction never writes both: putting `Mick` back over `Mik`
 is a use of Mick and says nothing about Mik. "Something else" writes no row at
-all. A counter-example and the term stops being read against a floor. Each answer also goes to `trace.jsonl` as `kind: chose`, kept apart from
+all. A counter-example and the term stops being read against a floor.
+
+**A name picked on the pill becomes a term.** Every person is a term, and plain
+is for ordinary words — but a person the recogniser spells right is never
+corrected, so nothing ever creates their term and every sentence about them
+piles up as a counter under somebody else's name. When the word picked is not a
+term and either the tagger or the proposing term's `kind: person` says it is a
+name, it is written to `vocabulary.yaml` as a person with no pronunciation, and
+the sentence is a use of it. The group then holds both names.
+
+**A sentence naming two members of one group is recorded nowhere.** It belongs
+to neither, and the rival clip cannot save it: cutting the window at the other
+name leaves the words between them, which are the sentence. "So I tried again
+with Erik the musician and Eric the software engineer." was kept as a counter
+under Erik on 2026-09-10, and every later "Eric the musician" was refused,
+0.80 against 0.93 and 0.90 against 0.92. Corrections and pill answers both
+refuse it, and the log names the two. Each answer also goes to `trace.jsonl` as `kind: chose`, kept apart from
 the hand edits: a place the app said out loud it could not decide is a harder
 label than a mistake somebody fixed.
 

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -459,10 +459,36 @@ counter says nothing until it gets either a counter or a third use.
 `--portrait <term> "<sentence>" <word>` prints both scores and the verdict;
 `scripts/check-counter-portrait.sh` is the run.
 
-**What nothing settles is asked.** The pill draws the sentence with the two
-readings stacked where the open place is, and 1 or 2 answers it. The words wait
-for the answer: nothing is typed until the last question is answered, so the
-sentence is only ever written once.
+**Two names with one sound are a group.** `Mik` and `Mick` are two people and
+the decoder writes "Mick" for both. A group is derived, never declared: two
+terms are in one when one term's spelling is a `heard:` rendering of the other,
+when they share a rendering, or when a counter row under one has a span that is
+the other's spelling. The links are transitive, and almost every term is a
+group of one, which behaves exactly as above.
+
+A rendering that opens a group is no longer a substitution rule. The word opens
+the place instead, and every member is a reading of it. Each is scored against
+its own portrait, and one more member has no name — **plain**, the ordinary
+word that sounds like this, whose portrait is the counter rows of the whole
+group pooled. A member below its own floor is out; the best of the rest wins if
+it leads the second by more than 0.01. A named member winning writes its
+spelling, plain winning keeps what was heard, and nobody standing keeps it too.
+Two standing and no lead is an open place, and the pill asks.
+
+`--portrait <heard> "<sentence>"` prints the group a word opens, every member's
+score and floor, plain's score and the verdict.
+`scripts/check-sound-group.sh` scores the derivation, the decision rule and
+what a correction records; the portraits behind them have no bench of their own.
+See `docs/proposals/sound-groups.md`.
+
+**What nothing settles is asked.** The pill draws the sentence with the
+readings stacked where the open place is, and a digit answers it. Two readings
+almost always — what was heard and the one word that could not be ruled out —
+and one row per member where several names share the sound, four at most. The
+last row of every question is "something else": it writes what was heard and
+records nothing, so the correction you then make by hand goes through the panel
+as any other does. The words wait for the answer: nothing is typed until the
+last question is answered, so the sentence is only ever written once.
 
 Every way of not answering writes what the gates settled on, which is what an
 open place has always shipped. Escape, a click outside the pill, any other key,
@@ -473,11 +499,14 @@ sentence.
 Several open places in one sentence are several questions, asked one at a time,
 and the count on the pill says how many are left.
 
-The answers are the reason to ask. Confirming a term keeps that sentence as a
-use; refusing one keeps it as a counter-example — the half a portrait cannot
+The answers are the reason to ask. What is recorded depends on the word that
+was written, not on which row it sat in: a word that is a term is a **use** of
+that term, with `heard:` set to the spelling it replaced, and an ordinary word
+is a **counter** under the term that was proposed — the half a portrait cannot
 get any other way, because accepting an offer only ever teaches where a term
-*does* live. Three counter-examples and the term stops being read against a
-floor. Each answer also goes to `trace.jsonl` as `kind: chose`, kept apart from
+*does* live. One correction never writes both: putting `Mick` back over `Mik`
+is a use of Mick and says nothing about Mik. "Something else" writes no row at
+all. A counter-example and the term stops being read against a floor. Each answer also goes to `trace.jsonl` as `kind: chose`, kept apart from
 the hand edits: a place the app said out loud it could not decide is a harder
 label than a mistake somebody fixed.
 

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -437,6 +437,17 @@ judge is simply left open, which is the behaviour before this tier. This tier is
 reached only from the sound pass, and that pass is English only, so it was
 measured in English only and runs nowhere else.
 
+**The slot is not asked about one name against another.** It compares the term
+with the word that was heard, and a term is unknown to the tokenizer by
+construction, so a heard word that is itself a name wins every time whatever
+the sentence says: `Eric` against the term `Erik` scored −0.254, −0.253 and
+−0.257 in three different sentences, refusing all three. A place is read as
+name against name when the term says `kind: person`, when `NLTagger` reads the
+heard word as a personal name, or when the heard word is a `heard:` rendering
+somebody wrote down. Those go straight to the portrait, and to the pill when it
+says nothing — which is how a second name starts from nothing. An ordinary word
+against a term — `versus` against `Vercel` — still goes to the slot.
+
 **What the slot cannot settle, the term itself can.** Every sentence you
 confirm a term in is kept in `vocabulary-uses.yaml`, and one of them gives the
 term a portrait: the average of what those sentences look like, with the term

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -545,6 +545,17 @@ is written as a person only when the term proposed over it says `kind: person`,
 which is the one thing left saying this is a name at all. The group then holds
 both names.
 
+**A correction onto a name with no term creates it.** `Anna` corrected to
+`Annah` where only `Anna` is a term is not an ordinary word being put back: it
+is a third person. The rendering is written, the term is created with
+`kind: person`, and the sentence is a use of it — the ordinary correction path,
+which the counter branch used to intercept. A place or an organization put back
+is still a counter, because a counter is what a portrait is built from:
+`Vercel` corrected to `Versailles` says where Vercel does not live. Measured on
+decoded audio, 2026-09-10: five sentences about a third person had become five
+counters under the second, and the pooled plain centre then scored 0.945 on a
+sentence that was hers.
+
 **A sentence naming two members of one group is recorded nowhere.** It belongs
 to neither, and the rival clip cannot save it: cutting the window at the other
 name leaves the words between them, which are the sentence. "So I tried again

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -486,11 +486,20 @@ it leads the second by more than 0.01. A named member winning writes its
 spelling, plain winning keeps what was heard, and nobody standing keeps it too.
 Two standing and no lead is an open place, and the pill asks.
 
-A member with no confirmed use at all is **unknown**, which is not the same as
-out: it has never been seen, so it cannot lose a comparison it was never in.
-One unknown member opens the place and the pill lists it, which is the only way
-that member gets a first sentence. Once every member has a use the rule above
-runs as written.
+A member with no portrait is **unknown**, which is not the same as out: nothing
+is known about it, so it cannot lose a comparison it was never in. One unknown
+member opens the place and the pill lists it, which is the only way that member
+gets a first sentence. And "nobody standing" is the ordinary word winning, so
+it needs an ordinary word to win: with no counter row anywhere in the group
+there is no plain centre, and the place is opened rather than kept — best
+first, so the pill's top row carries the ranking the floors threw away.
+
+Both were measured on decoded audio, 2026-09-10. Two names, three sentences
+each, no counters: every score sat below a floor read off three short
+sentences, and keeping what was heard typed the wrong name and asked nothing.
+Opened instead, the right name is the top row on both held-out sentences —
+Erik 0.791 against Eric 0.649 on "Eric is a musician.", and Eric 0.747 against
+Erik 0.647 on "Eric is a software engineer."
 
 `--portrait <heard> "<sentence>"` prints the group a word opens, every member's
 score and floor, plain's score and the verdict.

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -529,9 +529,12 @@ all. A counter-example and the term stops being read against a floor.
 is for ordinary words — but a person the recogniser spells right is never
 corrected, so nothing ever creates their term and every sentence about them
 piles up as a counter under somebody else's name. When the word picked is not a
-term and either the tagger or the proposing term's `kind: person` says it is a
-name, it is written to `vocabulary.yaml` as a person with no pronunciation, and
-the sentence is a use of it. The group then holds both names.
+term and the tagger reads it as a name, it is written to `vocabulary.yaml` with
+no pronunciation, under the kind the tagger read — `person`, `place` or
+`organization` — and the sentence is a use of it. A word the tagger cannot read
+is written as a person only when the term proposed over it says `kind: person`,
+which is the one thing left saying this is a name at all. The group then holds
+both names.
 
 **A sentence naming two members of one group is recorded nowhere.** It belongs
 to neither, and the rival clip cannot save it: cutting the window at the other

--- a/scripts/check-sound-group.sh
+++ b/scripts/check-sound-group.sh
@@ -313,6 +313,46 @@ print(len([u for u in d.get("Sarah", []) if not u.get("counter")]))
 check "the blocked sentence is not written from the pill either" \
   "blocked Eric Erik" "$(pick Eric Erik "$BOTH")"
 
+# A correction onto a name the vocabulary has never seen. It is not an ordinary
+# word, so it is not a counter: the rendering is written, the term is created
+# with the kind the tagger read, and the sentence is a use of it. Measured on
+# decoded audio, 2026-09-10 — five sentences about a third person had become
+# five counters under the second, and the pooled plain centre then scored 0.945
+# on a sentence that was hers.
+rm -f "$USES"
+cat > "$WORK/vocabulary.yaml" <<'YAML'
+terms:
+  Ana:
+    kind: person
+    pronunciations:
+      - heard: Anna
+  Anna:
+    kind: person
+  Vercel:
+    pronunciations:
+      - heard: Versal
+YAML
+check "a correction onto a new name learns it" "learn Annah person heard Anna" \
+  "$("$BIN" --correction Anna Annah --in "Annah booked the dentist." 2>/dev/null)"
+check "written with its kind and the rendering it replaced" "person Anna" "$(python3 -c '
+import sys, yaml
+term = yaml.safe_load(open(sys.argv[1]))["terms"]["Annah"] or {}
+heard = [p["heard"] if isinstance(p, dict) else p
+         for p in (term.get("pronunciations") or [])]
+print(term.get("kind", "—"), " ".join(heard))
+' "$WORK/vocabulary.yaml" 2>/dev/null)"
+check "the sentence is a use of the new name" 1 "$(python3 -c '
+import sys, yaml
+d = yaml.safe_load(open(sys.argv[1]))["terms"]
+print(len([u for u in d.get("Annah", []) if not u.get("counter")]))
+' "$USES" 2>/dev/null)"
+check "with no counter anywhere" 0 "$(counters)"
+check "and the new name joins the group" "Ana Anna Annah" "$(members Anna)"
+check "the rendering it was learnt with is not a rule" "none" "$(rule Anna)"
+check "an ordinary word put back is still a counter" \
+  'counter Vercel "Versailles"' \
+  "$("$BIN" --correction Vercel Versailles --in "The Versailles gardens." 2>/dev/null)"
+
 echo
 printf '  %d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/scripts/check-sound-group.sh
+++ b/scripts/check-sound-group.sh
@@ -201,16 +201,18 @@ check "a possessive is read as its name" "names" "$(place "Eric's" Erik)"
 # joins dictations with no space after the stop, so one field holds several
 # sentences and the same name more than once. Measured on the live app,
 # 2026-09-10: the second correction wrote nothing at all.
-FIELD='Eric is software engineer.Erik is a musician.Erik plays the piano.'
+FIELD='❯ Eric is software engineer.Erik is a musician.Erik plays the piano.'
 rm -f "$USES"
 "$BIN" --for Erik "$FIELD" Erik >/dev/null 2>&1
 check "with nothing to say which, the first occurrence is stored" \
   "Erik is a musician." "$(stored 0)"
-"$BIN" --for Erik "$FIELD" Erik --near 7 >/dev/null 2>&1
+# 6, the way `EditWatch` counts: the shell prompt in front of the line is not
+# a word, and the periods glue the sentences into single words.
+"$BIN" --for Erik "$FIELD" Erik --near 6 >/dev/null 2>&1
 check "the position picks the sentence that was corrected" \
   "Erik plays the piano." "$(stored 1)"
 check "and both rows are there" 2 "$(said)"
-"$BIN" --for Erik "$FIELD" Erik --near 7 >/dev/null 2>&1
+"$BIN" --for Erik "$FIELD" Erik --near 6 >/dev/null 2>&1
 check "the same row again is still one row" 2 "$(said)"
 
 echo

--- a/scripts/check-sound-group.sh
+++ b/scripts/check-sound-group.sh
@@ -124,6 +124,12 @@ rows () { "$BIN" --correction "$1" "$2" --in "$3" 2>/dev/null; }
 USES="$WORK/vocabulary-uses.yaml"
 counters () { [ -f "$USES" ] || { echo 0; return; }; grep -c '^      counter: true' "$USES"; }
 said () { [ -f "$USES" ] || { echo 0; return; }; grep -c '^    - said:' "$USES"; }
+# The nth stored sentence of the file, whichever term it is under.
+stored () { python3 -c '
+import sys, yaml
+rows = [r for term in yaml.safe_load(open(sys.argv[1]))["terms"].values() for r in term]
+print(rows[int(sys.argv[2])]["said"])
+' "$USES" "$1" 2>/dev/null; }
 
 check "a term put back over another is a use of the one you typed" \
   'use Mick "Mick" heard Mik' "$(rows Mik Mick "Mick is adjusting the piano.")"
@@ -165,6 +171,47 @@ check "something else writes what was heard" \
 check "and it records nothing" "Mick nothing" "$(pick 2 --taught)"
 check "where taking the other reading records" "mixed bend teaches" "$(pick 1 --taught)"
 check "and keeping what stands there records too" "Mick teaches" "$(pick 0 --taught)"
+
+# One name against another. The slot test cannot read such a place — the heard
+# word is in the tokenizer and the term never is — so it must not be asked.
+# Measured on the live app: `Eric` against `Erik` refused at -0.254, -0.253 and
+# -0.257 in three different sentences.
+cat > "$WORK/vocabulary.yaml" <<'YAML'
+terms:
+  Erik:
+    kind: person
+    pronunciations:
+      - heard: Eric
+  Vercel:
+    pronunciations:
+      - heard: Versal
+  Ghostty:
+    pronunciations:
+      - heard: Ghosty
+YAML
+place () { "$BIN" --name-place "$1" "$2" 2>/dev/null; }
+check "a rendering of a term is a name against a name" "names" "$(place Eric Erik)"
+check "kind: person on the term says so on its own" "names" "$(place zzarq Erik)"
+check "a name the tagger knows counts on its own" "names" "$(place Sarah Ghostty)"
+check "an ordinary word against a term is not" "ordinary" "$(place versus Vercel)"
+check "nor is a rare word the lists have never seen" "ordinary" "$(place superbase Ghostty)"
+check "a possessive is read as its name" "names" "$(place "Eric's" Erik)"
+
+# The occurrence that was corrected, not the first copy of the word. A terminal
+# joins dictations with no space after the stop, so one field holds several
+# sentences and the same name more than once. Measured on the live app,
+# 2026-09-10: the second correction wrote nothing at all.
+FIELD='Eric is software engineer.Erik is a musician.Erik plays the piano.'
+rm -f "$USES"
+"$BIN" --for Erik "$FIELD" Erik >/dev/null 2>&1
+check "with nothing to say which, the first occurrence is stored" \
+  "Erik is a musician." "$(stored 0)"
+"$BIN" --for Erik "$FIELD" Erik --near 7 >/dev/null 2>&1
+check "the position picks the sentence that was corrected" \
+  "Erik plays the piano." "$(stored 1)"
+check "and both rows are there" 2 "$(said)"
+"$BIN" --for Erik "$FIELD" Erik --near 7 >/dev/null 2>&1
+check "the same row again is still one row" 2 "$(said)"
 
 echo
 printf '  %d passed, %d failed\n' "$pass" "$fail"

--- a/scripts/check-sound-group.sh
+++ b/scripts/check-sound-group.sh
@@ -365,6 +365,64 @@ check "an ordinary word put back is still a counter" \
   'counter Vercel "Versailles"' \
   "$("$BIN" --correction Vercel Versailles --in "The Versailles gardens." 2>/dev/null)"
 
+# One sentence, one owner. Two members of a group both holding the same
+# sentence at the same place pull their centres toward each other: the pill
+# records "Eric has a new piano." under Eric, the correction that follows
+# records "Erik has a new piano." under Erik, and the first row stays.
+cat > "$WORK/vocabulary.yaml" <<'YAML'
+terms:
+  Erik:
+    kind: person
+    pronunciations:
+      - heard: Eric
+  Eric:
+    kind: person
+  Vercel:
+    pronunciations:
+      - heard: Versal
+YAML
+# The terms that still hold a row, and how many rows there are in all.
+owners () { python3 -c '
+import sys, yaml
+d = (yaml.safe_load(open(sys.argv[1])) or {}).get("terms") or {}
+print(" ".join(sorted(t for t, rows in d.items() if rows)))
+' "$USES" 2>/dev/null; }
+
+rm -f "$USES"
+"$BIN" --picked Eric Erik --in "Eric has a new piano." >/dev/null 2>&1
+"$BIN" --correction Eric Erik --in "Erik has a new piano." >/dev/null 2>&1
+check "the member you correct to takes the place from the other" "Erik" "$(owners)"
+check "and one row is left" 1 "$(said)"
+
+rm -f "$USES"
+"$BIN" --correction Eric Erik --in "Erik has a new piano." >/dev/null 2>&1
+"$BIN" --picked Eric Erik --in "Eric has a new piano." >/dev/null 2>&1
+check "and it works the other way round" "Eric" "$(owners)"
+check "with one row again" 1 "$(said)"
+
+# Whatever polarity: a counter under one member is a claim on the place too,
+# and the pooled plain centre is built from it.
+rm -f "$USES"
+cat > "$USES" <<'YAML'
+terms:
+  "Erik":
+    - said: "Eric has a new piano."
+      span: "Eric"
+      from: correction
+      counter: true
+YAML
+"$BIN" --picked Eric Erik --in "Eric has a new piano." >/dev/null 2>&1
+check "a counter at the place goes when another member takes it" "Eric" "$(owners)"
+check "leaving one row" 1 "$(said)"
+check "and no counter" 0 "$(counters)"
+
+rm -f "$USES"
+"$BIN" --picked Eric Erik --in "Eric is a software engineer." >/dev/null 2>&1
+"$BIN" --correction Eric Erik --in "Erik has a new piano." >/dev/null 2>&1
+check "a different sentence under the other member is left alone" \
+  "Eric Erik" "$(owners)"
+check "and both rows are kept" 2 "$(said)"
+
 echo
 printf '  %d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/scripts/check-sound-group.sh
+++ b/scripts/check-sound-group.sh
@@ -198,6 +198,10 @@ check "something else writes what was heard" \
 check "and it records nothing" "Mick nothing" "$(pick 2 --taught)"
 check "where taking the other reading records" "mixed bend teaches" "$(pick 1 --taught)"
 check "and keeping what stands there records too" "Mick teaches" "$(pick 0 --taught)"
+# A row past "something else" was never offered. Taken as given, the answer
+# kept what stands there and was recorded as teaching.
+pick 3 >/dev/null 2>&1
+check "a row the place never offered is a usage error" 2 "$?"
 
 # One name against another. The slot test cannot read such a place — the heard
 # word is in the tokenizer and the term never is — so it must not be asked.
@@ -245,6 +249,8 @@ check "the position picks the sentence that was corrected" \
 check "and both rows are there" 2 "$(said)"
 "$BIN" --for Erik "$FIELD" Erik --near 6 >/dev/null 2>&1
 check "the same row again is still one row" 2 "$(said)"
+"$BIN" --for Erik "$FIELD" Erik --near abc >/dev/null 2>&1
+check "--near without a number is a usage error" 2 "$?"
 
 # A member nobody has ever confirmed — zero uses, and nothing else — is
 # unknown, not out. It cannot lose a comparison it was never in, so the place

--- a/scripts/check-sound-group.sh
+++ b/scripts/check-sound-group.sh
@@ -219,6 +219,68 @@ check "and both rows are there" 2 "$(said)"
 "$BIN" --for Erik "$FIELD" Erik --near 6 >/dev/null 2>&1
 check "the same row again is still one row" 2 "$(said)"
 
+# A member nobody has ever confirmed is unknown, not out. It cannot lose a
+# comparison it was never in, so the place is open and the pill lists it —
+# which is the only way that member gets a first sentence.
+check "a member with no uses opens the place" \
+  "open Erik Eric" "$(verdict Erik:0.898:0.80 Eric:-:-:0 --plain 0.600)"
+check "and it is listed after the ones that stand" \
+  "open Erik Eric" "$(verdict Eric:-:-:0 Erik:0.898:0.80 --plain 0.600)"
+check "once every member has a use, the rule runs as before" \
+  "write Erik" "$(verdict Erik:0.898:0.80 Eric:0.600:-:1 --plain 0.600)"
+check "a member with a use but no portrait is out, not unknown" \
+  "write Erik" "$(verdict Erik:0.898:0.80 Eric:-:-:1 --plain 0.600)"
+
+# A sentence naming two members of one group belongs to neither. The rival clip
+# cuts the window at the other name and what is left is still the sentence:
+# "Erik the musician and Eric the software engineer" was kept as a counter
+# under Erik on 2026-09-10, and every later "Eric the musician" was refused.
+cat > "$WORK/vocabulary.yaml" <<'YAML'
+terms:
+  Erik:
+    kind: person
+    pronunciations:
+      - heard: Eric
+  Eric:
+    kind: person
+  Vercel:
+    pronunciations:
+      - heard: Versal
+YAML
+rm -f "$USES"
+BOTH='So I tried again with Erik the musician and Eric the software engineer.'
+check "a sentence naming two members is recorded nowhere" \
+  "blocked Eric Erik" "$("$BIN" --correction Erik Eric --in "$BOTH" 2>/dev/null)"
+check "and no row is written" 0 "$(said)"
+check "one member standing is recorded as before" \
+  'use Eric "Eric" heard Erik' \
+  "$("$BIN" --correction Erik Eric --in "Eric is reviewing my pull request." 2>/dev/null)"
+check "which does write a row" 1 "$(said)"
+
+# Picking a name on the pill. Every person is a term; plain is for ordinary
+# words. A person the recogniser spells right is never corrected, so the pill
+# is the only place their term can be created.
+rm -f "$USES"
+pick () { "$BIN" --picked "$1" "$2" --in "$3" 2>/dev/null; }
+check "a word that is already a term is a use of it" \
+  "use Eric" "$(pick Eric Erik "Eric is a software engineer.")"
+check "an ordinary word is still a counter" \
+  "counter Vercel" "$(pick versus Vercel "It is versus the other one.")"
+check "a name with no term yet is written as a person" \
+  "create Sarah" "$(pick Sarah Erik "Sarah is on the call.")"
+check "with kind: person and no pronunciation" "person none" "$(python3 -c '
+import sys, yaml
+term = yaml.safe_load(open(sys.argv[1]))["terms"]["Sarah"] or {}
+print(term.get("kind", "—"), len(term.get("pronunciations") or []) or "none")
+' "$WORK/vocabulary.yaml" 2>/dev/null)"
+check "and the sentence is a use of the new term" 1 "$(python3 -c '
+import sys, yaml
+d = yaml.safe_load(open(sys.argv[1]))["terms"]
+print(len([u for u in d.get("Sarah", []) if not u.get("counter")]))
+' "$USES" 2>/dev/null)"
+check "the blocked sentence is not written from the pill either" \
+  "blocked Eric Erik" "$(pick Eric Erik "$BOTH")"
+
 echo
 printf '  %d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/scripts/check-sound-group.sh
+++ b/scripts/check-sound-group.sh
@@ -195,6 +195,10 @@ check "kind: person on the term says so on its own" "names" "$(place zzarq Erik)
 check "a name the tagger knows counts on its own" "names" "$(place Sarah Ghostty)"
 check "an ordinary word against a term is not" "ordinary" "$(place versus Vercel)"
 check "nor is a rare word the lists have never seen" "ordinary" "$(place superbase Ghostty)"
+# A sentence opens with a capital, and the frame the tagger reads must not turn
+# every capitalised word into a name. `Price` and `Match` are surnames as well.
+check "a capital at the start of a sentence is not a name" "ordinary" "$(place Cancel Vercel)"
+check "nor is a word that is also a surname" "ordinary" "$(place Price Ghostty)"
 check "a possessive is read as its name" "names" "$(place "Eric's" Erik)"
 
 # The occurrence that was corrected, not the first copy of the word. A terminal

--- a/scripts/check-sound-group.sh
+++ b/scripts/check-sound-group.sh
@@ -102,6 +102,23 @@ check "a rendering two terms share is no longer a rule" "none" "$(rule meek)"
 check "a rendering nobody else claims is still a rule" "Vercel" "$(rule Versal)"
 check "and so is one whose term is a group of one" "Praisy" "$(rule Prezi)"
 
+# Two spellings of one rendering under one term are two renderings of it, not
+# two terms claiming it. Counted as two owners, the word opened no group — a
+# group of one is not a group — and stopped being a rule as well.
+cat > "$WORK/vocabulary-owners.yaml" <<'YAML'
+terms:
+  Vercel:
+    pronunciations:
+      - heard: Versal
+      - heard: versal
+YAML
+cp "$WORK/vocabulary.yaml" "$WORK/vocabulary-kept.yaml"
+cp "$WORK/vocabulary-owners.yaml" "$WORK/vocabulary.yaml"
+check "one term with two spellings of a rendering keeps its rule" \
+  "Vercel" "$(rule Versal)"
+check "and the rendering opens no group" "Vercel" "$(members Versal)"
+cp "$WORK/vocabulary-kept.yaml" "$WORK/vocabulary.yaml"
+
 # The decision rule, on scores nobody measured. A floor of - is a member with
 # too few uses to have one.
 verdict () { "$BIN" --group-decide "$@" 2>/dev/null | tail -1; }
@@ -277,6 +294,17 @@ BOTH='So I tried again with Erik the musician and Eric the software engineer.'
 check "a sentence naming two members is recorded nowhere" \
   "blocked Eric Erik" "$("$BIN" --correction Erik Eric --in "$BOTH" 2>/dev/null)"
 check "and no row is written" 0 "$(said)"
+# The sentence the row is recorded in, not the whole field. A terminal joins
+# every dictation since the last Return, so a field naming both members can
+# still hold a sentence that names one.
+FIELD_BOTH='Erik presented first. Eric plays cello.'
+rm -f "$USES"
+check "a field of two sentences is blocked only by the one recorded" \
+  'use Eric "Eric" heard Erik' \
+  "$("$BIN" --correction Erik Eric --in "$FIELD_BOTH" 2>/dev/null)"
+check "and the row is the sentence naming one member" "Eric plays cello." "$(stored 0)"
+rm -f "$USES"
+
 check "one member standing is recorded as before" \
   'use Eric "Eric" heard Erik' \
   "$("$BIN" --correction Erik Eric --in "Eric is reviewing my pull request." 2>/dev/null)"

--- a/scripts/check-sound-group.sh
+++ b/scripts/check-sound-group.sh
@@ -109,8 +109,14 @@ check "a member with no floor is never out on that ground" \
   "write Mick" "$(verdict Mik:0.10:0.80 Mick:0.20:-)"
 check "plain winning keeps what was heard" \
   "keep" "$(verdict Mik:0.70:0.60 Mick:0.65:- --plain 0.90)"
-check "nobody standing keeps what was heard" \
-  "keep" "$(verdict Mik:0.70:0.80 Mick:0.65:0.90)"
+# Nobody standing is the ordinary word winning, so it needs an ordinary word to
+# win: with a plain centre, keeping is a decision; without one it is a guess,
+# and the place is a question. Measured on decoded audio, 2026-09-10 — see
+# SoundGroup.decide.
+check "nobody standing lets plain keep what was heard" \
+  "keep" "$(verdict Mik:0.70:0.80 Mick:0.65:0.90 --plain 0.50)"
+check "nobody standing and no plain opens the place, best first" \
+  "open Mik Mick" "$(verdict Mik:0.70:0.80 Mick:0.65:0.90)"
 check "two standing and no lead opens the place" \
   "open Mik Mick" "$(verdict Mik:0.900:0.80 Mick:0.895:- --plain 0.70)"
 check "a member tying with plain opens it as well" \
@@ -228,8 +234,15 @@ check "and it is listed after the ones that stand" \
   "open Erik Eric" "$(verdict Eric:-:-:0 Erik:0.898:0.80 --plain 0.600)"
 check "once every member has a use, the rule runs as before" \
   "write Erik" "$(verdict Erik:0.898:0.80 Eric:0.600:-:1 --plain 0.600)"
-check "a member with a use but no portrait is out, not unknown" \
-  "write Erik" "$(verdict Erik:0.898:0.80 Eric:-:-:1 --plain 0.600)"
+# A use is not a portrait. A term needs a counter or three uses before it has
+# one, and until then nothing can be said about it — which is a question, not a
+# loss. Measured on decoded audio, 2026-09-10: with two members and no portrait
+# between them, reading "nobody stands" as a decision kept the heard word on
+# every sentence and the pill was never asked.
+check "a member with a use but no portrait is unknown too" \
+  "open Erik Eric" "$(verdict Erik:0.898:0.80 Eric:-:-:1 --plain 0.600)"
+check "and a place where nothing can be scored is open, not kept" \
+  "open Erik Eric" "$(verdict Erik:-:-:2 Eric:-:-:1)"
 
 # A sentence naming two members of one group belongs to neither. The rival clip
 # cuts the window at the other name and what is left is still the sentence:

--- a/scripts/check-sound-group.sh
+++ b/scripts/check-sound-group.sh
@@ -262,17 +262,36 @@ check "which does write a row" 1 "$(said)"
 # is the only place their term can be created.
 rm -f "$USES"
 pick () { "$BIN" --picked "$1" "$2" --in "$3" 2>/dev/null; }
+# What a created term says about itself: its kind, and that it has no
+# pronunciation — nothing was misheard, so there is nothing to record.
+kindOf () { python3 -c '
+import sys, yaml
+term = yaml.safe_load(open(sys.argv[1]))["terms"].get(sys.argv[2]) or {}
+print(term.get("kind", "—"), len(term.get("pronunciations") or []) or "none")
+' "$WORK/vocabulary.yaml" "$1" 2>/dev/null; }
 check "a word that is already a term is a use of it" \
   "use Eric" "$(pick Eric Erik "Eric is a software engineer.")"
 check "an ordinary word is still a counter" \
   "counter Vercel" "$(pick versus Vercel "It is versus the other one.")"
 check "a name with no term yet is written as a person" \
-  "create Sarah" "$(pick Sarah Erik "Sarah is on the call.")"
-check "with kind: person and no pronunciation" "person none" "$(python3 -c '
-import sys, yaml
-term = yaml.safe_load(open(sys.argv[1]))["terms"]["Sarah"] or {}
-print(term.get("kind", "—"), len(term.get("pronunciations") or []) or "none")
-' "$WORK/vocabulary.yaml" 2>/dev/null)"
+  "create Sarah person" "$(pick Sarah Erik "Sarah is on the call.")"
+check "with kind: person and no pronunciation" "person none" "$(kindOf Sarah)"
+# The kind the tagger read, not the kind the branch was reached by. A place or
+# an organization is a term too, and labelling it `person` would put a guess in
+# the file where a fact belongs.
+check "a place is written as a place" \
+  "create Versailles place" "$(pick Versailles Erik "Versailles was closed.")"
+check "with kind: place and no pronunciation" "place none" "$(kindOf Versailles)"
+check "an organization is written as one" \
+  "create Microsoft organization" "$(pick Microsoft Erik "Microsoft shipped it.")"
+check "with kind: organization and no pronunciation" "organization none" \
+  "$(kindOf Microsoft)"
+# The fallback, and only where the tagger says nothing: a term that names a
+# person was proposed over the word, so a person is the only kind on offer.
+check "a word the tagger cannot read is a person under a person's term" \
+  "create Zorbek person" "$(pick Zorbek Erik "Zorbek is on the call.")"
+check "and an ordinary word under an ordinary term is still a counter" \
+  "counter Vercel" "$(pick Kliffax Vercel "Kliffax is on the call.")"
 check "and the sentence is a use of the new term" 1 "$(python3 -c '
 import sys, yaml
 d = yaml.safe_load(open(sys.argv[1]))["terms"]

--- a/scripts/check-sound-group.sh
+++ b/scripts/check-sound-group.sh
@@ -3,6 +3,10 @@
 #
 #   scripts/check-sound-group.sh
 #
+# The model-backed half — that a member has a centre from its first use — is
+# `--portrait <heard> "<sentence>"`, which needs the 400 MB word vectors. What
+# is scored here is the rule that reads those numbers.
+#
 # Three things, none of them needing a model. Which terms end up in one group
 # (`--sound-group`), what the decision rule does with scores somebody wrote
 # down (`--group-decide`), and what a correction that runs against a term
@@ -225,23 +229,31 @@ check "and both rows are there" 2 "$(said)"
 "$BIN" --for Erik "$FIELD" Erik --near 6 >/dev/null 2>&1
 check "the same row again is still one row" 2 "$(said)"
 
-# A member nobody has ever confirmed is unknown, not out. It cannot lose a
-# comparison it was never in, so the place is open and the pill lists it —
-# which is the only way that member gets a first sentence.
+# A member nobody has ever confirmed — zero uses, and nothing else — is
+# unknown, not out. It cannot lose a comparison it was never in, so the place
+# is open and the pill lists it, which is the only way that member gets a first
+# sentence.
 check "a member with no uses opens the place" \
   "open Erik Eric" "$(verdict Erik:0.898:0.80 Eric:-:-:0 --plain 0.600)"
 check "and it is listed after the ones that stand" \
   "open Erik Eric" "$(verdict Eric:-:-:0 Erik:0.898:0.80 --plain 0.600)"
 check "once every member has a use, the rule runs as before" \
   "write Erik" "$(verdict Erik:0.898:0.80 Eric:0.600:-:1 --plain 0.600)"
-# A use is not a portrait. A term needs a counter or three uses before it has
-# one, and until then nothing can be said about it — which is a question, not a
-# loss. Measured on decoded audio, 2026-09-10: with two members and no portrait
-# between them, reading "nobody stands" as a decision kept the heard word on
-# every sentence and the pill was never asked.
-check "a member with a use but no portrait is unknown too" \
-  "open Erik Eric" "$(verdict Erik:0.898:0.80 Eric:-:-:1 --plain 0.600)"
-check "and a place where nothing can be scored is open, not kept" \
+# One sentence is enough to take part. A group member is scored against the
+# other members, not against a fixed floor, so it has a centre from its first
+# use and can lose the comparison — and a floor, which needs three uses to read
+# off, is the only thing it cannot be out on before then.
+#
+# Measured on the live app, 2026-09-10: `Eric` at two uses had no centre at
+# all, so the pill asked nine times in a row and would have gone on asking
+# until both names reached three.
+check "one use is enough to lose the comparison" \
+  "write Erik" "$(verdict Erik:0.936:0.724 Eric:0.708:-:1)"
+check "and enough to win it" \
+  "write Eric" "$(verdict Erik:0.816:0.724 Eric:0.945:-:2)"
+check "a member with uses but no centre is out, not unknown" \
+  "write Erik" "$(verdict Erik:0.898:0.80 Eric:-:-:1 --plain 0.600)"
+check "and a place where nothing can be scored at all is open, not kept" \
   "open Erik Eric" "$(verdict Erik:-:-:2 Eric:-:-:1)"
 
 # A sentence naming two members of one group belongs to neither. The rival clip

--- a/scripts/check-sound-group.sh
+++ b/scripts/check-sound-group.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Several names, one sound: the group, the decision and what it records.
+#
+#   scripts/check-sound-group.sh
+#
+# Three things, none of them needing a model. Which terms end up in one group
+# (`--sound-group`), what the decision rule does with scores somebody wrote
+# down (`--group-decide`), and what a correction that runs against a term
+# writes (`--correction`). The whole thing with the portraits behind it is
+# `--portrait <heard> "<sentence>"`, which needs the 400 MB word vectors.
+#
+# Runs against a scratch PARROTFLOW_CONFIG_DIR, so it says nothing about the
+# vocabulary on this machine and writes nothing to it.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN=""
+for candidate in "$ROOT/.build/release/ParrotFlow" "$ROOT/.build/debug/ParrotFlow"; do
+  [ -x "$candidate" ] || continue
+  if [ -z "$BIN" ] || [ "$candidate" -nt "$BIN" ]; then BIN="$candidate"; fi
+done
+[ -n "$BIN" ] || { echo "build first: swift build"; exit 1; }
+
+WORK="$(mktemp -d -t parrotflow-sound-group)"
+trap 'rm -rf "$WORK"' EXIT
+export PARROTFLOW_CONFIG_DIR="$WORK"
+pass=0; fail=0
+
+check () {
+  local what="$1" want="$2" got="$3"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1)); printf '  ✓ %s\n' "$what"
+  else
+    fail=$((fail + 1)); printf '  ✗ %s: got "%s", expected "%s"\n' "$what" "$got" "$want"
+  fi
+}
+
+# Mik and Mick link through a rendering that is the other's spelling. Mic joins
+# through a rendering both claim, which is what makes the links transitive.
+# Vercel shares its sound with nothing and is a group of one.
+cat > "$WORK/vocabulary.yaml" <<'YAML'
+terms:
+  Mik:
+    pronunciations:
+      - heard: Mick
+  Mick:
+    pronunciations:
+      - heard: meek
+  Mic:
+    pronunciations:
+      - heard: meek
+  Vercel:
+    pronunciations:
+      - heard: Versal
+  Praisy:
+    pronunciations:
+      - heard: Prezi
+YAML
+
+members () { "$BIN" --sound-group "$1" 2>/dev/null | awk '$1 == "members" { $1 = ""; print substr($0, 2) }'; }
+
+check "a rendering that is another term's spelling links the two" \
+  "Mic Mick Mik" "$(members Mik)"
+check "a shared rendering links them too, and the links are transitive" \
+  "Mic Mick Mik" "$(members meek)"
+check "the heard word opens the group whichever member wrote it down" \
+  "Mic Mick Mik" "$(members Mick)"
+check "a term nothing sounds like is a group of one" "Vercel" "$(members Versal)"
+check "and so is a term whose rendering nobody shares" "Praisy" "$(members Prezi)"
+check "a word in no vocabulary opens nothing" "" "$(members zebra)"
+
+# A counter row whose span is another term's spelling is the third link. It is
+# written here through the shipped command rather than by hand.
+cat > "$WORK/vocabulary-uses.yaml" <<'YAML'
+terms:
+  "Praisy":
+    - said: "The Prezi deck is done."
+      span: "Prezi"
+      from: correction
+      counter: true
+YAML
+check "a counter span that is not a term links nothing" "Praisy" "$(members Praisy)"
+cat > "$WORK/vocabulary-uses.yaml" <<'YAML'
+terms:
+  "Vercel":
+    - said: "Praisy reviewed the deploy."
+      span: "Praisy"
+      from: correction
+      counter: true
+YAML
+check "a counter span that is a term links the two" "Praisy Vercel" "$(members Vercel)"
+rm -f "$WORK/vocabulary-uses.yaml"
+
+# The rules. A rendering that opens a group is not a substitution any more.
+rule () { "$BIN" --sound-group "$1" 2>/dev/null | awk '$1 == "rule" { print $2 }'; }
+check "a rendering that is another term's spelling is no longer a rule" \
+  "none" "$(rule Mick)"
+check "a rendering two terms share is no longer a rule" "none" "$(rule meek)"
+check "a rendering nobody else claims is still a rule" "Vercel" "$(rule Versal)"
+check "and so is one whose term is a group of one" "Praisy" "$(rule Prezi)"
+
+# The decision rule, on scores nobody measured. A floor of - is a member with
+# too few uses to have one.
+verdict () { "$BIN" --group-decide "$@" 2>/dev/null | tail -1; }
+check "the best member wins when it leads by more than the band" \
+  "write Mik" "$(verdict Mik:0.90:0.80 Mick:0.86:- --plain 0.70)"
+check "a member below its own floor is out, and the next one wins" \
+  "write Mick" "$(verdict Mik:0.79:0.80 Mick:0.86:- --plain 0.70)"
+check "a member with no floor is never out on that ground" \
+  "write Mick" "$(verdict Mik:0.10:0.80 Mick:0.20:-)"
+check "plain winning keeps what was heard" \
+  "keep" "$(verdict Mik:0.70:0.60 Mick:0.65:- --plain 0.90)"
+check "nobody standing keeps what was heard" \
+  "keep" "$(verdict Mik:0.70:0.80 Mick:0.65:0.90)"
+check "two standing and no lead opens the place" \
+  "open Mik Mick" "$(verdict Mik:0.900:0.80 Mick:0.895:- --plain 0.70)"
+check "a member tying with plain opens it as well" \
+  "open Mik" "$(verdict Mik:0.900:0.80 --plain 0.895)"
+check "a lead under the band decides nothing" \
+  "open Mik Mick" "$(verdict Mik:0.900:0.80 Mick:0.892:0.80)"
+
+# What a correction against a term writes. The rows are printed and the file is
+# read back, so this is the write and not a description of it.
+rows () { "$BIN" --correction "$1" "$2" --in "$3" 2>/dev/null; }
+USES="$WORK/vocabulary-uses.yaml"
+counters () { [ -f "$USES" ] || { echo 0; return; }; grep -c '^      counter: true' "$USES"; }
+said () { [ -f "$USES" ] || { echo 0; return; }; grep -c '^    - said:' "$USES"; }
+
+check "a term put back over another is a use of the one you typed" \
+  'use Mick "Mick" heard Mik' "$(rows Mik Mick "Mick is adjusting the piano.")"
+check "and one row is written" 1 "$(said)"
+check "with no counter under the term that lost" 0 "$(counters)"
+check "under the term you typed" 1 "$(python3 -c '
+import sys, yaml
+d = yaml.safe_load(open(sys.argv[1]))["terms"]
+print(len(d.get("Mick", [])))
+' "$USES" 2>/dev/null)"
+check "carrying the spelling it replaced" 1 \
+  "$(grep -c '^      heard: "\?Mik"\?$' "$USES")"
+
+rm -f "$USES"
+check "an ordinary word put back is a counter, as it always was" \
+  'counter Vercel "Versailles"' "$(rows Vercel Versailles "I love visiting the Versailles Castle.")"
+check "and it is the only row" 1 "$(said)"
+check "marked as a counter" 1 "$(counters)"
+
+rm -f "$USES"
+check "a word that was never a term writes nothing" \
+  "nothing: praise is not a term, or the two are the same term" \
+  "$(rows praise Praisy "Praisy reviewed the parser.")"
+check "and the file is not created" 0 "$(said)"
+
+check "the same term on both sides writes nothing" \
+  "nothing: Mick is not a term, or the two are the same term" \
+  "$(rows Mick "Mick's" "Mick's piano is out of tune.")"
+
+# "Something else" is the row past the last reading. It writes what was heard
+# and teaches nothing, so the correction that follows is an ordinary one.
+#
+# Nothing here wrote a term over the span — `--selector` builds every place
+# that way — so what was heard is also what stands, and this answer and 0 type
+# the same characters. What separates them is the row nobody writes.
+pick () { "$BIN" --selector "can you ask Mick to review it." "Mick|mixed bend|3|$1" "${@:2}" 2>/dev/null; }
+check "something else writes what was heard" \
+  "can you ask Mick to review it." "$(pick 2)"
+check "and it records nothing" "Mick nothing" "$(pick 2 --taught)"
+check "where taking the other reading records" "mixed bend teaches" "$(pick 1 --taught)"
+check "and keeping what stands there records too" "Mick teaches" "$(pick 0 --taught)"
+
+echo
+printf '  %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Two people whose names sound the same, Mik and Mick or Eric and Erik, are now two terms with two portraits, and the sentence decides between them. Before, one term owned the sound: its `heard:` rendering rewrote every "Mick" to "Mik", and the rival lived only as a counter-example inside the owner's portrait. Terms that share a sound are read as a group, derived from the files as they are, with no new field. A member scores from its first recorded sentence. When the two are too close to call, the pill asks: the members, then "something else". Reviewers should start with `SoundGroup.swift` and the group branch of `SentenceGate.swift`, then `CorrectionRecording.swift`, which is now the one path every recording goes through.

<details>
<summary>Why the old model could not do name against name</summary>

The vocabulary had one term per sound. Mik carried `heard: Mick`, which is a substitution rule, so "Mick" was rewritten before anything read the sentence. The only thing that could undo it was Mik's portrait, where Mick existed as a counter-example. On "Mick is adjusting the piano" the portrait scored 0.886 against 0.874, band 0.01, and wrote Mik. Mick had no portrait of his own and no way to get one.

The slot test made it worse. Eric is in the tokenizer, Erik is not, so the slot refused Erik on every sentence with a gap near -0.25 whatever the words around it. That settled the place before the portrait or the pill could act.

A sentence naming both people was recorded twice, as a use of one and a counter of the other, and poisoned both portraits. The sound score (edit distance over IPA) reads Ana/Anna at 0.67 and Anna/Hanna at 0.43, so it cannot say who is confusable with whom. The `heard:` rows can, because they record what the speaker's voice actually produced.

</details>

<details>
<summary>What the group does</summary>

- Two terms join when one's spelling is the other's `heard:` rendering, when they share a rendering, or when a counter span under one is the other's spelling. Transitive. A group of one runs the old path unchanged.
- A `heard:` that is another term's spelling is no longer a substitution rule. It opens the group.
- Every member is scored against its own centre over its own tightness. A member has a centre from its first use. The leave-one-out floor needs three uses and does not apply below that. "Plain", the ordinary-word member, is the pooled counter rows.
- Best member over second best by the band writes. Inside the band the pill asks. A member with zero uses is unknown and keeps the place open. Nobody standing keeps the heard word only when plain has a centre; otherwise the place opens.
- The slot test stands aside when the heard word and the term are both names (`NamePlace`).
- Recording: a word put back or picked that is a term is a use of that term with `heard:` set. An ordinary word is a counter. A name picked on the pill that is not a term yet becomes one, with the kind the tagger read. A correction onto a name with no term creates it. A sentence naming two members is recorded nowhere. A place has one owner: recording it under one member releases it from the others.
- `--portrait <heard> "<sentence>"` prints the group, each member's score, floor and standing, plain, and the verdict. `--correction`, `--picked`, `--group-decide` and `--name-place` expose the rules from the terminal.

</details>

<details>
<summary>Measurements: benches unchanged, arcs from 8 and 11 questions to 3</summary>

`scripts/check-counter-portrait.sh` on `tests/portrait-cases.tsv`, before and after every commit: comparison arm 20 right, 0 wrong, 0 quiet held-out; 23/1/0 over all 24. Floor arm 17/2/1 and 19/4/1. `scripts/check-slot-gate.sh` on `tests/judge-cases.yaml`: 50 scored, 12 applied, 15 declined, 23 open, 0 wrong. `scripts/check-sound-group.sh` is new, 87 cases, no model. `make test` passes.

Two decoder runs with clips made by `say`, decoded by Parakeet, run through the vocabulary stage with the gate live, in a private config directory:

| run | decoder wrote | questions before first silent write | held-out |
|---|---|---|---|
| Eric musician, Erik developer, 12 clips | "Eric" 12/12 | 3, was 8 and never | 3/3 right |
| Ana finance, Anna engineering, Annah home, 18 clips | "Anna" 18/18 | 3 + 3 + 1 hand correction, was 11 | 3/3 right |

</details>

<details>
<summary>Tried and rejected: three other scalings for a thin member</summary>

A one-use member has tightness 1.0, the largest, so it looked penalised against a broad member. Four arms were scored on the 26 recorded decisions of both runs: own tightness (ships), the group's largest, the group's smallest, and raw cosine. All four gave 6/0/2 on the Eric run; raw gave 17/0/1 on the Ana run against 18/0/0 for the rest. None fixed the one thin case ("Anna deployed the new release" with Anna at one use against Ana at five): one pull-request sentence is genuinely further from a deploy than five finance sentences. The fix there is a second sentence, which the pill collects.

</details>

<details>
<summary>What this does not fix</summary>

- `--learn` records a sentence directly and does not release the place from other members.
- Rows of a term deleted by hand stay in `vocabulary-uses.yaml`. Nothing reconciles at reload.
- A group linked only by a counter span keeps its renderings as substitution rules.
- A sentence naming one member twice releases no place from the other members. A row does not record which occurrence it is.

</details>

<details>
<summary>Review notes</summary>

Mechanical: `SoundGroupCommand.swift` and the `--portrait` extension, `scripts/check-sound-group.sh`, the docs. Worth reading closely: `SoundGroup.decide` (the standing, unknown and plain rules), `CorrectionRecording.apply` and `picked` (what a correction writes, and the both-names refusal), `TermUses.release` (one owner per place), `Config.vocabularyRules` (which renderings are still rules). The pill and selector changes in `OpenPlaces`, `PillHUD` and `SelectorCommand` grow the option list to k plus "something else" on the surface from #299 and #300. Squash on merge; the branch carries 21 commits, several of them corrections to earlier ones on the same branch.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kq8NKo33Ty3n7gsYcdY5mx

