### PR TITLE
chore: greptile reviews a pull request only when asked

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,3 @@
+{
+  "skipReview": "AUTOMATIC"
+}


### PR DESCRIPTION
Greptile no longer reviews a pull request on its own. It reviews when someone
asks. Comment `@greptileai` on the pull request to start one. The switch is
`skipReview: "AUTOMATIC"` in the new `.greptile/config.json`. Nothing else
about the review changes: same strictness, same comment types.

This suits how the tool behaves here. Rapid pushes wedge it, and a second pass
that cannot build re-posts findings the commit under review already fixed. On
demand means you push every fix first, then ask once.

<details>
<summary>Why the file, and not the dashboard toggle</summary>

app.greptile.com has the same switch. The repository file wins for two
reasons: it is in git with a reason attached, and it applies to everyone
working on the repository, not to one account's settings.

`.greptile/config.json` is the current name. A root-level `greptile.json` is
the legacy name and still works.

</details>

<details>
<summary>The nearby field, left alone: triggerOnUpdates</summary>

`triggerOnUpdates` controls whether a review runs again on each push. It only
matters while automatic review is on, so it is not set here. If we ever turn
automatic review back on, that is the field to reach for first.

</details>

<details>
<summary>Check this when the pull request opens</summary>

If Greptile posts a review on this pull request by itself, the config did not
take effect. Two likely causes: the file lands only after the review starts,
or the dashboard overrides it for this repository. Then comment `@greptileai`
to confirm the manual trigger still works.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
