### PR TITLE
feat: one timeline per dictation, and a way to read it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ CHECKS := replacements pipeline pipeline-config wake split dotted dates keyed \
           profiles span-rule clipboard default-config vocabulary-config learn \
           signing-identity no-voice sound slot-tokenizer sentence-case term-uses \
           edit-diff sentence-open invented-tail sentence-window lowercase-refused \
-          selector sound-group
+          selector sound-group trace-edits
 
 ## A shipped transform keeps its case set in its own folder and scores it with
 ## a script beside it, not with scripts/check-<name>.sh.

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2232,7 +2232,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     Trace.current?.recordCapture(
                         engine: capture?.engine, firstSample: capture?.firstSample,
                         at: capture?.at,
-                        stopped: capture.map { -$0.at.timeIntervalSinceNow }
+                        stopped: capture.map { stoppedAt.timeIntervalSince($0.at) }
                     )
                     let text = try await self?.transcriber.transcribe(
                         url: recording.url, config: config, app: app, press: press.run,

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -2144,11 +2144,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Taken at the press, not here: a transcript arrives seconds later and
         // the window you dictated into may not be the one in front by then.
         let app = appAtPress
+        // Zero on the timeline: the recording has just been stopped, so this is
+        // the moment the app started having work to do.
+        let stoppedAt = Date()
         // What the clip cost before it existed, both halves measured from the
         // key going down. Read off the recording rather than the recorder:
         // `stop` has already torn the recorder's own copy down.
         let capture = capturePress.map { press in
             (
+                at: press.at,
                 engine: press.engineAfter,
                 firstSample: recording.firstSampleAt.map { $0.timeIntervalSince(press.at) }
             )
@@ -2216,10 +2220,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 let text = try await Trace.record(
                     wav: recording.url.lastPathComponent, source: .live,
                     app: app.map { Trace.App(name: $0.name, bundleID: $0.bundleID) },
-                    beside: recording.url.deletingLastPathComponent()
+                    beside: recording.url.deletingLastPathComponent(),
+                    // Zero on the timeline is the key coming up, not going
+                    // down. Holding a key for fifteen seconds is not work the
+                    // app did, and drawn to scale it squashes the second that
+                    // is. What the press cost is in `capture` on the corpus
+                    // line, which is where a number belongs when it is not a
+                    // span.
+                    origin: stoppedAt
                 ) {
                     Trace.current?.recordCapture(
-                        engine: capture?.engine, firstSample: capture?.firstSample
+                        engine: capture?.engine, firstSample: capture?.firstSample,
+                        at: capture?.at,
+                        stopped: capture.map { -$0.at.timeIntervalSinceNow }
                     )
                     let text = try await self?.transcriber.transcribe(
                         url: recording.url, config: config, app: app, press: press.run,
@@ -2261,8 +2274,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         return
                     }
                     self.stopWatchingForEscapeIfIdle()
+                    // Timed from here, which is the wait a person actually
+                    // feels after the words are ready. Not only the paste:
+                    // this branches into commands and the panel too, and every
+                    // one of those is time between the transcript existing and
+                    // something happening.
+                    let delivering = Date()
                     self.finishTranscription(
                         text: text, destination: destination, focus: focus, for: press
+                    )
+                    Trace.deliver(
+                        wav: recording.url.lastPathComponent,
+                        seconds: Date().timeIntervalSince(delivering),
+                        route: destination.traceName,
+                        app: app?.name,
+                        beside: recording.url.deletingLastPathComponent()
                     )
                 }
             } catch {
@@ -4950,9 +4976,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         // Saying so beats replacing text with itself and calling it done, which
         // looks identical to the prompt having silently failed.
+        //
+        // Unless leaving the text alone was the point. A transform that opens a
+        // trace or a folder has done exactly what it was asked, and "nothing to
+        // change" reads as a failure — `done:` is how it says otherwise.
         guard cleaned != before else {
-            Log.write("offer: \(transform.name) changed nothing")
-            flashThenOffer("\(transform.name): nothing to change", tone: .plain)
+            let acted = !transform.done.isEmpty
+            Log.write("offer: \(transform.name) \(acted ? "ran" : "changed nothing")")
+            flashThenOffer(
+                acted ? transform.done : "\(transform.name): nothing to change",
+                tone: .plain
+            )
             return
         }
 

--- a/Sources/ParrotFlow/BugReport.swift
+++ b/Sources/ParrotFlow/BugReport.swift
@@ -70,6 +70,7 @@ enum BugReport {
         sections.append(permissions(fromTerminal: fromTerminal))
         sections.append("--check-config\n\(CheckConfigCommand.report().text)")
         sections.append("Log — last \(logLines) lines of \(Log.fileURL.path)\n\(logTail())")
+        if let timeline = lastTimeline() { sections.append(timeline) }
 
         return redacted(sections.joined(separator: "\n\n"))
     }
@@ -92,6 +93,36 @@ enum BugReport {
             }
         }
         return lines.joined(separator: "\n")
+    }
+
+    /// The last dictation's timeline, in durations and step names.
+    ///
+    /// "It got slow" is the report this app cannot act on: the log is
+    /// second-resolution prose and the numbers that would answer it sit in a
+    /// file nobody attaches. This is those numbers.
+    ///
+    /// **No words.** `notes: false` drops the transcript and everything a step
+    /// said about itself, because a note can quote what you dictated. The
+    /// span names that remain are the app's own vocabulary. The full one is
+    /// `--trace-view`, and it is yours to send or not.
+    private static func lastTimeline() -> String? {
+        guard let directory = (try? ConfigStore.load())?.resolvedOutputDir,
+              let contents = try? String(
+                  contentsOf: directory.appendingPathComponent(Trace.spansFile), encoding: .utf8
+              )
+        else { return nil }
+
+        var latest: [String: Any]?
+        for line in contents.split(separator: "\n") {
+            guard let data = line.data(using: .utf8),
+                  let record = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+                  record["source"] as? String == "live",
+                  record["spans"] != nil
+            else { continue }
+            latest = record
+        }
+        guard let latest, let drawn = TraceText.render(latest, notes: false) else { return nil }
+        return "Timeline — the last dictation, in seconds. No transcript.\n" + drawn
     }
 
     private static func logTail() -> String {

--- a/Sources/ParrotFlow/BugReport.swift
+++ b/Sources/ParrotFlow/BugReport.swift
@@ -112,14 +112,18 @@ enum BugReport {
               )
         else { return nil }
 
+        // Backwards, stopping at the first hit. `spans.jsonl` rotates at
+        // 64 MB, and parsing every line of that to keep the last one is a
+        // stall on the path somebody is already using to report a problem.
         var latest: [String: Any]?
-        for line in contents.split(separator: "\n") {
+        for line in contents.split(separator: "\n").reversed() {
             guard let data = line.data(using: .utf8),
                   let record = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
                   record["source"] as? String == "live",
                   record["spans"] != nil
             else { continue }
             latest = record
+            break
         }
         guard let latest, let drawn = TraceText.render(latest, notes: false) else { return nil }
         return "Timeline — the last dictation, in seconds. No transcript.\n" + drawn

--- a/Sources/ParrotFlow/Config.swift
+++ b/Sources/ParrotFlow/Config.swift
@@ -825,6 +825,13 @@ struct Config: Decodable, Equatable {
         var offer = false
         /// `key: f` — the letter shown on its chip.
         var offerKey = ""
+        /// `done: Trace opened` — what the pill says when this transform
+        /// returns the text unchanged.
+        ///
+        /// For a transform that acts instead of rewriting. One that opens a
+        /// trace leaves the sentence alone by design, and the pill's honest
+        /// "nothing to change" then reads as a failure.
+        var done = ""
         /// `say: [slack handles, handles]` — what to call it out loud.
         var say: [String] = []
         /// `model: gpt`, or `model: { use: gpt, reasoning: low }`.
@@ -832,7 +839,7 @@ struct Config: Decodable, Equatable {
 
         enum CodingKeys: String, CodingKey {
             case name, description, display, confirm, prompt, content, replace, command
-            case tests, returns, offer, model, say
+            case tests, returns, offer, model, say, done
             case offerKey = "key"
             case timeout = "timeout_seconds"
         }
@@ -909,6 +916,7 @@ struct Config: Decodable, Equatable {
             // keycap holds one character; a key is printed in capitals whatever
             // the config wrote it as.
             offerKey = String(try trimmed(.offerKey).prefix(1)).uppercased()
+            done = try trimmed(.done)
             // One string or a list, because most transforms want one alias and
             // writing `say: bullets` should not be an error.
             //
@@ -1098,7 +1106,8 @@ struct Config: Decodable, Equatable {
                 display: entry.display,
                 folder: entry.folder, timeout: entry.timeout,
                 confirm: entry.confirm, returnsJSON: entry.returnsJSON,
-                offer: entry.offer, offerKey: entry.offerKey, say: entry.say,
+                offer: entry.offer, offerKey: entry.offerKey, done: entry.done,
+                say: entry.say,
                 body: body, source: entry.source,
                 tests: entry.tests, model: entry.model
             ))
@@ -1182,6 +1191,10 @@ struct Config: Decodable, Equatable {
         /// The letter shown on that chip. Empty when the config named none; the
         /// chip is still there and still clickable.
         var offerKey: String = ""
+        /// `done:` — what the pill says when this transform leaves the text
+        /// alone on purpose. Empty for one that rewrites, which is all of them
+        /// but the ones that act.
+        var done: String = ""
         /// What to call this out loud, besides its name.
         ///
         /// A name is written for a config file — `slack_handles`, `code_identifiers` — and nobody says an underscore. An alias is what you would actually
@@ -2776,8 +2789,16 @@ struct Config: Decodable, Equatable {
         /// Keep each dictation's recording on disk, in `audio.output_dir`.
         /// Off by default: nothing written, nothing left behind.
         var audio: Bool = false
+        /// One timeline per dictation in `spans.jsonl`, beside `trace.jsonl` —
+        /// see `Trace.Span` and `--trace-view`.
+        ///
+        /// On, and rotating at 64 MB. It is on for people who will never open
+        /// one because a bug report needs a trace that already exists: you
+        /// cannot turn a flight recorder on after the thing you are reporting.
+        /// `--trace-view --redacted` is what makes one safe to send.
+        var spans: Bool = true
 
-        enum CodingKeys: String, CodingKey { case text, audio }
+        enum CodingKeys: String, CodingKey { case text, audio, spans }
 
         init() {}
 
@@ -2786,6 +2807,7 @@ struct Config: Decodable, Equatable {
             self.init()
             if let v = try c.decodeIfPresent(Bool.self, forKey: .text) { text = v }
             if let v = try c.decodeIfPresent(Bool.self, forKey: .audio) { audio = v }
+            if let v = try c.decodeIfPresent(Bool.self, forKey: .spans) { spans = v }
         }
     }
 
@@ -3591,6 +3613,7 @@ enum ConfigStore {
         // on every save, and each CLI command once — so this is the one place
         // that has to set it.
         Log.textEnabled = config.logging.text
+        Trace.spansEnabled = config.logging.spans
         return config
     }
 

--- a/Sources/ParrotFlow/Destination.swift
+++ b/Sources/ParrotFlow/Destination.swift
@@ -17,6 +17,21 @@ import ApplicationServices
 /// instead of being fired into a window that will swallow it.
 enum Destination: Equatable {
 
+    /// Which kind of surface this is, for `spans.jsonl`.
+    ///
+    /// The case alone. `String(describing:)` writes the associated values out
+    /// too, so a route reads `terminal(name: "Ghostty")` — the app name again,
+    /// beside the field that already holds it, and a string nothing can group
+    /// on.
+    var traceName: String {
+        switch self {
+        case .field: return "field"
+        case .terminal: return "terminal"
+        case .named: return "named"
+        case .nowhere(let reason): return "nowhere: \(reason)"
+        }
+    }
+
     /// Something with keyboard focus that will accept typed text, named by the
     /// accessibility role it reported — the log line is the only way to tell
     /// afterwards why a surface was accepted or refused.

--- a/Sources/ParrotFlow/Destination.swift
+++ b/Sources/ParrotFlow/Destination.swift
@@ -28,7 +28,7 @@ enum Destination: Equatable {
         case .field: return "field"
         case .terminal: return "terminal"
         case .named: return "named"
-        case .nowhere(let reason): return "nowhere: \(reason)"
+        case .nowhere(let reason): return "nowhere: \(reason.traceName)"
         }
     }
 
@@ -69,6 +69,17 @@ enum Destination: Equatable {
         case noAccessibility
         case nothingFocused
         case notAField(role: String)
+
+        /// The case alone, for the reason `Destination.traceName` gives:
+        /// `notAField` carries the role, and reflection would put it in the
+        /// route string that nothing could then group on.
+        var traceName: String {
+            switch self {
+            case .noAccessibility: return "no accessibility"
+            case .nothingFocused: return "nothing focused"
+            case .notAField: return "not a field"
+            }
+        }
 
         var described: String {
             switch self {

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -848,10 +848,13 @@ struct Pipeline: Equatable, Codable {
             // measured on your own sentences instead of quoted from a README.
             let before = output
             let started = CFAbsoluteTimeGetCurrent()
+            // `nests`, so the sub-steps a stage opens are filed under it.
+            let span = Trace.current?.open(named, kind: .stage, nests: true)
             let result = await apply(
                 step, to: output, config: config, app: app, scope: scope, words: words
             )
             let seconds = CFAbsoluteTimeGetCurrent() - started
+            span?.close(result.text == before ? nil : "changed")
             output = result.text
 
             // Derived, never claimed. `changed` is the comparison this loop just
@@ -1167,11 +1170,15 @@ struct Pipeline: Equatable, Codable {
         // and what it costs.
         if step.bySound ?? true, Pipeline.language(of: text, config: config) == "en" {
             let askedAt = Date()
+            let sound = Trace.current?.open("sound", kind: .part)
             let heard = await VocabularyPass.phonemeParts(
                 in: text, sounds: config.vocabularySounds, voice: "en-us",
                 language: "en", floor: config.soundBelow, claimed: parts
             )
             soundSeconds = Date().timeIntervalSince(askedAt)
+            sound?.close(config.vocabularySounds.isEmpty
+                ? "no terms with a sound"
+                : "\(heard.count) of \(config.vocabularySounds.count) over the floor")
             bySound = heard.count
             parts += heard
         }
@@ -1239,9 +1246,11 @@ struct Pipeline: Equatable, Codable {
             // machine without the 269 MB model already takes: the word lists
             // settle what they settle and the slot is never asked. Read inside
             // the branch so `gate: false` does not load it either.
+            let span = Trace.current?.open("slot_gate", kind: .part)
             let slot = (step.slotGate ?? true) ? await Vocabulary.shared.slotGate() : nil
             settled = VocabularyPass.settle(
                 changes, in: text, by: [.sound: .full, .rule: .lists], gate: slot)
+            span?.close("\(changes.count) change(s)")
         } else {
             settled = [Bool?](repeating: nil, count: changes.count)
         }
@@ -1250,6 +1259,8 @@ struct Pipeline: Equatable, Codable {
         }
         // The two tests that read the sentence, on whatever is still open.
         if config.gatesSentence, #available(macOS 14, *) {
+            let span = Trace.current?.open("sentence_gate", kind: .part)
+            defer { span?.close("\(decided.filter { $0 == nil }.count) still open") }
             let settledBySentence = await SentenceGate.settle(
                 changes, in: text, given: decided,
                 floor: config.transcription.slotFloor(

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -854,7 +854,7 @@ struct Pipeline: Equatable, Codable {
                 step, to: output, config: config, app: app, scope: scope, words: words
             )
             let seconds = CFAbsoluteTimeGetCurrent() - started
-            span?.close(result.text == before ? nil : "changed")
+            span?.close(Trace.changeSummary(from: before, to: result.text))
             output = result.text
 
             // Derived, never claimed. `changed` is the comparison this loop just

--- a/Sources/ParrotFlow/Trace.swift
+++ b/Sources/ParrotFlow/Trace.swift
@@ -30,7 +30,13 @@ enum Trace {
     /// One field, and the only moment it is free is before there is anything to
     /// migrate. A reader three months from now needs to know which shape it is
     /// holding without inferring it from which keys happen to be present.
-    static let version = 2
+    ///
+    /// 3 replaced a stage's `before` and `after` with `edits`, and added the
+    /// numbers a timeline needs: the press, the gate's own cost, the model
+    /// load, and one row per decode arm. Older lines are never converted —
+    /// nothing in 3 is derivable from 2 except `edits`, and a line claiming a
+    /// shape it does not have is exactly what this field exists to prevent.
+    static let version = 3
 
     /// The dictation being traced right now, if any. Nil on every path that
     /// did not ask for a trace — nothing here runs unless a collector is bound.
@@ -94,10 +100,71 @@ enum Trace {
         private var stages: [Stage] = []
         private var final: String?
         private var lang: String?
+        private var spans: [Span] = []
+        private var nextID = 1
+        private var prepare: Double?
+        /// Which decode the transcript came from. The first pass until an arm
+        /// beats it — a dictation always has a taken arm, and leaving this nil
+        /// would report every clean decode as one nobody used.
+        private var takenArm = "decode pass 1"
+        /// Zero on the timeline. The press for a live dictation, so the span
+        /// covering the recording itself starts at 0 rather than at a negative
+        /// number; the moment the collector was made for a replay, which was
+        /// never pressed for.
+        ///
+        /// Set here rather than by a later `record*` call, so a span opened
+        /// before anything else has the same zero as one opened after.
+        private let origin: Date
 
-        init(wav: String, source: Source) {
+        init(wav: String, source: Source, origin: Date) {
             self.wav = wav
             self.source = source
+            self.origin = origin
+        }
+
+        /// What a span opened right now hangs under. A stage sets it while it
+        /// runs, so a part opened deep inside `SentenceJoin` is filed under the
+        /// stage that called it without anyone threading an id through.
+        private var openParent: Int?
+
+        /// Opens a span and returns what closes it.
+        ///
+        /// The close is the write, so that is where the lock is taken — an
+        /// arm's span is closed from its own task and several arms run at once.
+        /// - Parameter nests: whether spans opened while this one is open
+        ///   belong to it. True for a stage, false for everything else.
+        func open(_ name: String, kind: Span.Kind, nests: Bool = false) -> OpenSpan {
+            lock.lock()
+            let id = nextID
+            nextID += 1
+            let parent = openParent
+            if nests { openParent = id }
+            lock.unlock()
+            return OpenSpan(id: id, name: name, kind: kind, parent: parent, nests: nests,
+                            at: Date().timeIntervalSince(origin), collector: self)
+        }
+
+        /// Seconds since the origin. No lock: `origin` never changes.
+        fileprivate func elapsed() -> Double { Date().timeIntervalSince(origin) }
+
+        fileprivate func close(_ span: Span, restoring: Bool) {
+            lock.lock(); defer { lock.unlock() }
+            if restoring { openParent = span.parent }
+            // A dictation cannot need more than this, and a runaway one must
+            // not grow without end for the sake of a debug artefact.
+            guard spans.count < Trace.spanLimit else { return }
+            spans.append(span)
+        }
+
+        fileprivate func timeline(app: App?) -> Timeline? {
+            lock.lock(); defer { lock.unlock() }
+            guard !spans.isEmpty else { return nil }
+            return Timeline(
+                v: Trace.spansVersion, kind: Kind.dictation.rawValue,
+                t0: Trace.stamp(origin, fractional: true), wav: wav,
+                source: source.rawValue, app: app, lang: lang,
+                spans: spans.sorted { $0.at < $1.at }, final: final
+            )
         }
 
         /// Which language the transcript was judged to be in.
@@ -116,6 +183,7 @@ enum Trace {
             lock.lock(); defer { lock.unlock() }
             asr = ASR(
                 model: model,
+                arm: spans.contains { $0.kind == .decode } ? takenArm : nil,
                 text: result.text,
                 confidence: result.confidence,
                 duration: result.duration,
@@ -124,12 +192,26 @@ enum Trace {
             )
         }
 
-        func recordVAD(speech: Double, total: Double, segments: [(Double, Double)]) {
+        func recordVAD(
+            speech: Double, total: Double, segments: [(Double, Double)], seconds: Double? = nil
+        ) {
             lock.lock(); defer { lock.unlock() }
             vad = VAD(
-                speech: speech, total: total,
+                seconds: seconds, speech: speech, total: total,
                 segments: segments.map { [$0.0, $0.1] }
             )
+        }
+
+        /// What loading the models cost, when they were not already up.
+        func recordPrepare(_ seconds: Double) {
+            lock.lock(); defer { lock.unlock() }
+            prepare = seconds
+        }
+
+        /// Which decode the transcript came from, named as its span is.
+        func recordArm(_ arm: String) {
+            lock.lock(); defer { lock.unlock() }
+            takenArm = arm
         }
 
         /// How long the press waited, in seconds, before the engine was running
@@ -140,9 +222,14 @@ enum Trace {
         /// said into a microphone that was not yet recording — the clips that
         /// begin mid-word have no other explanation, and until this field there
         /// was nothing on disk that could size it.
-        func recordCapture(engine: Double?, firstSample: Double?) {
+        func recordCapture(
+            engine: Double?, firstSample: Double?, at: Date? = nil, stopped: Double? = nil
+        ) {
             lock.lock(); defer { lock.unlock() }
-            capture = Capture(engine: engine, firstSample: firstSample)
+            capture = Capture(
+                at: at.map { Trace.stamp($0, fractional: true) },
+                engine: engine, firstSample: firstSample, stopped: stopped
+            )
         }
 
         /// - Parameter code: the category, for grouping. The prose beside it
@@ -191,10 +278,33 @@ enum Trace {
 
         fileprivate func record(at: String, app: App?) -> Record {
             lock.lock(); defer { lock.unlock() }
+            // Read off the timeline rather than gathered twice. A part is a
+            // span whose parent is a stage's span, and a decode is a span of
+            // that kind — so the two files cannot disagree about what a step
+            // cost, which is the whole reason they were built from one source.
+            let byID = Dictionary(uniqueKeysWithValues: spans.map { ($0.id, $0) })
+            var parts: [String: [Part]] = [:]
+            for span in spans where span.kind == .part || span.kind == .model {
+                guard let parent = span.parent.flatMap({ byID[$0] }),
+                      parent.kind == .stage else { continue }
+                parts[parent.name, default: []]
+                    .append(Part(name: span.name, seconds: span.dur, note: span.note))
+            }
+            let decodes = spans.filter { $0.kind == .decode }.map {
+                Decode(arm: $0.name, seconds: $0.dur,
+                       reached: Trace.reached($0.note), taken: $0.name == takenArm)
+            }
             return Record(
                 v: Trace.version, kind: Kind.dictation.rawValue,
                 at: at, wav: wav, source: source.rawValue, app: app, lang: lang,
-                asr: asr, vad: vad, capture: capture, stages: stages, final: final
+                asr: asr, vad: vad, capture: capture, prepare: prepare,
+                decodes: decodes.isEmpty ? nil : decodes,
+                stages: stages.map { stage in
+                    var stage = stage
+                    stage.parts = parts[stage.name]
+                    return stage
+                },
+                final: final
             )
         }
     }
@@ -208,11 +318,14 @@ enum Trace {
     /// - Parameter beside: the directory to write the line into. Pass the one
     ///   holding the clip; the global is only a fallback for callers that have
     ///   no clip on disk to point at.
+    /// - Parameter origin: zero on the timeline. The press, for a live
+    ///   dictation: this runs after the recording has stopped, so a collector
+    ///   that stamped its own start would put the recording at negative time.
     static func record<T>(
         wav: String, source: Source, app: App? = nil, beside: URL? = nil,
-        body: () async throws -> T
+        origin: Date = Date(), body: () async throws -> T
     ) async rethrows -> T {
-        let collector = Collector(wav: wav, source: source)
+        let collector = Collector(wav: wav, source: source, origin: origin)
         // Taken from where the clip actually is, not from the global, and not
         // snapshotted at a moment chosen for being early.
         //
@@ -229,7 +342,17 @@ enum Trace {
         // The clip's own URL has no such instant: it is where the file went,
         // whatever the config said at the time or says now.
         let directory = beside ?? Self.directory
-        defer { append(collector.record(at: stamp(), app: app), to: directory) }
+        defer {
+            append(collector.record(at: stamp(), app: app), to: directory)
+            // Its own file, and only when asked for. The corpus answers
+            // questions across every dictation ever given and so may never be
+            // deleted; a timeline answers one question about one dictation and
+            // is only ever wanted for a recent one. Splitting them is what lets
+            // this one be thrown away.
+            if spansEnabled, let timeline = collector.timeline(app: app) {
+                append(timeline, to: directory, named: spansFile)
+            }
+        }
         return try await $current.withValue(collector) { try await body() }
     }
 
@@ -296,6 +419,33 @@ enum Trace {
         )
     }
 
+    /// What it cost to put the words where they were going.
+    ///
+    /// Its own line rather than a span on the dictation: `record` appends in a
+    /// `defer`, and delivery happens after that — held open, a dictation that
+    /// threw would stop writing the numbers explaining why. So the contract
+    /// stays "append on exit, even if it threw", and this joins by `wav`.
+    static func deliver(wav: String, seconds: Double, route: String, app: String?, beside: URL?) {
+        guard spansEnabled else { return }
+        append(
+            Delivery(
+                v: spansVersion, kind: "deliver", at: stamp(fractional: true),
+                wav: wav, seconds: seconds, route: route, app: app
+            ),
+            to: beside ?? directory, named: spansFile
+        )
+    }
+
+    fileprivate struct Delivery: Encodable {
+        let v: Int
+        let kind: String
+        let at: String
+        let wav: String
+        let seconds: Double
+        let route: String
+        let app: String?
+    }
+
     private static let queue = DispatchQueue(label: "com.parrotflow.trace")
 
     /// Waits for queued writes to reach the file. Same reason as `Log.flush` —
@@ -327,9 +477,35 @@ enum Trace {
     /// Deliberately no size cap. This is the corpus, not a debug buffer: a year
     /// of heavy use is a few megabytes, and the whole point is being able to
     /// ask a question of every dictation you have ever given.
-    private static func append<Line: Encodable>(_ record: Line, to directory: URL?) {
+    /// How large `spans.jsonl` may get before the current one is set aside.
+    ///
+    /// The corpus has no cap and must not have one — it is what you ask
+    /// questions of years later. A timeline is the opposite: only ever wanted
+    /// for something recent, and about ten times the size. So this one rotates,
+    /// which is what lets it be on for everybody.
+    static let spansLimit = 64 * 1024 * 1024
+
+    /// Renames the file aside and starts a new one, keeping one generation.
+    ///
+    /// A rename rather than `Log`'s truncate-to-zero: truncating throws away
+    /// the timeline you were about to look at. Another process holding the old
+    /// descriptor keeps writing to the renamed file, which costs a line and
+    /// cannot corrupt one.
+    private static func rotateIfLarge(_ url: URL) {
+        let fm = FileManager.default
+        let attributes = try? fm.attributesOfItem(atPath: url.path)
+        guard let size = attributes?[.size] as? Int, size > spansLimit else { return }
+        let aside = url.deletingLastPathComponent()
+            .appendingPathComponent("spans.1.jsonl")
+        try? fm.removeItem(at: aside)
+        try? fm.moveItem(at: url, to: aside)
+    }
+
+    private static func append<Line: Encodable>(
+        _ record: Line, to directory: URL?, named file: String = "trace.jsonl"
+    ) {
         guard let directory else { return }
-        let url = directory.appendingPathComponent("trace.jsonl")
+        let url = directory.appendingPathComponent(file)
 
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.withoutEscapingSlashes]
@@ -340,6 +516,7 @@ enum Trace {
             try? FileManager.default.createDirectory(
                 at: directory, withIntermediateDirectories: true
             )
+            if file == spansFile { rotateIfLarge(url) }
             let fd = open(url.path, O_WRONLY | O_APPEND | O_CREAT, 0o644)
             guard fd >= 0 else { return }
             defer { close(fd) }
@@ -351,6 +528,113 @@ enum Trace {
                 _ = write(fd, base, buffer.count)
             }
         }
+    }
+
+    /// The `reached 3.52s` a decode span writes, as a number.
+    ///
+    /// Parsed back rather than carried twice: the note is what a person reads
+    /// on the timeline, and a second field holding the same figure is a second
+    /// field to keep in step.
+    fileprivate static func reached(_ note: String?) -> Double? {
+        guard let note, note.hasPrefix("reached "), note.hasSuffix("s") else { return nil }
+        return Double(note.dropFirst("reached ".count).dropLast())
+    }
+
+    // MARK: - What a stage changed
+
+    /// The changes between two versions of a sentence, in the first one's
+    /// coordinates.
+    ///
+    /// This replaces keeping both strings. Stage `before`/`after` was a quarter
+    /// of the corpus and 93.6% of it was one sentence written twice to say
+    /// nothing had happened, which `changed` already said.
+    ///
+    /// **No `String.Index` anywhere.** Swift traps on an out-of-range index,
+    /// and this runs on every stage of every dictation — a debug artefact must
+    /// not be able to stop a transcript. Character arrays and integer offsets
+    /// cannot trap, and a hunk that cannot be built is dropped rather than
+    /// guessed at.
+    static func edits(from before: String, to after: String) -> [Change] {
+        guard before != after else { return [] }
+        let old = Array(before)
+        let new = Array(after)
+        // Bounded: a pathological pair must not cost a dictation. Above this
+        // the change is stated as one hunk, which stays true and stays cheap.
+        guard old.count + new.count <= 20_000 else {
+            return [Change(at: 0, was: before, now: after)]
+        }
+
+        var removed = Set<Int>()
+        var inserted = Set<Int>()
+        for change in new.difference(from: old) {
+            switch change {
+            case .remove(let offset, _, _): removed.insert(offset)
+            case .insert(let offset, _, _): inserted.insert(offset)
+            }
+        }
+
+        var edits: [Change] = []
+        var i = 0
+        var j = 0
+        while i < old.count || j < new.count {
+            let cut = (i < old.count && removed.contains(i))
+                || (j < new.count && inserted.contains(j))
+            guard cut else {
+                i += 1
+                j += 1
+                continue
+            }
+            let at = i
+            var was = ""
+            var now = ""
+            while i < old.count, removed.contains(i) {
+                was.append(old[i])
+                i += 1
+            }
+            while j < new.count, inserted.contains(j) {
+                now.append(new[j])
+                j += 1
+            }
+            // Neither side moved, so the walk would not either. Cannot happen
+            // with a difference this loop built its sets from; stopping beats
+            // spinning if it ever does.
+            if was.isEmpty, now.isEmpty { break }
+            edits.append(Change(at: at, was: was, now: now))
+        }
+        return edits
+    }
+
+    /// Applies edits to the text they were measured against.
+    ///
+    /// The inverse of `edits`, and the only reason either is worth keeping: a
+    /// stage's input and output are no longer both on disk, so replaying is how
+    /// anyone gets the output back. Nil where an edit does not fit, which is a
+    /// corpus that has gone wrong and must read as one rather than as a
+    /// plausible sentence — see `--trace-edits`.
+    static func replay(_ edits: [Change], over text: String) -> String? {
+        var chars = Array(text)
+        var delta = 0
+        for edit in edits {
+            let start = edit.at + delta
+            let was = Array(edit.was)
+            guard start >= 0, start + was.count <= chars.count else { return nil }
+            guard Array(chars[start..<(start + was.count)]) == was else { return nil }
+            chars.replaceSubrange(start..<(start + was.count), with: Array(edit.now))
+            delta += edit.now.count - was.count
+        }
+        return String(chars)
+    }
+
+    /// One change a stage made. `at` is a character offset into the text that
+    /// stage was handed, so a list of these applies left to right with a
+    /// running delta, or right to left with none.
+    ///
+    /// Not `Edit`: that is a whole line of the file, written when somebody
+    /// corrects a word by hand. This is a field on a stage.
+    struct Change: Encodable, Sendable {
+        let at: Int
+        let was: String
+        let now: String
     }
 
     // MARK: - Words
@@ -414,10 +698,15 @@ enum Trace {
 
     // MARK: - Shape on disk
 
-    private static func stamp() -> String {
+    /// - Parameter fractional: milliseconds as well as seconds. A timeline
+    ///   measured to the millisecond cannot be joined to a zero stated to the
+    ///   second, and `NSLog` timestamps are sub-second too.
+    static func stamp(_ date: Date = Date(), fractional: Bool = false) -> String {
         let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime]
-        return formatter.string(from: Date())
+        formatter.formatOptions = fractional
+            ? [.withInternetDateTime, .withFractionalSeconds]
+            : [.withInternetDateTime]
+        return formatter.string(from: date)
     }
 
     /// What a `returns: json` transform is handed as `trace`.
@@ -449,6 +738,10 @@ enum Trace {
         let asr: ASR?
         let vad: VAD?
         let capture: Capture?
+        /// Seconds spent loading models before this dictation could start.
+        /// Absent when they were already warm, which is almost always.
+        let prepare: Double?
+        let decodes: [Decode]?
         let stages: [Stage]
         let final: String?
     }
@@ -533,6 +826,9 @@ enum Trace {
         /// The repository id is all FluidAudio exposes — there is no revision
         /// to log, so none is invented.
         let model: String
+        /// Which decode this came from — `first pass`, or the arm that beat
+        /// it. `decodes` says what the others cost.
+        let arm: String?
         let text: String
         let confidence: Float
         let duration: Double
@@ -540,7 +836,21 @@ enum Trace {
         let words: [Word]
     }
 
+    /// One decode of the clip. Several run on a dictation that looks short, and
+    /// until this only the winner was kept — so a dictation that paid for four
+    /// decodes reported one number, and an arm that failed every time was
+    /// invisible rather than losing.
+    fileprivate struct Decode: Encodable {
+        let arm: String
+        let seconds: Double
+        let reached: Double?
+        let taken: Bool
+    }
+
     fileprivate struct VAD: Encodable {
+        /// What the gate cost. Not `total`, which is how long the clip is:
+        /// one is wall clock and the other is audio.
+        let seconds: Double?
         let speech: Double
         let total: Double
         let segments: [[Double]]
@@ -549,13 +859,104 @@ enum Trace {
     /// Seconds from the hotkey press. Written by a live dictation only: a clip
     /// replayed from disk was never pressed for.
     fileprivate struct Capture: Encodable {
+        /// The press itself, in wall clock and to the millisecond. `at` on the
+        /// record is written when the pipeline ended and only to the second,
+        /// so without this there is no zero to measure anything from.
+        let at: String?
         let engine: Double?
         let firstSample: Double?
+        /// Key up, seconds from the press.
+        let stopped: Double?
 
         enum CodingKeys: String, CodingKey {
-            case engine
+            case at, engine, stopped
             case firstSample = "first_sample"
         }
+    }
+
+    // MARK: - The timeline
+
+    /// `logging.spans` — whether `spans.jsonl` is written.
+    ///
+    /// Only the file. Spans are always collected: they cost an array of about
+    /// thirty small structs, and the corpus reads its `parts` and `decodes`
+    /// straight off them, so a build with this off still gets the numbers in
+    /// `trace.jsonl`.
+    nonisolated(unsafe) static var spansEnabled = false
+
+    static let spansFile = "spans.jsonl"
+
+    /// Its own number. `spans.jsonl` is a new file, not a new shape of
+    /// `trace.jsonl`, and borrowing that file's version would say the corpus
+    /// had changed when it has not.
+    static let spansVersion = 1
+
+    /// Enough for any real dictation — about 30 — with room for a clip that
+    /// puts a boundary reading on every other word.
+    static let spanLimit = 400
+
+    /// One thing the app spent wall-clock time doing.
+    ///
+    /// Flat, with a `parent`, rather than nested. The decode arms overlap, so
+    /// they have no single place in a tree; a span finishes at a different time
+    /// from its parent, so appending is simpler than reaching into a nested
+    /// object; and one flat array is one query away from every question.
+    ///
+    /// **A span is wall-clock, never audio.** Word timings and speech segments
+    /// are positions in the recording. They look the same and mean nothing
+    /// alike, so they stay payload on the span that produced them — 19 word
+    /// "spans" on a timeline would draw a picture that is false.
+    struct Span: Encodable, Sendable {
+        enum Kind: String, Encodable, Sendable {
+            case load, gate, decode, stage, part, model
+        }
+
+        let id: Int
+        let parent: Int?
+        let name: String
+        let kind: Kind
+        /// Seconds from the collector's origin, and how long it took.
+        let at: Double
+        let dur: Double
+        /// Whatever this kind of span has to say about itself. Small, and never
+        /// the transcript again — a stage already writes its text to the
+        /// corpus, and repeating it here doubles the file for nothing.
+        let note: String?
+
+        enum CodingKeys: String, CodingKey { case id, parent, name, kind, at, dur, note }
+    }
+
+    /// A span that has started. Closing it is what records it.
+    struct OpenSpan {
+        let id: Int
+        fileprivate let name: String
+        fileprivate let kind: Span.Kind
+        fileprivate let parent: Int?
+        fileprivate let nests: Bool
+        fileprivate let at: Double
+        fileprivate let collector: Collector
+
+        /// - Parameter note: what the span found out while it ran, which is
+        ///   usually only knowable at the end.
+        func close(_ note: String? = nil) {
+            collector.close(Span(
+                id: id, parent: parent, name: name, kind: kind,
+                at: at, dur: max(0, collector.elapsed() - at), note: note
+            ), restoring: nests)
+        }
+    }
+
+    /// One dictation's timeline, one line of `spans.jsonl`.
+    fileprivate struct Timeline: Encodable {
+        let v: Int
+        let kind: String
+        let t0: String
+        let wav: String
+        let source: String
+        let app: App?
+        let lang: String?
+        let spans: [Span]
+        let final: String?
     }
 
     struct Word: Encodable, Sendable {
@@ -569,8 +970,15 @@ enum Trace {
         let name: String
         var skipCode: String?
         var skipped: String?
-        var before: String?
-        var after: String?
+        /// What this stage changed, in the coordinates of the text it was
+        /// handed — see `Trace.edits`. Absent when it changed nothing, which
+        /// is 93.6% of the time and which `vars.changed` already says.
+        var edits: [Change]?
+        /// The sub-steps, taken from the timeline this stage's span parents.
+        /// `vocabulary` was one number covering an exact pass, a near-miss
+        /// pass, a phoneme pass and two gates; on one measured dictation 817ms
+        /// of its 822 was the phoneme pass, matching nothing.
+        var parts: [Part]?
         var seconds: Double?
         /// What the stage published about itself — `count`, `language`, and the
         /// `ran`/`ok`/`changed`/`ms` the pipeline derives for every stage.
@@ -584,7 +992,7 @@ enum Trace {
         enum CodingKeys: String, CodingKey {
             case name
             case skipCode = "skip_reason"
-            case skipped, before, after, seconds, vars
+            case skipped, edits, parts, seconds, vars
         }
 
         init(name: String, skipCode: String, skipped: String) {
@@ -598,10 +1006,19 @@ enum Trace {
             vars: [String: Scope.Value]
         ) {
             self.name = name
-            self.before = before
-            self.after = after
+            let changed = Trace.edits(from: before, to: after)
+            self.edits = changed.isEmpty ? nil : changed
             self.seconds = seconds
             self.vars = vars.isEmpty ? nil : vars
         }
+    }
+
+    /// A sub-step of a stage, as it reaches the corpus. The same thing the
+    /// timeline calls a `part`, flattened next to the stage it belongs to so a
+    /// sweep can ask what one costs without reading the other file.
+    fileprivate struct Part: Encodable {
+        let name: String
+        let seconds: Double
+        let note: String?
     }
 }

--- a/Sources/ParrotFlow/Trace.swift
+++ b/Sources/ParrotFlow/Trace.swift
@@ -625,6 +625,75 @@ enum Trace {
         return String(chars)
     }
 
+    /// What a stage changed, in words, for its span's note.
+    ///
+    /// Words rather than the character runs `edits` returns. Those are minimal,
+    /// so `borderplay` to `boilerplate` comes back as two runs inside one word
+    /// and reads as noise. The corpus keeps the exact coordinates; this is the
+    /// line a person reads next to the step that made it.
+    ///
+    /// A side that is empty renders as `""`, so a deletion and an insertion are
+    /// told apart from a swap without a legend.
+    static func changeSummary(from before: String, to after: String) -> String? {
+        guard before != after else { return nil }
+        let old = before.split(whereSeparator: \.isWhitespace).map(String.init)
+        let new = after.split(whereSeparator: \.isWhitespace).map(String.init)
+
+        var removed = Set<Int>()
+        var inserted = Set<Int>()
+        for change in new.difference(from: old) {
+            switch change {
+            case .remove(let offset, _, _): removed.insert(offset)
+            case .insert(let offset, _, _): inserted.insert(offset)
+            }
+        }
+
+        var runs: [String] = []
+        var i = 0
+        var j = 0
+        while i < old.count || j < new.count {
+            let cut = (i < old.count && removed.contains(i))
+                || (j < new.count && inserted.contains(j))
+            guard cut else { i += 1; j += 1; continue }
+            var was: [String] = []
+            var now: [String] = []
+            while i < old.count, removed.contains(i) { was.append(old[i]); i += 1 }
+            while j < new.count, inserted.contains(j) { now.append(new[j]); j += 1 }
+            if was.isEmpty, now.isEmpty { break }
+            runs.append("\(side(was)) -> \(side(now))")
+        }
+
+        // The strings differ but no word does, so by construction the only
+        // thing between them is whitespace. `join` is the stage that does
+        // this, and saying nothing would read as a step that did nothing.
+        guard !runs.isEmpty else { return "spacing" }
+
+        var note = ""
+        for (index, run) in runs.enumerated() {
+            let joined = note.isEmpty ? run : note + ", " + run
+            guard joined.count <= noteLimit else {
+                return note.isEmpty
+                    ? String(run.prefix(noteLimit)) + "…"
+                    : note + ", +\(runs.count - index) more"
+            }
+            note = joined
+        }
+        return note
+    }
+
+    /// How many characters of `changeSummary` reach a span's note. The
+    /// timeline already spends 85 columns on the name, the number and the bar,
+    /// and a row that wraps is a row nobody reads.
+    private static let noteLimit = 56
+
+    /// One half of a change. A run longer than this is a rewrite, and printing
+    /// it would put the sentence in `spans.jsonl`.
+    private static func side(_ words: [String]) -> String {
+        guard !words.isEmpty else { return "\"\"" }
+        guard words.count <= 6 else { return "\(words.count) words" }
+        return words.joined(separator: " ")
+    }
+
     /// One change a stage made. `at` is a character offset into the text that
     /// stage was handed, so a list of these applies left to right with a
     /// running delta, or right to left with none.
@@ -918,9 +987,11 @@ enum Trace {
         /// Seconds from the collector's origin, and how long it took.
         let at: Double
         let dur: Double
-        /// Whatever this kind of span has to say about itself. Small, and never
-        /// the transcript again — a stage already writes its text to the
-        /// corpus, and repeating it here doubles the file for nothing.
+        /// Whatever this kind of span has to say about itself. A stage says
+        /// what it changed, in words — see `Trace.changeSummary`, which caps
+        /// both a run and the whole note. Capped and never the transcript
+        /// again: a stage already writes its text to the corpus, and repeating
+        /// it here doubles the file for nothing.
         let note: String?
 
         enum CodingKeys: String, CodingKey { case id, parent, name, kind, at, dur, note }

--- a/Sources/ParrotFlow/Trace.swift
+++ b/Sources/ParrotFlow/Trace.swift
@@ -535,9 +535,14 @@ enum Trace {
     /// Parsed back rather than carried twice: the note is what a person reads
     /// on the timeline, and a second field holding the same figure is a second
     /// field to keep in step.
+    ///
+    /// Found anywhere in the note, not at the front. A padded arm writes
+    /// `500ms pad, reached 3.02s`, and anchoring at the start left `reached`
+    /// nil on every arm but the first — which are the rows the field exists to
+    /// compare.
     fileprivate static func reached(_ note: String?) -> Double? {
-        guard let note, note.hasPrefix("reached "), note.hasSuffix("s") else { return nil }
-        return Double(note.dropFirst("reached ".count).dropLast())
+        guard let note, let at = note.range(of: "reached "), note.hasSuffix("s") else { return nil }
+        return Double(note[at.upperBound...].dropLast())
     }
 
     // MARK: - What a stage changed

--- a/Sources/ParrotFlow/TraceText.swift
+++ b/Sources/ParrotFlow/TraceText.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// One dictation's timeline, as something you can read in a terminal, paste
+/// into an issue, or diff against yesterday's.
+///
+/// The last of those is why this exists rather than a picture. A flamegraph
+/// answers "where did the time go" and nothing else; two of these run through
+/// `diff` answer "did that change make it slower", which is the question a
+/// timeline is usually opened for.
+///
+/// Reads the spans as they come off `spans.jsonl` — untyped, because both
+/// callers here already hold parsed JSON and giving them a type to decode into
+/// would mean maintaining the same shape twice.
+enum TraceText {
+
+    /// How wide the bars are. Narrow enough to survive a paste into a GitHub
+    /// comment, which wraps at about 90 columns with the name column in front.
+    static let width = 44
+
+    /// A parent chain longer than this is a cycle, which cannot happen from a
+    /// collector that only ever nests a stage — and must not hang if it does.
+    private static let maxDepth = 8
+
+    /// - Parameter notes: what each step found out. Off for anything leaving
+    ///   the machine: a note can quote a word — `sarah -> Sarah` — and nothing
+    ///   here can tell those from the ones that cannot.
+    static func render(_ record: [String: Any], notes: Bool = true) -> String? {
+        guard let spans = record["spans"] as? [[String: Any]], !spans.isEmpty else { return nil }
+
+        let ordered = spans.sorted {
+            let left = $0["at"] as? Double ?? 0, right = $1["at"] as? Double ?? 0
+            if left != right { return left < right }
+            // A parent opens at the same moment as its first child and lasts
+            // longer, so the longer one goes above.
+            return ($0["dur"] as? Double ?? 0) > ($1["dur"] as? Double ?? 0)
+        }
+        let total = ordered.map { ($0["at"] as? Double ?? 0) + ($0["dur"] as? Double ?? 0) }.max() ?? 0
+        guard total > 0 else { return nil }
+
+        var byID: [Int: [String: Any]] = [:]
+        for span in ordered { if let id = span["id"] as? Int { byID[id] = span } }
+
+        var lines: [String] = []
+        var head = record["t0"] as? String ?? ""
+        if let app = (record["app"] as? [String: Any])?["name"] as? String, notes {
+            head += "   \(app)"
+        }
+        lines.append(String(format: "%@   %.3fs", head, total))
+        lines.append("")
+
+        for span in ordered {
+            let name = span["name"] as? String ?? "?"
+            let at = span["at"] as? Double ?? 0
+            let duration = span["dur"] as? Double ?? 0
+
+            let indent = String(repeating: "  ", count: depth(of: span, in: byID))
+            let label = String("  \(indent)\(name)".prefix(32)).padding(
+                toLength: 32, withPad: " ", startingAt: 0
+            )
+            // At least one block for anything that ran at all: a step that took
+            // no measurable time still happened, and an empty row reads as one
+            // that did not.
+            let start = min(width - 1, Int(at / total * Double(width)))
+            let length = max(1, min(width - start, Int(duration / total * Double(width))))
+            let bar = String(repeating: " ", count: start)
+                + String(repeating: "█", count: length)
+
+            var line = label + String(format: "%7.3fs  ", duration)
+                + bar.padding(toLength: width, withPad: " ", startingAt: 0)
+            if notes, let note = span["note"] as? String, !note.isEmpty { line += "  \(note)" }
+            lines.append(line.replacingOccurrences(
+                of: " +$", with: "", options: .regularExpression
+            ))
+        }
+
+        if notes, let final = record["final"] as? String, !final.isEmpty {
+            lines.append("")
+            lines.append("  \(final)")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// How deep a span sits, by walking its parents.
+    private static func depth(of span: [String: Any], in byID: [Int: [String: Any]]) -> Int {
+        var found = 0
+        var current = span
+        while found < maxDepth, let parent = current["parent"] as? Int, let up = byID[parent] {
+            current = up
+            found += 1
+        }
+        return found
+    }
+}

--- a/Sources/ParrotFlow/TraceViewCommand.swift
+++ b/Sources/ParrotFlow/TraceViewCommand.swift
@@ -191,8 +191,44 @@ enum TraceViewCommand {
             }
         }
 
+        // The note a stage's span carries. A different question from replay:
+        // this one is read by a person, so what it says is the whole of it.
+        let summaries: [(String, String, String?)] = [
+            ("there is a lot of borderplay in this file",
+             "there is a lot of boilerplate in this file",
+             "borderplay -> boilerplate"),
+            ("ask Gwen about sarah", "ask Qwen about Sarah",
+             "Gwen -> Qwen, sarah -> Sarah"),
+            ("um I think so", "I think so", "um -> \"\""),
+            ("I think so", "I really think so", "\"\" -> really"),
+            ("nothing changes", "nothing changes", nil),
+            ("spacing   only", "spacing only", "spacing"),
+            ("one two three four five six seven eight",
+             "eight seven six five four three two one",
+             "7 words -> \"\", \"\" -> 7 words"),
+        ]
+        for (before, after, want) in summaries {
+            let got = Trace.changeSummary(from: before, to: after)
+            guard got == want else {
+                print("✗ summary \(before.debugDescription): got"
+                    + " \(got.debugDescription), wanted \(want.debugDescription)")
+                failed += 1
+                continue
+            }
+        }
+        // Never wider than the row it sits on, whatever a stage did.
+        for (before, after) in cases + summaries.map({ ($0.0, $0.1) }) {
+            let note = Trace.changeSummary(from: before, to: after) ?? ""
+            guard note.count <= 60 else {
+                print("✗ note is \(note.count) characters: \(note)")
+                failed += 1
+                continue
+            }
+        }
+
         print(failed == 0
-            ? "✓ \(cases.count) cases and \(fuzzed) fuzzed pairs replay exactly"
+            ? "✓ \(cases.count) cases, \(summaries.count) summaries"
+                + " and \(fuzzed) fuzzed pairs replay exactly"
             : "✗ \(failed) failed")
         return failed == 0 ? 0 : 1
     }

--- a/Sources/ParrotFlow/TraceViewCommand.swift
+++ b/Sources/ParrotFlow/TraceViewCommand.swift
@@ -1,0 +1,408 @@
+import AppKit
+import Foundation
+
+/// `--trace-view [wav]` — turns a dictation's timeline into something a trace
+/// viewer will draw, and prints where it went.
+///
+/// The corpus stays ours. Chrome's Trace Event format is what every viewer
+/// reads, but it is a poor thing to keep: `args` is untyped, and a file written
+/// for a flamegraph answers none of the questions `docs/cli.md` asks. So
+/// `spans.jsonl` holds the shape we designed and this converts a line of it on
+/// demand.
+///
+/// The output opens at https://ui.perfetto.dev — "Open trace file", or drag it
+/// on. Perfetto parses in the browser and uploads nothing, which matters
+/// because a trace carries what you said.
+///
+/// `--redacted` is what makes one safe to send to somebody else. **Timings
+/// survive redaction perfectly and text does not**, so dropping every field
+/// that holds words leaves the shape, the durations and the model calls
+/// intact: a timeline with nothing said in it still shows that the phoneme
+/// pass took 817 ms.
+enum TraceViewCommand {
+
+    /// Nesting in Trace Event format is inferred from time containment on a
+    /// track, not from a parent id — so the arms, which overlap, need tracks of
+    /// their own or the viewer draws them as one impossible stack.
+    private static let mainTrack = 1
+
+    /// Says something to whoever is watching, never to whatever is reading.
+    ///
+    /// stdout belongs to the transcript. A `command:` transform is handed the
+    /// text on stdin and whatever it prints becomes the new text — so a path
+    /// printed here would replace the dictation with a path. Everything a
+    /// person reads goes to stderr, which the runner logs and the terminal
+    /// shows.
+    private static func say(_ line: String) {
+        FileHandle.standardError.write(Data((line + "\n").utf8))
+    }
+
+    /// Gives the transcript back untouched, when this was run as a transform.
+    ///
+    /// The chip's whole point is to act and leave the sentence alone —
+    /// `finishOfferedTransform` writes nothing back when the text is unchanged,
+    /// so returning exactly what arrived is what makes it safe. A terminal has
+    /// a tty on stdin and nothing to pass through, and reading there would hang
+    /// waiting for a sentence nobody is going to type.
+    private static func passThrough() {
+        guard isatty(FileHandle.standardInput.fileDescriptor) == 0 else { return }
+        guard let text = try? FileHandle.standardInput.readToEnd() else { return }
+        FileHandle.standardOutput.write(text)
+    }
+
+    static func run(_ arguments: [String]) -> Int32 {
+        defer { passThrough() }
+        guard let directory = (try? ConfigStore.load())?.resolvedOutputDir else {
+            say("✗ no output directory; check `--check-config`")
+            return 1
+        }
+        let url = directory.appendingPathComponent(Trace.spansFile)
+        guard let contents = try? String(contentsOf: url, encoding: .utf8) else {
+            say("✗ no \(url.path)")
+            say("  Set `logging.spans: true` and dictate once.")
+            return 1
+        }
+
+        let redacted = arguments.contains("--redacted")
+        // The other output. Perfetto zooms, which text cannot, and a long
+        // dictation with a reading on every boundary is where that earns its
+        // keep. Everything else is easier to read as a page of text.
+        let perfetto = arguments.contains("--perfetto")
+        let wanted = value(of: "--trace-view", in: arguments)
+        guard let line = pick(wanted, from: contents) else {
+            say("✗ no timeline for \(wanted ?? "the last live dictation") in \(url.path)")
+            return 1
+        }
+
+        guard perfetto else {
+            guard let text = TraceText.render(line, notes: !redacted) else {
+                say("✗ that line carries no spans")
+                return 1
+            }
+            // A terminal gets it on stdout, where it can be piped, diffed
+            // against yesterday's, or read where you already are. Anything
+            // else — the chip — is not attached to a terminal and gets a file
+            // opened in front of it.
+            guard isatty(FileHandle.standardInput.fileDescriptor) == 0 else {
+                print(text)
+                return 0
+            }
+            let out = view(for: line, redacted: redacted, extension: "txt")
+            guard (try? Data((text + "\n").utf8).write(to: out)) != nil else {
+                say("✗ could not write \(out.path)")
+                return 1
+            }
+            if !arguments.contains("--no-open") { NSWorkspace.shared.open(out) }
+            say(out.path)
+            return 0
+        }
+
+        guard let events = try? convert(line, redacted: redacted) else {
+            say("✗ that line is not a timeline this build understands")
+            return 1
+        }
+        let out = view(for: line, redacted: redacted, extension: "json")
+        guard (try? events.write(to: out)) != nil else {
+            say("✗ could not write \(out.path)")
+            return 1
+        }
+        say(out.path)
+        if redacted {
+            say("  No transcript, no app name, no notes — timings only. Safe to attach.")
+        } else {
+            say("  Holds what you said. `--redacted` for a copy that does not.")
+        }
+        // Dragged, not linked. `?url=` is HTTPS-only — measured: an https page
+        // will not fetch http://127.0.0.1, whatever the localhost exemption
+        // does elsewhere — and the alternative is putting your dictations on a
+        // public host to look at a chart.
+        say("  Drag it onto https://ui.perfetto.dev — it parses in the browser.")
+        return 0
+    }
+
+    /// `--trace-edits` — proves that what a stage recorded replays.
+    ///
+    /// `v: 3` keeps what a stage changed instead of both versions of the
+    /// sentence, so the corpus is only as good as this: apply the edits in
+    /// order to the text a stage was handed, and you must get what it produced.
+    /// Nothing at run time reads an edit, so a bug here cannot damage a
+    /// transcript — it can quietly make the whole corpus wrong, which nothing
+    /// else would say.
+    ///
+    /// Cases and fuzz. The cases are the shapes that actually turn up — a
+    /// repeated word, a spoken number, a lowercased name, accents, emoji — and
+    /// the fuzz is there because the ones that break a diff are never the ones
+    /// anybody thinks to write down.
+    static func checkEdits() -> Int32 {
+        let cases: [(String, String)] = [
+            ("the 98.3 percent is is about", "the 98.3 percent is about"),
+            ("nothing changes", "nothing changes"),
+            ("", "everything appeared"),
+            ("everything vanished", ""),
+            ("parrot. At the start", "parrot at the start"),
+            ("ninety-eight point three", "98.3"),
+            ("naïve café über", "naive cafe uber"),
+            ("👋 hello 🌍", "👋 goodbye 🌍"),
+            ("Sarah went to Versailles", "sarah went to versailles"),
+            ("a b c d e", "a X c Y e"),
+            ("repeated repeated repeated", "repeated"),
+        ]
+
+        var failed = 0
+        for (before, after) in cases {
+            let edits = Trace.edits(from: before, to: after)
+            guard let replayed = Trace.replay(edits, over: before), replayed == after else {
+                print("✗ \(before.debugDescription) -> \(after.debugDescription)")
+                failed += 1
+                continue
+            }
+        }
+
+        // The same property over shapes nobody chose. Punctuation and spaces
+        // are in the alphabet because those are what the marks stages move.
+        let alphabet = Array("abcde .,")
+        var generator = SystemRandomNumberGenerator()
+        // By index rather than `randomElement()!`: the array is a literal and
+        // cannot be empty, but a check that says so beats one the compiler has
+        // to be told to skip.
+        func letter() -> Character {
+            alphabet[Int.random(in: 0..<alphabet.count, using: &generator)]
+        }
+        var fuzzed = 0
+        for _ in 0..<5000 {
+            let length = Int.random(in: 0...40, using: &generator)
+            let before = String((0..<length).map { _ in letter() })
+            var mutated = Array(before)
+            for _ in 0..<Int.random(in: 0...5, using: &generator) where !mutated.isEmpty {
+                let at = Int.random(in: 0..<mutated.count, using: &generator)
+                switch Int.random(in: 0...2, using: &generator) {
+                case 0: mutated.remove(at: at)
+                case 1: mutated.insert(letter(), at: at)
+                default: mutated[at] = letter()
+                }
+            }
+            let after = String(mutated)
+            fuzzed += 1
+            let edits = Trace.edits(from: before, to: after)
+            if Trace.replay(edits, over: before) != after {
+                print("✗ fuzz: \(before.debugDescription) -> \(after.debugDescription)")
+                failed += 1
+                break
+            }
+        }
+
+        print(failed == 0
+            ? "✓ \(cases.count) cases and \(fuzzed) fuzzed pairs replay exactly"
+            : "✗ \(failed) failed")
+        return failed == 0 ? 0 : 1
+    }
+
+    /// `--trace-spans` — hammers the collector from many tasks at once.
+    ///
+    /// The decode arms run as sibling tasks and each closes its own span, so
+    /// several threads append to one array. That is the one failure in this
+    /// whole feature that could take the app down rather than write a wrong
+    /// number: an unlocked array append from two threads is memory corruption,
+    /// not a bad reading.
+    ///
+    /// Run it under the thread sanitizer to prove the locking, and without to
+    /// prove the arithmetic:
+    ///
+    ///     swift build -c debug --sanitize=thread && .build/debug/ParrotFlow --trace-spans
+    static func checkSpans() -> Int32 {
+        var status: Int32 = 0
+        let done = DispatchSemaphore(value: 0)
+        Task {
+            status = await hammerSpans()
+            done.signal()
+        }
+        done.wait()
+        return status
+    }
+
+    private static func hammerSpans() async -> Int32 {
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent("parrotflow-spans-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        // Under `Trace.spanLimit`, so this measures the locking rather than
+        // the cap. The cap gets its own assertion below.
+        let wanted = 200
+        let was = Trace.spansEnabled
+        Trace.spansEnabled = true
+        defer { Trace.spansEnabled = was }
+
+        await Trace.record(wav: "check.wav", source: .cli, beside: scratch) {
+            // A stage span open over the whole of it, so the concurrent ones
+            // are reading `openParent` while others are writing it.
+            let stage = Trace.current?.open("stage", kind: .stage, nests: true)
+            await withTaskGroup(of: Void.self) { group in
+                for index in 0..<wanted {
+                    group.addTask {
+                        let span = Trace.current?.open("arm \(index)", kind: .decode)
+                        span?.close("reached 1.00s")
+                    }
+                }
+            }
+            stage?.close()
+        }
+        Trace.flush()
+
+        let url = scratch.appendingPathComponent(Trace.spansFile)
+        guard let text = try? String(contentsOf: url, encoding: .utf8),
+              let line = text.split(separator: "\n").first,
+              let data = line.data(using: .utf8),
+              let record = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              let spans = record["spans"] as? [[String: Any]]
+        else {
+            print("✗ no timeline written to \(url.path)")
+            return 1
+        }
+
+        // Every span, and every id distinct. A lost append and a reused id are
+        // the two shapes a race takes here.
+        let ids = Set(spans.compactMap { $0["id"] as? Int })
+        let arms = spans.filter { $0["kind"] as? String == "decode" }
+        var failed = 0
+        if arms.count != wanted {
+            print("✗ \(arms.count) of \(wanted) concurrent spans survived")
+            failed += 1
+        }
+        if ids.count != spans.count {
+            print("✗ \(spans.count - ids.count) duplicate span id(s)")
+            failed += 1
+        }
+        // Each one filed under the stage that was open while it ran.
+        let orphans = arms.filter { $0["parent"] as? Int == nil }
+        if !orphans.isEmpty {
+            print("✗ \(orphans.count) concurrent span(s) lost their parent")
+            failed += 1
+        }
+        // And the cap holds, which is the other half: a runaway dictation must
+        // stop growing the array rather than grow it without end.
+        if spans.count > Trace.spanLimit {
+            print("✗ \(spans.count) spans got past the \(Trace.spanLimit) limit")
+            failed += 1
+        }
+        if failed == 0 {
+            print("✓ \(wanted) spans closed from \(wanted) tasks at once, "
+                + "all present, parented and under the limit")
+        }
+        return failed == 0 ? 0 : 1
+    }
+
+    /// Where a rendered trace goes: the temporary directory, named after the
+    /// clip it describes.
+    ///
+    /// Named, because one fixed name means the second press rewrites a file an
+    /// editor already has open — and an editor shows you the buffer it loaded,
+    /// so you read the previous dictation and believe it is this one. That
+    /// happened.
+    ///
+    /// Temporary, because this is a view and not a record. `spans.jsonl` is
+    /// what keeps the timeline; these are one rendering of one line of it, and
+    /// leaving a file in the recordings folder every time somebody looks at a
+    /// dictation would bury the clips. The system clears them out, which is the
+    /// right owner for something regenerated by one command.
+    private static func view(
+        for record: [String: Any], redacted: Bool, extension suffix: String
+    ) -> URL {
+        let stem = (record["wav"] as? String).map {
+            URL(fileURLWithPath: $0).deletingPathExtension().lastPathComponent
+                .replacingOccurrences(of: "parrotflow-", with: "")
+        } ?? "last"
+        return FileManager.default.temporaryDirectory
+            .appendingPathComponent("trace-\(stem)\(redacted ? "-redacted" : "").\(suffix)")
+    }
+
+    /// The last **live** dictation, not the last line. The file also holds
+    /// replays from `--transcribe`, and a replay is not what you just said.
+    private static func pick(_ wav: String?, from contents: String) -> [String: Any]? {
+        var found: [String: Any]?
+        for line in contents.split(separator: "\n") {
+            guard let data = line.data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: data),
+                  let record = object as? [String: Any],
+                  record["spans"] != nil
+            else { continue }
+            if let wav {
+                if (record["wav"] as? String)?.contains(wav) == true { found = record }
+            } else if record["source"] as? String == "live" {
+                found = record
+            }
+        }
+        return found
+    }
+
+    private static func convert(_ record: [String: Any], redacted: Bool) throws -> Data {
+        guard let spans = record["spans"] as? [[String: Any]] else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        // One track per overlapping arm. Everything else shares the main one,
+        // where the viewer's own nesting rules do the work.
+        var track = mainTrack
+        var tracks: [String: Int] = [:]
+        var events: [[String: Any]] = []
+
+        for span in spans.sorted(by: { ($0["at"] as? Double ?? 0) < ($1["at"] as? Double ?? 0) }) {
+            let name = span["name"] as? String ?? "?"
+            let kind = span["kind"] as? String ?? "part"
+            let at = span["at"] as? Double ?? 0
+            let dur = span["dur"] as? Double ?? 0
+
+            if kind == "decode" {
+                track += 1
+                tracks[name] = track
+            }
+            var args: [String: Any] = ["kind": kind]
+            // A note can quote a word — "0 of 12 over the floor" cannot, but
+            // "sarah -> Sarah" can, and nothing here can tell them apart. So a
+            // redacted trace drops all of them.
+            if !redacted, let note = span["note"] as? String { args["note"] = note }
+
+            events.append([
+                "ph": "X", "name": name, "cat": kind,
+                "pid": 1, "tid": tracks[name] ?? mainTrack,
+                // Trace Event time is microseconds.
+                "ts": (at * 1_000_000).rounded(),
+                "dur": max(1, (dur * 1_000_000).rounded()),
+                "args": args,
+            ])
+        }
+        // Names the lanes, so a decode arm reads as itself rather than as
+        // "thread 2".
+        for (name, id) in tracks {
+            events.append([
+                "ph": "M", "name": "thread_name", "pid": 1, "tid": id,
+                "args": ["name": name],
+            ])
+        }
+        events.append([
+            "ph": "M", "name": "thread_name", "pid": 1, "tid": mainTrack,
+            "args": ["name": redacted
+                ? "dictation"
+                : record["app"].flatMap { ($0 as? [String: Any])?["name"] as? String }
+                    ?? "dictation"],
+        ])
+
+        var payload: [String: Any] = ["traceEvents": events]
+        guard !redacted else {
+            // The span names stay: `first pass`, `vocabulary`, `sound` are the
+            // app's own vocabulary and hold nothing anybody said.
+            return try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted])
+        }
+        // What was said, on the trace itself, so a timeline and its transcript
+        // cannot be separated by the time someone is looking at both.
+        if let final = record["final"] as? String { payload["parrotflow.final"] = final }
+        if let wav = record["wav"] as? String { payload["parrotflow.wav"] = wav }
+        return try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted])
+    }
+
+    private static func value(of flag: String, in arguments: [String]) -> String? {
+        guard let index = arguments.firstIndex(of: flag),
+              arguments.indices.contains(index + 1),
+              !arguments[index + 1].hasPrefix("--")
+        else { return nil }
+        return arguments[index + 1]
+    }
+}

--- a/Sources/ParrotFlow/TraceViewCommand.swift
+++ b/Sources/ParrotFlow/TraceViewCommand.swift
@@ -353,21 +353,25 @@ enum TraceViewCommand {
 
     /// The last **live** dictation, not the last line. The file also holds
     /// replays from `--transcribe`, and a replay is not what you just said.
+    /// The newest matching timeline, found from the end of the file.
+    ///
+    /// Backwards because the answer is almost always the last line, and this
+    /// file is capped at 64 MB: parsing all of it forward to keep the final
+    /// hit is work for a file that is written far more often than it is read.
     private static func pick(_ wav: String?, from contents: String) -> [String: Any]? {
-        var found: [String: Any]?
-        for line in contents.split(separator: "\n") {
+        for line in contents.split(separator: "\n").reversed() {
             guard let data = line.data(using: .utf8),
                   let object = try? JSONSerialization.jsonObject(with: data),
                   let record = object as? [String: Any],
                   record["spans"] != nil
             else { continue }
             if let wav {
-                if (record["wav"] as? String)?.contains(wav) == true { found = record }
+                if (record["wav"] as? String)?.contains(wav) == true { return record }
             } else if record["source"] as? String == "live" {
-                found = record
+                return record
             }
         }
-        return found
+        return nil
     }
 
     private static func convert(_ record: [String: Any], redacted: Bool) throws -> Data {

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -238,6 +238,18 @@ actor Transcriber {
                 try await SlotModel.shared.prepare { label in
                     Task { await self.reportSlotModel(label) }
                 }
+                // Through `slotGate`, which is what a dictation calls, rather
+                // than loading a probe this throws away: the two must not be
+                // able to warm different things. Preparing the model was only
+                // half of it — the tokenizer and the probe are the other half,
+                // and the first dictation of every launch paid 2.5s for them
+                // while the model sat ready. Measured on three launches.
+                let started = Date()
+                if await Vocabulary.shared.slotGate() != nil {
+                    Log.write(String(
+                        format: "slot gate: warmed in %.1fs", Date().timeIntervalSince(started)
+                    ))
+                }
             } catch {
                 Log.write("slot model: \(error.localizedDescription);"
                     + " the vocabulary pass leaves what it cannot settle as it stands")

--- a/Sources/ParrotFlow/Transcriber.swift
+++ b/Sources/ParrotFlow/Transcriber.swift
@@ -348,11 +348,29 @@ actor Transcriber {
         progress: (@Sendable (String) -> Void)? = nil,
         heard: (@Sendable (Decode) -> Void)? = nil
     ) async throws -> String {
+        // A span, not only a number. This is the largest thing on a cold
+        // dictation — 29.9s measured on the first one after a launch — and
+        // recorded as a field it left the timeline with a half-minute hole in
+        // it where the whole wait was, which reads as nothing having happened.
+        let loading = Date()
+        let span = Trace.current?.open("load models", kind: .load)
         try await prepare(config: config)
+        let loaded = Date().timeIntervalSince(loading)
+        // Only when it actually loaded. A stage timed against a cold start is
+        // not comparable with one timed against a warm process, and the two
+        // look identical without this.
+        if loaded > 0.05 {
+            Trace.current?.recordPrepare(loaded)
+            span?.close(String(format: "%.1fs cold", loaded))
+        } else {
+            span?.close("warm")
+        }
 
         var gated: SpeechGate?
         if config.audio.speechGate {
+            let span = Trace.current?.open("gate", kind: .gate)
             gated = try await runSpeechGate(url: url)
+            span?.close(gated.map { String(format: "%.2fs of speech", Self.speechSeconds($0)) })
             if let gated, gated.segments.isEmpty {
                 Log.write("speech gate: no speech detected; not transcribing")
                 return ""
@@ -403,7 +421,9 @@ actor Transcriber {
         // 13.9s, where windows 1 and 2 alone returned exactly the text that
         // was delivered and window 3 — the one holding "view transforms" —
         // returned empty.
+        let firstPass = Trace.current?.open("decode pass 1", kind: .decode)
         var result = try await asr.transcribe(url, decoderState: &decoderState)
+        firstPass?.close(String(format: "reached %.2fs", Self.lastWordEnd(result)))
 
         // Here rather than after the retries below, because an invented ending
         // is clamped to the end of the clip and every check downstream reads
@@ -423,7 +443,9 @@ actor Transcriber {
         // Every clip that decoded to the end is left exactly as it was.
         if let gated, Self.droppedTail(result, gate: gated), let closed = Self.closeLongPauses(gated) {
             var retryState = await TdtDecoderState.make(decoderLayers: asr.decoderLayerCount)
+            let span = Trace.current?.open("long-pause retry", kind: .decode)
             let raw = try await asr.transcribe(closed.samples, decoderState: &retryState)
+            span?.close(String(format: "reached %.2fs", Self.lastWordEnd(raw)))
             let retried = Self.withoutInventedTail(
                 Self.restoreTimings(raw, closed: closed, seconds: gated.seconds),
                 speechEnd: speechEnd,
@@ -436,6 +458,7 @@ actor Transcriber {
                     Self.lastSpeechEnd(gated) - Self.lastWordEnd(result),
                     closed.pauses, spliced.words, spliced.from, spliced.to
                 ))
+                Trace.current?.recordArm("long-pause retry")
                 result = spliced.result
             } else if Self.lastWordEnd(retried) > Self.lastWordEnd(result) {
                 Log.write(String(
@@ -508,6 +531,7 @@ actor Transcriber {
                         + "%.0fms of silence either side recovered it",
                     wrote, speech, recovered.pad * 1000
                 ))
+                Trace.current?.recordArm(Self.silenceArm(recovered.pad))
                 result = recovered.result
             } else {
                 Log.write(String(
@@ -555,6 +579,7 @@ actor Transcriber {
                         + "%.0fms of silence either side reached %.2fs; taking it",
                     Self.lastWordEnd(result), best.pad * 1000, Self.lastWordEnd(best.result)
                 ))
+                Trace.current?.recordArm(Self.silenceArm(best.pad))
                 result = best.result
             } else if let rejected = mostRecovered(
                 further.filter { !Self.extends(result, by: $0.result) }
@@ -565,6 +590,13 @@ actor Transcriber {
                     rejected.pad * 1000, Self.lastWordEnd(rejected.result)
                 ))
             }
+        }
+        // FluidAudio's chunked path leaves `duration` at 0, which is every
+        // clip over one window: measured at 167 of 637 recent traces, all of
+        // them 15.1s or longer, against 1 of 470 under it. The gate already
+        // knows how long the clip is, so a real-time factor stays computable.
+        if result.duration == 0, let gated {
+            result = Self.withDuration(result, seconds: gated.seconds)
         }
         Trace.current?.recordASR(result, model: Repo.parakeetV3.rawValue)
 
@@ -669,22 +701,59 @@ actor Transcriber {
     /// A fresh `TdtDecoderState` per pass: the state is per-clip, and handing
     /// the first pass's state to the second would decode the padded copy as a
     /// continuation of the clip it is a copy of.
+    /// The same result, saying how long the clip was.
+    private nonisolated static func withDuration(
+        _ result: ASRResult, seconds: Double
+    ) -> ASRResult {
+        ASRResult(
+            text: result.text,
+            confidence: result.confidence,
+            duration: seconds,
+            processingTime: result.processingTime,
+            tokenTimings: result.tokenTimings,
+            ctcDetectedTerms: result.ctcDetectedTerms,
+            ctcAppliedTerms: result.ctcAppliedTerms
+        )
+    }
+
+    /// What an arm is called, on the timeline and in `asr.arm`. One function,
+    /// so the two cannot drift into naming the same decode differently.
+    ///
+    /// Numbered rather than named after its padding. What a reader wants from
+    /// the timeline is how many decodes this dictation paid for and which one
+    /// was taken; how far the silence was moved is a detail of the third one,
+    /// and it stays in the note. The rungs are a fixed list, so the numbers are
+    /// stable across dictations and a query can group on them.
+    nonisolated static func silenceArm(_ pad: Double) -> String {
+        "decode pass \((silenceRetryPads.firstIndex(of: pad) ?? 0) + 2)"
+    }
+
     private nonisolated static func decodePadded(
         _ gate: SpeechGate, pad: Double, asr: AsrManager
     ) async throws -> ASRResult? {
         guard let padded = paddedWithSilence(gate, pad: pad) else { return nil }
         var state = await TdtDecoderState.make(decoderLayers: asr.decoderLayerCount)
+        let span = Trace.current?.open(silenceArm(pad), kind: .decode)
         let raw = try await asr.transcribe(padded, decoderState: &state)
         // Before the arm is compared with anything. An arm whose only addition
         // is an invented run then adds nothing, and loses on the guards that
         // are already there. Unpadding clamps a word running past the end of
         // the clip back to the clip's length, so those words land on one point
         // on the clock and the burst rule sees them.
-        return withoutInventedTail(
+        let decoded = withoutInventedTail(
             unpadTimings(raw, by: pad, seconds: gate.seconds),
             speechEnd: lastSpeechEnd(gate),
             note: String(format: "second opinion at %.0fms: ", pad * 1000)
         )
+        // Measured after unpadding, not before. The padded clip's clock starts
+        // `pad` seconds early, so a raw reading is that much further along than
+        // the arm really got — and read beside the first pass, which has no
+        // pad, it makes every arm look like it found seconds that are not
+        // there.
+        span?.close(String(
+            format: "%.0fms pad, reached %.2fs", pad * 1000, lastWordEnd(decoded)
+        ))
+        return decoded
     }
 
     /// Starts one padded decode per rung of `silenceRetryPads`, running now.
@@ -772,6 +841,9 @@ actor Transcriber {
     private func runSpeechGate(url: URL) async throws -> SpeechGate? {
         guard let vad else { return nil }
 
+        // Reading the whole clip off disk is part of what the gate costs, so
+        // the clock starts here rather than at the model call.
+        let started = Date()
         guard let clip = Self.read(url) else { return nil }
         let samples = clip.samples
         guard !samples.isEmpty else {
@@ -791,7 +863,8 @@ actor Transcriber {
         // stop, and the log line above cannot tell you either.
         Trace.current?.recordVAD(
             speech: speech, total: total,
-            segments: segments.map { ($0.startTime, $0.endTime) }
+            segments: segments.map { ($0.startTime, $0.endTime) },
+            seconds: Date().timeIntervalSince(started)
         )
         return SpeechGate(
             samples: samples,

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -62,6 +62,18 @@ if arguments.contains("--check-config") {
     exit(CheckConfigCommand.run())
 }
 
+if arguments.contains("--trace-spans") {
+    exit(TraceViewCommand.checkSpans())
+}
+
+if arguments.contains("--trace-edits") {
+    exit(TraceViewCommand.checkEdits())
+}
+
+if arguments.contains("--trace-view") {
+    exit(TraceViewCommand.run(arguments))
+}
+
 // Above the config, like the two around it: this reports on an install and has
 // to answer while one is half-finished.
 if arguments.contains("--setup-parsing") {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -38,6 +38,11 @@ audio:
   second_opinion: true
 
 logging:
+  # One timeline per dictation in spans.jsonl, beside the recordings: every
+  # step, every decode, what each cost. Rotates at 64 MB. `--trace-view` draws
+  # one, and `--bug-report` carries a wordless copy of the last. See docs/cli.md.
+  spans: true
+
   # Saves each dictation's recording to ~/.config/parrotflow/recordings, for
   # --transcribe, calibration, or hearing what the app heard.
   audio: false

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -276,3 +276,33 @@ transforms:
     command: examples/disfluency/disfluency.py
     returns: json
     tests: { path: examples/disfluency/cases.yaml }
+
+  # Opens the last dictation's timeline in a text editor: every step, every
+  # decode, what each cost and what each stage changed. See docs/cli.md.
+  #
+  # Asked for out loud, not offered on a chip. Uncomment `offer:` and `key:`
+  # for the chip — `t` collides with "the", "this" and "that", so a dictation
+  # starting with one of those inside the offer window opens a trace. That is
+  # the whole cost: this command only reads, and what it opens is a text file.
+  #
+  # A full path, because `ParrotFlow` is not on `PATH`, and picked at run time
+  # because the dev build lives at `/Applications/ParrotFlowDev.app` and reads
+  # its own `spans.jsonl`. A literal path here is also a `--check-config` error
+  # on any machine that has only the other build.
+  #
+  # `printf %s "$said"` hands the sentence back: whatever a `command:` prints
+  # becomes the new transcript, and this one must leave it alone.
+  #
+  # `done:` is what the pill says afterwards. Without it a transform that
+  # leaves the sentence alone on purpose reports "nothing to change", which is
+  # true and reads as a failure.
+  - name: trace
+    description: open this dictation's trace
+    display: Opening the trace
+    say: [timeline, timings, why that was slow]
+    # offer: true
+    # key: t
+    done: Trace opened
+    command: sh -c 'said=$(cat); app=/Applications/ParrotFlow.app;
+      [ -x "$app/Contents/MacOS/ParrotFlow" ] || app=/Applications/ParrotFlowDev.app;
+      "$app/Contents/MacOS/ParrotFlow" --trace-view >/dev/null; printf %s "$said"'

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1175,18 +1175,27 @@ ParrotFlow --trace-view --perfetto   # a file to drag onto ui.perfetto.dev
 2026-09-07T14:19:23.206Z   Ghostty   0.797s
 
   gate                            0.037s  ██                              2.50s of speech
-  first pass                      0.190s    ██████████                    reached 6.08s
-  500ms of silence either side    0.292s    ████████████████              reached 8.40s
-  1000ms of silence either side   0.241s    █████████████                 reached 9.36s
-  vocabulary                      0.245s                    █████████████
+  decode pass 1                   0.190s    ██████████                    reached 6.08s
+  decode pass 2                   0.292s    ████████████████              500ms pad, reached 8.40s
+  decode pass 3                   0.241s    █████████████                 1000ms pad, reached 9.36s
+  vocabulary                      0.245s                    █████████████ Gwen -> Qwen, sarah -> Sarah
     sound                         0.243s                    █████████████ 0 of 80 over the floor
-  transform punctuation           0.072s                                  ███
+  transform punctuation           0.072s                                  ███  dot -> .
 ```
 
 Three decodes of the same clip inside a fifth of a second, and a phoneme pass
 that took more than the decode and matched nothing. Both are invisible in
 `trace.jsonl`, which keeps one figure for the winning arm and one for the whole
 stage.
+
+A stage that changed the text says what it changed, in words. A side that is
+empty renders as `""`, so `um -> ""` is a deletion and `"" -> really` an
+insertion. A stage that moved only whitespace says `spacing`, which is what
+`join` usually did. Both halves are capped: a run over six words reads as
+`7 words`, and the whole note stops at 56 characters, because a row that wraps
+is a row nobody reads. The exact character offsets stay in `trace.jsonl`, where
+`edits` keeps them — see `--trace-edits`. `--redacted` drops every note, so a
+timeline in a bug report carries none of it.
 
 From a terminal it goes to stdout, so it pipes and it **diffs** — two of these
 through `diff` answer "did that change make it slower", which no chart does.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1011,9 +1011,15 @@ tail -1 ~/.config/parrotflow/recordings/trace.jsonl | jq .
 One JSON object per line, appended and never rotated, beside the clips it
 describes. It holds what the decoder actually returned before anything touched
 it — the raw text, its confidence, and **every word with its start, end and
-confidence** — plus the speech gate's segment boundaries, then each pipeline
-stage with its before, its after and what it cost in seconds, and finally the
-text that was delivered. `wav` joins a line to its recording; `source` is
+confidence** — plus the speech gate's segment boundaries and its own cost, one
+row per decode arm, then each pipeline stage with its sub-steps, what it
+changed and what it cost in seconds, and finally the text that was delivered.
+
+`v: 3` replaced a stage's `before` and `after` with `edits` — what it changed,
+in the coordinates of the text it was handed. Applying every stage's edits in
+order to `asr.text` gives `final`, which is the one thing that ties the stage
+list to the two ends. Older lines are `v: 2` and were never converted: nothing
+in 3 is derivable from 2 except the edits themselves. `wav` joins a line to its recording; `source` is
 `live` for something you spoke and `cli` for a `--transcribe` re-run, so a
 sweep over the archive does not read as a day of dictation.
 
@@ -1078,6 +1084,24 @@ jq -r 'select(((.asr.text // "") | length) == 0 and (.vad.segments|length > 0)) 
 jq -r 'select(.capture.first_sample) |
        [.wav, .capture.engine, .capture.first_sample] | @tsv' trace.jsonl
 
+# Which arm decoded what you heard, and what the losers cost.
+jq -r 'select(.decodes) | .decodes[] | [.arm, .seconds, .reached, .taken] | @tsv' trace.jsonl
+
+# Where a stage's time really goes. `vocabulary` is one number covering an
+# exact pass, a near-miss pass, a phoneme pass and two gates.
+jq -r '.stages[]? | .name as $s | (.parts // [])[] |
+       [$s, .name, .seconds, .note] | @tsv' trace.jsonl | sort -k3 -rn | head
+
+# Every word a stage changed, and to what.
+jq -r '.stages[]? | .name as $s | (.edits // [])[] |
+       [$s, .was, .now] | @tsv' trace.jsonl
+
+# Press to text, end to end. `capture.at` is the key going down, to the
+# millisecond; `at` is when the pipeline finished and only to the second.
+jq -r 'select(.capture.at) |
+       [.capture.stopped, .vad.seconds, .asr.processing,
+        ([.stages[].seconds // 0] | add)] | @tsv' trace.jsonl
+
 # What each stage really costs on your own sentences.
 jq -r '.stages[]? | select(.seconds) | [.name, .seconds] | @tsv' trace.jsonl |
   awk '{n[$1]++; s[$1]+=$2} END {for (k in n) printf "%-28s %6.3fs  ×%d\n", k, s[k]/n[k], n[k]}' |
@@ -1104,6 +1128,151 @@ jq -r '.stages[]? | select(.skip_reason) | .skip_reason' trace.jsonl |
 # Every rule you have ever taught, and from where.
 jq -r 'select(.kind == "correction") | [.via, .heard, .corrected] | @tsv' trace.jsonl
 ```
+
+## The timeline
+
+`trace.jsonl` says what each stage cost. It cannot say what the *decoder* cost,
+because only the winning arm is recorded, and it has no zero — `at` is written
+when the pipeline ended, to the second. A timeline has both.
+
+On by default, and rotating at 64 MB — `logging.spans: false` turns it off.
+
+One line per dictation in `spans.jsonl`, beside `trace.jsonl`. Each line is a
+flat list of spans threaded by `parent`, measured in seconds from `t0` — the
+key coming *up* for something you spoke, and the start of the run for a
+`--transcribe` replay.
+
+Zero is the key going up, not going down. Holding a key for fifteen seconds is
+not work the app did, and drawn to scale it squashes the second that is. What
+the press cost — the wait for the engine, the wait for the first sample, how
+long you held it — is in `capture` on the `trace.jsonl` line, which is where a
+number belongs when it is not a span.
+
+```sh
+# what the last dictation spent its time on, longest first
+jq -r '.spans[] | [.dur, .kind, .name, .note] | @tsv' spans.jsonl |
+  tail -40 | sort -rn | head
+
+# every decode of the same clip, including the arms that lost
+jq -r 'select(.source=="live") | .spans[] | select(.kind=="decode") |
+       [.name, .dur, .note] | @tsv' spans.jsonl
+```
+
+A span is wall-clock time the app spent. Word timings and speech segments are
+positions *in the audio* — they look the same and mean nothing alike, so they
+stay in `trace.jsonl` and never become spans.
+
+### Reading it
+
+```sh
+ParrotFlow --trace-view              # the last live dictation, on stdout
+ParrotFlow --trace-view clip.wav     # a particular one
+ParrotFlow --trace-view --redacted   # nothing anybody said in it
+ParrotFlow --trace-view --perfetto   # a file to drag onto ui.perfetto.dev
+```
+
+```
+2026-09-07T14:19:23.206Z   Ghostty   0.797s
+
+  gate                            0.037s  ██                              2.50s of speech
+  first pass                      0.190s    ██████████                    reached 6.08s
+  500ms of silence either side    0.292s    ████████████████              reached 8.40s
+  1000ms of silence either side   0.241s    █████████████                 reached 9.36s
+  vocabulary                      0.245s                    █████████████
+    sound                         0.243s                    █████████████ 0 of 80 over the floor
+  transform punctuation           0.072s                                  ███
+```
+
+Three decodes of the same clip inside a fifth of a second, and a phoneme pass
+that took more than the decode and matched nothing. Both are invisible in
+`trace.jsonl`, which keeps one figure for the winning arm and one for the whole
+stage.
+
+From a terminal it goes to stdout, so it pipes and it **diffs** — two of these
+through `diff` answer "did that change make it slower", which no chart does.
+
+Run from a transform, where there is no terminal, it writes a file and opens it.
+The file goes to the temporary directory, named after the clip:
+`trace-2026-09-07T16-36-41-18F52ACD.txt`. Named, so a second press opens a new
+document instead of rewriting one your editor already holds — an editor shows
+you the buffer it loaded, so a fixed name means reading the previous dictation
+and believing it is this one. Temporary, because this is a view and not a
+record: `spans.jsonl` keeps the timeline, and the system clears these out.
+
+Each decode arm is a row of its own because they overlap: they are three decodes
+of one clip running at once, and anything that stacked them would be drawing
+something that did not happen.
+
+**`--redacted` is what makes one safe to send.** Timings survive redaction
+perfectly and text does not, so it drops the transcript, the app name and every
+note, and keeps the shape: a timeline with no words in it still shows that the
+phoneme pass took 817 ms. `--bug-report` carries a wordless one already.
+
+**`--perfetto`** writes Chrome Trace Event JSON, beside the text one and named
+the same way, to drag onto
+<https://ui.perfetto.dev>, for a long dictation where you want to zoom.
+Perfetto parses it in the browser and uploads nothing — but the page itself
+loads from Google, and the file holds what you said unless you passed
+`--redacted`. There is no deep link: `?url=` is HTTPS-only, an `https` page
+will not fetch from `http://127.0.0.1` whatever the localhost exemption does
+elsewhere, and the alternative is putting your dictations on a public host to
+look at a chart.
+
+### A chip that opens it
+
+Not shipped, because a chip claims its letter from every dictation for the nine
+seconds the offer is up. Paste it into your own config if you want it:
+
+```yaml
+transforms:
+  - name: trace
+    description: open this dictation's trace
+    display: Opening the trace
+    offer: true
+    key: t
+    done: Trace opened
+    command: /Applications/ParrotFlow.app/Contents/MacOS/ParrotFlow --trace-view
+```
+
+The full path, because `ParrotFlow` is not on `PATH` — and the dev build's is
+`/Applications/ParrotFlowDev.app/...`, which is also the one whose `spans.jsonl`
+it will read.
+
+**Whatever a `command:` transform prints becomes the new transcript.** That is
+why `--trace-view` writes everything a person reads to stderr and hands stdin
+straight back on stdout: the sentence returns unchanged, so
+`finishOfferedTransform` writes nothing to the field and `done:` is what the
+pill says. A version before 2026-09-07 printed to stdout instead, and pressing
+the chip on one of those replaces the dictation with a file path. This form is
+right against either:
+
+```yaml
+    command: sh -c 'said=$(cat); "/Applications/ParrotFlow.app/Contents/MacOS/ParrotFlow"
+      --trace-view >/dev/null; printf %s "$said"'
+```
+
+`t` collides with "the", "this", "that" — so a dictation starting with one of
+those, within the offer window, opens a trace. That is the whole cost: the
+command only reads, and the window it opens is a text file. A chip that changed anything would want `x` or `z`, which
+nothing starts with.
+
+`done:` is what the pill says afterwards. Without it a transform that leaves
+the text alone reports "nothing to change" — true about the sentence, and it
+reads as a failure for a transform whose whole job is not to touch it.
+
+### Checking the trace itself
+
+```sh
+ParrotFlow --trace-edits    # what a stage recorded replays to what it produced
+ParrotFlow --trace-spans    # spans survive being closed from many tasks at once
+```
+
+Both are in `make test`, as `check-trace-edits`. The first is the one that
+matters: a stage stores what it changed rather than both versions of the
+sentence, so the corpus is only worth anything if applying the edits in order
+to `asr.text` gives `final`. It is checked on written cases and several
+thousand fuzzed pairs, because the pairs that break a diff are never the ones
+anybody thinks to write down.
 
 ### Watching it live
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1234,20 +1234,28 @@ look at a chart.
 Not shipped, because a chip claims its letter from every dictation for the nine
 seconds the offer is up. Paste it into your own config if you want it:
 
+`config.example.yaml` ships this entry with `offer:` and `key:` commented out,
+so a fresh install can ask for a trace out loud and gains no chip:
+
 ```yaml
 transforms:
   - name: trace
     description: open this dictation's trace
     display: Opening the trace
-    offer: true
-    key: t
+    say: [timeline, timings, why that was slow]
+    # offer: true
+    # key: t
     done: Trace opened
-    command: /Applications/ParrotFlow.app/Contents/MacOS/ParrotFlow --trace-view
+    command: sh -c 'said=$(cat); app=/Applications/ParrotFlow.app;
+      [ -x "$app/Contents/MacOS/ParrotFlow" ] || app=/Applications/ParrotFlowDev.app;
+      "$app/Contents/MacOS/ParrotFlow" --trace-view >/dev/null; printf %s "$said"'
 ```
 
-The full path, because `ParrotFlow` is not on `PATH` — and the dev build's is
-`/Applications/ParrotFlowDev.app/...`, which is also the one whose `spans.jsonl`
-it will read.
+A full path, because `ParrotFlow` is not on `PATH`, and chosen at run time
+because the dev build is at `/Applications/ParrotFlowDev.app/...` and reads its
+own `spans.jsonl`. Writing one path literally also makes `--check-config` report
+an error on a machine that has only the other build, and that is a check
+failure, not a warning.
 
 **Whatever a `command:` transform prints becomes the new transcript.** That is
 why `--trace-view` writes everything a person reads to stderr and hands stdin

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1098,9 +1098,11 @@ jq -r '.stages[]? | .name as $s | (.edits // [])[] |
 
 # Press to text, end to end. `capture.at` is the key going down, to the
 # millisecond; `at` is when the pipeline finished and only to the second.
+# `.stages[]?` and a default: a clip the gate refused has `capture.at` and no
+# stages at all, and `add` over nothing is null.
 jq -r 'select(.capture.at) |
        [.capture.stopped, .vad.seconds, .asr.processing,
-        ([.stages[].seconds // 0] | add)] | @tsv' trace.jsonl
+        ([.stages[]?.seconds // 0] | add // 0)] | @tsv' trace.jsonl
 
 # What each stage really costs on your own sentences.
 jq -r '.stages[]? | select(.seconds) | [.name, .seconds] | @tsv' trace.jsonl |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,6 +62,7 @@ feedback:
 logging:
   text: true    # ~/Library/Logs/ParrotFlow.log
   audio: false  # keep each dictation's recording on disk
+  spans: true   # one timeline per dictation, rotating at 64 MB
 ```
 
 ## Where things live
@@ -72,6 +73,7 @@ logging:
 | Transforms | `~/.config/parrotflow/transforms/<name>/` — one folder each |
 | Recordings | `~/.config/parrotflow/recordings` — empty unless `logging.audio: true`, and moved by `audio.output_dir` |
 | Trace | `~/.config/parrotflow/recordings/trace.jsonl` |
+| Timeline | `~/.config/parrotflow/recordings/spans.jsonl` — one per dictation, rotating at 64 MB; off with `logging.spans: false` |
 | Log | `~/Library/Logs/ParrotFlow.log` — off with `logging.text: false` |
 | The shipped examples | `~/.config/parrotflow/transforms/examples/` — refreshed from the app on every launch, not yours to edit in place |
 

--- a/docs/proposals/trace-v3.md
+++ b/docs/proposals/trace-v3.md
@@ -291,9 +291,10 @@ No new primitive. `command:`, `offer:` and `key:` already exist
 (`Config.swift:780-782`), the chip row is built from them
 (`AppDelegate.swift:513-515`), and `OfferKeys` claims the letter.
 
-**It does not ship in `config.example.yaml`.** No default pipeline gains a
-stage, and no install gains a chip. It is documented in `docs/cli.md` as
-something to paste into your own config:
+**No default pipeline gains a stage, and no install gains a chip.** It ships in
+`config.example.yaml` with `offer:` and `key:` commented out, so it is reachable
+by voice through `say:` and nothing else until you uncomment them. `docs/cli.md`
+carries the same entry:
 
 ```yaml
 transforms:
@@ -561,7 +562,9 @@ Two things in this document were **not** built:
    rejecting them correctly is now answerable from the trace, and is not
    answered here.
 4. **The per-call `model` span**, and the fields that depend on it.
-5. **Whether the chip ships.** It does not. It is documented in `docs/cli.md`.
+5. **Whether the chip ships.** It does not. The transform is in
+   `config.example.yaml` with `offer:` and `key:` commented out — reachable by
+   voice, and one uncomment away from a chip.
 
 ## Build order
 
@@ -581,7 +584,7 @@ guard (#272) and the empty-decode retry live. ~200 lines.
 
 **PR 3 — reading one.** `--trace-view` and `TraceText`, the Trace Event export
 behind `--perfetto`, `--redacted`, the `done:` key on a transform, the transform
-documented in `docs/cli.md` — not added to `config.example.yaml` — and the
-wordless timeline in `--bug-report`. None of it in the dictation path.
+in `config.example.yaml` with its chip commented out, and the wordless timeline
+in `--bug-report`. None of it in the dictation path.
 
 All three shipped together, in one pull request.

--- a/docs/proposals/trace-v3.md
+++ b/docs/proposals/trace-v3.md
@@ -1,0 +1,587 @@
+# Proposal: trace v3 — one timeline per dictation
+
+**Status.** Designed 2026-09-05 to 2026-09-07, written 2026-09-07, rebased onto
+main on 2026-09-12. This document is the design; what shipped differs from it in
+the ways noted under "What shipped".
+
+The stage called `interpret` throughout this document is named `sentence_repair`
+since #306. The old spelling is still read from a config. Every mention below is
+left as it was written, because the measurements were taken under that name.
+
+**Goal.** A dictation can be traced end to end: every step, every model call,
+every change to the text, with real timings. The trace is a feature, not a
+developer's private artefact — anyone running ParrotFlow can open one, and a
+bug report can carry one.
+
+**Why now.** The app measures a lot and keeps almost none of it. Three quarters
+of a dictation's wall clock is not recorded anywhere, and the parts that are
+recorded cannot be lined up against each other.
+
+---
+
+## What today's files can and cannot answer
+
+`ParrotFlow.log` is not a timing source. `Log.swift:23` formats to
+`yyyy-MM-dd HH:mm:ss` — one second of resolution — and the file truncates
+itself at 1 MB (`Log.swift:58`). It is prose for reading over someone's
+shoulder.
+
+`trace.jsonl` is the corpus. It times every pipeline step around the same span
+for a table, a script and a model call (`Pipeline.swift:817-843`), records a
+step that declined with its reason (`:797`), and keeps `asr.processing`,
+`asr.duration`, the VAD segments and the two `capture` numbers.
+
+What is missing, measured on the dev corpus of 23,545 lines:
+
+| Gap | Where |
+|---|---|
+| No absolute start | `at` is evaluated in `Trace.record`'s `defer`, so it is when the pipeline *ended*. The press's wall clock is never stored, and `stamp()` uses `.withInternetDateTime` — no fractional seconds. End-to-end latency is not reconstructable. |
+| The speech gate is untimed | `runSpeechGate` (`Transcriber.swift:772`) reads the whole clip and runs VAD with no clock. The 53 lines carrying `capture` but no `asr` are gate rejections: the verdict is kept, never its cost. |
+| Model load is untimed | `prepare(config:)` can download and load ~1 GB. |
+| Only the winning decode is recorded | `recordASR` fires once (`Transcriber.swift:569`). A dictation that ran the long-pause retry (`:426`) and both padded arms (`silenceRetryPads = [0.5, 1.0]`, `:1136`) reports one `processing` figure. These are the largest untimed cost in the app. |
+| A failed arm vanishes | The arm catch blocks log and return nil (`startSecondOpinions:699`). An arm failing every time is invisible in the file; it simply never wins. |
+| Delivery is outside the trace | `Trace.record` closes at `AppDelegate.swift:2179`; `finishTranscription` (`:5285`) runs after it. |
+| Sub-steps are one number | `vocabulary` publishes `sound_ms` and `gate_ms` (`Pipeline.swift:1092-1093`), but `gate_ms` covers the slot gate (`:1198`) and the sentence gate (`:1209`) together. `interpret` measures every boundary read (`SentenceJoin.swift:403`, `:419`) and throws the number into a log line. |
+
+Two data-quality problems in the file itself:
+
+- `asr.duration` is 0 on 167 of 637 recent lines. It is exactly the clips over
+  15 seconds: all 167 have `vad.total` ≥ 15.1s, and 469 of 470 good lines are
+  under it. FluidAudio's chunked path does not fill `duration`.
+- `capture` is on 690 of 8,343 live dev lines and 0 of 116 release lines. The
+  release build predates the field.
+
+---
+
+## Decisions already taken
+
+Settled 2026-09-05 to 2026-09-07. Do not relitigate.
+
+| | |
+|---|---|
+| Shape | One timeline per dictation: a flat array of spans threaded by `parent`. Not a stage list with model calls beside it. |
+| Two files | `trace.jsonl` stays the corpus and keeps every key it has. `spans.jsonl` is new, capped and rolling. |
+| Diff | Stage `before`/`after` become an `edits` array. |
+| Version | `Trace.version` → 3. |
+| Old lines | Never converted. Nothing in v3 is derivable from v2 except `edits`, and a line stamped v3 with no spans breaks the contract the version field exists to keep. |
+| Opening one | A `command:` transform with `offer: true` and `key: t`. No new config grammar, no new primitive beside transforms. |
+| Shipping it | Documented in `docs/cli.md`, never in `config.example.yaml`. No default pipeline changes and no install gains a chip. |
+| Viewer | Chrome Trace Event JSON, exported by a command, opened in Perfetto. Not stored in that format. |
+| Audience | Everyone, not the maintainer. Defaults, read path and redaction follow from that. |
+
+---
+
+## The two files
+
+The split is on retention, not on compatibility.
+
+`trace.jsonl` answers questions asked across every dictation ever given — what
+does the vocabulary stage cost, which words does the decoder doubt, how often
+does an arm win. `Trace.swift` says why it has no size cap: *"This is the
+corpus, not a debug buffer."*
+
+A span tree answers one question about one dictation, it is only ever wanted
+for something recent, and it is where the bytes are. The dev corpus is 90 MB
+over 34 days — about 970 MB a year. Spans roughly double a line. In their own
+file they can be capped and deleted; inside `trace.jsonl` nothing can ever be
+deleted again.
+
+Joined by `wav`. Both are JSONL, appended with `O_APPEND` as `Trace.append`
+already does.
+
+---
+
+## `trace.jsonl` v3
+
+Keeps every key. One removal, the rest additive — so every `jq` recipe in
+`docs/cli.md` that does not read `before`/`after` keeps working.
+
+**Removed:** `stages[].before` and `stages[].after`.
+
+**Added:**
+
+| Field | What |
+|---|---|
+| `stages[].edits` | See below. |
+| `stages[].parts[]` | `{name, seconds, note}` — the sub-steps of a stage. |
+| `capture.at` | The press, in wall clock, with milliseconds. |
+| `capture.stopped` | Key up, seconds from the press. |
+| `vad.seconds` | What the gate cost. Distinct from `vad.total`, which is audio. |
+| `prepare` | `{seconds}`, absent when the models were warm. |
+| `decodes[]` | `{pad, seconds, reached, taken, error}`, one per arm. |
+| `asr.arm` | Which row above won. |
+
+The file gets about 20% **smaller**. Stage `before`/`after` is 24.7% of it
+today, and only 6.4% of stages change the text at all — so 93.6% of those
+copies are one sentence written twice to say nothing happened, which
+`changed: false` already said.
+
+Fix `asr.duration` on clips over 15 seconds while here: fall back to the clip
+length the app already knows.
+
+---
+
+## `edits` — the diff
+
+One shape, on any node that changed the text.
+
+```jsonc
+{ "at": 71, "was": "is is", "now": "is" }
+```
+
+`at` is a character offset **into that node's input**, not into the running
+text — so a node's edits apply right to left, or left to right with a running
+delta. Characters, not bytes, matching `Trace.Edit.range`, which is already
+"in characters".
+
+**The invariant.** `asr.text` with every edit applied in order equals `final`.
+That is checkable, and the check is a test. Nothing today ties the stage list
+to the two anchors.
+
+It requires that text-editing nodes never overlap. True now — only pipeline
+stages edit, and they run in sequence. Write it down, because the day something
+edits in parallel the invariant is how anyone finds out.
+
+`scripts/watch.py:51` already computes a word-level diff at read time, with a
+comment complaining that seven stages printing input and output is fourteen
+copies of the sentence. This moves that into the file and makes it exact, which
+matters because `interpret` and `punctuation` change punctuation and a word
+diff cannot see it.
+
+---
+
+## `spans.jsonl` — the timeline
+
+One line per dictation.
+
+```jsonc
+{ "v": 3, "kind": "dictation",
+  "t0": "2026-09-05T17:26:35.412Z",
+  "wav": "parrotflow-2026-09-05T19-26-35-8716DE1C.wav",
+  "source": "live", "lang": "en",
+  "app": { "name": "Ghostty", "bundle_id": "com.mitchellh.ghostty" },
+  "spans": [ /* ~30 */ ],
+  "final": "…" }
+```
+
+### The span
+
+```jsonc
+{ "id": 12, "parent": 9, "name": "sound", "kind": "model",
+  "at": 14.940, "dur": 0.817,
+  "model": "kokoro", "runtime": "coreml", "n": 12,
+  "out": { "over_floor": 0 } }
+```
+
+Six fields carry the timeline; everything else is payload keyed by `kind`.
+`at` and `dur` are seconds from `t0`. `t0` is the press for a live dictation,
+and the start of the traced body for a `--transcribe` replay, which was never
+pressed for.
+
+Flat with a `parent`, not nested, for three reasons. The decode arms
+**overlap**, so they have no single place in a tree. A span finishes at a
+different time from its parent, so a writer that appends is simpler than one
+that reaches into a nested object. And a flat array is one query away from
+every question, where a nested one needs a different path per depth.
+
+### Two time domains
+
+**A span is something the app spent wall-clock time doing.** Word timings and
+VAD segments are positions **in the audio**. They both look like
+`{start, end}` and they mean nothing alike — 19 word "spans" on a timeline
+would draw a picture that is false.
+
+Word timings and VAD segments stay as payload on the spans that produced them.
+They never become spans.
+
+### Span kinds
+
+| `kind` | Payload |
+|---|---|
+| `dictation` | the root, id 1, parent null |
+| `record` | `engine`, `first_sample` — press to key up |
+| `gate` | `speech`, `total`, `segments` |
+| `decode` | `pad`, `text`, `confidence`, `reached`, `taken`, `words`, `error` |
+| `stage` | `vars`, `skip` |
+| `part` | `note` — a sub-step that calls no model |
+| `model` | `model`, `revision`, `runtime`, `units`, `n`, `cached`, `loaded`, `in`, `out`, `error` |
+| `deliver` | `route`, `app` |
+
+A skipped stage is a span with `dur: 0` and a `skip` object, so the stage list
+stays complete in one place.
+
+### Where the spans come from
+
+| Span | Call site |
+|---|---|
+| `record`, `deliver` | `AppDelegate.swift:2113`, `:5285` |
+| `gate` | `runSpeechGate`, `Transcriber.swift:772` |
+| `decode` × n | first pass `:406`, long-pause retry `:426`, padded arms `:677`, empty-decode retry `:480` |
+| `stage` × n | the pipeline loop, `Pipeline.swift:843` |
+| `part` in `vocabulary` | `exact`, `fuzzy`, `sound` (`:1140`), `slots` (`:1149`), `slot_gate` (`:1198`), `sentence_gate` (`:1209`) |
+| `part` in `interpret` | `scan`, `pauses`, and one `read` per boundary — `SentenceJoin.swift:403-419` already computes that number |
+| `model` | wherever a model is actually called, at whatever depth |
+
+### Model spans
+
+`model` and `revision` both. `Trace.ASR`'s comment says Parakeet exposes no
+revision so none is invented, but `SlotModel` pins `a983542`,
+`SentenceReadings` pins `f493c65` and `WordVectors` pins `6c3ae70`. A silent
+model swap between two runs is otherwise invisible.
+
+`units` — `ane`/`gpu`/`cpu` — because the ANE costs real fidelity and 74% of
+slot fillers differ from PyTorch. If a number moves, this is the first thing to
+check and it is nowhere on disk today.
+
+`loaded` — seconds this call paid loading. `SentenceReadings` is 320 MB and a
+1.3s load. A stage that includes a cold load is not comparable to one that does
+not, and today they look identical.
+
+`cached` — a G2P call that hits the `NeuralPhonemes` cache costs ~0 ms. Without
+this a cache hit and a fast model are the same row.
+
+`error` — **a failed call is still a row.** This is the one that fixes a real
+blind spot.
+
+Three rules on `in`/`out`, or the payload becomes the file again:
+
+1. **Never store a vector.** Store the decision it produced.
+2. **Never store a prompt body.** Name and hash. The hash is what says the
+   prompt changed between two runs.
+3. **Never repeat the transcript.** A call stores the clipped span it looked
+   at, not the sentence around it.
+
+### What it draws
+
+The dictation of 2026-09-05 17:26:35, real numbers except gate and delivery:
+
+```
+t0 = press                                                        16.05s total
+├─ record                    ████████████████████████████████████████  14.523
+│    engine ready 0.232 · first sample 0.361
+├─ gate            silero-vad                                       ▏  0.094
+├─ decode          parakeet · first pass · reached 14.08            ▏  0.318
+├─ pipeline                                                         ███ 1.033
+│  ├─ interpret                                                     ▏  0.004
+│  ├─ context                                                       ▏  0.001
+│  ├─ vocabulary                                                    ██  0.822
+│  │  ├─ exact                                                      ▏  0.001
+│  │  ├─ fuzzy                                                      ▏  0.003
+│  │  ├─ sound       kokoro · n=12 · 0 over floor                   ██  0.817
+│  │  └─ slots       0 slots from 0 proposals                       ▏  0.001
+│  ├─ numbers                                                       ▏  0.003
+│  ├─ punctuation                                                   ▎  0.107
+│  ├─ code_identifiers   ⨯ skipped: when_unmatched                  ·  —
+│  ├─ repetitions        "is is" → "is"                             ▏  0.045
+│  └─ join                                                          ▏  0.050
+└─ deliver         paste → Ghostty                                  ▏  0.081
+```
+
+80% of the pipeline went to a phoneme pass over 12 terms that matched none, and
+the only change to the transcript was five characters. Neither fact is
+available today.
+
+---
+
+## Opening a trace
+
+### The transform
+
+No new primitive. `command:`, `offer:` and `key:` already exist
+(`Config.swift:780-782`), the chip row is built from them
+(`AppDelegate.swift:513-515`), and `OfferKeys` claims the letter.
+
+**It does not ship in `config.example.yaml`.** No default pipeline gains a
+stage, and no install gains a chip. It is documented in `docs/cli.md` as
+something to paste into your own config:
+
+```yaml
+transforms:
+  - name: trace
+    description: open this dictation's trace
+    offer: true
+    key: t
+    command: parrotflow --trace-view
+```
+
+`returns: none` is **not** needed. `finishOfferedTransform:4574` already
+declines to write back when the text is unchanged:
+
+```swift
+guard cleaned != before else { … return }
+```
+
+So a command that does its side effect and echoes stdin is safe. The failure
+path is safe too — `runOfferedTransform:4522` fails open, *"losing a rewrite
+costs a second attempt; losing the sentence costs the sentence."*
+
+One visible seam. `finishOfferedTransform:4574` flashes
+`"trace: nothing to change"` after every open — true about the text, wrong
+about what happened. Nobody is given this by default, so it is not a shipped
+defect, but it is the first thing anyone who adds the transform will report:
+a `done:` key, one optional string of the same kind as `display:`. PR 3.
+
+The command reads `spans.jsonl` itself, so it needs nothing from `ctx`, and
+`ctx.trace` stays nil at chip time without anyone caring. The same command runs
+from the terminal and from a `when:` condition.
+
+Selecting the last one is not `tail -1` — the file has dictations, corrections,
+edits, and a concurrent `--transcribe` sweep by design:
+
+```sh
+jq -c 'select(.kind=="dictation" and .source=="live")' spans.jsonl | tail -1
+```
+
+### The letter
+
+`t`, for trace.
+
+`OfferKeys`' own doc warns that the offer holds its letters for nine seconds
+after every dictation, and *"a sentence that happens to start with a chip's own
+letter — `V` for Vocabulary — still runs that command on its first keystroke."*
+`t` is a common opener — "the", "this", "that" — so a misfire is likely.
+
+It is accepted here for two reasons. Nobody gets this chip without adding it, so
+the exposure is the person who chose it. And the misfire is benign: the command
+is read-only and the worst it does is open a viewer. A destructive chip would
+need `x` or `z`, which nothing starts with.
+
+The docs entry says this, so whoever pastes it in knows what they are choosing.
+
+### The viewer
+
+Chrome Trace Event JSON, exported by `--trace-view`, opened in Perfetto.
+
+| Ours | Trace Event |
+|---|---|
+| `at` | `ts`, × 1e6 |
+| `dur` | `dur`, × 1e6 |
+| `name` | `name` |
+| `kind` | `cat` |
+| payload | `args` |
+| — | `ph`, always `"X"` |
+| `parent` | dropped — nesting is inferred from time containment on a `tid` |
+
+Overlapping siblings need their own `tid`, so each decode arm is a lane. That
+is the picture the arms are worth drawing, and it is why Perfetto beats
+speedscope here: speedscope is a flamegraph and wants a stack, which
+overlapping arms do not have.
+
+Emit `visStart` at the `record` span's end, so the view opens on the 1.5s that
+matter instead of a hairline beside 14.5s of held key.
+
+Deep linking, checked against Perfetto's docs:
+
+- `?url=` is **HTTPS only — not localhost, not HTTP, not `file://`** — and
+  needs CORS. Useless here, and wrong for transcripts.
+- **postMessage** is the supported local path. Open `ui.perfetto.dev`, send
+  `PING` until it answers `PONG`, then post
+  `{perfetto: {buffer, title}}`. `window.open` must follow a user gesture, so
+  the shim is a page with a button — and that button is where the app says what
+  it is about to do, so the gesture Perfetto requires and the consent
+  `BugReport` requires are the same click. Their words: *"Traces pushed via
+  postMessage() are kept only in the browser memory/cache and are not sent to
+  any server."*
+
+So `--trace-view` writes the Trace Event file and a small HTML shim beside it,
+and calls `open`. Storing Trace Event as the corpus format would be the
+mistake: `args` is untyped, there is no place for the edit invariant, and every
+recipe would be reaching into a shape that exists to make a flamegraph draw.
+
+---
+
+## It is a feature, not a debug artefact
+
+This reframing arrived last and changes three things.
+
+### Defaults
+
+`logging.spans`, beside `text` and `audio` in `Config.Logging:2574`. On for
+everyone, not `AppVariant.isDev`.
+
+With the chip no longer shipped, the bug report carries this default on its own:
+you cannot turn a flight recorder on after the crash. A trace has to already
+exist on the day someone hits the thing they are reporting, and that is the only
+reason the setting is on for people who will never open one themselves.
+
+The cap is what makes that safe, and the config comment has to state it.
+
+**Deferred in the first cut.** With no cap, nothing is evicted, so a replay
+writing a timeline costs only bytes — and it is how the feature is tested from
+a terminal. The rule below lands with the rotation.
+
+**A `--transcribe` sweep must not write spans.** `Trace.append`'s doc says the
+sweep writes to the corpus concurrently by design, and that is right for
+`trace.jsonl`. For a capped `spans.jsonl` it is not: one sweep over 20,000 clips
+evicts every live dictation, and "re-open the last one" opens a replay. Either
+the sweep writes no spans at all, or the cap counts only `source: live`. The
+first is simpler.
+
+Still to decide: the cap. Something like 2,000 dictations or 50 MB, oldest
+dropped. Rotation is a rename, not `Log.write`'s truncate-to-zero — truncating
+loses the line you just wanted. One loss case remains: another process holding
+the old descriptor keeps writing to the renamed inode. That costs a line, not a
+crash.
+
+### The read path
+
+Perfetto is reasonable for this audience — ParrotFlow's users dictate into
+terminals and editors, and the config has `code_identifiers` and `github_refs`
+in it. But opening a Google-hosted page with a dictation in it is a statement
+the app has to make before it makes it, not after.
+
+`BugReport`'s first rule applies verbatim: *"Nothing is copied or opened before
+the person has read it — this app hears what people say, and the log can carry
+a transcript."*
+
+### Redaction, and the bug report
+
+**A timing-only trace is fully shareable.** Timings survive redaction perfectly;
+text does not. Drop every text field — `text`, `final`, `edits[].was/now`,
+`words`, `in`, `out`, `app` — and the shape, the durations and the model calls
+all survive. Someone can send a timeline with no words in it, and it still
+shows that the sound pass took 817 ms.
+
+That is the strongest use of this feature. `BugReport.swift` already assembles
+version, machine, permissions and 50 prose log lines, already writes every home
+path as `~` in one place, and already has `redacted(_:)` at `:116`. A redacted
+trace is the attachment that makes a report actionable, and it is what turns
+this from the maintainer's tool into everyone's.
+
+Proposed: `--trace-view --redacted`, and a checkbox in the bug report window.
+
+---
+
+## Risks
+
+**Everything here is write-only.** No span, no part, no edit is read back by
+the transcript path. A bug produces a wrong picture, never a wrong sentence.
+The one exception is a transform reading `ctx.trace` and acting on it, which is
+opt-in.
+
+Two real crash vectors, both on the path every user runs:
+
+1. **String index math in `edits`.** Swift traps on an out-of-range
+   `String.Index`. Derive edits from a diff that never indexes back into the
+   string, or clamp every offset before use and drop the edit rather than trust
+   it. This is the top review item, and it is where PR 1's effort actually goes:
+   the work is coalescing per-character `CollectionDifference` operations into
+   `{at, was, now}` runs stated in the node's *input* coordinates. The diff is
+   not the easy part of that PR.
+2. **Concurrent appends from the decode arms.** `stages` is appended only by
+   the pipeline loop today, sequentially. Per-arm spans mean several tasks
+   appending at once. `Collector` is `@unchecked Sendable` with an `NSLock` and
+   every existing recorder takes it; the rule has to hold for the new ones. An
+   unlocked array append from two threads is memory corruption.
+
+Everything else fails silent if it copies `Trace.append`: `guard let
+directory`, `try?` on the directory, `open()` < 0 → return, one `write`.
+
+Bound the collector: a cap on spans per dictation, so a pathological clip
+cannot grow the array without end.
+
+---
+
+## What shipped
+
+The open decisions, as they were settled.
+
+| | |
+|---|---|
+| The cap | 64 MB on `spans.jsonl`, rotated by renaming to `spans.1.jsonl`. A rename, not `Log`'s truncate-to-zero, which would throw away the timeline you were about to look at. |
+| `sound` | One span with a note, not one per term. |
+| `final` | Kept. Derivable, but it makes every "what did it say" query a one-liner and it is the check on the invariant. |
+| `deliver` | Its own line in `spans.jsonl`, joined by `wav`. `Trace.record` still appends in its `defer`, so "append on exit, even if it threw" is unchanged. |
+| Span collection | **Always on.** Only the *file* is behind `logging.spans`. `parts` and `decodes` in `trace.jsonl` are read off the same spans, so the two files cannot disagree about what a step cost. |
+| The bug report | No checkbox. `--bug-report` gains a wordless timeline, rendered by the same code as `--trace-view` with `notes: false`. |
+
+### The viewer is text
+
+The design assumed Perfetto. What shipped renders the timeline as text, and
+`--perfetto` is a secondary export for when you want to zoom.
+
+Two measurements pushed it there, both worth keeping written down:
+
+- **Perfetto will not take a trace from a `file://` page.** Its embedding guide:
+  *"Serve your host page over http(s), not file://. The embedding protocol
+  relies on postMessage between windows, which browsers disable for file://
+  origins."* So a page opened off disk cannot hand it anything.
+- **`?url=` cannot reach a local file either.** Tested: a loopback server with
+  `Access-Control-Allow-Origin: *`, reachable by `curl`, and Perfetto answered
+  *"Could not fetch the trace at http://127.0.0.1:8779/trace.json: TypeError:
+  Failed to fetch."* An `https` page will not fetch `http://127.0.0.1`. The
+  only URLs it accepts are public HTTPS ones, which would mean putting
+  dictations on a public host to look at a chart.
+
+Working around that took a loopback HTTP server inside the command, serving one
+page that did Perfetto's `PING`/`PONG` handshake. It worked — verified end to
+end in a browser — and it was ~130 lines to put a chart behind a random
+localhost port. Text is smaller, and it does three things the chart cannot:
+it **diffs**, it pastes into an issue, and it needs no network.
+
+### Other departures from the design
+
+- **No `record` span.** Holding a key for fifteen seconds is not work the app
+  did, and drawn to scale it squashes the second that is. Zero on the timeline
+  is the key coming *up*; what the press cost stays in `capture`.
+- **`load models` is a span**, which the design did not have. Measured at 29.9s
+  on the first dictation after a launch — recorded only as a field, it left the
+  timeline with a half-minute hole where the entire wait was.
+- **Decode arms are numbered** — `decode pass 1/2/3` — with the padding in the
+  note. How far the silence moved is a detail of the third one; how many
+  decodes you paid for is the thing being read.
+- **Renderings go to the temporary directory**, named after the clip. A fixed
+  name means the second press rewrites a file an editor already holds, and an
+  editor shows you the buffer it loaded — which produced a real case of reading
+  a sixteen-minute-old trace and believing it was the current one.
+
+Two things in this document were **not** built:
+
+- **A `model` span around each model call.** The spans go as deep as a stage's
+  sub-steps. `sound`, `slot_gate` and `sentence_gate` are `part` spans, because
+  they wrap a step that *may* call a model rather than the call itself.
+- **`revision`, `units`, `loaded`, `cached`, `n`, `in`/`out` on a span.** They
+  need the per-call spans above. `note` carries what a step found out, in one
+  string.
+
+## Still open
+
+1. **The cold start, and what the pill says during it.** A dictation that waits
+   on `prepare()` shows "Transcribing…" for as long as it takes —
+   `AppDelegate.swift:2095-2103` knows only "Downloading …" and "Transcribing…",
+   and loading from disk is neither. Measured at 29.9s, which reads as a hang.
+   Warming the models at startup, and the label, are **a separate PR** — not
+   this one.
+2. **A `--transcribe` sweep still writes spans.** With a cap in place, one sweep
+   over 20,000 clips evicts every live dictation. Gate it on `source == .live`,
+   or exempt replays from the cap.
+3. **The `extends` guard.** On three measured dictations the padded arms reached
+   further into the audio than the first pass and the first pass was taken every
+   time — the guard rejecting arms that rewrote earlier text. Whether it is
+   rejecting them correctly is now answerable from the trace, and is not
+   answered here.
+4. **The per-call `model` span**, and the fields that depend on it.
+5. **Whether the chip ships.** It does not. It is documented in `docs/cli.md`.
+
+## Build order
+
+Three PRs. Each is independently useful and each can ship alone.
+
+**PR 1 — `trace.jsonl` v3.** `edits` replacing `before`/`after`, the new
+timing fields, `decodes[]`, `parts[]`, the `asr.duration` fix, `v: 3`, and the
+`docs/cli.md` recipes. `scripts/watch.py` reads `before`/`after` at `:51` and is
+updated here, not later — it gets shorter, since it computes the diff itself
+today. No spans, no viewer. The riskiest code in the whole
+proposal is the diff, and it lands here alone where it can be reviewed by
+itself. ~180 lines.
+
+**PR 2 — `spans.jsonl`.** The span collection, the second file, the cap,
+`logging.spans`. Touches the decode path, which is where the invented-tail
+guard (#272) and the empty-decode retry live. ~200 lines.
+
+**PR 3 — reading one.** `--trace-view` and `TraceText`, the Trace Event export
+behind `--perfetto`, `--redacted`, the `done:` key on a transform, the transform
+documented in `docs/cli.md` — not added to `config.example.yaml` — and the
+wordless timeline in `--bug-report`. None of it in the dictation path.
+
+All three shipped together, in one pull request.

--- a/scripts/check-trace-edits.sh
+++ b/scripts/check-trace-edits.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# The invariant a v3 trace rests on.
+#
+#   scripts/check-trace-edits.sh
+#
+# A stage no longer stores its input and its output — it stores what it
+# changed, in the coordinates of the text it was handed. That is only worth
+# something if it replays: apply the edits in order and you must get the
+# output back.
+#
+# Nothing at run time reads an edit, so a bug here cannot damage a transcript.
+# It can quietly make the whole corpus wrong, which nothing else would say.
+#
+# No audio, no model, no config. `--trace-edits` carries its own cases and
+# fuzzes several thousand more, because the pairs that break a diff are never
+# the ones anybody thinks to write down.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/.build/release/ParrotFlow"
+[ -x "$BIN" ] || { echo "build first: swift build -c release"; exit 1; }
+
+cd "$ROOT" || exit 1
+"$BIN" --trace-edits || exit 1
+
+# And the other half: the decode arms close their spans from sibling tasks, so
+# several threads append to one array. An unlocked append there is memory
+# corruption rather than a wrong number — the one failure in this feature that
+# could take the app down. Run it under the thread sanitiser to prove the
+# locking itself:
+#
+#   swift build --sanitize=thread --scratch-path .build-tsan
+#   .build-tsan/debug/ParrotFlow --trace-spans
+"$BIN" --trace-spans

--- a/scripts/watch.py
+++ b/scripts/watch.py
@@ -48,12 +48,31 @@ if not sys.stdout.isatty():
 WORD = re.compile(r"\S+|\s+")
 
 
-def diff(before, after):
-    """What one stage changed, as words rather than as two sentences.
+def edits(stage):
+    """What one stage changed, from the `edits` the trace now carries.
 
-    Seven stages printing their input and their output is fourteen copies of the
-    same line. The change is the only part worth reading.
+    v3 stopped storing a stage's input and output — seven stages printing both
+    was fourteen copies of the same line, and 93.6% of them said nothing had
+    happened. The change itself is all that is kept, and all that is worth
+    reading.
     """
+    changes = stage.get("edits")
+    if changes is None:
+        # A v2 line, which is most of the file. Never converted, so this is how
+        # they still read.
+        return diff(stage.get("before"), stage.get("after"))
+    parts = []
+    for change in changes:
+        was, now = change.get("was", ""), change.get("now", "")
+        if was:
+            parts.append(f"{C['red']}{was}{C['off']}")
+        if now:
+            parts.append(f"{C['green']}{now}{C['off']}")
+    return " ".join(parts) if parts else "—"
+
+
+def diff(before, after):
+    """The same, for a v2 line, which keeps both sentences instead."""
     a, b = WORD.findall(before or ""), WORD.findall(after or "")
     out = []
     for tag, i1, i2, j1, j2 in difflib.SequenceMatcher(None, a, b).get_opcodes():
@@ -101,13 +120,24 @@ def render(record, only=None):
             why = stage.get("skip_reason") or stage.get("skipped")
             print(f"  {C['dim']}{name:<14}  skipped: {why}{C['off']}")
             continue
-        before, after = stage.get("before"), stage.get("after")
         ms = (stage.get("seconds") or 0) * 1000
         cost = f"{C['dim']}{ms:6.1f}ms{C['off']}" if ms >= 0.05 else ""
-        if before == after:
+        changed = stage.get("edits") or (
+            stage.get("edits") is None and stage.get("before") != stage.get("after")
+        )
+        if not changed:
             print(f"  {C['dim']}{name:<14}  —{C['off']}        {cost}")
         else:
-            print(f"  {C['yellow']}{name:<14}{C['off']}  {diff(before, after)}   {cost}")
+            print(f"  {C['yellow']}{name:<14}{C['off']}  {edits(stage)}   {cost}")
+        # The sub-steps, when one of them is where the time went. A stage that
+        # is 2ms of table lookups does not need four lines saying so.
+        for part in stage.get("parts") or []:
+            part_ms = (part.get("seconds") or 0) * 1000
+            if part_ms < 20:
+                continue
+            note = part.get("note") or ""
+            print(f"    {C['dim']}{part.get('name', '?'):<12}  {note:<34}"
+                  f"{part_ms:6.1f}ms{C['off']}")
         # Only the variables a stage chose to publish; the pipeline's own
         # ran/ok/ms are noise here because the line above already says them.
         published = {k: v for k, v in (stage.get("vars") or {}).items()


### PR DESCRIPTION
Three quarters of a dictation's wall clock was not recorded anywhere. `trace.jsonl` timed pipeline stages; the model load, the speech gate, every losing decode arm and the delivery were all untimed, and a stage's cost could not be lined up against anything else. This adds one timeline per dictation in `spans.jsonl`, beside the recordings: every step, every decode, what each cost, and what each stage changed to the text. `--trace-view` draws it as text, and `--bug-report` carries a wordless copy so a report about speed arrives with numbers in it.

The setting is `logging.spans`, and it is **on** by default. Collection is always on — `parts` and `decodes` in `trace.jsonl` are read off the same spans, so the two files cannot disagree — and only the file is behind the setting. The file is capped at 64 MB and rotates by renaming to `spans.1.jsonl`.

Start a review at `Trace.edits` and `Trace.replay` in `Trace.swift`. That pair replaces a stage's `before`/`after` with a diff, so it is the one place where a bug silently corrupts the corpus rather than failing. `--trace-edits` is the check that holds it.

<details>
<summary>Two things the timeline found on its first day of use</summary>

**The slot gate cost 2.5s on the first dictation of every launch.** `slot_gate` measured 2.545s, 2.598s and 2.487s on three first dictations, and 0.000s on a second dictation in the same launch. The number did not follow how many places there were to settle: one change cost 2.598s, another cost nothing.

`warmSlotModel` prepared the Core ML model and stopped. `slotGate` also loads the tokenizer and builds the probe, and nothing warmed those — the model sat ready while the first dictation paid for the other half. Fixed in this PR, through `Vocabulary.slotGate` itself so the two halves cannot warm different things again. After the fix, on the same kind of dictation:

| | before | after |
|---|---|---|
| `slot_gate` | 2.487s | 0.017s |
| `vocabulary` | 3.397s | 0.461s |
| whole dictation | 5.257s | 2.268s |

**`transform disfluency` has run on 40 dictations and changed the text on zero of them.** It costs about a second each time — 16 runs today between 0.786s and 1.364s — and on a short dictation that is over half the total. It is not touched here. The measurement is only possible because of this PR.

</details>

<details>
<summary>The viewer is text because Perfetto cannot be handed a local trace</summary>

Two things were built and measured before the text renderer:

- Perfetto refuses a `file://` host page. Its own documentation says to serve the host page over http(s).
- An HTTPS page will not fetch `http://127.0.0.1`. Tested with a loopback server and correct CORS headers: Perfetto answered "Could not fetch the trace… TypeError: Failed to fetch."

So the shipped viewer is text, which also pipes and **diffs** — two timelines through `diff` answer "did that change make it slower", which no chart does. `--trace-view --perfetto` stays as a secondary export you drag onto ui.perfetto.dev by hand.

</details>

<details>
<summary>What was measured before this was proposed, and what verifies it now</summary>

The gap this fills was measured first: 24.7% of `trace.jsonl` was stage `before`/`after` while only 6.4% of stages change text, and the corpus grew about 970 MB a year. `edits` replaces both strings with the diff.

Verified:

- **The edits invariant.** `asr.text` plus every stage's edits, applied in order, equals `final`. Holds on real v3 records, and `--trace-edits` covers 11 literal cases, 7 change summaries and 5000 fuzzed pairs.
- **No data races.** `--trace-spans` closes 200 spans from 200 tasks at once and asserts count, unique ids, parenting and the cap. Clean under `swift build --sanitize=thread`, three runs.
- **Rotation.** At 65 MB the file renames to `spans.1.jsonl` rather than truncating, because truncating throws away the timeline you were about to read.
- **Redaction.** Every string in a redacted timeline was walked by hand: all of them are the app's own span names.
- `make test`: 36 of 38. The two failures, `dotted` and `edit-diff`, reproduce on `origin/main` without this branch — `scripts/check-dotted.sh` does not exist, and the `borderplay` case fails identically.
- swiftlint: 37 findings on the branch, 37 on `origin/main`. None new.

</details>

<details>
<summary>Six findings from `coderabbit review`, five fixed in 99403a93</summary>

- `reached` anchored on the start of the note, but a padded arm writes `500ms pad, reached 3.02s`. So `decodes[].reached` was null on every arm but the first — the rows the field exists to compare.
- `capture.stopped` is documented as press to key-up and measured to whenever `recordCapture` ran, which is after the pipeline had started. It read about two seconds long and disagreed with the timeline's own zero.
- `Destination.traceName` interpolated `Reason` directly, and `notAField` carries the role, so a route read `nowhere: notAField(role: "AXStaticText")` — the shape that property's doc comment says it exists to prevent.
- `--bug-report` and `--trace-view` both parsed every line of a 64 MB file forward to keep the last one. Both scan backwards now and stop at the first hit.
- The end-to-end `jq` recipe used `.stages[]`, which fails on a clip the gate refused: those have `capture.at` and no stages.

The sixth is listed below as a known gap.

</details>

<details>
<summary>What this does not fix</summary>

- **A `--transcribe` sweep writes timelines too**, and a large sweep can rotate live dictations out of the capped file. `--trace-view` picks the last *live* record, so it degrades to "cannot find one" rather than showing the wrong one. The fix is to write timelines only for live dictations, which would mean a sweep produces none.
- **The pill says "Transcribing…" during the model load.** The timeline now shows that load as a `load models` span, so the label is visibly wrong for its 30 seconds. Left for the PR that warms the models at startup.
- **The `extends` guard.** On three measured dictations the padded arms reached further into the audio than the first pass, and the first pass was taken every time. That may be correct — the guard rejects an arm that rewrites earlier text — but it is now answerable from the trace, and it was not before.
- **The post-dictation chip is documented, not shipped.** `docs/cli.md` carries the transform; it is not in `config.example.yaml` and not in the default pipeline.
- `spans.jsonl` follows `audio.output_dir`, so it inherits #96.

</details>

<details>
<summary>Review notes — what is mechanical and what is not</summary>

- **Read first:** `Trace.edits` and `Trace.replay`. Index-safe over `[Character]` because Swift traps on an out-of-range `String.Index`, and bounded at 20,000 characters, above which it stores both strings instead.
- **Two time domains.** Spans are wall-clock. Word timings and VAD segments are positions in the audio. They look alike and mean nothing alike, so they stay in `trace.jsonl` and never become spans.
- **Zero on the timeline is the key coming up.** Holding a key for fifteen seconds is not work the app did, and drawn to scale it squashes the second that is.
- **The decode path** is where the invented-tail guard (#272) and the empty-decode retry live. The spans there are opens and closes only; the arm chosen is unchanged.
- **Mechanical:** `docs/cli.md`, `docs/proposals/trace-v3.md`, `config.example.yaml`, `scripts/watch.py`. 764 of the 2138 added lines are documentation.
- This branch is the 09-07 work rebased onto current `main`. The stage-span note compared `output` before the assignment that sets it, so it always closed as unchanged; that is fixed here.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
