### PR TITLE
fix: long dictations no longer lose words after a pause or at the 13s window seam

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "451075d2c24c7143e382e8a3600d704e6990f76098491d7d141b59ec71b6d793",
+  "originHash" : "758e19fc60f7d01909faf2444709151a31258c3a0e2e4d3a16511daf6c497390",
   "pins" : [
     {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "19600a485baa4998812e4654b70d2bab8f2c9949",
-        "version" : "0.15.5"
+        "revision" : "41540ea237350afe5117a082b5c28eda642d0612",
+        "version" : "0.15.7"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.1.0"),
-        .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.15.5"),
+        .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.15.7"),
         // Qwen3-Embedding, for the vectors the vocabulary stage compares. MLX
         // is the only local path that returns per-token states: Ollama's embed
         // endpoint returns one pooled vector per text, and pooling loses the

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -429,18 +429,18 @@ actor Transcriber {
                 speechEnd: speechEnd,
                 note: "long-pause retry: "
             )
-            if Self.lastWordEnd(retried) > Self.lastWordEnd(result), Self.extends(result, by: retried) {
+            if let spliced = Self.splicingTail(into: result, from: retried, gate: gated) {
                 Log.write(String(
                     format: "decoder stopped %.2fs before the speech did; "
-                        + "closed %d long pause(s) and recovered to %.2fs",
+                        + "closed %d long pause(s); spliced %d word(s) from %.2fs to %.2fs",
                     Self.lastSpeechEnd(gated) - Self.lastWordEnd(result),
-                    closed.pauses, Self.lastWordEnd(retried)
+                    closed.pauses, spliced.words, spliced.from, spliced.to
                 ))
-                result = retried
+                result = spliced.result
             } else if Self.lastWordEnd(retried) > Self.lastWordEnd(result) {
                 Log.write(String(
-                    format: "closed %d long pause(s) and reached %.2fs, but the retry "
-                        + "rewrote text the first pass had already decoded; keeping the first pass",
+                    format: "closed %d long pause(s) and reached %.2fs, but nothing could be "
+                        + "spliced; keeping the first pass",
                     closed.pauses, Self.lastWordEnd(retried)
                 ))
             }
@@ -921,22 +921,15 @@ actor Transcriber {
         gate.segments.last?.end ?? 0
     }
 
-    /// True when the retry says everything the first pass said, in the same
-    /// order, before it says anything new.
+    /// True when a second decode says everything the first pass said, in the
+    /// same order, before it says anything new.
     ///
-    /// Reaching further into the clip is not on its own a reason to take the
-    /// retry. It decodes the *whole* clip, not just the tail, and closing the
-    /// pauses moves every window boundary after the first pause — so its
-    /// version of the opening is a different decode of audio the first pass
-    /// may already have got right. Swapping wholesale on the strength of a
-    /// later ending would trade a recovered tail for a silently rewritten
-    /// beginning, which is a worse bug than the one being fixed: nobody
-    /// re-reads the part that was already correct.
-    ///
-    /// Prefix rather than equality, because what makes the retry worth having
-    /// is precisely the words it adds at the end. Compared on letters and
-    /// digits alone so that a different token split, a comma, or a capital at
-    /// a moved window boundary is not read as rewritten speech.
+    /// Used by the padded arms, which are taken or dropped whole: reaching
+    /// further into the clip is not on its own a reason to swap in a second
+    /// decode of the opening. Prefix rather than equality, because what makes
+    /// an arm worth having is the words it adds at the end. Compared on letters
+    /// and digits alone so that a different token split, a comma or a capital
+    /// is not read as rewritten speech.
     nonisolated static func extends(_ result: ASRResult, by retried: ASRResult) -> Bool {
         let first = comparable(result.text)
         guard !first.isEmpty else { return false }
@@ -1102,6 +1095,75 @@ actor Transcriber {
         return String(text[text.startIndex..<end])
     }
 
+    /// How far outside a gate segment a spliced word may start. Small because
+    /// the VAD's own 0.75s hangover has already stretched the bounds outwards.
+    static let splicedWordMargin = 0.3
+
+    /// The first pass with the retry's tail added to it, plus how many words
+    /// that was and where they sit. Nil when the retry added nothing.
+    ///
+    /// The first pass keeps its text and its tokens exactly. The retry decodes
+    /// the whole clip with every window boundary after the first pause moved,
+    /// so its opening is a second decode of audio the first pass may already
+    /// have got right. On the clip that prompted this it wrote "71%" where the
+    /// first pass wrote "seventy-one percent".
+    ///
+    /// The words taken are a run: from the first one that starts after the
+    /// first pass stopped and that the gate heard speech at, up to the first
+    /// one after that which the gate did not.
+    nonisolated static func splicingTail(
+        into result: ASRResult, from retried: ASRResult, gate: SpeechGate
+    ) -> (result: ASRResult, words: Int, from: Double, to: Double)? {
+        let timings = retried.tokenTimings ?? []
+        let grouped = Trace.grouped(from: timings)
+        let cutoff = lastWordEnd(result)
+        guard let lower = grouped.firstIndex(where: {
+            $0.word.start > cutoff && inSpeech($0.word.start, gate: gate)
+        }) else { return nil }
+        var upper = lower
+        while upper < grouped.count, inSpeech(grouped[upper].word.start, gate: gate) { upper += 1 }
+
+        // A first token with no word-start mark would be glued onto the first
+        // pass's last word the next time these timings are grouped, and the
+        // text and the tokens would stop agreeing on the word count.
+        let head = grouped[lower].tokens.lowerBound
+        let mark = timings[head].token
+        guard mark.hasPrefix("\u{2581}") || mark.hasPrefix(" ") else { return nil }
+
+        guard let before = trimmedText(retried.text, dropping: grouped.count - lower, of: grouped.count),
+              let through = trimmedText(retried.text, dropping: grouped.count - upper, of: grouped.count)
+        else { return nil }
+        var tail = through.dropFirst(before.count).trimmingCharacters(in: .whitespaces)
+        guard !tail.isEmpty else { return nil }
+        // The retry read the closed-up pause as one sentence, so its first
+        // spliced word is lowercase. On the recording that pause is 8s or more
+        // of silence, and the first pass put a full stop before it.
+        if let last = result.text.last, SentenceReadings.enders.contains(String(last)) {
+            tail = tail.prefix(1).uppercased() + tail.dropFirst()
+        }
+
+        let tokens = (result.tokenTimings ?? [])
+            + Array(timings[head..<grouped[upper - 1].tokens.upperBound])
+        let joined = ASRResult(
+            text: result.text + " " + tail,
+            confidence: confidence(of: tokens) ?? result.confidence,
+            duration: result.duration,
+            processingTime: result.processingTime,
+            tokenTimings: tokens,
+            performanceMetrics: result.performanceMetrics,
+            ctcDetectedTerms: result.ctcDetectedTerms,
+            ctcAppliedTerms: result.ctcAppliedTerms
+        )
+        return (joined, upper - lower, grouped[lower].word.start, grouped[upper - 1].word.end)
+    }
+
+    /// True when the gate heard speech where this word starts.
+    private nonisolated static func inSpeech(_ time: Double, gate: SpeechGate) -> Bool {
+        gate.segments.contains {
+            time >= $0.start - splicedWordMargin && time <= $0.end + splicedWordMargin
+        }
+    }
+
     /// A word this unsure, on its own, is not a word.
     static let loneYeahConfidence: Float = 0.6
 
@@ -1195,12 +1257,12 @@ actor Transcriber {
         )
     }
 
-    /// Only a pause approaching the decoder's own 14.88s window can starve one
-    /// of speech, and only a starved window decodes to nothing. Below this a
-    /// pause is just someone thinking mid-sentence, the windows either side of
-    /// it still hold plenty of speech, and touching the audio would be all risk
-    /// and no benefit — a sweep of the archive with this at 2s changed 166 of
-    /// 1219 clips, most of which were never at risk. At 8s it is 33.
+    /// Pauses of 1-5s also lost tails under FluidAudio 0.15.5, measured on
+    /// 2026-08-17 and again on 2026-09-11; 0.15.7 repairs its own window seams,
+    /// so those no longer reach here. What is left is a tail after a pause the
+    /// library's repair cannot see, and 8s is where a sweep of the archive
+    /// stops moving clips that were never at risk: 166 of 1219 changed at 2s,
+    /// 33 at 8s.
     static let minPauseToClose = 8.0
 
     /// What a closed pause is cut down to, half kept on each side so a sentence


### PR DESCRIPTION
Dictations longer than about 13s lost words after a pause: the end of a sentence, or a clause in the middle. Ten dictations were flagged for this between 09-06 and 09-11, and about 1% of all dictations show the same signature in the trace. The words were already missing from the recogniser's first pass, so no transform could put them back.

This bumps FluidAudio from 0.15.5 to 0.15.7. The library now repairs the gaps at its own window seams and starts windows at silence, so the first pass keeps those words. All seven flagged clips that lost a tail or a middle decode whole with the bump alone. No app code needed to change for that.

The second commit keeps the app's own long-pause retry working under the new library. Its old acceptance rule swapped in the whole retry, but only when the retry's opening matched the first pass letter for letter. Under 0.15.7 the retry decodes the opening a little differently more often, so a recovered tail was thrown away with it. The retry now splices only its tail onto the first pass. The first pass's own text and tokens stay exactly as they were.

A reviewer should check `splicingTail` in `Transcriber.swift`: the run of words it takes, the word-start guard, and the capital it adds after a full stop.

<details>
<summary>Why the words went missing — the decoder stopped a second after each 12.88s window seam</summary>

Above 15s FluidAudio's batch path decodes 14.88s windows on a 12.88s stride. On every flagged clip the last decoded word ended 0.3 to 1.8s after a seam, then nothing, although the VAD heard speech for several more seconds. One clip lost a clause in the middle the same way. Re-decoding the seven clips from disk reproduced every loss. Cutting their pauses to 0.4s before decoding brought all seven back, and moving one 2.1s pause by 0.1s was enough on its own, so the seam was the cause, not the audio.

The app's retry for this (`closeLongPauses`) never ran on any of them: it waits for a pause over 8s, and the longest pause in the seven is 4.9s.

FluidAudio 0.15.6 and 0.15.7 target exactly this on the batch path: seam-gap repair (#761), end-aligned final window (#800), merge token order (#830), silence-aligned window starts on v3 (#869). All on by default. The app builds `AsrManager` with the default config, so nothing else changes.

</details>

<details>
<summary>Measurements — 7 of 7 flagged clips recovered, 30 of 30 short clips unchanged</summary>

The seven flagged clips, re-decoded from disk with the 0.15.7 build (`--transcribe`, scratch config): all seven come back with the words the speaker reported, for example "possible resulting sentences", "in the natural language package", "banner dismissed", "into complex analysis".

A sample of 90 live dictations since 09-09, raw first-pass text against the live record:

| outcome | clips |
|---|---|
| identical | 69 |
| longer, a real tail recovered | 1 |
| shorter, a trailing "Mm-hmm" gone | 1 |
| one or two words differ | 15 |

Every differing clip is over 16s. All 30 clips under 12s decode identically, so the single-window path is untouched. Decode time median is unchanged; the longest went from 0.2s to 0.96s.

The app's other repairs were re-run against their own archived case sets under 0.15.7 and each still fires: 46 of 46 empty-decode clips are still empty on the first pass (the pad recovers 31), and 47 of 56 invented-ending clips still get an invented ending on the first pass. None was removed.

</details>

<details>
<summary>The retry splice — fires on 5 of 140 long-pause clips, recovers 18 words, changes nothing else</summary>

On the clip that showed the problem (10s pause, "will engage gently" lost), the two decodes differed by one number's notation: "seventy-one percent" against "71%". The letters-and-digits prefix test failed and the tail went with it.

`splicingTail` takes the retry's words that start after the first pass's last word and inside a VAD segment (0.3s margin over the VAD's own 0.75s hangover), as one contiguous run, and appends them. It refuses when the first taken token has no word-start mark, so text and tokens keep agreeing on word count. Confidence is recomputed from the joined tokens as `withoutInventedTail` does. When the first pass ended on a sentence mark, the tail gets a capital.

Every second archived live dictation with a pause over 8s, the population where the retry runs: 140 clips. The splice fired on 5 and recovered 18 words. Three match what the old build delivered live; two gain words the live delivery never had ("view transforms", "I came back to French transport"). The other 135 are untouched by the change. The seven flagged clips still decode exactly as with the bump alone; the retry does not fire on them.

`extends` stays for the padded second-opinion arms, which are still taken or dropped whole.

</details>

<details>
<summary>What this does not fix</summary>

- A pause inside a single window. One flagged clip (13.9s, 8s pause) still loses "that heartbeat". Closing pauses before the first pass was measured on 250 archived clips and rejected: at 4s it recovers 6 and loses 57, because the VAD calls soft speech silence and the cut deletes real words.
- Invented endings over trailing silence. One flagged clip still gets one; it passed the after-speech rule because one word scored 0.81 against the 0.8 ceiling. Unchanged here.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
