### PR TITLE
feat: setup ends on two screens, and the parsing Python installs itself

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,11 +140,19 @@ repo-settings:
 ## The export reaches scripts/release.sh through the prerequisite. Without it
 ## release.sh refuses to build without a Developer ID, which is what stops a
 ## mis-signed release reaching users — see the note there.
+## TRY_DEST=/Applications rehearses where TCC will actually keep a grant.
+## /tmp is world-writable and an app there may never appear in the
+## Accessibility list, so the permission half cannot be tested from there.
+##
+## The directory is no longer cleared first. install.sh replaces the bundle
+## itself, and an `rm -rf` of a path somebody can pass in is one keystroke
+## from deleting /Applications.
+TRY_DEST ?= /tmp/parrotflow-try
 try-install: export PARROTFLOW_REHEARSAL = 1
 try-install: release
-	@rm -rf /tmp/parrotflow-try && mkdir -p /tmp/parrotflow-try
+	@mkdir -p "$(TRY_DEST)"
 	@PARROTFLOW_BASE_URL="file://$(PWD)/dist" \
-	 PARROTFLOW_DEST=/tmp/parrotflow-try sh scripts/install.sh
+	 PARROTFLOW_DEST="$(TRY_DEST)" sh scripts/install.sh
 
 ## Put this variant back to a first run and install it again — the setup
 ## screen with something to do. Forgets its permissions, deletes its models,

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -6982,7 +6982,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(settingsItem)
 
         permissionsItem = NSMenuItem(
-            title: "Setup…",
+            title: "Finish Setup…",
             action: #selector(openPermissions),
             keyEquivalent: ""
         )
@@ -7333,12 +7333,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 extension AppDelegate: NSMenuDelegate {
 
-    /// Granting permissions is a chore, not a feature. The item is there while
-    /// one of them still needs doing and gone once they are done — checked as
-    /// the menu opens, because the answer changes in System Settings rather
-    /// than in this app.
+    /// Setting up is a chore, not a feature. The item is there while something
+    /// still needs doing and gone once nothing does — checked as the menu
+    /// opens, because both answers change outside this app: a permission in
+    /// System Settings, eSpeak NG in Terminal.
     func menuNeedsUpdate(_ menu: NSMenu) {
-        permissionsItem.isHidden = !hasPermissionProblem
+        permissionsItem.isHidden = !hasUnfinishedSetup
 
         // Here rather than in `updateUI`, which runs on a 0.1s timer while
         // recording: the device is picked in System Settings, so the moment the
@@ -7348,6 +7348,16 @@ extension AppDelegate: NSMenuDelegate {
         inputDeviceItem.isHidden = device == nil
         inputDeviceItem.title = device.map { "Microphone  ·  \($0)" } ?? ""
         inputDeviceItem.submenu = microphoneMenu()
+    }
+
+    /// What the menu bar offers to finish.
+    ///
+    /// eSpeak NG as well as the permissions, and it is the only reason this
+    /// item outlives a first run: the setup window is where the command to
+    /// install it lives, and without a way back there is no way to install it
+    /// later at all.
+    private var hasUnfinishedSetup: Bool {
+        hasPermissionProblem || Phonemes.locate() == nil
     }
 
     private var hasPermissionProblem: Bool {

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -629,6 +629,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         permissions.onRetryDownloads = { [weak self] in self?.retryDownloads() }
         warmModels()
 
+        // eSpeak NG on this Mac means Homebrew installed it, and the Homebrew
+        // installer installs the Command Line Tools — so there is a real
+        // python3 and no installer dialog to trigger. Measured on 24,576
+        // dictations: the first one carrying a marker was number 10, and all
+        // 33 days had one. Waiting for it saves nobody a download and costs
+        // that first one its rule.
+        if Phonemes.locate() != nil { ParsingInstall.finishQuietly() }
+
         // After a grace, not with the fetches. `warmModels` declares every row
         // as `waiting` and the ones already on disk report `installed` a moment
         // later, so asking immediately would put a panel up on every launch and

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -629,10 +629,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         permissions.onRetryDownloads = { [weak self] in self?.retryDownloads() }
         warmModels()
 
-        // The rest of the setup, if eSpeak NG is already here. Nothing waits
-        // for it and nothing is said about it — see `ParsingInstall`.
-        ParsingInstall.finishQuietly()
-
         // After a grace, not with the fetches. `warmModels` declares every row
         // as `waiting` and the ones already on disk report `installed` a moment
         // later, so asking immediately would put a panel up on every launch and

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -629,6 +629,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         permissions.onRetryDownloads = { [weak self] in self?.retryDownloads() }
         warmModels()
 
+        // The rest of the setup, if eSpeak NG is already here. Nothing waits
+        // for it and nothing is said about it — see `ParsingInstall`.
+        ParsingInstall.finishQuietly()
+
         // After a grace, not with the fetches. `warmModels` declares every row
         // as `waiting` and the ones already on disk report `installed` a moment
         // later, so asking immediately would put a panel up on every launch and

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -646,6 +646,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.launchPanelGraceSeconds) {
             [weak self] in
             guard let self else { return }
+            // Not underneath the setup walk. Its second screen is a list of
+            // the same downloads, and the panel would say it again in front of
+            // it. The walk owns the story until Done; the panel is for an
+            // ordinary launch, where there is no window and somebody wants to
+            // know why dictation is not answering yet.
+            guard !self.permissions.isShowing else { return }
             self.launch.showIfNeeded(hotkey: self.hotKeys.binding?.displayName)
         }
 

--- a/Sources/ParrotFlow/AppDelegate.swift
+++ b/Sources/ParrotFlow/AppDelegate.swift
@@ -7366,12 +7366,19 @@ extension AppDelegate: NSMenuDelegate {
 
     /// What the menu bar offers to finish.
     ///
-    /// eSpeak NG as well as the permissions, and it is the only reason this
-    /// item outlives a first run: the setup window is where the command to
-    /// install it lives, and without a way back there is no way to install it
-    /// later at all.
+    /// Three things, and none of them fixes itself. A permission is answered in
+    /// System Settings. eSpeak NG is a command in Terminal, and the setup
+    /// window is where that command lives. A blocking download that failed has
+    /// a Try again button on that same window, and this item is the only route
+    /// to it — the walk is over and the hotkey path only opens the window when
+    /// a permission is missing.
+    ///
+    /// A download still in flight is not here. It finishes on its own, and an
+    /// item that came and went every launch would say nothing.
     private var hasUnfinishedSetup: Bool {
-        hasPermissionProblem || Phonemes.locate() == nil
+        hasPermissionProblem
+            || Phonemes.locate() == nil
+            || ModelDownloads.shared.blockingFailure != nil
     }
 
     private var hasPermissionProblem: Bool {

--- a/Sources/ParrotFlow/CommandRunner.swift
+++ b/Sources/ParrotFlow/CommandRunner.swift
@@ -450,21 +450,32 @@ enum CommandRunner {
     /// install all answer the same question.
     private static let interpreterLock = NSLock()
     /// Outer nil means "not asked yet", inner nil means "asked, found nothing".
-    nonisolated(unsafe) private static var interpreterDirectory: String??
+    nonisolated(unsafe) private static var interpreterPath: String??
 
-    private static func realInterpreterDirectory() -> String? {
+    /// The `python3` a `command:` transform actually runs under.
+    ///
+    /// Exposed because the venv for a parse has to be built on this exact
+    /// interpreter. A site-packages tree built for 3.13 holds C extensions a
+    /// 3.9 cannot load, and `disfluency.py` looks for the tree by its own
+    /// version — so a venv built on a different one is invisible to it. See
+    /// `ParsingInstall.finishQuietly`.
+    static func transformInterpreter() -> String? {
         // Held across the probe on purpose. A second caller waits for the
         // answer instead of starting a second probe, and the wait is bounded
         // by the deadline in it. It happens once per run of the app.
         interpreterLock.lock()
         defer { interpreterLock.unlock() }
-        if let cached = interpreterDirectory { return cached }
-        let found = probeInterpreterDirectory()
-        interpreterDirectory = .some(found)
+        if let cached = interpreterPath { return cached }
+        let found = probeInterpreter()
+        interpreterPath = .some(found)
         return found
     }
 
-    private static func probeInterpreterDirectory() -> String? {
+    private static func realInterpreterDirectory() -> String? {
+        transformInterpreter().map { ($0 as NSString).deletingLastPathComponent }
+    }
+
+    private static func probeInterpreter() -> String? {
         let probe = Process()
         // `env`, not a shell. It execs the interpreter in place, so this holds
         // one process and the deadline below signals the interpreter itself. A
@@ -523,7 +534,7 @@ enum CommandRunner {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard !path.isEmpty, FileManager.default.isExecutableFile(atPath: path) else { return nil }
         Log.write("command: python3 resolves to \(path)")
-        return (path as NSString).deletingLastPathComponent
+        return path
     }
 
     /// Put the real interpreter ahead of the shim for one subprocess.

--- a/Sources/ParrotFlow/ModelDownloads.swift
+++ b/Sources/ParrotFlow/ModelDownloads.swift
@@ -210,6 +210,32 @@ final class ModelDownloads: ObservableObject {
         }
     }
 
+    /// How far every fetch has got together, 0 to 1, weighted by size.
+    ///
+    /// One bar rather than six percentages: the last screen asks "is this
+    /// nearly done", and a row-by-row answer to that is six answers. Weighted
+    /// by megabytes because Parakeet is 461 MB and Silero VAD is 1 MB, and an
+    /// unweighted mean jumps a sixth when the smallest one lands.
+    ///
+    /// A row a setting switched off is not counted at all. `loading` counts
+    /// whole: its bytes are down, and this bar is about the download.
+    var fraction: Double {
+        let counted = rows.filter { if case .off = $0.state { return false } else { return true } }
+        let total = counted.reduce(0) { $0 + $1.megabytes }
+        guard total > 0 else { return 0 }
+        let done = counted.reduce(0.0) { sum, row in
+            switch row.state {
+            case .installed, .loading:
+                return sum + Double(row.megabytes)
+            case .downloading(let percent):
+                return sum + Double(row.megabytes) * Double(percent ?? 0) / 100
+            case .waiting, .failed, .off:
+                return sum
+            }
+        }
+        return done / Double(total)
+    }
+
     /// A failure turned into the one sentence that says what happened.
     ///
     /// `needs` is the free space to name when the disk is full.

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -493,7 +493,16 @@ enum PanelsCommand {
             .environmentObject(ready))
         // The same screen with eSpeak NG never installed. Drawn to show that it
         // is the same screen: nothing on Ready reports what was installed.
+        // Setting up, not revisiting — a revisit is the one context where
+        // eSpeak NG takes the screen back.
         let readyWithoutEspeakPane = AnyView(PermissionsView()
+            .environmentObject(PermissionsModel.showingSetup(ready))
+            .environmentObject(ready))
+
+        // Opened from the menu bar with eSpeak NG still missing. Everything is
+        // downloaded, so nothing is greyed — the screen exists to offer the one
+        // thing that is left.
+        let revisitPane = AnyView(PermissionsView()
             .environmentObject(PermissionsModel.showingSetup(ready, context: .revisiting))
             .environmentObject(ready))
 
@@ -551,6 +560,7 @@ enum PanelsCommand {
             (almostTherePane, setupSize(almostTherePane), .dark, false),
             (readyPane, setupSize(readyPane), .dark, false),
             (readyWithoutEspeakPane, setupSize(readyWithoutEspeakPane), .dark, false),
+            (revisitPane, setupSize(revisitPane), .dark, false),
             (switchedOffPane, setupSize(switchedOffPane), .dark, false),
             (didNotArrivePane, setupSize(didNotArrivePane), .light, false),
             (vadPane, setupSize(vadPane), .dark, false),

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -491,6 +491,12 @@ enum PanelsCommand {
             .environmentObject(PermissionsModel.showingSetup(
                 ready, context: .revisiting, espeak: .found))
             .environmentObject(ready))
+        // The same screen with eSpeak NG never installed. Drawn to show that it
+        // is the same screen: nothing on Ready reports what was installed.
+        let readyWithoutEspeakPane = AnyView(PermissionsView()
+            .environmentObject(PermissionsModel.showingSetup(ready, context: .revisiting))
+            .environmentObject(ready))
+
         let switchedOffPane = AnyView(PermissionsView()
             .environmentObject(PermissionsModel.showingSetup(
                 ready, axStatus: .notGranted, espeak: .found))
@@ -544,6 +550,7 @@ enum PanelsCommand {
             (almostReadyPane, setupSize(almostReadyPane), .light, false),
             (almostTherePane, setupSize(almostTherePane), .dark, false),
             (readyPane, setupSize(readyPane), .dark, false),
+            (readyWithoutEspeakPane, setupSize(readyWithoutEspeakPane), .dark, false),
             (switchedOffPane, setupSize(switchedOffPane), .dark, false),
             (didNotArrivePane, setupSize(didNotArrivePane), .light, false),
             (vadPane, setupSize(vadPane), .dark, false),

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -764,7 +764,10 @@ enum PanelsCommand {
         downloads.update(NeuralPhonemes.soundDownload.id, to: .failed(.unreachable))
         downloads.expect(SlotModel.download)
         downloads.expect(SentenceReadings.download)
-        downloads.expect(WordVectors.download, off: ModelDownload.gateOff)
+        // Live, not `off`. It was switched off here to draw the "gate is off"
+        // row, and that row went with the old screen — all it did after that
+        // was keep the sixth model off the list.
+        downloads.expect(WordVectors.download)
         return downloads
     }
 

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -480,6 +480,13 @@ enum PanelsCommand {
         let almostReadyPane = AnyView(PermissionsView()
             .environmentObject(PermissionsModel.showingSetup(almostReady))
             .environmentObject(almostReady))
+        // eSpeak NG settled and the models still coming: the one state where
+        // the title is the state and there is still a bar under it.
+        let almostThere = sampleDownloads(speech: .downloading(percent: 62))
+        let almostTherePane = AnyView(PermissionsView()
+            .environmentObject(PermissionsModel.showingSetup(almostThere, espeak: .found))
+            .environmentObject(almostThere))
+
         let readyPane = AnyView(PermissionsView()
             .environmentObject(PermissionsModel.showingSetup(
                 ready, context: .revisiting, espeak: .found))
@@ -535,6 +542,7 @@ enum PanelsCommand {
             // the only place those sentences can be read against each other.
             (modelsPane, setupSize(modelsPane), .dark, false),
             (almostReadyPane, setupSize(almostReadyPane), .light, false),
+            (almostTherePane, setupSize(almostTherePane), .dark, false),
             (readyPane, setupSize(readyPane), .dark, false),
             (switchedOffPane, setupSize(switchedOffPane), .dark, false),
             (didNotArrivePane, setupSize(didNotArrivePane), .light, false),

--- a/Sources/ParrotFlow/PanelsCommand.swift
+++ b/Sources/ParrotFlow/PanelsCommand.swift
@@ -470,6 +470,13 @@ enum PanelsCommand {
         let vadDidNotArrive = sampleDownloads(speech: .installed)
         vadDidNotArrive.update(Transcriber.voiceDownload.id, to: .failed(.stopped))
 
+        // Screen one, which is a list and nothing else: the same registry the
+        // screen after it reports on, before any of it has started.
+        let listing = sampleDownloads(speech: .waiting)
+        let modelsPane = AnyView(PermissionsView()
+            .environmentObject(PermissionsModel.showingModels(listing))
+            .environmentObject(listing))
+
         let almostReadyPane = AnyView(PermissionsView()
             .environmentObject(PermissionsModel.showingSetup(almostReady))
             .environmentObject(almostReady))
@@ -487,13 +494,11 @@ enum PanelsCommand {
         let vadPane = AnyView(PermissionsView()
             .environmentObject(PermissionsModel.showingSetup(vadDidNotArrive, espeak: .found))
             .environmentObject(vadDidNotArrive))
-        // The same screen after "Not now": the card is gone and the line says
-        // what was decided. The alert that asks is a sheet on the window and
-        // cannot be drawn here.
-        let skippedPane = AnyView(PermissionsView()
-            .environmentObject(PermissionsModel.showingSetup(
-                ready, context: .revisiting, espeakDeclined: true))
-            .environmentObject(ready))
+        // The middle of the eSpeak NG install: Terminal has the command and
+        // this screen is waiting for the binary to turn up.
+        let openingPane = AnyView(PermissionsView()
+            .environmentObject(PermissionsModel.showingSetup(almostReady, espeak: .opening))
+            .environmentObject(almostReady))
 
         // The third element is the appearance to draw in. Every floating
         // surface is dark whatever the system is set to — that is decided in
@@ -525,15 +530,16 @@ enum PanelsCommand {
                     .accessibility, asked: true, context: .revisiting))
                 .environmentObject(ModelDownloads())),
              NSSize(width: PermissionMetrics.width, height: PermissionMetrics.height), .dark, false),
-            // The one screen the walk ends on, in its four states. The title
-            // is the state, so this is the only place the four sentences can
-            // be read against each other.
+            // The screen that lists what is coming, then the screen the walk
+            // ends on in each of its states. The title is the state, so this is
+            // the only place those sentences can be read against each other.
+            (modelsPane, setupSize(modelsPane), .dark, false),
             (almostReadyPane, setupSize(almostReadyPane), .light, false),
             (readyPane, setupSize(readyPane), .dark, false),
             (switchedOffPane, setupSize(switchedOffPane), .dark, false),
             (didNotArrivePane, setupSize(didNotArrivePane), .light, false),
             (vadPane, setupSize(vadPane), .dark, false),
-            (skippedPane, setupSize(skippedPane), .light, false),
+            (openingPane, setupSize(openingPane), .light, false),
             (AnyView(PillView().environmentObject(notice)),
              pillSize(notice), .dark, true),
             (AnyView(PillView().environmentObject(thinking)),
@@ -944,6 +950,17 @@ enum PanelsCommand {
                     later: { print("update: later") }
                 )
             )
+        // The screen that lists what is about to be fetched. A still, like the
+        // screen itself: nothing on it has started.
+        case "models":
+            let listing = sampleDownloads(speech: .waiting)
+            let pane = AnyView(
+                PermissionsView()
+                    .environmentObject(PermissionsModel.showingModels(listing))
+                    .environmentObject(listing)
+            )
+            setupWindow = window(for: pane, size: setupSize(pane))
+
         // The setup window, on the step that reports the downloads. A real
         // registry is empty in this process — nothing here fetches anything —
         // so it runs on a sample whose percentage climbs, which is the part

--- a/Sources/ParrotFlow/ParsingInstall.swift
+++ b/Sources/ParrotFlow/ParsingInstall.swift
@@ -166,14 +166,20 @@ enum ParsingInstall {
     /// Everything a parse needs is here, eSpeak NG aside.
     static var isComplete: Bool { isInstalled && models.allSatisfy(has) }
 
-    /// Installs it quietly, the first time something actually needs a parse.
+    /// Installs it quietly, once eSpeak NG is here.
     ///
-    /// Called when a transform publishes `needs: parsing` — see `Pipeline`.
-    /// That only happens when the work was wanted and the install was not
-    /// there, so a person whose dictations never reach the rule never fetches
-    /// the 170 MB. Nothing is asked and nothing is shown: a transform reported
-    /// this, so a `python3` already runs on this Mac and there is no installer
-    /// dialog left to trigger.
+    /// Two callers, and both know a real `python3` exists before they ring.
+    /// At launch and when the setup window sees eSpeak NG land: eSpeak NG came
+    /// from Homebrew, and the Homebrew installer installs the Command Line
+    /// Tools, so `/usr/bin/python3` is an interpreter rather than the shim that
+    /// opens Apple's installer dialog. From `Pipeline`, when a transform
+    /// publishes `needs: parsing`: that transform just ran, so one resolved.
+    ///
+    /// It was first-need only for a while. Measured on 24,576 dictations, the
+    /// first one carrying a marker was number 10 and all 33 days had one — so
+    /// waiting saved nobody the 170 MB and cost that first dictation its rule.
+    /// The `needs: parsing` path stays as the way in for a Mac that never
+    /// installed eSpeak NG.
     ///
     /// Built on the interpreter a transform will actually run under, not on
     /// whichever one this process would pick. `--setup-parsing` prefers

--- a/Sources/ParrotFlow/ParsingInstall.swift
+++ b/Sources/ParrotFlow/ParsingInstall.swift
@@ -190,7 +190,6 @@ enum ParsingInstall {
     ///
     /// Fails open, into the log. Nothing waits for it.
     static func finishQuietly() {
-        guard !isComplete else { return }
         lock.lock()
         guard !running else { lock.unlock(); return }
         running = true
@@ -202,6 +201,11 @@ enum ParsingInstall {
                 running = false
                 lock.unlock()
             }
+            // Asked here rather than at the call site. `isComplete` runs the
+            // venv's own python once per model, and both callers are on the
+            // main thread — two process launches there is a stutter in the
+            // window that is drawing at the time.
+            guard !isComplete else { return }
             guard let interpreter = CommandRunner.transformInterpreter() else {
                 Log.write("parsing: no python3 a transform could run — nothing installed")
                 return
@@ -244,7 +248,12 @@ enum ParsingInstall {
     private static func run(_ command: String) -> Int32 {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/sh")
-        process.arguments = ["-c", command]
+        // `exec`, so the tracked process is pip rather than the shell holding
+        // it. Without it the deadline below kills the shell and leaves pip
+        // running, `running` clears, and the next caller starts a second
+        // install into the same tree. Same reason as `CommandRunner`'s own
+        // prefix; these commands are generated here and hold no shell syntax.
+        process.arguments = ["-c", "exec " + command]
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
         do { try process.run() } catch { return 1 }

--- a/Sources/ParrotFlow/ParsingInstall.swift
+++ b/Sources/ParrotFlow/ParsingInstall.swift
@@ -227,6 +227,12 @@ enum ParsingInstall {
     private static let lock = NSLock()
     nonisolated(unsafe) private static var running = false
 
+    /// Long enough for 170 MB of wheels on a bad connection, and short enough
+    /// that a fetch which has stopped moving does not hold `running` for the
+    /// life of the app. `--setup-parsing` has no deadline because a person is
+    /// watching it and can press ctrl-C; nobody is watching this.
+    private static let deadlineSeconds: TimeInterval = 900
+
     /// Output to the log, not to a pipe nobody reads. pip writes a progress bar
     /// per wheel and none of it is worth keeping.
     private static func run(_ command: String) -> Int32 {
@@ -236,7 +242,23 @@ enum ParsingInstall {
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
         do { try process.run() } catch { return 1 }
-        process.waitUntilExit()
+
+        let deadline = Date().addingTimeInterval(deadlineSeconds)
+        while process.isRunning, Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.5)
+        }
+        guard !process.isRunning else {
+            Log.write("parsing: the install stopped moving after"
+                + " \(Int(deadlineSeconds))s and was terminated")
+            // SIGTERM, then SIGKILL, which cannot be ignored. Waiting for the
+            // exit is what reaps it — the same shape as `CommandRunner.stop`.
+            process.terminate()
+            let grace = Date().addingTimeInterval(1)
+            while process.isRunning, Date() < grace { Thread.sleep(forTimeInterval: 0.02) }
+            if process.isRunning { kill(process.processIdentifier, SIGKILL) }
+            process.waitUntilExit()
+            return process.terminationStatus == 0 ? 1 : process.terminationStatus
+        }
         return process.terminationStatus
     }
 

--- a/Sources/ParrotFlow/ParsingInstall.swift
+++ b/Sources/ParrotFlow/ParsingInstall.swift
@@ -166,15 +166,14 @@ enum ParsingInstall {
     /// Everything a parse needs is here, eSpeak NG aside.
     static var isComplete: Bool { isInstalled && models.allSatisfy(has) }
 
-    /// Installs it quietly, once eSpeak NG is on this Mac.
+    /// Installs it quietly, the first time something actually needs a parse.
     ///
-    /// The order is the whole point. eSpeak NG is the one thing a person has to
-    /// install themselves, and the line that installs it installs Homebrew in
-    /// front of it when there is none — and the Homebrew installer installs the
-    /// Command Line Tools. So the moment eSpeak NG lands, `/usr/bin/python3` is
-    /// a real interpreter rather than the shim that opens Apple's installer
-    /// dialog when it is run. That is what makes this safe to do silently,
-    /// where `--setup-parsing` had to be typed.
+    /// Called when a transform publishes `needs: parsing` — see `Pipeline`.
+    /// That only happens when the work was wanted and the install was not
+    /// there, so a person whose dictations never reach the rule never fetches
+    /// the 170 MB. Nothing is asked and nothing is shown: a transform reported
+    /// this, so a `python3` already runs on this Mac and there is no installer
+    /// dialog left to trigger.
     ///
     /// Built on the interpreter a transform will actually run under, not on
     /// whichever one this process would pick. `--setup-parsing` prefers
@@ -185,7 +184,7 @@ enum ParsingInstall {
     ///
     /// Fails open, into the log. Nothing waits for it.
     static func finishQuietly() {
-        guard Phonemes.locate() != nil, !isComplete else { return }
+        guard !isComplete else { return }
         lock.lock()
         guard !running else { lock.unlock(); return }
         running = true

--- a/Sources/ParrotFlow/ParsingInstall.swift
+++ b/Sources/ParrotFlow/ParsingInstall.swift
@@ -161,6 +161,86 @@ enum ParsingInstall {
         return out
     }
 
+    // MARK: - Finishing it without a terminal
+
+    /// Everything a parse needs is here, eSpeak NG aside.
+    static var isComplete: Bool { isInstalled && models.allSatisfy(has) }
+
+    /// Installs it quietly, once eSpeak NG is on this Mac.
+    ///
+    /// The order is the whole point. eSpeak NG is the one thing a person has to
+    /// install themselves, and the line that installs it installs Homebrew in
+    /// front of it when there is none — and the Homebrew installer installs the
+    /// Command Line Tools. So the moment eSpeak NG lands, `/usr/bin/python3` is
+    /// a real interpreter rather than the shim that opens Apple's installer
+    /// dialog when it is run. That is what makes this safe to do silently,
+    /// where `--setup-parsing` had to be typed.
+    ///
+    /// Built on the interpreter a transform will actually run under, not on
+    /// whichever one this process would pick. `--setup-parsing` prefers
+    /// Homebrew's; an app launched from the Dock inherits launchd's PATH and
+    /// resolves `/usr/bin/python3`. A venv built on one and read by the other
+    /// is invisible — four green ticks from the command and the rule still off.
+    /// Asking `CommandRunner` is what makes them the same by construction.
+    ///
+    /// Fails open, into the log. Nothing waits for it.
+    static func finishQuietly() {
+        guard Phonemes.locate() != nil, !isComplete else { return }
+        lock.lock()
+        guard !running else { lock.unlock(); return }
+        running = true
+        lock.unlock()
+
+        DispatchQueue.global(qos: .utility).async {
+            defer {
+                lock.lock()
+                running = false
+                lock.unlock()
+            }
+            guard let interpreter = CommandRunner.transformInterpreter() else {
+                Log.write("parsing: no python3 a transform could run — nothing installed")
+                return
+            }
+            var lines: [(String, String)] = []
+            if !isInstalled {
+                lines.append((
+                    "a Python for parsing",
+                    "\(shellQuoted(interpreter)) -m venv \(shellQuoted(root.path))"))
+            }
+            lines.append((
+                "spaCy and its models",
+                "\(shellQuoted(python.path)) -m pip install --upgrade"
+                    + " --disable-pip-version-check -r \(shellQuoted(requirements.path))"))
+
+            for (what, command) in lines {
+                let status = run(command)
+                guard status == 0 else {
+                    Log.write("parsing: \(what) exited \(status); nothing after it ran")
+                    return
+                }
+            }
+            Log.write(isComplete
+                ? "parsing: spaCy is in — the disfluency marker rule runs from now on"
+                : "parsing: the install finished and something is still missing")
+        }
+    }
+
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var running = false
+
+    /// Output to the log, not to a pipe nobody reads. pip writes a progress bar
+    /// per wheel and none of it is worth keeping.
+    private static func run(_ command: String) -> Int32 {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", command]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do { try process.run() } catch { return 1 }
+        process.waitUntilExit()
+        return process.terminationStatus
+    }
+
     struct Step {
         let what: String
         let command: String

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -355,7 +355,13 @@ final class PermissionsWindowController {
     /// looks for a ticked checkbox, so an install in Terminal lands on its own.
     private func pollEspeak() {
         if Phonemes.locate() != nil {
-            if model.espeak != .found { model.espeak = .found }
+            if model.espeak != .found {
+                model.espeak = .found
+                // Homebrew came with it, and the Command Line Tools came with
+                // Homebrew. Everything a parse needs can be fetched now,
+                // without a terminal and without asking.
+                ParsingInstall.finishQuietly()
+            }
             openedTerminalAt = nil
             return
         }

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -81,11 +81,11 @@ enum PermissionStep: CaseIterable {
     }
 }
 
-/// A screen in the walk. The permissions are asked for one at a time, and then
-/// there is one screen for everything: what was granted, what is downloading,
-/// and what is on this Mac already.
+/// A screen in the walk. The permissions are asked for one at a time, then the
+/// models this launch is fetching are listed, then the walk ends on eSpeak NG.
 enum SetupStep: Equatable {
     case permission(PermissionStep)
+    case models
     case setup
 }
 
@@ -164,6 +164,10 @@ final class PermissionsModel: ObservableObject {
         steps = PermissionStep.allCases
             .filter { status(of: $0) != .granted }
             .map(SetupStep.permission)
+        // Only while installing, and only when there is something to list. It
+        // says what is about to be downloaded, which is news once. Opening the
+        // window from the menu bar a week later, it is a screen to click past.
+        if context == .installing, !downloads.rows.isEmpty { steps.append(.models) }
         steps.append(.setup)
         index = 0
         asked = false
@@ -171,10 +175,10 @@ final class PermissionsModel: ObservableObject {
 
     func markAsked() { asked = true }
 
-    /// The skip a revisit offers on a permission screen. It cannot walk past
-    /// the setup screen: that is the end of the walk, and its button closes
-    /// the window rather than advancing.
-    func skip() {
+    /// Move on one screen: Next on the models screen, and the skip a revisit
+    /// offers on a permission screen. It cannot walk past the last one — that
+    /// is where the walk ends, and its button closes the window.
+    func advance() {
         guard index + 1 < steps.count else { return }
         index += 1
         asked = false
@@ -187,29 +191,42 @@ final class PermissionsModel: ObservableObject {
     ) -> PermissionsModel {
         let model = PermissionsModel()
         model.context = context
-        model.steps = PermissionStep.allCases.map(SetupStep.permission) + [.setup]
+        model.steps = walk
         model.index = PermissionStep.allCases.firstIndex(of: step) ?? 0
         model.asked = asked
         return model
+    }
+
+    /// Parked on the models screen, for `--panel-sheet`.
+    static func showingModels(_ downloads: ModelDownloads) -> PermissionsModel {
+        let model = PermissionsModel(downloads: downloads)
+        model.micStatus = .granted
+        model.axStatus = .granted
+        model.steps = walk
+        model.index = PermissionStep.allCases.count
+        return model
+    }
+
+    /// Every screen of a first run, which is what the sheet draws against.
+    private static var walk: [SetupStep] {
+        PermissionStep.allCases.map(SetupStep.permission) + [.models, .setup]
     }
 
     /// Parked on the setup screen, for `--panel-sheet` and `--panels setup`.
     static func showingSetup(
         _ downloads: ModelDownloads, context: PermissionsContext = .installing,
         axStatus: Permissions.Status = .granted, hotkeyDisplay: String = "Right ⌥",
-        hotkeyRegistered: Bool = true, espeak: EspeakPresence = .missing,
-        espeakDeclined: Bool = false
+        hotkeyRegistered: Bool = true, espeak: EspeakPresence = .missing
     ) -> PermissionsModel {
         let model = PermissionsModel(downloads: downloads)
         model.context = context
         model.micStatus = .granted
         model.axStatus = axStatus
-        model.steps = PermissionStep.allCases.map(SetupStep.permission) + [.setup]
-        model.index = PermissionStep.allCases.count
+        model.steps = walk
+        model.index = walk.count - 1
         model.hotkeyDisplay = hotkeyDisplay
         model.hotkeyRegistered = hotkeyRegistered
         model.espeak = espeak
-        model.espeakDeclined = espeakDeclined
         return model
     }
 
@@ -482,7 +499,7 @@ final class PermissionsWindowController {
 
     private func decline() {
         guard model.context == .installing else {
-            model.skip()
+            model.advance()
             return
         }
         window?.close()
@@ -519,7 +536,7 @@ enum PermissionMetrics {
     static func width(for step: SetupStep) -> CGFloat {
         switch step {
         case .permission: return width
-        case .setup: return setupWidth
+        case .models, .setup: return setupWidth
         }
     }
 
@@ -527,7 +544,7 @@ enum PermissionMetrics {
     static func padding(for step: SetupStep) -> CGFloat {
         switch step {
         case .permission: return 28
-        case .setup: return SetupMetrics.at(28)
+        case .models, .setup: return SetupMetrics.at(28)
         }
     }
     static let height: CGFloat = 328
@@ -542,7 +559,7 @@ enum PermissionMetrics {
     static func height(for step: SetupStep) -> CGFloat? {
         switch step {
         case .permission: return height
-        case .setup: return nil
+        case .models, .setup: return nil
         }
     }
 }
@@ -559,7 +576,8 @@ struct PermissionsView: View {
     /// The header belongs to whichever screen is under it, so it is drawn on
     /// that screen's scale.
     private func header(_ points: CGFloat) -> CGFloat {
-        model.current == .setup ? SetupMetrics.at(points) : points
+        if case .permission = model.current { return points }
+        return SetupMetrics.at(points)
     }
 
     var body: some View {
@@ -589,14 +607,15 @@ struct PermissionsView: View {
                     onAsk: { onAsk(step) },
                     onDecline: onDecline
                 )
+            case .models:
+                ModelsPane(onNext: { model.advance() })
             case .setup:
                 SetupPane(
                     micStatus: model.micStatus, axStatus: model.axStatus,
                     hotkeyDisplay: model.hotkeyDisplay,
                     hotkeyRegistered: model.hotkeyRegistered,
-                    context: model.context, espeak: model.espeak,
-                    espeakDeclined: model.espeakDeclined,
-                    onDecline: onDecline, onClose: onClose, onRetry: onRetry,
+                    espeak: model.espeak,
+                    onClose: onClose, onRetry: onRetry,
                     onInstallEspeak: onInstallEspeak
                 )
             }
@@ -860,24 +879,96 @@ enum SetupMetrics {
     static var fieldRadius: CGFloat { at(Parrot.fieldRadius) }
 }
 
-/// One screen: what was granted, what is being fetched, and what is on this
-/// Mac already.
+/// Screen one: every model this launch is about to fetch, and what it costs.
 ///
-/// The title is the state and the glyphs are the detail. Only the permissions
-/// and the models a dictation waits on can change the title. The other three
-/// arrive in their own time and say so on their own line.
+/// A list and nothing else. Nothing on it has started yet, so nothing on it has
+/// a state to draw — the spinner, the bar and the failures belong to the screen
+/// after it, where there is something to report.
+private struct ModelsPane: View {
+    let onNext: () -> Void
+
+    @EnvironmentObject private var downloads: ModelDownloads
+
+    private func at(_ points: CGFloat) -> CGFloat { SetupMetrics.at(points) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Models")
+                .font(.system(size: at(19), weight: .semibold, design: .rounded))
+                .padding(.top, at(20))
+                .padding(.bottom, at(7))
+
+            Text("ParrotFlow will download these models in the background while you"
+                + " finish setup.")
+                .font(.system(size: at(12)))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            group(
+                "Speech and sound",
+                "These audio models process your voice, transform it into text and provide"
+                    + " additional cues to correct transcription artifacts.",
+                in: .sound
+            )
+
+            group(
+                "Language",
+                "These language models help ParrotFlow apply your vocabulary and correct"
+                    + " transcription artifacts by understanding what you mean.",
+                in: .language
+            )
+
+            Spacer(minLength: at(20))
+
+            SetupFoot(title: "Next", action: onNext)
+        }
+    }
+
+    /// A model a setting switched off is never fetched, so it is not on a list
+    /// of what is about to be.
+    @ViewBuilder
+    private func group(
+        _ name: String, _ blurb: String, in group: ModelDownload.Group
+    ) -> some View {
+        let rows = downloads.rows(in: group).filter {
+            if case .off = $0.state { return false } else { return true }
+        }
+        if !rows.isEmpty {
+            SetupGroup(name: name, blurb: blurb) {
+                ForEach(rows) { row in
+                    HStack(spacing: at(8)) {
+                        Text(row.name).font(.system(size: at(12)))
+                        Spacer(minLength: at(8))
+                        Text(row.sizeLabel)
+                            .font(.system(size: at(11)))
+                            .monospacedDigit()
+                            .foregroundStyle(.tertiary)
+                    }
+                    .padding(.vertical, at(6))
+                }
+            }
+        }
+    }
+}
+
+/// The screen the walk ends on: the one thing the app cannot install for you,
+/// and then the state of everything it can.
+///
+/// While eSpeak NG is still a decision the title is its name. Once nothing is
+/// left to install the title becomes the state, and the last line is the key to
+/// hold. A permission that was switched off, a setting that turned dictation
+/// off and a fetch that failed all take the title back — they are the three
+/// things waiting cannot fix.
 ///
 /// Nothing here starts a download. They start at launch in `warmModels` and
-/// carry on with the window closed, which is why Done never waits.
+/// carry on with the window closed, which is why Done only waits for the models
+/// a dictation needs.
 private struct SetupPane: View {
     let micStatus: Permissions.Status
     let axStatus: Permissions.Status
     let hotkeyDisplay: String
     let hotkeyRegistered: Bool
-    let context: PermissionsContext
     let espeak: PermissionsModel.EspeakPresence
-    let espeakDeclined: Bool
-    let onDecline: () -> Void
     let onClose: () -> Void
     let onRetry: () -> Void
     let onInstallEspeak: () -> Void
@@ -895,69 +986,45 @@ private struct SetupPane: View {
 
             invitation
 
-            group("Permissions") {
-                SetupLine(glyph: micStatus.glyph, title: "Microphone", note: micStatus.note)
-                SetupLine(glyph: axStatus.glyph, title: "Accessibility", note: axStatus.note)
-            }
+            section
 
-            models(
-                "Speech and sound",
-                "These audio models process your voice, transform it into text and provide"
-                    + " additional cues to correct transcription artifacts.",
-                in: .sound
+            Spacer(minLength: at(20))
+
+            if showsBar { DownloadBar(fraction: downloads.fraction) }
+
+            SetupFoot(
+                title: primaryTitle,
+                prominent: moment != .espeak || espeak != .missing,
+                disabled: waiting,
+                action: primaryAction
             )
-
-            models(
-                "Language",
-                "These language models help ParrotFlow apply your vocabulary and correct"
-                    + " transcription artifacts by understanding what you mean.",
-                in: .language
-            )
-
-            group("Other") { espeakLines }
-
-            Spacer(minLength: at(12))
-
-            HStack(spacing: at(10)) {
-                // It means what it says: during setup this quits the app.
-                // Revisiting, there is no installation left to cancel.
-                if context == .installing {
-                    Button(context.declineTitle, action: onDecline)
-                        .buttonStyle(.plain)
-                        .foregroundStyle(.tertiary)
-                        .font(.system(size: at(12)))
-                }
-
-                Spacer()
-
-                Button(primaryTitle, action: primaryAction)
-                    .keyboardShortcut(.defaultAction)
-                    .controlSize(.large)
-            }
         }
     }
 
     // MARK: What the screen is saying
 
     private enum Moment {
+        case permissionLost
+        case dictationOff
+        case somethingDidNotArrive
+        /// eSpeak NG is missing or landing. The screen is about it and nothing
+        /// else until it is settled.
+        case espeak
         case almostReady
         case ready
-        case permissionLost
-        case somethingDidNotArrive
-        case dictationOff
     }
 
     /// A permission first: it is the only one of these that cannot be fixed by
     /// waiting, and it is fixed somewhere else.
     ///
     /// An empty registry means `transcription.enabled` is false. `warmModels`
-    /// declares all six rows before this window opens and returns before
-    /// declaring any only on that one setting, so there is nothing else it can
-    /// mean.
+    /// declares every row before this window opens and returns before declaring
+    /// any only on that one setting, so there is nothing else it can mean.
     private var moment: Moment {
         if lostPermission != nil { return .permissionLost }
         if downloads.rows.isEmpty { return .dictationOff }
         if downloads.blockingFailure != nil { return .somethingDidNotArrive }
+        if espeak != .found { return .espeak }
         return downloads.speechIsIn ? .ready : .almostReady
     }
 
@@ -973,10 +1040,19 @@ private struct SetupPane: View {
         // the switch is in System Settings or in config.yaml.
         case .permissionLost, .dictationOff: return "Something was switched off"
         case .somethingDidNotArrive: return "Something did not arrive"
+        case .espeak: return "eSpeak NG"
         case .almostReady: return "Almost ready"
         case .ready: return hotkeyRegistered ? "Ready" : "Almost ready"
         }
     }
+
+    /// The models are still coming and nothing has gone wrong. Both the bar and
+    /// the greyed button are that one condition.
+    private var waiting: Bool {
+        (moment == .espeak || moment == .almostReady) && !downloads.speechIsIn
+    }
+
+    private var showsBar: Bool { waiting }
 
     /// The sentence under the title, and the key it ends on.
     ///
@@ -1023,9 +1099,11 @@ private struct SetupPane: View {
             // The key line finishes this sentence. Without a hotkey there is no
             // key line, and it would end on "or".
             return hotkeyRegistered ? "\(opening) Try again, or" : "\(opening) Try again"
+        case .espeak:
+            return "Turns written words into phonemes (how they sound)."
         case .almostReady:
-            // Nothing under the title. The line for the model that is still
-            // coming down is a few lines below, with its own percentage.
+            // Nothing under the title. The bar below says the same thing
+            // without a sentence.
             return hotkeyRegistered ? nil : unregisteredHotkey
         case .ready:
             return hotkeyRegistered ? nil : unregisteredHotkey
@@ -1042,13 +1120,13 @@ private struct SetupPane: View {
 
     private var keySentence: (String, String)? {
         switch moment {
-        case .permissionLost, .dictationOff, .almostReady: return nil
+        case .permissionLost, .dictationOff, .espeak, .almostReady: return nil
         case .somethingDidNotArrive: return ("hold", "later and it tries again on its own.")
         case .ready: return ("Hold", "and start dictating.")
         }
     }
 
-    /// A failure nobody is waiting on stays on its own line. Only a model a
+    /// A failure nobody is waiting on stays off this screen. Only a model a
     /// dictation waits for reaches the foot.
     private var primaryTitle: String {
         guard moment == .somethingDidNotArrive else { return "Done" }
@@ -1064,124 +1142,113 @@ private struct SetupPane: View {
         }
     }
 
-    // MARK: The groups
-
     @ViewBuilder
-    private func group<Content: View>(
-        _ name: String, blurb: String? = nil, @ViewBuilder lines: () -> Content
-    ) -> some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text(name.uppercased())
-                .font(.system(size: at(9), weight: .semibold, design: .rounded))
-                .kerning(at(0.9))
-                .foregroundStyle(.tertiary)
-                .padding(.bottom, at(4))
-            // The group carries the explanation, so the lines are bare: a
-            // glyph, a name, a size.
-            if let blurb {
-                Text(blurb)
-                    .font(.system(size: at(11)))
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .padding(.bottom, at(5))
+    private var section: some View {
+        if moment == .espeak {
+            switch espeak {
+            case .missing:
+                EspeakCard(onInstall: onInstallEspeak).padding(.top, at(16))
+            case .opening:
+                EspeakWaitingCard().padding(.top, at(16))
+            case .found:
+                EmptyView()
             }
-            lines()
-        }
-        .padding(.top, at(14))
-    }
-
-    @ViewBuilder
-    private func models(
-        _ name: String, _ blurb: String, in group: ModelDownload.Group
-    ) -> some View {
-        let rows = downloads.rows(in: group)
-        if !rows.isEmpty {
-            self.group(name, blurb: blurb) {
-                ForEach(rows) { row in
-                    SetupLine(
-                        glyph: row.glyph, title: row.name, detail: row.sizeLabel,
-                        note: row.note, noteIsPercent: row.percent != nil,
-                        percent: row.percent
-                    )
-                    if let why = row.why {
-                        SetupNote(text: why, tone: row.blocking ? Parrot.scarlet : Parrot.amber)
-                    }
-                }
-            }
-        }
-    }
-
-    /// The one thing here the app cannot fetch, so the one thing that asks for
-    /// a decision — and the only thing on the screen drawn as a card.
-    ///
-    /// Amber, not scarlet: CharsiuG2P covers the base case, so an absent eSpeak
-    /// NG costs some names rather than the feature.
-    @ViewBuilder
-    private var espeakLines: some View {
-        SetupLine(
-            glyph: espeakGlyph,
-            title: "eSpeak NG",
-            detail: "GPL-3 · a separate program",
-            note: espeakNote
-        )
-        switch espeakState {
-        case .found:
-            EmptyView()
-        case .opening:
-            SetupNote(
-                text: "Terminal is running it now. This line notices on its own when it lands.",
-                tone: Parrot.amber
-            )
-        case .skipped:
-            SetupNote(
-                text: "Skipped. Install it any time from Setup… in the menu bar.",
-                tone: Parrot.amber
-            )
-        case .missing:
-            EspeakCard(onInstall: onInstallEspeak)
-        }
-    }
-
-    /// Four ways the line reads. "Skipped" is missing plus an answer already
-    /// given, which is not the same thing as missing and unanswered.
-    private enum EspeakState {
-        case found
-        case opening
-        case missing
-        case skipped
-    }
-
-    private var espeakState: EspeakState {
-        switch espeak {
-        case .found: return .found
-        case .opening: return .opening
-        case .missing: return espeakDeclined ? .skipped : .missing
-        }
-    }
-
-    private var espeakGlyph: SetupGlyph {
-        switch espeakState {
-        case .found: return .granted
-        case .opening: return .downloading
-        case .missing, .skipped: return .absent
-        }
-    }
-
-    private var espeakNote: String? {
-        switch espeakState {
-        case .found: return nil
-        case .opening: return "Terminal open"
-        case .missing: return "not installed"
-        case .skipped: return "skipped"
         }
     }
 }
 
-/// What is lost without eSpeak NG, what it is, and the two ways to install it.
+/// A heading, the sentence that says what the group is for, and its lines.
+private struct SetupGroup<Content: View>: View {
+    let name: String
+    var blurb: String?
+    @ViewBuilder var lines: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(name.uppercased())
+                .font(.system(size: SetupMetrics.at(9), weight: .semibold, design: .rounded))
+                .kerning(SetupMetrics.at(0.9))
+                .foregroundStyle(.tertiary)
+                .padding(.bottom, SetupMetrics.at(4))
+            // The group carries the explanation, so the lines are bare: a name
+            // and a size.
+            if let blurb {
+                Text(blurb)
+                    .font(.system(size: SetupMetrics.at(11)))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.bottom, SetupMetrics.at(5))
+            }
+            lines
+        }
+        .padding(.top, SetupMetrics.at(14))
+    }
+}
+
+/// The one button every screen in the walk ends on.
 ///
-/// A card because it is the one thing on this screen that asks for a decision.
-/// Amber because the decision is not urgent: an absent eSpeak costs some names,
-/// not the feature.
+/// There is no second one. The walk has no cancel in it: a first run is not
+/// something to back out of half way, and the only way out is quitting the app,
+/// which macOS already offers.
+private struct SetupFoot: View {
+    let title: String
+    /// Plain while a card on the same screen is asking for something. Two blue
+    /// buttons is two things to press first.
+    var prominent = true
+    /// Greyed while a dictation is still waiting on a download. A button that
+    /// closes the window over a half-finished fetch leaves an app that does not
+    /// work yet.
+    var disabled = false
+    let action: () -> Void
+
+    var body: some View {
+        HStack {
+            Spacer()
+            Group {
+                if prominent, !disabled {
+                    Button(title, action: action)
+                        .buttonStyle(.borderedProminent)
+                        .keyboardShortcut(.defaultAction)
+                } else {
+                    Button(title, action: action)
+                }
+            }
+            .controlSize(.large)
+            .disabled(disabled)
+            // SwiftUI greys a disabled button by a hair. On the one screen whose
+            // whole job is saying "not yet", the button has to look like it.
+            .opacity(disabled ? 0.45 : 1)
+        }
+    }
+}
+
+/// Every fetch as one bar.
+///
+/// No number, and no bar per model: one bar answers "is this nearly done" in a
+/// single look, and a percentage is a claim about the network that goes wrong
+/// the moment the connection does.
+private struct DownloadBar: View {
+    let fraction: Double
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .leading) {
+                Capsule().fill(Color.primary.opacity(0.12))
+                Capsule()
+                    .fill(Parrot.action)
+                    .frame(width: geometry.size.width * min(max(fraction, 0), 1))
+            }
+        }
+        .frame(height: SetupMetrics.at(5))
+        .padding(.bottom, SetupMetrics.at(14))
+    }
+}
+
+/// The command that installs eSpeak NG, and the two ways to run it.
+///
+/// A card because it is the one thing in the walk that asks for a decision.
+/// Amber because the decision is not urgent: an absent eSpeak NG costs some
+/// names, not the feature — CharsiuG2P covers the base case.
 private struct EspeakCard: View {
     let onInstall: () -> Void
 
@@ -1189,35 +1256,31 @@ private struct EspeakCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: SetupMetrics.at(5)) {
-            Text("Not installed. Some of your names will be missed without it.")
+            Text("Run the following command to install")
                 .font(.system(size: SetupMetrics.at(12), weight: .semibold))
                 .foregroundStyle(Parrot.amber)
                 .fixedSize(horizontal: false, vertical: true)
 
-            Text(what)
-                .font(.system(size: SetupMetrics.at(11)))
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-
-            // The chained one-liner is 140 characters. Inside a sentence it is
-            // unreadable and unselectable, so it gets a field of its own.
+            // With no Homebrew the chained one-liner is 140 characters. Inside
+            // a sentence it is unreadable and unselectable, so it gets a field
+            // of its own.
             Text(EspeakInstall.command)
                 .font(.system(size: SetupMetrics.at(10), design: .monospaced))
                 .textSelection(.enabled)
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, SetupMetrics.at(8))
-                .padding(.vertical, SetupMetrics.at(6))
+                .padding(.vertical, SetupMetrics.at(7))
                 .background(
                     Color.primary.opacity(0.08),
                     in: RoundedRectangle(
                         cornerRadius: SetupMetrics.fieldRadius, style: .continuous
                     )
                 )
-                .padding(.vertical, SetupMetrics.at(1))
+                .padding(.vertical, SetupMetrics.at(2))
 
             HStack(spacing: SetupMetrics.at(10)) {
-                Button("Run in Terminal", action: onInstall)
+                Button("Install with Terminal", action: onInstall)
                     .buttonStyle(.borderedProminent)
                 Button(copied ? "Copied" : "Copy the command") {
                     EspeakInstall.copyCommand()
@@ -1226,9 +1289,9 @@ private struct EspeakCard: View {
             }
             .padding(.top, SetupMetrics.at(2))
         }
-        .padding(.horizontal, SetupMetrics.at(10))
-        .padding(.top, SetupMetrics.at(8))
-        .padding(.bottom, SetupMetrics.at(9))
+        .padding(.horizontal, SetupMetrics.at(11))
+        .padding(.top, SetupMetrics.at(9))
+        .padding(.bottom, SetupMetrics.at(10))
         .background(
             Parrot.amber.opacity(0.11),
             in: RoundedRectangle(cornerRadius: SetupMetrics.radius, style: .continuous)
@@ -1237,148 +1300,51 @@ private struct EspeakCard: View {
             RoundedRectangle(cornerRadius: SetupMetrics.radius, style: .continuous)
                 .strokeBorder(Parrot.amber.opacity(0.38), lineWidth: SetupMetrics.at(1))
         }
-        .padding(.leading, SetupMetrics.indent)
-        .padding(.top, SetupMetrics.at(2))
-    }
-
-    private var what: String {
-        let backs = "It backs up CharsiuG2P on the names it misses. It is a separate program"
-            + " under GPL-3, so ParrotFlow cannot install it for you."
-        if EspeakInstall.brew != nil {
-            return "\(backs) This runs the install in Terminal, where you can watch it."
-        }
-        return "\(backs) Homebrew is missing too, so this installs Homebrew first, then"
-            + " eSpeak NG, in Terminal."
     }
 }
 
-/// One line: a glyph in a fixed column, a name, what it costs, and a word at
-/// the right edge only where the glyph cannot say it.
-private struct SetupLine: View {
-    let glyph: SetupGlyph
-    let title: String
-    var detail: String?
-    var note: String?
-    var noteIsPercent = false
-    /// Draws a 2 px bar under this line and no other.
-    var percent: Int?
-    var button: (title: String, action: () -> Void)?
-
-    var body: some View {
-        HStack(spacing: SetupMetrics.gap) {
-            GlyphView(glyph: glyph)
-            Text(title).font(.system(size: SetupMetrics.at(12)))
-            if let detail {
-                Text(detail)
-                    .font(.system(size: SetupMetrics.at(11)))
-                    .foregroundStyle(.tertiary)
-            }
-            Spacer(minLength: SetupMetrics.at(8))
-            if let note {
-                Text(note)
-                    .font(.system(
-                        size: SetupMetrics.at(11),
-                        weight: noteIsPercent ? .semibold : .regular
-                    ))
-                    .monospacedDigit()
-                    .foregroundStyle(
-                        noteIsPercent
-                            ? AnyShapeStyle(Parrot.action) : AnyShapeStyle(.tertiary)
-                    )
-            }
-            if let button {
-                Button(button.title, action: button.action)
-            }
-        }
-        .padding(.vertical, SetupMetrics.at(4))
-        .overlay(alignment: .bottomLeading) { bar }
-    }
-
-    @ViewBuilder
-    private var bar: some View {
-        if let percent {
-            GeometryReader { geometry in
-                let room = max(0, geometry.size.width - SetupMetrics.indent)
-                Rectangle()
-                    .fill(Parrot.action)
-                    .frame(width: room * CGFloat(percent) / 100, height: SetupMetrics.at(2))
-                    .offset(x: SetupMetrics.indent)
-                    .frame(maxHeight: .infinity, alignment: .bottom)
-            }
-        }
-    }
-}
-
-/// The one line under a name that says why it failed, or what to do about it.
-private struct SetupNote: View {
-    let text: String
-    let tone: Color
-
-    var body: some View {
-        Text(text)
-            .font(.system(size: SetupMetrics.at(11)))
-            .foregroundStyle(tone)
-            .fixedSize(horizontal: false, vertical: true)
-            .padding(.leading, SetupMetrics.indent)
-            .padding(.bottom, SetupMetrics.at(4))
-    }
-}
-
-/// The six states a line can be in, drawn rather than written.
-enum SetupGlyph: Equatable {
-    case granted
-    case switchedOff
-    case downloading
-    case queued
-    case turnedOff
-    case absent
-}
-
-private struct GlyphView: View {
-    let glyph: SetupGlyph
+/// While Terminal has it.
+///
+/// Nothing to press. The binary is looked for on the same tick that looks for a
+/// ticked checkbox, so an install in Terminal lands on this screen by itself.
+private struct EspeakWaitingCard: View {
     @State private var spinning = false
 
     var body: some View {
-        Group {
-            switch glyph {
-            case .granted:
-                Image(systemName: "checkmark").bold().foregroundStyle(Parrot.leaf)
-            case .switchedOff:
-                Image(systemName: "xmark").bold().foregroundStyle(Parrot.scarlet)
-            case .turnedOff:
-                Image(systemName: "minus").bold().foregroundStyle(.tertiary)
-            case .downloading:
-                Circle()
-                    .trim(from: 0, to: 0.72)
-                    .stroke(
-                        Parrot.action,
-                        style: StrokeStyle(lineWidth: SetupMetrics.at(1.6), lineCap: .round)
-                    )
-                    .frame(width: SetupMetrics.at(10), height: SetupMetrics.at(10))
-                    .rotationEffect(.degrees(spinning ? 360 : 0))
-                    .onAppear {
-                        withAnimation(.linear(duration: 0.9).repeatForever(autoreverses: false)) {
-                            spinning = true
-                        }
+        HStack(alignment: .top, spacing: SetupMetrics.gap) {
+            Circle()
+                .trim(from: 0, to: 0.72)
+                .stroke(
+                    Parrot.action,
+                    style: StrokeStyle(lineWidth: SetupMetrics.at(1.6), lineCap: .round)
+                )
+                .frame(width: SetupMetrics.at(10), height: SetupMetrics.at(10))
+                .rotationEffect(.degrees(spinning ? 360 : 0))
+                .padding(.top, SetupMetrics.at(2))
+                .onAppear {
+                    withAnimation(.linear(duration: 0.9).repeatForever(autoreverses: false)) {
+                        spinning = true
                     }
-            case .queued:
-                Circle()
-                    .stroke(
-                        Color.secondary.opacity(0.6),
-                        style: StrokeStyle(
-                            lineWidth: SetupMetrics.at(1.2),
-                            dash: [SetupMetrics.at(2.2), SetupMetrics.at(2.2)]
-                        )
-                    )
-                    .frame(width: SetupMetrics.at(10), height: SetupMetrics.at(10))
-            case .absent:
-                Circle()
-                    .stroke(Parrot.amber, lineWidth: SetupMetrics.at(1.5))
-                    .frame(width: SetupMetrics.at(10), height: SetupMetrics.at(10))
-            }
+                }
+
+            Text("Terminal is installing it now. This screen notices on its own when"
+                + " it lands.")
+                .font(.system(size: SetupMetrics.at(11)))
+                .foregroundStyle(Parrot.amber)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Spacer(minLength: 0)
         }
-        .font(.system(size: SetupMetrics.at(10), weight: .bold))
-        .frame(width: SetupMetrics.glyph, height: SetupMetrics.glyph)
+        .padding(.horizontal, SetupMetrics.at(11))
+        .padding(.vertical, SetupMetrics.at(10))
+        .background(
+            Parrot.amber.opacity(0.11),
+            in: RoundedRectangle(cornerRadius: SetupMetrics.radius, style: .continuous)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: SetupMetrics.radius, style: .continuous)
+                .strokeBorder(Parrot.amber.opacity(0.38), lineWidth: SetupMetrics.at(1))
+        }
     }
 }
 
@@ -1401,54 +1367,5 @@ private struct HotkeyBadge: View {
                 RoundedRectangle(cornerRadius: SetupMetrics.fieldRadius, style: .continuous)
                     .strokeBorder(Parrot.action.opacity(0.55), lineWidth: SetupMetrics.at(1.5))
             }
-    }
-}
-
-private extension Permissions.Status {
-    var glyph: SetupGlyph {
-        self == .granted ? .granted : .switchedOff
-    }
-
-    /// Nothing beside a granted permission: the glyph says it.
-    var note: String? {
-        self == .granted ? nil : "switched off"
-    }
-}
-
-private extension ModelDownload {
-    var glyph: SetupGlyph {
-        switch state {
-        case .installed: return .granted
-        case .downloading, .loading: return .downloading
-        case .waiting: return .queued
-        case .off: return .turnedOff
-        // Amber for a fetch the app retries by itself, a cross for one that
-        // holds a dictation up.
-        case .failed: return blocking ? .switchedOff : .absent
-        }
-    }
-
-    var percent: Int? {
-        if case .downloading(let percent) = state { return percent }
-        return nil
-    }
-
-    /// The word at the right edge, where a glyph cannot carry it.
-    var note: String? {
-        switch state {
-        case .downloading(let percent): return percent.map { "\($0)%" }
-        case .loading: return "loading"
-        case .off(let reason): return reason
-        case .installed, .waiting, .failed: return nil
-        }
-    }
-
-    /// The one line under the name, only on a failure. A model nothing waits
-    /// on clears its own failed fetch, so its line says what happens next
-    /// rather than asking for a decision.
-    var why: String? {
-        guard let failure = state.failure else { return nil }
-        guard !blocking else { return failure.message }
-        return failure.message + " The next dictation that needs it tries again."
     }
 }

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -258,6 +258,11 @@ final class PermissionsWindowController {
     /// Set by `AppDelegate`; the window neither owns nor starts a download.
     var onRetryDownloads: (() -> Void)?
     private var window: NSWindow?
+
+    /// Whether the walk is on screen. The launch panel asks, so it does not
+    /// list the same downloads a second time underneath the screen whose job
+    /// that is.
+    var isShowing: Bool { window?.isVisible == true }
     private var timer: Timer?
     private var sizeWatch: AnyCancellable?
     /// Set once the window has been centred, so a later resize can keep the

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -1338,11 +1338,16 @@ private struct EspeakWaitingCard: View {
                     }
                 }
 
-            Text("Terminal is installing it now. This screen notices on its own when"
-                + " it lands.")
-                .font(.system(size: SetupMetrics.at(11)))
-                .foregroundStyle(Parrot.amber)
-                .fixedSize(horizontal: false, vertical: true)
+            VStack(alignment: .leading, spacing: SetupMetrics.at(4)) {
+                Text("Terminal is installing it now. This screen notices on its own when"
+                    + " it lands.")
+                // Homebrew asks before it does anything, and a window that only
+                // says "installing" reads as one nobody has to answer.
+                Text("Terminal will ask you to confirm.")
+            }
+            .font(.system(size: SetupMetrics.at(11)))
+            .foregroundStyle(Parrot.amber)
+            .fixedSize(horizontal: false, vertical: true)
 
             Spacer(minLength: 0)
         }

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -456,7 +456,7 @@ final class PermissionsWindowController {
         alert.messageText = "Install eSpeak NG?"
         alert.informativeText = "Without it, ParrotFlow misses some of the names in your"
             + " vocabulary. It is a separate program, so it installs in Terminal and takes"
-            + " about a minute."
+            + " about a minute. Terminal will ask you to confirm."
         // The real app icon, the same file System Settings reads. `NSAlert`
         // finds it by itself in the app; running the bare binary it does not.
         if let url = Bundle.main.url(forResource: "AppIcon", withExtension: "icns"),

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -355,7 +355,12 @@ final class PermissionsWindowController {
     /// looks for a ticked checkbox, so an install in Terminal lands on its own.
     private func pollEspeak() {
         if Phonemes.locate() != nil {
-            if model.espeak != .found { model.espeak = .found }
+            if model.espeak != .found {
+                model.espeak = .found
+                // Homebrew came with it and the Command Line Tools came with
+                // Homebrew, so the rest can be fetched now without asking.
+                ParsingInstall.finishQuietly()
+            }
             openedTerminalAt = nil
             return
         }

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -355,13 +355,7 @@ final class PermissionsWindowController {
     /// looks for a ticked checkbox, so an install in Terminal lands on its own.
     private func pollEspeak() {
         if Phonemes.locate() != nil {
-            if model.espeak != .found {
-                model.espeak = .found
-                // Homebrew came with it, and the Command Line Tools came with
-                // Homebrew. Everything a parse needs can be fetched now,
-                // without a terminal and without asking.
-                ParsingInstall.finishQuietly()
-            }
+            if model.espeak != .found { model.espeak = .found }
             openedTerminalAt = nil
             return
         }

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -614,7 +614,7 @@ struct PermissionsView: View {
                     micStatus: model.micStatus, axStatus: model.axStatus,
                     hotkeyDisplay: model.hotkeyDisplay,
                     hotkeyRegistered: model.hotkeyRegistered,
-                    espeak: model.espeak,
+                    context: model.context, espeak: model.espeak,
                     onClose: onClose, onRetry: onRetry,
                     onInstallEspeak: onInstallEspeak
                 )
@@ -967,6 +967,7 @@ private struct SetupPane: View {
     let axStatus: Permissions.Status
     let hotkeyDisplay: String
     let hotkeyRegistered: Bool
+    let context: PermissionsContext
     let espeak: PermissionsModel.EspeakPresence
     let onClose: () -> Void
     let onRetry: () -> Void
@@ -1023,9 +1024,13 @@ private struct SetupPane: View {
         if lostPermission != nil { return .permissionLost }
         if downloads.rows.isEmpty { return .dictationOff }
         if downloads.blockingFailure != nil { return .somethingDidNotArrive }
-        // Ready wins over eSpeak NG. Once the models are in there is nothing
-        // left to wait for, and this screen reads the same whether eSpeak NG
-        // was installed or not — Done asks about it once, in its own alert.
+        // Opened from the menu bar, eSpeak NG is the reason: the item only
+        // appears while something is unfinished, and this is where the command
+        // to install it lives. Ready would hide the one thing being asked for.
+        if context == .revisiting, espeak != .found { return .espeak }
+        // Setting up, Ready wins. The walk ends the moment the models land,
+        // and this screen reads the same whether eSpeak NG was installed or
+        // not — Done asks about it once, in its own alert.
         if downloads.speechIsIn { return .ready }
         return espeak == .found ? .almostReady : .espeak
     }
@@ -1050,7 +1055,9 @@ private struct SetupPane: View {
 
     /// The models are still coming and nothing has gone wrong. Both the bar and
     /// the greyed button are that one condition.
-    private var waiting: Bool { moment == .espeak || moment == .almostReady }
+    private var waiting: Bool {
+        (moment == .espeak || moment == .almostReady) && !downloads.speechIsIn
+    }
 
     /// The bar waits for eSpeak NG to be settled. While the card is up the
     /// screen is asking for one thing, and a bar under it is a second thing

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -1052,7 +1052,10 @@ private struct SetupPane: View {
     /// the greyed button are that one condition.
     private var waiting: Bool { moment == .espeak || moment == .almostReady }
 
-    private var showsBar: Bool { waiting }
+    /// The bar waits for eSpeak NG to be settled. While the card is up the
+    /// screen is asking for one thing, and a bar under it is a second thing
+    /// moving in the corner of the eye.
+    private var showsBar: Bool { moment == .almostReady }
 
     /// The sentence under the title, and the key it ends on.
     ///
@@ -1100,8 +1103,8 @@ private struct SetupPane: View {
             // key line, and it would end on "or".
             return hotkeyRegistered ? "\(opening) Try again, or" : "\(opening) Try again"
         case .espeak:
-            return "A separate GPL-3 library. It helps ParrotFlow understand your own"
-                + " terms, such as your work jargon and your teammates' names."
+            return "A separate GPL-3 library. eSpeak helps ParrotFlow understand your"
+                + " own terms, such as your work jargon and your teammates' names."
         case .almostReady:
             // Nothing under the title. The bar below says the same thing
             // without a sentence.

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -900,8 +900,7 @@ private struct ModelsPane: View {
 
             Text("ParrotFlow will download these models in the background while you"
                 + " finish setup.")
-                .font(.system(size: at(12)))
-                .foregroundStyle(.secondary)
+                .font(.system(size: at(13)))
                 .fixedSize(horizontal: false, vertical: true)
 
             group(
@@ -920,7 +919,7 @@ private struct ModelsPane: View {
 
             Spacer(minLength: at(20))
 
-            SetupFoot(title: "Next", action: onNext)
+            SetupFoot(title: "Download", action: onNext)
         }
     }
 
@@ -1101,7 +1100,8 @@ private struct SetupPane: View {
             // key line, and it would end on "or".
             return hotkeyRegistered ? "\(opening) Try again, or" : "\(opening) Try again"
         case .espeak:
-            return "Turns written words into phonemes (how they sound)."
+            return "A separate GPL-3 library. It helps ParrotFlow understand your own"
+                + " terms, such as your work jargon and your teammates' names."
         case .almostReady:
             // Nothing under the title. The bar below says the same thing
             // without a sentence.

--- a/Sources/ParrotFlow/PermissionsWindow.swift
+++ b/Sources/ParrotFlow/PermissionsWindow.swift
@@ -982,7 +982,7 @@ private struct SetupPane: View {
             Text(title)
                 .font(.system(size: at(19), weight: .semibold, design: .rounded))
                 .padding(.top, at(20))
-                .padding(.bottom, at(7))
+                .padding(.bottom, moment == .ready ? at(9) : at(7))
 
             invitation
 
@@ -1007,8 +1007,8 @@ private struct SetupPane: View {
         case permissionLost
         case dictationOff
         case somethingDidNotArrive
-        /// eSpeak NG is missing or landing. The screen is about it and nothing
-        /// else until it is settled.
+        /// The models are still coming and eSpeak NG is missing or landing.
+        /// The card only ever shows in the time the downloads leave for it.
         case espeak
         case almostReady
         case ready
@@ -1024,8 +1024,11 @@ private struct SetupPane: View {
         if lostPermission != nil { return .permissionLost }
         if downloads.rows.isEmpty { return .dictationOff }
         if downloads.blockingFailure != nil { return .somethingDidNotArrive }
-        if espeak != .found { return .espeak }
-        return downloads.speechIsIn ? .ready : .almostReady
+        // Ready wins over eSpeak NG. Once the models are in there is nothing
+        // left to wait for, and this screen reads the same whether eSpeak NG
+        // was installed or not — Done asks about it once, in its own alert.
+        if downloads.speechIsIn { return .ready }
+        return espeak == .found ? .almostReady : .espeak
     }
 
     private var lostPermission: PermissionStep? {
@@ -1048,9 +1051,7 @@ private struct SetupPane: View {
 
     /// The models are still coming and nothing has gone wrong. Both the bar and
     /// the greyed button are that one condition.
-    private var waiting: Bool {
-        (moment == .espeak || moment == .almostReady) && !downloads.speechIsIn
-    }
+    private var waiting: Bool { moment == .espeak || moment == .almostReady }
 
     private var showsBar: Bool { waiting }
 

--- a/Sources/ParrotFlow/Pipeline.swift
+++ b/Sources/ParrotFlow/Pipeline.swift
@@ -870,6 +870,17 @@ struct Pipeline: Equatable, Codable {
                 "ms": .double((seconds * 1000).rounded()),
             ], under: namespace)
             scope.merge(result.vars, under: namespace)
+
+            // The one thing a transform may ask the app for. It is published
+            // only when the work was actually wanted and the install is not
+            // there — `disfluency` asks after somebody said "you know" and it
+            // had nothing to judge it with. Nothing is fetched for a person
+            // whose dictations never reach the rule.
+            if result.vars["needs"] == .string("parsing") {
+                // The interpreter is already resolved: a transform reported
+                // this, so one just ran through `CommandRunner`.
+                ParsingInstall.finishQuietly()
+            }
             // The one bare name that moves. A condition reads the text as it
             // stands at that point in the pipeline — that has always been true
             // of a `when:` pattern, and an expression asking `text.matches(…)`

--- a/Sources/ParrotFlow/SetupParsingCommand.swift
+++ b/Sources/ParrotFlow/SetupParsingCommand.swift
@@ -8,6 +8,12 @@ import Foundation
 /// has yet, and the audience for it is somebody who is already in a terminal.
 ///
 /// `--check` reports and changes nothing, which is what a script wants.
+///
+/// The app installs this by itself once eSpeak NG is here — see
+/// `ParsingInstall.finishQuietly`, which builds the venv on the interpreter a
+/// transform will actually run under. This command picks its own, and the two
+/// can differ: a venv built here on Homebrew's python is invisible to an app
+/// launched from the Dock, which resolves `/usr/bin/python3`.
 enum SetupParsingCommand {
 
     static func run(check: Bool) -> Int32 {

--- a/Sources/ParrotFlow/SetupParsingCommand.swift
+++ b/Sources/ParrotFlow/SetupParsingCommand.swift
@@ -9,11 +9,11 @@ import Foundation
 ///
 /// `--check` reports and changes nothing, which is what a script wants.
 ///
-/// The app installs this by itself once eSpeak NG is here — see
-/// `ParsingInstall.finishQuietly`, which builds the venv on the interpreter a
-/// transform will actually run under. This command picks its own, and the two
-/// can differ: a venv built here on Homebrew's python is invisible to an app
-/// launched from the Dock, which resolves `/usr/bin/python3`.
+/// The app installs this by itself the first time a transform asks for a parse
+/// — see `ParsingInstall.finishQuietly`, which builds the venv on the
+/// interpreter a transform will actually run under. This command picks its own,
+/// and the two can differ: a venv built here on Homebrew's python is invisible
+/// to an app launched from the Dock, which resolves `/usr/bin/python3`.
 enum SetupParsingCommand {
 
     static func run(check: Bool) -> Int32 {

--- a/Sources/ParrotFlow/main.swift
+++ b/Sources/ParrotFlow/main.swift
@@ -845,7 +845,7 @@ if let index = arguments.firstIndex(of: "--panel-sheet") {
 
 if let index = arguments.firstIndex(of: "--panels") {
     guard arguments.indices.contains(index + 1) else {
-        print("usage: ParrotFlow --panels <notice|caution|failure|thinking|offer|confidence|learn|learn-long|selector|selector-long|selector-two|vocabulary|punctuation|rule|dictation|preview|microphone|keyboard|pill|update|setup|launch|sequence> [seconds]")
+        print("usage: ParrotFlow --panels <notice|caution|failure|thinking|offer|confidence|learn|learn-long|selector|selector-long|selector-two|vocabulary|punctuation|rule|dictation|preview|microphone|keyboard|pill|update|models|setup|launch|sequence> [seconds]")
         exit(2)
     }
     let seconds = arguments.indices.contains(index + 2) ? Double(arguments[index + 2]) : nil

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -858,7 +858,8 @@ $PF --panel-sheet s.png   # draw every surface into one PNG, light beside dark
 `--panels` takes `pill`, `notice`, `caution`, `failure`, `thinking`, `offer`,
 `confidence`, `learn`, `learn-long`, `selector`, `selector-long`,
 `selector-two`, `vocabulary`, `punctuation`, `rule`, `dictation`, `preview`,
-`microphone`, `keyboard`, `update`, `setup`, `launch` or `sequence`.
+`microphone`, `keyboard`, `update`, `models`, `setup`, `launch` or
+`sequence`.
 `--panel-sheet` draws all of
 them at once, which is where drift between them shows up.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,7 +81,8 @@ The menu bar item shows the current state and offers *Open Recordings
 Folder* — the wavs, if `logging.audio` is on, and `trace.jsonl` — *Settings*,
 which holds *Edit Config…* (`config.yaml`) and *Open Config Folder* —
 everything you own, so `vocabulary.yaml`, `transforms/` and `voice/` too —
-and *Setup…*. Both open in VS Code if it is installed, and in whatever
+and *Finish Setup…*, which is there while a permission is missing or eSpeak
+NG is not installed. Both open in VS Code if it is installed, and in whatever
 the system would otherwise use if it is not. See [`logging`](#logging).
 
 ### A folder per transform

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -134,16 +134,21 @@ grep "launched —" ~/Library/Logs/ParrotFlow.log | tail -1
 Want `accessibility=Granted`. `NotGranted` means the switch is off or they
 ticked a different app.
 
-**The last screen.** After the two permissions the setup window shows one
-screen: both permissions, the six models it is fetching (about 1.5 GB, started
-at launch), and eSpeak NG. Nothing there has to be waited for — *Done* closes
-the window and the downloads carry on. The title says the state, and only the
-permissions and the speech model change it: "Almost ready" until Parakeet is
-in, then "Ready". The one line with a button is eSpeak NG, which the app looks
-for rather than downloads: it is GPL-3 and a separate program, so *Run in
-Terminal* runs the Homebrew command where it can be watched. Pressing *Done*
-without it asks once — *Install it* or *Not now* — and remembers the answer, so
-the question is asked once per install and not once per launch.
+**The last two screens.** After the permissions the setup window lists the
+models it is fetching — about 1.5 GB, started at launch — with what each one
+costs. *Next* moves on; the downloads carry on behind it.
+
+The last screen is eSpeak NG, the one thing the app cannot fetch for you. It is
+GPL-3 and a separate program, so the screen shows the Homebrew command, and
+*Install with Terminal* runs it where it can be watched. The screen notices the
+binary landing by itself. Once eSpeak NG is settled the title becomes the state:
+"Almost ready" while a model a dictation waits on is still coming, then "Ready"
+with the key to hold. A bar under it says how far the downloads have got.
+
+*Done* is greyed until those models are in — it closes the window, and an app
+closed over a half-finished fetch is one that does not work yet. Pressing it
+without eSpeak NG asks once, *Install it* or *Not now*, and remembers the
+answer, so the question is asked once per install and not once per launch.
 
 ## Step 3 — Prove transcription works with no voice
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -153,6 +153,9 @@ closed over a half-finished fetch is one that does not work yet. Pressing it
 without eSpeak NG asks once, *Install it* or *Not now*, and remembers the
 answer, so the question is asked once per install and not once per launch.
 
+*Finish Setup…* stays in the menu bar while eSpeak NG is missing, and opening it
+that way shows the command again — it is the only route back to it.
+
 ## Step 3 — Prove transcription works with no voice
 
 Needs no microphone.
@@ -395,7 +398,8 @@ mention but notifies nobody — tell them that.
 >
 > Settings are in `~/.config/parrotflow/config.yaml`, and the names it has
 > learnt are in `vocabulary.yaml` beside it. Both reload on save. The menu bar
-> icon has *Settings* — *Edit Config…* and *View Transforms* — and *Setup…*.
+> icon has *Settings* — *Edit Config…* and *View Transforms* — and *Finish
+> Setup…* while something is still missing.
 
 ---
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -156,18 +156,21 @@ answer, so the question is asked once per install and not once per launch.
 *Finish Setup…* stays in the menu bar while eSpeak NG is missing, and opening it
 that way shows the command again — it is the only route back to it.
 
-**The Python a parse needs.** Nothing fetches it until something wants it. The
-fifth rule of the `disfluency` transform needs a parse — it is the one that
-tells "we'll let you know" from "you know, it broke" — and it only runs when a
-dictation actually carries `you know`, `i mean` or `like`. On 24,576 dictations
-in one archive that was 3.8% of them.
+**The Python a parse needs.** Once eSpeak NG is here, the app installs it in the
+background: about 170 MB into `~/Library/Application Support/ParrotFlow/python`.
+Nothing is asked and nothing waits for it. It is safe to do without a terminal
+because eSpeak NG came from Homebrew and the Homebrew installer installs the
+Command Line Tools, so by then there is a real `python3` to build on.
 
-The first time one of those arrives with no spaCy on the Mac, the transform
-publishes `needs: parsing` and the app installs it in the background: about
-170 MB into `~/Library/Application Support/ParrotFlow/python`. That dictation
-keeps the other four rules and says so in `disfluency.declined`; the next one
-is judged. Nothing is asked, nothing waits for it, and a failure is one line in
-the log. Someone who never says any of the three never downloads it.
+It pays for the fifth rule of the `disfluency` transform, the one that tells
+"we'll let you know" from "you know, it broke". That rule only runs when a
+dictation carries `you know`, `i mean` or `like` — 3.8% of 24,576 dictations in
+one archive, but the first one was number 10 and all 33 days had one.
+
+A Mac that never installed eSpeak NG still gets it: the transform publishes
+`needs: parsing` the first time the rule is reachable and cannot run, and the
+app installs it then. That dictation keeps its other four rules and says why in
+`disfluency.declined`.
 
 `ParrotFlow --setup-parsing` still does it by hand.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -136,10 +136,12 @@ ticked a different app.
 
 **The last two screens.** After the permissions the setup window lists the
 models it is fetching — about 1.5 GB, started at launch — with what each one
-costs. *Next* moves on; the downloads carry on behind it.
+costs. *Download* moves on; the fetches started at launch and carry on behind it.
 
-The last screen is eSpeak NG, the one thing the app cannot fetch for you. It is
-GPL-3 and a separate program, so the screen shows the Homebrew command, and
+The last screen is eSpeak NG, the one thing the app cannot fetch for you. It
+helps ParrotFlow understand your own terms — your jargon, your teammates'
+names. It is GPL-3 and a separate library, so the screen shows the Homebrew
+command, and
 *Install with Terminal* runs it where it can be watched. The screen notices the
 binary landing by itself. Once eSpeak NG is settled the title becomes the state:
 "Almost ready" while a model a dictation waits on is still coming, then "Ready"

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -156,14 +156,20 @@ answer, so the question is asked once per install and not once per launch.
 *Finish Setup…* stays in the menu bar while eSpeak NG is missing, and opening it
 that way shows the command again — it is the only route back to it.
 
-**What happens after eSpeak NG lands.** The app installs the Python a parse
-needs, quietly, in the background: about 170 MB into `~/Library/Application
-Support/ParrotFlow/python`. It is the fifth rule of the `disfluency` transform,
-the one that tells "we'll let you know" from "you know, it broke". The order is
-the point — the line that installs eSpeak NG installs Homebrew first when there
-is none, and the Homebrew installer installs the Command Line Tools, so by then
-there is a real `python3` to build on. Nothing waits for it and a failure is one
-line in the log. `ParrotFlow --setup-parsing` still does it by hand.
+**The Python a parse needs.** Nothing fetches it until something wants it. The
+fifth rule of the `disfluency` transform needs a parse — it is the one that
+tells "we'll let you know" from "you know, it broke" — and it only runs when a
+dictation actually carries `you know`, `i mean` or `like`. On 24,576 dictations
+in one archive that was 3.8% of them.
+
+The first time one of those arrives with no spaCy on the Mac, the transform
+publishes `needs: parsing` and the app installs it in the background: about
+170 MB into `~/Library/Application Support/ParrotFlow/python`. That dictation
+keeps the other four rules and says so in `disfluency.declined`; the next one
+is judged. Nothing is asked, nothing waits for it, and a failure is one line in
+the log. Someone who never says any of the three never downloads it.
+
+`ParrotFlow --setup-parsing` still does it by hand.
 
 ## Step 3 — Prove transcription works with no voice
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -145,7 +145,8 @@ command, and
 *Install with Terminal* runs it where it can be watched. The screen notices the
 binary landing by itself. Once eSpeak NG is settled the title becomes the state:
 "Almost ready" while a model a dictation waits on is still coming, then "Ready"
-with the key to hold. A bar under it says how far the downloads have got.
+with the key to hold. The bar appears once eSpeak NG is settled: while the card
+is up the screen is asking for one thing.
 
 *Done* is greyed until those models are in — it closes the window, and an app
 closed over a half-finished fetch is one that does not work yet. Pressing it

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -156,6 +156,15 @@ answer, so the question is asked once per install and not once per launch.
 *Finish Setup…* stays in the menu bar while eSpeak NG is missing, and opening it
 that way shows the command again — it is the only route back to it.
 
+**What happens after eSpeak NG lands.** The app installs the Python a parse
+needs, quietly, in the background: about 170 MB into `~/Library/Application
+Support/ParrotFlow/python`. It is the fifth rule of the `disfluency` transform,
+the one that tells "we'll let you know" from "you know, it broke". The order is
+the point — the line that installs eSpeak NG installs Homebrew first when there
+is none, and the Homebrew installer installs the Command Line Tools, so by then
+there is a real `python3` to build on. Nothing waits for it and a failure is one
+line in the log. `ParrotFlow --setup-parsing` still does it by hand.
+
 ## Step 3 — Prove transcription works with no voice
 
 Needs no microphone.

--- a/examples/transforms/disfluency/disfluency.py
+++ b/examples/transforms/disfluency/disfluency.py
@@ -587,12 +587,12 @@ def clean(text, language="en"):
         out = collapse(text, applied)
     except Exception:
         # Fail open — never drop the whole transcript because a guard threw.
-        return text, [], ""
+        return text, [], "", ""
 
     # The parse rule last: by now "I mean I mean" is one marker, and a restart
     # that hid a marker has been cleared out of the way.
     if language != "en":
-        return out, applied, ""
+        return out, applied, "", ""
     markers = dict(CLAUSE)
     markers["like"] = None
 
@@ -602,17 +602,22 @@ def clean(text, language="en"):
     # load — measured 0.53s and 0.21s, against 0.04s for the rest of this
     # file — on every dictation that carries no marker at all.
     if not any(marker_pattern(phrase).search(out) for phrase in markers):
-        return out, applied, ""
+        return out, applied, "", ""
 
     spacy = spacy_or_none()
     if spacy is None:
-        return out, applied, "word fillers: no spacy — run ParrotFlow --setup-parsing"
+        # A marker was said and there is nothing to judge it with. `needs` is
+        # what the app watches for: it installs the parsing Python in the
+        # background, so the next dictation carrying a marker is judged. Only
+        # reached behind the gate above, so nothing is fetched for a person
+        # who never says one.
+        return out, applied, "word fillers: no spacy — run ParrotFlow --setup-parsing", "parsing"
     try:
         out, marked = resolve(out, markers, spacy.load("en_core_web_sm"))
         applied.extend(marked)
     except Exception as error:
         declined = "word fillers: %s" % error
-    return out, applied, declined
+    return out, applied, declined, ""
 
 
 def main():
@@ -620,7 +625,7 @@ def main():
     raw = sys.stdin.read()
     payload = json.loads(raw) if structured else {"text": raw}
 
-    out, applied, declined = clean(
+    out, applied, declined, needs = clean(
         payload["text"], (payload.get("ctx") or {}).get("language", "en"))
 
     if not structured:
@@ -633,7 +638,8 @@ def main():
         # Deduplicated: three of the same fault name it once.
         "vars": {"applied": ", ".join(dict.fromkeys(applied)),
                  "edits": len(applied),
-                 "declined": declined},
+                 "declined": declined,
+                 "needs": needs},
     }))
     return 0
 

--- a/examples/transforms/disfluency/disfluency.py
+++ b/examples/transforms/disfluency/disfluency.py
@@ -511,6 +511,12 @@ def cut(sentence, spans):
     return lead + body
 
 
+def marker_pattern(phrase):
+    """The one pattern a marker is found by. Built here so the gate in `clean`
+    and the search in `resolve` cannot drift apart."""
+    return re.compile(r"\b" + phrase.replace(" ", r"\s+") + r"\b", re.I)
+
+
 def resolve(text, markers, nlp):
     """Every marker judged against what was said, then cut a sentence at a time.
 
@@ -519,8 +525,7 @@ def resolve(text, markers, nlp):
     """
     per_sentence = {}
     for phrase, lemma in markers.items():
-        pattern = re.compile(r"\b" + phrase.replace(" ", r"\s+") + r"\b", re.I)
-        for m in pattern.finditer(text):
+        for m in marker_pattern(phrase).finditer(text):
             sentence, a, b, offset = sentence_of(text, m.start(), m.end())
             doc = nlp(sentence)
             if lemma is None:
@@ -588,11 +593,20 @@ def clean(text, language="en"):
     # that hid a marker has been cleared out of the way.
     if language != "en":
         return out, applied, ""
+    markers = dict(CLAUSE)
+    markers["like"] = None
+
+    # Nothing said that a parse could judge, so nothing is loaded. `resolve`
+    # builds these same patterns and does nothing when none of them matches,
+    # so this cannot change the text. It skips `import spacy` and a model
+    # load — measured 0.53s and 0.21s, against 0.04s for the rest of this
+    # file — on every dictation that carries no marker at all.
+    if not any(marker_pattern(phrase).search(out) for phrase in markers):
+        return out, applied, ""
+
     spacy = spacy_or_none()
     if spacy is None:
         return out, applied, "word fillers: no spacy — run ParrotFlow --setup-parsing"
-    markers = dict(CLAUSE)
-    markers["like"] = None
     try:
         out, marked = resolve(out, markers, spacy.load("en_core_web_sm"))
         applied.extend(marked)

--- a/examples/transforms/disfluency/score.py
+++ b/examples/transforms/disfluency/score.py
@@ -53,7 +53,7 @@ def collapsed(text):
     string you wanted.
     """
     applied = []
-    out, applied, _ = disfluency.clean(text)
+    out, applied, _, _ = disfluency.clean(text)
     return out, applied
 
 

--- a/scripts/fresh-setup.sh
+++ b/scripts/fresh-setup.sh
@@ -11,10 +11,11 @@ set -eu
 cd "$(dirname "$0")/.."
 . scripts/variant.sh
 
-ESPEAK=1 CONFIG=0 PURGE=0 INSTALL=1
+ESPEAK=1 PARSING=1 CONFIG=0 PURGE=0 INSTALL=1
 for arg in "$@"; do
     case "$arg" in
         --keep-espeak) ESPEAK=0 ;;
+        --keep-parsing) PARSING=0 ;;
         --config)      CONFIG=1 ;;
         --purge-old)   PURGE=1 ;;
         --no-install)  INSTALL=0 ;;
@@ -23,6 +24,7 @@ for arg in "$@"; do
 usage: scripts/fresh-setup.sh [options]
 
   --keep-espeak   leave eSpeak NG installed
+  --keep-parsing  leave the spaCy venv in place
   --config        move the config directory aside too
   --purge-old     delete .moved-* copies left by earlier runs
   --no-install    stop after the reset, do not build or launch
@@ -35,6 +37,10 @@ USAGE
 done
 
 SUPPORT="$HOME/Library/Application Support/$DISPLAY_NAME"
+# Not under $SUPPORT: the parsing venv has no variant suffix, because both
+# builds read the one copy. So a reset that only cleared $SUPPORT left it, and
+# the install that fetches it on first need had nothing left to do.
+PARSING_DIR="$HOME/Library/Application Support/ParrotFlow/python"
 SHARED="$HOME/Library/Application Support/FluidAudio/Models"
 G2P="$HOME/.cache/fluidaudio/Models"
 STAMP="$(date +%Y-%m-%d-%H%M%S)"
@@ -54,6 +60,8 @@ echo "  move aside the speech models, which the other build reads from the same 
 echo "      $SHARED/{parakeet-tdt-0.6b-v3,silero-vad}"
 echo "      $G2P"
 espeak_here && echo "  brew uninstall espeak-ng — this takes it from the other build too"
+[ "$PARSING" -eq 1 ] && [ -d "$PARSING_DIR" ] \
+    && echo "  move aside the spaCy venv — the other build reads the same copy"
 [ "$CONFIG" -eq 1 ] && echo "  move $HOME/$CONFIG_DIR aside"
 [ "$PURGE" -eq 1 ] && echo "  delete every .moved-* copy from earlier runs"
 [ "$INSTALL" -eq 1 ] && echo "  build, install and launch it again"
@@ -92,6 +100,14 @@ if [ -d "$G2P" ]; then
 fi
 echo "==> Shared speech models moved aside as .moved-$STAMP."
 
+# Moved, like the speech models and for the same reason: it is shared with the
+# other build, and this run only fetches it again if a dictation asks for a
+# parse. `ParsingInstall.finishQuietly` rebuilds it on the first marker said.
+if [ "$PARSING" -eq 1 ] && [ -d "$PARSING_DIR" ]; then
+    mv "$PARSING_DIR" "$PARSING_DIR.moved-$STAMP"
+    echo "==> spaCy venv moved aside as .moved-$STAMP."
+fi
+
 if espeak_here; then
     brew uninstall espeak-ng
     echo "==> eSpeak NG uninstalled."
@@ -103,7 +119,7 @@ if [ "$CONFIG" -eq 1 ] && [ -d "$HOME/$CONFIG_DIR" ]; then
 fi
 
 if [ "$PURGE" -eq 1 ]; then
-    find "$SHARED" "$SUPPORT" "$(dirname "$G2P")" -maxdepth 1 \
+    find "$SHARED" "$SUPPORT" "$(dirname "$G2P")" "$(dirname "$PARSING_DIR")" -maxdepth 1 \
         -name "*.moved-*" ! -name "*$STAMP" -exec rm -rf {} + 2>/dev/null || true
     echo "==> Earlier .moved-* copies deleted."
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -183,7 +183,7 @@ cat <<'EOF'
 
     Next:
       1. Say yes to the microphone prompt — wait until it's granted.
-      2. Click the 🦜 icon, choose Setup…, grant Accessibility, and
+      2. Click the 🦜 icon, choose Finish Setup…, grant Accessibility, and
          wait until that's granted too — without it, dictation transcribes
          but can't type the result in for you.
       3. Hold Right Command, say something, let go.


### PR DESCRIPTION
The setup walk ends on two screens instead of one. The first lists the six models
the launch is fetching, with what each costs. The second is eSpeak NG, the one
thing the app cannot install for you: it shows the Homebrew command and runs it
in Terminal. Once the models land the title becomes the state, "Almost ready"
then "Ready" with the key to hold, and a single bar replaces six percentages.

*Finish Setup…* now stays in the menu bar while eSpeak NG is missing, so there is
a way back to that command. There was none before: the item was hidden the moment
both permissions were granted.

The Python a parse needs is no longer a terminal command either. It installs
itself, in the background, the first time a dictation actually needs it. Nobody
who never says "you know", "i mean" or "like" downloads it at all.

Reviewers: start with `SetupPane.moment` in `PermissionsWindow.swift` — it decides
every title, and three of its six cases are failure states the mock-ups do not
show. Then `ParsingInstall.finishQuietly`.

<details>
<summary>The per-row glyphs and percentages are gone, and three failure states are not</summary>

The old screen was one list: both permissions, six model rows with their own
glyphs and percentages, and eSpeak NG. All of that goes. `SetupLine`,
`SetupNote`, `SetupGlyph` and the two extensions that fed them are deleted.

What is kept, because the new shape has nowhere to show it:

| Moment | Title | Foot |
|---|---|---|
| a permission was switched off | Something was switched off | Done |
| `transcription.enabled: false` | Something was switched off | Done |
| a blocking fetch failed | Something did not arrive | Try again |

Without these three, *Done* would be greyed forever on two of them and there
would be no retry on the third. `speechIsIn` is false by construction in all
three cases.

The decline button is also gone from both screens. The permission screens keep
theirs. A first run is not something to back out of half way.

</details>

<details>
<summary>Ready wins over eSpeak NG, except from the menu bar</summary>

While the models are still coming, the screen is about eSpeak NG. Once they are
in, the title is the state and the card is gone, whether eSpeak NG was installed
or not — the two renders are byte-identical.

A window opened from *Finish Setup…* is the exception. The item only appears
when something is unfinished, so Ready there would hide the one thing being
offered. Nothing is greyed on it: the downloads are long done.

</details>

<details>
<summary>Measured: the marker rule ran spaCy on every English dictation, and 96% of them have no marker</summary>

`disfluency.py` imported spaCy and loaded a model whether or not the rule could
fire.

```
import spacy                 0.53 s
spacy.load en_core_web_sm    0.21 s
the parse itself             0.009 s

disfluency.py with a marker  0.83 s
disfluency.py without        0.04 s
```

The rule can only fire on `i mean`, `you know` or `like`. `resolve` builds those
three patterns and does nothing when none matches, so testing for them first
cannot change the text. Both now build the pattern through `marker_pattern`, so
the gate and the search cannot drift apart.

On 24,576 dictations in one archive, 927 carry a marker — 3.8%.

```
like 468 · i mean 354 · you know 144
```

The case set is 102/102 before and after.

</details>

<details>
<summary>How "install on first use" works, and why a venv built by the terminal command can be invisible</summary>

`disfluency` publishes one reserved var, `needs: parsing`, when a marker was said
and there was nothing to judge it with. Only reachable behind the cue gate, so a
dictation with no marker asks for nothing. `Pipeline` watches for that var and
starts the install in the background. That dictation keeps its other four rules
and says why in `disfluency.declined`; the next one is judged.

The venv is built on the interpreter a transform will actually run under, asked
of `CommandRunner`. `--setup-parsing` picks its own, and the two can differ: that
command prefers Homebrew's python, while an app launched from the Dock inherits
launchd's PATH and resolves `/usr/bin/python3`. A venv built on one is invisible
to the other, because `disfluency.py` looks for site-packages by its own version.
Reproduced before this change: four green ticks from `--setup-parsing` and the
rule still off.

That is why `CommandRunner.probeInterpreter` now keeps the full path rather than
only its directory.

</details>

<details>
<summary>What this does not do</summary>

Both spaCy models are still fetched, and the marker rule is English-only, so
`fr_core_news_sm` is 25 MB nothing reads. Making the manifest follow
`transcription.languages` is the obvious next step and is not here.

`ParsingInstall.steps()`, `interpreter()` and `--setup-parsing` are untouched.
`scripts/check-setup-parsing.sh` scores them, and a terminal cannot know the Dock
app's PATH anyway.

</details>

<details>
<summary>Checks</summary>

```
check-pipeline          107/107
check-transform-folders  30/30
check-keyed              26/26
check-setup-parsing      16/16
disfluency score        102/102
swiftlint                clean
```

CodeRabbit found one issue, a missing deadline on the background install, fixed
in the last commit. The re-run was rate-limited by the free plan.

All seven states of the two screens are drawn by `--panel-sheet`, and
`--panels models` puts the first one on screen.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
