### PR TITLE
feat: a pause that cuts a French sentence in two is repaired

### DIFF
--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -1729,7 +1729,9 @@ struct Config: Decodable, Equatable {
             /// wrong rewrites it catches.
             static let builtIn: [String: Language] = [
                 "en": Language(marks: defaultMarks, slotFloor: defaultSlotFloor),
-                "fr": Language(marks: defaultMarks, slotFloor: 0.30),
+                // French writes a colon where English writes a full stop, so
+                // it is a reading here and not an ender.
+                "fr": Language(marks: [".", ",", "?", ":"], slotFloor: 0.30),
             ]
 
             init(marks: [String]? = nil, slotFloor: Double? = nil) {

--- a/Sources/ParrotFlow/SentenceJoin.swift
+++ b/Sources/ParrotFlow/SentenceJoin.swift
@@ -109,6 +109,21 @@ actor SentenceJoin {
     /// Tags a capital must survive. A name stays a name once the mark goes.
     static let names: Set<String> = ["PersonalName", "PlaceName", "OrganizationName"]
 
+    /// The languages the boundary is read in.
+    ///
+    /// English and French. The reason this was English alone — "the readings
+    /// are scored by an English base model" — went when ModernBERT left; the
+    /// model is Qwen3 and it is multilingual. Measured over 234 French
+    /// boundaries, 103 real periods mined from real dictation and 131 cuts made
+    /// by inserting one: AUC 0.968 against 0.984 in English, 91% of cuts
+    /// repaired, and 6 false joins of which four are repairs the mining
+    /// mislabelled — about 2 per 100 real periods.
+    ///
+    /// The bare-capital half is not measured in French, and French capitalises
+    /// far less than English, so `capitals:` is off for anything but English at
+    /// the call site.
+    static let languages: Set<String> = ["en", "fr"]
+
     // MARK: - Finding the boundaries
 
     /// Every place one of `marks` is followed by a word.
@@ -126,7 +141,11 @@ actor SentenceJoin {
             guard at > text.startIndex, cursor < text.endIndex, text[cursor] != mark else {
                 continue
             }
-            let word = text[..<at].reversed().prefix { $0.isLetter || $0.isNumber }
+            // French sets a space before `?` and `!` — "travailler ?" — so the
+            // word is looked for past it. Without this every French question
+            // boundary is invisible and nothing says so.
+            let ahead = text[..<at].reversed().drop { $0.isWhitespace }
+            let word = ahead.prefix { $0.isLetter || $0.isNumber }
             guard word.count > 1 else { continue }
 
             var start = cursor
@@ -368,11 +387,13 @@ actor SentenceJoin {
         words: [Trace.Word] = []
     ) async -> Outcome {
         let language = Pipeline.language(of: text, config: config)
-        guard language == "en" else { return .unchanged(text) }
+        guard Self.languages.contains(language) else { return .unchanged(text) }
         let marks = written ?? config.transcription.marks(for: language)
         let found = (
             Self.boundaries(in: text, scanning: Self.scanned(marks))
-            + (capitals ? Self.bareBoundaries(in: text) : [])
+            // English only: the refusal rules for a bare capital were tuned on
+            // English capitalisation, and French capitalises far less.
+            + (capitals && language == "en" ? Self.bareBoundaries(in: text) : [])
         ).sorted { $0.next.lowerBound < $1.next.lowerBound }
         guard !found.isEmpty else { return .unchanged(text) }
         guard await SentenceReadings.shared.isLoaded else {

--- a/Sources/ParrotFlow/SentenceJoin.swift
+++ b/Sources/ParrotFlow/SentenceJoin.swift
@@ -109,6 +109,13 @@ actor SentenceJoin {
     /// Tags a capital must survive. A name stays a name once the mark goes.
     static let names: Set<String> = ["PersonalName", "PlaceName", "OrganizationName"]
 
+    /// The tagger reads the dictation's language. Asked in English, `NLTagger`
+    /// gives no lemma for most French words, and "no lemma" is what this rule
+    /// reads as a name — so a joined French boundary kept its capital.
+    static func tag(for language: String) -> NLLanguage {
+        language == "fr" ? .french : .english
+    }
+
     /// The languages the boundary is read in.
     ///
     /// English and French. The reason this was English alone — "the readings
@@ -141,9 +148,10 @@ actor SentenceJoin {
             guard at > text.startIndex, cursor < text.endIndex, text[cursor] != mark else {
                 continue
             }
-            // French sets a space before `?` and `!` — "travailler ?" — so the
-            // word is looked for past it. Without this every French question
-            // boundary is invisible and nothing says so.
+            // French sets a space before `?` — "travailler ?" — so the word is
+            // looked for past it. Without this every French question boundary
+            // is invisible and nothing says so. `!` is in no mark set, in
+            // either language, so it is not scanned here and not a boundary.
             let ahead = text[..<at].reversed().drop { $0.isWhitespace }
             let word = ahead.prefix { $0.isLetter || $0.isNumber }
             guard word.count > 1 else { continue }
@@ -245,7 +253,8 @@ actor SentenceJoin {
     /// than at the head of one: with the period still in place the same set
     /// scored 20 of its first 24 cases, and without it 21.
     static func written(
-        _ word: String, in joined: String, at offset: Int, terms: [String]
+        _ word: String, in joined: String, at offset: Int, terms: [String],
+        language: String = "en"
     ) -> String {
         let bare = String(word.prefix { $0.isLetter })
         guard let first = word.first, first.isUppercase, !bare.isEmpty else { return word }
@@ -259,7 +268,7 @@ actor SentenceJoin {
 
         let tagger = NLTagger(tagSchemes: [.nameTypeOrLexicalClass, .lemma])
         tagger.string = joined
-        tagger.setLanguage(.english, range: joined.startIndex..<joined.endIndex)
+        tagger.setLanguage(Self.tag(for: language), range: joined.startIndex..<joined.endIndex)
         let tag = tagger.tag(at: from, unit: .word, scheme: .nameTypeOrLexicalClass).0?.rawValue
         guard !Self.names.contains(tag ?? "") else { return word }
         let lemma = tagger.tag(at: from, unit: .word, scheme: .lemma).0?.rawValue ?? ""
@@ -292,7 +301,9 @@ actor SentenceJoin {
     ///
     /// The tagger is built with the scheme set `written` uses. Asking for
     /// `.lexicalClass` alongside changes the answer on 3 of the same 621.
-    static func readable(_ word: String, in joined: String, at offset: Int) -> Bool {
+    static func readable(
+        _ word: String, in joined: String, at offset: Int, language: String = "en"
+    ) -> Bool {
         let bare = String(word.prefix { $0.isLetter })
         guard !bare.dropFirst().contains(where: \.isUppercase) else { return false }
         guard let from = joined.index(
@@ -300,7 +311,7 @@ actor SentenceJoin {
         ) else { return false }
         let tagger = NLTagger(tagSchemes: [.nameTypeOrLexicalClass, .lemma])
         tagger.string = joined
-        tagger.setLanguage(.english, range: joined.startIndex..<joined.endIndex)
+        tagger.setLanguage(Self.tag(for: language), range: joined.startIndex..<joined.endIndex)
         let tag = tagger.tag(at: from, unit: .word, scheme: .nameTypeOrLexicalClass).0?.rawValue
         if Self.readableClasses.contains(tag ?? "") { return true }
         // An adjective is a quantifier as often as it is a name, so the class
@@ -418,12 +429,15 @@ actor SentenceJoin {
         for boundary in found {
             let word = String(text[boundary.next])
             let (whole, offset) = Self.joining(text, at: boundary)
-            let now = Self.written(word, in: whole, at: offset, terms: terms)
+            let now = Self.written(
+                word, in: whole, at: offset, terms: terms, language: language
+            )
             // A bare capital is filtered before it is read, never after. Half
             // of them are a name the transcriber was right about, and a name
             // must not reach a reading that could vote to lowercase it.
             if boundary.mark == nil,
-               now == word || !Self.readable(word, in: whole, at: offset) {
+               now == word
+                   || !Self.readable(word, in: whole, at: offset, language: language) {
                 continue
             }
             if boundary.mark == nil, pause > 0, let gap = pauses[offset], gap < pause {
@@ -465,7 +479,15 @@ actor SentenceJoin {
             readings.append(Reading(change: change, scores: scores, winner: best.key))
 
             if best.key == SentenceReadings.join {
-                rebuilt += text[cursor..<boundary.at]
+                let head = text[cursor..<boundary.at]
+                // With a mark, the space French sets in front of it goes with
+                // it — "travailler ? Oui" joins to "travailler oui" and not to
+                // "travailler  oui". The separator is the one after the mark.
+                // With no mark there is no separator after it, so the one in
+                // `head` is the only one and it stays.
+                rebuilt += boundary.mark == nil
+                    ? String(head)
+                    : String(head.reversed().drop { $0.isWhitespace }.reversed())
                 let after = boundary.mark == nil ? boundary.at : text.index(after: boundary.at)
                 rebuilt += text[after..<boundary.next.lowerBound]
                 rebuilt += now

--- a/Sources/ParrotFlow/SentenceJoin.swift
+++ b/Sources/ParrotFlow/SentenceJoin.swift
@@ -283,7 +283,15 @@ actor SentenceJoin {
         tagger.string = joined
         tagger.setLanguage(.english, range: joined.startIndex..<joined.endIndex)
         let tag = tagger.tag(at: from, unit: .word, scheme: .nameTypeOrLexicalClass).0?.rawValue
-        return Self.readableClasses.contains(tag ?? "")
+        if Self.readableClasses.contains(tag ?? "") { return true }
+        // An adjective is a quantifier as often as it is a name, so the class
+        // alone cannot decide it. The lemma can: it keeps the capital on
+        // `French` and `English` and drops it on `several`, `many`, `most`.
+        // Only an adjective is asked — `Slack` lemmatises lowercase too, but it
+        // tags Noun and never reaches here.
+        guard tag == "Adjective" else { return false }
+        let lemma = tagger.tag(at: from, unit: .word, scheme: .lemma).0?.rawValue ?? ""
+        return lemma.first?.isLowercase == true
     }
 
     /// The whole text with one mark taken out, and where the word after it

--- a/Sources/ParrotFlow/SentenceJoinCommand.swift
+++ b/Sources/ParrotFlow/SentenceJoinCommand.swift
@@ -50,7 +50,7 @@ enum SentenceJoinCommand {
 
         let language = Pipeline.language(of: text, config: config)
         print("  language   \(language)")
-        guard language == "en" else {
+        guard SentenceJoin.languages.contains(language) else {
             print("  text       \(text)")
             return 0
         }

--- a/Sources/ParrotFlow/SentenceProbeCommand.swift
+++ b/Sources/ParrotFlow/SentenceProbeCommand.swift
@@ -133,10 +133,12 @@ enum SentenceProbeCommand {
             /// with it. `enq_real.json` is mined by splitting on the mark, so
             /// its left halves have none.
             let mark: String?
+            /// Which mark set to read the boundary with. English where absent.
+            let language: String?
         }
         var exitCode: Int32 = 0
         let done = DispatchSemaphore(value: 0)
-        let marks = ((try? ConfigStore.load()) ?? Config()).transcription.marks(for: "en")
+        let transcription = ((try? ConfigStore.load()) ?? Config()).transcription
 
         Task {
             do {
@@ -149,6 +151,7 @@ enum SentenceProbeCommand {
                 var times: [Double] = []
                 for (i, row) in rows.enumerated() {
                     let start = DispatchTime.now().uptimeNanoseconds
+                    let marks = transcription.marks(for: row.language ?? "en")
                     let mark = row.mark ?? found(in: row.left, marks: marks)
                     guard let scores = try? await SentenceReadings.shared.read(
                         left: row.left, right: row.right, found: mark, marks: marks

--- a/Sources/ParrotFlow/SentenceReadings.swift
+++ b/Sources/ParrotFlow/SentenceReadings.swift
@@ -14,7 +14,7 @@ import MLXLMCommon
 ///
 /// The first reading is the mark the transcriber actually wrote, so a
 /// `word? Capital` boundary is read `"? Word"`, `", word"` and `" word"`. A
-/// boundary with no mark is read four ways — see `bareReadings` — because the
+/// boundary with no mark is read three ways — see `bareReadings` — because the
 /// text as decoded is then a candidate rather than what happens by default.
 /// Reading every configured ender at every boundary was measured too and is
 /// worse: 259 of 325 question cuts repaired against 265, for a fourth forward
@@ -29,6 +29,14 @@ import MLXLMCommon
 /// The comma is a reading, not a term in a subtraction. 26% of real sentence
 /// endings pick it, and that is why none of them picks `join`. Scoring
 /// `max(mark) - log P(next)` instead gives 64% against this shape's 81%.
+///
+/// **It is a marked-boundary reading only.** Where there is no mark, nothing is
+/// written unless `join` wins, so a comma win there is not a decision but a veto
+/// on a join that already beat both readings that keep the capital. Measured
+/// over 616 bare capitals mined from 3,336 English dictations, 225 of which
+/// reach the model: dropping it lowercases 129 against 87, and of the 42 it
+/// changes, 40 are right and 2 destroy a correct capital. A margin threshold
+/// does not buy those two back — 13 of the 40 repairs sit below their margin.
 ///
 /// `mlx-community/Qwen3-0.6B-Base-4bit`, not the DWQ checkpoint: despite the
 /// name that one is a quant of the *instruct* model and repairs 76%.
@@ -152,9 +160,6 @@ actor SentenceReadings {
             [Reading(key: $0, mark: $0, capital: true)]
         } ?? [])
         + [Reading(key: asDecoded, mark: "", capital: true)]
-        + marks.filter { !enders.contains($0) }.map {
-            Reading(key: $0, mark: $0, capital: false)
-        }
         + [Reading(key: join, mark: "", capital: false)]
     }
 

--- a/docs/proposals/fixed-passes.md
+++ b/docs/proposals/fixed-passes.md
@@ -1,0 +1,260 @@
+# Proposal: `interpret` and `vocabulary` leave the pipeline
+
+Status: **proposed, nothing built.** This is a shape to agree on before any
+code moves.
+
+**Goal.** `pipeline:` holds only the stages a person can genuinely order. The
+two passes that read the decoder's own output become settings blocks and run
+at a fixed point. A config can then no longer put them in the wrong place.
+
+---
+
+## 1. Why a list is the wrong home for these two
+
+`Pipeline.swift` says what a stage is, at the top of the file: every stage is
+`String -> String`, and the whole point of the list is that the order is data.
+
+Neither of these two is `String -> String`.
+
+| Pass | What else it reads | So it must run |
+|---|---|---|
+| `interpret` | The decoder's own words and their timings (`[Trace.Word]`). A rewrite above it moves a word and the pause gate lines up against the wrong token. | First. |
+| `vocabulary` | Spans measured before the pipeline started. Any edit above it moves them — the bug that put the menu on the wrong `Versailles` (F3, F10). | Above everything that edits text. |
+
+Neither constraint is a choice. Both are already written down in the code as
+rules the config must not break:
+
+- `Pipeline.vocabularyOrderProblems()` — one method whose only job is to
+  refuse an order.
+- `Stage.editsText` — one property, with the comment "only used to say where
+  `vocabulary` belongs".
+- `Stage.isAutomatic` — `vocabulary` excluded by hand.
+- The `interpret` exception inside the order check, plus the paragraph
+  explaining it.
+- 12 of the 17 fields on `Pipeline.Step` are options only one of these two
+  stages reads: `prompt`, `caps`, `nearMisses`, `bySound`, `gate`, `slotGate`,
+  `portrait`, `lowercaseRefused`, `slotFloor`, `marks`, `capitals`, `pause`.
+- `PipelineEntry.stageKeys` and `misplacedOptions` — a whole mechanism that
+  exists to say "`slot_gate:` is an option on the `vocabulary` stage, it does
+  nothing here".
+
+None of that would exist if the two passes were not in the list.
+
+The list also decides what gets downloaded. `PipelineCommand` gates a 320 MB
+model on `.interpret` being in it, and `warmModels` gates 400 MB on
+`gate_sentence:`. A block is a plainer switch for both.
+
+**The rule to adopt.** A pipeline stage rewrites text and may go anywhere. A
+pass that reads the decoder's output, or the machine, is fixed and takes a
+settings block.
+
+---
+
+## 2. The new shape
+
+`config.example.yaml`, in house comment style:
+
+```yaml
+transcription:
+  insert_mode: paste
+  languages: [en, fr]
+
+  # What you meant, where the decoder wrote what it heard. A pause makes it
+  # write a period or a question mark mid-sentence and capitalise the next
+  # word; this reads each boundary and takes the mark out again. English only.
+  # Runs before everything below — it reads the decoder's own timings, so it
+  # cannot be moved.
+  interpret:
+    enabled: true
+    # What a boundary may be written with. The enders in it — `.` and `?` —
+    # are where a boundary is looked for; the rest is a reading tried at each
+    # one. Left out, the built-in set for the language.
+    # marks: [".", ",", "?"]
+    # Read a capital with no mark in front of it as a boundary too.
+    capitals: true
+    # Seconds of silence a bare capital needs first. 0 reads every one.
+    # pause: 0.35
+
+  # Names from vocabulary.yaml, matched then settled against the sentence they
+  # stand in. No model. Runs after `interpret` and before the pipeline: it is
+  # handed spans measured on the transcript as the decoder wrote it, and any
+  # edit moves them.
+  vocabulary:
+    enabled: true
+    near_misses: true        # also match a rendering one edit away
+    by_sound: true           # also match words that sound like a term
+    gate: true               # the two word lists and the slot's part of speech
+    slot_gate: true          # the mmBERT slot — false downloads nothing
+    portrait: true           # a term's own sentences and its counter-examples
+    lowercase_refused: true  # a refused glued span goes back in lowercase
+    # slot_floor: {en: 0.20, fr: 0.30}
+    # max_per_slot: 3
+    # max_per_term: 2
+
+  # What a transcript runs through, in order. Everything here rewrites text
+  # and may be moved.
+  pipeline:
+    - numbers
+    - transform: punctuation
+    - transform: repetitions
+```
+
+### Key by key
+
+| Written today | Written after |
+|---|---|
+| `- interpret` | `transcription.interpret.enabled: true` |
+| `- stage: interpret` + `marks:` `capitals:` `pause:` | the same keys in the block |
+| `- vocabulary`, `- stage: vocabulary` | `transcription.vocabulary.enabled: true` |
+| `near_misses:` `by_sound:` `gate:` `slot_gate:` `portrait:` `lowercase_refused:` `slot_floor:` `max_per_slot:` `max_per_term:` | the same keys in the block |
+| `- vocabulary: <prompt file>`, `review:` | already retired; keep saying so |
+
+Nothing is renamed. Every option keeps the spelling it has, so a config is
+migrated by moving lines, not by rewriting them.
+
+---
+
+## 3. What runs when
+
+```
+asr → vad → interpret → vocabulary → pipeline (numbers, transforms, …)
+```
+
+Both passes keep publishing into the scope, as `asr` and `vad` already do
+without being stages. So `when: vocabulary.count > 0` and
+`unless: interpret.count == 0` on a transform go on working, and
+`--pipeline --vars` prints the same variables. That is what makes the move
+lossless.
+
+`context` and `input` stay stages. They do not edit text and nothing above
+them can hurt them, so they are ordinary lines in the list.
+
+### On and off
+
+`enabled:` inside the block. The alternative is the repo's scalar-or-map
+idiom — `vocabulary: false` to turn it off, a map to configure it, the way
+`floor:` and `slot_floor:` already take two shapes. I recommend `enabled:`:
+a fixture and a bench want to keep the block and flip one key, and with the
+scalar spelling `vocabulary: false` would also delete the terms under it.
+
+---
+
+## 4. The other half: one home per thing
+
+`vocabulary.yaml` already holds six settings above `terms:`. Adding a
+`transcription.vocabulary:` block without moving them leaves the pass with two
+homes.
+
+Three of the six are live and should move: `sound_below`, `gate_sentence`,
+`asks`. The other three are read and ignored already — `acoustic` and
+`decide_above` went with the acoustic pass, and nothing outside `Config`
+consumes `offer_below`, since `vocabularyTerms` has no caller left. Leave
+those where they are, with the notice they already get.
+
+The split is wrong for a second reason. The file header says **DO NOT EDIT
+UNLESS YOU REALLY KNOW WHAT YOU ARE DOING** and the struct doc says the app
+writes the file, but `ConfigWriter` only ever writes `terms:`. Three
+person-chosen switches sit in a file people are told not to touch.
+
+| File | Holds | Written by |
+|---|---|---|
+| `config.yaml` | every switch and threshold | a person |
+| `vocabulary.yaml` | `terms:`, plus the retired keys | the app: the panel, `--learn`, calibrate |
+
+Read the old location as legacy, with a `notices()` line naming each key and
+where it goes now. The repo does exactly this for `floor:`, `heard:` and
+`review:`.
+
+This is a separable PR and it should come second. It still belongs to this
+shape. Without it, "where do I turn the sentence gate off" has two answers.
+
+---
+
+## 5. Conditions
+
+`when:`, `unless:` and `app:` are dropped from both. Nothing in the repo uses
+them on these two stages except `scripts/check-pipeline-config.sh`, which
+tests the parsing rather than a need — including a config with two
+`vocabulary` steps carrying different floors, which is not a thing anybody
+runs.
+
+If "no vocabulary in Terminal" is ever wanted, `app:` goes into the block as
+one key. It is a smaller change than keeping the machinery for it now.
+
+---
+
+## 6. Fixtures barely move
+
+A fixture already has a `vocabulary:` key. It mirrors `vocabulary.yaml`
+today; after this it holds the settings as well as the terms, and the step
+options move into it:
+
+```yaml
+# before
+vocabulary:
+  terms: {BetterStack: {…}}
+pipeline:
+  - {stage: vocabulary, lowercase_refused: false}
+
+# after
+vocabulary:
+  lowercase_refused: false
+  terms: {BetterStack: {…}}
+```
+
+`PipelineCommand` gates a 320 MB download on `pipeline.stages.contains(.interpret)`;
+that becomes a read of the block.
+
+---
+
+## 7. Migration
+
+`problems()` is a menu bar warning, not a refusal, so nothing here stops an
+app that is already installed from working.
+
+| An old config says | What happens |
+|---|---|
+| `- interpret`, `- vocabulary`, `- stage: vocabulary` | Read, ignored, one notice: it runs anyway, delete the line. |
+| the same with options | The options are read into the block for one release, with a notice naming the block. |
+| a `pipeline:` that omits one of them | **See below.** |
+| no `pipeline:` key at all | **See below.** `everything` runs `interpret` but not `vocabulary`. |
+| an option on the wrong stage | Unchanged message, minus the stage half. |
+
+**Two behaviour flips, and they need a decision.**
+
+A hand-written `pipeline:` that leaves `- vocabulary` out means the pass is
+off today. A config with no `pipeline:` key at all runs `Pipeline.everything`,
+which excludes `vocabulary` too, because `Stage.isAutomatic` excludes it. If
+the block defaults to `enabled: true`, both configs turn the pass on at
+upgrade.
+
+Recommendation, in two parts:
+
+- A written `pipeline:` and no block: the list decides, for one release, with
+  a `--check-config` line saying so.
+- No `pipeline:` at all: turn it on. The reason `isAutomatic` excluded it is
+  stale — the comment says the stage "names a prompt file", and it has not for
+  some time. `config.example.yaml` turns it on, so a new install already gets
+  it. Say it once in `--check-config`.
+
+---
+
+## 8. Footprint
+
+| File | What changes |
+|---|---|
+| `Pipeline.swift` | Two `Stage` cases gone. `editsText`, `isAutomatic` exceptions and `vocabularyOrderProblems()` deleted. 12 `Step` fields deleted. The two pass bodies move out or take settings instead of a `Step`. |
+| `Config.swift` | `PipelineEntry` loses the option decoding and `stageKeys`. Two new settings structs. `Vocabulary` gains the six file-level keys and their legacy readers. |
+| `Transcriber.swift` | Where the two fixed passes run. |
+| `CheckConfigCommand.swift` | Reads the blocks; the "delete the `interpret` step" wording goes. |
+| `PipelineCommand.swift` | Fixture blocks; the interpret model gate. |
+| `config.example.yaml`, `docs/pipelines.md`, `docs/configuration.md` | The shape above. |
+| `tests/pipelines/*.yaml`, `scripts/check-pipeline-config.sh` | Options move up one level. |
+
+---
+
+## 9. Not in this proposal
+
+`respell` (on `feat/respell`) reads the decoder's top-64 and protects the
+spans `vocabulary` wrote. It is the same shape and will want the same
+treatment. Naming it here so the rule is not re-argued when it lands.

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -741,9 +741,12 @@ English word is the one case the lemma rule cannot see.
 
 English and French, and the stage refuses the rest itself, so a `when:` on the
 step is not needed. French adds `:` to its mark set, where English writes a full
-stop, and the space French sets before `?` and `!` is stepped over when the
-boundary is looked for — without that every French question is skipped and
-nothing says so. Over 234 French boundaries the readings score AUC 0.968 against
+stop, and the space French sets before `?` is stepped over when the boundary is
+looked for — without that every French question is skipped and nothing says so.
+When a join wins, that space goes with the mark, so one separator is left and
+not two. `NLTagger` is asked in the language of the dictation: in English it
+gives no lemma for most French words, and "no lemma" is what the lowercasing
+rule reads as a name, so a joined French boundary used to keep its capital. Over 234 French boundaries the readings score AUC 0.968 against
 0.984 in English and repair 91% of cuts, for about 2 false joins per 100 real
 periods. Nothing is waited for:
 with no cached model, a load that threw or a boundary it cannot read, the text

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -610,8 +610,8 @@ said     "you should see a parrot at the top right of your screen"
 written  "You should see a parrot. At the top right of your screen."
 ```
 
-The `interpret` step reads every such boundary in an English transcript three
-ways and scores each with a small causal language model
+The `interpret` step reads every such boundary in an English or French
+transcript three ways and scores each with a small causal language model
 (`mlx-community/Qwen3-0.6B-Base-4bit`, 320 MB):
 
 ```
@@ -647,20 +647,31 @@ never been measured.
 
 A pause does not always make the transcriber write the mark. It writes
 `imports name definitions And all the things`, and that shape is about a third
-as common as `word. Capital`. It is scanned too, with a **fourth reading**: the
-text exactly as it was decoded.
+as common as `word. Capital`. It is scanned too, and the comma is dropped for
+a different reading: the text exactly as it was decoded.
 
 ```
 ". A before section B"     the sentence really ended
 " A before section B"      as decoded, a capital that belongs
 " a before section B"      a pause cut one sentence in two
-", a before section B"     it is really a comma
 ```
 
-The fourth reading exists because there is no mark to take out. Everywhere else
-"leave it alone" is what happens when a mark wins; here it is a candidate of its
-own, and it is the one that saves `paste it into Outlook and the other apps`.
-Only the third writes anything. The period is never inserted — where a mark
+The as-decoded reading exists because there is no mark to take out. Everywhere
+else "leave it alone" is what happens when a mark wins; here it is a candidate
+of its own, and it is the one that saves `paste it into Outlook and the other
+apps`. Only the third writes anything.
+
+**The comma is not read here.** Since only the join writes, a comma win was
+never a decision — it was a veto on a join that had already beaten both readings
+that keep the capital. Over 616 bare capitals mined from 3,336 English
+dictations, 225 of which get past the part-of-speech filter, dropping it
+lowercases 129 against 87. Of the 42 it changes, 40 are right and 2 destroy a
+correct capital, and no margin threshold buys those back — 13 of the 40 repairs
+sit below theirs. The marked path keeps its comma, where 26% of real sentence
+endings pick it.
+
+This half is English only: its refusal rules were tuned on English
+capitalisation and French capitalises far less. The period is never inserted — where a mark
 wins, the text is left as it was decoded and the decision is logged.
 
 Half of these capitals are correct and must not be touched: `Slack`, `English`,
@@ -728,10 +739,13 @@ never seen it, which is what a name it has not been told about looks like. A
 term in your `vocabulary.yaml` is asked first, because a name that is also an
 English word is the one case the lemma rule cannot see.
 
-English only, and the stage refuses the rest itself, so `when: language == "en"`
-on the step is not needed. The readings are scored by an English base model, and
-the mark set is English: French uses `:` where English does not. Nothing is
-waited for:
+English and French, and the stage refuses the rest itself, so a `when:` on the
+step is not needed. French adds `:` to its mark set, where English writes a full
+stop, and the space French sets before `?` and `!` is stepped over when the
+boundary is looked for — without that every French question is skipped and
+nothing says so. Over 234 French boundaries the readings score AUC 0.968 against
+0.984 in English and repair 91% of cuts, for about 2 false joins per 100 real
+periods. Nothing is waited for:
 with no cached model, a load that threw or a boundary it cannot read, the text
 arrives as it was. A dictation that arrives before the weights are in memory
 keeps its boundaries and starts the load.

--- a/scripts/check-bare-capital.sh
+++ b/scripts/check-bare-capital.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# A capital with no mark in front of it: is it a name, or a pause?
+#
+#   scripts/check-bare-capital.sh
+#
+# The readings the boundary gets here are the period, the text as decoded, and
+# the join. The comma is not among them: nothing is written unless `join` wins,
+# so a comma win is a veto rather than a decision. The cases below are the ones
+# that veto used to swallow — mined from real dictation and labelled by hand.
+#
+# Not in `make test`: it needs the 320 MB sentence model. Run it after touching
+# SentenceReadings or the bare half of SentenceJoin.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN=""
+for candidate in "$ROOT/.build/release/ParrotFlow" "$ROOT/.build/debug/ParrotFlow"; do
+  [ -x "$candidate" ] || continue
+  if [ -z "$BIN" ] || [ "$candidate" -nt "$BIN" ]; then BIN="$candidate"; fi
+done
+[ -n "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+
+CASES="$ROOT/tests/bare-capital-cases.json"
+WORK="$(mktemp -d -t parrotflow-bare-capital)"
+trap 'rm -rf "$WORK"' EXIT
+
+# The bench reads left, right and mark and ignores the rest, so the labels
+# travel in the same file as the cases they label.
+"$BIN" --sentence-probe --bench "$CASES" --out "$WORK/out.json" >/dev/null 2>&1 \
+  || { echo "  ✗ the bench did not run"; exit 1; }
+
+python3 - "$CASES" "$WORK/out.json" <<'PY'
+import json, sys
+cases = json.load(open(sys.argv[1]))
+out = json.load(open(sys.argv[2]))
+rows = out if isinstance(out, list) else out.get("results", [])
+if len(rows) != len(cases):
+    print(f"  ✗ {len(rows)} results for {len(cases)} cases"); sys.exit(1)
+ok = bad = cost = 0
+for case, row in zip(cases, rows):
+    joined = row["winner"] == "join"
+    right = joined == (case["want"] == "lower")
+    got = "lower" if joined else "keep"
+    if case.get("cost"):
+        # The measured price of dropping the comma, not a regression. Printed
+        # so it stays visible, and it fails the run only if it stops being a
+        # price — a case that starts passing is a better rule, not a broken one.
+        cost += 1
+        print(f"  ·  {case['word']:12} want {case['want']:5} got {got:5} — {case['why']}")
+        continue
+    ok, bad = ok + right, bad + (not right)
+    if not right:
+        print(f"  ✗  {case['word']:12} want {case['want']:5} got {got:5} — {case['why']}")
+print()
+print(f"  {ok}/{len(cases) - cost}  and {cost} known costs  (tests/bare-capital-cases.json)")
+sys.exit(0 if bad == 0 else 1)
+PY

--- a/scripts/check-french-boundary.sh
+++ b/scripts/check-french-boundary.sh
@@ -54,3 +54,31 @@ print()
 print(f"  {ok}/{len(cases) - cost}  and {cost} known costs  (tests/french-boundary-cases.json)")
 sys.exit(0 if bad == 0 else 1)
 PY
+bench=$?
+
+# The bench above scores which reading wins. It never applies one, so it cannot
+# see what is written. These three do.
+echo
+echo "  what a won join writes"
+echo
+fail=$bench
+check () {   # $1 said, $2 wanted, $3 why
+  got="$("$BIN" --sentence-join "$1" 2>/dev/null | sed -n 's/^  text       //p')"
+  if [ "$got" = "$2" ]; then
+    printf '  ✓  %s\n' "$3"
+  else
+    printf '  ✗  %s\n     got  %s\n     want %s\n' "$3" "$got" "$2"
+    fail=1
+  fi
+}
+check "Je me demande si on ne devrait pas ? Attendre la prochaine version." \
+      "Je me demande si on ne devrait pas attendre la prochaine version." \
+      "the space French sets before ? goes with the mark, and one is left"
+check "On ne peut pas continuer comme ça. Parce que le budget est déjà dépassé." \
+      "On ne peut pas continuer comme ça. Parce que le budget est déjà dépassé." \
+      "a real French period is left alone"
+check "You should see a parrot. At the top right of your screen." \
+      "You should see a parrot at the top right of your screen." \
+      "English is unchanged"
+exit $fail
+

--- a/scripts/check-french-boundary.sh
+++ b/scripts/check-french-boundary.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Does the boundary read French? Same three readings, plus the colon.
+#
+#   scripts/check-french-boundary.sh
+#
+# The reason this stage was English alone went when ModernBERT left: the model
+# is Qwen3 and it is multilingual. Measured over 234 French boundaries — 103
+# real periods mined from real dictation and 131 cuts made by inserting one —
+# AUC 0.968 against 0.984 in English and 91% of cuts repaired. These 28 are a
+# subset with names filtered out.
+#
+# Not in `make test`: it needs the 320 MB sentence model.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN=""
+for candidate in "$ROOT/.build/release/ParrotFlow" "$ROOT/.build/debug/ParrotFlow"; do
+  [ -x "$candidate" ] || continue
+  if [ -z "$BIN" ] || [ "$candidate" -nt "$BIN" ]; then BIN="$candidate"; fi
+done
+[ -n "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+
+CASES="$ROOT/tests/french-boundary-cases.json"
+WORK="$(mktemp -d -t parrotflow-french-boundary)"
+trap 'rm -rf "$WORK"' EXIT
+
+# The bench reads left, right and mark and ignores the rest, so the labels
+# travel in the same file as the cases they label.
+"$BIN" --sentence-probe --bench "$CASES" --out "$WORK/out.json" >/dev/null 2>&1 \
+  || { echo "  ✗ the bench did not run"; exit 1; }
+
+python3 - "$CASES" "$WORK/out.json" <<'PY'
+import json, sys
+cases = json.load(open(sys.argv[1]))
+out = json.load(open(sys.argv[2]))
+rows = out if isinstance(out, list) else out.get("results", [])
+if len(rows) != len(cases):
+    print(f"  ✗ {len(rows)} results for {len(cases)} cases"); sys.exit(1)
+ok = bad = cost = 0
+for case, row in zip(cases, rows):
+    joined = row["winner"] == "join"
+    right = joined == (case["want"] == "lower")
+    got = "lower" if joined else "keep"
+    if case.get("cost"):
+        # The measured price of dropping the comma, not a regression. Printed
+        # so it stays visible, and it fails the run only if it stops being a
+        # price — a case that starts passing is a better rule, not a broken one.
+        cost += 1
+        print(f"  ·  {case['right'].split()[0][:12]:12} want {case['want']:5} got {got:5} — {case['why']}")
+        continue
+    ok, bad = ok + right, bad + (not right)
+    if not right:
+        print(f"  ✗  {case['right'].split()[0][:12]:12} want {case['want']:5} got {got:5} — {case['why']}")
+print()
+print(f"  {ok}/{len(cases) - cost}  and {cost} known costs  (tests/french-boundary-cases.json)")
+sys.exit(0 if bad == 0 else 1)
+PY

--- a/scripts/check-sentence-join.sh
+++ b/scripts/check-sentence-join.sh
@@ -5,7 +5,7 @@
 #
 # Half the cases are real sentence endings and half are pauses that cut one
 # sentence in two, in both the period and the question-mark shape. A third
-# shape, a capital with no mark in front of it, carries its four readings and
+# shape, a capital with no mark in front of it, carries its three readings and
 # is checked on drift alone: it has no real/cut pair. Two numbers
 # decide per shape: how many cuts were repaired, and how many real endings were
 # joined by mistake. A joined real ending is a sentence nobody wrote, with

--- a/tests/bare-capital-cases.json
+++ b/tests/bare-capital-cases.json
@@ -1,0 +1,364 @@
+[
+ {
+  "left": "we could just increase the frequency of those meetings and the other one was hmm",
+  "right": "Uh why not increasing the temperature?",
+  "mark": "",
+  "word": "Uh",
+  "want": "lower",
+  "why": "\"Uh\" after a pause, mid-sentence"
+ },
+ {
+  "left": "So what was happening was that the vocabulary was",
+  "right": "Too influent. Vocabulary terms would replace very distantly similar phonetic. Uh fragments.",
+  "mark": "",
+  "word": "Too",
+  "want": "lower",
+  "why": "\"Too\" after a pause, mid-sentence"
+ },
+ {
+  "left": "Context is uh technical terms and acronyms from the code base and from Slack conversations",
+  "right": "And the people I interacted with the last thirty days so a prompt to put",
+  "mark": "",
+  "word": "And",
+  "want": "lower",
+  "why": "\"And\" after a pause, mid-sentence"
+ },
+ {
+  "left": "terms based on the context, but also based on the app name. Currently it's only",
+  "right": "But it could be Slack or Outlook or anything in the future.",
+  "mark": "",
+  "word": "But",
+  "want": "lower",
+  "why": "\"But\" after a pause, mid-sentence"
+ },
+ {
+  "left": "case the LM path should have retries And if after several retries retries it fails",
+  "right": "The ingest should stop. And in case of the short content, then we can just",
+  "mark": "",
+  "word": "The",
+  "want": "keep",
+  "why": "the comma used to veto this; dropping it loses 2 of the 42 it changes",
+  "cost": true
+ },
+ {
+  "left": "he how he went from one PR fruit to another? How many commits are specifically",
+  "right": "For the purpose of that PR it seems like there was a lot of rebase",
+  "mark": "",
+  "word": "For",
+  "want": "lower",
+  "why": "\"For\" after a pause, mid-sentence"
+ },
+ {
+  "left": "onboarding step the calibration but is there something we can learn from the sounds of",
+  "right": "Returned by the C C DTC. For example, for non-native speakers, they will pronounce same",
+  "mark": "",
+  "word": "Returned",
+  "want": "lower",
+  "why": "\"Returned\" after a pause, mid-sentence"
+ },
+ {
+  "left": "There are a few caveats, for example",
+  "right": "The input may contain several dictations or they could have added content such as a",
+  "mark": "",
+  "word": "The",
+  "want": "lower",
+  "why": "\"The\" after a pause, mid-sentence"
+ },
+ {
+  "left": "How can you know it's not",
+  "right": "How can you know it's not the prompt?",
+  "mark": "",
+  "word": "How",
+  "want": "lower",
+  "why": "\"How\" after a pause, mid-sentence"
+ },
+ {
+  "left": "Which mean would we subtract the global mean or the per page mean? And",
+  "right": "And how would we process the query? And do we have to Because if we",
+  "mark": "",
+  "word": "And",
+  "want": "lower",
+  "why": "\"And\" after a pause, mid-sentence"
+ },
+ {
+  "left": "that currently vectors are too close to each other and therefore content is hard to",
+  "right": "Relevant content is hard to get surfaced in at the retrieval stage.",
+  "mark": "",
+  "word": "Relevant",
+  "want": "lower",
+  "why": "\"Relevant\" after a pause, mid-sentence"
+ },
+ {
+  "left": "definition we discussed above, then it works by difference. Everything that is not in the",
+  "right": "Everything that is not in",
+  "mark": "",
+  "word": "Everything",
+  "want": "lower",
+  "why": "\"Everything\" after a pause, mid-sentence"
+ },
+ {
+  "left": "Sorry, yes, we had a one on one yesterday, Henny told me",
+  "right": "That in the end you changed some setting universal and IPs are not visible anymore.",
+  "mark": "",
+  "word": "That",
+  "want": "lower",
+  "why": "\"That\" after a pause, mid-sentence"
+ },
+ {
+  "left": "one of the terms heard in the transcription, you can see that the same th",
+  "right": "Matches a term in the herd list for for one of the vocabulary term, then",
+  "mark": "",
+  "word": "Matches",
+  "want": "lower",
+  "why": "\"Matches\" after a pause, mid-sentence"
+ },
+ {
+  "left": "be overridden by the configuration. So for example, if I V can mean something else",
+  "right": "For a specific brand, they can put it in the configuration and it will completely",
+  "mark": "",
+  "word": "For",
+  "want": "lower",
+  "why": "\"For\" after a pause, mid-sentence"
+ },
+ {
+  "left": "But also I want to see if we can leverage metadata on dictation such as",
+  "right": "Such as duration between clips.",
+  "mark": "",
+  "word": "Such",
+  "want": "lower",
+  "why": "\"Such\" after a pause, mid-sentence"
+ },
+ {
+  "left": "So I want to keep the narrative smaller",
+  "right": "And have the buy engine section. Under it. Then I want to use this area",
+  "mark": "",
+  "word": "And",
+  "want": "lower",
+  "why": "\"And\" after a pause, mid-sentence"
+ },
+ {
+  "left": "Something like a f fast local first programmable dictation tool",
+  "right": "That you can adapt to your very own workflows instead of work.",
+  "mark": "",
+  "word": "That",
+  "want": "lower",
+  "why": "\"That\" after a pause, mid-sentence"
+ },
+ {
+  "left": "is to op okay, so I would open a terminal window and it was just",
+  "right": "Uh scroll like a tail, yeah.",
+  "mark": "",
+  "word": "Uh",
+  "want": "lower",
+  "why": "\"Uh\" after a pause, mid-sentence"
+ },
+ {
+  "left": "I don't think an AI would go against the label, but more",
+  "right": "Yeah we'll just use the site as source of truth.",
+  "mark": "",
+  "word": "Yeah",
+  "want": "lower",
+  "why": "\"Yeah\" after a pause, mid-sentence"
+ },
+ {
+  "left": "how this should be so that the reader, which is usually a brand marketer, understand",
+  "right": "What need expansion? How shallow it is, and how the AI goes deeper.",
+  "mark": "",
+  "word": "What",
+  "want": "lower",
+  "why": "\"What\" after a pause, mid-sentence"
+ },
+ {
+  "left": "Okay, it's catchy, but as a brand manager, I think I would want to understand",
+  "right": "And how and where it drifts.",
+  "mark": "",
+  "word": "And",
+  "want": "lower",
+  "why": "\"And\" after a pause, mid-sentence"
+ },
+ {
+  "left": "Exact same it added the word quote do unquote before quote you unquote",
+  "right": "But without a space and then it reverted the change and said the app couldn't",
+  "mark": "",
+  "word": "But",
+  "want": "lower",
+  "why": "\"But\" after a pause, mid-sentence"
+ },
+ {
+  "left": "Going from one question to a set of questions allows to aggregate metrics but also",
+  "right": "So extract patterns of content drift between AI and The brand websites with some that",
+  "mark": "",
+  "word": "So",
+  "want": "lower",
+  "why": "\"So\" after a pause, mid-sentence"
+ },
+ {
+  "left": "My question is is the first voyage re ranker result generally close to",
+  "right": "Or generate the first from the evaluation set. If we exclude questions where the data",
+  "mark": "",
+  "word": "Or",
+  "want": "lower",
+  "why": "\"Or\" after a pause, mid-sentence"
+ },
+ {
+  "left": "result and below a list of candidates with where the content is the additional information",
+  "right": "Compared to the pinned s result. The candidate could have more the candidates content could",
+  "mark": "",
+  "word": "Compared",
+  "want": "lower",
+  "why": "\"Compared\" after a pause, mid-sentence"
+ },
+ {
+  "left": "We could just show the panel without the fancy border under the string",
+  "right": "But only with the rounded angles at the at the bottom and not just under",
+  "mark": "",
+  "word": "But",
+  "want": "lower",
+  "why": "\"But\" after a pause, mid-sentence"
+ },
+ {
+  "left": "to the centroid of examples or the centroid built from the vectors on the ten",
+  "right": "Generated words by Bert on the basque.",
+  "mark": "",
+  "word": "Generated",
+  "want": "lower",
+  "why": "\"Generated\" after a pause, mid-sentence"
+ },
+ {
+  "left": "is no nothing more than calculating the probability of the dot and the word app",
+  "right": "And decide which one is bigger than the other.",
+  "mark": "",
+  "word": "And",
+  "want": "lower",
+  "why": "\"And\" after a pause, mid-sentence"
+ },
+ {
+  "left": "The borderplay that is common to every query imports name definitions",
+  "right": "And all the things we usually place in the first cells of a notebook to",
+  "mark": "",
+  "word": "And",
+  "want": "lower",
+  "why": "\"And\" after a pause, mid-sentence"
+ },
+ {
+  "left": "what are the most common actions? So you said click a button, a link, then",
+  "right": "What buttons and link specifically, and then Common clusters or clusters of common actions or",
+  "mark": "",
+  "word": "What",
+  "want": "lower",
+  "why": "\"What\" after a pause, mid-sentence"
+ },
+ {
+  "left": "There should be some minimal padding and",
+  "right": "If the sentence is too big, we should only show the segment with five words",
+  "mark": "",
+  "word": "If",
+  "want": "lower",
+  "why": "\"If\" after a pause, mid-sentence"
+ },
+ {
+  "left": "Also add by traffic source paid or organic",
+  "right": "And by landing topic with with two columns, one for paid and one for organic.",
+  "mark": "",
+  "word": "And",
+  "want": "lower",
+  "why": "\"And\" after a pause, mid-sentence"
+ },
+ {
+  "left": "as a hint in addition to the vector similarity, for example, we have to do",
+  "right": "If the majority of what we expect in the counter is an adjective how can",
+  "mark": "",
+  "word": "If",
+  "want": "lower",
+  "why": "\"If\" after a pause, mid-sentence"
+ },
+ {
+  "left": "In Google just ask quote",
+  "right": "What are the top ten questions asked about Darzal X by patients in Reddit?",
+  "mark": "",
+  "word": "What",
+  "want": "keep",
+  "why": "the comma used to veto this; dropping it loses 2 of the 42 it changes",
+  "cost": true
+ },
+ {
+  "left": "the sentence is very long and where ellipsis ellipsis is need is needed and also",
+  "right": "At examples where you have two um um decisions to make. In that case it",
+  "mark": "",
+  "word": "At",
+  "want": "lower",
+  "why": "\"At\" after a pause, mid-sentence"
+ },
+ {
+  "left": "gives the expected results. To get the comparison, we need to ingest the crawl file",
+  "right": "And run the evaluation against these expected results in our evaluation harness.",
+  "mark": "",
+  "word": "And",
+  "want": "lower",
+  "why": "\"And\" after a pause, mid-sentence"
+ },
+ {
+  "left": "I want to be able to select it. And uh if I say hey parrot",
+  "right": "With selected text in the current input I want to use it. To open the",
+  "mark": "",
+  "word": "With",
+  "want": "lower",
+  "why": "\"With\" after a pause, mid-sentence"
+ },
+ {
+  "left": "we don't need to change the summarization because it keeps the important words that would",
+  "right": "Like technical words, numbers, etc. But we could just verify that with an experiment. Control,",
+  "mark": "",
+  "word": "Like",
+  "want": "lower",
+  "why": "\"Like\" after a pause, mid-sentence"
+ },
+ {
+  "left": "we should use um uh a curl install dot sh um but ideally we just",
+  "right": "You know, we just have uh a link, so an instructions with a link to",
+  "mark": "",
+  "word": "You",
+  "want": "lower",
+  "why": "\"You\" after a pause, mid-sentence"
+ },
+ {
+  "left": "that we'll handle separately. But what I want here is to be able to uh",
+  "right": "Um have the awareness of the text field content the input field content as well",
+  "mark": "",
+  "word": "Um",
+  "want": "lower",
+  "why": "\"Um\" after a pause, mid-sentence"
+ },
+ {
+  "left": "the summarization keeps important technical words and numbers um wouldn't that be very much removed",
+  "right": "Remove the need for a keyword search, which I think it is what you are",
+  "mark": "",
+  "word": "Remove",
+  "want": "lower",
+  "why": "\"Remove\" after a pause, mid-sentence"
+ },
+ {
+  "left": "Keep in mind that usually",
+  "right": "Outlook generate email bullets. I mean HTML bullets.",
+  "mark": "",
+  "word": "Outlook",
+  "want": "keep",
+  "why": "a product name the filter lets through"
+ },
+ {
+  "left": "the jargon from The main channels they communicate into",
+  "right": "We feed it and then from that we identify the terms",
+  "mark": "",
+  "word": "We",
+  "want": "keep",
+  "why": "a real sentence start; join must still lose"
+ },
+ {
+  "left": "Iterating through the keys of each result before printing them",
+  "right": "So why would a type checker complaint.",
+  "mark": "",
+  "word": "So",
+  "want": "keep",
+  "why": "a real question; join must still lose"
+ }
+]

--- a/tests/french-boundary-cases.json
+++ b/tests/french-boundary-cases.json
@@ -1,0 +1,227 @@
+[
+ {
+  "left": "voulait faire qui était le formatage des fonctions et des variables, des éléments de code",
+  "right": "Selon un langage, programmation.",
+  "mark": ".",
+  "language": "fr",
+  "want": "keep",
+  "why": "a real period, from real dictation"
+ },
+ {
+  "left": "OS.com. Mais quand je clique sur continue, ça ouvre Chrome, mais rien ne se passe",
+  "right": "Est-ce qu'il y a moyen d'avoir le lien à la place ?",
+  "mark": ".",
+  "language": "fr",
+  "want": "keep",
+  "why": "a real period, from real dictation"
+ },
+ {
+  "left": "Au fait, tu ne m'as pas répondu",
+  "right": "Combien as-tu mangé aujourd'hui ?",
+  "mark": ".",
+  "language": "fr",
+  "want": "keep",
+  "why": "a real period, from real dictation"
+ },
+ {
+  "left": "Rédige moi un mail avec tout ce qu'on a besoin",
+  "right": "Moi je vais rajouter comme pièce jointe mon rib et ma mon passeport.",
+  "mark": ".",
+  "language": "fr",
+  "want": "keep",
+  "why": "a real period, from real dictation"
+ },
+ {
+  "left": "Son regard devrait pointer vers la caméra, fier",
+  "right": "Mais pour nous, il ne doit pas avoir l'air pain. Et il doit être...",
+  "mark": ".",
+  "language": "fr",
+  "want": "keep",
+  "why": "a real period, from real dictation"
+ },
+ {
+  "left": "Quand tu auras fini, tu peux effacer mon vocabulaire",
+  "right": "Comme ça on recommence de manière fraîche.",
+  "mark": ".",
+  "language": "fr",
+  "want": "keep",
+  "why": "a real period, from real dictation"
+ },
+ {
+  "left": "Aussi, il faudra peut-être expliquer que",
+  "right": "Pour expliquer que En fait, ce que l'user, ce que l'utilisateur dicte, c'est ce qu'il",
+  "mark": ".",
+  "language": "fr",
+  "want": "keep",
+  "why": "a real period, from real dictation"
+ },
+ {
+  "left": "Moi j'aurai deux choses à te dire. D'abord, je veux qu'on mange demain ensemble",
+  "right": "Ensuite, il faut qu'on discute des termes du contrat. Merci.",
+  "mark": ".",
+  "language": "fr",
+  "want": "keep",
+  "why": "a real period, from real dictation"
+ },
+ {
+  "left": "Le problème des dictées dans les apps, c'est que ça ne connaît pas ton vocabulaire",
+  "right": "Les noms des collègues. Le nom des produits ou des venders.",
+  "mark": ".",
+  "language": "fr",
+  "want": "keep",
+  "why": "a real period, from real dictation"
+ },
+ {
+  "left": "Quand il y a une transformation, le notch devrait réapparaître",
+  "right": "Après, par exemple, si je fais fixed grammar, pour l'instant, le notch ne réapparaît plus",
+  "mark": ".",
+  "language": "fr",
+  "want": "keep",
+  "why": "a real period read as a cut; the measured rate is about 2 per 100",
+  "cost": true
+ },
+ {
+  "left": "Je te dis pas ça pour que tu le fixes tout de suite",
+  "right": "Mais j'imagine que tu fais le tour du fonctionnement du crawler donc c'est peut-être un",
+  "mark": ".",
+  "language": "fr",
+  "want": "keep",
+  "why": "a real period, from real dictation"
+ },
+ {
+  "left": "Aussi, il y a la question de déclimatisation",
+  "right": "Ils ne retiennent que mille six cents euros. Est-ce que c'est justifié?",
+  "mark": ".",
+  "language": "fr",
+  "want": "keep",
+  "why": "a real period, from real dictation"
+ },
+ {
+  "left": "qu'on va faire. Peut-être qu'il faudra les changer. Les traces ne seront pas les mêmes",
+  "right": "Peut-être qu'on pourra enlever le juge.",
+  "mark": ".",
+  "language": "fr",
+  "want": "keep",
+  "why": "a real period, from real dictation"
+ },
+ {
+  "left": "que je voulais savoir c'est s'il y avait encore des entraînements de modèles à masque",
+  "right": "Parce que le vocabulaire change d'année en année, notamment sur le plan technologique.",
+  "mark": ".",
+  "language": "fr",
+  "want": "keep",
+  "why": "a real period, from real dictation"
+ },
+ {
+  "left": "Donc heard as devient une paire avec le",
+  "right": "Texte transcrit et le phonème reconnu",
+  "mark": ".",
+  "language": "fr",
+  "want": "lower",
+  "why": "a pause cut one sentence in two"
+ },
+ {
+  "left": "Oui mais Versal Je pensais que Versal n'était pas",
+  "right": "Reconnu donc le slot gate aurait dû le choper non",
+  "mark": ".",
+  "language": "fr",
+  "want": "lower",
+  "why": "a pause cut one sentence in two"
+ },
+ {
+  "left": "Le passage acoustique, on parle bien des phonèmes,",
+  "right": "Mais on parle pas de CTC",
+  "mark": ".",
+  "language": "fr",
+  "want": "lower",
+  "why": "a pause cut one sentence in two"
+ },
+ {
+  "left": "Pas forcément si le vecteur Est n'y a pas vraiment de différence entre le",
+  "right": "Vecteur des trois mots avec le mot de vocabulaire et avec celui de la moyenne",
+  "mark": ".",
+  "language": "fr",
+  "want": "lower",
+  "why": "a pause cut one sentence in two"
+ },
+ {
+  "left": "Pourquoi est-ce qu'il faut un appel au modèle lorsqu'il n'y a pas de substitution sur",
+  "right": "Sur une partie de la phrase sans problème grammatico",
+  "mark": ".",
+  "language": "fr",
+  "want": "lower",
+  "why": "a pause cut one sentence in two"
+ },
+ {
+  "left": "Mais si on avait des",
+  "right": "Parts of speech, l'idée du double complément ça fonctionnerait, non",
+  "mark": ".",
+  "language": "fr",
+  "want": "lower",
+  "why": "a pause cut one sentence in two"
+ },
+ {
+  "left": "Alors, à la place de la notice, ouvrons",
+  "right": "Simplement la boîte de vocabulaire qu'on a déjà",
+  "mark": ".",
+  "language": "fr",
+  "want": "lower",
+  "why": "a pause cut one sentence in two"
+ },
+ {
+  "left": "La décision d'utiliser M IK revient à l'utilisateur ou",
+  "right": "Simplement à une règle de l'application qui met une préférence au vocabulaire personnel",
+  "mark": ".",
+  "language": "fr",
+  "want": "lower",
+  "why": "a pause cut one sentence in two"
+ },
+ {
+  "left": "Donc que dois-je faire pour",
+  "right": "Que ce soit la dernière version de l'app qui soit",
+  "mark": ".",
+  "language": "fr",
+  "want": "lower",
+  "why": "a pause cut one sentence in two"
+ },
+ {
+  "left": "J'ai vu quelques commentaires sur X également de personnes qui",
+  "right": "Trouvaient que la prose était plus naturelle",
+  "mark": ".",
+  "language": "fr",
+  "want": "lower",
+  "why": "a pause cut one sentence in two"
+ },
+ {
+  "left": "Idéalement, oui, il aurait évolué",
+  "right": "Les deux points mais c'est peut-être en demandé beaucoup",
+  "mark": ".",
+  "language": "fr",
+  "want": "lower",
+  "why": "a pause cut one sentence in two"
+ },
+ {
+  "left": "De plus, si on prend des modèles",
+  "right": "Plus modernes qui ont une meilleure compréhension du langage, la nuance entre tes phrases sera",
+  "mark": ".",
+  "language": "fr",
+  "want": "lower",
+  "why": "a pause cut one sentence in two"
+ },
+ {
+  "left": "Est-ce que tu peux m'envoyer la liste des",
+  "right": "Topics tels qu'ils vont être dans les crawlfiles",
+  "mark": ".",
+  "language": "fr",
+  "want": "lower",
+  "why": "a pause cut one sentence in two"
+ },
+ {
+  "left": "Attends donne-moi deux minutes que je me",
+  "right": "Rafraîchisse un peu la mémoire",
+  "mark": ".",
+  "language": "fr",
+  "want": "lower",
+  "why": "a pause cut one sentence in two"
+ }
+]

--- a/tests/sentence-boundary-cases.json
+++ b/tests/sentence-boundary-cases.json
@@ -726,7 +726,6 @@
   "right": "A test set inspired from a couple of crawl files of HCP",
   "winner": "join",
   "mean": {
-   ",": -6.2126,
    ".": -6.2656,
    "as-decoded": -6.5784,
    "join": -5.9801
@@ -739,7 +738,6 @@
   "right": "The main channels they communicate into We feed it and then from",
   "winner": "join",
   "mean": {
-   ",": -6.2038,
    ".": -6.4045,
    "as-decoded": -6.5457,
    "join": -6.0074
@@ -750,9 +748,8 @@
   "mark": "",
   "left": "with and all the jargon from The main channels they communicate into",
   "right": "We feed it and then from that we identify the terms that",
-  "winner": ",",
+  "winner": ".",
   "mean": {
-   ",": -4.5055,
    ".": -4.5627,
    "as-decoded": -5.1056,
    "join": -4.6273
@@ -763,9 +760,8 @@
   "mark": "",
   "left": "technical terms and acronyms from the code base and from Slack conversations",
   "right": "And the people I interacted with the last thirty days so a",
-  "winner": ",",
+  "winner": "join",
   "mean": {
-   ",": -4.0813,
    ".": -4.2839,
    "as-decoded": -4.5694,
    "join": -4.1349
@@ -778,7 +774,6 @@
   "right": "A dot B and A dot B would be part of the",
   "winner": "as-decoded",
   "mean": {
-   ",": -2.8468,
    ".": -3.1882,
    "as-decoded": -2.3563,
    "join": -2.4674

--- a/tests/sentence-case-cases.json
+++ b/tests/sentence-case-cases.json
@@ -37,5 +37,14 @@
  { "text": "we are writing it in English for the other reviewers", "want": "English", "why": "no mark in front of it, the lexicon knows this noun" },
  { "text": "I want to paste it into WhatsApp and the other apps", "want": "WhatsApp", "why": "no mark in front of it, a capital inside the word" },
  { "text": "the release goes out on Friday if the checks are green", "want": "Friday", "why": "no mark in front of it, a weekday is a noun" },
- { "text": "we can format the functions in TypeScript for that case", "want": "TypeScript", "why": "no mark in front of it, a capital inside the word" }
+ { "text": "we can format the functions in TypeScript for that case", "want": "TypeScript", "why": "no mark in front of it, a capital inside the word" },
+ { "text": "boundaries for portrait examples containing Several versions of the same", "want": "several", "why": "a quantifier tagged Adjective; the dictation this rule was fixed for" },
+ { "text": "we looked at the logs and saw Many errors in a row", "want": "many", "why": "a quantifier tagged Adjective" },
+ { "text": "the migration finished and Most tables came over clean", "want": "most", "why": "a quantifier tagged Adjective" },
+ { "text": "we ran the suite again and Few tests failed", "want": "few", "why": "a quantifier tagged Adjective" },
+ { "text": "we shipped the first one and Other changes followed", "want": "other", "why": "a quantifier tagged Adjective" },
+ { "text": "we translated the page into French and it worked", "want": "French", "why": "a language tagged Adjective; the lemma keeps the capital" },
+ { "text": "the docs are only in English at the moment", "want": "English", "why": "a language tagged Noun, refused by the class" },
+ { "text": "we agreed to ship it Friday before the standup", "want": "Friday", "why": "a weekday tagged Noun, refused by the class" },
+ { "text": "the outage report came from Google before lunch", "want": "Google", "why": "an organisation name, refused by the class" }
 ]

--- a/tests/sentence-window-cases.json
+++ b/tests/sentence-window-cases.json
@@ -112,7 +112,7 @@
   }
  },
  {
-  "why": "a bare capital has four readings, and only as-decoded keeps the capital with no mark",
+  "why": "a bare capital has three readings: the comma is a marked-boundary reading",
   "left": "imports name definitions ",
   "right": "And all the things",
   "bare": true,
@@ -122,7 +122,6 @@
    "readings": [
     {"key": ".", "continuation": ". And all the things"},
     {"key": "as-decoded", "continuation": " And all the things"},
-    {"key": ",", "continuation": ", and all the things"},
     {"key": "join", "continuation": " and all the things"}
    ]
   }


### PR DESCRIPTION
A pause in the middle of a sentence makes the transcriber end it early. The
`interpret` step repairs that in English. This turns it on for French, and
fixes two reasons an English capital left over from a pause was not touched.

French reads at AUC 0.968 against 0.984 in English, repairs 91% of cuts, and
costs about 2 false joins per 100 real periods. Nothing is behind a setting: a
French dictation that runs `interpret` now gets its boundaries read. The
bare-capital half stays English, because its refusal rules were tuned on
English capitalisation.

Start the review at the false-join rate. English aims at zero and French is at
two per hundred, which is the one number here that is a judgement call rather
than a measurement.

<details>
<summary>French was refused for a reason that expired when ModernBERT left</summary>

`SentenceJoin.apply` held `guard language == "en"`, and the comment above it
gave two reasons. The first was that the readings are scored by an English base
model. That model is gone: the stage reads `Qwen3-0.6B-Base` through
`SentenceReadings`, and `RetiredModels.swift` exists to delete ModernBERT's
cache from machines that still hold it. Nobody revisited the guard when the
model was swapped.

The second reason, that the mark set is English, was real but small.
`Config.Language.builtIn` already had an `"fr"` entry carrying English's marks.

Three things had to change, not one:

- the guard, in the stage **and again in `SentenceJoinCommand`**, so
  `--sentence-join` answers in French too;
- the space French sets before `?`. `boundaries(in:scanning:)` took the
  letters immediately before the mark, so `travailler ?` yielded no boundary at
  all. Removing the guard alone would have read French periods and skipped every
  French question, silently;
- `:` in the French mark set, which French writes where English writes a full
  stop. It is a reading, not an ender.

</details>

<details>
<summary>French, measured on 234 boundaries — AUC 0.968, 91% of cuts repaired</summary>

103 real periods mined from real dictation and 131 cuts made by inserting
`. Majuscule` mid-clause, the same method the English work used.

    AUC (join margin separates cut from real)   0.968
    synthetic cuts repaired                     119/131   91%
    false joins per 100 real periods            5.8 raw, about 2 hand-checked
    median latency                              53 ms, same as English

For comparison: Qwen English 0.984, mmBERT French 0.918, ModernBERT French
0.870, XLM-R French 0.881.

The raw false-join column is overstated, the same way it was in English. All
six were read by hand: two are genuine — `…devrait réapparaître. | Après, par
exemple` and `…en dessous. | Des options plutôt que` — and the other four are
cuts the model repaired correctly, which the mining had labelled as real
periods.

**The comma decoy transfers.** 43 of 103 real periods pick the comma, against
26% in English, and only 6 pick join. That is the mechanism working in a
language it was never tuned on.

The colon changes no decision on the 234. It wins once, on a real period, where
it replaces a comma win. It can only cost a repair, never add a false join.

Earlier work put the corpus ceiling at 51 real periods. It is gone: the
transcript history holds 584 distinct French dictations.

</details>

<details>
<summary>A quantifier after a pause was refused before the model ever saw it</summary>

`…for portrait examples containing Several versions of the same` is a real
dictation, with 2.8s of silence before `Several`. It was never read.

`SentenceJoin.readable` allowed eight lexical classes and Adjective was not one,
because the class is mixed. Measured with `NLTagger`:

    quantifiers tagged Adjective   Several Many Most Few Other Such Same Half
                                   Various Certain Next Last First
    names tagged Adjective         French, Open

**The lemma separates them.** It keeps the capital on a name — `French`→French,
`English`→English, `Google`→Google, `Friday`→Friday — and drops it on a
quantifier — `Several`→several. So an adjective whose lemma starts lowercase may
now be read.

`readableClasses` is untouched, so the Noun refusal that carries most of the
measured 93% is intact. `Slack` lemmatises lowercase too, but it tags Noun and
never reaches the test.

Nine cases added to `tests/sentence-case-cases.json`: five quantifiers and four
names. 48/48, and the 39 that were there do not move.

</details>

<details>
<summary>On a bare capital the comma could only veto — dropping it gains 40 repairs for 2</summary>

A capital with no mark in front of it got four readings. They split two-two on
the only question that path asks:

    .            …then. The dot is wrong      capital kept
    as-decoded   …then The dot is wrong       capital kept
    ,            …then, the dot is wrong      lowercased
    join         …then the dot is wrong       lowercased

Only `join` writes. So a comma win was never a decision. It was a veto on a join
that had already beaten both readings that keep the capital.

Measured over 616 bare capitals mined from 3,336 English dictations, 225 of
which get past the part-of-speech filter:

    lowercased, of 225
      before                87
      after                129

The change acts on 42 cases. 40 are right and **2 destroy a correct capital** —
`…after several retries it fails | The ingest should stop`, and
`In Google just ask quote | What are the top ten questions…`, where the capital
opens a quotation. Both are marked `cost: true` in the fixture and printed by
the check, not hidden.

The marked path keeps its comma. 26% of real sentence endings pick it there,
which is why none of them picks join.

</details>

<details>
<summary>A margin threshold was tried on both, and loses on both</summary>

The two destroyed capitals are thin, +0.061 and +0.056. But so are many repairs:
17 of the 40 sit below +0.10 and the smallest is +0.004.

    threshold   repairs kept   destructions
      0.000        40/40            2
      0.040        30/40            2
      0.062        27/40            0
      0.150        17/40            0

Buying back those two costs 13 repairs. It also reintroduces the calibrated
constant `SentenceJoin.Tier` refuses: "an argmax has no threshold to hedge
with". So the change ships plain.

Grouping `{., as-decoded}` against `{,, join}` was also tried, and is worse: it
repairs 53 of 59 on a labelled sample but destroys 3, including two clean
sentence starts where only the comma was voting.

</details>

<details>
<summary>What this does not fix</summary>

- **The bare-capital half is English only.** Its refusal rules were tuned on
  English capitalisation and French capitalises far less — no days, months,
  nationalities. Untested in French, so it is gated off there.
- **A marked boundary the model reads as a comma still writes nothing.**
  `…the selected text. And also write` loses at `,` -4.05 against `join` -4.43.
  That is a model error on a hard case, not something a rule can reinterpret.
- **The French false-join rate is about 2 per 100**, against English's target of
  zero. One case is in the fixture as a recorded cost.
- **Synthetic cuts are easier than real ones.** They are inserted at a random
  word boundary; real spurious cuts fall at natural pause points. 91% is
  probably optimistic.
- The bare-capital labels are single-annotator, read from the text before any
  score was seen.

</details>

<details>
<summary>Review notes — 54 lines of behaviour, the rest is evidence</summary>

    Sources/ParrotFlow/SentenceJoin.swift          37   languages, the ? space,
                                                        readable()'s lemma clause,
                                                        the guard, the English gate
    Sources/ParrotFlow/SentenceReadings.swift      13   bareReadings drops the comma
    Sources/ParrotFlow/SentenceProbeCommand.swift   5   the bench reads row.language
    Sources/ParrotFlow/Config.swift                 4   ":" in the fr marks
    Sources/ParrotFlow/SentenceJoinCommand.swift    2   the second guard

Everything else is two check scripts, two fixtures and the docs.

`--sentence-probe --bench` now reads the mark set for each row's `language`, so
the French set is reproducible. It defaults to English, so existing case files
are unaffected.

Four commits, each self-contained, in the order the work was done.

Checks, all needing the 320 MB sentence model except `sentence-case`:

    scripts/check-sentence-case.sh       48/48
    scripts/check-sentence-window.sh     11/11
    scripts/check-bare-capital.sh        43/43  and 2 known costs
    scripts/check-french-boundary.sh     27/27  and 1 known cost
    make test                            93 passed, 0 failed

`tests/french-boundary-cases.json` is a 28-case subset of the 234 with names
filtered out.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
